### PR TITLE
Add update method to breadcrumbs

### DIFF
--- a/src/apps/companies/controllers/ch.js
+++ b/src/apps/companies/controllers/ch.js
@@ -18,7 +18,7 @@ async function getDetails (req, res, next) {
     res.locals.addUrl = `/companies/add/ltd/${company.company_number}`
 
     res
-      .breadcrumb(company.name)
+      .breadcrumb.add(company.name)
       .render('companies/views/details-ch')
   } catch (error) {
     next(error)

--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -26,8 +26,8 @@ async function getContacts (req, res, next) {
     res.locals.addContactUrl = `/contacts/create?company=${res.locals.company.id}`
 
     res
-      .breadcrumb(res.locals.company.name, `/companies/${res.locals.company.id}`)
-      .breadcrumb('Contacts')
+      .breadcrumb.add(res.locals.company.name, `/companies/${res.locals.company.id}`)
+      .breadcrumb.add('Contacts')
       .render('companies/views/contacts')
   } catch (error) {
     next(error)

--- a/src/apps/companies/controllers/exp.js
+++ b/src/apps/companies/controllers/exp.js
@@ -35,8 +35,8 @@ function common (req, res) {
       res.locals.tab = 'exports'
       res.locals.company = await getInflatedDitCompany(req.session.token, req.params.id)
 
-      res.breadcrumb(res.locals.company.name, `/viewcompanyresult/${res.locals.company.id}`)
-      res.breadcrumb('Exports', `/companies/${res.locals.company.id}/exports`)
+      res.breadcrumb.add(res.locals.company.name, `/viewcompanyresult/${res.locals.company.id}`)
+      res.breadcrumb.add('Exports', `/companies/${res.locals.company.id}/exports`)
 
       getCommonTitlesAndlinks(req, res, res.locals.company)
       resolve()
@@ -93,7 +93,7 @@ async function edit (req, res, next) {
     }
 
     res
-      .breadcrumb('Edit')
+      .breadcrumb.add('Edit')
       .render('companies/views/exports-edit', data)
   } catch (error) {
     next(error)

--- a/src/apps/companies/controllers/foreign.js
+++ b/src/apps/companies/controllers/foreign.js
@@ -23,7 +23,7 @@ async function getDetails (req, res, next) {
     res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
 
     res
-      .breadcrumb(company.name)
+      .breadcrumb.add(company.name)
       .render('companies/views/details-foreign')
   } catch (error) {
     next(error)
@@ -54,7 +54,7 @@ function addDetails (req, res, next) {
   res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
 
   res
-    .breadcrumb('Add company')
+    .breadcrumb.add('Add company')
     .render('companies/views/edit-foreign')
 }
 
@@ -70,8 +70,8 @@ async function editDetails (req, res, next) {
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
 
     res
-      .breadcrumb(company.name, `/companies/view/foreign/${company.id}`)
-      .breadcrumb('Edit')
+      .breadcrumb.add(company.name, `/companies/view/foreign/${company.id}`)
+      .breadcrumb.add('Edit')
       .render(`companies/views/edit-foreign`)
   } catch (error) {
     next(error)

--- a/src/apps/companies/controllers/interactions.js
+++ b/src/apps/companies/controllers/interactions.js
@@ -25,8 +25,8 @@ async function getInteractions (req, res, next) {
     }
 
     res
-      .breadcrumb(res.locals.company.name, `/viewcompanyresult/${res.locals.company.id}`)
-      .breadcrumb('Interactions')
+      .breadcrumb.add(res.locals.company.name, `/viewcompanyresult/${res.locals.company.id}`)
+      .breadcrumb.add('Interactions')
       .render('companies/views/interactions')
   } catch (error) {
     next(error)

--- a/src/apps/companies/controllers/ltd.js
+++ b/src/apps/companies/controllers/ltd.js
@@ -30,7 +30,7 @@ async function getDetails (req, res, next) {
     res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
 
     res
-      .breadcrumb(company.name)
+      .breadcrumb.add(company.name)
       .render('companies/views/details-ltd')
   } catch (error) {
     next(error)
@@ -66,7 +66,7 @@ async function addDetails (req, res, next) {
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
 
     res
-      .breadcrumb('Add company')
+      .breadcrumb.add('Add company')
       .render(`companies/views/edit-ltd`)
   } catch (error) {
     next(error)
@@ -77,12 +77,12 @@ async function editDetails (req, res, next) {
   try {
     if (containsFormData(req)) {
       res.locals.formData = req.body
-      res.breadcrumb('Edit company')
+      res.breadcrumb.add('Edit company')
     } else {
       const company = await companyRepository.getDitCompany(req.session.token, req.params.id)
       res.locals.formData = companyFormService.getLtdCompanyAsFormData(company)
-      res.breadcrumb(company.name, `/viewcompanyresult/${company.id}`)
-      res.breadcrumb('Edit')
+      res.breadcrumb.add(company.name, `/viewcompanyresult/${company.id}`)
+      res.breadcrumb.add('Edit')
     }
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
     res.render(`companies/views/edit-ltd`)

--- a/src/apps/companies/controllers/ukother.js
+++ b/src/apps/companies/controllers/ukother.js
@@ -23,7 +23,7 @@ async function getDetails (req, res, next) {
     res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
 
     res
-      .breadcrumb(company.name)
+      .breadcrumb.add(company.name)
       .render('companies/views/details-ukother')
   } catch (error) {
     next(error)
@@ -55,7 +55,7 @@ function addDetails (req, res, next) {
   res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
 
   res
-    .breadcrumb('Add company')
+    .breadcrumb.add('Add company')
     .render(`companies/views/edit-ukother`)
 }
 
@@ -71,8 +71,8 @@ async function editDetails (req, res, next) {
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
 
     res
-      .breadcrumb(company.name, `/viewcompanyresult/${company.id}`)
-      .breadcrumb('Edit')
+      .breadcrumb.add(company.name, `/viewcompanyresult/${company.id}`)
+      .breadcrumb.add('Edit')
       .render(`companies/views/edit-ukother`)
   } catch (error) {
     next(error)

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -27,7 +27,7 @@ const foreignOtherCompanyOptions = [
 
 function renderFormElements (req, res) {
   return res
-    .breadcrumb('Form elements')
+    .breadcrumb.add('Form elements')
     .render('components/views/form', {
       entitySearch: Object.assign({}, res.locals.entitySearch, {
         searchTerm: req.query.term,
@@ -46,25 +46,25 @@ function renderFormElements (req, res) {
 
 function renderMessages (req, res) {
   return res
-    .breadcrumb('Application messages')
+    .breadcrumb.add('Application messages')
     .render('components/views/messages')
 }
 
 function renderBreadcrumbs (req, res) {
   return res
-    .breadcrumb('Breadcrumbs')
+    .breadcrumb.add('Breadcrumbs')
     .render('components/views/breadcrumbs')
 }
 
 function renderPagination (req, res) {
   return res
-    .breadcrumb('Pagination')
+    .breadcrumb.add('Pagination')
     .render('components/views/pagination')
 }
 
 async function renderEntityList (req, res) {
   return res
-    .breadcrumb('Entity list')
+    .breadcrumb.add('Entity list')
     .render('components/views/entity-list', {
       investmentProjects: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/investment?limit=10`),
       companiesSearch: await authorisedRequest(req.session.token, `${config.apiRoot}/v3/search?term=samsung&entity=company&limit=10`),

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -20,7 +20,7 @@ async function getCommon (req, res, next) {
     res.locals.companyUrl = companyService.buildCompanyUrl(company)
     res.locals.reasonForArchiveOptions = reasonForArchiveOptions
 
-    res.breadcrumb(`${contact.first_name} ${contact.last_name}`, `/contacts/${contact.id}`)
+    res.breadcrumb.add(`${contact.first_name} ${contact.last_name}`, `/contacts/${contact.id}`)
 
     next()
   } catch (error) {

--- a/src/apps/contacts/controllers/edit.js
+++ b/src/apps/contacts/controllers/edit.js
@@ -41,10 +41,10 @@ async function editDetails (req, res, next) {
 
     if (req.params.contactId) {
       res.locals.backUrl = `/contacts/${req.params.contactId}`
-      res.breadcrumb('Edit')
+      res.breadcrumb.add('Edit')
     } else if (req.query.company) {
       res.locals.backUrl = `/companies/${req.query.company}/contacts`
-      res.breadcrumb(`Add contact at ${res.locals.company.name}`)
+      res.breadcrumb.add(`Add contact at ${res.locals.company.name}`)
     }
 
     // Labels and options needed for the form and error display

--- a/src/apps/contacts/controllers/interactions.js
+++ b/src/apps/contacts/controllers/interactions.js
@@ -9,7 +9,7 @@ async function getInteractions (req, res, next) {
     res.locals.addInteractionUrl = `/interactions/create/1?contact=${res.locals.contact.id}`
 
     res
-      .breadcrumb('Interactions')
+      .breadcrumb.add('Interactions')
       .render('contacts/views/interactions')
   } catch (error) {
     next(error)

--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -48,7 +48,7 @@ function getAddStep1 (req, res) {
   }
 
   res
-    .breadcrumb('Add interaction')
+    .breadcrumb.add('Add interaction')
     .render('interactions/views/add-step-1.njk', {
       query: req.query,
       interactionTypeColA,
@@ -75,7 +75,7 @@ function postAddStep1 (req, res) {
 
 function getInteractionDetails (req, res, next) {
   res
-    .breadcrumb(`Interaction with ${res.locals.interaction.company.name}`)
+    .breadcrumb.add(`Interaction with ${res.locals.interaction.company.name}`)
     .render('interactions/views/details', {
       interactionDetails: getDisplayInteraction(res.locals.interaction),
       interactionLabels: interactionLabels,

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -65,7 +65,7 @@ async function editDetails (req, res, next) {
     res.locals.serviceProviderOptions = metadataRepository.teams
     res.locals.labels = interactionLabels
     res
-      .breadcrumb(`Add interaction for ${res.locals.company.name}`)
+      .breadcrumb.add(`Add interaction for ${res.locals.company.name}`)
       .render('interactions/views/edit')
   } catch (error) {
     console.log(error)

--- a/src/apps/investment-projects/controllers/audit.js
+++ b/src/apps/investment-projects/controllers/audit.js
@@ -18,7 +18,7 @@ async function getInvestmentAudit (req, res, next) {
       const auditLog = rawAuditLog.map(formatAuditLog)
 
       return res
-        .breadcrumb('Audit history')
+        .breadcrumb.add('Audit history')
         .render('investment-projects/views/audit', {
           currentNavItem: 'audit',
           auditLog,

--- a/src/apps/investment-projects/controllers/create-1.js
+++ b/src/apps/investment-projects/controllers/create-1.js
@@ -39,7 +39,7 @@ function getHandler (req, res, next) {
       }
 
       res
-        .breadcrumb('Add investment project')
+        .breadcrumb.add('Add investment project')
         .render('investment-projects/views/create-1', {
           clientCompany,
           clientCompanyInvestments,
@@ -63,7 +63,7 @@ function postHandler (req, res, next) {
     getInflatedDitCompany(req.session.token, clientCompanyId)
       .then((clientCompany) => {
         res
-          .breadcrumb('Add investment project')
+          .breadcrumb.add('Add investment project')
           .render('investment-projects/views/create-1', {
             clientCompany,
             errors: {

--- a/src/apps/investment-projects/controllers/create-2.js
+++ b/src/apps/investment-projects/controllers/create-2.js
@@ -1,6 +1,6 @@
 function render (req, res) {
   return res
-    .breadcrumb('Add investment project')
+    .breadcrumb.add('Add investment project')
     .render('investment-projects/views/create-2')
 }
 

--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -5,13 +5,13 @@ const templateData = {
 
 function editDetailsGet (req, res) {
   res
-    .breadcrumb('Edit details')
+    .breadcrumb.add('Edit details')
     .render('investment-projects/views/details-edit', templateData)
 }
 
 function editValueGet (req, res) {
   res
-    .breadcrumb('Edit value')
+    .breadcrumb.add('Edit value')
     .render('investment-projects/views/value-edit', templateData)
 }
 

--- a/src/apps/investment-projects/controllers/evaluation.js
+++ b/src/apps/investment-projects/controllers/evaluation.js
@@ -19,7 +19,7 @@ function renderEvaluationPage (req, res, next) {
 
   if (get(res, 'locals.investmentData')) {
     return res
-      .breadcrumb('Evaluation')
+      .breadcrumb.add('Evaluation')
       .render('investment-projects/views/evaluation', {
         value: getDataLabels(transformedValue, evaluationValueLabels.view),
         fdi: getDataLabels(Object.assign({}, transformedValue, transformedFDI), evaluationFdiLabels.view),

--- a/src/apps/investment-projects/controllers/interactions/create.js
+++ b/src/apps/investment-projects/controllers/interactions/create.js
@@ -2,7 +2,7 @@ const { isEmpty } = require('lodash')
 
 function createGetInteractionHandler (req, res, next) {
   return res
-    .breadcrumb('Add interaction')
+    .breadcrumb.add('Add interaction')
     .render('investment-projects/views/interactions/create')
 }
 

--- a/src/apps/investment-projects/controllers/interactions/edit.js
+++ b/src/apps/investment-projects/controllers/interactions/edit.js
@@ -2,7 +2,7 @@ const { isEmpty } = require('lodash')
 
 function editGetInteractionHandler (req, res, next) {
   res
-    .breadcrumb('Edit interaction')
+    .breadcrumb.add('Edit interaction')
     .render('investment-projects/views/interactions/edit')
 }
 

--- a/src/apps/investment-projects/controllers/interactions/list.js
+++ b/src/apps/investment-projects/controllers/interactions/list.js
@@ -10,7 +10,7 @@ async function indexGetHandler (req, res, next) {
       const interactions = interactionsResponse.results.map(getDisplayCompanyInteraction)
 
       return res
-        .breadcrumb('Interactions')
+        .breadcrumb.add('Interactions')
         .render('investment-projects/views/interactions/index', {
           currentNavItem: 'interactions',
           interactions,

--- a/src/apps/investment-projects/controllers/team/details.js
+++ b/src/apps/investment-projects/controllers/team/details.js
@@ -6,7 +6,7 @@ function getDetailsHandler (req, res, next) {
     const projectManagementData = transformProjectManagementForView(res.locals.investmentData)
 
     res
-      .breadcrumb('Project team')
+      .breadcrumb.add('Project team')
       .render('investment-projects/views/team/details', {
         currentNavItem: 'team',
         projectManagementData,

--- a/src/apps/investment-projects/controllers/team/edit-project-management.js
+++ b/src/apps/investment-projects/controllers/team/edit-project-management.js
@@ -7,8 +7,8 @@ function getHandler (req, res, next) {
   const briefInvestmentSummary = getDataLabels(res.locals.briefInvestmentSummaryData, briefInvestmentSummaryLabels.view)
 
   res
-    .breadcrumb('Project team', 'team')
-    .breadcrumb('Project management')
+    .breadcrumb.add('Project team', 'team')
+    .breadcrumb.add('Project management')
     .render('investment-projects/views/team/edit-project-management', {
       currentNavItem: 'team',
       variant: 'edit',

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -50,7 +50,11 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
       valuation: investmentData.value_complete ? 'Project valued' : 'Not yet valued',
     }
 
-    res.breadcrumb({
+    res.breadcrumb.update('Investment projects', {
+      url: `/companies/${investmentData.investor_company.id}/investments`,
+    })
+
+    res.breadcrumb.add({
       name: investmentData.name,
       url: `/investment-projects/${investmentData.id}`,
     })

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -1,7 +1,7 @@
 function setHomeBreadcrumb (name) {
   return function (req, res, next) {
     if (name) {
-      res.breadcrumb({
+      res.breadcrumb.add({
         name,
         url: req.baseUrl,
       })

--- a/src/apps/profile/index.js
+++ b/src/apps/profile/index.js
@@ -2,7 +2,7 @@ const router = require('express').Router()
 
 function getHandler (req, res) {
   res
-    .breadcrumb('Your profile')
+    .breadcrumb.add('Your profile')
     .render('profile/views/profile')
 }
 

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -26,7 +26,7 @@ function searchAction (req, res, next) {
       const searchEntityResultsData = buildSearchEntityResultsData(results.aggregations)
 
       res
-        .breadcrumb('Search')
+        .breadcrumb.add('Search')
         .render(`search/views/results-${searchEntity}`, {
           searchTerm,
           searchEntity,

--- a/src/apps/service-deliveries/controllers.js
+++ b/src/apps/service-deliveries/controllers.js
@@ -51,7 +51,7 @@ async function getServiceDeliveryEdit (req, res, next) {
     res.locals.companyUrl = buildCompanyUrl(res.locals.serviceDelivery.company)
 
     res
-      .breadcrumb('Add service delivery')
+      .breadcrumb.add('Add service delivery')
       .render('service-deliveries/views/edit')
   } catch (error) {
     next(error)
@@ -76,7 +76,7 @@ async function postServiceDeliveryEdit (req, res, next) {
         res.locals.errors = transformV2Errors(response.error.errors)
         try {
           res.locals.serviceDelivery = await serviceDeliveryService.convertFormBodyBackToServiceDelivery(req.session.token, req.body)
-          res.breadcrumb('Edit service delivery')
+          res.breadcrumb.add('Edit service delivery')
         } catch (error) {
           return next(error)
         }

--- a/src/apps/support/controllers.js
+++ b/src/apps/support/controllers.js
@@ -4,7 +4,7 @@ function renderFeedbackPage (req, res) {
 
 function renderThankYouPage (req, res) {
   res
-    .breadcrumb('Thank you')
+    .breadcrumb.add('Thank you')
     .render('support/views/thank-you')
 }
 

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -10,7 +10,7 @@ try {
 
 module.exports = function locals (req, res, next) {
   const baseUrl = `${(req.encrypted ? 'https' : req.protocol)}://${req.get('host')}`
-  const breadcrumbItems = res.breadcrumb()
+  const breadcrumbItems = res.breadcrumb.get()
 
   res.locals = Object.assign({}, res.locals, {
     BASE_URL: baseUrl,

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -13,6 +13,13 @@ describe('Company add controller', function () {
   let companyAddController
 
   beforeEach(function () {
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
     searchLimitedCompaniesStub = sinon.stub().resolves(companiesHouseAndLtdCompanies)
     getDisplayCHStub = sinon.stub().resolves(displayHouseCompany)
     getCHCompanyStub = sinon.stub().resolves(companiesHouseCompany)
@@ -56,7 +63,7 @@ describe('Company add controller', function () {
     })
     it('should return labels for the types and error messages', function (done) {
       const req = { session: {} }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
         render: function (template, options) {
           const allOptions = mergeLocals(res, options)
@@ -69,14 +76,14 @@ describe('Company add controller', function () {
           expect(allOptions.companyDetailsLabels.business_type).to.equal('Business type')
           done()
         },
-      }
+      })
 
       companyAddController.getAddStepOne(req, res, next)
     })
     it('should pass through the request body to show previosuly selected options', function (done) {
       const body = { business_type: '1231231231232' }
       const req = { body, session: {} }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
         render: function (template, options) {
           const allOptions = mergeLocals(res, options)
@@ -89,7 +96,7 @@ describe('Company add controller', function () {
           expect(allOptions.company).to.deep.equal(body)
           done()
         },
-      }
+      })
 
       companyAddController.getAddStepOne(req, res, next)
     })
@@ -103,13 +110,13 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           redirect: function (url) {
             expect(url).to.equal('/companies/add-step-2/?business_type=ltd&country=uk')
             done()
           },
-        }
+        })
         companyAddController.postAddStepOne(req, res, next)
       })
       it('should forward the user to add screen when adding uk other', function (done) {
@@ -120,13 +127,13 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           redirect: function (url) {
             expect(url).to.equal('/companies/add/ukother?business_type=Charity&country=uk')
             done()
           },
-        }
+        })
         companyAddController.postAddStepOne(req, res, next)
       })
       it('should forward the user to add screen when adding a foreign company', function (done) {
@@ -137,13 +144,13 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           redirect: function (url) {
             expect(url).to.equal('/companies/add/foreign?business_type=Charity&country=non-uk')
             done()
           },
-        }
+        })
         companyAddController.postAddStepOne(req, res, next)
       })
     })
@@ -153,14 +160,14 @@ describe('Company add controller', function () {
           body: {},
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.errors.messages).to.have.property('business_type')
             done()
           },
-        }
+        })
         companyAddController.postAddStepOne(req, res, next)
       })
       it('should show an error if other uk selected but no option selected from the list', function (done) {
@@ -170,14 +177,14 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.errors.messages).to.have.property('business_type_uk_other')
             done()
           },
-        }
+        })
         companyAddController.postAddStepOne(req, res, next)
       })
       it('should show an error if foreign selected but no option selected from the list', function (done) {
@@ -187,14 +194,14 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.errors.messages).to.have.property('business_type_for_other')
             done()
           },
-        }
+        })
         companyAddController.postAddStepOne(req, res, next)
       })
     })
