### PR TITLE
Tweak layout and header appearance

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -3,6 +3,7 @@
 @import "components/data-table";
 @import "components/details-list";
 @import "components/form";
+@import "components/local-header";
 @import "components/local-nav";
 @import "components/messages";
 @import "components/metadata-list";

--- a/assets/stylesheets/_deprecated/_dashboard.scss
+++ b/assets/stylesheets/_deprecated/_dashboard.scss
@@ -1,13 +1,8 @@
 @import "../tools/mixins/typography";
 
 .dashboard-section {
-
   border-top: 5px solid $black;
   @include core-font(16);
-
-  &:first-child {
-    margin-top: 1.5em;
-  }
 
   .dashboard-section-title {
     @include bold-font(24);

--- a/assets/stylesheets/_deprecated/_errors.scss
+++ b/assets/stylesheets/_deprecated/_errors.scss
@@ -3,6 +3,7 @@
 
 .stack-trace {
   margin-bottom: $gutter;
+  max-width: 100%;
 }
 
 .stack-trace__heading {

--- a/assets/stylesheets/_deprecated/components/_backlink.scss
+++ b/assets/stylesheets/_deprecated/components/_backlink.scss
@@ -1,8 +1,10 @@
+@import "../../settings";
+
 .back-link {
   display: inline-block;
   padding-left: 20px;
   position: relative;
-  margin: 20px 0 0;
+  margin-bottom: $default-spacing-unit / 2;
 
   &::before {
     content: "<";

--- a/assets/stylesheets/_deprecated/components/_headings.scss
+++ b/assets/stylesheets/_deprecated/components/_headings.scss
@@ -1,4 +1,3 @@
 .page-heading {
   @extend .heading-large;
-  margin: 30px 0;
 }

--- a/assets/stylesheets/components/_.example.scss
+++ b/assets/stylesheets/components/_.example.scss
@@ -1,4 +1,5 @@
 @import "../settings";
+@import "../tools";
 
 * + .example {
   margin-top: $default-spacing-unit * 2;
@@ -34,4 +35,11 @@
   background-color: $white;
   border: 2px solid $grey-2;
   padding: $default-spacing-unit;
+}
+
+.example--wide .example__preview {
+  @include media($min-width: $site-width + $default-spacing-unit * 4) {
+    margin-left: -$default-spacing-unit * 2;
+    margin-right: -$default-spacing-unit * 2;
+  }
 }

--- a/assets/stylesheets/components/_breadcrumb.scss
+++ b/assets/stylesheets/components/_breadcrumb.scss
@@ -2,11 +2,7 @@
 @import "../settings/layout";
 @import "../tools/mixins";
 
-.c-breadcrumb {
-  margin-top: $default-spacing-unit / 2;
-}
-
-.c-breadcrumb__item {
+.c-breadcrumb__list-item {
   @include core-font(16);
   background: url("../../images/separator.png") left center no-repeat;
   background-size: 6px 11px;

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -1,0 +1,79 @@
+@import "../tools/mixins";
+
+.c-local-header {
+  padding-top: $default-spacing-unit * 4;
+  position: relative;
+
+  &[class*="c-local-header--"] {
+    padding-bottom: $default-spacing-unit * 2;
+  }
+
+  .c-breadcrumb {
+    position: absolute;
+    top: $default-spacing-unit;
+  }
+
+  .c-messages {
+    margin-top: -$default-spacing-unit * 2;
+    margin-bottom: $default-spacing-unit * 2;
+  }
+
+  .status-bar {
+    margin-top: $default-spacing-unit * 2;
+    margin-bottom: -$default-spacing-unit;
+  }
+
+  .c-entity-search__aggregations {
+    margin-bottom: -$default-spacing-unit * 2;
+  }
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    border-top: 10px solid $govuk-blue;
+    max-width: 100%;
+    width: $site-width;
+    margin: 0 auto;
+
+    @include media($max-width: $site-width) {
+      width: auto;
+      left: $default-spacing-unit;
+      right: $default-spacing-unit;
+    }
+  }
+}
+
+.c-local-header__heading-before {
+  @include core-font(20);
+  color: $grey-1;
+}
+
+.c-local-header__heading {
+  @include bold-font(36);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+* + .c-local-header__heading-after {
+  margin-top: $default-spacing-unit / 2;
+  margin-bottom: 0;
+}
+
+.c-local-header--light-banner {
+  background-color: $grey-4;
+}
+
+.c-local-header--dark-banner {
+  background-color: $grey-3;
+
+  &.c-local-header--keyline {
+    border-bottom: 1px solid $grey-2;
+  }
+}
+
+.c-local-header--keyline {
+  border-bottom: 1px solid $grey-3;
+}

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -26,24 +26,6 @@
   .c-entity-search__aggregations {
     margin-bottom: -$default-spacing-unit * 2;
   }
-
-  &::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    border-top: 10px solid $govuk-blue;
-    max-width: 100%;
-    width: $site-width;
-    margin: 0 auto;
-
-    @include media($max-width: $site-width) {
-      width: auto;
-      left: $default-spacing-unit;
-      right: $default-spacing-unit;
-    }
-  }
 }
 
 .c-local-header__heading-before {

--- a/assets/stylesheets/components/_local-nav.scss
+++ b/assets/stylesheets/components/_local-nav.scss
@@ -27,7 +27,6 @@
 
   &:hover,
   &:focus {
-    background-color: $grey-4;
     color: $text-colour;
     background-color: $grey-4;
   }

--- a/assets/stylesheets/components/_local-nav.scss
+++ b/assets/stylesheets/components/_local-nav.scss
@@ -3,7 +3,7 @@
 @import "../tools/mixins/layout";
 @import "../tools/mixins/typography";
 
-.local-nav {
+.c-local-nav {
   @include core-font(20);
   margin-left: -($gutter / 2);
   margin-right: -($gutter / 2);
@@ -15,7 +15,7 @@
   }
 }
 
-.local-nav__link {
+.c-local-nav__link {
   display: block;
   padding: ($default-spacing-unit / 2) $default-spacing-unit;
 
@@ -39,7 +39,7 @@
   }
 }
 
-.local-nav--background .is-active {
+.c-local-nav--background .is-active {
   background-color: $grey-1;
 }
 

--- a/assets/stylesheets/components/_local-nav.scss
+++ b/assets/stylesheets/components/_local-nav.scss
@@ -9,7 +9,6 @@
   margin-right: -($gutter / 2);
 
   @include media(tablet) {
-    border-right: 1px solid $grey-2;
     padding-right: 0;
     margin-left: 0;
     margin-right: 0;
@@ -18,16 +17,19 @@
 
 .local-nav__link {
   display: block;
-  padding: ($gutter / 2);
+  padding: ($default-spacing-unit / 2) $default-spacing-unit;
 
-  &,
+  &:link,
   &:visited {
-    color: $black;
+    color: $link-colour;
+    text-decoration: none;
   }
 
-  @include media(tablet) {
-    padding-left:  (($gutter / 3) * 2);
-    padding-right:  (($gutter / 3) * 2);
+  &:hover,
+  &:focus {
+    background-color: $grey-4;
+    color: $text-colour;
+    background-color: $grey-4;
   }
 
   &.is-active {

--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -1,3 +1,5 @@
+@import "../settings";
+
 .c-messages {
   // TODO: remove in favour of assemblies that handle consistent spacing
   // between elements
@@ -13,6 +15,7 @@
   border: 5px solid;
   padding: $default-spacing-unit 90px $default-spacing-unit $default-spacing-unit;
   position: relative;
+  background-color: $white;
 
   + * {
     margin-top: $default-spacing-unit;

--- a/assets/stylesheets/components/_proposition-menu.scss
+++ b/assets/stylesheets/components/_proposition-menu.scss
@@ -44,10 +44,6 @@
     color: inherit;
   }
 
-  &:focus {
-    color: $black;
-  }
-
   &:hover {
     text-decoration: underline;
   }

--- a/assets/stylesheets/components/_proposition-menu.scss
+++ b/assets/stylesheets/components/_proposition-menu.scss
@@ -1,8 +1,5 @@
-@import "../settings/colours";
-@import "../settings/layout";
-@import "../tools/mixins/addons";
-@import "../tools/mixins/conditionals";
-@import "../tools/mixins/layout";
+@import "../settings";
+@import "../tools";
 
 .proposition-menu {
   @include bold-font(14);
@@ -34,8 +31,12 @@
 .proposition-menu__link {
   color: inherit;
   display: block;
-  padding: $baseline-grid-unit;
+  padding: ($default-spacing-unit / 2) 0;
   text-decoration: none;
+
+  @include media(tablet) {
+    padding: 0;
+  }
 
   &:active,
   &:visited,
@@ -49,10 +50,6 @@
 
   &:hover {
     text-decoration: underline;
-  }
-
-  @include media(tablet) {
-    padding: 0;
   }
 
   &.is-active {

--- a/assets/stylesheets/components/_status-bar.scss
+++ b/assets/stylesheets/components/_status-bar.scss
@@ -3,8 +3,6 @@
 @import "../tools/mixins";
 
 .status-bar {
-  margin-top: 30px;
-  margin-bottom: 30px;
   position: relative;
 
   &::before {

--- a/assets/stylesheets/components/form/_entity-search.scss
+++ b/assets/stylesheets/components/form/_entity-search.scss
@@ -22,9 +22,6 @@ $search-button-width: 50px;
 }
 
 .c-entity-search--global {
-  background-color: $grey-3;
-  padding: $default-spacing-unit;
-
   .c-form-group {
     font-size: 1.1em;
     max-width: none;
@@ -33,7 +30,6 @@ $search-button-width: 50px;
 
 .c-entity-search__aggregations {
   margin-top: $default-spacing-unit;
-  margin-bottom: -$default-spacing-unit;
 }
 
 .c-entity-search__aggregations-item {

--- a/assets/stylesheets/elements/_base.scss
+++ b/assets/stylesheets/elements/_base.scss
@@ -16,6 +16,7 @@ body {
 a {
   color: $link-colour;
   text-decoration-skip: ink;
+  outline-color: transparent;
 
   &:hover {
     color: $link-hover-colour;
@@ -28,18 +29,24 @@ a {
   &:active {
     color: $link-active-colour;
   }
-
-  &:focus {
-    background-color: $focus-colour;
-    outline: 3px solid $focus-colour;
-    text-decoration: none;
-  }
 }
 
+a,
 input,
 textarea {
-  &:focus {
-    outline: 3px solid $focus-colour;
+  outline: 3px solid transparent;
+
+  &:focus,
+  &:focus + label::before {
+    transition: box-shadow .1s, outline-color .1s .1s;
+    box-shadow: 0 0 0 3px $focus-colour;
+    outline-color: $focus-colour;
+    text-decoration: none;
     outline-offset: 0;
   }
 }
+
+input:focus + label::before {
+  outline: none;
+}
+

--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -8,9 +8,7 @@
   .c-form-group,
   .c-form-fieldset,
   .c-error-summary,
-  .c-entity-search,
-  .results-summary,
-  .c-entity-search {
+  .results-summary {
     margin-top: $default-spacing-unit * 2;
   }
 

--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -1,6 +1,7 @@
 @import "../settings";
+@import "../tools/mixins/layout";
 
-// Form assemblies
+// View assemblies
 // Define how components stack in views
 
 * + {
@@ -8,7 +9,8 @@
   .c-form-fieldset,
   .c-error-summary,
   .c-entity-search,
-  .results-summary {
+  .results-summary,
+  .c-entity-search {
     margin-top: $default-spacing-unit * 2;
   }
 

--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -25,3 +25,7 @@
     margin-bottom: $default-spacing-unit;
   }
 }
+
+[type="hidden"] + .c-form-group {
+  margin-top: 0;
+}

--- a/assets/stylesheets/objects/base/_global-header.scss
+++ b/assets/stylesheets/objects/base/_global-header.scss
@@ -51,10 +51,6 @@
   &:focus {
     color: inherit;
   }
-
-  &:focus {
-    background: transparent;
-  }
 }
 
 .global-header__logo {

--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -1,9 +1,29 @@
 @import "../../settings";
 
 .main-content {
+  position: relative;
   background-color: $white;
   min-height: 60vh;
   flex-grow: 1;
+
+  &::before {
+    content: "";
+    position: absolute;
+    z-index: 10;
+    top: 0;
+    right: 0;
+    left: 0;
+    border-top: 10px solid $govuk-blue;
+    max-width: 100%;
+    width: $site-width;
+    margin: 0 auto;
+
+    @include media($max-width: $site-width) {
+      width: auto;
+      left: $default-spacing-unit;
+      right: $default-spacing-unit;
+    }
+  }
 }
 
 .main-content__inner {

--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -9,35 +9,6 @@
   flex-grow: 1;
 }
 
-.main-content__header {
-  padding-top: $default-spacing-unit * 4;
-  padding-bottom: $default-spacing-unit * 2;
-  background-color: $grey-3;
-
-  .c-breadcrumb,
-  .c-messages {
-    margin-top: -$default-spacing-unit * 3;
-    margin-bottom: $default-spacing-unit * 2;
-  }
-
-  .status-bar {
-    margin-top: $default-spacing-unit * 2;
-    margin-bottom: -$default-spacing-unit;
-  }
-
-  .c-entity-search__aggregations {
-    margin-bottom: -$default-spacing-unit * 2;
-  }
-
-  h1,
-  h2,
-  p,
-  .page-heading {
-    margin-top: $default-spacing-unit / 2;
-    margin-bottom: 0;
-  }
-}
-
 .main-content__inner {
   padding-top: $default-spacing-unit * 2;
   padding-bottom: $default-spacing-unit * 4;

--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -1,7 +1,4 @@
-@import "../../settings/colours";
-@import "../../settings/typography";
-@import "../../tools/mixins/conditionals";
-@import "../../tools/mixins/layout";
+@import "../../settings";
 
 .main-content {
   background-color: $white;

--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -9,16 +9,36 @@
   flex-grow: 1;
 }
 
-.main-content__inner {
-  @include site-width-container;
-  border-top: 10px solid $govuk-blue;
+.main-content__header {
+  padding-top: $default-spacing-unit * 4;
   padding-bottom: $default-spacing-unit * 2;
+  background-color: $grey-3;
 
-  @include media(desktop) {
-    padding-bottom: $default-spacing-unit * 4;
+  .c-breadcrumb,
+  .c-messages {
+    margin-top: -$default-spacing-unit * 3;
+    margin-bottom: $default-spacing-unit * 2;
+  }
+
+  .status-bar {
+    margin-top: $default-spacing-unit * 2;
+    margin-bottom: -$default-spacing-unit;
+  }
+
+  .c-entity-search__aggregations {
+    margin-bottom: -$default-spacing-unit * 2;
+  }
+
+  h1,
+  h2,
+  p,
+  .page-heading {
+    margin-top: $default-spacing-unit / 2;
+    margin-bottom: 0;
   }
 }
 
-.main-content__header {
-  margin: 30px 0;
+.main-content__inner {
+  padding-top: $default-spacing-unit * 2;
+  padding-bottom: $default-spacing-unit * 4;
 }

--- a/assets/stylesheets/objects/base/_skip-links.scss
+++ b/assets/stylesheets/objects/base/_skip-links.scss
@@ -18,8 +18,7 @@
   position: absolute;
 
   &:focus {
-    background-color: $light-blue-25;
-    border: 3px solid $yellow;
+    margin: 3px 0;
     color: $black;
     outline: 0;
     position: static;

--- a/assets/stylesheets/trumps/_layout.scss
+++ b/assets/stylesheets/trumps/_layout.scss
@@ -1,6 +1,6 @@
 @import "../tools/mixins/layout";
 
-.container {
+.l-container {
   margin-left: auto;
   margin-right: auto;
   padding-left: $default-spacing-unit;

--- a/assets/stylesheets/trumps/_layout.scss
+++ b/assets/stylesheets/trumps/_layout.scss
@@ -7,7 +7,7 @@
   padding-right: $default-spacing-unit;
   max-width: $site-width;
 
-  @include media(tablet) {
+  @include media($min-width: $site-width) {
     padding-left: 0;
     padding-right: 0;
   }

--- a/assets/stylesheets/trumps/_layout.scss
+++ b/assets/stylesheets/trumps/_layout.scss
@@ -1,5 +1,18 @@
 @import "../tools/mixins/layout";
 
+.container {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: $default-spacing-unit;
+  padding-right: $default-spacing-unit;
+  max-width: $site-width;
+
+  @include media(tablet) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
 .column-two-quarters,
 .column-three-quarters {
   > h1,

--- a/src/apps/auth/views/sign-in.njk
+++ b/src/apps/auth/views/sign-in.njk
@@ -1,5 +1,9 @@
 {% extends "_layouts/datahub-base.njk" %}
 
+{% block local_header %}
+  {{ LocalHeader({ pageHeading: 'Sign in', messages: messages }) }}
+{% endblock %}
+
 {% block body_main_content %}
   {% call Form(form | assign({ buttonText: 'Sign in' })) %}
     {{ TextField({

--- a/src/apps/auth/views/sign-in.njk
+++ b/src/apps/auth/views/sign-in.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/datahub-base.njk" %}
 
 {% block local_header %}
-  {{ LocalHeader({ pageHeading: 'Sign in', messages: messages }) }}
+  {{ LocalHeader({ heading: 'Sign in', messages: messages }) }}
 {% endblock %}
 
 {% block body_main_content %}

--- a/src/apps/auth/views/sign-in.njk
+++ b/src/apps/auth/views/sign-in.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/datahub-base.njk" %}
 
 {% block local_header %}
-  {{ LocalHeader({ heading: 'Sign in', messages: messages }) }}
+  {{ LocalHeader({ heading: 'Sign in' }) }}
 {% endblock %}
 
 {% block body_main_content %}

--- a/src/apps/auth/views/sign-in.njk
+++ b/src/apps/auth/views/sign-in.njk
@@ -1,9 +1,5 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  <h2 class="heading-xlarge">Sign in</h2>
-{% endblock %}
-
 {% block body_main_content %}
   {% call Form(form | assign({ buttonText: 'Sign in' })) %}
     {{ TextField({

--- a/src/apps/companies/views/_layout-edit.njk
+++ b/src/apps/companies/views/_layout-edit.njk
@@ -3,7 +3,7 @@
 {% block local_header %}
   {{
     LocalHeader({
-      pageHeading: 'Edit company' if formData.id else 'Add company',
+      heading: 'Edit company' if formData.id else 'Add company',
       breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })

--- a/src/apps/companies/views/_layout-edit.njk
+++ b/src/apps/companies/views/_layout-edit.njk
@@ -1,11 +1,11 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="page-heading">
-    {% if formData.id %}
-      Edit company
-    {% else %}
-      Add company
-    {% endif %}
-  </h1>
+{% block local_header %}
+  {{
+    LocalHeader({
+      pageHeading: 'Edit company' if formData.id else 'Add company',
+      breadcrumbs: BREADCRUMBS,
+      modifier: 'light-banner'
+    })
+  }}
 {% endblock %}

--- a/src/apps/companies/views/_layout-edit.njk
+++ b/src/apps/companies/views/_layout-edit.njk
@@ -4,7 +4,6 @@
   {{
     LocalHeader({
       heading: 'Edit company' if formData.id else 'Add company',
-      breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })
   }}

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -1,19 +1,24 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="u-visually-hidden">Company Details</h1>
-  <h2 class="page-heading">{{ headingName }}</h2>
-  <p>{{ headingAddress }}</p>
-
-  {% if company.archived %}
-    <p class="infostrip">
-      This company was archived on {{company.archived_on | formatDate}} by {{company.archived_by.first_name}} {{company.archived_by.last_name}}. <br>
-      <strong>Reason:</strong> {{company.archived_reason}}<br>
-      <br>
-      <a href="/companies/unarchive/{{company.id}}">Unarchive</a>
-    </p>
-  {% endif %}
+{% block local_header %}
+  {% call LocalHeader({
+      pageHeading: headingName,
+      breadcrumbs: BREADCRUMBS,
+      modifier: 'light-banner'
+    })
+  %}
+    <p class="c-local-header__heading-after">{{ headingAddress }}</p>
+    {% if company.archived %}
+      <p class="infostrip">
+        This company was archived on {{company.archived_on | formatDate}} by {{company.archived_by.first_name}} {{company.archived_by.last_name}}. <br>
+        <strong>Reason:</strong> {{company.archived_reason}}<br>
+        <br>
+        <a href="/companies/unarchive/{{company.id}}">Unarchive</a>
+      </p>
+    {% endif %}
+  {% endcall %}
 {% endblock %}
+
 
 {% block main_grid_left_column %}
   <nav class="local-nav">

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -20,15 +20,15 @@
 
 
 {% block main_grid_left_column %}
-  <nav class="local-nav">
-    <a class="local-nav__link {% if tab == 'details' %}is-active{% endif %}" href="{{companyUrl}}">Company details</a>
+  <nav class="c-local-nav">
+    <a class="c-local-nav__link {% if tab == 'details' %}is-active{% endif %}" href="{{companyUrl}}">Company details</a>
     {% if company.id %}
-      {# <a class="local-nav__link {% if tab == 'hierarchy' %}is-active{% endif %}" href="">Company hierarchy</a> #}
-      <a class="local-nav__link {% if tab == 'contacts' %}is-active{% endif %}" href="/companies/{{company.id}}/contacts">Contacts</a>
-      <a class="local-nav__link {% if tab == 'interactions' %}is-active{% endif %}" href="/companies/{{company.id}}/interactions">Interactions</a>
-      {# <a class="local-nav__link {% if tab == 'documents' %}is-active{% endif %}" href="">Documents</a> #}
-      <a class="local-nav__link {% if tab == 'exports' %}is-active{% endif %}" href="/companies/{{company.id}}/exports">Exports</a>
-      <a class="local-nav__link {% if tab == 'investments' %}is-active{% endif %}" href="/companies/{{ company.id }}/investments">Investments</a>
+      {# <a class="c-local-nav__link {% if tab == 'hierarchy' %}is-active{% endif %}" href="">Company hierarchy</a> #}
+      <a class="c-local-nav__link {% if tab == 'contacts' %}is-active{% endif %}" href="/companies/{{company.id}}/contacts">Contacts</a>
+      <a class="c-local-nav__link {% if tab == 'interactions' %}is-active{% endif %}" href="/companies/{{company.id}}/interactions">Interactions</a>
+      {# <a class="c-local-nav__link {% if tab == 'documents' %}is-active{% endif %}" href="">Documents</a> #}
+      <a class="c-local-nav__link {% if tab == 'exports' %}is-active{% endif %}" href="/companies/{{company.id}}/exports">Exports</a>
+      <a class="c-local-nav__link {% if tab == 'investments' %}is-active{% endif %}" href="/companies/{{ company.id }}/investments">Investments</a>
     {% endif %}
   </nav>
 {% endblock %}

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -2,7 +2,7 @@
 
 {% block local_header %}
   {% call LocalHeader({
-      pageHeading: headingName,
+      heading: headingName,
       breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -3,7 +3,6 @@
 {% block local_header %}
   {% call LocalHeader({
       heading: headingName,
-      breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })
   %}

--- a/src/apps/companies/views/add-step-1.njk
+++ b/src/apps/companies/views/add-step-1.njk
@@ -1,9 +1,5 @@
 {% extends "./_layout-edit.njk" %}
 
-{% block main_heading %}
-  <h1 class="page-heading">Add company</h1>
-{% endblock %}
-
 {% block main_grid_right_column %}
   {% call Form({ buttonText: 'Continue', errors: errors }) %}
     {{ MultipleChoiceField({

--- a/src/apps/companies/views/add-step-2.njk
+++ b/src/apps/companies/views/add-step-2.njk
@@ -1,9 +1,5 @@
 {% extends "./_layout-edit.njk" %}
 
-{% block main_heading %}
-  <h1 class="page-heading">Add company</h1>
-{% endblock %}
-
 {% block main_grid_right_column %}
   <div class="key-value key-value--vertical">
     <div id="business-type" class="key-value__key form-label-bold">Business type

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -56,6 +56,12 @@ function renderBreadcrumbs (req, res) {
     .render('components/views/breadcrumbs')
 }
 
+function renderLocalHeader (req, res) {
+  return res
+    .breadcrumb('Local header')
+    .render('components/views/local-header')
+}
+
 function renderPagination (req, res) {
   return res
     .breadcrumb('Pagination')
@@ -77,6 +83,7 @@ module.exports = {
   renderFormElements,
   renderIndex,
   renderMessages,
+  renderLocalHeader,
   renderBreadcrumbs,
   renderPagination,
 }

--- a/src/apps/components/router.js
+++ b/src/apps/components/router.js
@@ -6,6 +6,7 @@ const {
   renderFormElements,
   renderIndex,
   renderMessages,
+  renderLocalHeader,
   renderBreadcrumbs,
   renderPagination,
 } = require('./controllers')
@@ -15,6 +16,7 @@ router
   .get('/breadcrumbs', renderBreadcrumbs)
   .get('/messages', renderMessages)
   .get('/entity-list', renderEntityList)
+  .get('/local-header', renderLocalHeader)
   .get('/pagination', renderPagination)
   .get('/form', handleEntitySearch, renderFormElements)
   .post('/form', handleFormPost, renderFormElements)

--- a/src/apps/components/views/_layout.njk
+++ b/src/apps/components/views/_layout.njk
@@ -1,11 +1,3 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% set heading = title or getPageTitle()[0] %}
-
 {% from "_macros/dev.njk" import Example %}
-
-{% if heading %}
-  {% block body_main_header_content %}
-    <h1 class="heading-xlarge">{{ heading }}</h1>
-  {% endblock %}
-{% endif %}

--- a/src/apps/components/views/index.njk
+++ b/src/apps/components/views/index.njk
@@ -18,5 +18,8 @@
     <li>
       <a href="components/pagination">Pagination</a>
     </li>
+    <li>
+      <a href="components/local-header">Local header</a>
+    </li>
   </ul>
 {% endblock %}

--- a/src/apps/components/views/local-header.njk
+++ b/src/apps/components/views/local-header.njk
@@ -4,8 +4,8 @@
   {% call Example('Standard', true) %}
     {{
       LocalHeader({
-        pageHeadingBefore: '<strong>Strong text before <a href="#">with a link</a></strong>',
-        pageHeading: 'Standard header',
+        headingBefore: '<strong>Strong text before <a href="#">with a link</a></strong>',
+        heading: 'Standard header',
         breadcrumbs: BREADCRUMBS
       })
     }}
@@ -14,7 +14,7 @@
   {% call Example('Light banner', true) %}
     {{
       LocalHeader({
-        pageHeading: 'Light banner',
+        heading: 'Light banner',
         breadcrumbs: BREADCRUMBS,
         modifier: 'light-banner'
       })
@@ -24,8 +24,8 @@
   {% call Example('Light banner + keyline', true) %}
     {{
       LocalHeader({
-        pageHeadingBefore: '<em>Emphasied text before</em>',
-        pageHeading: 'Light banner with keyline',
+        headingBefore: '<em>Emphasied text before</em>',
+        heading: 'Light banner with keyline',
         breadcrumbs: BREADCRUMBS,
         modifier: ['light-banner', 'keyline']
       })
@@ -35,8 +35,8 @@
   {% call Example('Dark banner', true) %}
     {{
       LocalHeader({
-        pageHeadingBefore: 'Raw text before',
-        pageHeading: 'Dark banner',
+        headingBefore: 'Raw text before',
+        heading: 'Dark banner',
         breadcrumbs: BREADCRUMBS,
         modifier: 'dark-banner'
       })
@@ -46,8 +46,8 @@
   {% call Example('Dark banner + keyline', true) %}
     {{
       LocalHeader({
-        pageHeadingBefore: '<strong>Strong text before</strong>',
-        pageHeading: 'Dark banner with keyline',
+        headingBefore: '<strong>Strong text before</strong>',
+        heading: 'Dark banner with keyline',
         breadcrumbs: BREADCRUMBS,
         modifier: ['dark-banner', 'keyline']
       })

--- a/src/apps/components/views/local-header.njk
+++ b/src/apps/components/views/local-header.njk
@@ -1,0 +1,56 @@
+{% extends "./_layout.njk" %}
+
+{% block body_main_content %}
+  {% call Example('Standard') %}
+    {{
+      LocalHeader({
+        pageHeadingBefore: '<strong>Strong text before <a href="#">with a link</a></strong>',
+        pageHeading: 'Standard header',
+        breadcrumbs: BREADCRUMBS
+      })
+    }}
+  {% endcall %}
+
+  {% call Example('Light banner') %}
+    {{
+      LocalHeader({
+        pageHeading: 'Light banner',
+        breadcrumbs: BREADCRUMBS,
+        modifier: 'light-banner'
+      })
+    }}
+  {% endcall %}
+
+  {% call Example('Light banner + keyline') %}
+    {{
+      LocalHeader({
+        pageHeadingBefore: '<em>Emphasied text before</em>',
+        pageHeading: 'Light banner with keyline',
+        breadcrumbs: BREADCRUMBS,
+        modifier: ['light-banner', 'keyline']
+      })
+    }}
+  {% endcall %}
+
+  {% call Example('Dark banner') %}
+    {{
+      LocalHeader({
+        pageHeadingBefore: 'Raw text before',
+        pageHeading: 'Dark banner',
+        breadcrumbs: BREADCRUMBS,
+        modifier: 'dark-banner'
+      })
+    }}
+  {% endcall %}
+
+  {% call Example('Dark banner + keyline') %}
+    {{
+      LocalHeader({
+        pageHeadingBefore: '<strong>Strong text before</strong>',
+        pageHeading: 'Dark banner with keyline',
+        breadcrumbs: BREADCRUMBS,
+        modifier: ['dark-banner', 'keyline']
+      })
+    }}
+  {% endcall %}
+{% endblock %}

--- a/src/apps/components/views/local-header.njk
+++ b/src/apps/components/views/local-header.njk
@@ -1,7 +1,7 @@
 {% extends "./_layout.njk" %}
 
 {% block body_main_content %}
-  {% call Example('Standard') %}
+  {% call Example('Standard', true) %}
     {{
       LocalHeader({
         pageHeadingBefore: '<strong>Strong text before <a href="#">with a link</a></strong>',
@@ -11,7 +11,7 @@
     }}
   {% endcall %}
 
-  {% call Example('Light banner') %}
+  {% call Example('Light banner', true) %}
     {{
       LocalHeader({
         pageHeading: 'Light banner',
@@ -21,7 +21,7 @@
     }}
   {% endcall %}
 
-  {% call Example('Light banner + keyline') %}
+  {% call Example('Light banner + keyline', true) %}
     {{
       LocalHeader({
         pageHeadingBefore: '<em>Emphasied text before</em>',
@@ -32,7 +32,7 @@
     }}
   {% endcall %}
 
-  {% call Example('Dark banner') %}
+  {% call Example('Dark banner', true) %}
     {{
       LocalHeader({
         pageHeadingBefore: 'Raw text before',
@@ -43,7 +43,7 @@
     }}
   {% endcall %}
 
-  {% call Example('Dark banner + keyline') %}
+  {% call Example('Dark banner + keyline', true) %}
     {{
       LocalHeader({
         pageHeadingBefore: '<strong>Strong text before</strong>',

--- a/src/apps/components/views/local-header.njk
+++ b/src/apps/components/views/local-header.njk
@@ -5,8 +5,7 @@
     {{
       LocalHeader({
         headingBefore: '<strong>Strong text before <a href="#">with a link</a></strong>',
-        heading: 'Standard header',
-        breadcrumbs: BREADCRUMBS
+        heading: 'Standard header'
       })
     }}
   {% endcall %}
@@ -15,7 +14,6 @@
     {{
       LocalHeader({
         heading: 'Light banner',
-        breadcrumbs: BREADCRUMBS,
         modifier: 'light-banner'
       })
     }}
@@ -26,7 +24,6 @@
       LocalHeader({
         headingBefore: '<em>Emphasied text before</em>',
         heading: 'Light banner with keyline',
-        breadcrumbs: BREADCRUMBS,
         modifier: ['light-banner', 'keyline']
       })
     }}
@@ -37,7 +34,6 @@
       LocalHeader({
         headingBefore: 'Raw text before',
         heading: 'Dark banner',
-        breadcrumbs: BREADCRUMBS,
         modifier: 'dark-banner'
       })
     }}
@@ -48,7 +44,6 @@
       LocalHeader({
         headingBefore: '<strong>Strong text before</strong>',
         heading: 'Dark banner with keyline',
-        breadcrumbs: BREADCRUMBS,
         modifier: ['dark-banner', 'keyline']
       })
     }}

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -10,6 +10,10 @@ const reasonForArchiveOptions = [
   'Contact changed role/responsibility',
 ]
 
+function redirectToDetails (req, res) {
+  res.redirect(`${req.params.contactId}/details`)
+}
+
 async function getCommon (req, res, next) {
   try {
     const token = req.session.token
@@ -42,6 +46,7 @@ function getDetails (req, res, next) {
 }
 
 module.exports = {
+  redirectToDetails,
   getDetails,
   getCommon,
 }

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -1,25 +1,35 @@
 const router = require('express').Router()
 
-const contactController = require('./controllers/details')
-const contactEditController = require('./controllers/edit')
-const contactArchiveController = require('./controllers/archive')
-const contactInteractionController = require('./controllers/interactions')
+const localNavMiddleware = require('../../middleware/local-nav')
+
+const { getCommon, getDetails, redirectToDetails } = require('./controllers/details')
+const { postDetails, editDetails } = require('./controllers/edit')
+const { archiveContact, unarchiveContact } = require('./controllers/archive')
+const { getInteractions } = require('./controllers/interactions')
+
+const LOCAL_NAV = [
+  { path: '../details', label: 'Details' },
+  { path: '../interactions', label: 'Interactions' },
+]
+
+router.use(localNavMiddleware(LOCAL_NAV))
 
 router
   .route('/create')
-  .get(contactEditController.editDetails)
-  .post(contactEditController.postDetails)
+  .get(editDetails)
+  .post(postDetails)
 
-router.get('/:contactId', contactController.getCommon, contactController.getDetails)
+router.get('/:contactId', redirectToDetails)
+router.get('/:contactId/details', getCommon, getDetails)
 
 router
   .route('/:contactId/edit')
-  .get(contactController.getCommon, contactEditController.editDetails)
-  .post(contactController.getCommon, contactEditController.postDetails)
+  .get(getCommon, editDetails)
+  .post(getCommon, postDetails)
 
-router.post('/:id/archive', contactArchiveController.archiveContact)
-router.get('/:id/unarchive', contactArchiveController.unarchiveContact)
+router.post('/:id/archive', archiveContact)
+router.get('/:id/unarchive', unarchiveContact)
 
-router.get('/:contactId/interactions', contactController.getCommon, contactInteractionController.getInteractions)
+router.get('/:contactId/interactions', getCommon, getInteractions)
 
 module.exports = router

--- a/src/apps/contacts/views/_layout.njk
+++ b/src/apps/contacts/views/_layout.njk
@@ -1,14 +1,14 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block local_header %}
-  {% set pageHeadingBefore %}
+  {% set headingBefore %}
     <a href="{{companyUrl}}">{{contact.company.name}}</a>
   {% endset %}
 
   {% call LocalHeader({
-    pageHeadingBefore: pageHeadingBefore,
-    pageHeading: contact.first_name + ' ' + contact.last_name,
-    pageHeadingSuffix: statusbadge('Primary', variation="fuschia") if contact.primary,
+    headingBefore: headingBefore,
+    heading: contact.first_name + ' ' + contact.last_name,
+    headingSuffix: statusbadge('Primary', variation='fuschia') if contact.primary,
     breadcrumbs: BREADCRUMBS,
     modifier: 'light-banner'
   }) %}

--- a/src/apps/contacts/views/_layout.njk
+++ b/src/apps/contacts/views/_layout.njk
@@ -1,23 +1,26 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="u-visually-hidden">Contact Details</h1>
-  <h2 class="page-heading">
-    {{contact.first_name}} {{contact.last_name}}
-    {% if contact.primary == true %}{{ statusbadge('Primary', variation="fuschia") }}{% endif %}
-  </h2>
-  <p>
+{% block local_header %}
+  {% set pageHeadingBefore %}
     <a href="{{companyUrl}}">{{contact.company.name}}</a>
-  </p>
+  {% endset %}
 
-  {% if contact.archived %}
-    <p class="infostrip">
-      This contact has been archived on {{contact.archived_on | formatDate}} by {{contact.archived_by.first_name}} {{contact.archived_by.last_name}}.<br>
-      <strong>Reason:</strong> {{contact.archived_reason}}<br>
-      <br>
-      <a href="/contacts/{{contact.id}}/unarchive">Unarchive</a>
-    </p>
-  {% endif %}
+  {% call LocalHeader({
+    pageHeadingBefore: pageHeadingBefore,
+    pageHeading: contact.first_name + ' ' + contact.last_name,
+    pageHeadingSuffix: statusbadge('Primary', variation="fuschia") if contact.primary,
+    breadcrumbs: BREADCRUMBS,
+    modifier: 'light-banner'
+  }) %}
+    {% if contact.archived %}
+      <p class="infostrip">
+        This contact has been archived on {{contact.archived_on | formatDate}} by {{contact.archived_by.first_name}} {{contact.archived_by.last_name}}.<br>
+        <strong>Reason:</strong> {{contact.archived_reason}}<br>
+        <br>
+        <a href="/contacts/{{contact.id}}/unarchive">Unarchive</a>
+      </p>
+    {% endif %}
+  {% endcall %}
 {% endblock %}
 
 {% block main_grid_left_column %}

--- a/src/apps/contacts/views/_layout.njk
+++ b/src/apps/contacts/views/_layout.njk
@@ -9,7 +9,6 @@
     headingBefore: headingBefore,
     heading: contact.first_name + ' ' + contact.last_name,
     headingSuffix: statusbadge('Primary', variation='fuschia') if contact.primary,
-    breadcrumbs: BREADCRUMBS,
     modifier: 'light-banner'
   }) %}
     {% if contact.archived %}

--- a/src/apps/contacts/views/_layout.njk
+++ b/src/apps/contacts/views/_layout.njk
@@ -23,8 +23,5 @@
 {% endblock %}
 
 {% block main_grid_left_column %}
-  <nav class="local-nav">
-    <a class="local-nav__link {% if tab == 'details' %}is-active{% endif %}" href="/contacts/{{id}}">Details</a>
-    <a class="local-nav__link {% if tab == 'interactions' %}is-active{% endif %}" href="/contacts/{{id}}/interactions">Interactions</a>
-  </nav>
+  {{ LocalNav({ items: localNavItems }) }}
 {% endblock %}

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -1,7 +1,7 @@
 {% extends "./_layout.njk" %}
 
 
-{% block main_heading %}
+{% block body_main_header_content %}
   <h1 class="page-heading">
     {% if formData and formData.id %}
       Edit contact

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -1,14 +1,19 @@
 {% extends "./_layout.njk" %}
 
+{% block local_header %}
+  {% set pageHeadingBefore %}
+    <div class="u-visually-hidden">Company:</div>
+    <a href="{{companyUrl}}">{{contact.company.name}}</a>
+  {% endset %}
 
-{% block body_main_header_content %}
-  <h1 class="page-heading">
-    {% if formData and formData.id %}
-      Edit contact
-    {% else %}
-      Add contact
-    {% endif %}
-  </h1>
+  {{
+    LocalHeader({
+      pageHeadingBefore: pageHeadingBefore,
+      pageHeading: 'Edit contact' if formData.id else 'Add contact',
+      breadcrumbs: BREADCRUMBS,
+      modifier: 'light-banner'
+    })
+  }}
 {% endblock %}
 
 {% block main_grid_left_column %}{% endblock %}

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -1,15 +1,14 @@
 {% extends "./_layout.njk" %}
 
 {% block local_header %}
-  {% set pageHeadingBefore %}
-    <div class="u-visually-hidden">Company:</div>
+  {% set headingBefore %}
     <a href="{{companyUrl}}">{{contact.company.name}}</a>
   {% endset %}
 
   {{
     LocalHeader({
-      pageHeadingBefore: pageHeadingBefore,
-      pageHeading: 'Edit contact' if formData.id else 'Add contact',
+      headingBefore: headingBefore,
+      heading: 'Edit contact' if formData.id else 'Add contact',
       breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -9,7 +9,6 @@
     LocalHeader({
       headingBefore: headingBefore,
       heading: 'Edit contact' if formData.id else 'Add contact',
-      breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })
   }}

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -1,12 +1,14 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  {{ EntitySearchForm({
-    inputName: 'term',
-    modifier: 'global',
-    action: '/search/companies',
-    inputLabel: 'Search for company, contact or investment project'
-  }) }}
+{% block local_header %}
+  {% call LocalHeader({ modifier: 'dark-banner' }) %}
+    {{ EntitySearchForm({
+      inputName: 'term',
+      modifier: 'global',
+      action: '/search/companies',
+      inputLabel: 'Search for company, contact or investment project'
+    }) }}
+  {% endcall %}
 {% endblock %}
 
 {% block body_main_content %}

--- a/src/apps/interactions/views/add-step-1.njk
+++ b/src/apps/interactions/views/add-step-1.njk
@@ -1,17 +1,5 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  {% if query.contact %}
-    {% set backUrl="/contacts/" + query.contact + "/interactions"  %}
-    <a class="back-link" href="{{backUrl}}">Back to contact interactions</a>
-  {% elseif query.company %}
-    {% set backUrl="/companies/" + query.company + "/interactions" %}
-    <a class="back-link" href="{{backUrl}}">Back to company interactions</a>
-  {% endif %}
-
-  <h1 class="heading-xlarge">Add interaction</h1>
-{% endblock %}
-
 {% block body_main_content %}
   <form method="POST">
     <input name="company" type="hidden" value="{{query.company}}"/>

--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -1,10 +1,6 @@
-{% extends "_layouts/datahub-base.njk" %}
+{% extends "_layouts/two-column.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge record-title">Interaction</h1>
-{% endblock %}
-
-{% block body_main_content %}
+{% block main_grid_right_column %}
   {{ keyvaluetable(interactionDetails, stripey=true, labels=interactionLabels, keyorder=interactionDisplayOrder) }}
   <a class="button button-secondary" href="{{interaction.id}}/edit">Edit interaction</a>
 {% endblock %}

--- a/src/apps/interactions/views/edit.njk
+++ b/src/apps/interactions/views/edit.njk
@@ -1,19 +1,7 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  {% if query.contactId %}
-    {% set backUrl="/contacts/" + query.contact + "/interactions"  %}
-    <a class="back-link" href="{{backUrl}}">Back to contact interactions</a>
-  {% elseif query.companyId %}
-    {% set backUrl="/companies/" + query.companyId + "/interactions" %}
-    <a class="back-link" href="{{backUrl}}">Back to company interactions</a>
-  {% endif %}
-
-  <h1 class="heading-xlarge">Add interaction for {{ company.name }}</h1>
-  {{ errorPanel( errors, labels=labels ) }}
-{% endblock %}
-
 {% block body_main_content %}
+  {{ errorPanel( errors, labels=labels ) }}
   <form method="POST">
     <input type="hidden" name="interaction_type" value="{{formData.interaction_type}}">
     <input type="hidden" name="company" value="{{formData.company}}">

--- a/src/apps/investment-projects/controllers/audit.js
+++ b/src/apps/investment-projects/controllers/audit.js
@@ -20,7 +20,6 @@ async function getInvestmentAudit (req, res, next) {
       return res
         .breadcrumb('Audit history')
         .render('investment-projects/views/audit', {
-          currentNavItem: 'audit',
           auditLog,
         })
     }

--- a/src/apps/investment-projects/controllers/details.js
+++ b/src/apps/investment-projects/controllers/details.js
@@ -22,7 +22,6 @@ function detailsGetHandler (req, res, next) {
       details: getDataLabels(transformedDetails, detailsLabels.view),
       values: getDataLabels(transformedValue, valueLabels.view),
       requirements: getDataLabels(transformedRequirements, requirementsLabels.view),
-      currentNavItem: 'details',
     })
   }
   return next()

--- a/src/apps/investment-projects/controllers/evaluation.js
+++ b/src/apps/investment-projects/controllers/evaluation.js
@@ -24,7 +24,6 @@ function renderEvaluationPage (req, res, next) {
         value: getDataLabels(transformedValue, evaluationValueLabels.view),
         fdi: getDataLabels(Object.assign({}, transformedValue, transformedFDI), evaluationFdiLabels.view),
         landing: getDataLabels(transformedLanding, evaluationLandingLabels.view),
-        currentNavItem: 'evaluation',
       })
   }
 

--- a/src/apps/investment-projects/controllers/interactions/list.js
+++ b/src/apps/investment-projects/controllers/interactions/list.js
@@ -12,7 +12,6 @@ async function indexGetHandler (req, res, next) {
       return res
         .breadcrumb('Interactions')
         .render('investment-projects/views/interactions/index', {
-          currentNavItem: 'interactions',
           interactions,
         })
     }

--- a/src/apps/investment-projects/controllers/team/details.js
+++ b/src/apps/investment-projects/controllers/team/details.js
@@ -8,7 +8,6 @@ function getDetailsHandler (req, res, next) {
     res
       .breadcrumb('Project team')
       .render('investment-projects/views/team/details', {
-        currentNavItem: 'team',
         projectManagementData,
         projectManagementLabels,
       })

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -4,6 +4,7 @@ const { isValidGuid } = require('../../../lib/controller-utils')
 const { getInteraction } = require('../../interactions/repos')
 const { getDitCompany } = require('../../companies/repos')
 const { transformFromApi } = require('../../interactions/services/formatting')
+const { buildCompanyUrl } = require('../../companies/services/data')
 const { getInvestment } = require('../repos')
 
 function handleEmptyMiddleware (req, res, next) {
@@ -48,6 +49,10 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
       projectCode: investmentData.project_code,
       stageName: investmentData.stage.name,
       valuation: investmentData.value_complete ? 'Project valued' : 'Not yet valued',
+      company: {
+        name: investmentData.investor_company.name,
+        url: buildCompanyUrl(investmentData.investor_company),
+      },
     }
 
     res.breadcrumb({

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -14,17 +14,6 @@ function handleEmptyMiddleware (req, res, next) {
   next()
 }
 
-function getLocalNavMiddleware (req, res, next) {
-  res.locals.localNavItems = [
-    { label: 'Project details', slug: 'details' },
-    { label: 'Project team', slug: 'team' },
-    { label: 'Interactions', slug: 'interactions' },
-    { label: 'Evaluation', slug: 'evaluation' },
-    { label: 'Audit history', slug: 'audit' },
-  ]
-  next()
-}
-
 async function getInvestmentDetails (req, res, next, id = req.params.id) {
   if (!isValidGuid(id)) {
     return next()
@@ -83,7 +72,6 @@ async function getInteractionDetails (req, res, next, interactionId = req.params
 
 module.exports = {
   handleEmptyMiddleware,
-  getLocalNavMiddleware,
   getInvestmentDetails,
   getInteractionDetails,
 }

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,5 +1,7 @@
 const router = require('express').Router()
 
+const localNavMiddleware = require('../../middleware/local-nav')
+
 const { shared } = require('./middleware')
 const { getBriefInvestmentSummary } = require('./middleware/team')
 const {
@@ -20,8 +22,16 @@ const requirementsMiddleware = require('./middleware/forms/requirements')
 const interactionsMiddleware = require('./middleware/forms/interactions')
 const projectManagementForm = require('./middleware/forms/project-management')
 
+const LOCAL_NAV = [
+  { path: '../details', label: 'Project details' },
+  { path: '../team', label: 'Project team' },
+  { path: '../interactions', label: 'Interactions' },
+  { path: '../evaluation', label: 'Evaluations' },
+  { path: '../audit', label: 'Audit history' },
+]
+
 router.use(shared.handleEmptyMiddleware)
-router.use(shared.getLocalNavMiddleware)
+router.use(localNavMiddleware(LOCAL_NAV))
 
 router.param('id', shared.getInvestmentDetails)
 router.param('interactionId', shared.getInteractionDetails)

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -8,7 +8,6 @@
   {% call LocalHeader({
     headingBefore: headingBefore,
     heading: investmentData.name,
-    breadcrumbs: BREADCRUMBS,
     modifier: 'light-banner'
   }) %}
     {% component 'investment-status', investmentStatus %}

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -1,13 +1,13 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block local_header %}
-  {% set pageHeadingBefore %}
+  {% set headingBefore %}
     <a href="{{ investmentStatus.company.url }}">{{ investmentStatus.company.name }}</a>
   {% endset %}
 
   {% call LocalHeader({
-    pageHeadingBefore: pageHeadingBefore,
-    pageHeading: investmentData.name,
+    headingBefore: headingBefore,
+    heading: investmentData.name,
     breadcrumbs: BREADCRUMBS,
     modifier: 'light-banner'
   }) %}

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -24,17 +24,5 @@
 {% endblock %}
 
 {% block main_grid_left_column %}
-  {% if localNavItems %}
-    <nav class="local-nav {{ 'local-nav--background' if variant in ['edit', 'create'] }}">
-      {% for item in localNavItems %}
-        {% set isSelected = currentNavItem == item.slug %}
-        <a
-          href="{{ item.slug }}"
-          class="local-nav__link {{ 'is-active' if isSelected}}"
-        >
-          {{ item.label }}
-        </a>
-      {% endfor %}
-    </nav>
-  {% endif %}
+  {{ LocalNav({ items: localNavItems }) }}
 {% endblock %}

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -1,9 +1,16 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block body_main_header_content %}
-  {% if investmentData %}
-    <h1 class="u-visually-hidden">Investment details</h1>
-    <h2 class="page-heading">{{ investmentData.name }}</h2>
+{% block local_header %}
+  {% set pageHeadingBefore %}
+    <a href="{{ investmentStatus.company.url }}">{{ investmentStatus.company.name }}</a>
+  {% endset %}
+
+  {% call LocalHeader({
+    pageHeadingBefore: pageHeadingBefore,
+    pageHeading: investmentData.name,
+    breadcrumbs: BREADCRUMBS,
+    modifier: 'light-banner'
+  }) %}
     {% component 'investment-status', investmentStatus %}
 
     {% if investmentData.archived %}
@@ -14,8 +21,7 @@
         <a href="unarchive">Unarchive</a>
       </p>
     {% endif %}
-
-  {% endif %}
+  {% endcall %}
 {% endblock %}
 
 {% block main_grid_left_column %}

--- a/src/apps/investment-projects/views/create-1.njk
+++ b/src/apps/investment-projects/views/create-1.njk
@@ -1,9 +1,5 @@
-{% extends "./_layout.njk" %}
+{% extends "_layouts/two-column.njk" %}
 
-
-{% block main_heading %}
-  <h1 class="page-heading">Add investment project</h1>
-{% endblock %}
 
 {% block main_grid_left_column %}{% endblock %}
 

--- a/src/apps/investment-projects/views/create-2.njk
+++ b/src/apps/investment-projects/views/create-2.njk
@@ -1,15 +1,10 @@
-{% extends "./_layout.njk" %}
+{% extends "_layouts/two-column.njk" %}
 
-
-{% block main_heading %}
-  <h1 class="page-heading">Add investment project</h1>
-
-  {{ errorPanel(form.errors) }}
-{% endblock %}
 
 {% block main_grid_left_column %}{% endblock %}
 
 {% block main_grid_right_column %}
+  {{ errorPanel(form.errors) }}
 
   {% if equityCompany %}
     <h2 class="heading-medium">Source of foreign equity investment</h2>

--- a/src/apps/investment-projects/views/edit.njk
+++ b/src/apps/investment-projects/views/edit.njk
@@ -2,7 +2,7 @@
 
 
 {% block local_header %}
-  {{ LocalHeader({ heading: 'Edit investment project', breadcrumbs: BREADCRUMBS, modifier: 'light-banner' }) }}
+  {{ LocalHeader({ heading: 'Edit investment project', modifier: 'light-banner' }) }}
 {% endblock %}
 
 {% block main_grid_right_column %}

--- a/src/apps/investment-projects/views/edit.njk
+++ b/src/apps/investment-projects/views/edit.njk
@@ -1,12 +1,11 @@
 {% extends "./_layout.njk" %}
 
 
-{% block main_heading %}
-  <h1 class="page-heading">Edit investment project</h1>
-
-  {{ errorPanel(form.errors) }}
+{% block local_header %}
+  {{ LocalHeader({ pageHeading: 'Edit investment project', breadcrumbs: BREADCRUMBS, modifier: 'light-banner' }) }}
 {% endblock %}
 
 {% block main_grid_right_column %}
+  {{ errorPanel(form.errors) }}
   {% include './_details-form.njk' %}
 {% endblock %}

--- a/src/apps/investment-projects/views/edit.njk
+++ b/src/apps/investment-projects/views/edit.njk
@@ -2,7 +2,7 @@
 
 
 {% block local_header %}
-  {{ LocalHeader({ pageHeading: 'Edit investment project', breadcrumbs: BREADCRUMBS, modifier: 'light-banner' }) }}
+  {{ LocalHeader({ heading: 'Edit investment project', breadcrumbs: BREADCRUMBS, modifier: 'light-banner' }) }}
 {% endblock %}
 
 {% block main_grid_right_column %}

--- a/src/apps/profile/views/profile.njk
+++ b/src/apps/profile/views/profile.njk
@@ -1,9 +1,5 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  <h2 class="heading-xlarge">Your profile</h2>
-{% endblock %}
-
 {% block body_main_content %}
   <table class="table-detail">
     <tbody>

--- a/src/apps/service-deliveries/controllers.js
+++ b/src/apps/service-deliveries/controllers.js
@@ -51,7 +51,7 @@ async function getServiceDeliveryEdit (req, res, next) {
     res.locals.companyUrl = buildCompanyUrl(res.locals.serviceDelivery.company)
 
     res
-      .breadcrumb('Add service delivery')
+      .breadcrumb('Edit service delivery')
       .render('service-deliveries/views/edit')
   } catch (error) {
     next(error)
@@ -90,10 +90,15 @@ async function postServiceDeliveryEdit (req, res, next) {
 }
 
 function getServiceDeliveryDetails (req, res, next) {
-  res.locals.serviceDeliveryDetails = getDisplayServiceDelivery(res.locals.serviceDelivery)
-  res.locals.serviceDeliveryLabels = serviceDeliverylabels
-  res.locals.serviceDeliveryDisplayOrder = serviceDeliveryDisplayOrder
-  res.render('service-deliveries/views/details')
+  res.locals = Object.assign({}, res.locals, {
+    serviceDeliveryDetails: getDisplayServiceDelivery(res.locals.serviceDelivery),
+    serviceDeliveryLabels: serviceDeliverylabels,
+    serviceDeliveryDisplayOrder: serviceDeliveryDisplayOrder,
+  })
+
+  res
+    .breadcrumb('Service delivery details')
+    .render('service-deliveries/views/details')
 }
 
 module.exports = {

--- a/src/apps/service-deliveries/views/details.njk
+++ b/src/apps/service-deliveries/views/details.njk
@@ -1,9 +1,5 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge record-title">Service delivery details</h1>
-{% endblock %}
-
 {% block body_main_content %}
   {{ keyvaluetable(serviceDeliveryDetails, stripey=true, labels=serviceDeliveryLabels, keyorder=serviceDeliveryDisplayOrder) }}
   <a class="button" href="/service-deliveries/{{serviceDelivery.id}}/edit">Edit service delivery details</a>

--- a/src/apps/service-deliveries/views/edit.njk
+++ b/src/apps/service-deliveries/views/edit.njk
@@ -1,25 +1,28 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  {% if query.contact %}
-    {% set backUrl="/contacts/" + query.contact + "/interactions"  %}
-    <a class="back-link" href="{{backUrl}}">Back to contact interactions</a>
-  {% elseif query.company %}
-    {% set backUrl="/companies/" + query.company + "/interactions" %}
-    <a class="back-link" href="{{backUrl}}">Back to company interactions</a>
-  {% endif %}
-
-  <h1 class="heading-xlarge">
-    {% if serviceDelivery.id %}
-      Edit service delivery
-    {% else %}
-      Add service delivery
+{% block local_header %}
+  {% set pageHeadingBefore %}
+    {% if query.contact %}
+      {% set backUrl="/contacts/" + query.contact + "/interactions"  %}
+      <a class="back-link" href="{{backUrl}}">Back to contact interactions</a>
+    {% elseif query.company %}
+      {% set backUrl="/companies/" + query.company + "/interactions" %}
+      <a class="back-link" href="{{backUrl}}">Back to company interactions</a>
     {% endif %}
-  </h1>
-  {{ errorPanel( errors, labels=labels ) }}
+  {% endset %}
+
+  {{
+    LocalHeader({
+      pageHeadingBefore: pageHeadingBefore,
+      pageHeading: 'Edit service delivery' if serviceDelivery.id else 'Add service delivery',
+      breadcrumbs: BREADCRUMBS,
+      modifier: 'light-banner'
+    })
+  }}
 {% endblock %}
 
 {% block body_main_content %}
+  {{ errorPanel( errors, labels=labels ) }}
   <form method="POST">
     <input type="hidden" name="company" value="{{serviceDelivery.company.id}}">
     <input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/src/apps/service-deliveries/views/edit.njk
+++ b/src/apps/service-deliveries/views/edit.njk
@@ -13,8 +13,8 @@
 
   {{
     LocalHeader({
-      pageHeadingBefore: pageHeadingBefore,
-      pageHeading: 'Edit service delivery' if serviceDelivery.id else 'Add service delivery',
+      headingBefore: headingBefore,
+      heading: 'Edit service delivery' if serviceDelivery.id else 'Add service delivery',
       breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })

--- a/src/apps/service-deliveries/views/edit.njk
+++ b/src/apps/service-deliveries/views/edit.njk
@@ -15,7 +15,6 @@
     LocalHeader({
       headingBefore: headingBefore,
       heading: 'Edit service delivery' if serviceDelivery.id else 'Add service delivery',
-      breadcrumbs: BREADCRUMBS,
       modifier: 'light-banner'
     })
   }}

--- a/src/apps/support/controllers.js
+++ b/src/apps/support/controllers.js
@@ -1,6 +1,6 @@
 function renderFeedbackPage (req, res) {
   res.render('support/views/feedback', {
-    pageHeading: 'Report a problem or leave feedback',
+    heading: 'Report a problem or leave feedback',
   })
 }
 
@@ -8,7 +8,7 @@ function renderThankYouPage (req, res) {
   res
     .breadcrumb('Thank you')
     .render('support/views/thank-you', {
-      pageHeading: 'Thank you',
+      heading: 'Thank you',
     })
 }
 

--- a/src/apps/support/controllers.js
+++ b/src/apps/support/controllers.js
@@ -1,11 +1,15 @@
 function renderFeedbackPage (req, res) {
-  res.render('support/views/feedback')
+  res.render('support/views/feedback', {
+    pageHeading: 'Report a problem or leave feedback',
+  })
 }
 
 function renderThankYouPage (req, res) {
   res
     .breadcrumb('Thank you')
-    .render('support/views/thank-you')
+    .render('support/views/thank-you', {
+      pageHeading: 'Thank you',
+    })
 }
 
 module.exports = {

--- a/src/apps/support/views/feedback.njk
+++ b/src/apps/support/views/feedback.njk
@@ -1,9 +1,5 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="heading-xlarge">Report a problem or leave feedback</h1>
-{% endblock %}
-
 {% block body_main_content %}
   {% call Form(form | assign({buttonText: 'Send'})) %}
     {{ TextField({

--- a/src/middleware/local-nav.js
+++ b/src/middleware/local-nav.js
@@ -1,0 +1,16 @@
+const path = require('path')
+
+function localNavMiddleware (items = []) {
+  return function buildLocalNav (req, res, next) {
+    res.locals.localNavItems = items.map(item => {
+      const url = path.resolve(res.locals.CURRENT_PATH, item.path)
+      return Object.assign(item, {
+        url,
+        isActive: res.locals.CURRENT_PATH === url,
+      })
+    })
+    next()
+  }
+}
+
+module.exports = localNavMiddleware

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -25,7 +25,7 @@ module.exports = function locals (req, res, next) {
 
       if (title) {
         if (items.length === 1) {
-          return title
+          return [title]
         }
 
         items.pop()

--- a/src/templates/_components/breadcrumbs.njk
+++ b/src/templates/_components/breadcrumbs.njk
@@ -18,10 +18,10 @@
  #}
 
 {% if items|length > 1 %}
-  <nav aria-label="Breadcrumbs">
-    <ul class="c-breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+  <nav class="c-breadcrumb" aria-label="Breadcrumbs">
+    <ul class="c-breadcrumb__list" itemscope itemtype="http://schema.org/BreadcrumbList">
       {% for breadcrumb in items %}
-        <li class="c-breadcrumb__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <li class="c-breadcrumb__list-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
           {% if loop.last %}
             <a href="#main-content" class="c-breadcrumb__link is-active" itemprop="url">
               <span itemprop="name">{{ breadcrumb.name }}</span>

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block header_menu %}
-  <nav>
+  <nav aria-label="global nav">
     <ul class="proposition-menu">
       {% if user %}
         <li class="proposition-menu__item">

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -13,7 +13,7 @@
 
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/form.njk" import Fieldset, TextField, MultipleChoiceField, HiddenField %}
-{% from "_macros/common.njk" import Pagination %}
+{% from "_macros/common.njk" import LocalHeader, Pagination %}
 {% from "_macros/address.njk" import addressFormatter %}
 
 {% set pageTitle = [getPageTitle(), 'DIT Data Hub'] | flatten | join(' - ') %}
@@ -60,9 +60,13 @@
   </nav>
 {% endblock %}
 
-{% block body_main_header_info %}
-  {% component 'breadcrumbs', { items: BREADCRUMBS } %}
-  {% component 'messages', { messages: messages } %}
+{% block body_main_header %}
+  {{ super() }}
+  {% block local_header %}
+    {% set pageTitle = getPageTitle() %}
+    {% set pageHeading = pageHeading or pageTitle[0] %}
+    {{ LocalHeader({ pageHeading: pageHeading, breadcrumbs: BREADCRUMBS, messages: messages, modifier: 'light-banner' }) }}
+  {% endblock %}
 {% endblock %}
 
 {% block body %}

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -14,7 +14,7 @@
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/form.njk" import Fieldset, TextField, MultipleChoiceField, HiddenField %}
 {% from "_macros/common.njk" import LocalHeader with context %}
-{% from "_macros/common.njk" import Pagination %}
+{% from "_macros/common.njk" import Pagination, LocalNav %}
 {% from "_macros/address.njk" import addressFormatter %}
 
 {% set pageTitle = [getPageTitle(), 'DIT Data Hub'] | flatten | join(' - ') %}

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -13,7 +13,8 @@
 
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/form.njk" import Fieldset, TextField, MultipleChoiceField, HiddenField %}
-{% from "_macros/common.njk" import LocalHeader, Pagination %}
+{% from "_macros/common.njk" import LocalHeader with context %}
+{% from "_macros/common.njk" import Pagination %}
 {% from "_macros/address.njk" import addressFormatter %}
 
 {% set pageTitle = [getPageTitle(), 'DIT Data Hub'] | flatten | join(' - ') %}
@@ -65,7 +66,7 @@
   {% block local_header %}
     {% set pageTitle = getPageTitle() %}
     {% set heading = heading or pageTitle[0] %}
-    {{ LocalHeader({ heading: heading, breadcrumbs: BREADCRUMBS, messages: messages, modifier: 'light-banner' }) }}
+    {{ LocalHeader({ heading: heading, modifier: 'light-banner' }) }}
   {% endblock %}
 {% endblock %}
 

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -64,8 +64,8 @@
   {{ super() }}
   {% block local_header %}
     {% set pageTitle = getPageTitle() %}
-    {% set pageHeading = pageHeading or pageTitle[0] %}
-    {{ LocalHeader({ pageHeading: pageHeading, breadcrumbs: BREADCRUMBS, messages: messages, modifier: 'light-banner' }) }}
+    {% set heading = heading or pageTitle[0] %}
+    {{ LocalHeader({ heading: heading, breadcrumbs: BREADCRUMBS, messages: messages, modifier: 'light-banner' }) }}
   {% endblock %}
 {% endblock %}
 

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -60,10 +60,9 @@
   </nav>
 {% endblock %}
 
-{% block body_main_header %}
+{% block body_main_header_info %}
   {% component 'breadcrumbs', { items: BREADCRUMBS } %}
   {% component 'messages', { messages: messages } %}
-  {{ super() }}
 {% endblock %}
 
 {% block body %}

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -111,12 +111,6 @@
                 </div>
               {% endif %}
             {% endblock %}
-            <header class="main-content__header">
-              <div class="container">
-                {% block body_main_header_info %}{% endblock %}
-                {% block body_main_header_content %}{% endblock %}
-              </div>
-            </header>
           {% endblock %}
           <div class="main-content__inner container">
             {% block body_main_content %}{% endblock %}

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -94,29 +94,34 @@
       {% endblock %}
 
       {% block body_main %}
-        <div class="main-content">
-          <main id="main-content" role="main" class="main-content__inner">
+        <main class="main-content" id="main-content" role="main">
+          {% block body_main_header %}
             {% block body_main_phase_banner %}
               {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta'] or feedbackLink) %}
                 <div class="phase-banner">
-                  <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
-                  <span class="phase-banner__message">
-                    This is a new service
-                    {% if feedbackLink %}
-                    – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.
-                    {% endif %}
-                  </span>
+                  <div class="container">
+                    <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
+                    <span class="phase-banner__message">
+                      This is a new service
+                      {% if feedbackLink %}
+                      – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.
+                      {% endif %}
+                    </span>
+                  </div>
                 </div>
               {% endif %}
             {% endblock %}
-            {% block body_main_header %}
-              <header class="main-content__header">
+            <header class="main-content__header">
+              <div class="container">
+                {% block body_main_header_info %}{% endblock %}
                 {% block body_main_header_content %}{% endblock %}
-              </header>
-            {% endblock %}
+              </div>
+            </header>
+          {% endblock %}
+          <div class="main-content__inner container">
             {% block body_main_content %}{% endblock %}
-          </main>
-        </div>
+          </div>
+        </main>
       {% endblock %}
 
       {% block body_footer %}

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -70,7 +70,7 @@
       {% endblock %}
 
       {% block body_site_header %}
-        <header role="banner" class="global-header">
+        <header class="global-header" aria-label="global header">
           <div class="global-header__inner">
             {% block header_site_title %}
               <div class="global-header__site-title">
@@ -94,7 +94,7 @@
       {% endblock %}
 
       {% block body_main %}
-        <main class="main-content" id="main-content" role="main">
+        <main class="main-content" id="main-content">
           {% block body_main_header %}
             {% block body_main_phase_banner %}
               {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta'] or feedbackLink) %}

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -99,7 +99,7 @@
             {% block body_main_phase_banner %}
               {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta'] or feedbackLink) %}
                 <div class="phase-banner">
-                  <div class="container">
+                  <div class="l-container">
                     <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
                     <span class="phase-banner__message">
                       This is a new service
@@ -112,7 +112,7 @@
               {% endif %}
             {% endblock %}
           {% endblock %}
-          <div class="main-content__inner container">
+          <div class="main-content__inner l-container">
             {% block body_main_content %}{% endblock %}
           </div>
         </main>

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block body_main_header_content %}
-  <h1 class="page-heading">{{ pageHeading }}</h1>
+  <h1 class="page-heading">{{ heading }}</h1>
 {% endblock %}
 
 {% block main_grid_right_column %}

--- a/src/templates/_layouts/search.njk
+++ b/src/templates/_layouts/search.njk
@@ -13,11 +13,6 @@
 {% endblock %}
 
 
-{% block main_grid_left_column %}
-  &nbsp; {# // TODO filters #}
-{% endblock %}
-
-
 {% block main_grid_right_column %}
   {% if results %}
     {% block actions %}{% endblock %}

--- a/src/templates/_layouts/search.njk
+++ b/src/templates/_layouts/search.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ modifier: 'dark-banner', breadcrumbs: BREADCRUMBS, messages: messages }) %}
+  {% call LocalHeader({ modifier: 'dark-banner' }) %}
     {{ EntitySearchForm({
       inputName: 'term',
       modifier: 'global',

--- a/src/templates/_layouts/search.njk
+++ b/src/templates/_layouts/search.njk
@@ -1,15 +1,17 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block body_main_header_content %}
-  {{ EntitySearchForm({
-    inputName: 'term',
-    modifier: 'global',
-    action: '/search/' + searchPath | default('companies'),
-    searchTerm: searchTerm,
-    entityType: searchEntity,
-    inputLabel: 'Search for company, contact or investment project',
-    aggregations: searchEntityResultsData
-  }) }}
+{% block local_header %}
+  {% call LocalHeader({ modifier: 'dark-banner', breadcrumbs: BREADCRUMBS, messages: messages }) %}
+    {{ EntitySearchForm({
+      inputName: 'term',
+      modifier: 'global',
+      action: '/search/' + searchPath | default('companies'),
+      searchTerm: searchTerm,
+      entityType: searchEntity,
+      inputLabel: 'Search for company, contact or investment project',
+      aggregations: searchEntityResultsData
+    }) }}
+  {% endcall %}
 {% endblock %}
 
 

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -94,3 +94,22 @@
     </header>
   {% endif %}
 {% endmacro %}
+
+{##
+ # Render local nav
+ # @param {object} props
+ # @param {string} [props.modifier] - nav modifier
+ # @param {string} [props.items] - nav items
+ #
+ #}
+{% macro LocalNav(props) %}
+  {% set modifier = props.modifier | concat('') | reverse | join(' c-local-nav--') if props.modifier %}
+
+  {% if props|length %}
+    <nav class="c-local-nav {{ modifier }}" aria-label="local navigation">
+      {% for item in props.items %}
+        <a class="c-local-nav__link {{ 'is-active' if item.isActive }}" href="{{item.url}}">{{ item.label }}</a>
+      {% endfor %}
+    </nav>
+  {% endif %}
+{% endmacro %}

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -53,9 +53,10 @@
 {##
  # Render page local header
  # @param {object} props - An object containing local header properties
- # @param {string} [pageHeading] - page heading
- # @param {string} [pageHeadingBefore] - a string before heading (safe to render HTML)
- # @param {string} [pageHeadingSuffix] - a string suffix for heading (safe to render HTML)
+ # @param {string} [heading] - page heading
+ # @param {string} [heading] - page heading
+ # @param {string} [headingBefore] - a string before heading (safe to render HTML)
+ # @param {string} [headingSuffix] - a string suffix for heading (safe to render HTML)
  # @param {object} [breadcrumbs] - an object containing page breadcrumbs
  # @param {object} [messages] - an object containing flash messages
  #
@@ -65,7 +66,7 @@
   {% set modifier = props.modifier | concat('') | reverse | join(' c-local-header--') if props.modifier %}
 
   {% if props %}
-    <header class="c-local-header {{ modifier }}">
+    <header class="c-local-header {{ modifier }}" aria-label="local header">
       <div class="l-container">
         {% if props.breadcrumbs|length %}
           {% component 'breadcrumbs', { items: props.breadcrumbs } %}
@@ -74,15 +75,15 @@
           {% component 'messages', { messages: props.messages } %}
         {% endif %}
 
-        {% if props.pageHeadingBefore %}
+        {% if props.headingBefore %}
           <div class="c-local-header__heading-before">
-            {{ props.pageHeadingBefore | safe }}
+            {{ props.headingBefore | safe }}
           </div>
         {% endif %}
 
-        {% if props.pageHeading %}
+        {% if props.heading %}
           <h1 class="c-local-header__heading">
-            {{ props.pageHeading }} {{ props.pageHeadingSuffix | safe }}
+            {{ props.heading }} {{ props.headingSuffix | safe }}
           </h1>
         {% endif %}
 

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -49,3 +49,45 @@
     </nav>
   {% endif %}
 {% endmacro %}
+
+{##
+ # Render page local header
+ # @param {object} props - An object containing local header properties
+ # @param {string} [pageHeading] - page heading
+ # @param {string} [pageHeadingBefore] - a string before heading (safe to render HTML)
+ # @param {string} [pageHeadingSuffix] - a string suffix for heading (safe to render HTML)
+ # @param {object} [breadcrumbs] - an object containing page breadcrumbs
+ # @param {object} [messages] - an object containing flash messages
+ #
+ # @param {function} [props.caller] - Optional inner contents
+ #}
+{% macro LocalHeader(props) %}
+  {% set modifier = props.modifier | concat('') | reverse | join(' c-local-header--') if props.modifier %}
+
+  {% if props %}
+    <header class="c-local-header {{ modifier }}">
+      <div class="container">
+        {% if props.breadcrumbs|length %}
+          {% component 'breadcrumbs', { items: props.breadcrumbs } %}
+        {% endif %}
+        {% if props.messages|length %}
+          {% component 'messages', { messages: props.messages } %}
+        {% endif %}
+
+        {% if props.pageHeadingBefore %}
+          <div class="c-local-header__heading-before">
+            {{ props.pageHeadingBefore | safe }}
+          </div>
+        {% endif %}
+
+        {% if props.pageHeading %}
+          <h1 class="c-local-header__heading">
+            {{ props.pageHeading }} {{ props.pageHeadingSuffix | safe }}
+          </h1>
+        {% endif %}
+
+        {{ caller() if caller }}
+      </div>
+    </header>
+  {% endif %}
+{% endmacro %}

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -63,16 +63,18 @@
  # @param {function} [props.caller] - Optional inner contents
  #}
 {% macro LocalHeader(props) %}
+  {% set breadcrumbs = props.breadcrumbs | default(BREADCRUMBS) %}
+  {% set messages = props.messages | default(messages) %}
   {% set modifier = props.modifier | concat('') | reverse | join(' c-local-header--') if props.modifier %}
 
   {% if props %}
     <header class="c-local-header {{ modifier }}" aria-label="local header">
       <div class="l-container">
-        {% if props.breadcrumbs|length %}
-          {% component 'breadcrumbs', { items: props.breadcrumbs } %}
+        {% if breadcrumbs|length %}
+          {% component 'breadcrumbs', { items: breadcrumbs } %}
         {% endif %}
-        {% if props.messages|length %}
-          {% component 'messages', { messages: props.messages } %}
+        {% if messages|length %}
+          {% component 'messages', { messages: messages } %}
         {% endif %}
 
         {% if props.headingBefore %}

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -66,7 +66,7 @@
 
   {% if props %}
     <header class="c-local-header {{ modifier }}">
-      <div class="container">
+      <div class="l-container">
         {% if props.breadcrumbs|length %}
           {% component 'breadcrumbs', { items: props.breadcrumbs } %}
         {% endif %}

--- a/src/templates/_macros/dev.njk
+++ b/src/templates/_macros/dev.njk
@@ -1,5 +1,5 @@
-{% macro Example(title) %}
-  <article class="example" {% if title %}id="{{ title | urlencode }}"{% endif %}>
+{% macro Example(title, isWide = false) %}
+  <article class="example {{ 'example--wide' if isWide }}" {% if title %}id="{{ title | urlencode }}"{% endif %}>
     <header class="example__header">
       {% if title %}
         <h3 class="example__title">{{ title }}</h3>

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -146,7 +146,7 @@
     {% endcall %}
 
     {% if props.aggregations|length %}
-      <nav class="c-entity-search__aggregations">
+      <nav class="c-entity-search__aggregations" aria-label="search results aggregation options">
         <ul>
           {% for item in props.aggregations %}
             {% set isCurrentPage = item.entity === props.entityType %}

--- a/src/templates/errors.njk
+++ b/src/templates/errors.njk
@@ -1,8 +1,9 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="heading-large">{{ statusCode }}</h1>
-  <p>{{ statusMessage }}</p>
+{% block local_header %}
+  {% call LocalHeader({ heading: statusMessage, modifier: 'light-banner' }) %}
+    <p>{{ statusCode }}</p>
+  {% endcall %}
 {% endblock %}
 
 {% block body_main_content %}

--- a/src/templates/errors.njk
+++ b/src/templates/errors.njk
@@ -1,9 +1,11 @@
 {% extends "_layouts/datahub-base.njk" %}
 
-{% block body_main_content %}
-  <h1 class="heading-medium error">{{ statusCode }}</h1>
+{% block body_main_header_content %}
+  <h1 class="heading-large">{{ statusCode }}</h1>
   <p>{{ statusMessage }}</p>
+{% endblock %}
 
+{% block body_main_content %}
   {% if devErrorDetail %}
     <dl class="stack-trace">
       <dt class="stack-trace__heading">{{ devErrorDetail.message }}</dt>

--- a/test/unit/apps/companies/controllers/investments.test.js
+++ b/test/unit/apps/companies/controllers/investments.test.js
@@ -16,6 +16,7 @@ describe('Company investments controller', function () {
     this.getCompanyInvestmentProjectsStub = this.sandbox.stub().resolves(investmentProjects)
     this.getCommonTitlesAndlinksStub = this.sandbox.stub()
     this.nextStub = this.sandbox.stub()
+    this.breadcrumbStub = function () { return this }
 
     this.controller = proxyquire('~/src/apps/companies/controllers/investments', {
       '../services/data': {
@@ -44,6 +45,7 @@ describe('Company investments controller', function () {
           },
         }
         const resStub = {
+          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(this.getInflatedDitCompanyStub).to.be.calledWith(token, company.id)

--- a/test/unit/apps/investment-projects/controllers/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/details.test.js
@@ -25,7 +25,6 @@ describe('Investment details controller', () => {
         render: (template, data) => {
           try {
             expect(template).to.equal('investment-projects/views/details')
-            expect(data.currentNavItem).to.equal('details')
             done()
           } catch (error) {
             done(error)

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -42,7 +42,6 @@ describe('Investment evaluation controller', () => {
         render: (template, data) => {
           try {
             expect(template).to.equal('investment-projects/views/evaluation')
-            expect(data.currentNavItem).to.equal('evaluation')
             done()
           } catch (error) {
             done(error)
@@ -97,7 +96,6 @@ describe('Investment evaluation controller', () => {
       render: (template, data) => {
         try {
           expect(template).to.equal('investment-projects/views/evaluation')
-          expect(data.currentNavItem).to.equal('evaluation')
           expect(data.value).to.deep.equal(expectedValue)
           expect(data.fdi).to.deep.equal(expectFDI)
           expect(data.landing).to.deep.equal(expectedLanding)
@@ -167,7 +165,6 @@ describe('Investment evaluation controller', () => {
       render: (template, data) => {
         try {
           expect(template).to.equal('investment-projects/views/evaluation')
-          expect(data.currentNavItem).to.equal('evaluation')
           expect(data.value).to.deep.equal(expectedValue)
           expect(data.fdi).to.deep.equal(expectFDI)
           expect(data.landing).to.deep.equal(expectedLanding)

--- a/test/unit/apps/investment-projects/controllers/interactions/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions/list.test.js
@@ -36,7 +36,6 @@ describe('Investment Interactions Index controller', () => {
         render: (template, data) => {
           try {
             expect(template).to.equal('investment-projects/views/interactions/index')
-            expect(data.currentNavItem).to.equal('interactions')
             expect(data.interactions).to.deep.equal(interactionCompanyDisplayFormated)
             done()
           } catch (error) {

--- a/test/unit/apps/investment-projects/middleware/shared.test.js
+++ b/test/unit/apps/investment-projects/middleware/shared.test.js
@@ -21,15 +21,6 @@ describe('Investment shared middleware', () => {
     this.sandbox.restore()
   })
 
-  describe('#getLocalNavMiddleware', () => {
-    it('should return local nav items', () => {
-      this.controller.getLocalNavMiddleware(this.reqMock, this.resMock, this.nextSpy)
-
-      expect(this.resMock.locals).to.haveOwnProperty('localNavItems')
-      expect(this.nextSpy.calledOnce).to.be.true
-    })
-  })
-
   describe('#handleEmptyMiddleware', () => {
     it('should redirect to start when no sub-routes are given', (done) => {
       const nextSpy = this.sandbox.spy()

--- a/test/unit/components/breadcrumbs.test.js
+++ b/test/unit/components/breadcrumbs.test.js
@@ -37,12 +37,12 @@ describe('Breadcrumb component', () => {
     })
 
     it('should render 2 items', () => {
-      const items = this.component.querySelectorAll('.c-breadcrumb__item')
+      const items = this.component.querySelectorAll('.c-breadcrumb__list-item')
       expect(items.length).to.equal(3)
     })
 
     it('should contain the correct text', () => {
-      const items = this.component.querySelectorAll('.c-breadcrumb__item')
+      const items = this.component.querySelectorAll('.c-breadcrumb__list-item')
       expect(items[0].textContent).to.contain('Home')
       expect(items[1].textContent).to.contain('Second level')
       expect(items[2].textContent).to.contain('Third level')

--- a/test/unit/components/local-header.js
+++ b/test/unit/components/local-header.js
@@ -12,7 +12,7 @@ describe('LocalHeader macro', () => {
   describe('valid props', () => {
     it('should render page heading', () => {
       const component = commonMacros.renderToDom('LocalHeader', {
-        pageHeading: 'I am hot',
+        heading: 'I am hot',
       })
       expect(component.className.trim()).to.equal('c-local-header')
       expect(component.querySelector('.c-local-header__heading').textContent.trim()).to.equal('I am hot')
@@ -73,7 +73,7 @@ describe('LocalHeader macro', () => {
 
   it('should render local header with string heading heading', () => {
     const component = commonMacros.renderToDom('LocalHeader', {
-      pageHeadingBefore: '<strong>Superb</strong>',
+      headingBefore: '<strong>Superb</strong>',
     })
 
     const headingBeforeEl = component.querySelector('.c-local-header__heading-before')
@@ -83,8 +83,8 @@ describe('LocalHeader macro', () => {
 
   it('should render local header with string heading suffix', () => {
     const component = commonMacros.renderToDom('LocalHeader', {
-      pageHeading: 'Tyom',
-      pageHeadingSuffix: '<strong>S</strong>',
+      heading: 'Tyom',
+      headingSuffix: '<strong>S</strong>',
     })
 
     const headingEl = component.querySelector('.c-local-header__heading')

--- a/test/unit/components/local-header.js
+++ b/test/unit/components/local-header.js
@@ -1,0 +1,95 @@
+const { getMacros } = require('~/test/unit/component-helper')
+const commonMacros = getMacros('common')
+
+describe('LocalHeader macro', () => {
+  describe('invalid props', () => {
+    it('should not render if props is not given', () => {
+      const component = commonMacros.renderToDom('LocalHeader')
+      expect(component).to.be.null
+    })
+  })
+
+  describe('valid props', () => {
+    it('should render page heading', () => {
+      const component = commonMacros.renderToDom('LocalHeader', {
+        pageHeading: 'I am hot',
+      })
+      expect(component.className.trim()).to.equal('c-local-header')
+      expect(component.querySelector('.c-local-header__heading').textContent.trim()).to.equal('I am hot')
+    })
+
+    it('should render local header with custom modifier', () => {
+      const component = commonMacros.renderToDom('LocalHeader', {
+        modifier: ['azure'],
+      })
+      expect(component.className).to.contain('c-local-header--azure')
+    })
+
+    it('should render local header with multiple custom modifiers', () => {
+      const component = commonMacros.renderToDom('LocalHeader', {
+        modifier: ['beautiful', 'azure'],
+      })
+      expect(component.className).to.contain.all('c-local-header--beautiful', 'c-local-header--azure')
+    })
+
+    it('should render local header with breadcrumbs', () => {
+      const component = commonMacros.renderToDom('LocalHeader', {
+        breadcrumbs: [
+          {
+            name: 'Home',
+            url: '/',
+          }, {
+            name: 'Second level',
+            url: '/second-level',
+          },
+        ],
+      })
+
+      const breadcrumbItems = component.querySelectorAll('.c-breadcrumb__list-item')
+      expect(component.querySelector('.c-breadcrumb')).to.exist
+      expect(breadcrumbItems).to.have.length(2)
+      expect(breadcrumbItems[0].querySelector('a').getAttribute('href')).to.equal('/')
+      expect(breadcrumbItems[0].querySelector('a').textContent.trim()).to.equal('Home')
+      expect(breadcrumbItems[1].querySelector('a').getAttribute('href')).to.equal('#main-content')
+      expect(breadcrumbItems[1].querySelector('a').textContent.trim()).to.equal('Second level')
+    })
+  })
+
+  it('should render local header with flash message', () => {
+    const component = commonMacros.renderToDom('LocalHeader', {
+      messages: {
+        error: ['Error message'],
+        success: ['Success message'],
+      },
+    })
+
+    const messagesEls = component.querySelectorAll('.c-messages__item')
+    expect(component.querySelector('.c-messages')).to.exist
+    expect(messagesEls[0].className).to.contain('c-messages__item--error')
+    expect(messagesEls[0].textContent).to.equal('Error message')
+    expect(messagesEls[1].className).to.contain('c-messages__item--success')
+    expect(messagesEls[1].textContent).to.equal('Success message')
+  })
+
+  it('should render local header with string heading heading', () => {
+    const component = commonMacros.renderToDom('LocalHeader', {
+      pageHeadingBefore: '<strong>Superb</strong>',
+    })
+
+    const headingBeforeEl = component.querySelector('.c-local-header__heading-before')
+    expect(headingBeforeEl).to.exist
+    expect(headingBeforeEl.querySelector('strong').textContent.trim()).to.equal('Superb')
+  })
+
+  it('should render local header with string heading suffix', () => {
+    const component = commonMacros.renderToDom('LocalHeader', {
+      pageHeading: 'Tyom',
+      pageHeadingSuffix: '<strong>S</strong>',
+    })
+
+    const headingEl = component.querySelector('.c-local-header__heading')
+    expect(headingEl).to.exist
+    expect(headingEl.textContent.trim()).to.equal('Tyom S')
+    expect(headingEl.querySelector('strong').textContent.trim()).to.equal('S')
+  })
+})

--- a/test/unit/components/local-nav.js
+++ b/test/unit/components/local-nav.js
@@ -1,0 +1,35 @@
+const { getMacros } = require('~/test/unit/component-helper')
+const commonMacros = getMacros('common')
+
+describe('LocalNav macro', () => {
+  describe('invalid props', () => {
+    it('should not render if props is not given', () => {
+      const component = commonMacros.renderToDom('LocalNav')
+      expect(component).to.be.null
+    })
+  })
+
+  describe('valid props', () => {
+    it('should render local nav', () => {
+      const component = commonMacros.renderToDom('LocalNav', {
+        items: [
+          { path: '/first-item', label: 'First item' },
+          { path: '/second-item', label: 'Second item' },
+        ],
+      })
+      expect(component.className.trim()).to.equal('c-local-nav')
+      expect(component.querySelectorAll('.c-local-nav__link')).to.have.length(2)
+    })
+
+    it('should render local nav with currently selected item', () => {
+      const component = commonMacros.renderToDom('LocalNav', {
+        items: [
+          { path: '/first-item', label: 'First item', isActive: true },
+          { path: '/second-item', label: 'Second item' },
+        ],
+      })
+      expect(component.className.trim()).to.equal('c-local-nav')
+      expect(component.querySelectorAll('.c-local-nav__link.is-active')).to.have.length(1)
+    })
+  })
+})

--- a/test/unit/middleware/local-nav.test.js
+++ b/test/unit/middleware/local-nav.test.js
@@ -1,0 +1,46 @@
+describe('#localNavMiddleware', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.localNavMiddleware = require('~/src/middleware/local-nav')
+
+    this.nextSpy = this.sandbox.spy()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  const NAV_ITEMS = [
+    { path: '../first', label: 'First' },
+    { path: '../second', label: 'Second' },
+  ]
+
+  it('should attach nav items props to locals', () => {
+    const resMock = {
+      locals: {
+        CURRENT_PATH: '/sub-app/resource',
+      },
+    }
+
+    this.localNavMiddleware(NAV_ITEMS)({}, resMock, this.nextSpy)
+
+    expect(resMock.locals).to.haveOwnProperty('localNavItems')
+    expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
+    expect(resMock.locals.localNavItems[0].isActive).to.be.false
+    expect(this.nextSpy.calledOnce).to.be.true
+  })
+
+  it('should set new isActive to true for the current path', () => {
+    const resMock = {
+      locals: {
+        CURRENT_PATH: '/sub-app/first',
+      },
+    }
+    this.localNavMiddleware(NAV_ITEMS)({}, resMock, this.nextSpy)
+
+    expect(resMock.locals).to.haveOwnProperty('localNavItems')
+    expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
+    expect(resMock.locals.localNavItems[0].isActive).to.be.true
+    expect(this.nextSpy.calledOnce).to.be.true
+  })
+})


### PR DESCRIPTION
Make structural and visual changes to page header. By making the header visually stand out from from the rest of the content it helps the user to scan the page and contain certain global UI elements (such as search, page-level actions).

Additionally tweak local nav styles by tightening the buttons and removing side border.

Fix a number of issues with inconsistent or missing heading on some of the pages.

### 💥 [Demo](https://datahub-beta2-pr-345.herokuapp.com/) 💥

![localhost-3001-search-companies-term samsung](https://user-images.githubusercontent.com/203886/28484192-f86d9bac-6e68-11e7-9da3-4fbc15874454.png)

![localhost-3001-companies-view-ukother-dcdabbc9-1781-e411-8955-e4115bead28a](https://user-images.githubusercontent.com/203886/28484194-fa3f72f2-6e68-11e7-9b9d-bfe204f2952d.png)

![localhost-3001-contacts-64f7aa36-0334-4628-a7c3-682328d613f6](https://user-images.githubusercontent.com/203886/28484198-fd301066-6e68-11e7-9c7a-22b8150a3b34.png)

![localhost-3001-components-local-header](https://user-images.githubusercontent.com/203886/28484200-fec05b52-6e68-11e7-9fee-a329d1c7f59b.png)
