### PR TITLE
Remove dependency on req in pagination

### DIFF
--- a/assets/stylesheets/components/_pagination.scss
+++ b/assets/stylesheets/components/_pagination.scss
@@ -32,12 +32,23 @@
 }
 
 .c-pagination__label {
+  @include bold-font(16);
   display: inline-block;
   padding: ($default-spacing-unit / 2) $default-spacing-unit;
   background-color: $grey-4;
 
+  &:link,
+  &:visited {
+    color: $link-colour;
+    text-decoration: none;
+
+    &:hover:not(.is-current) {
+      background-color: $grey-3;
+    }
+  }
+
   &.is-current {
-    background-color: $white;
+    background-color: transparent;
     color: $text-colour;
     text-decoration: none;
   }
@@ -47,6 +58,7 @@
   background-color: transparent;
   padding-right: $default-spacing-unit / 2;
   padding-left: $default-spacing-unit / 2;
+  color: $grey-1;
 }
 
 @include media(mobile) {

--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -25,10 +25,14 @@
   }
 
   .c-form-fieldset--subfield,
-  .c-form-group--subfield,
-  .c-pagination {
+  .c-form-group--subfield {
     margin-top: $default-spacing-unit;
     margin-bottom: $default-spacing-unit;
+  }
+
+  .c-pagination {
+    margin-top: $default-spacing-unit * 2;
+    margin-bottom: $default-spacing-unit * 2;
   }
 }
 

--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -96,7 +96,7 @@ async function getAddStepTwo (req, res, next) {
       searchTerm,
     })
     const companies = companiesHouseAndLtdCompanies.results
