### PR TITLE
Remove duplicated options transforms

### DIFF
--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -1,18 +1,15 @@
 const metadata = require('../../lib/metadata')
 const authorisedRequest = require('../../lib/authorised-request')
 const config = require('../../../config')
+const {
+  transformObjectToOption,
+  transformStringToOption,
+} = require('../transformers')
 
 function renderIndex (req, res) {
   return res.render('components/views/index', {
     title: 'Data Hub Components',
   })
-}
-
-function transformOption (option) {
-  return {
-    value: option.id,
-    label: option.name,
-  }
 }
 
 const foreignOtherCompanyOptions = [
@@ -34,11 +31,11 @@ function renderFormElements (req, res) {
       }),
       form: Object.assign({}, res.locals.form, {
         options: {
-          countries: metadata.countryOptions.map(transformOption),
-          averageSalaryRange: metadata.salaryRangeOptions.map(transformOption),
-          strategicDrivers: metadata.strategicDriverOptions.map(transformOption),
-          sectors: metadata.sectorOptions.map(transformOption),
-          foreignOtherCompany: foreignOtherCompanyOptions.map(i => ({ value: i, label: i })),
+          countries: metadata.countryOptions.map(transformObjectToOption),
+          averageSalaryRange: metadata.salaryRangeOptions.map(transformObjectToOption),
+          strategicDrivers: metadata.strategicDriverOptions.map(transformObjectToOption),
+          sectors: metadata.sectorOptions.map(transformObjectToOption),
+          foreignOtherCompany: foreignOtherCompanyOptions.map(transformStringToOption),
         },
       }),
     })

--- a/src/apps/contacts/controllers/edit.js
+++ b/src/apps/contacts/controllers/edit.js
@@ -4,6 +4,7 @@ const { contactLabels } = require('../labels')
 const metadataRepository = require('../../../lib/metadata')
 const companyRepository = require('../../companies/repos')
 const { buildCompanyUrl } = require('../../companies/services/data')
