### PR TITLE
Correct spelling and ensure dependencies are correct

### DIFF
--- a/src/views/_macros/_deprecated/trade-elements/autocomplete.njk
+++ b/src/views/_macros/_deprecated/trade-elements/autocomplete.njk
@@ -1,3 +1,5 @@
+{% from "_macros/_deprecated/trade-elements/dropdown.njk" import dropdown %}
+
 {% macro autocomplete(name, label, value='', displayvalue, hint, id, class, error, url, options) %}
 
   {% if not id %}

--- a/src/views/interaction/interaction-edit.njk
+++ b/src/views/interaction/interaction-edit.njk
@@ -45,7 +45,7 @@
       error=errors.notes
     ) }}
 
-    {{ automplete("contact",
+    {{ autocomplete("contact",
       label=labels.contact,
       emptyLabel="Pick a contact",
       hint="Please start typing to search for a contact",
@@ -56,7 +56,7 @@
 
     {{ date('date', label=labels.date, value=formData.date ) }}
 
-    {{ automplete('dit_adviser',
+    {{ autocomplete('dit_adviser',
       label=labels.dit_adviser,
       value=formData.dit_adviser,
       displayvalue=dit_adviser.name,
@@ -66,7 +66,7 @@
       url='/api/accountmanagerlookup?term=')
     }}
 
-    {{ automplete("service",
+    {{ autocomplete("service",
       label="Service offer",
       emptyLabel="Pick a service",
       hint="Please start typing to search for a service",
@@ -75,7 +75,7 @@
       options=serviceOfferOptions)
     }}
 
-    {{ automplete("dit_team",
+    {{ autocomplete("dit_team",
       label="Service provider",
       emptyLabel="Pick a provider",
       hint="Please start typing to search for a provider",

--- a/src/views/interaction/service-delivery-edit.njk
+++ b/src/views/interaction/service-delivery-edit.njk
@@ -46,7 +46,7 @@
       Service delivery
     </div>
 
-    {{ automplete("dit_team",
+    {{ autocomplete("dit_team",
       label="Service provider",
       emptyLabel="Pick a provider",
       hint="Please start typing to search for a provider",
@@ -55,7 +55,7 @@
       options=serviceProviderOptions)
     }}
 
-    {{ automplete('service',
+    {{ autocomplete('service',
       label=labels.service,
       value=serviceDelivery.service.id,
       hint="Please start typing to search for a service",
@@ -92,7 +92,7 @@
 
     {{ date('date', label='Service delivery start date', value=serviceDelivery.date ) }}
 
-    {{ automplete("contact",
+    {{ autocomplete("contact",
       label=labels.contact,
       emptyLabel="Pick a contact",
       hint="Please start typing to search for a contact",
@@ -101,7 +101,7 @@
       options=contacts)
     }}
 
-    {{ automplete('dit_adviser',
+    {{ autocomplete('dit_adviser',
       label=labels.dit_adviser,
       value=serviceDelivery.dit_adviser.id,
       displayvalue=serviceDelivery.dit_adviser.name,

--- a/src/views/investment/_details-form.njk
+++ b/src/views/investment/_details-form.njk
@@ -2,7 +2,7 @@
   <input type="hidden" name="_csrf" value="{{ csrfToken }}">
   <input type="hidden" name="investor_company" value="{{ equityCompany.id }}">
 
-  {{ automplete('client_contacts',
+  {{ autocomplete('client_contacts',
     label="Client contact for this project",
     value=form.state['client_contacts'],
     options=form.options.contacts)
@@ -23,7 +23,7 @@
   } %}
 
   <div class="panel panel-border-narrow js-ConditionalSubfield" data-controlled-by="is-relationship-manager" data-control-value="No">
-    {{ automplete('client_relationship_manager',
+    {{ autocomplete('client_relationship_manager',
       label="Client relationship manager",
       value=form.state['client_relationship_manager'],
       options=form.options.advisers)
@@ -45,7 +45,7 @@
   } %}
 
   <div class="panel panel-border-narrow js-ConditionalSubfield" data-controlled-by="is-referral-source" data-control-value="No">
-    {{ automplete('referral_source_adviser',
+    {{ autocomplete('referral_source_adviser',
       label="Referral source adviser",
       value=form.state['referral_source_adviser'],
       options=form.options.advisers)

--- a/src/views/investment/interaction/_form.njk
+++ b/src/views/investment/interaction/_form.njk
@@ -21,7 +21,7 @@
     error=form.errors.notes)
   }}
 
-  {{ automplete('contact',
+  {{ autocomplete('contact',
     label=form.labels['contact'],
     value=form.state['contact'],
     options=form.options.contacts)
@@ -32,7 +32,7 @@
     value=form.state['date'])
   }}
 
-  {{ automplete('dit_adviser',
+  {{ autocomplete('dit_adviser',
     label=form.labels['dit_adviser'],
     value=form.state['dit_adviser'],
     options=form.options.advisers)


### PR DESCRIPTION
Autocomplete was spelt wrong when loading macros. This change
fixes that typo and also ensure that the dropdown macro is included
in the autocomplete macro.