### PR TITLE
Fix add company URL

### DIFF
--- a/src/apps/search/views/results-company.njk
+++ b/src/apps/search/views/results-company.njk
@@ -2,7 +2,7 @@
 
 {% block actions %}
   <div class="action-bar">
-    <a class="button button-secondary" href="/company/add-step-1/">
+    <a class="button button-secondary" href="/companies/add-step-1/">
       Add company
     </a>
   </div>


### PR DESCRIPTION
This may have been overridden during a rebase so this ensures we're
using the correct URL again.