### PR TITLE
Fix broken archive form as a result of merge with trade elements.

### DIFF
--- a/src/views/_components/archive-form.njk
+++ b/src/views/_components/archive-form.njk
@@ -26,8 +26,13 @@
   } %}
 
   <div class="js-ConditionalSubfield" data-controlled-by="archived_reason" data-control-value="Other">
-    {{ textbox("archived_reason_other", label="Other") }}
+    <div class="form-group">
+      <label class="form-label-bold">Other</label>
+      <input class="form-control" type="text" name="archived_reason_other">
+    </div>
   </div>
 
-  {{ save(buttonText="Archive") }}
+  <div class="save-bar">
+    <button class="button button--save" type="submit">Archive</button>
+  </div>
 </form>


### PR DESCRIPTION
New style components don't seem to be able to call macros for the components merged from trade elements.

As no other new components use those macros it seems simpler to just not call them