+const { transformObjectToOption } = require('../../transformers')
 
 /**
  * GET the edit detail screen, used for editing contacts.
@@ -49,12 +50,7 @@ async function editDetails (req, res, next) {
 
     // Labels and options needed for the form and error display
     res.locals.contactLabels = contactLabels
-    res.locals.countryOptions = metadataRepository.countryOptions.map(item => {
-      return {
-        value: item.id,
-        label: item.name,
-      }
-    })
+    res.locals.countryOptions = metadataRepository.countryOptions.map(transformObjectToOption)
     res.locals.companyUrl = buildCompanyUrl(res.locals.company)
 
     res.render('contacts/views/edit')

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -7,6 +7,7 @@ const adviserRepository = require('../../adviser/repos')
 const interactionDataService = require('../services/data')
 const interactionFormService = require('../services/form')
 const { containsFormData } = require('../../../lib/controller-utils')
+const { transformContactToOption } = require('../../transformers')
 
 async function editDetails (req, res, next) {
   try {
@@ -48,12 +49,7 @@ async function editDetails (req, res, next) {
     }
 
     const companyContacts = await contactsRepository.getContactsForCompany(req.session.token, res.locals.formData.company)
-    res.locals.contacts = companyContacts.map((contact) => {
-      return {
-        id: contact.id,
-        name: `${contact.first_name} ${contact.last_name}`,
-      }
-    })
+    res.locals.contacts = companyContacts.map(transformContactToOption)
 
     if (res.locals.formData.dit_adviser) {
       res.locals.dit_adviser = await adviserRepository.getAdviser(req.session.token, res.locals.formData.dit_adviser)

--- a/src/apps/investment-projects/middleware/collection.js
+++ b/src/apps/investment-projects/middleware/collection.js
@@ -4,15 +4,8 @@ const { buildPagination } = require('../../../lib/pagination')
 const { buildQueryString } = require('../../../lib/url-helpers')
 const metadataRepo = require('../../../lib/metadata')
 const { collectionFilterLabels } = require('../labels')
-
 const { searchInvestmentProjects } = require('../../search/services')
-
-function transformMetadataToOption (item) {
-  return {
-    value: item.id,
-    label: item.name,
-  }
-}
+const { transformObjectToOption } = require('../../transformers')
 
 const currentYear = (new Date()).getFullYear()
 const RANGE_FROM_DATE = `${currentYear}-04-05`
@@ -43,9 +36,9 @@ function setDefaults (req, res, next) {
 
 async function getInvestmentProjectsCollection (req, res, next) {
   const formOptions = {
-    stage: metadataRepo.investmentStageOptions.map(transformMetadataToOption),
-    investment_type: metadataRepo.investmentTypeOptions.map(transformMetadataToOption),
-    sector: metadataRepo.sectorOptions.map(transformMetadataToOption),
+    stage: metadataRepo.investmentStageOptions.map(transformObjectToOption),
+    investment_type: metadataRepo.investmentTypeOptions.map(transformObjectToOption),
+    sector: metadataRepo.sectorOptions.map(transformObjectToOption),
     sortby: SORTBY_OPTIONS,
   }
 

--- a/src/apps/investment-projects/middleware/forms/client-relationship-management.js
+++ b/src/apps/investment-projects/middleware/forms/client-relationship-management.js
@@ -3,18 +3,14 @@ const { getAdvisers } = require('../../../adviser/repos')
 const { updateCompany } = require('../../../companies/repos')
 const { updateInvestment } = require('../../repos')
 const { clientRelationshipManagementLabels } = require('../../labels')
+const { transformObjectToOption } = require('../../../transformers')
 
 async function populateForm (req, res, next) {
   try {
     const investmentData = res.locals.investmentData
 
     const advisersResponse = await getAdvisers(req.session.token)
-    const advisers = advisersResponse.results.map((adviser) => {
-      return {
-        value: adviser.id,
-        label: `${adviser.first_name} ${adviser.last_name}`,
-      }
-    })
+    const advisers = advisersResponse.results.map(transformObjectToOption)
 
     res.locals.form = Object.assign({}, res.locals.form, {
       labels: clientRelationshipManagementLabels.edit,

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -5,6 +5,10 @@ const { isValidGuid } = require('../../../../lib/controller-utils')
 const metadataRepo = require('../../../../lib/metadata')
 const { getAdvisers } = require('../../../adviser/repos')
 const {
+  transformObjectToOption,
+  transformContactToOption,
+} = require('../../../transformers')
+const {
   createInvestmentProject,
   getEquityCompanyDetails,
   updateInvestment,
@@ -24,27 +28,9 @@ async function populateForm (req, res, next) {
       equityCompanyInvestment,
     } = await getEquityCompanyDetails(req.session.token, equityCompanyId)
 
-    const contacts = equityCompany.contacts.map((contact) => {
-      return {
-        id: contact.id,
-        name: `${contact.first_name} ${contact.last_name}`,
-      }
-    })
-
-    const advisers = advisersResponse.results.map((adviser) => {
-      return {
-        id: adviser.id,
-        name: `${adviser.first_name} ${adviser.last_name}`,
-      }
-    })
-
-    const investmentTypes = metadataRepo.investmentTypeOptions.map((type) => {
-      return {
-        value: type.id,
-        label: type.name,
-      }
-    })
-
+    const contacts = equityCompany.contacts.map(transformContactToOption)
+    const advisers = advisersResponse.results.map(transformObjectToOption)
+    const investmentTypes = metadataRepo.investmentTypeOptions.map(transformObjectToOption)
     const investmentData = transformFromApi(res.locals.investmentData)
 
     res.locals.equityCompany = equityCompany

--- a/src/apps/investment-projects/middleware/forms/interactions.js
+++ b/src/apps/investment-projects/middleware/forms/interactions.js
@@ -4,6 +4,7 @@ const metadataRepo = require('../../../../lib/metadata')
 const { getAdvisers } = require('../../../adviser/repos')
 const interactionFormattingService = require('../../../interactions/services/formatting')
 const { interactionsLabels } = require('../../labels')
+const { transformObjectToOption } = require('../../../transformers')
 const {
   createInvestmentInteraction,
   updateInvestmentInteraction,
@@ -14,13 +15,7 @@ async function populateForm (req, res, next) {
     const interactionTypes = metadataRepo.interactionTypeOptions
     const advisersResponse = await getAdvisers(req.session.token)
     const contacts = res.locals.investmentData.client_contacts
-
-    const advisers = advisersResponse.results.map((adviser) => {
-      return {
-        id: adviser.id,
-        name: `${adviser.first_name} ${adviser.last_name}`,
-      }
-    })
+    const advisers = advisersResponse.results.map(transformObjectToOption)
 
     res.locals.form = get(res, 'locals.form', {})
     res.locals.form.labels = interactionsLabels.edit

--- a/src/apps/investment-projects/middleware/forms/project-management.js
+++ b/src/apps/investment-projects/middleware/forms/project-management.js
@@ -2,19 +2,14 @@ const { get } = require('lodash')
 const { getAdvisers } = require('../../../adviser/repos')
 const { updateInvestment } = require('../../repos')
 const { projectManagementLabels } = require('../../labels')
+const { transformObjectToOption } = require('../../../transformers')
 
 async function populateForm (req, res, next) {
   try {
     const investmentData = res.locals.investmentData
 
     const advisersResponse = await getAdvisers(req.session.token)
-    const advisers = advisersResponse.results.map((adviser) => {
-      return {
-        value: adviser.id,
-        label: `${adviser.first_name} ${adviser.last_name}`,
-      }
-    })
-    .filter(adviser => adviser.label.trim().length > 0)
+    const advisers = advisersResponse.results.map(transformObjectToOption)
 
     res.locals.form = Object.assign({}, res.locals.form, {
       labels: projectManagementLabels.edit,

--- a/src/apps/omis/apps/create/controllers/assign-ita.js
+++ b/src/apps/omis/apps/create/controllers/assign-ita.js
@@ -2,12 +2,12 @@ const { sortBy } = require('lodash')
 
 const Controller = require('./base')
 const { getAdvisers } = require('../../../../adviser/repos')
-const { transformToOptions } = require('../../../../transformers')
+const { transformObjectToOption } = require('../../../../transformers')
 
 class AssignItaController extends Controller {
   async configure (req, res, next) {
     const advisers = await getAdvisers(req.session.token)
-    const options = transformToOptions(advisers.results)
+    const options = advisers.results.map(transformObjectToOption)
 
     req.form.options.fields.ita.options = sortBy(options, 'label')
     super.configure(req, res, next)

--- a/src/apps/omis/apps/create/controllers/company-details.js
+++ b/src/apps/omis/apps/create/controllers/company-details.js
@@ -1,7 +1,7 @@
 const { sortBy } = require('lodash')
 
 const Controller = require('./base')
-const { transformContactsToOptions } = require('../../../../transformers')
+const { transformContactToOption } = require('../../../../transformers')
 
 class CompanyDetailsController extends Controller {
   configure (req, res, next) {
@@ -9,7 +9,7 @@ class CompanyDetailsController extends Controller {
     let contacts = []
 
     if (company) {
-      contacts = transformContactsToOptions(company.contacts)
+      contacts = company.contacts.map(transformContactToOption)
       contacts = sortBy(contacts, 'label')
     }
 

--- a/src/apps/omis/apps/create/controllers/market.js
+++ b/src/apps/omis/apps/create/controllers/market.js
@@ -1,10 +1,10 @@
 const Controller = require('./base')
 const metadataRepo = require('../../../../../lib/metadata')
-const { transformToOptions } = require('../../../../transformers')
+const { transformObjectToOption } = require('../../../../transformers')
 
 class MarketController extends Controller {
   configure (req, res, next) {
-    req.form.options.fields.primary_market.options = transformToOptions(metadataRepo.countryOptions)
+    req.form.options.fields.primary_market.options = metadataRepo.countryOptions.map(transformObjectToOption)
     super.configure(req, res, next)
   }
 }

--- a/src/apps/service-deliveries/controllers.js
+++ b/src/apps/service-deliveries/controllers.js
@@ -7,6 +7,7 @@ const serviceDeliveryRepository = require('./repos')
 const serviceDeliveryService = require('./services/data')
 const { getDisplayServiceDelivery } = require('./services/formatting')
 const { buildCompanyUrl } = require('../companies/services/data')
+const { transformContactToOption } = require('../transformers')
 
 const serviceDeliveryDisplayOrder = ['company', 'dit_team', 'service', 'status', 'subject', 'notes', 'date', 'dit_adviser', 'uk_region', 'sector', 'contact', 'country_of_interest']
 
@@ -33,13 +34,7 @@ async function getServiceDeliveryEdit (req, res, next) {
     } else {
       res.locals.backUrl = `/service-deliveries/${req.params.serviceDeliveryId}`
     }
-    res.locals.contacts = res.locals.serviceDelivery.company.contacts.map((contact) => {
-      return {
-        id: contact.id,
-        name: `${contact.first_name} ${contact.last_name}`,
-      }
-    })
-
+    res.locals.contacts = res.locals.serviceDelivery.company.contacts.map(transformContactToOption)
     res.locals.labels = serviceDeliverylabels
     res.locals.serviceProviderOptions = metadataRepository.teams
     res.locals.serviceOptions = metadataRepository.serviceDeliveryServiceOptions

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -1,19 +1,28 @@
-function transformToOptions (items, labelIteratee = (item) => item.name) {
-  return items.map((item) => {
-    return {
-      value: item.id,
-      label: labelIteratee(item),
-    }
-  })
+/* eslint-disable camelcase */
+
+function transformObjectToOption ({ id, name }) {
+  return {
+    value: id,
+    label: name,
+  }
 }
 
