### PR TITLE
let assets passthrough so they are not recorded on locals.returnTo

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,6 +1,6 @@
 module.exports = function auth (req, res, next) {
   const url = req.url
-  const passThrough = /^\/(support|ping|login)\b/.test(url) || req.session.token
+  const passThrough = /^\/(support|ping|login|assets)\b/.test(url) || req.session.token
 
   if (passThrough) {
     return next()

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -27,7 +27,7 @@ module.exports = function locals (req, res, next) {
     CANONICAL_URL: baseUrl + req.originalUrl,
 
     getAssetPath (asset) {
-      const assetsUrl = config.assetsHost || baseUrl
+      const assetsUrl = `${config.assetsHost || baseUrl}/assets`
       const webpackAssetPath = webpackManifest[asset]
 
       if (webpackAssetPath) {

--- a/src/server.js
+++ b/src/server.js
@@ -55,10 +55,7 @@ nunjucks(app, config)
 // Static files
 app.use(favicon(path.join(config.root, 'public/images', 'favicon.ico')))
 app.use(express.static(path.join(config.root, 'public')))
-app.use('/js', express.static(path.join(config.buildDir, 'js')))
-app.use('/css', express.static(path.join(config.buildDir, 'css')))
-app.use('/images', express.static(path.join(config.buildDir, 'images')))
-app.use('/fonts', express.static(path.join(config.buildDir, 'fonts')))
+app.use('/assets', express.static(config.buildDir))
 
 app.use(flash())
 app.use(locals)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const common = {
   },
   output: {
     path: config.buildDir,
-    publicPath: '/',
+    publicPath: '/assets/',
   },
   module: {
     rules: [


### PR DESCRIPTION
### For consideration

This was originally for a bug fix that now does not exist. It feels like it may be worth keeping the part that places client side assets within an `assets` folder?

@tyom thoughts?