@@ -209,13 +216,13 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             expect(template).to.equal('companies/views/add-step-2.njk')
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should pass the company type labels', function (done) {
@@ -226,7 +233,7 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
@@ -238,7 +245,7 @@ describe('Company add controller', function () {
             })
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should pass through the query variables', function (done) {
@@ -249,7 +256,7 @@ describe('Company add controller', function () {
           },
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
@@ -257,7 +264,7 @@ describe('Company add controller', function () {
             expect(allOptions.country).to.equal('uk')
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
     })
@@ -273,13 +280,13 @@ describe('Company add controller', function () {
             term: 'test',
           },
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             expect(searchLimitedCompaniesStub).to.be.calledWith({ searchTerm: 'test', token: '1234' })
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include parsed search results in page', function (done) {
@@ -293,7 +300,7 @@ describe('Company add controller', function () {
             term: 'test',
           },
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
@@ -301,7 +308,7 @@ describe('Company add controller', function () {
             expect(company.name).to.equal('ACHME LIMITED')
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include business information after search in page when selected is blank', function (done) {
@@ -316,7 +323,7 @@ describe('Company add controller', function () {
             selected: '',
           },
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
@@ -325,7 +332,7 @@ describe('Company add controller', function () {
             expect(allOptions.searchTerm).to.equal('test')
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include business information after search in page when selected has a value', function (done) {
@@ -340,7 +347,7 @@ describe('Company add controller', function () {
             selected: '9999',
           },
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
@@ -349,7 +356,7 @@ describe('Company add controller', function () {
             expect(allOptions.searchTerm).to.equal('test')
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
     })
@@ -366,13 +373,13 @@ describe('Company add controller', function () {
             selected: '08311441',
           },
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             expect(getCHCompanyStub).to.be.calledWith('1234', '08311441')
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should parse the CH details for display', function (done) {
@@ -387,13 +394,13 @@ describe('Company add controller', function () {
             selected: '08311441',
           },
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             expect(getDisplayCHStub).to.have.been.called
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include labels and display order for the table', function (done) {
@@ -408,14 +415,14 @@ describe('Company add controller', function () {
             selected: '08311441',
           },
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {},
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.displayDetails).to.deep.equal(displayHouseCompany)
             done()
           },
-        }
+        })
         companyAddController.getAddStepTwo(req, res, next)
       })
     })

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -23,6 +23,13 @@ describe('Company controller, archive', function () {
   let companyArchiveController
 
   beforeEach(function () {
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
     getDitCompanyStub = sinon.stub().resolves(company)
     buildCompanyUrlStub = sinon.stub().returns('/testurl')
     companyRepositoryArchiveCompanyStub = sinon.stub().resolves(null)
@@ -48,13 +55,13 @@ describe('Company controller, archive', function () {
       },
       flash: flashStub,
     }
-    const res = {
+    const res = Object.assign(this.resMock, {
       locals: {},
       redirect: function () {
         expect(companyRepositoryArchiveCompanyStub).to.be.calledWith(token, company.id, req.body.archived_reason)
         done()
       },
-    }
+    })
 
     companyArchiveController.postArchiveCompany(req, res, next)
   })
@@ -67,13 +74,13 @@ describe('Company controller, archive', function () {
       },
       flash: flashStub,
     }
-    const res = {
+    const res = Object.assign(this.resMock, {
       locals: {},
       redirect: function () {
         expect(companyRepositoryArchiveCompanyStub).to.be.calledWith(token, company.id, req.body.archived_reason_other)
         done()
       },
-    }
+    })
 
     companyArchiveController.postArchiveCompany(req, res, next)
   })
@@ -86,7 +93,7 @@ describe('Company controller, archive', function () {
       },
       flash: flashStub,
     }
-    const res = {
+    const res = Object.assign(this.resMock, {
       locals: {},
       redirect: function (url) {
         expect(getDitCompanyStub).to.be.calledWith(token, company.id)
@@ -94,7 +101,7 @@ describe('Company controller, archive', function () {
         expect(url).to.equal('/testurl')
         done()
       },
-    }
+    })
 
     companyArchiveController.postArchiveCompany(req, res, next)
   })
@@ -107,13 +114,13 @@ describe('Company controller, archive', function () {
       },
       flash: flashStub,
     }
-    const res = {
+    const res = Object.assign(this.resMock, {
       locals: {},
       redirect: function (url) {
         expect(flashStub).to.be.calledWith('success', 'Updated company record')
         done()
       },
-    }
+    })
 
     companyArchiveController.postArchiveCompany(req, res, next)
   })
@@ -126,13 +133,13 @@ describe('Company controller, archive', function () {
       },
       flash: flashStub,
     }
-    const res = {
+    const res = Object.assign(this.resMock, {
       locals: {},
       redirect: function (url) {
         expect(flashStub).to.be.calledWith('error', 'Unable to archive company, no reason given')
         done()
       },
-    }
+    })
 
     companyArchiveController.postArchiveCompany(req, res, next)
   })
