### PR TITLE
Feature/invest team members

### DIFF
--- a/src/apps/investment-projects/controllers/team/details.js
+++ b/src/apps/investment-projects/controllers/team/details.js
@@ -1,17 +1,22 @@
 const {
   projectManagementLabels,
   clientRelationshipManagementLabels,
+  teamMembersLabels,
 } = require('../../labels')
 
 const {
   transformProjectManagementForView,
   transformClientRelationshipManagementForView,
+  transformTeamMembersForView,
 } = require('../../services/formatting')
 
 function getDetailsHandler (req, res, next) {
   try {
-    const projectManagementData = transformProjectManagementForView(res.locals.investmentData)
-    const clientRelationshipManagementData = transformClientRelationshipManagementForView(res.locals.investmentData)
+    const investmentData = res.locals.investmentData
+
+    const projectManagementData = transformProjectManagementForView(investmentData)
+    const clientRelationshipManagementData = transformClientRelationshipManagementForView(investmentData)
+    const teamMembersData = investmentData.team_members.map(transformTeamMembersForView)
 
     res
       .breadcrumb('Project team')
@@ -20,6 +25,8 @@ function getDetailsHandler (req, res, next) {
         projectManagementLabels,
         clientRelationshipManagementData,
         clientRelationshipManagementLabels,
+        teamMembersData,
+        teamMembersLabels,
       })
   } catch (error) {
     next(error)

--- a/src/apps/investment-projects/controllers/team/edit-team-members.js
+++ b/src/apps/investment-projects/controllers/team/edit-team-members.js
@@ -1,0 +1,22 @@
+const { isEmpty } = require('lodash')
+
+function getHandler (req, res, next) {
+  res
+    .breadcrumb('Project team', 'team')
+    .breadcrumb('Team members')
+    .render('investment-projects/views/team/edit-team-members')
+}
+
+function postHandler (req, res, next) {
+  if (isEmpty(res.locals.form.errors)) {
+    req.flash('success', 'Updated investment details')
+    return res.redirect(`/investment-projects/${res.locals.investmentData.id}/team`)
+  }
+
+  return next()
+}
+
+module.exports = {
+  getHandler,
+  postHandler,
+}

--- a/src/apps/investment-projects/controllers/team/index.js
+++ b/src/apps/investment-projects/controllers/team/index.js
@@ -1,9 +1,11 @@
 const details = require('./details')
 const editClientRelationshipManagement = require('./edit-client-relationship-management')
 const editProjectManagement = require('./edit-project-management')
+const editTeamMembers = require('./edit-team-members')
 
 module.exports = {
   details,
   editClientRelationshipManagement,
   editProjectManagement,
+  editTeamMembers,
 }

--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -1,3 +1,9 @@
+const roleAdviserTeam = {
+  role: 'Role',
+  adviser: 'Adviser',
+  team: 'Team',
+}
+
 const labels = {
   detailsLabels: {
     view: {
@@ -99,11 +105,7 @@ const labels = {
       project_manager: 'Project manager',
       project_assurance_adviser: 'Project assurance adviser',
     },
-    view: {
-      role: 'Role',
-      adviser: 'Adviser',
-      team: 'Team',
-    },
+    view: roleAdviserTeam,
   },
   briefInvestmentSummaryLabels: {
     view: {
@@ -128,15 +130,15 @@ const labels = {
     },
   },
   clientRelationshipManagementLabels: {
-    view: {
-      role: 'Role',
-      adviser: 'Adviser',
-      team: 'Team',
-    },
+    view: roleAdviserTeam,
     edit: {
       client_relationship_manager: 'Client relationship manager',
       account_manager: 'Account manager',
     },
+  },
+  teamMembersLabels: {
+    view: roleAdviserTeam,
+    edit: roleAdviserTeam,
   },
 }
 

--- a/src/apps/investment-projects/middleware/team.js
+++ b/src/apps/investment-projects/middleware/team.js
@@ -1,4 +1,5 @@
 const { transformBriefInvestmentSummary } = require('../services/formatting')
+const { getAdviser } = require('../../adviser/repos')
 
 function getBriefInvestmentSummary (req, res, next) {
   try {
@@ -9,6 +10,29 @@ function getBriefInvestmentSummary (req, res, next) {
   }
 }
 
+async function expandTeamMembers (req, res, next) {
+  try {
+    // Fetch further details about any team members so their team can be displayed.
+    // Note - Looping through items and fetching data instead of using map
+    // as await cannot be used arrow functions
+    const teamMembers = []
+
+    for (const teamMember of res.locals.investmentData.team_members) {
+      const teamMemberAdvisor = await getAdviser(req.session.token, teamMember.adviser.id)
+      teamMembers.push({
+        adviser: teamMemberAdvisor,
+        role: teamMember.role,
+      })
+    }
+
+    res.locals.investmentData.team_members = teamMembers
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
   getBriefInvestmentSummary,
+  expandTeamMembers,
 }

--- a/src/apps/investment-projects/repos.js
+++ b/src/apps/investment-projects/repos.js
@@ -66,14 +66,17 @@ function unarchiveInvestmentProject (token, investmentId) {
 }
 
 async function updateInvestmentTeamMembers (token, investmentId, investmentTeamMembers) {
-  // Todo - Delete all existing records before saving (in case an advisor was changes.)
+  // Delete all existing records before saving
+  await authorisedRequest(token, {
+    url: `${config.apiRoot}/v3/investment/${investmentId}/team-member`,
+    method: 'DELETE',
+  })
 
   // Loop through each of the team members, saving it
-  /*
   for (const investmentTeamMember of investmentTeamMembers) {
     await authorisedRequest(token, {
       url: `${config.apiRoot}/v3/investment/${investmentId}/team-member`,
-      mothod: 'POST',
+      method: 'POST',
       body: {
         investment_project: investmentId,
         adviser: investmentTeamMember.adviser,
@@ -81,7 +84,6 @@ async function updateInvestmentTeamMembers (token, investmentId, investmentTeamM
       },
     })
   }
-  */
 }
 
 module.exports = {

--- a/src/apps/investment-projects/repos.js
+++ b/src/apps/investment-projects/repos.js
@@ -65,6 +65,25 @@ function unarchiveInvestmentProject (token, investmentId) {
   })
 }
 
+async function updateInvestmentTeamMembers (token, investmentId, investmentTeamMembers) {
+  // Todo - Delete all existing records before saving (in case an advisor was changes.)
+
+  // Loop through each of the team members, saving it
+  /*
+  for (const investmentTeamMember of investmentTeamMembers) {
+    await authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/investment/${investmentId}/team-member`,
+      mothod: 'POST',
+      body: {
+        investment_project: investmentId,
+        adviser: investmentTeamMember.adviser,
+        role: investmentTeamMember.role,
+      },
+    })
+  }
+  */
+}
+
 module.exports = {
   getCompanyInvestmentProjects,
   getInvestment,
@@ -74,4 +93,5 @@ module.exports = {
   getInvestmentProjectAuditLog,
   archiveInvestmentProject,
   unarchiveInvestmentProject,
+  updateInvestmentTeamMembers,
 }

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -2,7 +2,11 @@ const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../middleware')
 const { shared } = require('./middleware')
-const { getBriefInvestmentSummary } = require('./middleware/team')
+const {
+  getBriefInvestmentSummary,
+  expandTeamMembers,
+} = require('./middleware/team')
+
 const {
   createStep1,
   createStep2,
@@ -75,7 +79,7 @@ router
   .get(requirementsFormMiddleware.populateForm, edit.editRequirementsGet)
   .post(requirementsFormMiddleware.populateForm, requirementsFormMiddleware.handleFormPost, edit.editRequirementsPost)
 
-router.get('/:id/team', team.details.getDetailsHandler)
+router.get('/:id/team', expandTeamMembers, team.details.getDetailsHandler)
 
 router
   .route('/:id/edit-project-management')

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -21,6 +21,7 @@ const requirementsFormMiddleware = require('./middleware/forms/requirements')
 const interactionsFormMiddleware = require('./middleware/forms/interactions')
 const projectManagementFormMiddleware = require('./middleware/forms/project-management')
 const clientRelationshipManagementFormMiddleware = require('./middleware/forms/client-relationship-management')
+const teamMembersFormMiddleware = require('./middleware/forms/team-members')
 const { renderInvestmentList } = require('./controllers/list')
 const { handleDefaultFilters, getInvestmentProjectsCollection } = require('./middleware/collection')
 
@@ -75,6 +76,7 @@ router
   .post(requirementsFormMiddleware.populateForm, requirementsFormMiddleware.handleFormPost, edit.editRequirementsPost)
 
 router.get('/:id/team', team.details.getDetailsHandler)
+
 router
   .route('/:id/edit-project-management')
   .get(getBriefInvestmentSummary, projectManagementFormMiddleware.populateForm, team.editProjectManagement.getHandler)
@@ -97,6 +99,19 @@ router
     clientRelationshipManagementFormMiddleware.handleFormPost,
     team.editClientRelationshipManagement.postHandler,
     team.editClientRelationshipManagement.getHandler
+  )
+
+router
+  .route('/:id/edit-team-members')
+  .get(
+    teamMembersFormMiddleware.populateForm,
+    team.editTeamMembers.getHandler
+  )
+  .post(
+    teamMembersFormMiddleware.populateForm,
+    teamMembersFormMiddleware.handleFormPost,
+    team.editTeamMembers.postHandler,
+    team.editTeamMembers.getHandler
   )
 
 router.get('/:id/interactions', interactions.list.indexGetHandler)

--- a/src/apps/investment-projects/services/formatting.js
+++ b/src/apps/investment-projects/services/formatting.js
@@ -293,6 +293,14 @@ function transformClientRelationshipManagementForView (investmentData) {
   return result
 }
 
+function transformTeamMembersForView ({ adviser, role }) {
+  return {
+    adviser: adviser.name,
+    team: adviser.dit_team.name,
+    role: role,
+  }
+}
+
 module.exports = {
   transformInvestmentDataForView,
   transformInvestmentValueForView,
@@ -304,4 +312,5 @@ module.exports = {
   transformBriefInvestmentSummary,
   transformProjectManagementForView,
   transformClientRelationshipManagementForView,
+  transformTeamMembersForView,
 }

--- a/src/apps/investment-projects/views/team/details.njk
+++ b/src/apps/investment-projects/views/team/details.njk
@@ -44,7 +44,7 @@
     }]
   } %}
 
-  <a href="edit-details" class="button button-secondary">Change</a>
+  <a href="edit-team-members" class="button button-secondary">Change</a>
 
   <h2 class="heading-medium">Success verifier</h2>
 

--- a/src/apps/investment-projects/views/team/details.njk
+++ b/src/apps/investment-projects/views/team/details.njk
@@ -1,9 +1,5 @@
 {% extends "../_layout.njk" %}
 
-{% set stage = investmentData.stage.name %}
-{% set crm = investmentData.client_relationship_manager %}
-{% set rsa = investmentData.referral_source_adviser %}
-
 {% block main_grid_right_column %}
   <h2 class="heading-medium">Client relationship management</h2>
 
@@ -32,16 +28,8 @@
   <h2 class="heading-medium">Specialist team members</h2>
 
   {% component 'data-table', {
-    columns: {
-      adviser: 'Adviser',
-      role: 'Role',
-      team: 'Team'
-    },
-    data: [{
-      adviser: rsa.first_name + ' ' + rsa.last_name,
-      role: 'Referral source adviser',
-      team: crm.dit_team.name
-    }]
+    columns: teamMembersLabels.view,
+    data: teamMembersData
   } %}
 
   <a href="edit-team-members" class="button button-secondary">Change</a>

--- a/src/apps/investment-projects/views/team/edit-team-members.njk
+++ b/src/apps/investment-projects/views/team/edit-team-members.njk
@@ -1,0 +1,31 @@
+{% extends "../_layout.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Assign project team members</h2>
+
+  {% call Form(form) %}
+    {% if form.errors.team_members %}
+      <div class="error">{{ form.errors.team_members }}</div>
+    {% endif %}
+
+    {% for teamMember in form.state.teamMembers %}
+      {% call Fieldset({ legend: 'Team member' }) %}
+        {{ MultipleChoiceField({
+          name: 'adviser',
+          label: form.labels.adviser,
+          options: form.options.advisers,
+          value: teamMember.adviser,
+          idSuffix: loop.index,
+          initialOption: '-- Select an adviser --'
+        }) }}
+
+        {{ TextField({
+          name: 'role',
+          label: form.labels.role,
+          value: teamMember.role,
+          idSuffix: loop.index
+        }) }}
+      {% endcall %}
+      {% endfor %}
+  {% endcall %}
+{% endblock %}

--- a/test/unit/apps/investment-projects/controllers/team/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/details.test.js
@@ -12,17 +12,17 @@ describe('Investment team details controller', () => {
     this.reqStub = this.sandbox.stub()
     this.nextStub = this.sandbox.stub()
     this.clientRelationshipManagementData = { name: 'fred' }
+    this.teamMembersData = { adviser: 'Fred' }
     this.projectManagementData = [{ name: 'fred' }]
     this.transformProjectManagementForViewStub = this.sandbox.stub().returns(this.projectManagementData)
     this.transformClientRelationshipManagementForViewStub = this.sandbox.stub().returns(this.clientRelationshipManagementData)
+    this.transformTeamMembersForViewStub = this.sandbox.stub().returns(this.teamMembersData)
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/team/details', {
-      '../../../../lib/controller-utils': {
-        getDataLabels: this.getDataLabelsStub,
-      },
       '../../services/formatting': {
         transformProjectManagementForView: this.transformProjectManagementForViewStub,
         transformClientRelationshipManagementForView: this.transformClientRelationshipManagementForViewStub,
+        transformTeamMembersForView: this.transformTeamMembersForViewStub,
       },
     })
   })
@@ -58,6 +58,26 @@ describe('Investment team details controller', () => {
       render: (template, options) => {
         expect(this.transformClientRelationshipManagementForViewStub).to.be.calledWith(data)
         expect(options.clientRelationshipManagementData).to.deep.equal(this.clientRelationshipManagementData)
+        done()
+      },
+    }, (error) => {
+      done(error)
+    })
+  })
+
+  it('should get formatted team member data', (done) => {
+    const data = Object.assign({}, investmentData)
+    data.team_members = [{
+      name: 'Fred Smith',
+    }]
+
+    this.controller.getDetailsHandler(this.reqStub, {
+      locals: {
+        investmentData: data,
+      },
+      breadcrumb: this.breadcrumbStub,
+      render: (template, options) => {
+        expect(options.teamMembersData).to.deep.equal([this.teamMembersData])
         done()
       },
     }, (error) => {

--- a/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
@@ -1,0 +1,90 @@
+const investmentData = require('~/test/unit/data/investment/investment-data.json')
+
+describe('Investment project, team members, edit controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextStub = this.sandbox.stub()
+    this.flashStub = this.sandbox.stub()
+    this.breadcrumbStub = function () { return this }
+
+    this.controller = require('~/src/apps/investment-projects/controllers/team/edit-team-members')
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#getHandler', () => {
+    it('should render edit project management view', (done) => {
+      this.controller.getHandler({
+        session: {
+          token: 'abcd',
+        },
+      }, {
+        locals: {
+          investmentData,
+        },
+        breadcrumb: this.breadcrumbStub,
+        render: (template) => {
+          try {
+            expect(template).to.equal('investment-projects/views/team/edit-team-members')
+            done()
+          } catch (e) {
+            done(e)
+          }
+        },
+      }, this.nextStub)
+    })
+  })
+
+  describe('#postHandler', () => {
+    describe('without errors', () => {
+      it('should redirect to the product team details page', (done) => {
+        this.controller.postHandler({
+          session: {
+            token: 'abcd',
+          },
+          flash: this.flashStub,
+        }, {
+          locals: {
+            form: {
+              errors: {},
+            },
+            investmentData,
+          },
+          breadcrumb: this.breadcrumbStub,
+          redirect: (url) => {
+            try {
+              expect(url).to.equal(`/investment-projects/${investmentData.id}/team`)
+              expect(this.flashStub).to.calledWith('success', 'Updated investment details')
+              done()
+            } catch (e) {
+              done(e)
+            }
+          },
+        }, this.nextStub)
+      })
+    })
+
+    describe('when form errors exist', () => {
+      it('should pass the error onto the edit form', () => {
+        this.controller.postHandler({
+          session: {
+            token: 'abcd',
+          },
+        }, {
+          locals: {
+            form: {
+              errors: {
+                subject: 'example error',
+              },
+            },
+          },
+          breadcrumb: this.breadcrumbStub,
+        }, this.nextStub)
+
+        expect(this.nextStub).to.be.calledOnce
+      })
+    })
+  })
+})

--- a/test/unit/apps/investment-projects/formatting.test.js
+++ b/test/unit/apps/investment-projects/formatting.test.js
@@ -130,4 +130,31 @@ describe('Investment project formatting service', () => {
       expect(actualResult).to.deep.equal(expectedResult)
     })
   })
