### PR TITLE
Fix truncation in pagination

### DIFF
--- a/assets/stylesheets/components/_pagination.scss
+++ b/assets/stylesheets/components/_pagination.scss
@@ -1,6 +1,24 @@
 @import "../settings";
+@import "../tools/mixins";
+
+@mixin _pageless {
+  .c-pagination__list {
+    display: none;
+  }
+
+  .c-pagination__label--prev,
+  .c-pagination__label--next {
+    float: left;
+    font-size: 24px;
+  }
+
+  .c-pagination__label--next {
+    float: right;
+  }
+}
 
 .c-pagination {
+  @include clearfix;
   text-align: center;
   line-height: 1;
 }
@@ -29,4 +47,12 @@
   background-color: transparent;
   padding-right: $default-spacing-unit / 2;
   padding-left: $default-spacing-unit / 2;
+}
+
+@include media(mobile) {
+  @include _pageless;
+}
+
+.c-pagination--pageless {
+  @include _pageless;
 }

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -6,7 +6,7 @@
  # Pagination object has the following structure:
  #
  # {
- #   totalPages: 6,
+ #   totalPages: 7,
  #   currentPage: 1,
  #   prev: null,
  #   next: '?page=2',
@@ -16,7 +16,7 @@
  #     { label: 3, url: '?page=3' },
  #     { label: 4, url: '?page=4' },
  #     { label: '…' },
- #     { label: 6, url: '?page=6' },
+ #     { label: 7, url: '?page=7' },
  #   ]
  # }
  #}

--- a/test/unit/lib/pagination.test.js
+++ b/test/unit/lib/pagination.test.js
@@ -103,5 +103,25 @@ describe('Pagination', () => {
       }
       expect(actual).to.deep.equal(expected)
     })
+
+    it('should return pagination object with no truncation when block start page is close to first or last pages', () => {
+      const actual = buildPagination(reqMock, { count: 21, limit: 3, page: 4 }, 4)
+      const expected = {
+        totalPages: 7,
+        currentPage: 4,
+        prev: '?term=samsung&page=3',
+        next: '?term=samsung&page=5',
+        pages: [
+          { label: 1, url: '?term=samsung&page=1' },
+          { label: 2, url: '?term=samsung&page=2' },
+          { label: 3, url: '?term=samsung&page=3' },
+          { label: 4, url: '?term=samsung&page=4' },
+          { label: 5, url: '?term=samsung&page=5' },
+          { label: 6, url: '?term=samsung&page=6' },
+          { label: 7, url: '?term=samsung&page=7' },
+        ],
+      }
+      expect(actual).to.deep.equal(expected)
+    })
   })
 })


### PR DESCRIPTION
1. Fixes pagination truncation for pagination block start/end that is next to the first/last pages.

### Before
<img src="https://user-images.githubusercontent.com/203886/28343222-2e7ee464-6c14-11e7-8f51-8a089482004f.png" width="340">
<img src="https://user-images.githubusercontent.com/203886/28343128-b1c2ea24-6c13-11e7-98d7-9f8d4bb5d95e.png" width="530">

### After
<img src="https://user-images.githubusercontent.com/203886/28343222-2e7ee464-6c14-11e7-8f51-8a089482004f.png" width="340">
<img src="https://user-images.githubusercontent.com/203886/28343117-a2265b3c-6c13-11e7-8bd7-c983b7a7fb4f.png" width="530">

2. Removes page numbers on smaller screens and makes previous/next buttons larger

<img src="https://user-images.githubusercontent.com/203886/28362367-13a572b0-6c74-11e7-9753-03b1b3813293.png" width="300">

