### PR TITLE
Form components unit tests

### DIFF
--- a/test/unit/component-helper.js
+++ b/test/unit/component-helper.js
@@ -28,17 +28,45 @@ const normaliseHtml = (string) => {
 function getMacros (fileName) {
   const filePath = `${MACROS_PATH}${fileName}.${EXT}`
 
+  function renderMacro (name, caller, props, ...rest) {
+    const importString = `{% from "${filePath}" import ${name} %}`
+    const args = rest.length ? `,${[...rest].map(JSON.stringify)}` : ''
+    let macroOutput
+
+    if (caller) {
+      macroOutput = nunjucks.renderString(`
+        ${importString}
+        {% call ${name}(${JSON.stringify(props, undefined, 1)}${args}) %}
+          ${caller.join(' ')}
+        {% endcall %}
+      `)
+    } else {
+      macroOutput = nunjucks.renderString(`${importString} {{ ${name}(${JSON.stringify(props)}${args}) }}`)
+    }
+
+    return normaliseHtml(macroOutput)
+  }
+
   return {
     render (macroName, props, ...rest) {
-      const importString = `{% from "${filePath}" import ${macroName} %}`
-      const args = rest.length ? `,${[...rest].map(JSON.stringify)}` : ''
-      const macroOutput = nunjucks.renderString(`${importString} {{ ${macroName}(${JSON.stringify(props)}${args}) }}`)
-      return normaliseHtml(macroOutput)
+      return renderMacro(macroName, null, props, ...rest)
+    },
+
+    renderWithCaller (macroName, caller, props, ...rest) {
+      return renderMacro(macroName, caller, props, ...rest)
     },
 
     renderToDom (macroName, props, ...rest) {
       const macroOutput = this.render(macroName, props, ...rest)
       return (new JSDOM(macroOutput)).window.document.body.firstElementChild
+    },
+
+    renderWithCallerToDom (macroName, props, ...rest) {
+      return function (...caller) {
+        if (!caller.length) { return null }
+        const macroOutput = this.renderWithCaller(macroName, caller, props, ...rest)
+        return (new JSDOM(macroOutput)).window.document.body.firstElementChild
+      }.bind(this)
     },
   }
 }

--- a/test/unit/components/form.test.js
+++ b/test/unit/components/form.test.js
@@ -3,6 +3,132 @@ const { getMacros } = require('~/test/unit/component-helper')
 describe('Nunjucks form macros', () => {
   const macros = getMacros('form')
 
+  describe('Form component', () => {
+    describe('invalid call', () => {
+      it('should not render without caller', () => {
+        const component = macros.renderWithCallerToDom('Form')()
+        expect(component).to.be.null
+      })
+    })
+
+    describe('valid call', () => {
+      it('should render a `post` form by default', () => {
+        const component = macros.renderWithCallerToDom('Form')(
+          macros.renderToDom('TextField')
+        )
+        expect(component.method).to.equal('post')
+      })
+
+      it('should render with submit button by default', () => {
+        const component = macros.renderWithCallerToDom('Form')(
+          macros.renderToDom('TextField')
+        )
+        expect(component.querySelector('.c-form-group--actions')).to.exist
+        expect(component.querySelector('button.button').textContent).to.equal('Submit')
+      })
+
+      it('should render form with custom props', () => {
+        const formProps = {
+          method: 'get',
+          action: '/form-url',
+          role: 'search',
+          class: 'c-form-component',
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+        expect(component.method).to.equal('get')
+        expect(component.action).to.equal('/form-url')
+        expect(component.className).to.equal('c-form-component')
+        expect(component.getAttribute('role')).to.equal('search')
+      })
+
+      it('should render form with custom submit button text', () => {
+        const formProps = {
+          buttonText: 'Save',
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+        expect(component.querySelector('button.button').textContent).to.equal('Save')
+      })
+
+      it('should render form without submit button', () => {
+        const formProps = {
+          disableFormActions: true,
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+        expect(component.querySelector('.c-form-group--actions')).to.not.exist
+      })
+
+      it('should render form with return link', () => {
+        const formProps = {
+          returnLink: '/previous-page',
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+        const returnLink = component.querySelector('[href="/previous-page"]')
+        expect(returnLink).to.exist
+        expect(returnLink.textContent).to.equal('Back')
+      })
+
+      it('should render form with custom text for return link', () => {
+        const formProps = {
+          returnLink: '/previous-page',
+          returnText: 'Go back',
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+        expect(component.querySelector('[href="/previous-page"]').textContent).to.equal('Go back')
+      })
+
+      it('should render form with hidden fields', () => {
+        const formProps = {
+          hiddenFields: {
+            'csrf': 'abcd',
+            'company-id': '12345',
+          },
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+
+        const hiddenInputs = component.querySelectorAll('[type="hidden"]')
+        expect(hiddenInputs[0].name).to.equal('csrf')
+        expect(hiddenInputs[0].value).to.equal('abcd')
+        expect(hiddenInputs[1].name).to.equal('company-id')
+        expect(hiddenInputs[1].value).to.equal('12345')
+      })
+
+      it('should render form errors component', () => {
+        const formProps = {
+          errors: {
+            summary: 'Error summary',
+            messages: {
+              field_name: 'Error message',
+              another_field_name: 'Another error message',
+            },
+          },
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+
+        const formErrorsEl = component.querySelector('.c-form-errors')
+        const formErrorsMessagesEls = formErrorsEl.querySelectorAll('.c-form-errors__list-item')
+        expect(formErrorsEl).to.exist
+        expect(formErrorsEl.querySelector('.c-form-errors__summary').textContent.trim()).to.equal('Error summary')
+        expect(formErrorsMessagesEls).to.have.length(2)
+        expect(formErrorsMessagesEls[0].textContent.trim()).to.equal('Error message')
+        expect(formErrorsMessagesEls[1].textContent.trim()).to.equal('Another error message')
+      })
+    })
+  })
+
   describe('TextField component', () => {
     describe('invalid props', () => {
       it('should not render without props', () => {


### PR DESCRIPTION
- Improve macro unit test helper to allow testing macro calls:
```js
macros.renderWithCallerToDom('Form')(
  macros.renderToDom('TextField')
)
```
- Add unit tests for Form macro