@@ -144,13 +151,13 @@ describe('Company controller, archive', function () {
       },
       flash: flashStub,
     }
-    const res = {
+    const res = Object.assign(this.resMock, {
       locals: {},
       redirect: function () {
         expect(companyRepositoryUnArchiveCompanyStub).to.be.calledWith(token, company.id)
         done()
       },
-    }
+    })
 
     companyArchiveController.getUnarchiveCompany(req, res, next)
   })

--- a/test/unit/apps/companies/controllers/ch.test.js
+++ b/test/unit/apps/companies/controllers/ch.test.js
@@ -41,7 +41,13 @@ describe('Company controller, Companies House', function () {
     getDisplayCompanyStub = sinon.stub().returns({ company_number: '1234' })
     getCHCompanyStub = sinon.stub().resolves(chCompany)
 
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     companyControllerCh = proxyquire('~/src/apps/companies/controllers/ch', {
       '../services/data': {
@@ -68,25 +74,23 @@ describe('Company controller, Companies House', function () {
         params: {
           id: '9999',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getCHCompanyStub).to.be.calledWith('1234', '9999')
           done()
         },
-      }, next)
+      }), next)
     })
     it('should return the company heading name and address', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('ADALEOP LTD')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
         },
-      }
+      })
 
       companyControllerCh.getDetails({
         session: {
@@ -98,9 +102,8 @@ describe('Company controller, Companies House', function () {
       }, res, next)
     })
     it('should get a formatted copy of the company house data to display', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.be.calledWith(chCompany)
           expect(res.locals).to.have.property('chDetails')
@@ -108,7 +111,7 @@ describe('Company controller, Companies House', function () {
           expect(res.locals.chDetailsDisplayOrder).to.deep.equal(['name', 'company_number', 'registered_address', 'business_type', 'company_status', 'incorporation_date', 'sic_code'])
           done()
         },
-      }
+      })
 
       companyControllerCh.getDetails({
         session: {
@@ -120,15 +123,14 @@ describe('Company controller, Companies House', function () {
       }, res, next)
     })
     it('should not try and get formatted data for CDMS company details', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.not.be.called
           expect(res.locals).to.not.have.property('companyDetails')
           done()
         },
-      }
+      })
 
       companyControllerCh.getDetails({
         session: {
@@ -140,15 +142,14 @@ describe('Company controller, Companies House', function () {
       }, res, next)
     })
     it('should not provide account management information', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals).to.not.have.property('accountManagementDisplay')
           expect(res.locals).to.not.have.property('accountManagementDisplayLabels')
           done()
         },
