### PR TITLE
Change dismiss text on messages components

### DIFF
--- a/assets/javascripts/modules/messages.js
+++ b/assets/javascripts/modules/messages.js
@@ -26,7 +26,7 @@ const Messages = {
     if (element.className.indexOf('error') === -1) {
       let link = document.createElement('a')
 
-      link.innerHTML = 'Close'
+      link.innerHTML = 'Dismiss'
       link.className = 'c-messages__close'
       link.href = '#'
       link.onclick = (e) => {

--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -13,9 +13,13 @@
 .c-messages__item {
   @include bold-font(20);
   border: 5px solid;
-  padding: $default-spacing-unit 90px $default-spacing-unit $default-spacing-unit;
+  padding: $default-spacing-unit;
   position: relative;
   background-color: $white;
+
+  @include media(tablet) {
+    padding-right: 90px;
+  }
 
   + * {
     margin-top: $default-spacing-unit;
@@ -24,10 +28,16 @@
 
 .c-messages__close {
   @include bold-font(16);
-  position: absolute;
-  top: $default-spacing-unit;
-  right: $default-spacing-unit;
+  display: table;
+  line-height: 32px;
   text-decoration: none;
+
+  @include media(tablet) {
+    position: absolute;
+    line-height: 32px;
+    top: $default-spacing-unit;
+    right: $default-spacing-unit;
+  }
 
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
Noticed after seeing a notification on GitHub that the term _dismiss_ seems more appropriate than _close_.

## Before

![image](https://user-images.githubusercontent.com/3327997/28829702-90804802-76cc-11e7-808e-94311552354d.png)

## After

![image](https://user-images.githubusercontent.com/3327997/28829731-ae7adf48-76cc-11e7-8435-0eefa3e243f2.png)
