### PR TITLE
Rename investment phase to stage (internally)

### DIFF
--- a/src/apps/companies/views/investments.njk
+++ b/src/apps/companies/views/investments.njk
@@ -24,8 +24,8 @@
             <dt class="metadata-list__term u-visually-hidden">Type of investment</dt>
             <dd class="metadata-list__value">{{ project.investment_type.name }}</dd>
 
-            <dt class="metadata-list__term u-visually-hidden">Phase</dt>
-            <dd class="metadata-list__value">{{ project.phase.name }}</dd>
+            <dt class="metadata-list__term u-visually-hidden">Stage</dt>
+            <dd class="metadata-list__value">{{ project.stage.name }}</dd>
 
             <dt class="metadata-list__term u-visually-hidden">Sector</dt>
             <dd class="metadata-list__value">{{ project.sector.name }}</dd>

--- a/src/apps/components/views/entity-list.njk
+++ b/src/apps/components/views/entity-list.njk
@@ -19,8 +19,8 @@
                 <dt class="metadata-list__term u-visually-hidden">Type of investment</dt>
                 <dd class="metadata-list__value">{{ project.investment_type.name }}</dd>
 
-                <dt class="metadata-list__term u-visually-hidden">Phase</dt>
-                <dd class="metadata-list__value">{{ project.phase.name }}</dd>
+                <dt class="metadata-list__term u-visually-hidden">Stage</dt>
+                <dd class="metadata-list__value">{{ project.stage.name }}</dd>
 
                 <dt class="metadata-list__term u-visually-hidden">Sector</dt>
                 <dd class="metadata-list__value">{{ project.sector.name }}</dd>

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -35,7 +35,7 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
     res.locals.investmentStatus = {
       id: investmentData.id,
       projectCode: investmentData.project_code,
-      phaseName: investmentData.phase.name,
+      stageName: investmentData.stage.name,
       valuation: investmentData.value_complete ? 'Project valued' : 'Not yet valued',
     }
 

