### PR TITLE
Allow empty router to pass to next middleware

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -14,7 +14,7 @@ subApps.forEach(subAppDir => {
     } else if (subApp.router) {
       appsRouters.push(router.use(subApp.router))
     } else {
-      appsRouters.push(() => {}) // add dummy router as fallback
+      appsRouters.push((req, res, next) => next())
     }
   } catch (err) {
     logger.warn(err.message)


### PR DESCRIPTION
When no router is defined for a feature app the default needs to
just call next to allow the app to pass through.