-    companies.pagination = buildPagination(req, companiesHouseAndLtdCompanies.results)
+    companies.pagination = buildPagination(req.query, companiesHouseAndLtdCompanies.results)
     const highlightedCompany = companiesHouseAndLtdCompanies.results.find((company) => {
       return company.id === currentlySelected ||
         (company.company_number && company.company_number === currentlySelected)

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -80,7 +80,7 @@ async function renderEntityList (req, res) {
       return Object.assign(result, {
         page: 1,
         limit: 10,
-        pagination: buildPagination(req, result),
+        pagination: buildPagination(req.query, result),
         items: result.results.map(transformInvestmentProjectToListItem),
       })
     })

--- a/src/apps/investment-projects/controllers/create-1.js
+++ b/src/apps/investment-projects/controllers/create-1.js
@@ -31,7 +31,7 @@ function getHandler (req, res, next) {
       let showSearch = req.query['show-search'] || false
 
       if (searchResult) {
-        searchResult.pagination = buildPagination(req, searchResult)
+        searchResult.pagination = buildPagination(req.query, searchResult)
       }
 
       if (clientCompanyId && clientCompany.uk_based) {

--- a/src/apps/investment-projects/middleware/collection.js
+++ b/src/apps/investment-projects/middleware/collection.js
@@ -119,7 +119,7 @@ async function getInvestmentProjectsCollection (req, res, next) {
         result.items = result.items
           .map(transformInvestmentProjectToListItem)
           .map(augmentProjectListItem.bind(res))
-        result.pagination = buildPagination(req, result)
+        result.pagination = buildPagination(req.query, result)
         return result
       })
 

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -22,7 +22,7 @@ function searchAction (req, res, next) {
     page: req.query.page,
   })
     .then((results) => {
-      results.pagination = buildPagination(req, results)
+      results.pagination = buildPagination(req.query, results)
       const searchEntityResultsData = buildSearchEntityResultsData(results.aggregations)
 
       res

--- a/src/lib/pagination.js
+++ b/src/lib/pagination.js
@@ -1,10 +1,8 @@
 const { range, take, get, omitBy } = require('lodash')
 const { buildQueryString } = require('./url-helpers')
 
-function getPageLink (page, req) {
-  const query = Object.assign({}, req.query, {
-    page,
-  })
+function getPageLink (page, query = {}) {
+  query.page = page
   return buildQueryString(omitBy(query, val => val === ''))
 }
 
@@ -52,7 +50,7 @@ function truncatePages (pagination, blockSize) {
   return pagination
 }
 
-function buildPagination (req, results, truncate = 4) {
+function buildPagination (query = {}, results, truncate = 4) {
   const limit = results.limit || Math.max(get(results, 'results.length', 10), 10)
   const totalPages = results.count ? Math.ceil(results.count / limit) : 0
   results.page = parseInt(results.page, 10)
@@ -62,12 +60,12 @@ function buildPagination (req, results, truncate = 4) {
   const pagination = {
     totalPages,
     currentPage: results.page,
-    prev: results.page > 1 ? getPageLink(results.page - 1, req) : null,
-    next: results.page === totalPages ? null : getPageLink(results.page + 1, req),
+    prev: results.page > 1 ? getPageLink(results.page - 1, query) : null,
+    next: results.page === totalPages ? null : getPageLink(results.page + 1, query),
     pages: range(0, totalPages).map((page, idx) => {
       return {
         label: idx + 1,
-        url: getPageLink(idx + 1, req),
+        url: getPageLink(idx + 1, query),
       }
     }),
   }

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -22,7 +22,10 @@
  #}
 {% macro Pagination(pagination, showPages=true) %}
   {% if pagination %}
-    <nav class="c-pagination {{ 'c-pagination--pageless' if not showPages }}">
+    <nav
+      class="c-pagination {{ 'c-pagination--pageless' if not showPages }}"
+      aria-label="pagination: total {{ pagination.totalPages }} pages"
+    >
       {% if pagination.prev %}
         <a href="{{ pagination.prev }}" class="c-pagination__label c-pagination__label--prev">Previous</a>
       {% endif %}

--- a/test/unit/lib/pagination.test.js
+++ b/test/unit/lib/pagination.test.js
@@ -2,28 +2,28 @@ const { getPageLink, buildPagination } = require('~/src/lib/pagination')
 
 describe('Pagination', () => {
   describe('#getPageLink', () => {
-    const reqMock = { query: { term: 'samsung' } }
+    const query = { term: 'samsung' }
 
     it('should return a query string for query object', () => {
-      expect(getPageLink(1, reqMock)).to.equal('?term=samsung&page=1')
+      expect(getPageLink(1, query)).to.equal('?term=samsung&page=1')
     })
   })
 
   describe('#buildPagination', () => {
-    const reqMock = { query: { term: 'samsung' } }
+    const query = { term: 'samsung' }
 
     it('should return null if current page is not given', () => {
-      const actual = buildPagination(reqMock, { limit: 10, count: 20 })
+      const actual = buildPagination(query, { limit: 10, count: 20 })
       expect(actual).to.be.null
     })
 
     it('should return null if count is not given', () => {
-      const actual = buildPagination(reqMock, { limit: 10 })
+      const actual = buildPagination(query, { limit: 10 })
       expect(actual).to.be.null
     })
 
     it('should return pagination object when all required props a given', () => {
-      const actual = buildPagination(reqMock, { count: 10, limit: 5, page: 1 })
+      const actual = buildPagination(query, { count: 10, limit: 5, page: 1 })
       const expected = {
         totalPages: 2,
         currentPage: 1,
@@ -38,7 +38,7 @@ describe('Pagination', () => {
     })
 
     it('should return pagination object with correct current page', () => {
-      const actual = buildPagination(reqMock, { count: 10, limit: 5, page: 2 })
+      const actual = buildPagination(query, { count: 10, limit: 5, page: 2 })
       const expected = {
         totalPages: 2,
         currentPage: 2,
@@ -53,7 +53,7 @@ describe('Pagination', () => {
     })
 
     it('should return pagination object with truncation', () => {
-      const actual = buildPagination(reqMock, { count: 10, limit: 2, page: 1 }, 2)
+      const actual = buildPagination(query, { count: 10, limit: 2, page: 1 }, 2)
       const expected = {
         totalPages: 5,
         currentPage: 1,
@@ -70,7 +70,7 @@ describe('Pagination', () => {
     })
 
     it('should return pagination object without truncation when it’s not needed', () => {
-      const actual = buildPagination(reqMock, { count: 10, limit: 2, page: 1 }, 4)
+      const actual = buildPagination(query, { count: 10, limit: 2, page: 1 }, 4)
       const expected = {
         totalPages: 5,
         currentPage: 1,
@@ -88,7 +88,7 @@ describe('Pagination', () => {
     })
 
     it('should return pagination object with truncation in right place when current page is changed', () => {
-      const actual = buildPagination(reqMock, { count: 10, limit: 2, page: 4 }, 2)
+      const actual = buildPagination(query, { count: 10, limit: 2, page: 4 }, 2)
       const expected = {
         totalPages: 5,
         currentPage: 4,
@@ -105,7 +105,7 @@ describe('Pagination', () => {
     })
 
     it('should return pagination object with no truncation when block start page is close to first or last pages', () => {
-      const actual = buildPagination(reqMock, { count: 21, limit: 3, page: 4 }, 4)
+      const actual = buildPagination(query, { count: 21, limit: 3, page: 4 }, 4)
       const expected = {
         totalPages: 7,
         currentPage: 4,


### PR DESCRIPTION
As pagination resides in `lib` it should work with specific `query` parameter instead of relying on property of `req`.

Additional stylistic tweaks to make pagination stand out a little better and and remove visited links.

<img src="https://user-images.githubusercontent.com/203886/28841667-dc97f2b4-76f2-11e7-9037-88b933d00329.png" width="470">
