### PR TITLE
Bugfix for unresponsive service deliveries

### DIFF
--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -67,7 +67,7 @@ function postAddStep1 (req, res) {
 
   // redirect to edit, passing param
   if (req.body.interaction_type === '999') {
-    return res.redirect(`/service-deliveries/edit/?company=${req.body.company}&contact=${req.body.contact}`)
+    return res.redirect(`/service-deliveries/create/?company=${req.body.company}&contact=${req.body.contact}`)
   }
 
   return res.redirect(`2?company=${req.body.company}&contact=${req.body.contact}&interaction_type=${req.body.interaction_type}`)

--- a/src/apps/service-deliveries/controllers.js
+++ b/src/apps/service-deliveries/controllers.js
@@ -13,13 +13,7 @@ const serviceDeliveryDisplayOrder = ['company', 'dit_team', 'service', 'status',
 async function getCommon (req, res, next) {
   try {
     const token = req.session.token
-    // if we are creating a new service delivery then the id comes through as edit
-    // @TODO make the routes a bit more sensible
-    if (req.params.serviceDeliveryId === 'edit') {
-      return {}
-    } else {
-      res.locals.serviceDelivery = await serviceDeliveryService.getHydratedServiceDelivery(token, req.params.serviceDeliveryId)
-    }
+    res.locals.serviceDelivery = await serviceDeliveryService.getHydratedServiceDelivery(token, req.params.serviceDeliveryId)
     next()
   } catch (error) {
     next(error)

--- a/src/apps/service-deliveries/router.js
+++ b/src/apps/service-deliveries/router.js
@@ -7,6 +7,11 @@ const {
   getServiceDeliveryDetails,
 } = require('./controllers')
 
+router
+  .route('/create')
+  .get(getServiceDeliveryEdit)
+  .post(postServiceDeliveryEdit)
+
 router.get('/:serviceDeliveryId/*', getCommon)
 
 router.get('/:serviceDeliveryId', getCommon, getServiceDeliveryDetails)


### PR DESCRIPTION
Changed the routing for creating a new SD, as it was hanging when hitting the get details flow without an ID