### PR TITLE
Feature/relationship management

### DIFF
--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -65,10 +65,19 @@ function unarchiveCompany (token, companyId) {
   })
 }
 
+function updateCompany (token, companyId, body) {
+  return authorisedRequest(token, {
+    url: `${config.apiRoot}/v3/company/${companyId}`,
+    method: 'PATCH',
+    body,
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
   getCHCompany,
   archiveCompany,
   unarchiveCompany,
+  updateCompany,
 }

--- a/src/apps/investment-projects/controllers/team/details.js
+++ b/src/apps/investment-projects/controllers/team/details.js
@@ -1,15 +1,25 @@
-const { projectManagementLabels } = require('../../labels')
-const { transformProjectManagementForView } = require('../../services/formatting')
+const {
+  projectManagementLabels,
+  clientRelationshipManagementLabels,
+} = require('../../labels')
+
+const {
+  transformProjectManagementForView,
+  transformClientRelationshipManagementForView,
+} = require('../../services/formatting')
 
 function getDetailsHandler (req, res, next) {
   try {
     const projectManagementData = transformProjectManagementForView(res.locals.investmentData)
+    const clientRelationshipManagementData = transformClientRelationshipManagementForView(res.locals.investmentData)
 
     res
       .breadcrumb('Project team')
       .render('investment-projects/views/team/details', {
         projectManagementData,
         projectManagementLabels,
+        clientRelationshipManagementData,
+        clientRelationshipManagementLabels,
       })
   } catch (error) {
     next(error)

--- a/src/apps/investment-projects/controllers/team/edit-client-relationship-management.js
+++ b/src/apps/investment-projects/controllers/team/edit-client-relationship-management.js
@@ -1,0 +1,22 @@
+const { isEmpty } = require('lodash')
+
+function getHandler (req, res, next) {
+  res
+    .breadcrumb('Project team', 'team')
+    .breadcrumb('Client relationship management')
+    .render('investment-projects/views/team/edit-client-relationship-management')
+}
+
+function postHandler (req, res, next) {
+  if (isEmpty(res.locals.form.errors)) {
+    req.flash('success', 'Updated investment details')
+    return res.redirect(`/investment-projects/${res.locals.investmentData.id}/team`)
+  }
+
+  return next()
+}
+
+module.exports = {
+  getHandler,
+  postHandler,
+}

--- a/src/apps/investment-projects/controllers/team/index.js
+++ b/src/apps/investment-projects/controllers/team/index.js
@@ -1,7 +1,9 @@
 const details = require('./details')
+const editClientRelationshipManagement = require('./edit-client-relationship-management')
 const editProjectManagement = require('./edit-project-management')
 
 module.exports = {
   details,
+  editClientRelationshipManagement,
   editProjectManagement,
 }

--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -127,6 +127,17 @@ const labels = {
       estimated_land_date_after: 'Estimated land date after',
     },
   },
+  clientRelationshipManagementLabels: {
+    view: {
+      role: 'Role',
+      adviser: 'Adviser',
+      team: 'Team',
+    },
+    edit: {
+      client_relationship_manager: 'Client relationship manager',
+      account_manager: 'Account manager',
+    },
+  },
 }
 
 labels.valueLabels.edit = Object.assign({}, labels.valueLabels.view, labels.valueLabels.edit)

--- a/src/apps/investment-projects/middleware/forms/client-relationship-management.js
+++ b/src/apps/investment-projects/middleware/forms/client-relationship-management.js
@@ -1,0 +1,63 @@
+const { get } = require('lodash')
+const { getAdvisers } = require('../../../adviser/repos')
+const { updateCompany } = require('../../../companies/repos')
+const { updateInvestment } = require('../../repos')
+const { clientRelationshipManagementLabels } = require('../../labels')
+
+async function populateForm (req, res, next) {
+  try {
+    const investmentData = res.locals.investmentData
+
+    const advisersResponse = await getAdvisers(req.session.token)
+    const advisers = advisersResponse.results.map((adviser) => {
+      return {
+        value: adviser.id,
+        label: `${adviser.first_name} ${adviser.last_name}`,
+      }
+    })
+
+    res.locals.form = Object.assign({}, res.locals.form, {
+      labels: clientRelationshipManagementLabels.edit,
+      state: {
+        client_relationship_manager: get(investmentData, 'client_relationship_manager.id', null),
+        account_manager: get(investmentData, 'investor_company.account_manager.id', null),
+      },
+      options: {
+        advisers,
+      },
+      hiddenFields: {
+        investor_company: get(investmentData, 'investor_company.id'),
+      },
+      buttonText: 'Save',
+      returnLink: `/investment-projects/${investmentData.id}/team`,
+    })
+
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function handleFormPost (req, res, next) {
+  try {
+    res.locals.projectId = req.params.id
+    await updateCompany(req.session.token, req.body.investor_company, { account_manager: req.body.account_manager })
+    await updateInvestment(req.session.token, res.locals.projectId, { client_relationship_manager: req.body.client_relationship_manager })
+    next()
+  } catch (err) {
+    if (err.statusCode === 400) {
+      res.locals.form = Object.assign({}, res.locals.form, {
+        errors: err.error,
+        state: req.body,
+      })
+      next()
+    } else {
+      next(err)
+    }
+  }
+}
+
+module.exports = {
+  populateForm,
+  handleFormPost,
+}

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -3,6 +3,7 @@ const { get } = require('lodash')
 const { isValidGuid } = require('../../../lib/controller-utils')
 const { getDitCompany } = require('../../companies/repos')
 const { getInteraction } = require('../../interactions/repos')
+const { getAdviser } = require('../../adviser/repos')
 const { transformFromApi } = require('../../interactions/services/formatting')
 const { buildCompanyUrl } = require('../../companies/services/data')
 const { getInvestment } = require('../repos')
@@ -22,6 +23,9 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
       const companyDetails = await getDitCompany(req.session.token, ukCompanyId)
       investmentData.uk_company = Object.assign({}, investmentData.uk_company, companyDetails)
     }
+
+    const clientRelationshipManager = await getAdviser(req.session.token, investmentData.client_relationship_manager.id)
+    investmentData.client_relationship_manager = clientRelationshipManager
 
     res.locals.investmentData = investmentData
     res.locals.equityCompany = investmentData.investor_company

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -21,6 +21,7 @@ const valueFormMiddleware = require('./middleware/forms/value')
 const requirementsFormMiddleware = require('./middleware/forms/requirements')
 const interactionsFormMiddleware = require('./middleware/forms/interactions')
 const projectManagementFormMiddleware = require('./middleware/forms/project-management')
+const clientRelationshipManagementFormMiddleware = require('./middleware/forms/client-relationship-management')
 const { renderInvestmentList } = require('./controllers/list')
 const { setDefaults, getInvestmentProjectsCollection } = require('./middleware/collection')
 
@@ -84,6 +85,19 @@ router
     projectManagementFormMiddleware.handleFormPost,
     team.editProjectManagement.postHandler,
     team.editProjectManagement.getHandler
+  )
+
+router
+  .route('/:id/edit-client-relationship-management')
+  .get(
+    clientRelationshipManagementFormMiddleware.populateForm,
+    team.editClientRelationshipManagement.getHandler
+  )
+  .post(
+    clientRelationshipManagementFormMiddleware.populateForm,
+    clientRelationshipManagementFormMiddleware.handleFormPost,
+    team.editClientRelationshipManagement.postHandler,
+    team.editClientRelationshipManagement.getHandler
   )
 
 router.get('/:id/interactions', interactions.list.indexGetHandler)

--- a/src/apps/investment-projects/services/formatting.js
+++ b/src/apps/investment-projects/services/formatting.js
@@ -274,6 +274,27 @@ function transformProjectManagementForView (investmentData) {
   return null
 }
 
+function transformClientRelationshipManagementForView (investmentData) {
+  const crm = investmentData.client_relationship_manager
+
+  const result = [{
+    role: 'Client relationship manager',
+    adviser: crm.first_name + ' ' + crm.last_name,
+    team: crm.dit_team.name,
+  }]
+
+  const accountManager = get(investmentData, 'investor_company.accountManager.id', null)
+  if (accountManager) {
+    result.push({
+      advisor: get(investmentData, 'investor_company.accountManager.name', null),
+      role: 'Account manager',
+      team: get(investmentData, 'investor_company.accountManager.dit_team.name', null),
+    })
+  }
+
+  return result
+}
+
 module.exports = {
   transformInvestmentDataForView,
   transformInvestmentValueForView,
@@ -284,4 +305,5 @@ module.exports = {
   transformFromApi,
   transformBriefInvestmentSummary,
   transformProjectManagementForView,
+  transformClientRelationshipManagementForView,
 }

--- a/src/apps/investment-projects/services/formatting.js
+++ b/src/apps/investment-projects/services/formatting.js
@@ -261,7 +261,7 @@ function getAdviserName (investmentData, key) {
 function transformProjectManagementForView (investmentData) {
   if (investmentData.project_manager || investmentData.project_assurance_adviser) {
     return [{
-      role: 'Project assuranace adviser',
+      role: 'Project assurance adviser',
       adviser: getAdviserName(investmentData, 'project_assurance_adviser'),
       team: get(investmentData, 'project_assurance_team.name', null),
     }, {
@@ -275,20 +275,18 @@ function transformProjectManagementForView (investmentData) {
 }
 
 function transformClientRelationshipManagementForView (investmentData) {
-  const crm = investmentData.client_relationship_manager
-
   const result = [{
     role: 'Client relationship manager',
-    adviser: crm.first_name + ' ' + crm.last_name,
-    team: crm.dit_team.name,
+    adviser: getAdviserName(investmentData, 'client_relationship_manager'),
+    team: get(investmentData, 'client_relationship_manager.dit_team.name', null),
   }]
 
-  const accountManager = get(investmentData, 'investor_company.accountManager.id', null)
+  const accountManager = get(investmentData, 'investor_company.account_manager.id', null)
   if (accountManager) {
     result.push({
-      advisor: get(investmentData, 'investor_company.accountManager.name', null),
+      adviser: get(investmentData, 'investor_company.account_manager.name', null),
       role: 'Account manager',
-      team: get(investmentData, 'investor_company.accountManager.dit_team.name', null),
+      team: get(investmentData, 'investor_company.account_manager.dit_team.name', null),
     })
   }
 

--- a/src/apps/investment-projects/views/_details-form.njk
+++ b/src/apps/investment-projects/views/_details-form.njk
@@ -8,27 +8,29 @@
     options=form.options.contacts)
   }}
 
-  {% component 'form-multiple-choice', {
-    variant: 'radio',
-    label: 'Are you the client relationship manager for this project?',
-    name: 'is-relationship-manager',
-    inline: true,
-    value: form.state['is-relationship-manager'],
-    children: [{
-      label: 'Yes',
-      value: user.id
-    }, {
-      label: 'No'
-    }]
-  } %}
+  {% if not investmentData.id %}
+    {% component 'form-multiple-choice', {
+      variant: 'radio',
+      label: 'Are you the client relationship manager for this project?',
+      name: 'is-relationship-manager',
+      inline: true,
+      value: form.state['is-relationship-manager'],
+      children: [{
+        label: 'Yes',
+        value: user.id
+      }, {
+        label: 'No'
+      }]
+    } %}
 
-  <div class="panel panel-border-narrow js-ConditionalSubfield" data-controlled-by="is-relationship-manager" data-control-value="No">
-    {{ autocomplete('client_relationship_manager',
-      label="Client relationship manager",
-      value=form.state['client_relationship_manager'],
-      options=form.options.advisers)
-    }}
-  </div>
+    <div class="panel panel-border-narrow js-ConditionalSubfield" data-controlled-by="is-relationship-manager" data-control-value="No">
+      {{ autocomplete('client_relationship_manager',
+        label="Client relationship manager",
+        value=form.state['client_relationship_manager'],
+        options=form.options.advisers)
+      }}
+    </div>
+  {% endif %}
 
   {% component 'form-multiple-choice', {
     variant: 'radio',

--- a/src/apps/investment-projects/views/team/details.njk
+++ b/src/apps/investment-projects/views/team/details.njk
@@ -20,7 +20,7 @@
     }]
   } %}
 
-  <a href="edit-details" class="button button-secondary">Change</a>
+  <a href="edit-client-relationship-management" class="button button-secondary">Change</a>
 
   <h2 class="heading-medium">Project management</h2>
 

--- a/src/apps/investment-projects/views/team/details.njk
+++ b/src/apps/investment-projects/views/team/details.njk
@@ -8,16 +8,8 @@
   <h2 class="heading-medium">Client relationship management</h2>
 
   {% component 'data-table', {
-    columns: {
-      adviser: 'Adviser',
-      role: 'Role',
-      team: 'Team'
-    },
-    data: [{
-      adviser: crm.first_name + ' ' + crm.last_name,
-      role: 'Client relationship manager',
-      team: crm.dit_team.name
-    }]
+    columns: clientRelationshipManagementLabels.view,
+    data: clientRelationshipManagementData
   } %}
 
   <a href="edit-client-relationship-management" class="button button-secondary">Change</a>

--- a/src/apps/investment-projects/views/team/edit-client-relationship-management.njk
+++ b/src/apps/investment-projects/views/team/edit-client-relationship-management.njk
@@ -1,0 +1,30 @@
+{% extends "../_layout.njk" %}
+
+{% set phase = investmentData.stage.name %}
+{% set crm = investmentData.client_relationship_manager %}
+{% set rsa = investmentData.referral_source_adviser %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Edit client relationship management</h2>
+
+  {% call Form(form) %}
+    {{ MultipleChoiceField({
+      name: 'client_relationship_manager',
+      label: form.labels.client_relationship_manager,
+      error: form.errors.client_relationship_manager,
+      options: form.options.advisers,
+      value: form.state.client_relationship_manager,
+      initialOption: '-- Select an adviser --'
+    }) }}
+
+    {{ MultipleChoiceField({
+      name: 'account_manager',
+      label: form.labels.account_manager,
+      error: form.errors.account_manager,
+      options: form.options.advisers,
+      value: form.state.account_manager,
+      initialOption: '-- Select an adviser --'
+    }) }}
+
+  {% endcall %}
+{% endblock %}

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -1,4 +1,5 @@
 /* eslint prefer-promise-reject-errors: 0 */
+const companyData = require('~/test/unit/data/company.json')
 
 describe('Company repository', () => {
   describe('Save company', () => {
@@ -235,6 +236,36 @@ describe('Company repository', () => {
             throw Error(error)
           })
       })
+    })
+  })
+
+  describe('Update company', () => {
+    beforeEach(() => {
+      this.sandbox = sinon.sandbox.create()
+      this.authorisedRequestStub = this.sandbox.stub().resolves(companyData)
+      this.repo = proxyquire('~/src/apps/companies/repos', {
+        '../../lib/authorised-request': this.authorisedRequestStub,
+        '../../../config': {
+          apiRoot: 'http://test.com',
+        },
+      })
+    })
+
+    afterEach(() => {
+      this.sandbox.restore()
+    })
+
+    it('should make the correct call to the API', () => {
+      return this.repo.updateCompany('1234', '999', { account_manager: '8888' })
+        .then(() => {
+          expect(this.authorisedRequestStub).to.be.calledWith('1234', {
+            url: 'http://test.com/v3/company/999',
+            method: 'PATCH',
+            body: {
+              account_manager: '8888',
+            },
+          })
+        })
     })
   })
 

--- a/test/unit/apps/investment-projects/controllers/team/edit-client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-client-relationship-management.test.js
@@ -1,0 +1,95 @@
+const investmentData = require('~/test/unit/data/investment/investment-data.json')
+
+describe('Investment project, client relationship management, edit controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextStub = this.sandbox.stub()
+    this.flashStub = this.sandbox.stub()
+    this.getDataLabelsStub = this.sandbox.stub()
+    this.breadcrumbStub = function () { return this }
+
+    this.controller = proxyquire('~/src/apps/investment-projects/controllers/team/edit-client-relationship-management', {
+      '../../../../lib/controller-utils': {
+        getDataLabels: this.getDataLabelsStub,
+      },
+    })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#getHandler', () => {
+    it('should render edit client relationship management view', (done) => {
+      this.controller.getHandler({
+        session: {
+          token: 'abcd',
+        },
+      }, {
+        locals: {
+          investmentData,
+        },
+        breadcrumb: this.breadcrumbStub,
+        render: (template) => {
+          try {
+            expect(template).to.equal('investment-projects/views/team/edit-client-relationship-management')
+            done()
+          } catch (e) {
+            done(e)
+          }
+        },
+      }, this.nextStub)
+    })
+  })
+
+  describe('#postHandler', () => {
+    describe('without errors', () => {
+      it('should redirect to the product team details page', (done) => {
+        this.controller.postHandler({
+          session: {
+            token: 'abcd',
+          },
+          flash: this.flashStub,
+        }, {
+          locals: {
+            form: {
+              errors: {},
+            },
+            investmentData,
+          },
+          breadcrumb: this.breadcrumbStub,
+          redirect: (url) => {
+            try {
+              expect(url).to.equal(`/investment-projects/${investmentData.id}/team`)
+              expect(this.flashStub).to.calledWith('success', 'Updated investment details')
+              done()
+            } catch (e) {
+              done(e)
+            }
+          },
+        }, this.nextStub)
+      })
+    })
+
+    describe('when form errors exist', () => {
+      it('should pass the error onto the edit form', () => {
+        this.controller.postHandler({
+          session: {
+            token: 'abcd',
+          },
+        }, {
+          locals: {
+            form: {
+              errors: {
+                subject: 'example error',
+              },
+            },
+          },
+          breadcrumb: this.breadcrumbStub,
+        }, this.nextStub)
+
+        expect(this.nextStub).to.be.calledOnce
+      })
+    })
+  })
+})

