### PR TITLE
Reuse Form components In EntitySearch

### DIFF
--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -32,6 +32,8 @@
  # @param {object} [props.errors] - Object containing form errors
  # @param {object} [props.hiddenFields] - Custom fields to be added as hidden inputs
  # @param {boolean} [props.disableFormActions] - Avoid rendering form actions
+ # @param {string} [props.class] - Form class name
+ # @param {string} [props.role] - Form role attribute value
  # @param {string} [props.buttonText=Submit] - Text for submit button
  #
  # @callback {function} caller - Required inner contents
@@ -42,9 +44,15 @@
   <form
     method="{{ method }}"
     {% if props.action %}action="{{ props.action }}"{% endif -%}
+    {% if props.class %}class="{{ props.class }}"{% endif %}
+    {% if props.role %}role="{{ props.role }}"{% endif %}
   >
     {{ ErrorSummary(props.errors) }}
-    {{ CSRF(csrfToken) }}
+
+    {% if method|lower === 'post' %}
+      {{ CSRF(csrfToken) }}
+    {% endif %}
+
     {% if props.hiddenFields|length %}
       {% for fieldName, fieldValue in props.hiddenFields | removeNilAndEmpty %}
         <input type="hidden" name="{{ fieldName }}" value="{{ fieldValue }}">
@@ -82,26 +90,28 @@
   {% set inputPlaceholder = props.inputPlaceholder | default(props.inputLabel) -%}
   {% set isLabelHidden = props.isLabelHidden | default(true) %}
   {% set entityType = props.entityType | default('company') %}
-  <form
-    method="{{ method }}"
-    action="{{ props.action }}"
-    class="c-entity-search {{ 'c-entity-search--' + props.modifier if props.modifier}}"
-    role="search"
-  >
-    {% if props.hiddenFields|length %}
-      {% for fieldName, fieldValue in props.hiddenFields %}
-        <input type="hidden" name="{{ fieldName }}" value="{{ fieldValue }}">
-      {% endfor %}
-    {% endif %}
+  {% set modifier = 'c-entity-search--' + props.modifier if props.modifier %}
+
+  {% call Form(props | assign({
+    class: 'c-entity-search ' + modifier,
+    role: 'search',
+    method: method,
+    disableFormActions: true,
+    inputName: inputName,
+    inputPlaceholder: inputPlaceholder,
+    isLabelHidden: isLabelHidden,
+    entityType: entityType
+  })) %}
+
     {% call TextField({
       type: 'search',
-      name: inputName,
+      class: 'c-entity-search__input',
+      name: props.inputName,
       value: props.searchTerm,
       hint: props.inputHint,
-      class: 'c-entity-search__input',
       label: props.inputLabel,
-      placeholder: inputPlaceholder,
-      isLabelHidden: isLabelHidden
+      placeholder: props.inputPlaceholder,
+      isLabelHidden: props.isLabelHidden
     }) %}
       <button class="c-entity-search__button">Search</button>
     {% endcall %}
@@ -110,7 +120,7 @@
       <nav class="c-entity-search__aggregations">
         <ul>
           {% for item in props.aggregations %}
-            {% set isCurrentPage = item.entity === entityType %}
+            {% set isCurrentPage = item.entity === props.entityType %}
             <li class="c-entity-search__aggregations-item {{ 'is-active' if isCurrentPage }}">
               {% if isCurrentPage %}
                 {{ item.text }}
@@ -123,7 +133,7 @@
         </ul>
       </nav>
     {% endif %}
-  </form>
+  {% endcall %}
 {% endmacro %}
 
 {##

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -105,7 +105,7 @@
 
     {% call TextField({
       type: 'search',
-      class: 'c-entity-search__input',
+      inputClass: 'c-entity-search__input',
       name: props.inputName,
       value: props.searchTerm,
       hint: props.inputHint,
@@ -244,6 +244,8 @@
  # @param {string} props.name - Field name
  # @param {string} props.label - Field label
  # @param {string} [props.type] - Field type
+ # @param {string} [props.groupClass] - Group class name
+ # @param {string} [props.inputClass] - Input class name
  # @param {string} [props.hint] - Field hint
  # @param {string} [props.error] - Field error
  # @param {string} [props.modifier] - Field modifier
@@ -254,11 +256,11 @@
 {% macro TextField(props) %}
   {% set fieldId = 'field-' + props.name if props.name %}
   {% set innerContent = caller() if caller else null %}
-  {% call FormGroup(props | assign({ fieldId: fieldId, modifier: props.modifier, innerContent: innerContent })) %}
+  {% call FormGroup(props | assign({ fieldId: fieldId, modifier: props.modifier, innerContent: innerContent, class: props.groupClass })) %}
     {% if props.type === 'textarea' %}
-      {{ TextArea(props) }}
+      {{ TextArea(props | assign({ class: props.inputClass })) }}
     {% else %}
-      {{ Input(props) }}
+      {{ Input(props | assign({ class: props.inputClass })) }}
     {% endif %}
   {% endcall %}
 {% endmacro %}
@@ -273,6 +275,8 @@
  # @param {string} [props.placeholder] - Field placeholder
  # @param {string} [props.hint] - Field hint
  # @param {string} [props.error] - Field error
+ # @param {string} [props.groupClass] - Group class name
+ # @param {string} [props.inputClass] - Input class name
  # @param {boolean} [props.optional] - Marks field as optional
  #
  # @param {function} [props.caller] - Optional inner contents
@@ -280,11 +284,11 @@
 {% macro MultipleChoiceField(props) %}
   {% set fieldId = 'field-' + props.name if props.name %}
   {% set element = 'fieldset' if props.type in ['checkbox', 'radio'] %}
-  {% call FormGroup(props | assign({ fieldId: fieldId, caller: caller, element: element })) %}
+  {% call FormGroup(props | assign({ fieldId: fieldId, caller: caller, element: element, class: groupClass })) %}
     {% if props.type in ['checkbox', 'radio'] %}
       {{ MultipleChoice(props) }}
     {% else %}
-      {% call SelectBox(props) %}
+      {% call SelectBox(props | assign({ class: inputClass })) %}
         {{ props.caller() if props.caller }}
       {% endcall %}
     {% endif %}
@@ -344,6 +348,7 @@
  # @param {object} props - An object containing field properties
  # @param {string} props.name - Field name
  # @param {string} props.fieldId - Field id
+ # @param {string} [props.class] - Field class name
  # @param {string} [props.options] - Field options
  # @param {string} [props.modifier] - form-control modifier
  # @param {string} [props.error] - Mark form-control with error
@@ -354,7 +359,7 @@
   <select
     id="{{ props.fieldId }}"
     name="{{ props.name }}"
-    class="c-form-control {{ 'c-form-control--' + props.modifier if props.modifier }} {{ 'has-error' if props.error }}"
+    class="c-form-control {{ 'c-form-control--' + props.modifier if props.modifier }} {{ 'has-error' if props.error }} {{ props.class }}"
     {% if props.hint %}aria-describedby="hint-{{ props.fieldId }}"{% endif %}
   >
     {% if props.initialOption %}


### PR DESCRIPTION
Ensure consistency by reusing the same form components within other form components.

Also allow configuring form groups and input fields from container components such as `Form`.