### PR TITLE
Add Pagination to components page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -12,3 +12,6 @@
 @import "components/results-summary";
 @import "components/entity-list";
 @import "components/status-bar";
+
+// Style examples on components page
+@import "components/.example";

--- a/assets/stylesheets/components/_.example.scss
+++ b/assets/stylesheets/components/_.example.scss
@@ -1,0 +1,37 @@
+@import "../settings";
+
+* + .example {
+  margin-top: $default-spacing-unit * 2;
+}
+
+.example__header {
+  padding-top: $default-spacing-unit / 4;
+  padding-bottom: $default-spacing-unit / 4;
+
+  &::before {
+    content: "Example";
+    background-color: $grey-1;
+    color: $white;
+    text-transform: uppercase;
+    font-size: 16px;
+    line-height: 32px;
+    font-weight: 600;
+    padding: 0 ($default-spacing-unit / 2);
+    margin-right: $default-spacing-unit / 2;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+.example__title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+  display: inline-block;
+}
+
+.example__preview {
+  background-color: $white;
+  border: 2px solid $grey-2;
+  padding: $default-spacing-unit;
+}

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -57,7 +57,9 @@ function renderBreadcrumbs (req, res) {
 }
 
 function renderPagination (req, res) {
-  return res.render('components/views/pagination')
+  return res
+    .breadcrumb('Pagination')
+    .render('components/views/pagination')
 }
 
 async function renderEntityList (req, res) {

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -27,9 +27,8 @@ const foreignOtherCompanyOptions = [
 
 function renderFormElements (req, res) {
   return res
-    .breadcrumb('Form')
+    .breadcrumb('Form elements')
     .render('components/views/form', {
-      title: 'Form Elements',
       entitySearch: Object.assign({}, res.locals.entitySearch, {
         searchTerm: req.query.term,
       }),
@@ -48,23 +47,27 @@ function renderFormElements (req, res) {
 function renderMessages (req, res) {
   return res
     .breadcrumb('Application messages')
-    .render('components/views/messages', {
-      title: 'Application messages',
-    })
+    .render('components/views/messages')
 }
 
 function renderBreadcrumbs (req, res) {
-  return res.render('components/views/breadcrumbs', {
-    title: 'Breadcrumbs',
-  })
+  return res
+    .breadcrumb('Breadcrumbs')
+    .render('components/views/breadcrumbs')
+}
+
+function renderPagination (req, res) {
+  return res.render('components/views/pagination')
 }
 
 async function renderEntityList (req, res) {
-  return res.render('components/views/entity-list', {
-    investmentProjects: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/investment?limit=10`),
-    companiesSearch: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/search?term=samsung&entity=company&limit=10`),
-    contactsSearch: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/search?term=samsung&entity=contact&limit=10`),
-  })
+  return res
+    .breadcrumb('Entity list')
+    .render('components/views/entity-list', {
+      investmentProjects: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/investment?limit=10`),
+      companiesSearch: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/search?term=samsung&entity=company&limit=10`),
+      contactsSearch: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/search?term=samsung&entity=contact&limit=10`),
+    })
 }
 
 module.exports = {
@@ -73,4 +76,5 @@ module.exports = {
   renderIndex,
   renderMessages,
   renderBreadcrumbs,
+  renderPagination,
 }

--- a/src/apps/components/router.js
+++ b/src/apps/components/router.js
@@ -7,6 +7,7 @@ const {
   renderIndex,
   renderMessages,
   renderBreadcrumbs,
+  renderPagination,
 } = require('./controllers')
 
 router
@@ -14,6 +15,7 @@ router
   .get('/breadcrumbs', renderBreadcrumbs)
   .get('/messages', renderMessages)
   .get('/entity-list', renderEntityList)
+  .get('/pagination', renderPagination)
   .get('/form', handleEntitySearch, renderFormElements)
   .post('/form', handleFormPost, renderFormElements)
 

--- a/src/apps/components/views/_layout.njk
+++ b/src/apps/components/views/_layout.njk
@@ -1,0 +1,9 @@
+{% extends "_layouts/datahub-base.njk" %}
+
+{% set heading = title or getPageTitle()[0] %}
+
+{% if heading %}
+  {% block body_main_header_content %}
+    <h1 class="heading-xlarge">{{ heading }}</h1>
+  {% endblock %}
+{% endif %}

--- a/src/apps/components/views/_layout.njk
+++ b/src/apps/components/views/_layout.njk
@@ -2,6 +2,8 @@
 
 {% set heading = title or getPageTitle()[0] %}
 
+{% from "_macros/dev.njk" import Example %}
+
 {% if heading %}
   {% block body_main_header_content %}
     <h1 class="heading-xlarge">{{ heading }}</h1>

--- a/src/apps/components/views/breadcrumbs.njk
+++ b/src/apps/components/views/breadcrumbs.njk
@@ -1,16 +1,18 @@
 {% extends "./_layout.njk" %}
 
 {% block body_main_content %}
-  {% component 'breadcrumbs', {
-    items: [{
-      url: '/',
-      name: 'Home'
-    }, {
-      url: '/second-level',
-      name: 'Second level'
-    }, {
-      url: '/second-level/third-level',
-      name: 'Third level'
-    }]
-  } %}
+  {% call Example() %}
+    {% component 'breadcrumbs', {
+      items: [{
+        url: '/',
+        name: 'Home'
+      }, {
+        url: '/second-level',
+        name: 'Second level'
+      }, {
+        url: '/second-level/third-level',
+        name: 'Third level'
+      }]
+    } %}
+  {% endcall %}
 {% endblock %}

--- a/src/apps/components/views/breadcrumbs.njk
+++ b/src/apps/components/views/breadcrumbs.njk
@@ -1,11 +1,6 @@
-{% extends "_layouts/datahub-base.njk" %}
-
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge">{{ title }}</h1>
-{% endblock %}
+{% extends "./_layout.njk" %}
 
 {% block body_main_content %}
-
   {% component 'breadcrumbs', {
     items: [{
       url: '/',
@@ -18,5 +13,4 @@
       name: 'Third level'
     }]
   } %}
-
 {% endblock %}

--- a/src/apps/components/views/entity-list.njk
+++ b/src/apps/components/views/entity-list.njk
@@ -3,104 +3,106 @@
 {% from "_macros/address.njk" import addressFormatter %}
 
 {% block body_main_content %}
-  <h2 class="heading-medium">Investments</h2>
+  {% call Example('Investment projects') %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <ul class="c-entity-list">
+          {% for project in investmentProjects.results %}
+            <li class="c-entity-list__item">
+              <h3 class="c-entity-list__item-header">
+                <a href="/investment-projects/{{ project.id }}">{{ project.name}}</a>
+              </h3>
+              <dl class="metadata-list">
+                <dt class="metadata-list__term">Land date</dt>
+                <dd class="metadata-list__value">{{ project.estimated_land_date | formatDate('MMM YYYY') }}</dd>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <ul class="c-entity-list">
-        {% for project in investmentProjects.results %}
-          <li class="c-entity-list__item">
-            <h3 class="c-entity-list__item-header">
-              <a href="/investment-projects/{{ project.id }}">{{ project.name}}</a>
-            </h3>
-            <dl class="metadata-list">
-              <dt class="metadata-list__term">Land date</dt>
-              <dd class="metadata-list__value">{{ project.estimated_land_date | formatDate('MMM YYYY') }}</dd>
+                <dt class="metadata-list__term u-visually-hidden">Type of investment</dt>
+                <dd class="metadata-list__value">{{ project.investment_type.name }}</dd>
 
-              <dt class="metadata-list__term u-visually-hidden">Type of investment</dt>
-              <dd class="metadata-list__value">{{ project.investment_type.name }}</dd>
+                <dt class="metadata-list__term u-visually-hidden">Phase</dt>
+                <dd class="metadata-list__value">{{ project.phase.name }}</dd>
 
-              <dt class="metadata-list__term u-visually-hidden">Phase</dt>
-              <dd class="metadata-list__value">{{ project.phase.name }}</dd>
-
-              <dt class="metadata-list__term u-visually-hidden">Sector</dt>
-              <dd class="metadata-list__value">{{ project.sector.name }}</dd>
-            </dl>
-          </li>
-        {% endfor %}
-      </ul>
+                <dt class="metadata-list__term u-visually-hidden">Sector</dt>
+                <dd class="metadata-list__value">{{ project.sector.name }}</dd>
+              </dl>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
-  </div>
+  {% endcall %}
 
-  <h2 class="heading-medium">Companies</h2>
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <ul class="c-entity-list">
-        {% for company in companiesSearch.companies %}
-          <li class="c-entity-list__item">
-            <h3 class="c-entity-list__item-header">
-              <a href="/viewcompanyresult/{{ company.id }}">{{ company.name}}</a>
-            </h3>
+  {% call Example('Companies') %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <ul class="c-entity-list">
+          {% for company in companiesSearch.companies %}
+            <li class="c-entity-list__item">
+              <h3 class="c-entity-list__item-header">
+                <a href="/viewcompanyresult/{{ company.id }}">{{ company.name}}</a>
+              </h3>
 
-            <dl class="metadata-list">
-              {% if company.companies_house_data %}
-                <dt class="metadata-list__term u-visually-hidden">Companies House Number</dt>
-                <dd class="metadata-list__value">{{ company.companies_house_data.company_number }}</dd>
-              {% endif %}
+              <dl class="metadata-list">
+                {% if company.companies_house_data %}
+                  <dt class="metadata-list__term u-visually-hidden">Companies House Number</dt>
+                  <dd class="metadata-list__value">{{ company.companies_house_data.company_number }}</dd>
+                {% endif %}
 
-              <dt class="metadata-list__term u-visually-hidden">Address</dt>
-              <dd class="metadata-list__value">
-                {{ addressFormatter( [
-                  company.registered_address_1,
-                  company.registered_address_2,
-                  company.registered_address_county,
-                  company.registered_address_town,
-                  company.registered_address_postcode
-                ]) }}
-              </dd>
-            </dl>
-          </li>
-        {% endfor %}
-      </ul>
+                <dt class="metadata-list__term u-visually-hidden">Address</dt>
+                <dd class="metadata-list__value">
+                  {{ addressFormatter( [
+                    company.registered_address_1,
+                    company.registered_address_2,
+                    company.registered_address_county,
+                    company.registered_address_town,
+                    company.registered_address_postcode
+                  ]) }}
+                </dd>
+              </dl>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
-  </div>
+  {% endcall %}
 
-  <h2 class="heading-medium">Contacts</h2>
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <ul class="c-entity-list">
-        {% for contact in contactsSearch.contacts %}
-          <li class="c-entity-list__item">
-            <h3 class="c-entity-list__item-header">
-              <a href="/contacts/{{ contact.id }}">
-                {{ (contact.first_name + ' ' + contact.last_name) | highlight(searchTerm) }}
-              </a>
-            </h3>
+  {% call Example('Contacts') %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <ul class="c-entity-list">
+          {% for contact in contactsSearch.contacts %}
+            <li class="c-entity-list__item">
+              <h3 class="c-entity-list__item-header">
+                <a href="/contacts/{{ contact.id }}">
+                  {{ (contact.first_name + ' ' + contact.last_name) | highlight(searchTerm) }}
+                </a>
+              </h3>
 
-            <dl class="metadata-list">
-              {% if (contact.company) %}
-                <dt class="metadata-list__term u-visually-hidden">Company</dt>
-                <dd class="metadata-list__value">{{ contact.company.name }}</dd>
-              {% endif %}
-              {% if results.job_title %}
-                <dt class="metadata-list__term u-visually-hidden">Job Title</dt>
-                <dd class="metadata-list__value">{{ results.job_title }}</dd>
-              {% endif %}
+              <dl class="metadata-list">
+                {% if (contact.company) %}
+                  <dt class="metadata-list__term u-visually-hidden">Company</dt>
+                  <dd class="metadata-list__value">{{ contact.company.name }}</dd>
+                {% endif %}
+                {% if results.job_title %}
+                  <dt class="metadata-list__term u-visually-hidden">Job Title</dt>
+                  <dd class="metadata-list__value">{{ results.job_title }}</dd>
+                {% endif %}
 
-              <dt class="metadata-list__term u-visually-hidden">Address</dt>
-              <dd class="metadata-list__value">
-                {{ addressFormatter([
-                  contact.registered_address_1,
-                  contact.registered_address_2,
-                  contact.registered_address_county,
-                  contact.registered_address_town,
-                  contact.registered_address_postcode
-                ]) }}
-            </dl>
-          </li>
-        {% endfor %}
-      </ul>
+                <dt class="metadata-list__term u-visually-hidden">Address</dt>
+                <dd class="metadata-list__value">
+                  {{ addressFormatter([
+                    contact.registered_address_1,
+                    contact.registered_address_2,
+                    contact.registered_address_county,
+                    contact.registered_address_town,
+                    contact.registered_address_postcode
+                  ]) }}
+              </dl>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
-  </div>
+  {% endcall %}
 
 {% endblock %}

--- a/src/apps/components/views/entity-list.njk
+++ b/src/apps/components/views/entity-list.njk
@@ -1,10 +1,6 @@
-{% extends "_layouts/datahub-base.njk" %}
+{% extends "./_layout.njk" %}
 
 {% from "_macros/address.njk" import addressFormatter %}
-
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge">Entity list</h1>
-{% endblock %}
 
 {% block body_main_content %}
   <h2 class="heading-medium">Investments</h2>

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -1,152 +1,157 @@
 {% extends "./_layout.njk" %}
 
 {% block body_main_content %}
-  <h2 class="page-heading">Search</h2>
+  <h2 class="page-heading">Entity search</h2>
 
-  <h3 class="heading-small">Simple</h3>
-  {{ EntitySearchForm({
-    inputName: 'term',
-    inputLabel: 'Search for a company name or contact',
-    searchTerm: entitySearch.searchTerm
-  }) }}
+  {% call Example('Simple') %}
+    {{ EntitySearchForm({
+      inputName: 'term',
+      inputLabel: 'Search for a company name or contact',
+      searchTerm: entitySearch.searchTerm
+    }) }}
+  {% endcall %}
 
-  <h3 class="heading-small">Global</h3>
-  {{ EntitySearchForm({
-    inputName: 'term',
-    modifier: 'global',
-    inputLabel: 'Search for a company name or contact',
-    searchTerm: entitySearch.searchTerm,
-    aggregations: entitySearch.searchEntityResultsData
-  }) }}
+  {% call Example('Global') %}
+    {{ EntitySearchForm({
+      inputName: 'term',
+      modifier: 'global',
+      inputLabel: 'Search for a company name or contact',
+      searchTerm: entitySearch.searchTerm,
+      aggregations: entitySearch.searchEntityResultsData
+    }) }}
+  {% endcall %}
 
   <h2 class="page-heading">Standard</h2>
-  {% call Form(form) %}
-    {{ TextField({
-      name: 'name',
-      label: 'Company name',
-      placeholder: 'e.g. Hooli',
-      error: form.errors.messages.name,
-      value: form.state.name
-    }) }}
+  {% call Example() %}
+    {% call Form(form) %}
+      {{ TextField({
+        name: 'name',
+        label: 'Company name',
+        placeholder: 'e.g. Hooli',
+        error: form.errors.messages.name,
+        value: form.state.name
+      }) }}
 
-    {{ TextField({
-      name: 'description',
-      label: 'Describe yourself',
-      placeholder: 'Lorem ipsum',
-      type: 'textarea',
-      hint: 'A few words about yourself',
-      optional: true,
-      error: form.errors.messages.description,
-      value: form.state.description
-    }) }}
+      {{ TextField({
+        name: 'description',
+        label: 'Describe yourself',
+        placeholder: 'Lorem ipsum',
+        type: 'textarea',
+        hint: 'A few words about yourself',
+        optional: true,
+        error: form.errors.messages.description,
+        value: form.state.description
+      }) }}
 
-    {{ MultipleChoiceField({
-      name: 'country',
-      label: 'Country',
-      error: form.errors.messages.country,
-      options: form.options.countries,
-      selected: form.state.country
-    }) }}
-
-  {{ MultipleChoiceField({
-      name: 'sectors',
-      label: 'Sectors',
-      options: form.options.sectors,
-      selected: form.state.sectors,
-      initialOption: '-- Select sector --'
-    })
-  }}
+      {{ MultipleChoiceField({
+        name: 'country',
+        label: 'Country',
+        error: form.errors.messages.country,
+        options: form.options.countries,
+        selected: form.state.country
+      }) }}
 
     {{ MultipleChoiceField({
-        type: 'checkbox',
-        name: 'strategicDrivers',
-        label: 'Strategic drivers',
-        options: form.options.strategicDrivers,
-        selected: form.state.strategicDrivers
+        name: 'sectors',
+        label: 'Sectors',
+        options: form.options.sectors,
+        selected: form.state.sectors,
+        initialOption: '-- Select sector --'
       })
     }}
 
-    {{ MultipleChoiceField({
-        type: 'radio',
-        name: 'averageSalary',
-        label: 'Average salary range',
-        options: form.options.averageSalaryRange,
-        error: form.errors.messages.averageSalary,
-        selected: form.state.averageSalary
-      })
-    }}
+      {{ MultipleChoiceField({
+          type: 'checkbox',
+          name: 'strategicDrivers',
+          label: 'Strategic drivers',
+          options: form.options.strategicDrivers,
+          selected: form.state.strategicDrivers
+        })
+      }}
 
-    {% call Fieldset({
-      legend: 'A conditional set of fields',
-      modifier: 'subfield',
-      condition: {
-        name: 'averageSalary',
-        value: '2943bf3d-32dd-43be-8ad4-969b006dee7b'
-      }
-    }) %}
-      {{ TextField({
-        name: 'firstName',
-        label: 'First name',
-        value: form.state.firstName
-      }) }}
+      {{ MultipleChoiceField({
+          type: 'radio',
+          name: 'averageSalary',
+          label: 'Average salary range',
+          options: form.options.averageSalaryRange,
+          error: form.errors.messages.averageSalary,
+          selected: form.state.averageSalary
+        })
+      }}
 
-      {{ TextField({
-        name: 'lastName',
-        label: 'Last name',
-        value: form.state.lastName
-      }) }}
-    {% endcall %}
+      {% call Fieldset({
+        legend: 'A conditional set of fields',
+        modifier: 'subfield',
+        condition: {
+          name: 'averageSalary',
+          value: '2943bf3d-32dd-43be-8ad4-969b006dee7b'
+        }
+      }) %}
+        {{ TextField({
+          name: 'firstName',
+          label: 'First name',
+          value: form.state.firstName
+        }) }}
 
-    {{ MultipleChoiceField({
-        type: 'radio',
-        name: 'businessType',
-        label: 'Company type',
-        selected: form.state.businessType,
-        error: form.errors.messages.businessType,
-        options: [
-          {
-            value: 'ltd',
-            label: 'UK private or public limited company',
-            hint: 'Must be a company registered with Companies House'
-          }, {
-            value: 'ukother',
-            label: 'Other type of UK organisation',
-            hint: 'UK organisation not registered with Companies House',
-            children:  [
-              MultipleChoiceField({
-                name: 'foreignOtherCompany',
-                label: 'Type of organisation',
-                error: form.errors.messages.foreignOtherCompany,
-                selected: form.state.foreignOtherCompany,
-                options: form.options.foreignOtherCompany,
-                initialOption: '-- Select company --',
-                condition: {
-                  name: 'businessType',
-                  value: 'ukother'
-                },
-                modifier: 'subfield'
-              })
-            ]
-          }, {
-            value: 'foreign',
-            label: 'Foreign organisation'
-          }
-        ]
-      })
-    }}
+        {{ TextField({
+          name: 'lastName',
+          label: 'Last name',
+          value: form.state.lastName
+        }) }}
+      {% endcall %}
 
-    {% call Fieldset({ legend: 'A set of fields' }) %}
-      {{ TextField({
-        name: 'firstName',
-        label: 'First name',
-        value: form.state.firstName
-      }) }}
+      {{ MultipleChoiceField({
+          type: 'radio',
+          name: 'businessType',
+          label: 'Company type',
+          selected: form.state.businessType,
+          error: form.errors.messages.businessType,
+          options: [
+            {
+              value: 'ltd',
+              label: 'UK private or public limited company',
+              hint: 'Must be a company registered with Companies House'
+            }, {
+              value: 'ukother',
+              label: 'Other type of UK organisation',
+              hint: 'UK organisation not registered with Companies House',
+              children:  [
+                MultipleChoiceField({
+                  name: 'foreignOtherCompany',
+                  label: 'Type of organisation',
+                  error: form.errors.messages.foreignOtherCompany,
+                  selected: form.state.foreignOtherCompany,
+                  options: form.options.foreignOtherCompany,
+                  initialOption: '-- Select company --',
+                  condition: {
+                    name: 'businessType',
+                    value: 'ukother'
+                  },
+                  modifier: 'subfield'
+                })
+              ]
+            }, {
+              value: 'foreign',
+              label: 'Foreign organisation'
+            }
+          ]
+        })
+      }}
 
-      {{ TextField({
-        name: 'lastName',
-        label: 'Last name',
-        value: form.state.lastName
-      }) }}
+      {% call Fieldset({ legend: 'A set of fields' }) %}
+        {{ TextField({
+          name: 'firstName',
+          label: 'First name',
+          value: form.state.firstName
+        }) }}
+
+        {{ TextField({
+          name: 'lastName',
+          label: 'Last name',
+          value: form.state.lastName
+        }) }}
+      {% endcall %}
+
     {% endcall %}
 
   {% endcall %}

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -1,8 +1,4 @@
-{% extends "_layouts/datahub-base.njk" %}
-
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge">{{ title }}</h1>
-{% endblock %}
+{% extends "./_layout.njk" %}
 
 {% block body_main_content %}
   <h2 class="page-heading">Search</h2>

--- a/src/apps/components/views/index.njk
+++ b/src/apps/components/views/index.njk
@@ -1,8 +1,4 @@
-{% extends "_layouts/datahub-base.njk" %}
-
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge">{{ title }}</h1>
-{% endblock %}
+{% extends "./_layout.njk" %}
 
 {% block body_main_content %}
   <ul>
@@ -18,6 +14,9 @@
     </li>
     <li>
       <a href="components/breadcrumbs">Breadcrumbs</a>
+    </li>
+    <li>
+      <a href="components/pagination">Pagination</a>
     </li>
   </ul>
 {% endblock %}

--- a/src/apps/components/views/messages.njk
+++ b/src/apps/components/views/messages.njk
@@ -1,12 +1,14 @@
 {% extends "./_layout.njk" %}
 
 {% block body_main_content %}
-  {% component 'messages', {
-    messages: {
-      info: ['An information message'],
-      success: ['A success message'],
-      warning: ['A warning message'],
-      error: ['An error message']
-    }
-  } %}
+  {% call Example() %}
+    {% component 'messages', {
+      messages: {
+        info: ['An information message'],
+        success: ['A success message'],
+        warning: ['A warning message'],
+        error: ['An error message']
+      }
+    } %}
+  {% endcall %}
 {% endblock %}

--- a/src/apps/components/views/messages.njk
+++ b/src/apps/components/views/messages.njk
@@ -1,11 +1,6 @@
-{% extends "_layouts/datahub-base.njk" %}
-
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge">{{ title }}</h1>
-{% endblock %}
+{% extends "./_layout.njk" %}
 
 {% block body_main_content %}
-
   {% component 'messages', {
     messages: {
       info: ['An information message'],
@@ -14,5 +9,4 @@
       error: ['An error message']
     }
   } %}
-
 {% endblock %}

--- a/src/apps/components/views/pagination.njk
+++ b/src/apps/components/views/pagination.njk
@@ -1,0 +1,49 @@
+{% extends "./_layout.njk" %}
+
+{% block body_main_content %}
+  <h3 class="heading-medium">Standard</h3>
+  {{
+    Pagination({
+      totalPages: 2,
+      currentPage: 1,
+      prev: null,
+      next: '?term=samsung&page=2',
+      pages: [
+        { label: 1, url: '?term=samsung&page=1' },
+        { label: 2, url: '?term=samsung&page=2' }
+      ]
+    })
+  }}
+
+  <h3 class="heading-medium">Showing truncation</h3>
+  {{
+    Pagination({
+      totalPages: 5,
+      currentPage: 1,
+      prev: null,
+      next: '?term=samsung&page=2',
+      pages: [
+        { label: 1, url: '?term=samsung&page=1' },
+        { label: 2, url: '?term=samsung&page=2' },
+        { label: '…' },
+        { label: 5, url: '?term=samsung&page=5' }
+      ]
+    })
+  }}
+
+  <h3 class="heading-medium">Pageless</h3>
+  {{
+    Pagination({
+      totalPages: 5,
+      currentPage: 4,
+      prev: '?term=samsung&page=3',
+      next: '?term=samsung&page=5',
+      pages: [
+        { label: 1, url: '?term=samsung&page=1' },
+        { label: '…' },
+        { label: 4, url: '?term=samsung&page=4' },
+        { label: 5, url: '?term=samsung&page=5' }
+      ]
+    }, showPages=false)
+  }}
+{% endblock %}

--- a/src/apps/components/views/pagination.njk
+++ b/src/apps/components/views/pagination.njk
@@ -1,49 +1,52 @@
 {% extends "./_layout.njk" %}
 
 {% block body_main_content %}
-  <h3 class="heading-medium">Standard</h3>
-  {{
-    Pagination({
-      totalPages: 2,
-      currentPage: 1,
-      prev: null,
-      next: '?term=samsung&page=2',
-      pages: [
-        { label: 1, url: '?term=samsung&page=1' },
-        { label: 2, url: '?term=samsung&page=2' }
-      ]
-    })
-  }}
+  {% call Example('Standard') %}
+    {{
+      Pagination({
+        totalPages: 2,
+        currentPage: 1,
+        prev: null,
+        next: '?term=samsung&page=2',
+        pages: [
+          { label: 1, url: '?term=samsung&page=1' },
+          { label: 2, url: '?term=samsung&page=2' }
+        ]
+      })
+    }}
+  {% endcall %}
 
-  <h3 class="heading-medium">Showing truncation</h3>
-  {{
-    Pagination({
-      totalPages: 5,
-      currentPage: 1,
-      prev: null,
-      next: '?term=samsung&page=2',
-      pages: [
-        { label: 1, url: '?term=samsung&page=1' },
-        { label: 2, url: '?term=samsung&page=2' },
-        { label: '…' },
-        { label: 5, url: '?term=samsung&page=5' }
-      ]
-    })
-  }}
+  {% call Example('Showing truncation') %}
+    {{
+      Pagination({
+        totalPages: 5,
+        currentPage: 1,
+        prev: null,
+        next: '?term=samsung&page=2',
+        pages: [
+          { label: 1, url: '?term=samsung&page=1' },
+          { label: 2, url: '?term=samsung&page=2' },
+          { label: '…' },
+          { label: 5, url: '?term=samsung&page=5' }
+        ]
+      })
+    }}
+  {% endcall %}
 
-  <h3 class="heading-medium">Pageless</h3>
-  {{
-    Pagination({
-      totalPages: 5,
-      currentPage: 4,
-      prev: '?term=samsung&page=3',
-      next: '?term=samsung&page=5',
-      pages: [
-        { label: 1, url: '?term=samsung&page=1' },
-        { label: '…' },
-        { label: 4, url: '?term=samsung&page=4' },
-        { label: 5, url: '?term=samsung&page=5' }
-      ]
-    }, showPages=false)
-  }}
+  {% call Example('Pageless') %}
+    {{
+      Pagination({
+        totalPages: 5,
+        currentPage: 4,
+        prev: '?term=samsung&page=3',
+        next: '?term=samsung&page=5',
+        pages: [
+          { label: 1, url: '?term=samsung&page=1' },
+          { label: '…' },
+          { label: 4, url: '?term=samsung&page=4' },
+          { label: 5, url: '?term=samsung&page=5' }
+        ]
+      }, showPages=false)
+    }}
+  {% endcall %}
 {% endblock %}

--- a/src/templates/_macros/dev.njk
+++ b/src/templates/_macros/dev.njk
@@ -1,0 +1,12 @@
+{% macro Example(title) %}
+  <article class="example" {% if title %}id="{{ title | urlencode }}"{% endif %}>
+    <header class="example__header">
+      {% if title %}
+        <h3 class="example__title">{{ title }}</h3>
+      {% endif %}
+    </header>
+    <div class="example__preview">
+      {{ caller() }}
+    </div>
+  </article>
+{% endmacro %}


### PR DESCRIPTION
Additionally refactor components page to use consistent breadcrumbs and layout.

Add Example component to contain component examples.

![image](https://user-images.githubusercontent.com/203886/28164984-b867136c-67c9-11e7-8572-3fa9c0119df3.png)
