### PR TITLE
Fix formatting in macro import syntax for unit test macro utility

### DIFF
--- a/test/unit/component-helper.js
+++ b/test/unit/component-helper.js
@@ -41,7 +41,7 @@ function getMacros (fileName) {
         {% endcall %}
       `)
     } else {
-      macroOutput = nunjucks.renderString(`${importString} {{ ${name}(${JSON.stringify(props)}${args}) }}`)
+      macroOutput = nunjucks.renderString(`${importString} {{ ${name}(${JSON.stringify(props, undefined, 1)}${args}) }}`)
     }
 
     return normaliseHtml(macroOutput)


### PR DESCRIPTION
Use the same format as for call macro import a few lines above. This allows to pass deep objects without Nunjucks failing to interpret `}}`.