-      }
+      })
 
       companyControllerCh.getDetails({
         session: {
@@ -160,9 +161,8 @@ describe('Company controller, Companies House', function () {
       }, res, next)
     })
     it('should use a template for ch data', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-ch')
@@ -171,7 +171,7 @@ describe('Company controller, Companies House', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerCh.getDetails({
         session: {

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -9,6 +9,14 @@ describe('Company contacts controller', function () {
   }
 
   beforeEach(function () {
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
+
     company = {
       id: '3f2b2a0f-0eb6-4299-8489-7390ccaa17f5',
       name: 'Fred',
@@ -186,18 +194,17 @@ describe('Company contacts controller', function () {
         session: {},
         params: { id: '1' },
       }
-      res = {
+      res = Object.assign(this.resMock, {
         locals: {
           headingName: 'Freds Company',
           headingAddress: '1234 Road, London, EC1 1AA',
           id: '44332211',
         },
-        breadcrumb: function () { return this },
         render: function (template, options) {
           locals = Object.assign({}, res.locals, options)
           done()
         },
-      }
+      })
 
       companyContactController = proxyquire('~/src/apps/companies/controllers/contacts', {
         '../services/data': {

--- a/test/unit/apps/companies/controllers/exp.test.js
+++ b/test/unit/apps/companies/controllers/exp.test.js
@@ -4,6 +4,13 @@ const _company = require('~/test/unit/data/api-response-intermediary-company.jso
 
 describe('Company export controller', () => {
   beforeEach(() => {
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
     this.company = Object.assign({}, _company, {
       export_to_countries: [{ id: '1234', name: 'France' }, { id: '2234', name: 'Italy' }],
       future_interest_countries: [{ id: '4321', name: 'Germany' }],
@@ -18,7 +25,6 @@ describe('Company export controller', () => {
     this.saveCompany = this.sandbox.stub().resolves(this.company)
     this.flattenIdFields = this.sandbox.spy(controllerUtils, 'flattenIdFields')
     this.getCommonTitlesAndlinks = this.sandbox.stub()
-    this.breadcrumbsStub = function () { return this }
 
     this.companyExportController = proxyquire('~/src/apps/companies/controllers/exp', {
       '../services/data': {
@@ -57,10 +63,9 @@ describe('Company export controller', () => {
         },
       }
 
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
-      }
+      })
 
       return this.companyExportController.common(req, res)
         .then(() => {
@@ -78,10 +83,9 @@ describe('Company export controller', () => {
         },
       }
 
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
-      }
+      })
 
       return this.companyExportController.common(req, res)
         .then(() => {
@@ -100,10 +104,9 @@ describe('Company export controller', () => {
         },
       }
 
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
-      }
+      })
 
       return this.companyExportController.common(req, res)
         .then(() => {
@@ -121,11 +124,10 @@ describe('Company export controller', () => {
         params: {
           id: this.company.id,
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           company: this.company,
         },
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.exportDetails).to.deep.equal({
             exportToCountries: 'France, Italy',
@@ -133,7 +135,7 @@ describe('Company export controller', () => {
           })
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('should return empty strings when no value', (done) => {
@@ -159,16 +161,15 @@ describe('Company export controller', () => {
           id: this.company.id,
         },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {
           company: this.company,
         },
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.exportDetails.exportToCountries).to.equal('')
           done()
         },
-      }
+      })
 
       this.companyExportController.view(req, res, this.next)
     })
@@ -181,17 +182,16 @@ describe('Company export controller', () => {
         params: {
           id: this.company.id,
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           company: this.company,
         },
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data).to.have.property('exportDetailsDisplayOrder')
           expect(data).to.have.property('exportDetailsLabels')
           done()
         },
-      }, this.next)
+      }), this.next)
     })
   })
 
@@ -211,15 +211,14 @@ describe('Company export controller', () => {
         params: {
           id: '1234',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(export_to_countries)
           expect(data.future_interest_countries).to.deep.equal(future_interest_countries)
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('parse company export data into a form format if called for first time', (done) => {
@@ -231,33 +230,31 @@ describe('Company export controller', () => {
           id: this.company.id,
         },
         body: {},
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           company: this.company,
         },
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(['1234', '2234'])
           expect(data.future_interest_countries).to.deep.equal(['4321'])
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('should include labels', (done) => {
       this.companyExportController.edit({
         session: { token: '1234' },
         params: { id: '1234' },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           company: this.company,
         },
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data).to.have.property('exportDetailsLabels')
           done()
         },
-      }, this.next)
+      }), this.next)
     })
   })
 
@@ -275,9 +272,8 @@ describe('Company export controller', () => {
           export_to_countries: ['888', '333'],
           future_interest_countries: ['555', '666'],
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           expect(this.getDitCompany).to.be.calledWith('1234', this.company.id)
           expect(controllerUtils.flattenIdFields).to.be.calledWith(this.company)
@@ -290,7 +286,7 @@ describe('Company export controller', () => {
           expect(firstCallArgs).to.have.property('future_interest_countries')
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('should handle an ideal situation, simply upading the company with the countries selected', (done) => {
@@ -309,16 +305,15 @@ describe('Company export controller', () => {
           export_to_countries,
           future_interest_countries,
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           const firstCallArgs = this.saveCompany.firstCall.args[1]
           expect(firstCallArgs.export_to_countries).to.deep.equal(export_to_countries)
           expect(firstCallArgs.future_interest_countries).to.deep.equal(future_interest_countries)
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('should turn all single fields to an array', (done) => {
@@ -337,14 +332,13 @@ describe('Company export controller', () => {
           export_to_countries,
           future_interest_countries,
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           expect(this.saveCompany.firstCall.args[1].future_interest_countries).to.be.deep.equal(['4321'])
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('it should remove empty, none selected, values', (done) => {
@@ -361,14 +355,13 @@ describe('Company export controller', () => {
           export_to_countries,
           future_interest_countries,
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
         redirect: (url) => {
           expect(this.saveCompany.firstCall.args[1].export_to_countries).to.deep.equal(['1234'])
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('should handle when saving throws error', (done) => {
@@ -400,10 +393,9 @@ describe('Company export controller', () => {
           export_to_countries: ['1234', '3211'],
           future_interest_countries: '4321',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
-      }, (_error) => {
+      }), (_error) => {
         expect(_error).to.deep.equal(error)
         done()
       })
@@ -423,14 +415,13 @@ describe('Company export controller', () => {
           future_interest_countries: ['555', '666'],
           addExportToCountry: 'Add country',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(['888', '333', ''])
           done()
         },
-      }, this.next)
+      }), this.next)
     })
 
     it('should add a new future interest country when instructed to', (done) => {
@@ -447,14 +438,13 @@ describe('Company export controller', () => {
           future_interest_countries: ['555', '666'],
           addFutureInterestCountry: 'Add country',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbsStub,
         render: (template, data) => {
           expect(data.future_interest_countries).to.deep.equal(['555', '666', ''])
           done()
         },
-      }, this.next)
+      }), this.next)
     })
   })
 })

--- a/test/unit/apps/companies/controllers/foreign.test.js
+++ b/test/unit/apps/companies/controllers/foreign.test.js
@@ -16,7 +16,6 @@ describe('Company controller, foreign', function () {
   let fakeCompanyForm
   let saveCompanyFormStub
   let flashStub
-  let breadcrumbStub
   const company = {
     id: '9999',
     company_number: '10620176',
@@ -47,6 +46,13 @@ describe('Company controller, foreign', function () {
   }
 
   beforeEach(function () {
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
     fakeCompanyForm = { id: '999', sector: 10 }
     getInflatedDitCompanyStub = sinon.stub().resolves(company)
     getDisplayCHStub = sinon.stub().returns({ company_number: '1234' })
@@ -56,7 +62,6 @@ describe('Company controller, foreign', function () {
     getForeignCompanyAsFormDataStub = sinon.stub().returns(fakeCompanyForm)
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
     flashStub = sinon.stub()
-    breadcrumbStub = function () { return this }
 
     companyControllerForeign = proxyquire('~/src/apps/companies/controllers/foreign', {
       '../services/data': {
@@ -87,25 +92,23 @@ describe('Company controller, foreign', function () {
         params: {
           id: '9999',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
         },
-      }, next)
+      }), next)
     })
     it('should return the company heading name and address', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('Freds ltd')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
         },
-      }
+      })
 
       companyControllerForeign.getDetails({
         session: {
@@ -117,9 +120,8 @@ describe('Company controller, foreign', function () {
       }, res, next)
     })
     it('should get not get a formatted copy of the company house data to display', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.not.be.called
           expect(res.locals).to.not.have.property('chDetails')
@@ -127,7 +129,7 @@ describe('Company controller, foreign', function () {
           expect(res.locals).to.not.have.property('chDetailsDisplayOrder')
           done()
         },
-      }
+      })
 
       companyControllerForeign.getDetails({
         session: {
@@ -139,9 +141,8 @@ describe('Company controller, foreign', function () {
       }, res, next)
     })
     it('should get formatted data for CDMS company details', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.be.calledWith(company)
           expect(res.locals).to.have.property('companyDetails')
@@ -149,7 +150,7 @@ describe('Company controller, foreign', function () {
           expect(res.locals.companyDetailsDisplayOrder).to.deep.equal(['business_type', 'registered_address', 'alias', 'trading_address', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range'])
           done()
         },
-      }
+      })
 
       companyControllerForeign.getDetails({
         session: {
@@ -161,15 +162,14 @@ describe('Company controller, foreign', function () {
       }, res, next)
     })
     it('should provide account management information', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
           done()
         },
-      }
+      })
 
       companyControllerForeign.getDetails({
         session: {
@@ -181,9 +181,8 @@ describe('Company controller, foreign', function () {
       }, res, next)
     })
     it('should use a template for ch data', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-foreign')
@@ -192,7 +191,7 @@ describe('Company controller, foreign', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerForeign.getDetails({
         session: {
@@ -211,14 +210,13 @@ describe('Company controller, foreign', function () {
         query: { business_type: 'charity' },
         params: {},
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal({ business_type: '1' })
           done()
         },
-      }
+      })
 
       companyControllerForeign.addDetails(req, res, next)
     })
@@ -233,14 +231,13 @@ describe('Company controller, foreign', function () {
         query: { business_type: 'charity' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
         },
-      }
+      })
 
       companyControllerForeign.addDetails(req, res, next)
     })
@@ -250,14 +247,13 @@ describe('Company controller, foreign', function () {
         query: { business_type: 'charity' },
         params: { id: '00112233' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function (template) {
           expect(template).to.equal('companies/views/edit-foreign')
           done()
         },
-      }
+      })
 
       companyControllerForeign.addDetails(req, res, next)
     })
@@ -345,16 +341,15 @@ describe('Company controller, foreign', function () {
         session: { token: '1234' },
         params: { id: '9999' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           expect(getForeignCompanyAsFormDataStub).to.be.calledWith(company)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
         },
-      }
+      })
 
       companyControllerForeign.editDetails(req, res, next)
     })
@@ -368,15 +363,14 @@ describe('Company controller, foreign', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function () {
           expect(getForeignCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
           done()
         },
-      }
+      })
 
       companyControllerForeign.editDetails(req, res, next)
     })
@@ -390,9 +384,8 @@ describe('Company controller, foreign', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-foreign')
@@ -401,7 +394,7 @@ describe('Company controller, foreign', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerForeign.editDetails(req, res, next)
     })
@@ -413,14 +406,13 @@ describe('Company controller, foreign', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
         },
-      }
+      })
 
       companyControllerForeign.editDetails(req, res, next)
     })
@@ -432,14 +424,13 @@ describe('Company controller, foreign', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
         },
-      }
+      })
 
       companyControllerForeign.editDetails(req, res, next)
     })
@@ -457,9 +448,8 @@ describe('Company controller, foreign', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         redirect: function () {
           expect(saveCompanyFormStub).to.be.calledWith('1234', body)
           done()
@@ -467,7 +457,7 @@ describe('Company controller, foreign', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerForeign.postDetails(req, res, next)
     })
     it('should forward to the detail screen if save is good', function (done) {
@@ -482,9 +472,8 @@ describe('Company controller, foreign', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/foreign/999')
           done()
@@ -492,7 +481,7 @@ describe('Company controller, foreign', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerForeign.postDetails(req, res, next)
     })
     it('should re-render the edit form with form data on error', function (done) {
@@ -532,9 +521,8 @@ describe('Company controller, foreign', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         redirect: function () {
           throw Error('error')
         },
@@ -547,7 +535,7 @@ describe('Company controller, foreign', function () {
             done(e)
           }
         },
-      }
+      })
       companyControllerForeign.postDetails(req, res, next)
     })
     it('should flash a message to let people know they did something', function (done) {
@@ -562,9 +550,8 @@ describe('Company controller, foreign', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
         redirect: function () {
           expect(flashStub).to.be.calledWith('success', 'Updated company record')
           done()
@@ -572,7 +559,7 @@ describe('Company controller, foreign', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerForeign.postDetails(req, res, next)
     })
   })
@@ -586,10 +573,9 @@ describe('Company controller, foreign', function () {
           token: '1234',
         },
       }
-      res = {
+      res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: breadcrumbStub,
-      }
+      })
     })
     it('should include the require properties in the response', function () {
       companyControllerForeign.editCommon(req, res)

--- a/test/unit/apps/companies/controllers/interactions.test.js
+++ b/test/unit/apps/companies/controllers/interactions.test.js
@@ -84,7 +84,13 @@ describe('Company interactions controller', function () {
       },
     })
 
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
   })
 
   describe('data', function () {
@@ -93,15 +99,14 @@ describe('Company interactions controller', function () {
         session: { token: '1234' },
         params: { id: '1' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.have.property('interactions')
           expect(res.locals.interactions).to.have.length(2)
           done()
         },
-      }
+      })
       companyinteractioncontroller.getInteractions(req, res, next)
     })
     it('should return a url to add interactions if a valid company and has contacts', function (done) {
@@ -109,14 +114,13 @@ describe('Company interactions controller', function () {
         session: { token: '1234' },
         params: { id: '1' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.have.property('addInteractionUrl')
           done()
         },
-      }
+      })
       companyinteractioncontroller.getInteractions(req, res, next)
     })
     it('should not return a url to add interactions if not a valid company', function (done) {
@@ -131,14 +135,13 @@ describe('Company interactions controller', function () {
         session: { token: '1234' },
         params: { id: '1' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.not.have.property('addInteractionUrl')
           done()
         },
-      }
+      })
       companyinteractioncontroller.getInteractions(req, res, next)
     })
     it('should not return a url to add interactions if no contacts', function (done) {
@@ -152,14 +155,13 @@ describe('Company interactions controller', function () {
         session: { token: '1234' },
         params: { id: '1' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.not.have.property('addInteractionUrl')
           done()
         },
-      }
+      })
       companyinteractioncontroller.getInteractions(req, res, next)
     })
   })

--- a/test/unit/apps/companies/controllers/ltd.test.js
+++ b/test/unit/apps/companies/controllers/ltd.test.js
@@ -79,7 +79,13 @@ describe('Company controller, ltd', function () {
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
     flashStub = sinon.stub()
 
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     companyControllerLtd = proxyquire('~/src/apps/companies/controllers/ltd', {
       '../services/data': {
@@ -111,25 +117,23 @@ describe('Company controller, ltd', function () {
         params: {
           id: '9999',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
         },
-      }, next)
+      }), next)
     })
     it('should return the company heading name and address', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('ADALEOP LTD')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
         },
