### PR TITLE
Refactor local nav middleware to use req.baseUrl

### DIFF
--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -10,10 +10,6 @@ const reasonForArchiveOptions = [
   'Contact changed role/responsibility',
 ]
 
-function redirectToDetails (req, res) {
-  res.redirect(`${req.params.contactId}/details`)
-}
-
 async function getCommon (req, res, next) {
   try {
     const token = req.session.token
@@ -46,7 +42,6 @@ function getDetails (req, res, next) {
 }
 
 module.exports = {
-  redirectToDetails,
   getDetails,
   getCommon,
 }

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -1,24 +1,23 @@
 const router = require('express').Router()
 
-const { setLocalNav } = require('../middleware')
-const { getCommon, getDetails, redirectToDetails } = require('./controllers/details')
+const { setLocalNav, redirectToFirstNavItem } = require('../middleware')
+const { getCommon, getDetails } = require('./controllers/details')
 const { postDetails, editDetails } = require('./controllers/edit')
 const { archiveContact, unarchiveContact } = require('./controllers/archive')
 const { getInteractions } = require('./controllers/interactions')
 
 const LOCAL_NAV = [
-  { path: '../details', label: 'Details' },
-  { path: '../interactions', label: 'Interactions' },
+  { path: 'details', label: 'Details' },
+  { path: 'interactions', label: 'Interactions' },
 ]
-
-router.use(setLocalNav(LOCAL_NAV))
 
 router
   .route('/create')
   .get(editDetails)
   .post(postDetails)
 
-router.get('/:contactId', redirectToDetails)
+router.use('/:contactId', setLocalNav(LOCAL_NAV))
+router.get('/:contactId', redirectToFirstNavItem)
 router.get('/:contactId/details', getCommon, getDetails)
 
 router

--- a/src/apps/investment-projects/controllers/details.js
+++ b/src/apps/investment-projects/controllers/details.js
@@ -27,11 +27,6 @@ function detailsGetHandler (req, res, next) {
   return next()
 }
 
-function redirectToDetails (req, res) {
-  res.redirect(`${req.params.id}/details`)
-}
-
 module.exports = {
-  redirectToDetails,
   detailsGetHandler,
 }

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const { setLocalNav } = require('../middleware')
+const { setLocalNav, redirectToFirstNavItem } = require('../middleware')
 const { shared } = require('./middleware')
 const { getBriefInvestmentSummary } = require('./middleware/team')
 const {
@@ -25,14 +25,14 @@ const { renderInvestmentList } = require('./controllers/list')
 const { setDefaults, getInvestmentProjectsCollection } = require('./middleware/collection')
 
 const LOCAL_NAV = [
-  { path: '../details', label: 'Project details' },
-  { path: '../team', label: 'Project team' },
-  { path: '../interactions', label: 'Interactions' },
-  { path: '../evaluation', label: 'Evaluations' },
-  { path: '../audit', label: 'Audit history' },
+  { path: 'details', label: 'Project details' },
+  { path: 'team', label: 'Project team' },
+  { path: 'interactions', label: 'Interactions' },
+  { path: 'evaluation', label: 'Evaluations' },
+  { path: 'audit', label: 'Audit history' },
 ]
 
-router.use(setLocalNav(LOCAL_NAV))
+router.use('/:id/', setLocalNav(LOCAL_NAV))
 
 router.param('id', shared.getInvestmentDetails)
 router.param('interactionId', shared.getInteractionDetails)
@@ -56,7 +56,7 @@ router
   .get(detailsFormMiddleware.populateForm, createStep2.createGetHandler)
   .post(detailsFormMiddleware.populateForm, detailsFormMiddleware.handleFormPost, createStep2.createPostHandler)
 
-router.get('/:id', details.redirectToDetails)
+router.get('/:id', redirectToFirstNavItem)
 router.get('/:id/details', details.detailsGetHandler)
 
 router

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -15,7 +15,7 @@ function setHomeBreadcrumb (name) {
 function setLocalNav (items = []) {
   return function buildLocalNav (req, res, next) {
     res.locals.localNavItems = items.map(item => {
-      const url = path.resolve(res.locals.CURRENT_PATH, item.path)
+      const url = path.resolve(req.baseUrl, item.path)
       return Object.assign(item, {
         url,
         isActive: res.locals.CURRENT_PATH === url,
@@ -25,7 +25,12 @@ function setLocalNav (items = []) {
   }
 }
 
+function redirectToFirstNavItem (req, res) {
+  return res.redirect(res.locals.localNavItems[0].url)
+}
+
 module.exports = {
   setHomeBreadcrumb,
   setLocalNav,
+  redirectToFirstNavItem,
 }

--- a/test/unit/apps/investment-projects/controllers/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/details.test.js
@@ -33,22 +33,4 @@ describe('Investment details controller', () => {
       }, this.next)
     })
   })
-
-  describe('#redirectToDetails', () => {
-    it('should redirect to details when a valid investment project GUID is given', (done) => {
-      this.controller.redirectToDetails({
-        session: {
-          token: 'abcd',
-        },
-        params: {
-          id: '12345abc-1234-abcd-12ab-123456abcdef',
-        },
-      }, {
-        redirect: (url) => {
-          expect(url).to.equal('12345abc-1234-abcd-12ab-123456abcdef/details')
-          done()
-        },
-      }, this.next)
-    })
-  })
 })

--- a/test/unit/apps/middleware.test.js
+++ b/test/unit/apps/middleware.test.js
@@ -12,18 +12,21 @@ describe('Apps middleware', () => {
 
   describe('setLocalNav()', () => {
     const NAV_ITEMS = [
-      { path: '../first', label: 'First' },
-      { path: '../second', label: 'Second' },
+      { path: 'first', label: 'First' },
+      { path: 'second', label: 'Second' },
     ]
 
     it('should attach nav items props to locals', () => {
+      const reqMock = {
+        baseUrl: '/sub-app',
+      }
       const resMock = {
         locals: {
           CURRENT_PATH: '/sub-app/resource',
         },
       }
 
-      this.middleware.setLocalNav(NAV_ITEMS)({}, resMock, this.nextSpy)
+      this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
       expect(resMock.locals).to.haveOwnProperty('localNavItems')
       expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
@@ -32,17 +35,46 @@ describe('Apps middleware', () => {
     })
 
     it('should set new isActive to true for the current path', () => {
+      const reqMock = {
+        baseUrl: '/sub-app',
+      }
       const resMock = {
         locals: {
           CURRENT_PATH: '/sub-app/first',
         },
       }
-      this.middleware.setLocalNav(NAV_ITEMS)({}, resMock, this.nextSpy)
+      this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
       expect(resMock.locals).to.haveOwnProperty('localNavItems')
       expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
       expect(resMock.locals.localNavItems[0].isActive).to.be.true
       expect(this.nextSpy.calledOnce).to.be.true
+    })
+  })
+
+  describe('redirectToFirstNavItem()', () => {
+    const NAV_ITEMS = [{
+      path: 'first',
+      label: 'First',
+      url: '/base-url/first',
+    }, {
+      path: 'second',
+      label: 'Second',
+      url: '/base-url/second',
+    }]
+
+    it('should redirect to the first item', () => {
+      const redirectMock = this.sandbox.spy()
+      const resMock = this.reqMock = Object.assign({}, globalRes, {
+        redirect: redirectMock,
+        locals: {
+          localNavItems: NAV_ITEMS,
+        },
+      })
+
+      this.middleware.redirectToFirstNavItem({}, resMock)
+
+      expect(redirectMock).to.have.been.calledWith('/base-url/first')
     })
   })
 })


### PR DESCRIPTION
This changes the local nav middleware so that it uses the baseUrl
sent with the request to build the path rather than using the
current url and relative paths in the local nav definition object.

It also adds a shared redirect middleware that will redirect to the
first local nav item.