-function transformContactsToOptions (items) {
-  return transformToOptions(items, (item) => {
-    return `${item.first_name} ${item.last_name}`
-  })
+function transformStringToOption (string) {
+  return {
+    value: string,
+    label: string,
+  }
+}
+
+function transformContactToOption ({ id, first_name, last_name }) {
+  return {
+    value: id,
+    label: `${first_name} ${last_name}`,
+  }
 }
 
 module.exports = {
-  transformToOptions,
-  transformContactsToOptions,
+  transformObjectToOption,
+  transformStringToOption,
+  transformContactToOption,
 }

--- a/test/unit/apps/investment-projects/middleware/forms/interactions.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/interactions.test.js
@@ -39,7 +39,7 @@ describe('Investment form middleware - interactions', () => {
     it('should call next', (done) => {
       const mockAdviser = advisorData.results[0]
       const expectedAdvisors = [
-        { id: mockAdviser.id, name: mockAdviser.name },
+        { value: mockAdviser.id, label: mockAdviser.name },
       ]
 
       this.resMock.locals.investmentData = investmentData
@@ -50,28 +50,32 @@ describe('Investment form middleware - interactions', () => {
           token: 'mock-token',
         },
       }, this.resMock, () => {
-        expect(this.resMock.locals).to.deep.equal({
-          investmentData,
-          interaction: interactionTransformedFromApiData,
-          form: {
-            labels: interactionsLabels.edit,
-            state: interactionTransformedFromApiData,
-            options: {
-              advisers: expectedAdvisors,
-              contacts: investmentData.client_contacts,
-              interactionTypes: metadataRepositoryStub.interactionTypeOptions,
+        try {
+          expect(this.resMock.locals).to.deep.equal({
+            investmentData,
+            interaction: interactionTransformedFromApiData,
+            form: {
+              labels: interactionsLabels.edit,
+              state: interactionTransformedFromApiData,
+              options: {
+                advisers: expectedAdvisors,
+                contacts: investmentData.client_contacts,
+                interactionTypes: metadataRepositoryStub.interactionTypeOptions,
+              },
             },
-          },
-        })
+          })
 
-        done()
+          done()
+        } catch (error) {
+          done(error)
+        }
       })
     })
 
     it('should set correct form data', (done) => {
       const mockAdviser = advisorData.results[0]
       const expectedAdvisors = [
-        { id: mockAdviser.id, name: mockAdviser.name },
+        { value: mockAdviser.id, label: mockAdviser.name },
       ]
 
       this.resMock.locals.investmentData = investmentData
@@ -81,11 +85,15 @@ describe('Investment form middleware - interactions', () => {
           token: 'mock-token',
         },
       }, this.resMock, () => {
-        expect(this.resMock.locals.form.labels).to.eql(interactionsLabels.edit)
-        expect(this.resMock.locals.form.options.interactionTypes).to.deep.equal(metadataRepositoryStub.interactionTypeOptions)
-        expect(this.resMock.locals.form.options.advisers).to.deep.equal(expectedAdvisors)
-        expect(this.resMock.locals.form.options.contacts).to.deep.equal(investmentData.client_contacts)
-        done()
+        try {
+          expect(this.resMock.locals.form.labels).to.eql(interactionsLabels.edit)
+          expect(this.resMock.locals.form.options.interactionTypes).to.deep.equal(metadataRepositoryStub.interactionTypeOptions)
+          expect(this.resMock.locals.form.options.advisers).to.deep.equal(expectedAdvisors)
+          expect(this.resMock.locals.form.options.contacts).to.deep.equal(investmentData.client_contacts)
+          done()
+        } catch (error) {
+          done(error)
+        }
       })
     })
   })

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -1,71 +1,44 @@
 const transformers = require('~/src/apps/transformers')
 
 describe('Global transformers', () => {
-  describe('transformToOptions()', () => {
-    context('with default value iteratee', () => {
-      it('should map id and name to value and label', () => {
-        const options = transformers.transformToOptions([{
-          id: '1',
-          name: 'One',
-        }, {
-          id: '2',
-          name: 'Two',
-        }])
+  describe('transformObjectToOption()', () => {
+    it('should return value and label from id and name', () => {
+      const option = transformers.transformObjectToOption({
+        id: '1',
+        name: 'One',
+        foo: 'bar',
+      })
 
-        expect(options).to.deep.equal([{
-          value: '1',
-          label: 'One',
-        }, {
-          value: '2',
-          label: 'Two',
-        }])
+      expect(option).to.deep.equal({
+        value: '1',
+        label: 'One',
       })
     })
+  })
+  describe('transformStringToOption()', () => {
+    it('should return value and label from string', () => {
+      const option = transformers.transformStringToOption('One')
 
-    context('when custom value iteratee is supplied', () => {
-      it('should map those values to value and label', () => {
-        const items = [{
-          id: '1',
-          custom: 'Custom iteratee one',
-        }, {
-          id: '2',
-          custom: 'Custom iteratee two',
-        }]
-        const iteratee = (item) => {
-          return item.custom
-        }
-        const options = transformers.transformToOptions(items, iteratee)
-
-        expect(options).to.deep.equal([{
-          value: '1',
-          label: 'Custom iteratee one',
-        }, {
-          value: '2',
-          label: 'Custom iteratee two',
-        }])
+      expect(option).to.deep.equal({
+        value: 'One',
+        label: 'One',
       })
     })
   })
 
-  describe('transformContactsToOptions()', () => {
-    it('should map id and first_name/last_name to value and label', () => {
-      const options = transformers.transformContactsToOptions([{
+  describe('transformContactToOption()', () => {
+    it('should return value and label from id and first_name/last_name', () => {
+      const option = transformers.transformContactToOption({
         id: '1',
         first_name: 'Steve',
         last_name: 'George',
-      }, {
-        id: '2',
-        first_name: 'Graham',
-        last_name: 'Nice',
-      }])
+        foo: 'bar',
+      })
 
-      expect(options).to.deep.equal([{
+      expect(option).to.deep.equal({
         value: '1',
         label: 'Steve George',
-      }, {
-        value: '2',
-        label: 'Graham Nice',
-      }])
+      })
     })
   })
 })


### PR DESCRIPTION
This change replaces lots of duplicated maps that transform data into the expected format for multiple choice macros with the method from global transformers.