### PR TITLE
dh 420: adviser lookup fails in interactions

### DIFF
--- a/src/apps/api/controllers.js
+++ b/src/apps/api/controllers.js
@@ -1,11 +1,20 @@
 const { lookupAddress } = require('./services')
 const metadata = require('../../lib/metadata')
+const { adviserSearch } = require('../adviser/repos')
+
+async function adviserSearchHandler (req, res, next) {
+  try {
+    const advisers = await adviserSearch(req.session.token, req.params.term)
+    res.json(advisers)
+  } catch (error) {
+    next(error)
+  }
+}
 
 async function postcodeLookupHandler (req, res) {
   try {
     const postcode = req.params.postcode
     const addresses = await lookupAddress(postcode)
-
     const augmentedAddresses = addresses.map(address => {
       return Object.assign({}, address, {
         country: metadata.countryOptions.find(country => country.name.toLowerCase() === 'united kingdom').id,
@@ -19,5 +28,6 @@ async function postcodeLookupHandler (req, res) {
 }
 
 module.exports = {
+  adviserSearchHandler,
   postcodeLookupHandler,
 }

--- a/src/apps/api/index.js
+++ b/src/apps/api/index.js
@@ -1,7 +1,10 @@
 const router = require('express').Router()
-const { postcodeLookupHandler } = require('./controllers')
+const { adviserSearchHandler, postcodeLookupHandler } = require('./controllers')
+
+router.get('/adviserlookup/:term', adviserSearchHandler)
+router.get('/postcodelookup/:postcode', postcodeLookupHandler)
 
 module.exports = {
   mountpath: '/api',
-  router: router.get('/postcodelookup/:postcode', postcodeLookupHandler),
+  router,
 }

--- a/src/apps/interactions/views/edit.njk
+++ b/src/apps/interactions/views/edit.njk
@@ -50,7 +50,7 @@
       hint="Please start typing to search for an adviser",
       error=errors.dit_adviser,
       autofocus=false,
-      url='/api/accountmanagerlookup?term=')
+      url='/api/adviserlookup/')
     }}
 
     {{ autocomplete("service",


### PR DESCRIPTION
This recreates the Ajax-driven Adviser lookup used in Interactions. Possible need to change this to the pre-loaded list of advisers? Not sure I like that approach, but this has an obvious non-JS issue.

This is just a bugfix for something that is broken in production: maybe raise a ticket for more extensive changes?