+
+  describe('#transformTeamMembersForView', () => {
+    it('should return a formatted version of team member data', () => {
+      const teamMembers = [{
+        adviser: {
+          id: '1234',
+          first_name: 'Fred',
+          last_name: 'Smith',
+          name: 'Fred Smith',
+          dit_team: {
+            id: '444',
+            name: 'Freds Team',
+          },
+        },
+        role: 'Director',
+      }]
+
+      const expected = [{
+        adviser: 'Fred Smith',
+        team: 'Freds Team',
+        role: 'Director',
+      }]
+
+      const actual = teamMembers.map(formattingService.transformTeamMembersForView)
+      expect(actual).to.deep.equal(expected)
+    })
+  })
 })

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -1,0 +1,318 @@
+const investmentData = require('~/test/unit/data/investment/investment-data.json')
+const adviserData = require('~/test/unit/data/investment/interaction/advisers')
+const { teamMembersLabels } = require('~/src/apps/investment-projects/labels')
+
+describe('Investment form middleware - team members', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.getAdvisersStub = this.sandbox.stub().resolves(adviserData)
+    this.updateInvestmentTeamMembersStub = this.sandbox.stub().resolves({})
+    this.nextSpy = this.sandbox.spy()
+    this.resMock = {
+      locals: {
+        form: {},
+        investmentData,
+      },
+    }
+
+    this.controller = proxyquire('~/src/apps/investment-projects/middleware/forms/team-members', {
+      '../../../adviser/repos': {
+        getAdvisers: this.getAdvisersStub,
+      },
+      '../../repos': {
+        updateInvestmentTeamMembers: this.updateInvestmentTeamMembersStub,
+      },
+    })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#populateForm', () => {
+    it('should generate a list of advisers to use for adviser dropdowns', (done) => {
+      const mockAdviser = adviserData.results[0]
+      const expectedAdvisers = [{
+        value: mockAdviser.id,
+        label: mockAdviser.name,
+      }]
+
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.options.advisers).to.deep.equal(expectedAdvisers)
+        done()
+      })
+    })
+
+    it('should populate the form state with the existing team members if there is data', (done) => {
+      const investmentDataWithTeam = Object.assign({}, investmentData, {
+        team_members: [{
+          adviser: {
+            id: '1234',
+          },
+          role: 'manager',
+        }, {
+          adviser: {
+            id: '4321',
+          },
+          role: 'director',
+        }],
+      })
+
+      this.resMock = {
+        locals: {
+          form: {},
+          investmentData: investmentDataWithTeam,
+        },
+      }
+
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        const state = this.resMock.locals.form.state
+        expect(state.teamMembers[0].adviser).to.equal('1234')
+        expect(state.teamMembers[0].role).to.equal('manager')
+        expect(state.teamMembers[1].adviser).to.equal('4321')
+        expect(state.teamMembers[1].role).to.equal('director')
+        done()
+      })
+    })
+
+    it('should include a blank record to allow things to be added when there are existing members', (done) => {
+      const investmentDataWithTeam = Object.assign({}, investmentData, {
+        team_members: [{
+          adviser: {
+            id: '1234',
+          },
+          role: 'manager',
+        }, {
+          adviser: {
+            id: '4321',
+          },
+          role: 'director',
+        }],
+      })
+
+      this.resMock = {
+        locals: {
+          form: {},
+          investmentData: investmentDataWithTeam,
+        },
+      }
+
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        const state = this.resMock.locals.form.state
+        expect(state.teamMembers[2].adviser).to.equal(null)
+        expect(state.teamMembers[2].role).to.equal(null)
+        done()
+      })
+    })
+
+    it('should include a blank record to allow things to be added when there are no existing members', (done) => {
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        const state = this.resMock.locals.form.state
+        expect(state.teamMembers[0].adviser).to.equal(null)
+        expect(state.teamMembers[0].role).to.equal(null)
+        done()
+      })
+    })
+
+    it('should include labels for the form', (done) => {
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.labels).to.deep.equal(teamMembersLabels.edit)
+        done()
+      })
+    })
+
+    it('should include button text and a return link', (done) => {
+      this.controller.populateForm({
+        session: {
+          token: 'mock-token',
+        },
+      }, this.resMock, () => {
+        expect(this.resMock.locals.form.buttonText).to.equal('Save')
+        expect(this.resMock.locals.form.returnLink).to.equal(`/investment-projects/${investmentData.id}/team`)
+        done()
+      })
+    })
+  })
+
+  describe('#handleFormpost', () => {
+    beforeEach(() => {
+      this.body = {
+        adviser: ['1234', '4321'],
+        role: ['manager', 'supervisor'],
+      }
+    })
+
+    describe('post with no errors', () => {
+      it('updates the investment data', (done) => {
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, () => {
+          expect(this.updateInvestmentTeamMembersStub).to.be.calledWith('mock-token', investmentData.id, [{
+            adviser: '1234',
+            role: 'manager',
+          }, {
+            adviser: '4321',
+            role: 'supervisor',
+          }])
+          done()
+        })
+      })
+
+      it('continues onto the next middleware with no errors', (done) => {
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, (error) => {
+          expect(error).to.equal(undefined)
+          done()
+        })
+      })
+    })
+
+    describe('When a form is posted with errors', () => {
+      it('should set form error data for the following controllers if form error', (done) => {
+        this.error = {
+          statusCode: 400,
+          error: {
+            project_assurance_adviser: 'Cannot be null',
+          },
+        }
+
+        this.updateInvestmentTeamMembersStub.rejects(this.error)
+
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, (error) => {
+          expect(error).to.equal(undefined)
+          expect(this.resMock.locals.form.state).to.deep.equal(this.body)
+          expect(this.resMock.locals.form.errors).to.deep.equal(this.error.error)
+          done()
+        })
+      })
+
+      it('should pass a none form error to next middleware', (done) => {
+        this.error = {
+          statusCode: 500,
+        }
+
+        this.updateInvestmentTeamMembersStub.rejects(this.error)
+
+        this.controller.handleFormPost({
+          session: {
+            token: 'mock-token',
+          },
+          params: {
+            id: investmentData.id,
+          },
+          body: this.body,
+        }, this.resMock, (error) => {
+          expect(error).to.deep.equal(this.error)
+          done()
+        })
+      })
+    })
+  })
+
+  describe('#transformDataToTeamMemberArray', () => {
+    it('should transform a single populated line into a single team member object', () => {
+      const body = {
+        adviser: '1234',
+        role: 'Director',
+      }
+
+      const expected = [{
+        adviser: '1234',
+        role: 'Director',
+      }]
+
+      const actual = this.controller.transformDataToTeamMemberArray(body)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('should transform multiple lines into an array of team member objects', () => {
+      const body = {
+        adviser: ['1234', '4321'],
+        role: ['Director', 'Manager'],
+      }
+
+      const expected = [{
+        adviser: '1234',
+        role: 'Director',
+      }, {
+        adviser: '4321',
+        role: 'Manager',
+      }]
+
+      const actual = this.controller.transformDataToTeamMemberArray(body)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('should strip empty lines when transforming to team member objects', () => {
+      const body = {
+        adviser: ['1234', ''],
+        role: ['manager', ''],
+      }
+
+      const expected = [{
+        adviser: '1234',
+        role: 'manager',
+      }]
+
+      const actual = this.controller.transformDataToTeamMemberArray(body)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('should strip out empty single line and return empty array', () => {
+      const body = {
+        adviser: '',
+        role: '',
+      }
+
+      const expected = []
+
+      const actual = this.controller.transformDataToTeamMemberArray(body)
+
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+})

--- a/test/unit/data/investment/investment-data.json
+++ b/test/unit/data/investment/investment-data.json
@@ -181,5 +181,6 @@
     "id": "1111",
     "name": "Team B"
   },
-  "team_complete": true
+  "team_complete": true,
+  "team_members": []
 }


### PR DESCRIPTION
![team](https://user-images.githubusercontent.com/56056/28820419-84145e0a-76a9-11e7-931e-b6109b8c1e7d.gif)

Allows a user to add, edit and remove team members.

Team members are displayed in the team page.
Clicking change goes to an edit page, more members can be added via the add another button or add one, save it and then return to add another.

Removal is done by clearing the team member to remove.