-      }
+      })
 
       companyControllerLtd.getDetails({
         session: {
@@ -141,9 +145,8 @@ describe('Company controller, ltd', function () {
       }, res, next)
     })
     it('should get a formatted copy of the company house data to display', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.be.calledWith(chCompany)
           expect(res.locals).to.have.property('chDetails')
@@ -151,7 +154,7 @@ describe('Company controller, ltd', function () {
           expect(res.locals.chDetailsDisplayOrder).to.deep.equal(['name', 'company_number', 'registered_address', 'business_type', 'company_status', 'incorporation_date', 'sic_code'])
           done()
         },
-      }
+      })
 
       companyControllerLtd.getDetails({
         session: {
@@ -163,9 +166,8 @@ describe('Company controller, ltd', function () {
       }, res, next)
     })
     it('should get formatted data for CDMS company details', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.be.calledWith(company)
           expect(res.locals).to.have.property('companyDetails')
@@ -173,7 +175,7 @@ describe('Company controller, ltd', function () {
           expect(res.locals.companyDetailsDisplayOrder).to.deep.equal(['alias', 'trading_address', 'uk_region', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range'])
           done()
         },
-      }
+      })
 
       companyControllerLtd.getDetails({
         session: {
@@ -185,15 +187,14 @@ describe('Company controller, ltd', function () {
       }, res, next)
     })
     it('should provide account management information', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
           done()
         },
-      }
+      })
 
       companyControllerLtd.getDetails({
         session: {
@@ -205,9 +206,8 @@ describe('Company controller, ltd', function () {
       }, res, next)
     })
     it('should use a template for ltd data', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-ltd')
@@ -216,7 +216,7 @@ describe('Company controller, ltd', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerLtd.getDetails({
         session: {
@@ -234,15 +234,14 @@ describe('Company controller, ltd', function () {
         session: { token: '1234' },
         params: { company_number: '00112233' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDefaultLtdFormForCHStub).to.be.calledWith(chCompany)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
         },
-      }
+      })
 
       companyControllerLtd.addDetails(req, res, next)
     })
@@ -256,14 +255,13 @@ describe('Company controller, ltd', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
         },
-      }
+      })
 
       companyControllerLtd.addDetails(req, res, next)
     })
@@ -272,9 +270,8 @@ describe('Company controller, ltd', function () {
         session: { token: '1234' },
         params: { company_number: '00112233' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getCHCompanyStub).to.be.calledWith('1234', '00112233')
           expect(getDisplayCHStub).to.be.calledWith(chCompany)
@@ -282,7 +279,7 @@ describe('Company controller, ltd', function () {
           expect(res.locals).to.have.property('chDetails')
           done()
         },
-      }
+      })
 
       companyControllerLtd.addDetails(req, res, next)
     })
@@ -291,9 +288,8 @@ describe('Company controller, ltd', function () {
         session: { token: '1234' },
         params: { company_number: '00112233' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ltd')
@@ -302,7 +298,7 @@ describe('Company controller, ltd', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerLtd.addDetails(req, res, next)
     })
@@ -404,16 +400,15 @@ describe('Company controller, ltd', function () {
         session: { token: '1234' },
         params: { id: '9999' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           expect(getLtdCompanyAsFormDataStub).to.be.calledWith(company)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
         },
-      }
+      })
 
       companyControllerLtd.editDetails(req, res, next)
     })
@@ -427,16 +422,15 @@ describe('Company controller, ltd', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.not.be.called
           expect(getLtdCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
           done()
         },
-      }
+      })
 
       companyControllerLtd.editDetails(req, res, next)
     })
@@ -450,9 +444,8 @@ describe('Company controller, ltd', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ltd')
@@ -461,7 +454,7 @@ describe('Company controller, ltd', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerLtd.editDetails(req, res, next)
     })
@@ -473,14 +466,13 @@ describe('Company controller, ltd', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
         },
-      }
+      })
 
       companyControllerLtd.editDetails(req, res, next)
     })
@@ -492,14 +484,13 @@ describe('Company controller, ltd', function () {
         params: { company_number: '00112233' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
         },
-      }
+      })
 
       companyControllerLtd.editDetails(req, res, next)
     })
@@ -517,9 +508,8 @@ describe('Company controller, ltd', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(saveCompanyFormStub).to.be.calledWith('1234', body)
           done()
@@ -527,7 +517,7 @@ describe('Company controller, ltd', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerLtd.postDetails(req, res, next)
     })
     it('should forward to the detail screen if save is good', function (done) {
@@ -542,9 +532,8 @@ describe('Company controller, ltd', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ltd/999')
           done()
@@ -552,7 +541,7 @@ describe('Company controller, ltd', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerLtd.postDetails(req, res, next)
     })
     it('should re-render the edit form with form data on error', function (done) {
@@ -592,9 +581,8 @@ describe('Company controller, ltd', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           throw Error('error')
         },
@@ -607,7 +595,7 @@ describe('Company controller, ltd', function () {
             done(e)
           }
         },
-      }
+      })
       companyControllerLtd.postDetails(req, res, next)
     })
     it('should flash a message to let people know they did something', function (done) {
@@ -622,9 +610,8 @@ describe('Company controller, ltd', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(flashStub).to.be.calledWith('success', 'Updated company record')
           done()
@@ -632,7 +619,7 @@ describe('Company controller, ltd', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerLtd.postDetails(req, res, next)
     })
   })
@@ -646,10 +633,9 @@ describe('Company controller, ltd', function () {
           token: '1234',
         },
       }
-      res = {
+      res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
-      }
+      })
     })
     it('should include the require properties in the response', function () {
       companyControllerLtd.editCommon(req, res)

--- a/test/unit/apps/companies/controllers/ukother.test.js
+++ b/test/unit/apps/companies/controllers/ukother.test.js
@@ -57,7 +57,13 @@ describe('Company controller, uk other', function () {
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
     flashStub = sinon.stub()
 
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     companyControllerUkOther = proxyquire('~/src/apps/companies/controllers/ukother', {
       '../services/data': {
@@ -88,25 +94,23 @@ describe('Company controller, uk other', function () {
         params: {
           id: '9999',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
         },
-      }, next)
+      }), next)
     })
     it('should return the company heading name and address', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.headingName).to.equal('Freds ltd')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
         },
-      }
+      })
 
       companyControllerUkOther.getDetails({
         session: {
@@ -118,9 +122,8 @@ describe('Company controller, uk other', function () {
       }, res, next)
     })
     it('should get not get a formatted copy of the company house data to display', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCHStub).to.not.be.called
           expect(res.locals).to.not.have.property('chDetails')
@@ -128,7 +131,7 @@ describe('Company controller, uk other', function () {
           expect(res.locals).to.not.have.property('chDetailsDisplayOrder')
           done()
         },
-      }
+      })
 
       companyControllerUkOther.getDetails({
         session: {
@@ -140,9 +143,8 @@ describe('Company controller, uk other', function () {
       }, res, next)
     })
     it('should get formatted data for CDMS company details', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDisplayCompanyStub).to.be.calledWith(company)
           expect(res.locals).to.have.property('companyDetails')
@@ -150,7 +152,7 @@ describe('Company controller, uk other', function () {
           expect(res.locals.companyDetailsDisplayOrder).to.deep.equal(['business_type', 'registered_address', 'alias', 'trading_address', 'uk_region', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range'])
           done()
         },
-      }
+      })
 
       companyControllerUkOther.getDetails({
         session: {
@@ -162,15 +164,14 @@ describe('Company controller, uk other', function () {
       }, res, next)
     })
     it('should provide account management information', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
           done()
         },
-      }
+      })
 
       companyControllerUkOther.getDetails({
         session: {
@@ -182,9 +183,8 @@ describe('Company controller, uk other', function () {
       }, res, next)
     })
     it('should use a template for ch data', function (done) {
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/details-ukother')
@@ -193,7 +193,7 @@ describe('Company controller, uk other', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerUkOther.getDetails({
         session: {
@@ -213,14 +213,13 @@ describe('Company controller, uk other', function () {
         params: {},
         query: { business_type: 'charity' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal({ business_type: '1' })
           done()
         },
-      }
+      })
 
       companyControllerUkOther.addDetails(req, res, next)
     })
@@ -235,14 +234,13 @@ describe('Company controller, uk other', function () {
         query: { business_type: 'charity' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
         },
-      }
+      })
 
       companyControllerUkOther.addDetails(req, res, next)
     })
@@ -252,9 +250,8 @@ describe('Company controller, uk other', function () {
         params: { id: '00112233' },
         query: { business_type: 'charity' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ukother')
@@ -263,7 +260,7 @@ describe('Company controller, uk other', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerUkOther.addDetails(req, res, next)
     })
@@ -353,16 +350,15 @@ describe('Company controller, uk other', function () {
         params: { id: '9999' },
         query: { business_type: 'charity' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           expect(getUkOtherCompanyAsFormDataStub).to.be.calledWith(company)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
         },
-      }
+      })
 
       companyControllerUkOther.editDetails(req, res, next)
     })
@@ -377,15 +373,14 @@ describe('Company controller, uk other', function () {
         query: { business_type: 'charity' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(getUkOtherCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
           done()
         },
-      }
+      })
 
       companyControllerUkOther.editDetails(req, res, next)
     })
@@ -402,9 +397,8 @@ describe('Company controller, uk other', function () {
         },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           try {
             expect(template).to.equal('companies/views/edit-ukother')
@@ -413,7 +407,7 @@ describe('Company controller, uk other', function () {
             done(e)
           }
         },
-      }
+      })
 
       companyControllerUkOther.editDetails(req, res, next)
     })
@@ -426,14 +420,13 @@ describe('Company controller, uk other', function () {
         query: { business_type: 'charity' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
         },
-      }
+      })
 
       companyControllerUkOther.editDetails(req, res, next)
     })
@@ -446,14 +439,13 @@ describe('Company controller, uk other', function () {
         query: { business_type: 'charity' },
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
         },
-      }
+      })
 
       companyControllerUkOther.editDetails(req, res, next)
     })
@@ -472,9 +464,8 @@ describe('Company controller, uk other', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(saveCompanyFormStub).to.be.calledWith('1234', body)
           done()
@@ -482,7 +473,7 @@ describe('Company controller, uk other', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerUkOther.postDetails(req, res, next)
     })
     it('should forward to the detail screen if save is good', function (done) {
@@ -498,9 +489,8 @@ describe('Company controller, uk other', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ukother/999')
           done()
@@ -508,7 +498,7 @@ describe('Company controller, uk other', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerUkOther.postDetails(req, res, next)
     })
     it('should re-render the edit form with form data on error', function (done) {
@@ -550,9 +540,8 @@ describe('Company controller, uk other', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           throw Error('error')
         },
@@ -565,7 +554,7 @@ describe('Company controller, uk other', function () {
             done(e)
           }
         },
-      }
+      })
       companyControllerUkOther.postDetails(req, res, next)
     })
     it('should flash a message to let people know they did something', function (done) {
@@ -581,9 +570,8 @@ describe('Company controller, uk other', function () {
         flash: flashStub,
         body,
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function () {
           expect(flashStub).to.be.calledWith('success', 'Updated company record')
           done()
@@ -591,7 +579,7 @@ describe('Company controller, uk other', function () {
         render: function () {
           throw Error('error')
         },
-      }
+      })
       companyControllerUkOther.postDetails(req, res, next)
     })
   })
@@ -605,10 +593,9 @@ describe('Company controller, uk other', function () {
           token: '1234',
         },
       }