--- a/test/unit/apps/investment-projects/formatting.test.js
+++ b/test/unit/apps/investment-projects/formatting.test.js
@@ -1,0 +1,133 @@
+const investmentData = require('~/test/unit/data/investment/investment-data.json')
+const formattingService = require('~/src/apps/investment-projects/services/formatting')
+
+describe('Investment project formatting service', () => {
+  describe('#transformProjectManagementForView', () => {
+    it('should return null if there is no project manager or assurance adviser', () => {
+      const data = Object.assign({}, investmentData)
+      data.project_manager = null
+      data.project_assurance_adviser = null
+
+      const projectManagementData = formattingService.transformProjectManagementForView(data)
+      expect(projectManagementData).to.deep.equal(null)
+    })
+
+    it('should return formatted data for the project manager and assurance adviser if there are both', () => {
+      const data = Object.assign({}, investmentData)
+      const expectedProjectManagementData = [{
+        role: 'Project assurance adviser',
+        adviser: 'John Brown',
+        team: 'Team B',
+      }, {
+        role: 'Project manager',
+        adviser: 'Fred Smith',
+        team: 'Team A',
+      }]
+
+      const projectManagementData = formattingService.transformProjectManagementForView(data)
+      expect(projectManagementData).to.deep.equal(expectedProjectManagementData)
+    })
+
+    it('should return formatted data for project manager, and todo for assurance officer if no assurance officer', () => {
+      const data = Object.assign({}, investmentData)
+      data.project_assurance_adviser = null
+      data.project_assurance_team = null
+
+      const expectedProjectManagementData = [{
+        role: 'Project assurance adviser',
+        adviser: 'To do',
+        team: null,
+      }, {
+        role: 'Project manager',
+        adviser: 'Fred Smith',
+        team: 'Team A',
+      }]
+
+      const projectManagementData = formattingService.transformProjectManagementForView(data)
+      expect(projectManagementData).to.deep.equal(expectedProjectManagementData)
+    })
+
+    it('should return formatted data for assurance adviser and todo for project manager is there is no project manager', () => {
+      const data = Object.assign({}, investmentData)
+      data.project_manager = null
+      data.project_manager_team = null
+
+      const expectedProjectManagementData = [{
+        role: 'Project assurance adviser',
+        adviser: 'John Brown',
+        team: 'Team B',
+      }, {
+        role: 'Project manager',
+        adviser: 'To do',
+        team: null,
+      }]
+
+      const projectManagementData = formattingService.transformProjectManagementForView(data)
+      expect(projectManagementData).to.deep.equal(expectedProjectManagementData)
+    })
+  })
+
+  describe('#transformClientRelationshipManagementForView', () => {
+    it('should return just the client relationship manager details if there is no account manager', () => {
+      const data = {
+        client_relationship_manager: {
+          id: '123',
+          first_name: 'Fred',
+          last_name: 'Smith',
+          dit_team: {
+            id: '3321',
+            name: 'Team Fred',
+          },
+        },
+        investor_company: {
+          account_manager: null,
+        },
+      }
+
+      const expectedResult = [{
+        adviser: 'Fred Smith',
+        role: 'Client relationship manager',
+        team: 'Team Fred',
+      }]
+
+      const actualResult = formattingService.transformClientRelationshipManagementForView(data)
+      expect(actualResult).to.deep.equal(expectedResult)
+    })
+
+    it('should return account manager details if there is an account manager also', () => {
+      const data = {
+        client_relationship_manager: {
+          id: '123',
+          first_name: 'Fred',
+          last_name: 'Smith',
+          dit_team: {
+            id: '3321',
+            name: 'Team Fred',
+          },
+        },
+        investor_company: {
+          account_manager: {
+            id: '321',
+            name: 'John Brown',
+            dit_team: {
+              name: 'Johns Team',
+            },
+          },
+        },
+      }
+
+      const expectedResult = [{
+        adviser: 'Fred Smith',
+        role: 'Client relationship manager',
+        team: 'Team Fred',
+      }, {
+        adviser: 'John Brown',
+        role: 'Account manager',
+        team: 'Johns Team',
+      }]
+
+      const actualResult = formattingService.transformClientRelationshipManagementForView(data)
+      expect(actualResult).to.deep.equal(expectedResult)
+    })
+  })
+})

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -1,0 +1,275 @@
+const investmentData = require('~/test/unit/data/investment/investment-data-account-manager.json')
+const companyData = require('~/test/unit/data/company.json')
+const advisorData = require('~/test/unit/data/investment/interaction/advisers')
+const { clientRelationshipManagementLabels } = require('~/src/apps/investment-projects/labels')
+
+describe('Investment form middleware - client relationship management', () => {
+  describe('#populateForm', () => {
+    beforeEach(() => {
+      this.sandbox = sinon.sandbox.create()
+      this.getAdvisersStub = this.sandbox.stub().resolves(advisorData)
+      this.updateCompanyStub = this.sandbox.stub().resolves(companyData)
+      this.nextSpy = this.sandbox.spy()
+      this.resMock = {
+        locals: {
+          form: {},
+          investmentData,
+        },
+      }
+
+      this.controller = proxyquire('~/src/apps/investment-projects/middleware/forms/client-relationship-management', {
+        '../../../adviser/repos': {
+          getAdvisers: this.getAdvisersStub,
+        },
+        '../../../companies/repos': {
+          updateCompany: this.updateCompanyStub,
+        },
+      })
+    })
+
+    afterEach(() => {
+      this.sandbox.restore()
+    })
+
+    it('should generate a list of advisers to use for adviser dropdowns', (done) => {
+      const mockAdviser = advisorData.results[0]
+      const expectedAdvisors = [{
+        value: mockAdviser.id,
+        label: mockAdviser.name,
+      }]
+
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.options.advisers).to.deep.equal(expectedAdvisors)
+        done()
+      })
+    })
+
+    it('should populate the form state with the existing client relationship management if there is data', (done) => {
+      const expectedFormState = {
+        client_relationship_manager: investmentData.client_relationship_manager.id,
+        account_manager: investmentData.investor_company.account_manager.id,
+      }
+
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
+        done()
+      })
+    })
+
+    it('should include the investor company as a hidden field', (done) => {
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.hiddenFields).to.deep.equal({ investor_company: investmentData.investor_company.id })
+        done()
+      })
+    })
+
+    it('should not throw an error if you render a form for a company with no account manager', (done) => {
+      this.resMock.locals.investmentData.investor_company.account_manager = null
+
+      const expectedFormState = {
+        client_relationship_manager: investmentData.client_relationship_manager.id,
+        account_manager: null,
+      }
+
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
+        done()
+      })
+    })
+
+    it('should include labels for the form', (done) => {
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.labels).to.deep.equal(clientRelationshipManagementLabels.edit)
+        done()
+      })
+    })
+
+    it('should include button text and a return link', (done) => {
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.buttonText).to.equal('Save')
+        expect(this.resMock.locals.form.returnLink).to.equal(`/investment-projects/${investmentData.id}/team`)
+        done()
+      })
+    })
+  })
+
+  describe('#handleFormpost', () => {
+    beforeEach(() => {
+      this.body = {
+        client_relationship_manager: '1234',
+        account_manager: '4321',
+        investor_company: '0909',
+      }
+    })
+
+    describe('post with no errors', () => {
+      beforeEach(() => {
+        this.sandbox = sinon.sandbox.create()
+        this.updateInvestmentStub = this.sandbox.stub().resolves(advisorData)
+        this.updateCompanyStub = this.sandbox.stub().resolves(companyData)
+        this.nextSpy = this.sandbox.spy()
+        this.resMock = {
+          locals: {},
+        }
+
+        this.controller = proxyquire('~/src/apps/investment-projects/middleware/forms/client-relationship-management', {
+          '../../repos': {
+            updateInvestment: this.updateInvestmentStub,
+          },
+          '../../../companies/repos': {
+            updateCompany: this.updateCompanyStub,
+          },
+        })
+      })
+
+      afterEach(() => {
+        this.sandbox.restore()
+      })
+
+      it('updates the investment data', (done) => {
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, () => {
+          expect(this.updateInvestmentStub).to.be.calledWith('mock-token', investmentData.id, { client_relationship_manager: this.body.client_relationship_manager })
+          done()
+        })
+      })
+
+      it('updates the company data', (done) => {
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, () => {
+          expect(this.updateCompanyStub).to.be.calledWith('mock-token', this.body.investor_company, { account_manager: this.body.account_manager })
+          done()
+        })
+      })
+
+      it('continues onto the next middleware with no errors', (done) => {
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, (error) => {
+          expect(error).to.equal(undefined)
+          done()
+        })
+      })
+    })
+
+    describe('When a form is posted with errors', () => {
+      beforeEach(() => {
+        this.sandbox = sinon.sandbox.create()
+
+        this.updateInvestmentStub = this.sandbox.stub()
+        this.updateCompanyStub = this.sandbox.stub().resolves(companyData)
+        this.nextSpy = this.sandbox.spy()
+        this.resMock = {
+          locals: {},
+        }
+
+        this.controller = proxyquire('~/src/apps/investment-projects/middleware/forms/client-relationship-management', {
+          '../../../adviser/repos': {
+            getAdvisers: this.getAdvisersStub,
+          },
+          '../../repos': {
+            updateInvestment: this.updateInvestmentStub,
+          },
+          '../../../companies/repos': {
+            updateCompany: this.updateCompanyStub,
+          },
+        })
+      })
+
+      afterEach(() => {
+        this.sandbox.restore()
+      })
+
+      it('should set form error data for the following controllers if form error', (done) => {
+        this.error = {
+          statusCode: 400,
+          error: {
+            project_assurance_adviser: 'Cannot be null',
+          },
+        }
+
+        this.updateInvestmentStub.rejects(this.error)
+
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, (error) => {
+          expect(error).to.equal(undefined)
+          expect(this.resMock.locals.form.state).to.deep.equal(this.body)
+          expect(this.resMock.locals.form.errors).to.deep.equal(this.error.error)
+          done()
+        })
+      })
+
+      it('should pass a none form error to next middleware', (done) => {
+        this.error = {
+          statusCode: 500,
+        }
+
+        this.updateInvestmentStub.rejects(this.error)
+
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, (error) => {
+          expect(error).to.deep.equal(this.error)
+          done()
+        })
+      })
+    })
+  })
+})

