### PR TITLE
Ensure there is a bottom margin on form-errors

### DIFF
--- a/assets/stylesheets/components/form/_form-errors.scss
+++ b/assets/stylesheets/components/form/_form-errors.scss
@@ -4,6 +4,7 @@
   border: 5px solid $error-colour;
   padding: $default-spacing-unit;
   max-width: 40em;
+  margin-bottom: $default-spacing-unit * 2;
 
   &:focus {
     outline: 3px solid $focus-colour;


### PR DESCRIPTION
As form-errors can be followed by non-stackable element (e.g. hidden inputs) it makes sense to always add bottom margin to ensure there's space between errors block and following elements.