-      res = {
+      res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
-      }
+      })
     })
     it('should include the require properties in the response', function () {
       companyControllerUkOther.editCommon(req, res)

--- a/test/unit/apps/contacts/controllers/details.test.js
+++ b/test/unit/apps/contacts/controllers/details.test.js
@@ -75,7 +75,13 @@ describe('Contact controller', function () {
       },
     })
 
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
   })
 
   describe('getCommon', function () {
@@ -86,10 +92,9 @@ describe('Contact controller', function () {
           contactId: '1234',
         },
       }
-      const res = {
-        breadcrumb: this.breadcrumbStub,
+      const res = Object.assign(this.resMock, {
         render: function () {},
-      }
+      })
       const next = function () {
         expect(getContactStub).to.have.been.calledWith(token, req.params.contactId)
         done()
@@ -103,13 +108,12 @@ describe('Contact controller', function () {
           contactId: '1234',
         },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {
           contact,
         },
-        breadcrumb: this.breadcrumbStub,
         render: function () {},
-      }
+      })
       const next = function () {
         expect(getDitCompanyStub).to.have.been.calledWith(token, contact.company.id)
         expect(getContactStub).to.have.been.calledWith(token, req.params.contactId)
@@ -124,13 +128,12 @@ describe('Contact controller', function () {
           contactId: '1234',
         },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {
           company,
         },
-        breadcrumb: this.breadcrumbStub,
         render: function () {},
-      }
+      })
       const next = function () {
         expect(buildCompanyUrlStub).to.have.been.calledWith(company)
         done()
@@ -144,11 +147,10 @@ describe('Contact controller', function () {
           contactId: '1234',
         },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         render: function () {},
-      }
+      })
       const next = function () {
         expect(res.locals.id).to.equal(req.params.contactId)
         done()
@@ -178,10 +180,9 @@ describe('Contact controller', function () {
           contactId: '1234',
         },
       }
-      const res = {
-        breadcrumb: this.breadcrumbStub,
+      const res = Object.assign(this.resMock, {
         render: function () {},
-      }
+      })
       const next = function (err) {
         expect(err.message).to.equal(error.message)
         done()
@@ -197,20 +198,19 @@ describe('Contact controller', function () {
         const req = {
           session: {},
         }
-        const res = {
+        const res = Object.assign(this.resMock, {
           locals: {
             contact,
             company,
             id: '1234',
           },
-          breadcrumb: this.breadcrumbStub,
           render: function (url, options) {
             expect(getDisplayContactStub).to.be.calledWith(contact, company)
             expect(res.locals.contactDetails).to.deep.equal(contactFormatted)
             expect(res.locals.contactDetailsLabels).to.deep.equal(contactDetailsLabels)
             done()
           },
-        }
+        })
         contactController.getDetails(req, res, next)
       })
     })

--- a/test/unit/apps/contacts/controllers/edit.test.js
+++ b/test/unit/apps/contacts/controllers/edit.test.js
@@ -24,7 +24,13 @@ describe('Contact controller, edit', function () {
     getContactAsFormDataStub = sinon.stub().returns({ id: '1234', name: 'Thing' })
     saveContactFormStub = sinon.stub().returns({ id: '1234', first_name: 'Fred', last_name: 'Smith' })
 
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     contactEditController = proxyquire('~/src/apps/contacts/controllers/edit', {
       '../services/form': {
@@ -95,12 +101,11 @@ describe('Contact controller, edit', function () {
             contactId: '12651151-2149-465e-871b-ac45bc568a62',
           },
         }
-        res = {
+        res = Object.assign(this.resMock, {
           locals: {
             contact,
           },
-          breadcrumb: this.breadcrumbStub,
-        }
+        })
       })
 
       it('should create a form based on the existing contact', function (done) {
@@ -145,10 +150,9 @@ describe('Contact controller, edit', function () {
           },
           params: {},
         }
-        res = {
+        res = Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
-        }
+        })
       })
 
       it('should return a form pre-populated with just the company id', function (done) {
@@ -199,10 +203,9 @@ describe('Contact controller, edit', function () {
             company: '1234',
           },
         }
-        res = {
+        res = Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
-        }
+        })
       })
       it('should use the pre posted form for edit', function (done) {
         res.render = function () {

--- a/test/unit/apps/contacts/controllers/interactions.test.js
+++ b/test/unit/apps/contacts/controllers/interactions.test.js
@@ -21,7 +21,13 @@ describe('Contact interactions controller', function () {
     contactDataService.getContactInteractionsAndServiceDeliveries = sinon.stub().resolves([interaction])
     interactionFormattingService.getDisplayContactInteraction = sinon.stub().resolves(formattedInteraction)
 
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
   })
 
   describe('data', function () {
@@ -30,16 +36,15 @@ describe('Contact interactions controller', function () {
         session: { token: '1234' },
         params: { contactId: '1' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {
           contact,
         },
-        breadcrumb: this.breadcrumbStub,
         render: function () {
           expect(contactDataService.getContactInteractionsAndServiceDeliveries).to.be.calledWith(req.session.token, req.params.contactId)
           done()
         },
-      }
+      })
       contactInteractionController.getInteractions(req, res, next)
     })
 
@@ -48,16 +53,15 @@ describe('Contact interactions controller', function () {
         session: { token: '1234' },
         params: { contactId: '1' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {
           contact,
         },
-        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(interactionFormattingService.getDisplayContactInteraction).to.be.calledWith(interaction)
           done()
         },
-      }
+      })
       contactInteractionController.getInteractions(req, res, next)
     })
 
@@ -66,17 +70,16 @@ describe('Contact interactions controller', function () {
         session: { token: '1234' },
         params: { contactId: '1' },
       }
-      const res = {
+      const res = Object.assign(this.resMock, {
         locals: {
           contact,
         },
-        breadcrumb: this.breadcrumbStub,
         render: function (template, options) {
           expect(res.locals).to.have.property('interactions')
           expect(res.locals.interactions).to.have.length(1)
           done()
         },
-      }
+      })
       contactInteractionController.getInteractions(req, res, next)
     })
   })

--- a/test/unit/apps/investment-projects/controllers/audit.test.js
+++ b/test/unit/apps/investment-projects/controllers/audit.test.js
@@ -7,7 +7,13 @@ describe('Investment audit controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
     this.getInvestmentProjectAuditLog = this.sandbox.stub().resolves(investmentProjectAuditData.results)
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/audit', {
       '../repos': {
@@ -24,11 +30,10 @@ describe('Investment audit controller', () => {
       params: {
         id: '9999',
       },
-    }, {
+    }, Object.assign(this.resMock, {
       locals: {
         investmentData: {},
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(this.getInvestmentProjectAuditLog).to.be.calledWith(token, '9999')
@@ -37,7 +42,7 @@ describe('Investment audit controller', () => {
           done(error)
         }
       },
-    }, this.next)
+    }), this.next)
   })
   it('should send a parsed copy of audit data to the view', (done) => {
     const expected = [{
@@ -57,11 +62,10 @@ describe('Investment audit controller', () => {
       params: {
         id: '9999',
       },
-    }, {
+    }, Object.assign(this.resMock, {
       locals: {
         investmentData: {},
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)
@@ -70,7 +74,7 @@ describe('Investment audit controller', () => {
           done(error)
         }
       },
-    }, this.next)
+    }), this.next)
   })
   it('should handle audit entry containing an empty timestamp', (done) => {
     const badDate = [{
@@ -106,11 +110,10 @@ describe('Investment audit controller', () => {
       params: {
         id: '9999',
       },
-    }, {
+    }, Object.assign(this.resMock, {
       locals: {
         investmentData: {},
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)
@@ -119,7 +122,7 @@ describe('Investment audit controller', () => {
           done(error)
         }
       },
-    }, this.next)
+    }), this.next)
   })
   it('should handle when changes is null', (done) => {
     const nullChangeSet = [{
@@ -153,11 +156,10 @@ describe('Investment audit controller', () => {
       params: {
         id: '9999',
       },
-    }, {
+    }, Object.assign(this.resMock, {
       locals: {
         investmentData: {},
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)
@@ -166,7 +168,7 @@ describe('Investment audit controller', () => {
           done(error)
         }
       },
-    }, this.next)
+    }), this.next)
   })
   it('should handle when the changeset is empty', (done) => {
     const emptyChangeSet = [{
@@ -200,11 +202,10 @@ describe('Investment audit controller', () => {
       params: {
         id: '9999',
       },
-    }, {
+    }, Object.assign(this.resMock, {
       locals: {
         investmentData: {},
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(data.auditLog).to.deep.equal(expected)
@@ -213,6 +214,6 @@ describe('Investment audit controller', () => {
           done(error)
         }
       },
-    }, this.next)
+    }), this.next)
   })
 })

