### PR TITLE
expose javascript errors and make them human readable

### DIFF
--- a/config/logger.js
+++ b/config/logger.js
@@ -10,6 +10,7 @@ loggingTransports.push(new (winston.transports.Console)({
   json: false,
   colorize: true,
   handleExceptions: true,
+  humanReadableUnhandledException: true,
 }))
 
 if (config.env === 'production') {

--- a/src/apps/adviser/index.js
+++ b/src/apps/adviser/index.js
@@ -1,0 +1,2 @@
+// TODO adviser will become an app soon, this is a stop gap to avoid routers.js reporting an error
+module.exports = {}

--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -2,24 +2,19 @@ const router = require('express').Router()
 const fs = require('fs')
 
 const { setHomeBreadcrumb } = require('./middleware')
-const logger = require('../../config/logger')
 
 const appsRouters = []
 const subApps = fs.readdirSync(__dirname)
 
 subApps.forEach(subAppDir => {
-  try {
-    const subApp = require(`./${subAppDir}`)
+  const subApp = require(`./${subAppDir}`)
 
-    if (subApp.mountpath) {
-      appsRouters.push(router.use(subApp.mountpath, setHomeBreadcrumb(subApp.displayName), subApp.router))
-    } else if (subApp.router) {
-      appsRouters.push(router.use(subApp.router))
-    } else {
-      appsRouters.push((req, res, next) => next())
-    }
-  } catch (err) {
-    logger.warn(err.message)
+  if (subApp.mountpath) {
+    appsRouters.push(router.use(subApp.mountpath, setHomeBreadcrumb(subApp.displayName), subApp.router))
+  } else if (subApp.router) {
+    appsRouters.push(router.use(subApp.router))
+  } else {
+    appsRouters.push((req, res, next) => next())
   }
 })
 


### PR DESCRIPTION
We have been loosing node errors to a `404` and that makes it hard to debug. This work exposes the errors by removing the `try/catch` in the `src/apps/routers` file and makes the `uncaughtException` (handled by winston/churchill) human readable.