### PR TITLE
Use constant case for global level template variables

### DIFF
--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -1,8 +1,5 @@
 const logger = require('../../config/logger')
-const pjson = require('../../package.json')
 const config = require('../../config')
-
-const startTime = new Date().getTime()
 
 let webpackManifest = {}
 try {
@@ -12,19 +9,13 @@ try {
 }
 
 module.exports = function locals (req, res, next) {
-  logger.debug('locals:start')
   const baseUrl = `${(req.encrypted ? 'https' : req.protocol)}://${req.get('host')}`
 
   res.locals = Object.assign({}, res.locals, {
-    releaseVersion: pjson.version,
-    startTime: startTime,
-    referer: req.headers.referer,
-    env: config.env,
-    googleTagManagerKey: config.googleTagManagerKey,
-    query: req.query,
-    currentPath: req.path,
     BASE_URL: baseUrl,
     CANONICAL_URL: baseUrl + req.originalUrl,
+    CURRENT_PATH: req.path,
+    GOOGLE_TAG_MANAGER_KEY: config.googleTagManagerKey,
 
     getAssetPath (asset) {
       const assetsUrl = config.assetsHost || baseUrl
@@ -37,7 +28,5 @@ module.exports = function locals (req, res, next) {
       return `${assetsUrl}/${asset}`
     },
   })
-
-  logger.debug('locals:end')
   next()
 }

--- a/src/templates/_includes/google-tag-manager-no-script.njk
+++ b/src/templates/_includes/google-tag-manager-no-script.njk
@@ -1,6 +1,5 @@
-{% if googleTagManagerKey %}
+{% if GOOGLE_TAG_MANAGER_KEY %}
 <noscript>
-  <iframe src="https://www.googletagmanager.com/ns.html?id={{ googleTagManagerKey }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_KEY }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
 {% endif %}
-

--- a/src/templates/_includes/google-tag-manager-snippet.njk
+++ b/src/templates/_includes/google-tag-manager-snippet.njk
@@ -1,4 +1,4 @@
-{% if googleTagManagerKey %}
+{% if GOOGLE_TAG_MANAGER_KEY %}
 <script>
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
     var f=d.getElementsByTagName(s)[0],
@@ -6,6 +6,6 @@
         dl=l!='dataLayer'?'&l='+l:'';
     j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
     f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','{{ googleTagManagerKey }}');
+  })(window,document,'script','dataLayer','{{ GOOGLE_TAG_MANAGER_KEY }}');
 </script>
 {% endif %}

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -34,17 +34,17 @@
     <ul class="proposition-menu">
       {% if user %}
         <li class="proposition-menu__item">
-          <a href="/" class="proposition-menu__link{{ ' is-active' if currentPath == '/' }}">Dashboard</a>
+          <a href="/" class="proposition-menu__link {{ 'is-active' if CURRENT_PATH == '/' }}">Dashboard</a>
         </li>
       {% endif %}
       {% if feedbackLink %}
         <li class="proposition-menu__item">
-          <a href="{{ feedbackLink }}" class="proposition-menu__link{{ ' is-active' if currentPath and '/support' in currentPath }}">Support</a>
+          <a href="{{ feedbackLink }}" class="proposition-menu__link {{ 'is-active' if CURRENT_PATH and '/support' in CURRENT_PATH }}">Support</a>
         </li>
       {% endif %}
       {% if user %}
         <li class="proposition-menu__item">
-          <a href="/profile" class="proposition-menu__link{{ ' is-active' if currentPath == '/profile' }}">{{ user.name }}</a>
+          <a href="/profile" class="proposition-menu__link {{ 'is-active' if CURRENT_PATH == '/profile' }}">{{ user.name }}</a>
         </li>
       {% endif %}
       <li class="proposition-menu__item">


### PR DESCRIPTION
Using constant case makes it clear from the view that the variable
being used is defined in the global scope for all views.

This also clears out a few variables that were no longer being used in any views.