### PR TITLE
Fix bug where investment/start was redirected by earlier routes

### DIFF
--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -31,6 +31,11 @@ router
   .get(form.populateDetailsFormMiddleware, create.createGetHandler)
   .post(form.populateDetailsFormMiddleware, form.investmentDetailsFormPostMiddleware, create.createPostHandler)
 
+router
+  .route('/start')
+  .get(start.getHandler)
+  .post(start.postHandler)
+
 router.get('/:id', details.redirectToDetails)
 router.get('/:id/details', details.detailsGetHandler)
 
@@ -48,11 +53,6 @@ router
   .route('/:id/edit-requirements')
   .get(form.populateRequirementsFormMiddleware, edit.editRequirementsGet)
   .post(form.populateRequirementsFormMiddleware, form.investmentRequirementsFormPostMiddleware, edit.editRequirementsPost)
-
-router
-  .route('/start')
-  .get(start.getHandler)
-  .post(start.postHandler)
 
 router.get('/:id/team', team.getTeamHandler)
 


### PR DESCRIPTION
Move the `/start` further up the chain to ensure the page is not redirected by `redirectToDetails`.