### PR TITLE
Add initial OMIS creation journey

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -1,4 +1,5 @@
 @import "components/action-bar";
+@import "components/answers-summary";
 @import "components/breadcrumb";
 @import "components/data-table";
 @import "components/details-list";

--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -1,0 +1,51 @@
+@import "../settings";
+@import "../tools/mixins";
+
+.c-answers-summary {
+  border-top: 1px solid $grey-2;
+}
+
+.c-answers-summary__title,
+.c-answers-summary__content,
+.c-answers-summary__control {
+  border-bottom: 0;
+  display: block;
+  margin: 0;
+  padding: ($default-spacing-unit / 2) ($default-spacing-unit / 4) 0;
+
+  @include media(tablet) {
+    border-top: 1px solid $grey-2;
+    border-bottom: 1px solid $grey-2;
+    display: table-cell;
+    padding: $default-spacing-unit $baseline-grid-unit * 2;
+  }
+}
+
+.c-answers-summary__title {
+  @include bold-font(16);
+  padding-top: $default-spacing-unit;
+
+  @include media(tablet) {
+    width: 25%;
+  }
+}
+
+.c-answers-summary__control {
+  border-bottom: 1px solid $grey-2;
+  padding-bottom: $default-spacing-unit / 2;
+  text-align: left;
+
+  @include media(tablet) {
+    padding-bottom: $default-spacing-unit;
+    text-align: right;
+  }
+
+  .button {
+    @include core-font(16);
+    margin-bottom: $default-spacing-unit;
+
+    @include media(tablet) {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/assets/stylesheets/objects/_list.scss
+++ b/assets/stylesheets/objects/_list.scss
@@ -21,3 +21,8 @@
     border-top: 1px solid $border-colour;
   }
 }
+
+.list-disc {
+  list-style: disc outside;
+  padding-left: 1em;
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "postcss-loader": "^2.0.6",
     "proxyquire": "^1.7.10",
     "query-string": "^5.0.0",
+    "reqres": "^1.3.0",
     "request": "^2.74.0",
     "request-promise": "^4.1.1",
     "resolve-url-loader": "^2.0.3",

--- a/src/apps/omis/apps/create/controllers/assign-ita.js
+++ b/src/apps/omis/apps/create/controllers/assign-ita.js
@@ -1,0 +1,17 @@
+const { sortBy } = require('lodash')
+
+const Controller = require('./base')
+const { getAdvisers } = require('../../../../adviser/repos')
+const { transformToOptions } = require('../../../../transformers')
+
+class AssignItaController extends Controller {
+  async configure (req, res, next) {
+    const advisers = await getAdvisers(req.session.token)
+    const options = transformToOptions(advisers.results)
+
+    req.form.options.fields.ita.options = sortBy(options, 'label')
+    super.configure(req, res, next)
+  }
+}
+
+module.exports = AssignItaController

--- a/src/apps/omis/apps/create/controllers/base.js
+++ b/src/apps/omis/apps/create/controllers/base.js
@@ -1,0 +1,25 @@
+const { get, last } = require('lodash')
+const { Controller } = require('hmpo-form-wizard')
+
+class CreateBaseController extends Controller {
+  locals (req, res) {
+    let locals = super.locals(req, res)
+    locals.pageHeading = 'Create order'
+    return locals
+  }
+
+  errorHandler (err, req, res, next) {
+    if (get(err, 'code') === 'MISSING_PREREQ') {
+      const lastStep = last(req.journeyModel.get('history'))
+
+      if (!lastStep) {
+        return res.redirect('/omis/create')
+      }
+      return res.redirect(lastStep.path)
+    }
+
+    super.errorHandler(err, req, res, next)
+  }
+}
+
+module.exports = CreateBaseController

--- a/src/apps/omis/apps/create/controllers/base.js
+++ b/src/apps/omis/apps/create/controllers/base.js
@@ -2,12 +2,6 @@ const { get, last } = require('lodash')
 const { Controller } = require('hmpo-form-wizard')
 
 class CreateBaseController extends Controller {
-  locals (req, res) {
-    let locals = super.locals(req, res)
-    locals.pageHeading = 'Create order'
-    return locals
-  }
-
   errorHandler (err, req, res, next) {
     if (get(err, 'code') === 'MISSING_PREREQ') {
       const lastStep = last(req.journeyModel.get('history'))

--- a/src/apps/omis/apps/create/controllers/company-details.js
+++ b/src/apps/omis/apps/create/controllers/company-details.js
@@ -1,0 +1,31 @@
+const { sortBy } = require('lodash')
+
+const Controller = require('./base')
+const { transformContactsToOptions } = require('../../../../transformers')
+
+class CompanyDetailsController extends Controller {
+  configure (req, res, next) {
+    const company = res.locals.company
+    let contacts = []
+
+    if (company) {
+      contacts = transformContactsToOptions(company.contacts)
+      contacts = sortBy(contacts, 'label')
+    }
+
+    req.form.options.fields.contact.options = contacts
+    super.configure(req, res, next)
+  }
+
+  getValues (req, res, next) {
+    const company = res.locals.company
+
+    super.getValues(req, res, (err, values) => {
+      values.company = company.id
+
+      next(err, values)
+    })
+  }
+}
+
+module.exports = CompanyDetailsController

--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -1,0 +1,42 @@
+const { find, unset } = require('lodash')
+
+const Controller = require('./base')
+const metadataRepo = require('../../../../../lib/metadata')
+const { getAdvisers } = require('../../../../adviser/repos')
+const { Order } = require('../../../models')
+
+class ConfirmController extends Controller {
+  async getValues (req, res, next) {
+    const advisers = await getAdvisers(req.session.token)
+
+    super.getValues(req, res, (err, values) => {
+      const company = res.locals.company
+      const contact = find(company.contacts, { id: values.contact })
+
+      values.contact = `${contact.first_name} ${contact.last_name}`
+      values.company = company
+      values.primary_market = find(metadataRepo.countryOptions, { id: values.primary_market })
+      values.ita = find(advisers.results, { id: values.ita })
+
+      next(err, values)
+    })
+  }
+
+  async successHandler (req, res, next) {
+    const data = req.sessionModel.toJSON()
+
+    // clean un-needed properties
+    unset(data, 'csrf-secret')
+    unset(data, 'errors')
+
+    try {
+      const order = await Order.save(req.session.token, data)
+      req.journeyModel.reset()
+      res.redirect(`/omis/${order.id}`)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = ConfirmController

--- a/src/apps/omis/apps/create/controllers/index.js
+++ b/src/apps/omis/apps/create/controllers/index.js
@@ -1,0 +1,13 @@
+const AssignItaController = require('./assign-ita')
+const BaseController = require('./base')
+const CompanyDetailsController = require('./company-details')
+const MarketController = require('./market')
+const ConfirmController = require('./confirm')
+
+module.exports = {
+  AssignItaController,
+  BaseController,
+  CompanyDetailsController,
+  MarketController,
+  ConfirmController,
+}

--- a/src/apps/omis/apps/create/controllers/market.js
+++ b/src/apps/omis/apps/create/controllers/market.js
@@ -1,0 +1,12 @@
+const Controller = require('./base')
+const metadataRepo = require('../../../../../lib/metadata')
+const { transformToOptions } = require('../../../../transformers')
+
+class MarketController extends Controller {
+  configure (req, res, next) {
+    req.form.options.fields.primary_market.options = transformToOptions(metadataRepo.countryOptions)
+    super.configure(req, res, next)
+  }
+}
+
+module.exports = MarketController

--- a/src/apps/omis/apps/create/fields.js
+++ b/src/apps/omis/apps/create/fields.js
@@ -1,0 +1,29 @@
+module.exports = {
+  'company': {
+    fieldType: 'HiddenField',
+    validate: 'required',
+  },
+  'contact': {
+    fieldType: 'MultipleChoiceField',
+    label: 'Company contact',
+    hint: 'Select a contact for the company',
+    validate: 'required',
+    initialOption: '-- Select contact --',
+    options: [],
+  },
+  'primary_market': {
+    fieldType: 'MultipleChoiceField',
+    label: 'Primary market',
+    hint: 'The market which should be providing the service',
+    validate: 'required',
+    initialOption: '-- Select market --',
+    options: [],
+  },
+  'ita': {
+    fieldType: 'MultipleChoiceField',
+    label: 'International Trade Adviser (optional)',
+    hint: 'The ITA responsible for overseeing the work from a UK region',
+    initialOption: '-- Select adviser --',
+    options: [],
+  },
+}

--- a/src/apps/omis/apps/create/index.js
+++ b/src/apps/omis/apps/create/index.js
@@ -1,7 +1,7 @@
 const router = require('./router')
 
 module.exports = {
-  displayName: 'Create new order',
+  displayName: 'Create order',
   mountpath: '/create',
   router,
 }

--- a/src/apps/omis/apps/create/index.js
+++ b/src/apps/omis/apps/create/index.js
@@ -1,0 +1,7 @@
+const router = require('./router')
+
+module.exports = {
+  displayName: 'Create new order',
+  mountpath: '/create',
+  router,
+}

--- a/src/apps/omis/apps/create/router.js
+++ b/src/apps/omis/apps/create/router.js
@@ -1,0 +1,19 @@
+const router = require('express').Router()
+const wizard = require('hmpo-form-wizard')
+
+const steps = require('./steps')
+const fields = require('./fields')
+const { params } = require('../../middleware')
+const { BaseController } = require('./controllers')
+
+const config = {
+  controller: BaseController,
+  name: 'omis-create-order',
+  template: '_layouts/form-wizard-step',
+}
+
+router.param('companyId', params.getCompany)
+
+router.use('/:companyId?', wizard(steps, fields, config))
+
+module.exports = router

--- a/src/apps/omis/apps/create/steps.js
+++ b/src/apps/omis/apps/create/steps.js
@@ -1,0 +1,41 @@
+const {
+  AssignItaController,
+  CompanyDetailsController,
+  MarketController,
+  ConfirmController,
+} = require('./controllers')
+
+module.exports = {
+  '/': {
+    entryPoint: true,
+    resetJourney: true,
+    next: 'client-details',
+    templatePath: 'omis/apps/create/views',
+    template: 'start',
+  },
+  '/client-details': {
+    backLink: null,
+    editable: true,
+    next: 'market',
+    fields: ['company', 'contact'],
+    controller: CompanyDetailsController,
+  },
+  '/market': {
+    editable: true,
+    next: 'assign-ita',
+    fields: ['primary_market'],
+    controller: MarketController,
+  },
+  '/assign-ita': {
+    editable: true,
+    next: 'confirm',
+    fields: ['ita'],
+    controller: AssignItaController,
+  },
+  '/confirm': {
+    backLink: null,
+    templatePath: 'omis/apps/create/views',
+    template: 'summary',
+    controller: ConfirmController,
+  },
+}

--- a/src/apps/omis/apps/create/views/start.njk
+++ b/src/apps/omis/apps/create/views/start.njk
@@ -1,0 +1,15 @@
+{% extends "_layouts/form-wizard-step.njk" %}
+
+{% block form %}
+  {% call MultiStepForm({
+    buttonText: 'Start'
+  }) %}
+    <p>Things you will need in order to create a new order:</p>
+
+    <ul class="list-disc">
+      <li>a client company</li>
+      <li>a contact at the client company</li>
+      <li>which market the client is interested in</li>
+    </ul>
+  {% endcall %}
+{% endblock %}

--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -1,0 +1,43 @@
+{% extends "_layouts/form-wizard-step.njk" %}
+
+{% set heading = 'Check order details' %}
+
+{% block form %}
+  {% call MultiStepForm({
+    buttonText: 'Create order'
+  }) %}
+
+    <table class="c-answers-summary">
+      <caption class="c-answers-summary__heading">Client</caption>
+      <tr>
+        <th class="c-answers-summary__title" scope="row">Company</th>
+        <td class="c-answers-summary__content">{{ values.company.name }}</td>
+        <td class="c-answers-summary__control"></td>
+      </tr>
+      <tr>
+        <th class="c-answers-summary__title" scope="row">Contact</th>
+        <td class="c-answers-summary__content">{{ values.contact }}</td>
+        <td class="c-answers-summary__control"><a class="button button-secondary" href="client-details/edit">Change</a></td>
+      </tr>
+    </table>
+
+    <table class="c-answers-summary">
+      <caption class="c-answers-summary__heading">Market of interest</caption>
+      <tr>
+        <th class="c-answers-summary__title" scope="row">Primary market</th>
+        <td class="c-answers-summary__content">{{ values.primary_market.name }}</td>
+        <td class="c-answers-summary__control"><a class="button button-secondary" href="market/edit">Change</a></td>
+      </tr>
+    </table>
+
+    <table class="c-answers-summary">
+      <caption class="c-answers-summary__heading">Team</caption>
+      <tr>
+        <th class="c-answers-summary__title" scope="row">ITA</th>
+        <td class="c-answers-summary__content">{{ values.ita.name if values.ita else 'Not selected' }}</td>
+        <td class="c-answers-summary__control"><a class="button button-secondary" href="assign-ita/edit">Change</a></td>
+      </tr>
+    </table>
+
+  {% endcall %}
+{% endblock %}

--- a/src/apps/omis/middleware/index.js
+++ b/src/apps/omis/middleware/index.js
@@ -1,0 +1,5 @@
+const params = require('./params')
+
+module.exports = {
+  params,
+}

--- a/src/apps/omis/middleware/params.js
+++ b/src/apps/omis/middleware/params.js
@@ -1,0 +1,16 @@
+const logger = require('../../../../config/logger')
+const { getInflatedDitCompany } = require('../../companies/services/data')
+
+async function getCompany (req, res, next, companyId) {
+  try {
+    res.locals.company = await getInflatedDitCompany(req.session.token, companyId)
+    next()
+  } catch (e) {
+    logger.error(e)
+    res.redirect('/')
+  }
+}
+
+module.exports = {
+  getCompany,
+}

--- a/src/apps/omis/models.js
+++ b/src/apps/omis/models.js
@@ -1,0 +1,16 @@
+const config = require('../../../config')
+const authorisedRequest = require('../../lib/authorised-request')
+
+const Order = {
+  save (token, data) {
+    return authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/omis/order`,
+      method: 'POST',
+      body: data,
+    })
+  },
+}
+
+module.exports = {
+  Order,
+}

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -1,3 +1,8 @@
 const router = require('express').Router()
 
+const { setHomeBreadcrumb } = require('../middleware')
+const createApp = require('./apps/create')
+
+router.use(createApp.mountpath, setHomeBreadcrumb(createApp.displayName), createApp.router)
+
 module.exports = router

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -1,0 +1,19 @@
+function transformToOptions (items, labelIteratee = (item) => item.name) {
+  return items.map((item) => {
+    return {
+      value: item.id,
+      label: labelIteratee(item),
+    }
+  })
+}
+
+function transformContactsToOptions (items) {
+  return transformToOptions(items, (item) => {
+    return `${item.first_name} ${item.last_name}`
+  })
+}
+
+module.exports = {
+  transformToOptions,
+  transformContactsToOptions,
+}

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -1,7 +1,9 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block body_main_header_content %}
-  <h1 class="page-heading">{{ heading }}</h1>
+{% block local_header %}
+  {% set pageTitle = getPageTitle() %}
+  {% set heading = heading or pageTitle[0] %}
+  {{ LocalHeader({ heading: heading }) }}
 {% endblock %}
 
 {% block main_grid_right_column %}

--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -6,7 +6,9 @@
     "expect": true,
     "proxyquire": true,
     "sinon": true,
-    "rootPath": true
+    "rootPath": true,
+    "globalReq": true,
+    "globalRes": true
   },
   "rules": {
     "no-unused-expressions": 0

--- a/test/unit/apps/omis/apps/create/controllers/assign-ita.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/assign-ita.test.js
@@ -1,0 +1,66 @@
+const FormController = require('hmpo-form-wizard').Controller
+
+const getAdvisersMock = require('~/test/unit/data/investment/interaction/advisers')
+
+describe('OMIS create assign controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.getAdvisersStub = this.sandbox.stub().resolves(getAdvisersMock)
+
+    this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/assign-ita', {
+      '../../../../adviser/repos': {
+        getAdvisers: this.getAdvisersStub,
+      },
+    })
+
+    this.controller = new this.ControllerClass({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('configure()', () => {
+    beforeEach(() => {
+      this.reqMock = Object.assign({}, globalReq, {
+        form: {
+          options: {
+            fields: {
+              ita: {},
+            },
+          },
+        },
+      })
+
+      FormController.prototype.configure = this.sandbox.spy()
+    })
+
+    it('should set options for advisers', (done) => {
+      FormController.prototype.configure = (req, res, next) => {
+        try {
+          expect(req).to.deep.equal(this.reqMock)
+          expect(res).to.deep.equal(globalRes)
+          next()
+        } catch (err) {
+          done(err)
+        }
+      }
+
+      const nextSpy = () => {
+        try {
+          expect(this.reqMock.form.options.fields.ita.options).to.deep.equal([
+            {
+              value: '0513453c-86bc-e211-a646-e4115bead28a',
+              label: 'Tom Thumb',
+            },
+          ])
+          done()
+        } catch (err) {
+          done(err)
+        }
+      }
+
+      this.controller.configure(this.reqMock, globalRes, nextSpy)
+    })
+  })
+})

--- a/test/unit/apps/omis/apps/create/controllers/base.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/base.test.js
@@ -1,0 +1,119 @@
+const FormController = require('hmpo-form-wizard').Controller
+
+const Controller = require('~/src/apps/omis/apps/create/controllers/base')
+
+describe('OMIS create base controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.controller = new Controller({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('locals()', () => {
+    describe('when the parent class returns an empty object', () => {
+      beforeEach(() => {
+        FormController.prototype.locals = this.sandbox.stub().returns({})
+      })
+
+      it('should return an object with only new properties', () => {
+        const locals = this.controller.locals(globalReq, globalRes)
+
+        expect(locals).to.have.property('pageHeading')
+        expect(Object.keys(locals).length).to.equal(1)
+      })
+    })
+
+    describe('when the parent class returns an object', () => {
+      beforeEach(() => {
+        FormController.prototype.locals = this.sandbox.stub().returns({
+          foo: 'bar',
+          fizz: 'buzz',
+        })
+      })
+
+      it('should append new properties', () => {
+        const locals = this.controller.locals(globalReq, globalRes)
+
+        expect(locals).to.have.property('foo')
+        expect(locals.foo).to.equal('bar')
+
+        expect(locals).to.have.property('fizz')
+        expect(locals.fizz).to.equal('buzz')
+
+        expect(locals).to.have.property('pageHeading')
+
+        expect(Object.keys(locals).length).to.equal(3)
+      })
+    })
+  })
+
+  describe('errorHandler()', () => {
+    beforeEach(() => {
+      this.nextSpy = this.sandbox.spy()
+      this.redirectSpy = this.sandbox.spy()
+      this.errorHandlerSpy = this.sandbox.spy()
+      this.resMock = Object.assign({}, globalRes, {
+        redirect: this.redirectSpy,
+      })
+
+      FormController.prototype.errorHandler = this.errorHandlerSpy
+    })
+
+    describe('when it doesn\'t return missing prereq error', () => {
+      beforeEach(() => {
+        this.errorMock = new Error()
+        this.errorMock.code = 'OTHER_ERROR'
+      })
+
+      it('should call next', () => {
+        this.controller.errorHandler(this.errorMock, globalReq, this.resMock, this.nextSpy)
+
+        expect(this.errorHandlerSpy).to.be.calledWith(this.errorMock, globalReq, this.resMock, this.nextSpy)
+        expect(this.redirectSpy).not.to.be.called
+      })
+    })
+
+    describe('when it returns missing prereq error', () => {
+      beforeEach(() => {
+        this.getStub = this.sandbox.stub()
+        this.errorMock = new Error()
+        this.errorMock.code = 'MISSING_PREREQ'
+        this.reqMock = Object.assign({}, globalReq, {
+          journeyModel: {
+            get: this.getStub,
+          },
+        })
+      })
+
+      describe('when last step is not defined', () => {
+        it('should redirect to the create first step', () => {
+          this.getStub.returns([])
+          this.controller.errorHandler(this.errorMock, this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.redirectSpy).to.be.calledWith('/omis/create')
+          expect(this.errorHandlerSpy).not.to.be.called
+        })
+      })
+
+      describe('when last step is defined', () => {
+        it('should redirect to the create first step', () => {
+          const historyMock = [{
+            path: 'first-item',
+          }, {
+            path: 'last-item',
+          }]
+
+          this.getStub.returns(historyMock)
+
+          this.controller.errorHandler(this.errorMock, this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.redirectSpy).to.be.calledWith('last-item')
+          expect(this.errorHandlerSpy).not.to.be.called
+        })
+      })
+    })
+  })
+})

--- a/test/unit/apps/omis/apps/create/controllers/base.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/base.test.js
@@ -12,44 +12,6 @@ describe('OMIS create base controller', () => {
     this.sandbox.restore()
   })
 
-  describe('locals()', () => {
-    describe('when the parent class returns an empty object', () => {
-      beforeEach(() => {
-        FormController.prototype.locals = this.sandbox.stub().returns({})
-      })
-
-      it('should return an object with only new properties', () => {
-        const locals = this.controller.locals(globalReq, globalRes)
-
-        expect(locals).to.have.property('pageHeading')
-        expect(Object.keys(locals).length).to.equal(1)
-      })
-    })
-
-    describe('when the parent class returns an object', () => {
-      beforeEach(() => {
-        FormController.prototype.locals = this.sandbox.stub().returns({
-          foo: 'bar',
-          fizz: 'buzz',
-        })
-      })
-
-      it('should append new properties', () => {
-        const locals = this.controller.locals(globalReq, globalRes)
-
-        expect(locals).to.have.property('foo')
-        expect(locals.foo).to.equal('bar')
-
-        expect(locals).to.have.property('fizz')
-        expect(locals.fizz).to.equal('buzz')
-
-        expect(locals).to.have.property('pageHeading')
-
-        expect(Object.keys(locals).length).to.equal(3)
-      })
-    })
-  })
-
   describe('errorHandler()', () => {
     beforeEach(() => {
       this.nextSpy = this.sandbox.spy()

--- a/test/unit/apps/omis/apps/create/controllers/company-details.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/company-details.test.js
@@ -1,0 +1,137 @@
+const FormController = require('hmpo-form-wizard').Controller
+
+const Controller = require('~/src/apps/omis/apps/create/controllers/company-details')
+
+const contactsMockData = [{
+  id: '1',
+  first_name: 'Fred',
+  last_name: 'Stevens',
+}, {
+  id: '2',
+  first_name: 'Alex',
+  last_name: 'George',
+}]
+
+describe('OMIS create company details controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.controller = new Controller({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('configure()', () => {
+    beforeEach(() => {
+      this.reqMock = Object.assign({}, globalReq, {
+        form: {
+          options: {
+            fields: {
+              contact: {},
+            },
+          },
+        },
+      })
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          company: undefined,
+        },
+      })
+
+      FormController.prototype.configure = this.sandbox.spy()
+    })
+
+    describe('when a company exists', () => {
+      it('should set the list of contacts', () => {
+        this.resMock.locals.company = {
+          contacts: contactsMockData,
+        }
+
+        this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+
+        expect(this.reqMock.form.options.fields.contact.options).to.deep.equal([
+          {
+            value: '2',
+            label: 'Alex George',
+          },
+          {
+            value: '1',
+            label: 'Fred Stevens',
+          },
+        ])
+        expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, this.resMock, this.nextSpy)
+      })
+    })
+
+    describe('when a company doesn\'t exist', () => {
+      it('should set empty contacts', () => {
+        this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+
+        expect(this.reqMock.form.options.fields.contact.options).to.deep.equal([])
+        expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, this.resMock, this.nextSpy)
+      })
+    })
+  })
+
+  describe('getValues()', () => {
+    beforeEach(() => {
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          company: {
+            id: '1234567890',
+          },
+        },
+      })
+    })
+
+    describe('when the parent has set some values', () => {
+      beforeEach(() => {
+        FormController.prototype.getValues = (req, res, next) => {
+          next(null, {
+            foo: 'bar',
+          })
+        }
+      })
+
+      it('should set the correct values', (done) => {
+        const nextMock = (e, values) => {
+          try {
+            expect(Object.keys(values).length).to.equal(2)
+            expect(values).to.have.property('company')
+            expect(values.company).to.equal('1234567890')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        }
+
+        this.controller.getValues(globalReq, this.resMock, nextMock)
+      })
+    })
+
+    describe('when the parent hasn\'t set some values', () => {
+      beforeEach(() => {
+        FormController.prototype.getValues = (req, res, next) => {
+          next(null, {})
+        }
+      })
+
+      it('should set the correct values', (done) => {
+        const nextMock = (e, values) => {
+          try {
+            expect(Object.keys(values).length).to.equal(1)
+            expect(values).to.have.property('company')
+            expect(values.company).to.equal('1234567890')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        }
+
+        this.controller.getValues(globalReq, this.resMock, nextMock)
+      })
+    })
+  })
+})

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -1,0 +1,173 @@
+const FormController = require('hmpo-form-wizard').Controller
+
+const getAdvisersMockData = require('~/test/unit/data/investment/interaction/advisers')
+const saveMockData = {
+  id: '1234567890',
+}
+const metadataCountryMockData = [{
+  id: '1',
+  name: 'Country One',
+}, {
+  id: '2',
+  name: 'Country Two',
+}]
+const contactsMockData = [{
+  id: '1',
+  first_name: 'Fred',
+  last_name: 'Stevens',
+}, {
+  id: '2',
+  first_name: 'Alex',
+  last_name: 'George',
+}]
+
+describe('OMIS create confirm controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.getAdvisersStub = this.sandbox.stub().resolves(getAdvisersMockData)
+    this.orderSaveStub = this.sandbox.stub()
+
+    this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/confirm', {
+      '../../../../adviser/repos': {
+        getAdvisers: this.getAdvisersStub,
+      },
+      '../../../../../lib/metadata': {
+        countryOptions: metadataCountryMockData,
+      },
+      '../../../models': {
+        Order: {
+          save: this.orderSaveStub,
+        },
+      },
+    })
+
+    this.controller = new this.ControllerClass({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('getValues()', () => {
+    beforeEach(() => {
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          company: {
+            id: '1234567890',
+            contacts: contactsMockData,
+          },
+        },
+      })
+      this.valuesMock = {
+        contact: '1',
+        company: 'company-12345',
+        ita: '0513453c-86bc-e211-a646-e4115bead28a',
+        primary_market: '2',
+      }
+    })
+
+    describe('when the parent has set some values', () => {
+      beforeEach(() => {
+        FormController.prototype.getValues = (req, res, next) => {
+          next(null, this.valuesMock)
+        }
+      })
+
+      it('should set the correct values', (done) => {
+        const nextMock = (e, values) => {
+          try {
+            expect(Object.keys(values).length).to.equal(4)
+            expect(values).to.deep.equal({
+              company: {
+                id: '1234567890',
+                contacts: contactsMockData,
+              },
+              contact: 'Fred Stevens',
+              primary_market: metadataCountryMockData[1],
+              ita: getAdvisersMockData.results[0],
+            })
+            done()
+          } catch (err) {
+            done(err)
+          }
+        }
+
+        this.controller.getValues(globalReq, this.resMock, nextMock)
+      })
+    })
+  })
+
+  describe('successHandler()', () => {
+    beforeEach(() => {
+      this.resetSpy = this.sandbox.spy()
+      this.reqMock = Object.assign({}, globalReq, {
+        session: {
+          token: 'token-12345',
+        },
+        sessionModel: {
+          toJSON: this.sandbox.stub().returns({
+            'csrf-secret': 'secret-key',
+            errors: {},
+            foo: 'bar',
+            fizz: 'buzz',
+          }),
+        },
+        journeyModel: {
+          reset: this.resetSpy,
+        },
+      })
+    })
+
+    describe('when the order save was successful', () => {
+      beforeEach(() => {
+        this.orderSaveStub.resolves(saveMockData)
+      })
+
+      it('should save an order', (done) => {
+        const resMock = {
+          redirect: (url) => {
+            try {
+              expect(this.orderSaveStub).to.have.been.calledWith('token-12345', {
+                foo: 'bar',
+                fizz: 'buzz',
+              })
+              expect(this.resetSpy).to.have.been.calledOnce
+              expect(this.nextSpy).not.to.have.been.called
+              expect(url).to.equal(`/omis/${saveMockData.id}`)
+              done()
+            } catch (e) {
+              done(e)
+            }
+          },
+        }
+
+        this.controller.successHandler(this.reqMock, resMock, this.nextSpy)
+      })
+    })
+
+    describe('when the order save was successful', () => {
+      beforeEach(() => {
+        this.orderSaveStub.rejects(new Error())
+      })
+
+      it('should save an order', (done) => {
+        const resMock = {
+          redirect: this.sandbox.spy(),
+        }
+        const nextMock = (error) => {
+          try {
+            expect(error).to.be.an('error')
+            expect(resMock.redirect).to.not.have.been.called
+            expect(this.resetSpy).to.not.have.been.called
+            done()
+          } catch (e) {
+            done(e)
+          }
+        }
+
+        this.controller.successHandler(this.reqMock, resMock, nextMock)
+      })
+    })
+  })
+})

--- a/test/unit/apps/omis/apps/create/controllers/market.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/market.test.js
@@ -1,0 +1,57 @@
+const FormController = require('hmpo-form-wizard').Controller
+
+const Controller = proxyquire('~/src/apps/omis/apps/create/controllers/market', {
+  '../../../../../lib/metadata': {
+    countryOptions: [{
+      id: '1',
+      name: 'One',
+    }, {
+      id: '2',
+      name: 'Two',
+    }],
+  },
+})
+
+describe('OMIS create market controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.controller = new Controller({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('configure()', () => {
+    beforeEach(() => {
+      this.reqMock = Object.assign({}, globalReq, {
+        form: {
+          options: {
+            fields: {
+              primary_market: {},
+            },
+          },
+        },
+      })
+
+      FormController.prototype.configure = this.sandbox.spy()
+    })
+
+    it('should set the list of markets', () => {
+      this.controller.configure(this.reqMock, globalRes, this.nextSpy)
+
+      expect(this.reqMock.form.options.fields.primary_market.options).to.deep.equal([
+        {
+          value: '1',
+          label: 'One',
+        },
+        {
+          value: '2',
+          label: 'Two',
+        },
+      ])
+      expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, globalRes, this.nextSpy)
+    })
+  })
+})

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -1,0 +1,71 @@
+const transformers = require('~/src/apps/transformers')
+
+describe('Global transformers', () => {
+  describe('transformToOptions()', () => {
+    context('with default value iteratee', () => {
+      it('should map id and name to value and label', () => {
+        const options = transformers.transformToOptions([{
+          id: '1',
+          name: 'One',
+        }, {
+          id: '2',
+          name: 'Two',
+        }])
+
+        expect(options).to.deep.equal([{
+          value: '1',
+          label: 'One',
+        }, {
+          value: '2',
+          label: 'Two',
+        }])
+      })
+    })
+
+    context('when custom value iteratee is supplied', () => {
+      it('should map those values to value and label', () => {
+        const items = [{
+          id: '1',
+          custom: 'Custom iteratee one',
+        }, {
+          id: '2',
+          custom: 'Custom iteratee two',
+        }]
+        const iteratee = (item) => {
+          return item.custom
+        }
+        const options = transformers.transformToOptions(items, iteratee)
+
+        expect(options).to.deep.equal([{
+          value: '1',
+          label: 'Custom iteratee one',
+        }, {
+          value: '2',
+          label: 'Custom iteratee two',
+        }])
+      })
+    })
+  })
+
+  describe('transformContactsToOptions()', () => {
+    it('should map id and first_name/last_name to value and label', () => {
+      const options = transformers.transformContactsToOptions([{
+        id: '1',
+        first_name: 'Steve',
+        last_name: 'George',
+      }, {
+        id: '2',
+        first_name: 'Graham',
+        last_name: 'Nice',
+      }])
+
+      expect(options).to.deep.equal([{
+        value: '1',
+        label: 'Steve George',
+      }, {
+        value: '2',
+        label: 'Graham Nice',
+      }])
+    })
+  })
+})

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -1,6 +1,7 @@
 const chai = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const reqres = require('reqres')
 
 chai.use(require('sinon-chai'))
 chai.use(require('chai-as-promised'))
@@ -10,6 +11,9 @@ global.expect = chai.expect
 global.sinon = sinon
 global.proxyquire = proxyquire
 global.rootPath = `${process.cwd()}`
+global.rootPath = `${process.cwd()}`
+global.globalReq = reqres.req()
+global.globalRes = reqres.res()
 
 chai.config.truncateThreshold = 0
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2914,7 +2914,7 @@ express@2.5.x:
     mkdirp "0.3.0"
     qs "0.4.x"
 
-express@^4.12.2, express@^4.12.3, express@^4.14.0:
+express@^4.12.2, express@^4.12.3, express@^4.14.0, express@^4.15.2:
   version "4.15.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
   dependencies:
@@ -3265,6 +3265,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
 
 formatio@1.2.0:
   version "1.2.0"
@@ -5222,6 +5228,10 @@ logalot@^2.0.0:
     figures "^1.3.5"
     squeak "^1.0.0"
 
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+
 lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
@@ -7108,6 +7118,13 @@ replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
+reqres@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reqres/-/reqres-1.3.0.tgz#82a2b85486cbb690b36991352b79cb7d07a578af"
+  dependencies:
+    express "^4.15.2"
+    sinon "^1.14.1"
+
 request-promise-core@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
@@ -7361,6 +7378,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.1.2, samsam@~1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
 samsam@1.x, samsam@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
@@ -7603,6 +7624,15 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
 sinon-chai@^2.10.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.11.0.tgz#93d90f989fff67ce45767077ffe575dde1faea6d"
+
+sinon@^1.14.1:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 sinon@^2.1.0:
   version "2.3.5"
@@ -8586,7 +8616,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util@0.10.3, util@^0.10.3:
+util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:


### PR DESCRIPTION
This creates the basis for the OMIS order creation journey.

It currently supports the company name being passed in as part of the URL which then allows datasets like the contacts to be populated from it.

It support being able to go back to steps within the journey and update the fields.

There is currently no way to get to the journey by navigating pages so you will have to access using the URL: `/omis/create/:companyId`. There is a link to the journey on heroku in the _what it looks like_ section.

## Todo

- [x] Controller/middleware tests
- [x] Reset session after submission

## Not included in this change

- Field validation
- Order view (it will currently `404` after submission)
- Final content (includes placeholder copy)

## What it looks like

[Journey link](https://datahub-beta2-pr-355.herokuapp.com/omis/create/dcdabbc9-1781-e411-8955-e4115bead28a)

![omis-create](https://user-images.githubusercontent.com/3327997/28412353-e5ccdce8-6d3b-11e7-9c14-ce84cfc4bb6d.gif)