--- a/test/unit/apps/investment-projects/controllers/create-1.test.js
+++ b/test/unit/apps/investment-projects/controllers/create-1.test.js
@@ -26,7 +26,13 @@ describe('Investment start controller', () => {
     this.getCompanyInvestmentProjects = this.sandbox.stub().resolves(investmentProjects)
     this.searchForeignCompanies = this.sandbox.stub().resolves(searchResults)
     this.buildPagination = this.sandbox.stub().returns(null)
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/create-1', {
       '../../companies/services/data': {
@@ -56,9 +62,8 @@ describe('Investment start controller', () => {
             token,
           },
           query: {},
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(data.clientCompany).to.be.undefined
@@ -69,7 +74,7 @@ describe('Investment start controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
 
@@ -82,9 +87,8 @@ describe('Investment start controller', () => {
           query: {
             'client-company': '12345',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(this.getInflatedDitCompany).to.be.calledWith(token, '12345')
@@ -98,7 +102,7 @@ describe('Investment start controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
 
@@ -115,9 +119,8 @@ describe('Investment start controller', () => {
           query: {
             'client-company': '12345',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(this.getInflatedDitCompany).to.be.calledWith(token, '12345')
@@ -131,7 +134,7 @@ describe('Investment start controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
 
       it('should render search', (done) => {
@@ -143,9 +146,8 @@ describe('Investment start controller', () => {
             'client-company': '12345',
             'show-search': true,
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(data.showSearch).to.equal(true)
@@ -154,7 +156,7 @@ describe('Investment start controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
 
@@ -168,9 +170,8 @@ describe('Investment start controller', () => {
             'client-company': '12345',
             'q': 'samsung',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
               expect(data.searchTerm).to.equal('samsung')
@@ -181,7 +182,7 @@ describe('Investment start controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
   })
@@ -228,8 +229,7 @@ describe('Investment start controller', () => {
           body: {
             'client-company': '12345',
           },
-        }, {
-          breadcrumb: this.breadcrumbStub,
+        }, Object.assign(this.resMock, {
           render: (template, data) => {
             try {
               expect(data.clientCompany).to.deep.equal(ukCompany)
@@ -239,7 +239,7 @@ describe('Investment start controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
   })

--- a/test/unit/apps/investment-projects/controllers/create-2.test.js
+++ b/test/unit/apps/investment-projects/controllers/create-2.test.js
@@ -2,7 +2,13 @@ describe('Investment create controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     this.controller = require('~/src/apps/investment-projects/controllers/create-2')
   })
@@ -18,9 +24,8 @@ describe('Investment create controller', () => {
           session: {
             token: 'abcd',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {},
-          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal('/investment-projects/create/1')
@@ -29,7 +34,7 @@ describe('Investment create controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
 
@@ -39,13 +44,12 @@ describe('Investment create controller', () => {
           session: {
             token: 'abcd',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             equityCompany: {
               id: '12345',
             },
           },
-          breadcrumb: this.breadcrumbStub,
           render: (template) => {
             try {
               expect(template).to.equal('investment-projects/views/create-2')
@@ -54,7 +58,7 @@ describe('Investment create controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
   })
@@ -66,12 +70,11 @@ describe('Investment create controller', () => {
           session: {
             token: 'abcd',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             resultId: '12345',
             form: {},
           },
-          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal('/investment-projects/12345')
@@ -80,7 +83,7 @@ describe('Investment create controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
 
@@ -90,13 +93,12 @@ describe('Investment create controller', () => {
           session: {
             token: 'abcd',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             form: {
               errors: {},
             },
           },
-          breadcrumb: this.breadcrumbStub,
           render: (template) => {
             try {
               expect(template).to.equal('investment-projects/views/create-2')
@@ -105,7 +107,7 @@ describe('Investment create controller', () => {
               done(e)
             }
           },
-        }, this.next)
+        }), this.next)
       })
     })
   })

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -13,8 +13,12 @@ describe('Investment evaluation controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
-    this.breadcrumbStub = function () {
-      return this
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
     }
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/evaluation', {
@@ -34,11 +38,10 @@ describe('Investment evaluation controller', () => {
         session: {
           token: 'abcd',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           investmentData,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template, data) => {
           try {
             expect(template).to.equal('investment-projects/views/evaluation')
@@ -48,7 +51,7 @@ describe('Investment evaluation controller', () => {
             done(error)
           }
         },
-      }, this.next)
+      }), this.next)
     })
   })
 
@@ -89,11 +92,10 @@ describe('Investment evaluation controller', () => {
       session: {
         token: 'abcd',
       },
-    }, {
+    }, Object.assign(this.resMock, {
       locals: {
         investmentData,
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(template).to.equal('investment-projects/views/evaluation')
@@ -106,7 +108,7 @@ describe('Investment evaluation controller', () => {
           done(error)
         }
       },
-    }, this.next)
+    }), this.next)
   })
 
   it('should return evaluation details with correct investment data with UK company', (done) => {
@@ -159,11 +161,10 @@ describe('Investment evaluation controller', () => {
       session: {
         token: 'abcd',
       },
-    }, {
+    }, Object.assign(this.resMock, {
       locals: {
         investmentData: investmentDataUkCompany,
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, data) => {
         try {
           expect(template).to.equal('investment-projects/views/evaluation')
@@ -176,6 +177,6 @@ describe('Investment evaluation controller', () => {
           done(error)
         }
       },
-    }, this.next)
+    }), this.next)
   })
 })

--- a/test/unit/apps/investment-projects/controllers/interactions/create.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions/create.test.js
@@ -5,7 +5,13 @@ describe('Investment Interactions create controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.nextStub = this.sandbox.stub()
     this.flashStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     this.controller = require('~/src/apps/investment-projects/controllers/interactions/create')
   })
@@ -20,11 +26,10 @@ describe('Investment Interactions create controller', () => {
         session: {
           token: 'abcd',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           investmentData,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template) => {
           try {
             expect(template).to.equal('investment-projects/views/interactions/create')
@@ -33,7 +38,7 @@ describe('Investment Interactions create controller', () => {
             done(e)
           }
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
   })
 
@@ -45,14 +50,13 @@ describe('Investment Interactions create controller', () => {
             token: 'abcd',
           },
           flash: this.flashStub,
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             form: {
               errors: {},
             },
             investmentData,
           },
-          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal(`/investment-projects/${investmentData.id}/interactions`)
@@ -62,7 +66,7 @@ describe('Investment Interactions create controller', () => {
               done(e)
             }
           },
-        }, this.nextStub)
+        }), this.nextStub)
       })
     })
 
@@ -72,7 +76,7 @@ describe('Investment Interactions create controller', () => {
           session: {
             token: 'abcd',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             form: {
               errors: {
@@ -80,8 +84,7 @@ describe('Investment Interactions create controller', () => {
               },
             },
           },
-          breadcrumb: this.breadcrumbStub,
-        }, this.nextStub)
+        }), this.nextStub)
 
         expect(this.nextStub).to.be.calledOnce
       })

--- a/test/unit/apps/investment-projects/controllers/interactions/edit.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions/edit.test.js
@@ -5,7 +5,13 @@ describe('Investment Interactions edit controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.nextStub = this.sandbox.stub()
     this.flashStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     this.controller = require('~/src/apps/investment-projects/controllers/interactions/edit')
   })
@@ -20,11 +26,10 @@ describe('Investment Interactions edit controller', () => {
         session: {
           token: 'abcd',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           investmentData,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template) => {
           try {
             expect(template).to.equal('investment-projects/views/interactions/edit')
@@ -33,7 +38,7 @@ describe('Investment Interactions edit controller', () => {
             done(e)
           }
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
   })
 
@@ -45,14 +50,13 @@ describe('Investment Interactions edit controller', () => {
             token: 'abcd',
           },
           flash: this.flashStub,
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             form: {
               errors: {},
             },
             investmentData,
           },
-          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal(`/investment-projects/${investmentData.id}/interactions`)
@@ -62,7 +66,7 @@ describe('Investment Interactions edit controller', () => {
               done(e)
             }
           },
-        }, this.nextStub)
+        }), this.nextStub)
       })
     })
 
@@ -72,7 +76,7 @@ describe('Investment Interactions edit controller', () => {
           session: {
             token: 'abcd',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             form: {
               errors: {
@@ -80,8 +84,7 @@ describe('Investment Interactions edit controller', () => {
               },
             },
           },
-          breadcrumb: this.breadcrumbStub,
-        }, this.nextStub)
+        }), this.nextStub)
 
         expect(this.nextStub).to.be.calledOnce
       })

--- a/test/unit/apps/investment-projects/controllers/interactions/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions/list.test.js
@@ -6,7 +6,13 @@ describe('Investment Interactions Index controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
     this.getInteractionsForInvestmentStub = this.sandbox.stub().resolves(interactionsListData)
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/interactions/list', {
       '../../../interactions/repos': {
@@ -28,11 +34,10 @@ describe('Investment Interactions Index controller', () => {
         params: {
           id: 'example-id-1234',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           investmentData,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template, data) => {
           try {
             expect(template).to.equal('investment-projects/views/interactions/index')
@@ -43,7 +48,7 @@ describe('Investment Interactions Index controller', () => {
             done(error)
           }
         },
-      }, this.next)
+      }), this.next)
     })
   })
 })

