### PR TITLE
OMIS skeleton

### DIFF
--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -1,6 +1,15 @@
+const { isFunction } = require('lodash')
+
 module.exports = {
   serviceTitle: 'Data Hub',
   projectPhase: 'alpha',
   description: 'Data Hub is a customer relationship, project management and analytical tool for Department for International Trade.',
   feedbackLink: '/support',
+  callAsMacro: function (name) {
+    const macro = this.ctx[name]
+
+    if (!isFunction(macro)) { return }
+
+    return macro
+  },
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "font-awesome": "^4.6.3",
     "govuk-elements-sass": "^2.2.1",
     "govuk_frontend_toolkit": "^5.0.2",
+    "hmpo-form-wizard": "^8.5.0",
     "html5shiv": "^3.7.3",
     "image-webpack-loader": "^3.3.1",
     "istanbul": "^0.4.5",

--- a/src/apps/omis/index.js
+++ b/src/apps/omis/index.js
@@ -1,0 +1,7 @@
+const router = require('./router')
+
+module.exports = {
+  displayName: 'OMIS',
+  mountpath: '/omis',
+  router,
+}

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -1,0 +1,3 @@
+const router = require('express').Router()
+
+module.exports = router

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -45,6 +45,10 @@ module.exports = function locals (req, res, next) {
 
       return `${assetsUrl}/${asset}`
     },
+
+    getLocal (key) {
+      return res.locals[key]
+    },
   })
   next()
 }

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -11,7 +11,7 @@
 {% from "_macros/_deprecated/trade-elements/textarea.njk" import textarea %}
 {% from "_macros/_deprecated/trade-elements/textbox.njk" import textbox %}
 