--- a/src/apps/investment-projects/repos.js
+++ b/src/apps/investment-projects/repos.js
@@ -3,7 +3,7 @@ const authorisedRequest = require('../../lib/authorised-request')
 const { getInflatedDitCompany } = require('../companies/services/data')
 
 function getCompanyInvestmentProjects (token, companyId) {
-  return authorisedRequest(token, `${config.apiRoot}/v3/investment/project?investor_company_id=${companyId}`)
+  return authorisedRequest(token, `${config.apiRoot}/v3/investment?investor_company_id=${companyId}`)
 }
 
 function getInvestment (token, investmentId) {
@@ -35,7 +35,7 @@ function getEquityCompanyDetails (token, equityCompanyId) {
 
 function createInvestmentProject (token, body) {
   return authorisedRequest(token, {
-    url: `${config.apiRoot}/v3/investment/project`,
+    url: `${config.apiRoot}/v3/investment`,
     method: 'POST',
     body,
   })

--- a/src/apps/investment-projects/views/team.njk
+++ b/src/apps/investment-projects/views/team.njk
@@ -1,6 +1,6 @@
 {% extends "./_layout.njk" %}
 
-{% set phase = investmentData.phase.name %}
+{% set stage = investmentData.stage.name %}
 {% set crm = investmentData.client_relationship_manager %}
 {% set rsa = investmentData.referral_source_adviser %}
 
@@ -24,9 +24,9 @@
 
   <h2 class="heading-medium">Project management</h2>
 
-  {% if phase == 'Prospect' %}
+  {% if stage == 'Prospect' %}
     <p class="infostrip">Will be assigned during "Assign PM" stage.</p>
-  {% elif phase == 'Assign PM' %}
+  {% elif stage == 'Assign PM' %}
     <p class="infostrip">Once both a Project Manager and a Project Assurance have been assigned, the project will move to "Active" stage.</p>
 
     <p><a href="" class="button">Assign</a></p>

--- a/src/apps/search/views/results-investment_project.njk
+++ b/src/apps/search/views/results-investment_project.njk
@@ -17,8 +17,8 @@
           <dt class="metadata-list__term u-visually-hidden">Type of investment</dt>
           <dd class="metadata-list__value">{{ project.investment_type.name }}</dd>
 
-          <dt class="metadata-list__term u-visually-hidden">Phase</dt>
-          <dd class="metadata-list__value">{{ project.phase.name }}</dd>
+          <dt class="metadata-list__term u-visually-hidden">Stage</dt>
+          <dd class="metadata-list__value">{{ project.stage.name }}</dd>
 
           <dt class="metadata-list__term u-visually-hidden">Sector</dt>
           <dd class="metadata-list__value">{{ project.sector.name }}</dd>

--- a/src/templates/_components/investment-status.njk
+++ b/src/templates/_components/investment-status.njk
@@ -1,7 +1,7 @@
 {##
  # @param {string} projectCode Project code
  #
- # @param {string} [phaseName] Name of project phase
+ # @param {string} [stageName] Name of project stage
  # @param {string} [valuation] Valuation status
  #
  # @return {string} HTML for project status
@@ -9,7 +9,7 @@
  # @example
  #   {% component 'investment-status', {
  #     projectCode: 'DHP-0000001
- #     phaseName: 'Prospect'
+ #     stageName: 'Prospect'
  #   } %}
  #}
 
@@ -21,12 +21,12 @@
         {{ projectCode }}
       </dd>
     </dl>
-    {% if phaseName or valuation %}
+    {% if stageName or valuation %}
       <dl class="status-bar__section column-one-quarter">
-        {% if phaseName %}
-          <dt>Phase</dt>
+        {% if stageName %}
+          <dt>Stage</dt>
           <dd class="status-bar__section-title">
-            {{ phaseName }} stage
+            {{ stageName }} stage
           </dd>
         {% endif %}
         {% if valuation %}

--- a/test/unit/apps/investment-projects/repos.test.js
+++ b/test/unit/apps/investment-projects/repos.test.js
@@ -17,7 +17,7 @@ const investmentProjectAuditData = require('~/test/unit/data/investment/audit-lo
 describe('Investment repository', () => {
   describe('#getCompanyInvestmentProjects', () => {
     nock(config.apiRoot)
-      .get(`/v3/investment/project?investor_company_id=${companyData.id}`)
+      .get(`/v3/investment?investor_company_id=${companyData.id}`)
       .reply(200, companyData)
 
     it('should return a company object', () => {
@@ -41,7 +41,7 @@ describe('Investment repository', () => {
 
   describe('#createInvestmentProject', () => {
     nock(config.apiRoot)
-      .post(`/v3/investment/project`)
+      .post(`/v3/investment`)
       .reply(200, { id: '12345' })
 
     it('should return an investment requirements object', () => {

--- a/test/unit/components/investment-status.test.js
+++ b/test/unit/components/investment-status.test.js
@@ -7,7 +7,7 @@ describe('Investment status component', () => {
       {
         id: 'project id',
         name: 'Project name',
-        phaseName: 'Initial',
+        stageName: 'Initial',
       }
     )
 
@@ -21,7 +21,7 @@ describe('Investment status component', () => {
         id: 'project id',
         name: 'Project name',
         projectCode: 'PROJECT-CODE',
-        phaseName: 'Initial',
+        stageName: 'Initial',
       }
     )
 
@@ -31,7 +31,7 @@ describe('Investment status component', () => {
     expect(sectionTitles[1].textContent).to.contain('Initial stage')
   })
 
-  it('should render one section title when phaseName is not given', () => {
+  it('should render one section title when stageName is not given', () => {
     const component = renderComponentToDom(
       'investment-status',
       {

--- a/test/unit/data/investment/interaction/interaction.json
+++ b/test/unit/data/investment/interaction/interaction.json
@@ -162,7 +162,7 @@
       "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b",
       "name": "FDI"
     },
-    "phase": {
+    "stage": {
       "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced",
       "name": "Prospect",
       "order": 200

--- a/test/unit/data/investment/interaction/interactions.json
+++ b/test/unit/data/investment/interaction/interactions.json
@@ -167,7 +167,7 @@
           "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b",
           "name": "FDI"
         },
-        "phase": {
+        "stage": {
           "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced",
           "name": "Prospect",
           "order": 200

--- a/test/unit/data/investment/investment-data.json
+++ b/test/unit/data/investment/investment-data.json
@@ -18,7 +18,7 @@
     "name": "Commitment to invest",
     "id": "031269ab-b7ec-40e9-8a4e-7371404f0622"
   },
-  "phase": {
+  "stage": {
     "name": "Prospect",
     "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced"
   },

--- a/test/unit/data/search/investment.json
+++ b/test/unit/data/search/investment.json
@@ -26,7 +26,7 @@
           "id": "031269ab-b7ec-40e9-8a4e-7371404f0622",
           "name": "Commitment to invest"
       },
-      "phase": {
+      "stage": {
           "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced",
           "name": "Prospect"
       },
@@ -109,7 +109,7 @@
           "id": "031269ab-b7ec-40e9-8a4e-7371404f0622",
           "name": "Commitment to invest"
       },
-      "phase": {
+      "stage": {
           "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced",
           "name": "Prospect"
       },


### PR DESCRIPTION
Phase for investment projects is being renamed in the API to stage to use one term consistently. This changes references in this repo to use stage.

Stage is already present in the API.