### PR TITLE
Replace page titles with breadcrumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "dotenv": "^4.0.0",
     "eslint": "^3.17.0",
     "express": "^4.14.0",
-    "express-breadcrumbs": "^0.0.2",
     "express-session": "^1.14.1",
     "express-sslify": "^1.2.0",
     "extract-text-webpack-plugin": "^2.1.2",

--- a/src/apps/auth/controllers/sign-in.js
+++ b/src/apps/auth/controllers/sign-in.js
@@ -28,9 +28,9 @@ function getHandler (req, res) {
     return res.redirect('/')
   }
 
-  res.render('auth/views/sign-in', {
-    title: 'Sign in',
-  })
+  res
+    .title('Sign in')
+    .render('auth/views/sign-in')
 }
 
 function postHandler (req, res, next) {

--- a/src/apps/auth/views/sign-in.njk
+++ b/src/apps/auth/views/sign-in.njk
@@ -1,7 +1,5 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_breadcrumbs %}{% endblock %}
-
 {% block body_main_header_content %}
   <h2 class="heading-xlarge">Sign in</h2>
 {% endblock %}

--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -9,7 +9,6 @@ const { companyDetailsLabels, chDetailsLabels, companyTypeOptions } = require('.
 
 function getAddStepOne (req, res, next) {
   res.render('companies/views/add-step-1.njk', {
-    title: 'Add company',
     ukOtherCompanyOptions,
     foreignOtherCompanyOptions,
     company: req.body,
@@ -82,7 +81,6 @@ async function getAddStepTwo (req, res, next) {
 
   if (!searchTerm) {
     return res.render('companies/views/add-step-2.njk', {
-      title: 'Add company',
       companyTypeOptions,
       businessType,
       country,

--- a/src/apps/companies/controllers/ch.js
+++ b/src/apps/companies/controllers/ch.js
@@ -16,9 +16,10 @@ async function getDetails (req, res, next) {
     res.locals.chDetailsDisplayOrder = chDetailsDisplayOrderLong
     res.locals.chDetailsLabels = chDetailsLabels
     res.locals.addUrl = `/companies/add/ltd/${company.company_number}`
-    res.locals.title = [company.name, 'Companies']
 
-    res.render('companies/views/details-ch')
+    res
+      .breadcrumb(company.name)
+      .render('companies/views/details-ch')
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -24,9 +24,11 @@ async function getContacts (req, res, next) {
       .map(contact => getDisplayArchivedCompanyContact(contact))
 
     res.locals.addContactUrl = `/contacts/create?company=${res.locals.company.id}`
-    res.locals.title = ['Contacts', res.locals.company.name, 'Companies']
 
-    res.render('companies/views/contacts')
+    res
+      .breadcrumb(res.locals.company.name, `/companies/${res.locals.company.id}`)
+      .breadcrumb('Contacts')
+      .render('companies/views/contacts')
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/controllers/exp.js
+++ b/src/apps/companies/controllers/exp.js
@@ -34,7 +34,9 @@ function common (req, res) {
     try {
       res.locals.tab = 'exports'
       res.locals.company = await getInflatedDitCompany(req.session.token, req.params.id)
-      res.locals.title = ['Exports', res.locals.company.name, 'Companies']
+
+      res.breadcrumb(res.locals.company.name, `/viewcompanyresult/${res.locals.company.id}`)
+      res.breadcrumb('Exports', `/companies/${res.locals.company.id}/exports`)
 
       getCommonTitlesAndlinks(req, res, res.locals.company)
       resolve()
@@ -89,9 +91,9 @@ async function edit (req, res, next) {
       data.future_interest_countries = res.locals.company.future_interest_countries.map(country => country.id)
     }
 
-    res.locals.title.unshift('Edit')
-
-    res.render('companies/views/exports-edit', data)
+    res
+      .breadcrumb('Edit')
+      .render('companies/views/exports-edit', data)
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/controllers/foreign.js
+++ b/src/apps/companies/controllers/foreign.js
@@ -21,9 +21,10 @@ async function getDetails (req, res, next) {
       oneListAccountManager: 'None',
     }
     res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
-    res.locals.title = [company.name, 'Companies']
 
-    res.render('companies/views/details-foreign')
+    res
+      .breadcrumb(company.name)
+      .render('companies/views/details-foreign')
   } catch (error) {
     next(error)
   }
@@ -51,9 +52,10 @@ function addDetails (req, res, next) {
   }
   res.locals.businessTypeName = req.query.business_type
   res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
-  res.locals.title = 'Add company'
 
-  res.render('companies/views/edit-foreign')
+  res
+    .breadcrumb('Add company')
+    .render('companies/views/edit-foreign')
 }
 
 async function editDetails (req, res, next) {
@@ -66,8 +68,11 @@ async function editDetails (req, res, next) {
     }
     res.locals.businessTypeName = company.business_type.name
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
-    res.locals.title = ['Edit', company.name, 'Companies']
-    res.render(`companies/views/edit-foreign`)
+
+    res
+      .breadcrumb(company.name, `/companies/view/foreign/${company.id}`)
+      .breadcrumb('Edit')
+      .render(`companies/views/edit-foreign`)
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/controllers/interactions.js
+++ b/src/apps/companies/controllers/interactions.js
@@ -24,9 +24,10 @@ async function getInteractions (req, res, next) {
       res.locals.addContact = `/contacts/create?company=${res.locals.company.id}`
     }
 
-    res.locals.title = ['Interactions', res.locals.company.name, 'Companies']
-
-    res.render('companies/views/interactions')
+    res
+      .breadcrumb(res.locals.company.name, `/viewcompanyresult/${res.locals.company.id}`)
+      .breadcrumb('Interactions')
+      .render('companies/views/interactions')
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/controllers/investments.js
+++ b/src/apps/companies/controllers/investments.js
@@ -12,7 +12,6 @@ async function getAction (req, res, next) {
     getCommonTitlesAndlinks(req, res, company)
 
     res.render('companies/views/investments', {
-      title: ['Investments', company.name, 'Companies'],
       tab: 'investments',
       company,
       projects,

--- a/src/apps/companies/controllers/ltd.js
+++ b/src/apps/companies/controllers/ltd.js
@@ -28,9 +28,10 @@ async function getDetails (req, res, next) {
       oneListAccountManager: 'None',
     }
     res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
-    res.locals.title = [company.name, 'Companies']
 
-    res.render('companies/views/details-ltd')
+    res
+      .breadcrumb(company.name)
+      .render('companies/views/details-ltd')
   } catch (error) {
     next(error)
   }
@@ -63,8 +64,10 @@ async function addDetails (req, res, next) {
       res.locals.formData = companyFormService.getDefaultLtdFormForCH(res.locals.chCompany)
     }
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
-    res.locals.title = 'Add company'
-    res.render(`companies/views/edit-ltd`)
+
+    res
+      .breadcrumb('Add company')
+      .render(`companies/views/edit-ltd`)
   } catch (error) {
     next(error)
   }
@@ -74,11 +77,12 @@ async function editDetails (req, res, next) {
   try {
     if (containsFormData(req)) {
       res.locals.formData = req.body
-      res.locals.title = ['Edit company', 'Companies']
+      res.breadcrumb('Edit company')
     } else {
       const company = await companyRepository.getDitCompany(req.session.token, req.params.id)
       res.locals.formData = companyFormService.getLtdCompanyAsFormData(company)
-      res.locals.title = ['Edit', company.name, 'Companies']
+      res.breadcrumb(company.name, `/viewcompanyresult/${company.id}`)
+      res.breadcrumb('Edit')
     }
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
     res.render(`companies/views/edit-ltd`)

--- a/src/apps/companies/controllers/ukother.js
+++ b/src/apps/companies/controllers/ukother.js
@@ -21,9 +21,10 @@ async function getDetails (req, res, next) {
       oneListAccountManager: 'None',
     }
     res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
-    res.locals.title = [company.name, 'Companies']
 
-    res.render('companies/views/details-ukother')
+    res
+      .breadcrumb(company.name)
+      .render('companies/views/details-ukother')
   } catch (error) {
     next(error)
   }
@@ -52,8 +53,10 @@ function addDetails (req, res, next) {
   }
   res.locals.businessTypeName = req.query.business_type
   res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
-  res.locals.title = 'Add company'
-  res.render(`companies/views/edit-ukother`)
+
+  res
+    .breadcrumb('Add company')
+    .render(`companies/views/edit-ukother`)
 }
 
 async function editDetails (req, res, next) {
@@ -66,8 +69,11 @@ async function editDetails (req, res, next) {
     }
     res.locals.businessTypeName = company.business_type.name
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
-    res.locals.title = ['Edit', company.name, 'Companies']
-    res.render(`companies/views/edit-ukother`)
+
+    res
+      .breadcrumb(company.name, `/viewcompanyresult/${company.id}`)
+      .breadcrumb('Edit')
+      .render(`companies/views/edit-ukother`)
   } catch (error) {
     next(error)
   }

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -26,29 +26,31 @@ const foreignOtherCompanyOptions = [
 ]
 
 function renderFormElements (req, res) {
-  req.breadcrumbs('Form')
-  return res.render('components/views/form', {
-    title: 'Form Elements',
-    entitySearch: Object.assign({}, res.locals.entitySearch, {
-      searchTerm: req.query.term,
-    }),
-    form: Object.assign({}, res.locals.form, {
-      options: {
-        countries: metadata.countryOptions.map(transformOption),
-        averageSalaryRange: metadata.salaryRangeOptions.map(transformOption),
-        strategicDrivers: metadata.strategicDriverOptions.map(transformOption),
-        sectors: metadata.sectorOptions.map(transformOption),
-        foreignOtherCompany: foreignOtherCompanyOptions.map(i => ({ value: i, label: i })),
-      },
-    }),
-  })
+  return res
+    .breadcrumb('Form')
+    .render('components/views/form', {
+      title: 'Form Elements',
+      entitySearch: Object.assign({}, res.locals.entitySearch, {
+        searchTerm: req.query.term,
+      }),
+      form: Object.assign({}, res.locals.form, {
+        options: {
+          countries: metadata.countryOptions.map(transformOption),
+          averageSalaryRange: metadata.salaryRangeOptions.map(transformOption),
+          strategicDrivers: metadata.strategicDriverOptions.map(transformOption),
+          sectors: metadata.sectorOptions.map(transformOption),
+          foreignOtherCompany: foreignOtherCompanyOptions.map(i => ({ value: i, label: i })),
+        },
+      }),
+    })
 }
 
 function renderMessages (req, res) {
-  req.breadcrumbs('Application messages')
-  return res.render('components/views/messages', {
-    title: 'Application messages',
-  })
+  return res
+    .breadcrumb('Application messages')
+    .render('components/views/messages', {
+      title: 'Application messages',
+    })
 }
 
 function renderBreadcrumbs (req, res) {

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -15,17 +15,12 @@ async function getCommon (req, res, next) {
     const token = req.session.token
     const contact = res.locals.contact = await contactsRepository.getContact(token, req.params.contactId)
     const company = res.locals.company = await companyRepository.getDitCompany(token, contact.company.id)
-    const name = `${contact.first_name} ${contact.last_name}`
 
     res.locals.id = req.params.contactId
     res.locals.companyUrl = companyService.buildCompanyUrl(company)
     res.locals.reasonForArchiveOptions = reasonForArchiveOptions
-    res.locals.title = [name, 'Contacts']
 
-    req.breadcrumbs({
-      name,
-      url: `/contacts/${contact.id}`,
-    })
+    res.breadcrumb(`${contact.first_name} ${contact.last_name}`, `/contacts/${contact.id}`)
 
     next()
   } catch (error) {

--- a/src/apps/contacts/controllers/edit.js
+++ b/src/apps/contacts/controllers/edit.js
@@ -41,10 +41,10 @@ async function editDetails (req, res, next) {
 
     if (req.params.contactId) {
       res.locals.backUrl = `/contacts/${req.params.contactId}`
-      res.locals.title.unshift('Edit')
+      res.breadcrumb('Edit')
     } else if (req.query.company) {
       res.locals.backUrl = `/companies/${req.query.company}/contacts`
-      res.locals.title = `Add contact at ${res.locals.company.name}`
+      res.breadcrumb(`Add contact at ${res.locals.company.name}`)
     }
 
     // Labels and options needed for the form and error display

--- a/src/apps/contacts/controllers/interactions.js
+++ b/src/apps/contacts/controllers/interactions.js
@@ -8,10 +8,9 @@ async function getInteractions (req, res, next) {
     res.locals.interactions = interactions.map(interaction => interactionFormattingService.getDisplayContactInteraction(interaction))
     res.locals.addInteractionUrl = `/interactions/create/1?contact=${res.locals.contact.id}`
 
-    res.locals.title.unshift('Interactions')
-    req.breadcrumbs('Interactions')
-
-    res.render('contacts/views/interactions')
+    res
+      .breadcrumb('Interactions')
+      .render('contacts/views/interactions')
   } catch (error) {
     next(error)
   }

--- a/src/apps/dashboard/controllers.js
+++ b/src/apps/dashboard/controllers.js
@@ -3,14 +3,16 @@ const dashboardService = require('./services')
 function getHandler (req, res) {
   const days = 15
 
-  dashboardService.getHomepageData(req.session.token, days)
+  dashboardService
+    .getHomepageData(req.session.token, days)
     .then((data) => {
-      res.render('dashboard/views/dashboard', {
-        title: 'Dashboard',
-        totalDays: days,
-        interactions: data.interactions,
-        contacts: data.contacts,
-      })
+      res
+        .title('Dashboard')
+        .render('dashboard/views/dashboard', {
+          totalDays: days,
+          interactions: data.interactions,
+          contacts: data.contacts,
+        })
     })
 }
 

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -1,7 +1,5 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_breadcrumbs %}{% endblock %}
-
 {% block body_main_header_content %}
   {{ EntitySearchForm({
     inputName: 'term',

--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -11,7 +11,6 @@ async function getCommon (req, res, next) {
     const token = req.session.token
     if (req.params.interactionId && req.params.interactionId !== 'add') {
       res.locals.interaction = await interactionDataService.getHydratedInteraction(token, req.params.interactionId)
-      req.breadcrumbs('Interaction')
     }
     next()
   } catch (error) {
@@ -48,12 +47,13 @@ function getAddStep1 (req, res) {
     interactionTypeColB.push(selectableTypes[pos])
   }
 
-  res.render('interactions/views/add-step-1.njk', {
-    title: ['Interaction type', 'Add interaction'],
-    query: req.query,
-    interactionTypeColA,
-    interactionTypeColB,
-  })
+  res
+    .breadcrumb('Add interaction')
+    .render('interactions/views/add-step-1.njk', {
+      query: req.query,
+      interactionTypeColA,
+      interactionTypeColB,
+    })
 }
 
 function postAddStep1 (req, res) {
@@ -74,12 +74,13 @@ function postAddStep1 (req, res) {
 }
 
 function getInteractionDetails (req, res, next) {
-  res.render('interactions/views/details', {
-    title: `Interaction with ${res.locals.interaction.company.name}`,
-    interactionDetails: getDisplayInteraction(res.locals.interaction),
-    interactionLabels: interactionLabels,
-    interactionDisplayOrder: interactonDisplayOrder,
-  })
+  res
+    .breadcrumb(`Interaction with ${res.locals.interaction.company.name}`)
+    .render('interactions/views/details', {
+      interactionDetails: getDisplayInteraction(res.locals.interaction),
+      interactionLabels: interactionLabels,
+      interactionDisplayOrder: interactonDisplayOrder,
+    })
 }
 
 module.exports = {

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -64,9 +64,9 @@ async function editDetails (req, res, next) {
     res.locals.serviceOfferOptions = await metadataRepository.getServiceOffers(token)
     res.locals.serviceProviderOptions = metadataRepository.teams
     res.locals.labels = interactionLabels
-    res.locals.title = `Add interaction for ${res.locals.company.name}`
-
-    res.render('interactions/views/edit')
+    res
+      .breadcrumb(`Add interaction for ${res.locals.company.name}`)
+      .render('interactions/views/edit')
   } catch (error) {
     console.log(error)
     next(error)

--- a/src/apps/investment-projects/controllers/audit.js
+++ b/src/apps/investment-projects/controllers/audit.js
@@ -17,12 +17,12 @@ async function getInvestmentAudit (req, res, next) {
       const rawAuditLog = await getInvestmentProjectAuditLog(req.session.token, req.params.id)
       const auditLog = rawAuditLog.map(formatAuditLog)
 
-      res.locals.title.unshift('Audit history')
-
-      return res.render('investment-projects/views/audit', {
-        currentNavItem: 'audit',
-        auditLog,
-      })
+      return res
+        .breadcrumb('Audit history')
+        .render('investment-projects/views/audit', {
+          currentNavItem: 'audit',
+          auditLog,
+        })
     }
 
     return next()

--- a/src/apps/investment-projects/controllers/create-1.js
+++ b/src/apps/investment-projects/controllers/create-1.js
@@ -39,15 +39,16 @@ function getHandler (req, res, next) {
         showSearch = true
       }
 
-      res.render('investment-projects/views/create-1', {
-        title: 'Add investment project',
-        clientCompany,
-        clientCompanyInvestments,
-        searchTerm,
-        searchResult,
-        pagination,
-        showSearch,
-      })
+      res
+        .breadcrumb('Add investment project')
+        .render('investment-projects/views/create-1', {
+          clientCompany,
+          clientCompanyInvestments,
+          searchTerm,
+          searchResult,
+          pagination,
+          showSearch,
+        })
     })
     .catch(next)
 }
@@ -63,13 +64,14 @@ function postHandler (req, res, next) {
   } else {
     getInflatedDitCompany(req.session.token, clientCompanyId)
       .then((clientCompany) => {
-        res.render('investment-projects/views/create-1', {
-          title: 'Add investment project',
-          clientCompany,
-          errors: {
-            isEquitySource: 'Please select whether this company will be the source of foreign equity',
-          },
-        })
+        res
+          .breadcrumb('Add investment project')
+          .render('investment-projects/views/create-1', {
+            clientCompany,
+            errors: {
+              isEquitySource: 'Please select whether this company will be the source of foreign equity',
+            },
+          })
       })
       .catch(next)
   }

--- a/src/apps/investment-projects/controllers/create-2.js
+++ b/src/apps/investment-projects/controllers/create-2.js
@@ -1,19 +1,19 @@
-function render (res) {
-  return res.render('investment-projects/views/create-2', {
-    title: 'Add investment project',
-  })
+function render (req, res) {
+  return res
+    .breadcrumb('Add investment project')
+    .render('investment-projects/views/create-2')
 }
 
 function createGetHandler (req, res) {
   if (!res.locals.equityCompany) {
     return res.redirect('/investment-projects/create/1')
   }
-  return render(res)
+  return render(req, res)
 }
 
 function createPostHandler (req, res) {
   if (res.locals.form.errors) {
-    return render(res)
+    return render(req, res)
   }
   return res.redirect(`/investment-projects/${res.locals.resultId}`)
 }

--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -4,13 +4,15 @@ const templateData = {
 }
 
 function editDetailsGet (req, res) {
-  res.locals.title.unshift('Edit details')
-  res.render('investment-projects/views/details-edit', templateData)
+  res
+    .breadcrumb('Edit details')
+    .render('investment-projects/views/details-edit', templateData)
 }
 
 function editValueGet (req, res) {
-  res.locals.title.unshift('Edit value')
-  res.render('investment-projects/views/value-edit', templateData)
+  res
+    .breadcrumb('Edit value')
+    .render('investment-projects/views/value-edit', templateData)
 }
 
 function editRequirementsGet (req, res) {

--- a/src/apps/investment-projects/controllers/interactions/create.js
+++ b/src/apps/investment-projects/controllers/interactions/create.js
@@ -1,9 +1,9 @@
 const { isEmpty } = require('lodash')
 
 function createGetInteractionHandler (req, res, next) {
-  res.locals.title.unshift('Add interaction')
-
-  return res.render('investment-projects/views/interactions/create')
+  return res
+    .breadcrumb('Add interaction')
+    .render('investment-projects/views/interactions/create')
 }
 
 function createPostInteractionHandler (req, res, next) {

--- a/src/apps/investment-projects/controllers/interactions/edit.js
+++ b/src/apps/investment-projects/controllers/interactions/edit.js
@@ -1,9 +1,9 @@
 const { isEmpty } = require('lodash')
 
 function editGetInteractionHandler (req, res, next) {
-  res.locals.title.unshift('Edit interaction')
-
-  res.render('investment-projects/views/interactions/edit')
+  res
+    .breadcrumb('Edit interaction')
+    .render('investment-projects/views/interactions/edit')
 }
 
 function editPostInteractionHandler (req, res, next) {

--- a/src/apps/investment-projects/controllers/interactions/list.js
+++ b/src/apps/investment-projects/controllers/interactions/list.js
@@ -9,12 +9,12 @@ async function indexGetHandler (req, res, next) {
       const interactionsResponse = await getInteractionsForInvestment(req.session.token, req.params.id)
       const interactions = interactionsResponse.results.map(getDisplayCompanyInteraction)
 
-      res.locals.title.unshift('Interactions')
-
-      return res.render('investment-projects/views/interactions/index', {
-        currentNavItem: 'interactions',
-        interactions,
-      })
+      return res
+        .breadcrumb('Interactions')
+        .render('investment-projects/views/interactions/index', {
+          currentNavItem: 'interactions',
+          interactions,
+        })
     }
     next()
   } catch (error) {

--- a/src/apps/investment-projects/controllers/team.js
+++ b/src/apps/investment-projects/controllers/team.js
@@ -1,9 +1,9 @@
 function getTeamHandler (req, res, next) {
-  res.locals.title.unshift('Team')
-
-  res.render('investment-projects/views/team', {
-    currentNavItem: 'team',
-  })
+  res
+    .breadcrumb('Project team')
+    .render('investment-projects/views/team', {
+      currentNavItem: 'team',
+    })
 }
 
 module.exports = {

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -12,7 +12,6 @@ function handleEmptyMiddleware (req, res, next) {
 }
 
 function getLocalNavMiddleware (req, res, next) {
-  req.breadcrumbs('Project details')
   res.locals.localNavItems = [
     { label: 'Project details', slug: 'details' },
     { label: 'Project team', slug: 'team' },
@@ -40,7 +39,10 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
       valuation: investmentData.value_complete ? 'Project valued' : 'Not yet valued',
     }
 
-    res.locals.title = [investmentData.name, 'Investments', investmentData.investor_company.name]
+    res.breadcrumb({
+      name: investmentData.name,
+      url: `/investment-projects/${investmentData.id}`,
+    })
 
     next()
   } catch (error) {

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -1,7 +1,7 @@
-function addBaseBreadcrumb (name) {
+function setHomeBreadcrumb (name) {
   return function (req, res, next) {
     if (name) {
-      req.breadcrumbs({
+      res.breadcrumb({
         name,
         url: req.baseUrl,
       })
@@ -11,5 +11,5 @@ function addBaseBreadcrumb (name) {
 }
 
 module.exports = {
-  addBaseBreadcrumb,
+  setHomeBreadcrumb,
 }

--- a/src/apps/profile/index.js
+++ b/src/apps/profile/index.js
@@ -1,10 +1,9 @@
 const router = require('express').Router()
 
 function getHandler (req, res) {
-  req.breadcrumbs('Your profile')
-  res.render('profile/views/profile', {
-    title: 'Your profile',
-  })
+  res
+    .breadcrumb('Your profile')
+    .render('profile/views/profile')
 }
 
 module.exports = {

--- a/src/apps/profile/views/profile.njk
+++ b/src/apps/profile/views/profile.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/datahub-base.njk" %}
 
 {% block body_main_header_content %}
-  <h2 class="heading-xlarge">{{ title }}</h2>
+  <h2 class="heading-xlarge">Your profile</h2>
 {% endblock %}
 
 {% block body_main_content %}

--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -1,7 +1,7 @@
 const router = require('express').Router()
 const fs = require('fs')
 
-const { addBaseBreadcrumb } = require('./middleware')
+const { setHomeBreadcrumb } = require('./middleware')
 const logger = require('../../config/logger')
 
 const appsRouters = []
@@ -12,7 +12,7 @@ subApps.forEach(subAppDir => {
     const subApp = require(`./${subAppDir}`)
 
     if (subApp.mountpath) {
-      appsRouters.push(router.use(subApp.mountpath, addBaseBreadcrumb(subApp.displayName), subApp.router))
+      appsRouters.push(router.use(subApp.mountpath, setHomeBreadcrumb(subApp.displayName), subApp.router))
     } else if (subApp.router) {
       appsRouters.push(router.use(subApp.router))
     } else {

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -25,16 +25,16 @@ function searchAction (req, res, next) {
       const pagination = getPagination(req, results)
       const searchEntityResultsData = buildSearchEntityResultsData(results.aggregations)
 
-      req.breadcrumbs('Search')
-      res.render(`search/views/results-${searchEntity}`, {
-        title: [searchTerm, `Search results`],
-        searchTerm,
-        searchEntity,
-        searchPath: entity.path,
-        searchEntityResultsData,
-        results,
-        pagination,
-      })
+      res
+        .breadcrumb('Search')
+        .render(`search/views/results-${searchEntity}`, {
+          searchTerm,
+          searchEntity,
+          searchPath: entity.path,
+          searchEntityResultsData,
+          results,
+          pagination,
+        })
     })
     .catch(next)
 }

--- a/src/apps/service-deliveries/controllers.js
+++ b/src/apps/service-deliveries/controllers.js
@@ -55,9 +55,10 @@ async function getServiceDeliveryEdit (req, res, next) {
     res.locals.statusOptions = metadataRepository.serviceDeliveryStatusOptions
     res.locals.eventOptions = metadataRepository.eventOptions
     res.locals.companyUrl = buildCompanyUrl(res.locals.serviceDelivery.company)
-    res.locals.title = 'Add service delivery'
 
-    res.render('service-deliveries/views/edit')
+    res
+      .breadcrumb('Add service delivery')
+      .render('service-deliveries/views/edit')
   } catch (error) {
     next(error)
   }
@@ -81,7 +82,7 @@ async function postServiceDeliveryEdit (req, res, next) {
         res.locals.errors = transformV2Errors(response.error.errors)
         try {
           res.locals.serviceDelivery = await serviceDeliveryService.convertFormBodyBackToServiceDelivery(req.session.token, req.body)
-          res.locals.title = 'Edit service delivery'
+          res.breadcrumb('Edit service delivery')
         } catch (error) {
           return next(error)
         }

--- a/src/apps/support/controllers.js
+++ b/src/apps/support/controllers.js
@@ -1,14 +1,11 @@
 function renderFeedbackPage (req, res) {
-  res.render('support/views/feedback', {
-    title: 'Feedback',
-  })
+  res.render('support/views/feedback')
 }
 
 function renderThankYouPage (req, res) {
-  req.breadcrumbs('Thank you')
-  res.render('support/views/thank-you', {
-    title: ['Thank you', 'Support'],
-  })
+  res
+    .breadcrumb('Thank you')
+    .render('support/views/thank-you')
 }
 
 module.exports = {

--- a/src/middleware/breadcrumbs.js
+++ b/src/middleware/breadcrumbs.js
@@ -1,0 +1,116 @@
+/**
+ * Easy to use generic breadcrumbs middleware for Express.
+ */
+
+const {
+  isArray,
+  isObject,
+  each,
+  extend,
+  find,
+  findIndex,
+} = require('lodash')
+
+/**
+ * Breadcrumbs initialization.
+ * Intializes Breadcrumbs for incoming requests, adds `breadcrumbs()` method to `res`.
+ *
+ * Examples:
+ *      app.use(breadcrumbs.init())
+ *
+ * @return {Function}
+ */
+function init () {
+  let breadcrumbs = []
+
+  function exists (breadcrumb) {
+    return findIndex(breadcrumbs, breadcrumb) !== -1
+  }
+
+  function addBreadcrumbs (name, url) {
+    if (arguments.length === 1) {
+      if (isArray(name)) {
+        each(name, (breadcrumb) => {
+          if (!exists(breadcrumb)) {
+            breadcrumbs.push(breadcrumb)
+          }
+        })
+      } else if (isObject(name)) {
+        if (!exists(name)) {
+          breadcrumbs.push(name)
+        }
+      } else {
+        if (!exists(name)) {
+          breadcrumbs.push({ name: name })
+        }
+      }
+    } else if (arguments.length === 2) {
+      if (!exists(name)) {
+        breadcrumbs.push({
+          name: name,
+          url: url,
+        })
+      }
+    } else {
+      return breadcrumbs
+    }
+
+    return this
+  }
+
+  function cleanBreadcrumbs () {
+    breadcrumbs = []
+  }
+
+  return function (req, res, next) {
+    cleanBreadcrumbs()
+    res.breadcrumb = addBreadcrumbs
+    next()
+  }
+}
+
+/**
+ * Set Breadcrumbs home information.
+ *
+ * Examples:
+ *      app.use(breadcrumbs.setHome())
+ *      app.use('/admin', breadcrumbs.setHome({
+ *        name: 'Dashboard',
+ *        url: '/admin'
+ *      }))
+ *
+ * @param {Object} options
+ *  - name    home name, default `Home`
+ *  - url     home url, default `/`
+ * @return {Function}
+ */
+function setHome (options = {}) {
+  const homeName = options.name || 'Home'
+  const homeUrl = options.url || '/'
+
+  return function (req, res, next) {
+    const homeBreadcrumb = find(res.breadcrumb(), (breadcrumb) => {
+      return breadcrumb._home
+    })
+
+    if (!homeBreadcrumb) {
+      res.breadcrumb({
+        name: homeName,
+        url: homeUrl,
+        _home: true,
+      })
+    } else {
+      extend(homeBreadcrumb, {
+        name: homeName,
+        url: homeUrl,
+      })
+    }
+
+    next()
+  }
+}
+
+module.exports = {
+  init,
+  setHome,
+}

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -10,13 +10,30 @@ try {
 
 module.exports = function locals (req, res, next) {
   const baseUrl = `${(req.encrypted ? 'https' : req.protocol)}://${req.get('host')}`
+  const breadcrumbItems = res.breadcrumb()
 
   res.locals = Object.assign({}, res.locals, {
     BASE_URL: baseUrl,
     CANONICAL_URL: baseUrl + req.originalUrl,
     CURRENT_PATH: req.path,
     GOOGLE_TAG_MANAGER_KEY: config.googleTagManagerKey,
-    BREADCRUMBS: req.breadcrumbs(),
+    BREADCRUMBS: breadcrumbItems,
+
+    getPageTitle: () => {
+      const items = breadcrumbItems.map(item => item.name)
+      const title = res.locals.title
+
+      if (title) {
+        if (items.length === 1) {
+          return title
+        }
+
+        items.pop()
+        items.push(title)
+      }
+
+      return items.reverse().slice(0, -1)
+    },
 
     getAssetPath (asset) {
       const assetsUrl = config.assetsHost || baseUrl

--- a/src/middleware/title.js
+++ b/src/middleware/title.js
@@ -1,0 +1,9 @@
+module.exports = () => {
+  return function titleMiddleware (req, res, next) {
+    res.title = function title (title) {
+      res.locals.title = title
+      return this
+    }
+    next()
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -10,8 +10,9 @@ const slashify = require('slashify')
 const churchill = require('churchill')
 const enforce = require('express-sslify')
 const favicon = require('serve-favicon')
-const breadcrumbs = require('express-breadcrumbs')
 
+const title = require('./middleware/title')
+const breadcrumbs = require('./middleware/breadcrumbs')
 const nunjucks = require('../config/nunjucks')
 const datahubFlash = require('./middleware/flash')
 const headers = require('./middleware/headers')
@@ -61,6 +62,7 @@ app.use('/css', express.static(path.join(config.buildDir, 'css')))
 app.use('/images', express.static(path.join(config.buildDir, 'images')))
 app.use('/fonts', express.static(path.join(config.buildDir, 'fonts')))
 
+app.use(title())
 app.use(breadcrumbs.init())
 app.use(breadcrumbs.setHome())
 

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -15,7 +15,7 @@
 {% from "_macros/form.njk" import Fieldset, TextField, MultipleChoiceField %}
 {% from "_macros/address.njk" import addressFormatter %}
 
-{% set pageTitle = [title, 'DIT Data Hub'] | flatten | removeNilAndEmpty | join(' - ') %}
+{% set pageTitle = [getPageTitle(), 'DIT Data Hub'] | flatten | join(' - ') %}
 
 {% block head %}
   {{ super() }}

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -60,9 +60,7 @@
 {% endblock %}
 
 {% block body_main_header %}
-  {% block body_main_header_breadcrumbs %}
-    {% component 'breadcrumbs', { items: BREADCRUMBS } %}
-  {% endblock %}
+  {% component 'breadcrumbs', { items: BREADCRUMBS } %}
   {% component 'messages', { messages: messages } %}
   {{ super() }}
 {% endblock %}

--- a/test/unit/apps/companies/controllers/ch.test.js
+++ b/test/unit/apps/companies/controllers/ch.test.js
@@ -41,6 +41,8 @@ describe('Company controller, Companies House', function () {
     getDisplayCompanyStub = sinon.stub().returns({ company_number: '1234' })
     getCHCompanyStub = sinon.stub().resolves(chCompany)
 
+    this.breadcrumbStub = function () { return this }
+
     companyControllerCh = proxyquire('~/src/apps/companies/controllers/ch', {
       '../services/data': {
         getInflatedDitCompany: getInflatedDitCompanyStub,
@@ -68,6 +70,7 @@ describe('Company controller, Companies House', function () {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getCHCompanyStub).to.be.calledWith('1234', '9999')
           done()
@@ -77,6 +80,7 @@ describe('Company controller, Companies House', function () {
     it('should return the company heading name and address', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('ADALEOP LTD')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
@@ -96,6 +100,7 @@ describe('Company controller, Companies House', function () {
     it('should get a formatted copy of the company house data to display', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.be.calledWith(chCompany)
           expect(res.locals).to.have.property('chDetails')
@@ -117,6 +122,7 @@ describe('Company controller, Companies House', function () {
     it('should not try and get formatted data for CDMS company details', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.not.be.called
           expect(res.locals).to.not.have.property('companyDetails')
@@ -136,6 +142,7 @@ describe('Company controller, Companies House', function () {
     it('should not provide account management information', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals).to.not.have.property('accountManagementDisplay')
           expect(res.locals).to.not.have.property('accountManagementDisplayLabels')
@@ -155,6 +162,7 @@ describe('Company controller, Companies House', function () {
     it('should use a template for ch data', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-ch')

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -192,6 +192,7 @@ describe('Company contacts controller', function () {
           headingAddress: '1234 Road, London, EC1 1AA',
           id: '44332211',
         },
+        breadcrumb: function () { return this },
         render: function (template, options) {
           locals = Object.assign({}, res.locals, options)
           done()

--- a/test/unit/apps/companies/controllers/exp.test.js
+++ b/test/unit/apps/companies/controllers/exp.test.js
@@ -18,6 +18,7 @@ describe('Company export controller', () => {
     this.saveCompany = this.sandbox.stub().resolves(this.company)
     this.flattenIdFields = this.sandbox.spy(controllerUtils, 'flattenIdFields')
     this.getCommonTitlesAndlinks = this.sandbox.stub()
+    this.breadcrumbsStub = function () { return this }
 
     this.companyExportController = proxyquire('~/src/apps/companies/controllers/exp', {
       '../services/data': {
@@ -58,6 +59,7 @@ describe('Company export controller', () => {
 
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
       }
 
       return this.companyExportController.common(req, res)
@@ -78,6 +80,7 @@ describe('Company export controller', () => {
 
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
       }
 
       return this.companyExportController.common(req, res)
@@ -99,6 +102,7 @@ describe('Company export controller', () => {
 
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
       }
 
       return this.companyExportController.common(req, res)
@@ -121,6 +125,7 @@ describe('Company export controller', () => {
         locals: {
           company: this.company,
         },
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.exportDetails).to.deep.equal({
             exportToCountries: 'France, Italy',
@@ -158,6 +163,7 @@ describe('Company export controller', () => {
         locals: {
           company: this.company,
         },
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.exportDetails.exportToCountries).to.equal('')
           done()
@@ -179,6 +185,7 @@ describe('Company export controller', () => {
         locals: {
           company: this.company,
         },
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data).to.have.property('exportDetailsDisplayOrder')
           expect(data).to.have.property('exportDetailsLabels')
@@ -206,6 +213,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(export_to_countries)
           expect(data.future_interest_countries).to.deep.equal(future_interest_countries)
@@ -227,6 +235,7 @@ describe('Company export controller', () => {
         locals: {
           company: this.company,
         },
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(['1234', '2234'])
           expect(data.future_interest_countries).to.deep.equal(['4321'])
@@ -243,6 +252,7 @@ describe('Company export controller', () => {
         locals: {
           company: this.company,
         },
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data).to.have.property('exportDetailsLabels')
           done()
@@ -267,6 +277,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           expect(this.getDitCompany).to.be.calledWith('1234', this.company.id)
           expect(controllerUtils.flattenIdFields).to.be.calledWith(this.company)
@@ -300,6 +311,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           const firstCallArgs = this.saveCompany.firstCall.args[1]
           expect(firstCallArgs.export_to_countries).to.deep.equal(export_to_countries)
@@ -327,6 +339,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           expect(this.saveCompany.firstCall.args[1].future_interest_countries).to.be.deep.equal(['4321'])
           done()
@@ -350,6 +363,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           expect(this.saveCompany.firstCall.args[1].export_to_countries).to.deep.equal(['1234'])
           done()
@@ -388,6 +402,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
       }, (_error) => {
         expect(_error).to.deep.equal(error)
         done()
@@ -410,6 +425,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(['888', '333', ''])
           done()
@@ -433,6 +449,7 @@ describe('Company export controller', () => {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.future_interest_countries).to.deep.equal(['555', '666', ''])
           done()

--- a/test/unit/apps/companies/controllers/foreign.test.js
+++ b/test/unit/apps/companies/controllers/foreign.test.js
@@ -16,6 +16,7 @@ describe('Company controller, foreign', function () {
   let fakeCompanyForm
   let saveCompanyFormStub
   let flashStub
+  let breadcrumbStub
   const company = {
     id: '9999',
     company_number: '10620176',
@@ -55,6 +56,7 @@ describe('Company controller, foreign', function () {
     getForeignCompanyAsFormDataStub = sinon.stub().returns(fakeCompanyForm)
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
     flashStub = sinon.stub()
+    breadcrumbStub = function () { return this }
 
     companyControllerForeign = proxyquire('~/src/apps/companies/controllers/foreign', {
       '../services/data': {
@@ -87,6 +89,7 @@ describe('Company controller, foreign', function () {
         },
       }, {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
@@ -96,6 +99,7 @@ describe('Company controller, foreign', function () {
     it('should return the company heading name and address', function (done) {
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('Freds ltd')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
@@ -115,6 +119,7 @@ describe('Company controller, foreign', function () {
     it('should get not get a formatted copy of the company house data to display', function (done) {
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.not.be.called
           expect(res.locals).to.not.have.property('chDetails')
@@ -136,6 +141,7 @@ describe('Company controller, foreign', function () {
     it('should get formatted data for CDMS company details', function (done) {
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.be.calledWith(company)
           expect(res.locals).to.have.property('companyDetails')
@@ -157,6 +163,7 @@ describe('Company controller, foreign', function () {
     it('should provide account management information', function (done) {
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
@@ -176,6 +183,7 @@ describe('Company controller, foreign', function () {
     it('should use a template for ch data', function (done) {
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-foreign')
@@ -205,6 +213,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal({ business_type: '1' })
           done()
@@ -226,6 +235,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
@@ -242,6 +252,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function (template) {
           expect(template).to.equal('companies/views/edit-foreign')
           done()
@@ -336,6 +347,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           expect(getForeignCompanyAsFormDataStub).to.be.calledWith(company)
@@ -358,6 +370,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getForeignCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
@@ -379,6 +392,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-foreign')
@@ -401,6 +415,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
@@ -419,6 +434,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
@@ -443,6 +459,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         redirect: function () {
           expect(saveCompanyFormStub).to.be.calledWith('1234', body)
           done()
@@ -467,6 +484,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/foreign/999')
           done()
@@ -516,6 +534,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         redirect: function () {
           throw Error('error')
         },
@@ -545,6 +564,7 @@ describe('Company controller, foreign', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
         redirect: function () {
           expect(flashStub).to.be.calledWith('success', 'Updated company record')
           done()
@@ -568,6 +588,7 @@ describe('Company controller, foreign', function () {
       }
       res = {
         locals: {},
+        breadcrumb: breadcrumbStub,
       }
     })
     it('should include the require properties in the response', function () {

--- a/test/unit/apps/companies/controllers/interactions.test.js
+++ b/test/unit/apps/companies/controllers/interactions.test.js
@@ -83,6 +83,8 @@ describe('Company interactions controller', function () {
         getInflatedDitCompany: sinon.stub().resolves(company),
       },
     })
+
+    this.breadcrumbStub = function () { return this }
   })
 
   describe('data', function () {
@@ -93,6 +95,7 @@ describe('Company interactions controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.have.property('interactions')
           expect(res.locals.interactions).to.have.length(2)
@@ -108,6 +111,7 @@ describe('Company interactions controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.have.property('addInteractionUrl')
           done()
@@ -129,6 +133,7 @@ describe('Company interactions controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.not.have.property('addInteractionUrl')
           done()
@@ -149,6 +154,7 @@ describe('Company interactions controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.not.have.property('addInteractionUrl')
           done()

--- a/test/unit/apps/companies/controllers/ltd.test.js
+++ b/test/unit/apps/companies/controllers/ltd.test.js
@@ -18,6 +18,7 @@ describe('Company controller, ltd', function () {
   let fakeCompanyForm
   let saveCompanyFormStub
   let flashStub
+
   const chCompany = {
     id: '972173',
     created_on: '2017-04-11T10:28:30.639369',
@@ -78,6 +79,8 @@ describe('Company controller, ltd', function () {
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
     flashStub = sinon.stub()
 
+    this.breadcrumbStub = function () { return this }
+
     companyControllerLtd = proxyquire('~/src/apps/companies/controllers/ltd', {
       '../services/data': {
         getInflatedDitCompany: getInflatedDitCompanyStub,
@@ -110,6 +113,7 @@ describe('Company controller, ltd', function () {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
@@ -119,6 +123,7 @@ describe('Company controller, ltd', function () {
     it('should return the company heading name and address', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('ADALEOP LTD')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
@@ -138,6 +143,7 @@ describe('Company controller, ltd', function () {
     it('should get a formatted copy of the company house data to display', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.be.calledWith(chCompany)
           expect(res.locals).to.have.property('chDetails')
@@ -159,6 +165,7 @@ describe('Company controller, ltd', function () {
     it('should get formatted data for CDMS company details', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.be.calledWith(company)
           expect(res.locals).to.have.property('companyDetails')
@@ -180,6 +187,7 @@ describe('Company controller, ltd', function () {
     it('should provide account management information', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
@@ -199,6 +207,7 @@ describe('Company controller, ltd', function () {
     it('should use a template for ltd data', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-ltd')
@@ -227,6 +236,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDefaultLtdFormForCHStub).to.be.calledWith(chCompany)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
@@ -248,6 +258,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
@@ -263,6 +274,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getCHCompanyStub).to.be.calledWith('1234', '00112233')
           expect(getDisplayCHStub).to.be.calledWith(chCompany)
@@ -281,6 +293,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ltd')
@@ -393,6 +406,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           expect(getLtdCompanyAsFormDataStub).to.be.calledWith(company)
@@ -415,6 +429,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.not.be.called
           expect(getLtdCompanyAsFormDataStub).to.not.be.called
@@ -437,6 +452,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ltd')
@@ -459,6 +475,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
@@ -477,6 +494,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
@@ -501,6 +519,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(saveCompanyFormStub).to.be.calledWith('1234', body)
           done()
@@ -525,6 +544,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ltd/999')
           done()
@@ -574,6 +594,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           throw Error('error')
         },
@@ -603,6 +624,7 @@ describe('Company controller, ltd', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(flashStub).to.be.calledWith('success', 'Updated company record')
           done()
@@ -626,6 +648,7 @@ describe('Company controller, ltd', function () {
       }
       res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
       }
     })
     it('should include the require properties in the response', function () {

--- a/test/unit/apps/companies/controllers/ukother.test.js
+++ b/test/unit/apps/companies/controllers/ukother.test.js
@@ -16,6 +16,7 @@ describe('Company controller, uk other', function () {
   let fakeCompanyForm
   let saveCompanyFormStub
   let flashStub
+
   const company = {
     id: '9999',
     company_number: '10620176',
@@ -56,6 +57,8 @@ describe('Company controller, uk other', function () {
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
     flashStub = sinon.stub()
 
+    this.breadcrumbStub = function () { return this }
+
     companyControllerUkOther = proxyquire('~/src/apps/companies/controllers/ukother', {
       '../services/data': {
         getInflatedDitCompany: getInflatedDitCompanyStub,
@@ -87,6 +90,7 @@ describe('Company controller, uk other', function () {
         },
       }, {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
@@ -96,6 +100,7 @@ describe('Company controller, uk other', function () {
     it('should return the company heading name and address', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('Freds ltd')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
@@ -115,6 +120,7 @@ describe('Company controller, uk other', function () {
     it('should get not get a formatted copy of the company house data to display', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.not.be.called
           expect(res.locals).to.not.have.property('chDetails')
@@ -136,6 +142,7 @@ describe('Company controller, uk other', function () {
     it('should get formatted data for CDMS company details', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.be.calledWith(company)
           expect(res.locals).to.have.property('companyDetails')
@@ -157,6 +164,7 @@ describe('Company controller, uk other', function () {
     it('should provide account management information', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
@@ -176,6 +184,7 @@ describe('Company controller, uk other', function () {
     it('should use a template for ch data', function (done) {
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-ukother')
@@ -206,6 +215,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal({ business_type: '1' })
           done()
@@ -227,6 +237,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
@@ -243,6 +254,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ukother')
@@ -343,6 +355,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           expect(getUkOtherCompanyAsFormDataStub).to.be.calledWith(company)
@@ -366,6 +379,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getUkOtherCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
@@ -390,6 +404,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ukother')
@@ -413,6 +428,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
@@ -432,6 +448,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
@@ -457,6 +474,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(saveCompanyFormStub).to.be.calledWith('1234', body)
           done()
@@ -482,6 +500,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ukother/999')
           done()
@@ -533,6 +552,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           throw Error('error')
         },
@@ -563,6 +583,7 @@ describe('Company controller, uk other', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(flashStub).to.be.calledWith('success', 'Updated company record')
           done()
@@ -586,6 +607,7 @@ describe('Company controller, uk other', function () {
       }
       res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
       }
     })
     it('should include the require properties in the response', function () {

--- a/test/unit/apps/contacts/controllers/details.test.js
+++ b/test/unit/apps/contacts/controllers/details.test.js
@@ -74,6 +74,8 @@ describe('Contact controller', function () {
         buildCompanyUrl: buildCompanyUrlStub,
       },
     })
+
+    this.breadcrumbStub = function () { return this }
   })
 
   describe('getCommon', function () {
@@ -85,9 +87,7 @@ describe('Contact controller', function () {
         },
       }
       const res = {
-        locals: {
-          title: [],
-        },
+        breadcrumb: this.breadcrumbStub,
         render: function () {},
       }
       const next = function () {
@@ -106,8 +106,8 @@ describe('Contact controller', function () {
       const res = {
         locals: {
           contact,
-          title: [],
         },
+        breadcrumb: this.breadcrumbStub,
         render: function () {},
       }
       const next = function () {
@@ -127,8 +127,8 @@ describe('Contact controller', function () {
       const res = {
         locals: {
           company,
-          title: [],
         },
+        breadcrumb: this.breadcrumbStub,
         render: function () {},
       }
       const next = function () {
@@ -145,9 +145,8 @@ describe('Contact controller', function () {
         },
       }
       const res = {
-        locals: {
-          title: [],
-        },
+        locals: {},
+        breadcrumb: this.breadcrumbStub,
         render: function () {},
       }
       const next = function () {
@@ -180,9 +179,7 @@ describe('Contact controller', function () {
         },
       }
       const res = {
-        locals: {
-          title: [],
-        },
+        breadcrumb: this.breadcrumbStub,
         render: function () {},
       }
       const next = function (err) {
@@ -205,8 +202,8 @@ describe('Contact controller', function () {
             contact,
             company,
             id: '1234',
-            title: [],
           },
+          breadcrumb: this.breadcrumbStub,
           render: function (url, options) {
             expect(getDisplayContactStub).to.be.calledWith(contact, company)
             expect(res.locals.contactDetails).to.deep.equal(contactFormatted)

--- a/test/unit/apps/contacts/controllers/edit.test.js
+++ b/test/unit/apps/contacts/controllers/edit.test.js
@@ -24,6 +24,8 @@ describe('Contact controller, edit', function () {
     getContactAsFormDataStub = sinon.stub().returns({ id: '1234', name: 'Thing' })
     saveContactFormStub = sinon.stub().returns({ id: '1234', first_name: 'Fred', last_name: 'Smith' })
 
+    this.breadcrumbStub = function () { return this }
+
     contactEditController = proxyquire('~/src/apps/contacts/controllers/edit', {
       '../services/form': {
         getContactAsFormData: getContactAsFormDataStub,
@@ -96,8 +98,8 @@ describe('Contact controller, edit', function () {
         res = {
           locals: {
             contact,
-            title: [],
           },
+          breadcrumb: this.breadcrumbStub,
         }
       })
 
@@ -144,9 +146,8 @@ describe('Contact controller, edit', function () {
           params: {},
         }
         res = {
-          locals: {
-            title: [],
-          },
+          locals: {},
+          breadcrumb: this.breadcrumbStub,
         }
       })
 
@@ -199,9 +200,8 @@ describe('Contact controller, edit', function () {
           },
         }
         res = {
-          locals: {
-            title: [],
-          },
+          locals: {},
+          breadcrumb: this.breadcrumbStub,
         }
       })
       it('should use the pre posted form for edit', function (done) {

--- a/test/unit/apps/contacts/controllers/interactions.test.js
+++ b/test/unit/apps/contacts/controllers/interactions.test.js
@@ -20,6 +20,8 @@ describe('Contact interactions controller', function () {
 
     contactDataService.getContactInteractionsAndServiceDeliveries = sinon.stub().resolves([interaction])
     interactionFormattingService.getDisplayContactInteraction = sinon.stub().resolves(formattedInteraction)
+
+    this.breadcrumbStub = function () { return this }
   })
 
   describe('data', function () {
@@ -27,13 +29,12 @@ describe('Contact interactions controller', function () {
       const req = {
         session: { token: '1234' },
         params: { contactId: '1' },
-        breadcrumbs: sinon.stub(),
       }
       const res = {
         locals: {
           contact,
-          title: [],
         },
+        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(contactDataService.getContactInteractionsAndServiceDeliveries).to.be.calledWith(req.session.token, req.params.contactId)
           done()
@@ -46,13 +47,12 @@ describe('Contact interactions controller', function () {
       const req = {
         session: { token: '1234' },
         params: { contactId: '1' },
-        breadcrumbs: sinon.stub(),
       }
       const res = {
         locals: {
           contact,
-          title: [],
         },
+        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(interactionFormattingService.getDisplayContactInteraction).to.be.calledWith(interaction)
           done()
@@ -65,13 +65,12 @@ describe('Contact interactions controller', function () {
       const req = {
         session: { token: '1234' },
         params: { contactId: '1' },
-        breadcrumbs: sinon.stub(),
       }
       const res = {
         locals: {
           contact,
-          title: [],
         },
+        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.have.property('interactions')
           expect(res.locals.interactions).to.have.length(1)

--- a/test/unit/apps/investment-projects/controllers/audit.test.js
+++ b/test/unit/apps/investment-projects/controllers/audit.test.js
@@ -7,6 +7,7 @@ describe('Investment audit controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
     this.getInvestmentProjectAuditLog = this.sandbox.stub().resolves(investmentProjectAuditData.results)
+    this.breadcrumbStub = function () { return this }
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/audit', {
       '../repos': {
@@ -26,8 +27,8 @@ describe('Investment audit controller', () => {
     }, {
       locals: {
         investmentData: {},
-        title: [],
       },
+      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(this.getInvestmentProjectAuditLog).to.be.calledWith(token, '9999')
@@ -59,8 +60,8 @@ describe('Investment audit controller', () => {
     }, {
       locals: {
         investmentData: {},
-        title: [],
       },
+      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)
@@ -108,8 +109,8 @@ describe('Investment audit controller', () => {
     }, {
       locals: {
         investmentData: {},
-        title: [],
       },
+      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)
@@ -155,8 +156,8 @@ describe('Investment audit controller', () => {
     }, {
       locals: {
         investmentData: {},
-        title: [],
       },
+      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)
@@ -202,8 +203,8 @@ describe('Investment audit controller', () => {
     }, {
       locals: {
         investmentData: {},
-        title: [],
       },
+      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)

--- a/test/unit/apps/investment-projects/controllers/create-1.test.js
+++ b/test/unit/apps/investment-projects/controllers/create-1.test.js
@@ -26,6 +26,7 @@ describe('Investment start controller', () => {
     this.getCompanyInvestmentProjects = this.sandbox.stub().resolves(investmentProjects)
     this.searchForeignCompanies = this.sandbox.stub().resolves(searchResults)
     this.getPagination = this.sandbox.stub().resolves({})
+    this.breadcrumbStub = function () { return this }
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/create-1', {
       '../../companies/services/data': {
@@ -57,6 +58,7 @@ describe('Investment start controller', () => {
           query: {},
         }, {
           locals: {},
+          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(data.clientCompany).to.be.undefined
@@ -82,6 +84,7 @@ describe('Investment start controller', () => {
           },
         }, {
           locals: {},
+          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(this.getInflatedDitCompany).to.be.calledWith(token, '12345')
@@ -114,6 +117,7 @@ describe('Investment start controller', () => {
           },
         }, {
           locals: {},
+          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(this.getInflatedDitCompany).to.be.calledWith(token, '12345')
@@ -141,6 +145,7 @@ describe('Investment start controller', () => {
           },
         }, {
           locals: {},
+          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(data.showSearch).to.equal(true)
@@ -165,6 +170,7 @@ describe('Investment start controller', () => {
           },
         }, {
           locals: {},
+          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(data.searchTerm).to.equal('samsung')
@@ -223,6 +229,7 @@ describe('Investment start controller', () => {
             'client-company': '12345',
           },
         }, {
+          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(data.clientCompany).to.deep.equal(ukCompany)

--- a/test/unit/apps/investment-projects/controllers/create-2.test.js
+++ b/test/unit/apps/investment-projects/controllers/create-2.test.js
@@ -2,6 +2,7 @@ describe('Investment create controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
+    this.breadcrumbStub = function () { return this }
 
     this.controller = require('~/src/apps/investment-projects/controllers/create-2')
   })
@@ -19,6 +20,7 @@ describe('Investment create controller', () => {
           },
         }, {
           locals: {},
+          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal('/investment-projects/create/1')
@@ -43,6 +45,7 @@ describe('Investment create controller', () => {
               id: '12345',
             },
           },
+          breadcrumb: this.breadcrumbStub,
           render: (template) => {
             try {
               expect(template).to.equal('investment-projects/views/create-2')
@@ -68,6 +71,7 @@ describe('Investment create controller', () => {
             resultId: '12345',
             form: {},
           },
+          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal('/investment-projects/12345')
@@ -92,6 +96,7 @@ describe('Investment create controller', () => {
               errors: {},
             },
           },
+          breadcrumb: this.breadcrumbStub,
           render: (template) => {
             try {
               expect(template).to.equal('investment-projects/views/create-2')

--- a/test/unit/apps/investment-projects/controllers/interactions/create.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions/create.test.js
@@ -5,6 +5,7 @@ describe('Investment Interactions create controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.nextStub = this.sandbox.stub()
     this.flashStub = this.sandbox.stub()
+    this.breadcrumbStub = function () { return this }
 
     this.controller = require('~/src/apps/investment-projects/controllers/interactions/create')
   })
@@ -21,9 +22,9 @@ describe('Investment Interactions create controller', () => {
         },
       }, {
         locals: {
-          title: [],
           investmentData,
         },
+        breadcrumb: this.breadcrumbStub,
         render: (template) => {
           try {
             expect(template).to.equal('investment-projects/views/interactions/create')
@@ -46,12 +47,12 @@ describe('Investment Interactions create controller', () => {
           flash: this.flashStub,
         }, {
           locals: {
-            title: [],
             form: {
               errors: {},
             },
             investmentData,
           },
+          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal(`/investment-projects/${investmentData.id}/interactions`)
@@ -73,13 +74,13 @@ describe('Investment Interactions create controller', () => {
           },
         }, {
           locals: {
-            title: [],
             form: {
               errors: {
                 subject: 'example error',
               },
             },
           },
+          breadcrumb: this.breadcrumbStub,
         }, this.nextStub)
 
         expect(this.nextStub).to.be.calledOnce

--- a/test/unit/apps/investment-projects/controllers/interactions/edit.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions/edit.test.js
@@ -5,6 +5,7 @@ describe('Investment Interactions edit controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.nextStub = this.sandbox.stub()
     this.flashStub = this.sandbox.stub()
+    this.breadcrumbStub = function () { return this }
 
     this.controller = require('~/src/apps/investment-projects/controllers/interactions/edit')
   })
@@ -21,9 +22,9 @@ describe('Investment Interactions edit controller', () => {
         },
       }, {
         locals: {
-          title: [],
           investmentData,
         },
+        breadcrumb: this.breadcrumbStub,
         render: (template) => {
           try {
             expect(template).to.equal('investment-projects/views/interactions/edit')
@@ -46,12 +47,12 @@ describe('Investment Interactions edit controller', () => {
           flash: this.flashStub,
         }, {
           locals: {
-            title: [],
             form: {
               errors: {},
             },
             investmentData,
           },
+          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal(`/investment-projects/${investmentData.id}/interactions`)
@@ -73,13 +74,13 @@ describe('Investment Interactions edit controller', () => {
           },
         }, {
           locals: {
-            title: [],
             form: {
               errors: {
                 subject: 'example error',
               },
             },
           },
+          breadcrumb: this.breadcrumbStub,
         }, this.nextStub)
 
         expect(this.nextStub).to.be.calledOnce

--- a/test/unit/apps/investment-projects/controllers/interactions/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions/list.test.js
@@ -6,6 +6,7 @@ describe('Investment Interactions Index controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
+    this.breadcrumbStub = function () { return this }
     this.getInteractionsForInvestmentStub = this.sandbox.stub().resolves(interactionsListData)
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/interactions/list', {
       '../../../interactions/repos': {
@@ -29,9 +30,9 @@ describe('Investment Interactions Index controller', () => {
         },
       }, {
         locals: {
-          title: [],
           investmentData,
         },
+        breadcrumb: this.breadcrumbStub,
         render: (template, data) => {
           try {
             expect(template).to.equal('investment-projects/views/interactions/index')

--- a/test/unit/apps/investment-projects/middleware/shared.test.js
+++ b/test/unit/apps/investment-projects/middleware/shared.test.js
@@ -7,9 +7,7 @@ describe('Investment shared middleware', () => {
     this.sandbox = sinon.sandbox.create()
     this.getInteractionStub = this.sandbox.stub().resolves(interactionData)
     this.nextSpy = this.sandbox.spy()
-    this.reqMock = {
-      breadcrumbs: this.sandbox.spy(),
-    }
+    this.reqMock = {}
     this.resMock = { locals: {} }
 
     this.controller = proxyquire('~/src/apps/investment-projects/middleware/shared', {
@@ -27,7 +25,6 @@ describe('Investment shared middleware', () => {
     it('should return local nav items', () => {
       this.controller.getLocalNavMiddleware(this.reqMock, this.resMock, this.nextSpy)
 
-      expect(this.reqMock.breadcrumbs.calledOnce).to.be.true
       expect(this.resMock.locals).to.haveOwnProperty('localNavItems')
       expect(this.nextSpy.calledOnce).to.be.true
     })

--- a/test/unit/apps/search/controllers.test.js
+++ b/test/unit/apps/search/controllers.test.js
@@ -6,6 +6,10 @@ const next = function (error) {
 }
 
 describe('Search controller', function () {
+  beforeEach(() => {
+    this.breadcrumbStub = function () { return this }
+  })
+
   describe('view company result', function () {
     it('should route a uk private ltd company', function (done) {
       const searchController = proxyquire('~/src/apps/search/controllers', {
@@ -30,6 +34,7 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ltd/9999')
           done()
@@ -60,6 +65,7 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ltd/9999')
           done()
@@ -90,6 +96,7 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ukother/9999')
           done()
@@ -120,6 +127,7 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/foreign/9999')
           done()
@@ -143,6 +151,7 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
+        breadcrumb: this.breadcrumbStub,
       }
       const nextStub = (error) => {
         try {
@@ -164,6 +173,7 @@ describe('Search Controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.spy()
     this.controller = require('~/src/apps/search/controllers')
+    this.breadcrumbStub = function () { return this }
   })
 
   afterEach(() => {
@@ -227,9 +237,9 @@ describe('Search Controller', () => {
             params: {
               searchPath,
             },
-            breadcrumbs: sinon.stub(),
           },
           {
+            breadcrumb: this.breadcrumbStub,
             render: (template, data) => {
               try {
                 expect(template).to.equal(`search/views/results-${entityType}`)
@@ -280,9 +290,9 @@ describe('Search Controller', () => {
             params: {
               searchPath,
             },
-            breadcrumbs: sinon.stub(),
           },
           {
+            breadcrumb: this.breadcrumbStub,
             render: (template, data) => {
               try {
                 expect(template).to.equal(`search/views/results-${entityType}`)
@@ -333,9 +343,9 @@ describe('Search Controller', () => {
             params: {
               searchPath,
             },
-            breadcrumbs: sinon.stub(),
           },
           {
+            breadcrumb: this.breadcrumbStub,
             render: (template, data) => {
               try {
                 expect(template).to.equal(`search/views/results-${entityType}`)

--- a/test/unit/middleware/breadcrumbs.test.js
+++ b/test/unit/middleware/breadcrumbs.test.js
@@ -1,0 +1,159 @@
+const breadcrumbs = require('~/src/middleware/breadcrumbs')
+
+describe('breadcrumbs middleware', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+
+    this.nextSpy = this.sandbox.spy()
+    this.resMock = {}
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('init()', () => {
+    beforeEach(() => {
+      this.init = breadcrumbs.init()
+    })
+
+    it('should attach a method to the response object', () => {
+      this.init({}, this.resMock, this.nextSpy)
+
+      expect(this.resMock).to.have.property('breadcrumb')
+      expect(this.resMock.breadcrumb).to.be.a('function')
+      expect(this.nextSpy.calledOnce).to.be.true
+    })
+  })
+
+  describe('res.breadcrumb()', () => {
+    beforeEach(() => {
+      this.init({}, this.resMock, this.nextSpy)
+    })
+
+    describe('when called with no arguments', () => {
+      it('should return the breadcrumb', () => {
+        expect(this.resMock.breadcrumb()).to.deep.equal([])
+      })
+    })
+
+    describe('when called with 1 argument', () => {
+      it('should set name', () => {
+        this.resMock.breadcrumb('Name')
+
+        expect(this.resMock.breadcrumb()).to.deep.equal([{
+          name: 'Name',
+        }])
+      })
+    })
+
+    describe('when called with 2 arguments', () => {
+      it('should set url and name', () => {
+        this.resMock.breadcrumb('Name', '/sample-url')
+
+        expect(this.resMock.breadcrumb()).to.deep.equal([{
+          name: 'Name',
+          url: '/sample-url',
+        }])
+      })
+    })
+
+    describe('when called with an object', () => {
+      it('should add the object to breadcrumb', () => {
+        this.resMock.breadcrumb({
+          name: 'Name',
+          url: '/sample-url',
+        })
+
+        expect(this.resMock.breadcrumb()).to.deep.equal([{
+          name: 'Name',
+          url: '/sample-url',
+        }])
+      })
+    })
+
+    describe('when called with an array of objects', () => {
+      it('should add each object to breadcrumb', () => {
+        this.resMock.breadcrumb([{
+          name: 'First item',
+          url: '/first-item',
+        },
+        {
+          name: 'Second item',
+          url: '/second-item',
+        }])
+
+        expect(this.resMock.breadcrumb()).to.deep.equal([{
+          name: 'First item',
+          url: '/first-item',
+        },
+        {
+          name: 'Second item',
+          url: '/second-item',
+        }])
+      })
+    })
+  })
+
+  describe('setHome()', () => {
+    beforeEach(() => {
+      this.init = breadcrumbs.init()
+      this.init({}, this.resMock, this.sandbox.spy())
+
+      this.setHome = breadcrumbs.setHome
+    })
+
+    describe('when called with no arguments', () => {
+      beforeEach(() => {
+        this.setHome()({}, this.resMock, this.nextSpy)
+      })
+
+      it('should set a default value for the home item', () => {
+        expect(this.nextSpy.calledOnce).to.be.true
+        expect(this.resMock.breadcrumb()).to.deep.equal([{
+          name: 'Home',
+          url: '/',
+          _home: true,
+        }])
+      })
+    })
+
+    describe('when called with an object', () => {
+      beforeEach(() => {
+        this.setHome({
+          name: 'Root',
+          url: '/root',
+        })({}, this.resMock, this.nextSpy)
+      })
+
+      it('should set the object as the home item', () => {
+        expect(this.nextSpy.calledOnce).to.be.true
+        expect(this.resMock.breadcrumb()).to.deep.equal([{
+          name: 'Root',
+          url: '/root',
+          _home: true,
+        }])
+      })
+    })
+
+    describe('when home is already set', () => {
+      beforeEach(() => {
+        this.setHome()({}, this.resMock, this.nextSpy)
+      })
+
+      it('should update the home item', () => {
+        this.setHome({
+          name: 'Root',
+          url: '/root',
+        })({}, this.resMock, this.nextSpy)
+
+        expect(this.nextSpy.calledTwice).to.be.true
+        expect(this.resMock.breadcrumb()).to.deep.equal([{
+          name: 'Root',
+          url: '/root',
+          _home: true,
+        }])
+      })
+    })
+  })
+})

--- a/test/unit/middleware/title.test.js
+++ b/test/unit/middleware/title.test.js
@@ -1,0 +1,28 @@
+describe('title middleware', () => {
+  beforeEach(() => {
+    this.title = require('~/src/middleware/title')()
+    this.sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('set title', () => {
+    it('should set title to the string passed', () => {
+      const nextSpy = this.sandbox.spy()
+      const resMock = { locals: {} }
+      const testTitle = 'Test title'
+
+      this.title({}, resMock, nextSpy)
+
+      expect(resMock).to.have.property('title')
+      expect(resMock.title).to.be.a('function')
+
+      resMock.title(testTitle)
+
+      expect(resMock.locals.title).to.equal(testTitle)
+      expect(nextSpy.calledOnce).to.be.true
+    })
+  })
+})

--- a/test/unit/nunjucks.js
+++ b/test/unit/nunjucks.js
@@ -21,6 +21,7 @@ Object.keys(filters).forEach((filterName) => {
 
 function render (template, options) {
   options.getAssetPath = () => {} // Stub method set in middleware locals
+  options.getPageTitle = () => {} // Stub method set in middleware locals
 
   return new Promise((resolve, reject) => {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2868,12 +2868,6 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-express-breadcrumbs@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/express-breadcrumbs/-/express-breadcrumbs-0.0.2.tgz#3e1c6804c1884cc7917a725743860d4953c13798"
-  dependencies:
-    lodash "~2.1.0"
-
 express-session@^1.14.1:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.15.3.tgz#db545f0435a7b1b228ae02da8197f65141735c67"
@@ -5133,10 +5127,6 @@ lodash@^3.10.1:
 lodash@~0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-0.9.2.tgz#8f3499c5245d346d682e5b0d3b40767e09f1a92c"
-
-lodash@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.1.0.tgz#0637eaaa36a8a1cfc865c3adfb942189bfb0998d"
 
 lodash@~2.4.1:
   version "2.4.2"


### PR DESCRIPTION
The breadcrumb functionality is giving us the same thing we're doing
with page titles. To keep consistency this change switches out the use
of manually setting the page title within all the views and uses
the breadcrumb object to construct the page titles.

## Notes

The breadcrumb middleware uses the original dependency ([express-breadcrumbs](https://github.com/heroicyang/express-breadcrumbs)) as a starting point.