--- a/test/unit/data/investment/investment-data-account-manager.json
+++ b/test/unit/data/investment/investment-data-account-manager.json
@@ -1,0 +1,196 @@
+{
+  "id": "f22ae6ac-b269-4fe5-aeba-d6a605b9a7a7",
+  "name": "ACHME Hotels - New hotel in Manchester 1",
+  "project_code": "DHP-00000003",
+  "description": "ACHME hotels wishes to open in a new part of Manchester under-served by its existing hotels",
+  "nda_signed": true,
+  "estimated_land_date": "2018-05-01",
+  "actual_land_date": null,
+  "project_shareable": false,
+  "not_shareable_reason": null,
+  "likelihood_of_landing": null,
+  "priority": null,
+  "approved_commitment_to_invest": null,
+  "approved_fdi": null,
+  "approved_good_value": null,
+  "approved_high_value": null,
+  "approved_landed": null,
+  "approved_non_fdi": null,
+  "investment_type": {
+    "name": "FDI",
+    "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+  },
+  "stage": {
+    "name": "Prospect",
+    "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced"
+  },
+  "phase": {
+    "name": "Prospect",
+    "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced"
+  },
+  "investor_company": {
+    "name": "Omnicorp SDS",
+    "id": "6c388e5b-a098-e211-a939-e4115bead28a",
+    "trading_name": "",
+    "companies_house_data": null,
+    "interactions": [],
+    "contacts": [],
+    "export_to_countries": [],
+    "future_interest_countries": [],
+    "uk_based": false,
+    "account_manager": {
+      "id": "0563a10b-0e34-e411-985c-e4115bead28a",
+      "name": "Yang Xiao",
+      "last_login": null,
+      "first_name": "Yang",
+      "last_name": "Xiao",
+      "email": "yang.xiao@mobile.ukti.gov.uk",
+      "dit_team": {
+        "id": "a84d24c2-9698-e211-a939-e4115bead28a",
+        "name": "British Embassy Beijing China"
+      }
+    },
+    "registered_address_1": "707-19 Yoksam2 dong",
+    "registered_address_2": "Gangnam-gu",
+    "registered_address_town": "Seoul",
+    "registered_address_country": {
+      "id": "7c6a9ab2-5d95-e211-a939-e4115bead28a",
+      "name": "Korea (South)"
+    },
+    "registered_address_county": "",
+    "registered_address_postcode": "135-918",
+    "created_on": "2008-04-02T06:00:34",
+    "modified_on": "2015-11-12T15:50:58",
+    "archived": false,
+    "archived_on": null,
+    "archived_reason": "",
+    "company_number": null,
+    "alias": "",
+    "description": "IT",
+    "website": null,
+    "trading_address_1": "",
+    "trading_address_2": "",
+    "trading_address_town": "",
+    "trading_address_county": "",
+    "trading_address_postcode": "",
+    "archived_by": null,
+    "business_type": {
+      "id": "98d14e94-5d95-e211-a939-e4115bead28a",
+      "name": "Company"
+    },
+    "sector": {
+      "id": "b3959812-6095-e211-a939-e4115bead28a",
+      "name": "ICT"
+    },
+    "employee_range": null,
+    "turnover_range": null,
+    "uk_region": {
+      "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",
+      "name": "Undefined"
+    },
+    "trading_address_country": null,
+    "headquarter_type": null,
+    "classification": null,
+    "parent": null,
+    "one_list_account_owner": null
+  },
+  "intermediate_company": null,
+  "client_contacts": [],
+  "client_relationship_manager": {
+    "first_name": "Jeff",
+    "last_name": "Moorthy",
+    "id": "05346184-9b98-e211-a939-e4115bead28a"
+  },
+  "referral_source_adviser": {
+    "first_name": "Rambo",
+    "last_name": "McCamley",
+    "id": "08536d0b-d000-e311-a78e-e4115bead28a"
+  },
+  "referral_source_activity": null,
+  "referral_source_activity_website": null,
+  "referral_source_activity_marketing": null,
+  "referral_source_activity_event": "",
+  "fdi_type": {
+    "name": "Capital only",
+    "id": "840f62c1-bbcb-44e4-b6d4-a258d2ffa07d"
+  },
+  "non_fdi_type": null,
+  "sector": {
+    "name": "Aerospace : Manufacturing and Assembly : Space Technology",
+    "id": "b622c9d2-5f95-e211-a939-e4115bead28a"
+  },
+  "business_activities": [
+    {
+      "name": "Call centre",
+      "id": "410da69e-0247-48cf-9f72-fbc10ed7a4fc"
+    }
+  ],
+  "archived": false,
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "created_on": null,
+  "modified_on": "2017-06-14T14:52:46.618779",
+  "total_investment": "100000",
+  "foreign_equity_investment": "50000",
+  "government_assistance": true,
+  "number_new_jobs": 10,
+  "average_salary": null,
+  "number_safeguarded_jobs": 5,
+  "r_and_d_budget": true,
+  "non_fdi_r_and_d_budget": false,
+  "new_tech_to_uk": true,
+  "export_revenue": false,
+  "value_complete": false,
+  "client_cannot_provide_total_investment": null,
+  "client_cannot_provide_foreign_investment": null,
+  "client_requirements": "Some interesting requirements here",
+  "site_decided": false,
+  "address_line_1": null,
+  "address_line_2": null,
+  "address_line_3": null,
+  "address_line_postcode": null,
+  "competitor_countries": [
+    {
+      "name": "Albania",
+      "id": "945f66a0-5d95-e211-a939-e4115bead28a"
+    },
+    {
+      "name": "Algeria",
+      "id": "955f66a0-5d95-e211-a939-e4115bead28a"
+    }
+  ],
+  "uk_region_locations": [
+    {
+      "name": "Alderney",
+      "id": "934cd12a-6095-e211-a939-e4115bead28a"
+    },
+    {
+      "name": "Channel Islands",
+      "id": "8b4cd12a-6095-e211-a939-e4115bead28a"
+    }
+  ],
+  "strategic_drivers": [],
+  "client_considering_other_countries": true,
+  "uk_company": null,
+  "requirements_complete": false,
+  "project_manager": {
+    "id": "1234",
+    "first_name": "Fred",
+    "last_name": "Smith"
+  },
+  "project_assurance_adviser": {
+    "id": "2234",
+    "first_name": "John",
+    "last_name": "Brown"
+  },
+  "project_manager_team": {
+    "id": "1111",
+    "name": "Team A"
+  },
+  "project_assurance_team":  {
+    "id": "1111",
+    "name": "Team B"
+  },
+  "team_complete": true
+}


### PR DESCRIPTION
Added the client relationship management editing screens.

Made an assumption that editing the account manager for the project updates the investor company account manager.

Refactored the tests a little as some changes to project management code structure didn't get moved in the tests, so had to refactor controller tests into formatter tests.

Formatter is getting big, needs a separate PR now to break ti up.

Will do screen grabs in the morning once some assumptions have been confirmed, plus doesn't work right now due to an error in the updated adviser api calls.

We also need to go back and add tests for the shared middleware as Bens changes don't have test coverage there and I need to add some too.