### PR TITLE
Updated breadcrumb for investment project management editing.

### DIFF
--- a/src/apps/investment-projects/controllers/team/edit-project-management.js
+++ b/src/apps/investment-projects/controllers/team/edit-project-management.js
@@ -7,8 +7,8 @@ function getHandler (req, res, next) {
   const briefInvestmentSummary = getDataLabels(res.locals.briefInvestmentSummaryData, briefInvestmentSummaryLabels.view)
 
   res
+    .breadcrumb('Project team', 'team')
     .breadcrumb('Project management')
-    .breadcrumb('Edit')
     .render('investment-projects/views/team/edit-project-management', {
       currentNavItem: 'team',
       variant: 'edit',


### PR DESCRIPTION
The previous breadcrumb pattern used didn't allow the user to return to the previous screen, level back, and the breadcrumb jumped around and didn't make sense. This pattern is logical and allows proper navigation, and works for other sections too.

Before
![before](https://user-images.githubusercontent.com/56056/28520069-0059ee0c-7066-11e7-9794-4b597f6fde63.PNG)


After
![after](https://user-images.githubusercontent.com/56056/28520073-046d9336-7066-11e7-94f6-8b2f2619d29c.PNG)
