### PR TITLE
Do set up within describe block in beforeEach

### DIFF
--- a/test/unit/macros/form.test.js
+++ b/test/unit/macros/form.test.js
@@ -154,36 +154,38 @@ describe('Nunjucks form macros', () => {
     })
 
     describe('valid props', () => {
-      const component = macros.renderToDom('TextField', {
-        name: 'firstName',
-        label: 'First name',
-        value: 'Joe',
+      beforeEach(() => {
+        this.component = macros.renderToDom('TextField', {
+          name: 'firstName',
+          label: 'First name',
+          value: 'Joe',
+        })
       })
 
       it('should render a component with group id', () => {
-        expect(component.id).to.equal('group-field-firstName')
+        expect(this.component.id).to.equal('group-field-firstName')
       })
 
       it('should render a component with correct group class name', () => {
-        expect(component.className.trim()).to.equal('c-form-group')
+        expect(this.component.className.trim()).to.equal('c-form-group')
       })
 
       it('should render a component with label and input field', () => {
-        expect(component.querySelector('label').textContent.trim()).to.equal('First name')
-        expect(component.querySelector('input')).to.not.be.null
+        expect(this.component.querySelector('label').textContent.trim()).to.equal('First name')
+        expect(this.component.querySelector('input')).to.not.be.null
       })
 
       it('should render a component which has input with name and id based on its name', () => {
-        expect(component.querySelector('input').name).to.equal('firstName')
-        expect(component.querySelector('input').id).to.equal('field-firstName')
+        expect(this.component.querySelector('input').name).to.equal('firstName')
+        expect(this.component.querySelector('input').id).to.equal('field-firstName')
       })
 
       it('should render a component with text input by default', () => {
-        expect(component.querySelector('input').type).to.equal('text')
+        expect(this.component.querySelector('input').type).to.equal('text')
       })
 
       it('should render a field with value given', () => {
-        expect(component.querySelector('input').value).to.equal('Joe')
+        expect(this.component.querySelector('input').value).to.equal('Joe')
       })
     })
 

--- a/test/unit/macros/results.test.js
+++ b/test/unit/macros/results.test.js
@@ -12,31 +12,33 @@ describe('Results macros', () => {
     })
 
     describe('valid props', () => {
-      const filter1 = formMacros.render('MultipleChoiceField', {
-        name: 'who-are-you',
-        label: 'Who are you?',
-        type: 'radio',
-        options: [
-          { label: 'Human', value: 'h' },
-          { label: 'Alien', value: 'a' },
-        ],
-      })
+      beforeEach(() => {
+        this.filter1 = formMacros.render('MultipleChoiceField', {
+          name: 'who-are-you',
+          label: 'Who are you?',
+          type: 'radio',
+          options: [
+            { label: 'Human', value: 'h' },
+            { label: 'Alien', value: 'a' },
+          ],
+        })
 
-      const filter2 = formMacros.render('MultipleChoiceField', {
-        name: 'fav-colour',
-        label: 'Favourite colour',
-        options: [
-          { label: 'Red', value: 'r' },
-          { label: 'Green', value: 'g' },
-          { label: 'Blue', value: 'b' },
-        ],
+        this.filter2 = formMacros.render('MultipleChoiceField', {
+          name: 'fav-colour',
+          label: 'Favourite colour',
+          options: [
+            { label: 'Red', value: 'r' },
+            { label: 'Green', value: 'g' },
+            { label: 'Blue', value: 'b' },
+          ],
+        })
       })
 
       it('should render results filters component', () => {
         const component = entitiesMacros.renderToDom('ResultsFilters', {
           filters: [
-            filter1,
-            filter2,
+            this.filter1,
+            this.filter2,
           ],
         })
         const renderedFilter1 = component.querySelector('#group-field-who-are-you')
@@ -60,7 +62,7 @@ describe('Results macros', () => {
         const component = entitiesMacros.renderToDom('ResultsFilters', {
           heading: 'Pick one',
           filters: [
-            filter1,
+            this.filter1,
           ],
         })
         expect(component.querySelector('.c-filters__heading').textContent.trim()).to.equal('Pick one')
@@ -72,7 +74,7 @@ describe('Results macros', () => {
             sortby: 'alphabetical',
           },
           filters: [
-            filter1,
+            this.filter1,
           ],
         })
 


### PR DESCRIPTION
The stuff inside `describe` block is not ignored when calling isolated tests using `.only`. Only `it` and relevant `before/afterEach` blocks are ignored, so anything that is defined in `describe` block is being called even when it shouldn't be making it harder to debug tests.