-{% from "_macros/form.njk" import EntitySearchForm, Form with context %}
+{% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/form.njk" import Fieldset, TextField, MultipleChoiceField, HiddenField %}
 {% from "_macros/common.njk" import Pagination %}
 {% from "_macros/address.njk" import addressFormatter %}

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -1,0 +1,28 @@
+{% extends "_layouts/two-column.njk" %}
+
+{% block body_main_header_content %}
+  <h1 class="page-heading">{{ pageHeading }}</h1>
+{% endblock %}
+
+{% block main_grid_right_column %}
+  {% block form %}
+    {% call MultiStepForm({
+      buttonText: 'Continue',
+      returnLink: backLink,
+      errors: errors
+    }) %}
+
+      {% block fields %}
+        {% for key, props in options.fields %}
+          {% if props.fieldType %}
+            {{ callAsMacro(props.fieldType)(props | assign({
+              name: key,
+              value: values[key]
+            })) }}
+          {% endif %}
+        {% endfor %}
+      {% endblock %}
+
+    {% endcall %}
+  {% endblock %}
+{% endblock %}

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -44,6 +44,7 @@
   {% set method = props.method or 'POST' -%}
   {% set buttonText = props.buttonText or 'Submit' %}
   {% set returnText = props.returnText or 'Back' %}
+
   <form
     method="{{ method }}"
     {% if props.action %}action="{{ props.action }}"{% endif -%}
@@ -52,12 +53,12 @@
   >
     {{ ErrorSummary(props.errors) }}
 
-    {% if method|lower === 'post' %}
-      {{ CSRF(csrfToken) }}
-    {% endif %}
+    {% set hiddenFields = props.hiddenFields | default({}) | assign({
+      '_csrf': csrfToken if method|lower === 'post'
+    }) %}
 
-    {% if props.hiddenFields|length %}
-      {% for fieldName, fieldValue in props.hiddenFields | removeNilAndEmpty %}
+    {% if hiddenFields|length %}
+      {% for fieldName, fieldValue in hiddenFields | removeNilAndEmpty %}
         <input type="hidden" name="{{ fieldName }}" value="{{ fieldValue }}">
       {% endfor %}
     {% endif %}
@@ -73,6 +74,25 @@
       </div>
     {% endif %}
   </form>
+{% endmacro %}
+
+{##
+ # Render multi-step form
+ # @param {object} props - A form object
+ #}
+{% macro MultiStepForm(props) %}
+  {% set formContent = caller() if caller else null %}
+  {% set method = props.method or 'POST' -%}
+  {% set hiddenFields = props.hiddenFields | default({}) | assign({
+    'x-csrf-token': getLocal('csrf-token') if method|lower === 'post'
+  }) %}
+
+  {% call Form(props | assign({
+    formContent: formContent,
+    hiddenFields: hiddenFields
+  })) %}
+    {{ props.formContent }}
+  {% endcall %}
 {% endmacro %}
 
 {##
@@ -140,16 +160,6 @@
       </nav>
     {% endif %}
   {% endcall %}
-{% endmacro %}
-
-{##
- # Render hidden input with CSRF value
- # @param {string} token - CSRF token
- #}
-{% macro CSRF(token) %}
-  {% if token -%}
-    <input type="hidden" name="_csrf" value="{{ token }}">
-  {%- endif %}
 {% endmacro %}
 
 {##

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,7 +1807,7 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
-csrf@~3.0.3:
+csrf@^3.0.2, csrf@~3.0.3:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/csrf/-/csrf-3.0.6.tgz#b61120ddceeafc91e76ed5313bb5c0b2667b710a"
   dependencies:
@@ -2012,7 +2012,7 @@ debug-log@^1.0.0, debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@2, debug@2.6.7, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3:
+debug@2, debug@2.6.7, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.6.3:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
   dependencies:
@@ -2902,7 +2902,7 @@ express@2.5.x:
     mkdirp "0.3.0"
     qs "0.4.x"
 
-express@^4.14.0:
+express@^4.12.2, express@^4.12.3, express@^4.14.0:
   version "4.15.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
   dependencies:
@@ -3925,6 +3925,37 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hmpo-form-controller@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hmpo-form-controller/-/hmpo-form-controller-1.1.0.tgz#85abb519125659682b2fe054de91a5a68e660d06"
+  dependencies:
+    debug "^2.1.1"
+    express "^4.12.3"
+    lodash.clonedeep "^4.5.0"
+    moment "^2.9.0"
+    underscore "^1.7.0"
+
+hmpo-form-wizard@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/hmpo-form-wizard/-/hmpo-form-wizard-8.5.0.tgz#b972e216f18141711a0df6d795597e225e203989"
+  dependencies:
+    csrf "^3.0.2"
+    debug "^2.1.2"
+    express "^4.12.2"
+    hmpo-form-controller "^1.1.0"
+    hmpo-model "^1.0.0"
+    hogan.js "^3.0.2"
+    i18n-lookup "^0.1.0"
+    moment "^2.17.1"
+    underscore "^1.8.2"
+
+hmpo-model@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hmpo-model/-/hmpo-model-1.0.0.tgz#b73aeb097d9fc45572604e15896ce6a210862cc0"
+  dependencies:
+    request "^2.72.0"
+    underscore "^1.7.0"
+
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
@@ -3932,6 +3963,13 @@ hoek@2.x.x:
 hoek@4.x.x:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.1.1.tgz#9cc573ffba2b7b408fb5e9c2a13796be94cddce9"
+
+hogan.js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
+  dependencies:
+    mkdirp "0.3.0"
+    nopt "1.0.10"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -4019,6 +4057,12 @@ https-proxy-agent@1:
     agent-base "2"
     debug "2"
     extend "3"
+
+i18n-lookup@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/i18n-lookup/-/i18n-lookup-0.1.0.tgz#ddd7df672263c8b8e87803ac6729d53569fdea8d"
+  dependencies:
+    underscore "^1.8.2"
 
 iconv-lite@0.4.13:
   version "0.4.13"
@@ -5476,7 +5520,7 @@ module-not-found-error@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
-moment@^2.17.1:
+moment@^2.17.1, moment@^2.9.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
@@ -5706,6 +5750,12 @@ nodemon@^1.11.0:
     undefsafe "0.0.3"
     update-notifier "0.5.0"
 
+nopt@1.0.10, nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
+
 "nopt@2 || 3", nopt@3.0.x, nopt@3.x, nopt@~3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -5718,12 +5768,6 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
-
-nopt@~1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  dependencies:
-    abbrev "1"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.3.8"
@@ -7053,7 +7097,7 @@ request-promise@^4.1.1:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.0"
 
-request@2, request@^2.74.0, request@^2.79.0, request@^2.81.0:
+request@2, request@^2.72.0, request@^2.74.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -8384,6 +8428,10 @@ underscore@1.4.x:
 underscore@1.7.x, underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+
+underscore@^1.7.0, underscore@^1.8.2:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This change creates the skeleton sub-app for the Overseas Market Introduction Service (OMIS) replacement. 

It also adds support for using the [HMPO form wizard](https://github.com/UKHomeOffice/passports-form-wizard) to create multi-step form journeys and creates a form step layout that will loop over a set of fields and render them.