--- a/test/unit/apps/investment-projects/controllers/team/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/details.test.js
@@ -6,7 +6,13 @@ describe('Investment team details controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.nextStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
     this.reqStub = this.sandbox.stub()
     this.nextStub = this.sandbox.stub()
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/team/edit-project-management', {
@@ -26,16 +32,15 @@ describe('Investment team details controller', () => {
       data.project_manager = null
       data.project_assurance_adviser = null
 
-      controller.getDetailsHandler(this.reqStub, {
+      controller.getDetailsHandler(this.reqStub, Object.assign(this.resMock, {
         locals: {
           investmentData: data,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template, options) => {
           expect(options.projectManagementData).to.deep.equal(null)
           done()
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
 
     it('should return formatted data for the project manager and assurance adviser if there are both', (done) => {
@@ -49,16 +54,15 @@ describe('Investment team details controller', () => {
         team: 'Team A',
       }]
 
-      controller.getDetailsHandler(this.reqStub, {
+      controller.getDetailsHandler(this.reqStub, Object.assign(this.resMock, {
         locals: {
           investmentData: Object.assign({}, investmentData),
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template, options) => {
           expect(options.projectManagementData).to.deep.equal(expectedProjectManagementData)
           done()
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
 
     it('should return formatted data for project manager, and todo for assurance officer if no assurance officer', (done) => {
@@ -76,16 +80,15 @@ describe('Investment team details controller', () => {
         team: 'Team A',
       }]
 
-      controller.getDetailsHandler(this.reqStub, {
+      controller.getDetailsHandler(this.reqStub, Object.assign(this.resMock, {
         locals: {
           investmentData: data,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template, options) => {
           expect(options.projectManagementData).to.deep.equal(expectedProjectManagementData)
           done()
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
 
     it('should return formatted data for assurance adviser and todo for project manager is there is no project manager', (done) => {
@@ -103,42 +106,39 @@ describe('Investment team details controller', () => {
         team: null,
       }]
 
-      controller.getDetailsHandler(this.reqStub, {
+      controller.getDetailsHandler(this.reqStub, Object.assign(this.resMock, {
         locals: {
           investmentData: data,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template, options) => {
           expect(options.projectManagementData).to.deep.equal(expectedProjectManagementData)
           done()
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
   })
 
   it('should return labels for the table', (done) => {
-    controller.getDetailsHandler(this.reqStub, {
+    controller.getDetailsHandler(this.reqStub, Object.assign(this.resMock, {
       locals: {
         investmentData: Object.assign({}, investmentData),
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, options) => {
         expect(options.projectManagementLabels).to.deep.equal(projectManagementLabels)
         done()
       },
-    }, this.nextStub)
+    }), this.nextStub)
   })
 
   it('should use the correct template to render', (done) => {
-    controller.getDetailsHandler(this.reqStub, {
+    controller.getDetailsHandler(this.reqStub, Object.assign(this.resMock, {
       locals: {
         investmentData: Object.assign({}, investmentData),
       },
-      breadcrumb: this.breadcrumbStub,
       render: (template, options) => {
         expect(template).to.equal('investment-projects/views/team/details')
         done()
       },
-    }, this.nextStub)
+    }), this.nextStub)
   })
 })

--- a/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
@@ -7,7 +7,13 @@ describe('Investment project, project management team, edit controller', () => {
     this.nextStub = this.sandbox.stub()
     this.flashStub = this.sandbox.stub()
     this.getDataLabelsStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/team/edit-project-management', {
       '../../../../lib/controller-utils': {
@@ -26,11 +32,10 @@ describe('Investment project, project management team, edit controller', () => {
         session: {
           token: 'abcd',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           investmentData,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template) => {
           try {
             expect(template).to.equal('investment-projects/views/team/edit-project-management')
@@ -39,7 +44,7 @@ describe('Investment project, project management team, edit controller', () => {
             done(e)
           }
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
 
     it('should get formatted data for summary view', (done) => {
@@ -51,12 +56,11 @@ describe('Investment project, project management team, edit controller', () => {
         session: {
           token: 'abcd',
         },
-      }, {
+      }, Object.assign(this.resMock, {
         locals: {
           investmentData,
           briefInvestmentSummaryData,
         },
-        breadcrumb: this.breadcrumbStub,
         render: (template) => {
           try {
             expect(this.getDataLabelsStub).to.be.calledWith(briefInvestmentSummaryData, briefInvestmentSummaryLabels.view)
@@ -65,7 +69,7 @@ describe('Investment project, project management team, edit controller', () => {
             done(e)
           }
         },
-      }, this.nextStub)
+      }), this.nextStub)
     })
   })
 
@@ -77,14 +81,13 @@ describe('Investment project, project management team, edit controller', () => {
             token: 'abcd',
           },
           flash: this.flashStub,
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             form: {
               errors: {},
             },
             investmentData,
           },
-          breadcrumb: this.breadcrumbStub,
           redirect: (url) => {
             try {
               expect(url).to.equal(`/investment-projects/${investmentData.id}/team`)
@@ -94,7 +97,7 @@ describe('Investment project, project management team, edit controller', () => {
               done(e)
             }
           },
-        }, this.nextStub)
+        }), this.nextStub)
       })
     })
 
@@ -104,7 +107,7 @@ describe('Investment project, project management team, edit controller', () => {
           session: {
             token: 'abcd',
           },
-        }, {
+        }, Object.assign(this.resMock, {
           locals: {
             form: {
               errors: {
@@ -112,8 +115,7 @@ describe('Investment project, project management team, edit controller', () => {
               },
             },
           },
-          breadcrumb: this.breadcrumbStub,
-        }, this.nextStub)
+        }), this.nextStub)
 
         expect(this.nextStub).to.be.calledOnce
       })

--- a/test/unit/apps/search/controllers.test.js
+++ b/test/unit/apps/search/controllers.test.js
@@ -6,10 +6,6 @@ const next = function (error) {
 }
 
 describe('Search controller', function () {
-  beforeEach(() => {
-    this.breadcrumbStub = function () { return this }
-  })
-
   describe('view company result', function () {
     it('should route a uk private ltd company', function (done) {
       const searchController = proxyquire('~/src/apps/search/controllers', {
@@ -34,7 +30,6 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ltd/9999')
           done()
@@ -65,7 +60,6 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ltd/9999')
           done()
@@ -96,7 +90,6 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/ukother/9999')
           done()
@@ -127,7 +120,6 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
         redirect: function (url) {
           expect(url).to.equal('/companies/view/foreign/9999')
           done()
@@ -151,7 +143,6 @@ describe('Search controller', function () {
       }
       const res = {
         locals: {},
-        breadcrumb: this.breadcrumbStub,
       }
       const nextStub = (error) => {
         try {
@@ -173,7 +164,13 @@ describe('Search Controller', () => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.spy()
     this.controller = require('~/src/apps/search/controllers')
-    this.breadcrumbStub = function () { return this }
+    this.resMock = {
+      breadcrumb: {
+        add: () => this.resMock,
+        update: () => this.resMock,
+        get: () => [],
+      },
+    }
   })
 
   afterEach(() => {
@@ -239,8 +236,7 @@ describe('Search Controller', () => {
               searchPath,
             },
           },
-          {
-            breadcrumb: this.breadcrumbStub,
+          Object.assign(this.resMock, {
             render: (template, data) => {
               try {
                 expect(template).to.equal(`search/views/results-${entityType}`)
@@ -253,7 +249,7 @@ describe('Search Controller', () => {
                 done(e)
               }
             },
-          }, this.next
+          }), this.next
         )
       })
     })
@@ -291,8 +287,7 @@ describe('Search Controller', () => {
               searchPath,
             },
           },
-          {
-            breadcrumb: this.breadcrumbStub,
+          Object.assign(this.resMock, {
             render: (template, data) => {
               try {
                 expect(template).to.equal(`search/views/results-${entityType}`)
@@ -305,7 +300,7 @@ describe('Search Controller', () => {
                 done(e)
               }
             },
-          }, this.next
+          }), this.next
         )
       })
     })
@@ -343,8 +338,7 @@ describe('Search Controller', () => {
               searchPath,
             },
           },
-          {
-            breadcrumb: this.breadcrumbStub,
+          Object.assign(this.resMock, {
             render: (template, data) => {
               try {
                 expect(template).to.equal(`search/views/results-${entityType}`)
@@ -357,7 +351,7 @@ describe('Search Controller', () => {
                 done(e)
               }
             },
-          }, this.next
+          }), this.next
         )
       })
     })

--- a/test/unit/middleware/breadcrumbs.test.js
+++ b/test/unit/middleware/breadcrumbs.test.js
@@ -17,11 +17,14 @@ describe('breadcrumbs middleware', () => {
       this.init = breadcrumbs.init()
     })
 
-    it('should attach a method to the response object', () => {
+    it('should attach a method to the response object with expected properties', () => {
       this.init({}, this.resMock, this.nextSpy)
 
       expect(this.resMock).to.have.property('breadcrumb')
-      expect(this.resMock.breadcrumb).to.be.a('function')
+      expect(this.resMock.breadcrumb).to.be.a('object')
+      expect(this.resMock.breadcrumb).to.have.property('get')
+      expect(this.resMock.breadcrumb).to.have.property('add')
+      expect(this.resMock.breadcrumb).to.have.property('update')
       expect(this.nextSpy.calledOnce).to.be.true
     })
   })
@@ -31,66 +34,102 @@ describe('breadcrumbs middleware', () => {
       this.init({}, this.resMock, this.nextSpy)
     })
 
-    describe('when called with no arguments', () => {
-      it('should return the breadcrumb', () => {
-        expect(this.resMock.breadcrumb()).to.deep.equal([])
-      })
-    })
-
-    describe('when called with 1 argument', () => {
-      it('should set name', () => {
-        this.resMock.breadcrumb('Name')
-
-        expect(this.resMock.breadcrumb()).to.deep.equal([{
-          name: 'Name',
-        }])
-      })
-    })
-
-    describe('when called with 2 arguments', () => {
-      it('should set url and name', () => {
-        this.resMock.breadcrumb('Name', '/sample-url')
-
-        expect(this.resMock.breadcrumb()).to.deep.equal([{
-          name: 'Name',
-          url: '/sample-url',
-        }])
-      })
-    })
-
-    describe('when called with an object', () => {
-      it('should add the object to breadcrumb', () => {
-        this.resMock.breadcrumb({
-          name: 'Name',
-          url: '/sample-url',
+    describe('#get', () => {
+      describe('when called should return expected breadcrumbs', () => {
+        it('should return the breadcrumb', () => {
+          expect(this.resMock.breadcrumb.get()).to.deep.equal([])
         })
-
-        expect(this.resMock.breadcrumb()).to.deep.equal([{
-          name: 'Name',
-          url: '/sample-url',
-        }])
+      })
+      describe('when called should return expected breadcrumbs', () => {
+        it('should return the breadcrumb', () => {
+          this.resMock.breadcrumb.add([
+            { name: 'mock', url: 'mockUrl' },
+            { name: 'mockOther', url: 'mockUrlOther' },
+          ])
+          expect(this.resMock.breadcrumb.get()).to.deep.equal([
+            { name: 'mock', url: 'mockUrl' },
+            { name: 'mockOther', url: 'mockUrlOther' },
+          ])
+        })
       })
     })
 
-    describe('when called with an array of objects', () => {
-      it('should add each object to breadcrumb', () => {
-        this.resMock.breadcrumb([{
-          name: 'First item',
-          url: '/first-item',
-        },
-        {
-          name: 'Second item',
-          url: '/second-item',
-        }])
+    describe('#update', () => {
+      describe('expected breadcrumb name and url should be updated', () => {
+        it('should set url', () => {
+          this.resMock.breadcrumb.add([
+            { name: 'mock', url: 'mockUrl' },
+            { name: 'mockOther', url: 'mockUrlOther' },
+          ])
+          this.resMock.breadcrumb.update('mock', {
+            name: 'updatedMock',
+            url: 'updatedMockUrl',
+          })
 
-        expect(this.resMock.breadcrumb()).to.deep.equal([{
-          name: 'First item',
-          url: '/first-item',
-        },
-        {
-          name: 'Second item',
-          url: '/second-item',
-        }])
+          expect(this.resMock.breadcrumb.get()).to.deep.equal([
+            { name: 'updatedMock', url: 'updatedMockUrl' },
+            { name: 'mockOther', url: 'mockUrlOther' },
+          ])
+        })
+      })
+    })
+
+    describe('#add', () => {
+      describe('when called with 1 argument', () => {
+        it('should set name', () => {
+          this.resMock.breadcrumb.add('Name')
+
+          expect(this.resMock.breadcrumb.get()).to.deep.equal([{
+            name: 'Name',
+          }])
+        })
+      })
+
+      describe('when called with 2 arguments', () => {
+        it('should set url and name', () => {
+          this.resMock.breadcrumb.add('Name', '/sample-url')
+
+          expect(this.resMock.breadcrumb.get()).to.deep.equal([{
+            name: 'Name',
+            url: '/sample-url',
+          }])
+        })
+      })
+
+      describe('when called with an object', () => {
+        it('should add the object to breadcrumb', () => {
+          this.resMock.breadcrumb.add({
+            name: 'Name',
+            url: '/sample-url',
+          })
+
+          expect(this.resMock.breadcrumb.get()).to.deep.equal([{
+            name: 'Name',
+            url: '/sample-url',
+          }])
+        })
+      })
+
+      describe('when called with an array of objects', () => {
+        it('should add each object to breadcrumb', () => {
+          this.resMock.breadcrumb.add([{
+            name: 'First item',
+            url: '/first-item',
+          },
+          {
+            name: 'Second item',
+            url: '/second-item',
+          }])
+
+          expect(this.resMock.breadcrumb.get()).to.deep.equal([{
+            name: 'First item',
+            url: '/first-item',
+          },
+          {
+            name: 'Second item',
+            url: '/second-item',
+          }])
+        })
       })
     })
   })
@@ -110,7 +149,7 @@ describe('breadcrumbs middleware', () => {
 
       it('should set a default value for the home item', () => {
         expect(this.nextSpy.calledOnce).to.be.true
-        expect(this.resMock.breadcrumb()).to.deep.equal([{
+        expect(this.resMock.breadcrumb.get()).to.deep.equal([{
           name: 'Home',
           url: '/',
           _home: true,
@@ -128,7 +167,7 @@ describe('breadcrumbs middleware', () => {
 
       it('should set the object as the home item', () => {
         expect(this.nextSpy.calledOnce).to.be.true
-        expect(this.resMock.breadcrumb()).to.deep.equal([{
+        expect(this.resMock.breadcrumb.get()).to.deep.equal([{
           name: 'Root',
           url: '/root',
           _home: true,
@@ -148,7 +187,7 @@ describe('breadcrumbs middleware', () => {
         })({}, this.resMock, this.nextSpy)
 
         expect(this.nextSpy.calledTwice).to.be.true
-        expect(this.resMock.breadcrumb()).to.deep.equal([{
+        expect(this.resMock.breadcrumb.get()).to.deep.equal([{
           name: 'Root',
           url: '/root',
           _home: true,


### PR DESCRIPTION
## Problem
The `investment projects` breadcrumb does not link to the `investment projects` page when you are in an investment project.

## Solution
When you are in an Investment project we know the company that the investment project is associated with. This work enables us to update the breadcrumb with the `investor_company.id` so users can navigate back to the parent company via the breadcrumb.

### This work involves:

- add `update` method to breadcrumbs to be able to change a breadcrumbs entry,
- introduce `add` and `get` methods onto `res.breadcrumb` to provide prior functionality in a clearer fashion,
- update all tests,
- introduce a way of merging mock response information so `res.breadcrumb` methods can be chained in tests

### Old
![old](https://user-images.githubusercontent.com/2305016/28569675-c61b280a-7132-11e7-985a-928f4d9dac35.gif)

### New
![new](https://user-images.githubusercontent.com/2305016/28569755-198b7116-7133-11e7-8a37-408d2a11aa2e.gif)
