### PR TITLE
Fix breadcrumb chevron on non-retina screens

### DIFF
--- a/assets/stylesheets/components/_breadcrumb.scss
+++ b/assets/stylesheets/components/_breadcrumb.scss
@@ -9,14 +9,13 @@
 .c-breadcrumb__item {
   @include core-font(16);
   background: url("../../images/separator.png") left center no-repeat;
-  background-size: contain;
+  background-size: 6px 11px;
   display: inline-block;
   margin: 0 0 0 $default-spacing-unit / 2;
   padding: 0 0 0 $default-spacing-unit;
 
   @include device-pixel-ratio(2) {
     background-image: url("../../images/separator@2x.png");
-    background-size: 6px 11px;
   }
 
   &:first-child {


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/203886/28110069-19979dd2-66e9-11e7-8eff-4f2272035d80.png)

## After
![image](https://user-images.githubusercontent.com/203886/28110053-082edd26-66e9-11e7-9efc-a89f1d2e459b.png)
