### PR TITLE
Highlight filter

### DIFF
--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -2,6 +2,7 @@
 
 .main-content {
   position: relative;
+  z-index: 1;
   background-color: $white;
   min-height: 60vh;
   flex-grow: 1;
@@ -23,6 +24,11 @@
       left: $default-spacing-unit;
       right: $default-spacing-unit;
     }
+  }
+
+  .u-highlight {
+    position: relative;
+    z-index: -1;
   }
 }
 

--- a/assets/stylesheets/trumps/_utility.scss
+++ b/assets/stylesheets/trumps/_utility.scss
@@ -28,8 +28,8 @@
 
 .u-highlight {
   background-color: $yellow-25;
-  border-bottom: 1px solid $yellow;
-  padding: 2px 1px;
+  padding: 2px;
+  margin: -2px;
 }
 
 .u-clearfix {

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -33,13 +33,13 @@ const filters = {
   mapValues,
   isArray,
 
-  highlight: (string, searchTerm) => {
-    if (!isString(string)) { return }
+  highlight (string, searchTerm, shouldMatchFullWord = false) {
+    if (!isString(string) || !isString(searchTerm) || !searchTerm.trim()) { return string }
 
-    const regEx = new RegExp(`(${searchTerm})`, 'gi')
-    return new nunjucks.runtime.SafeString(
-      string.replace(regEx, '<span class="u-highlight">$1</span>')
-    )
+    const regEx = new RegExp(`(${searchTerm})${shouldMatchFullWord ? '\\b' : ''}`, 'gi')
+    const result = string.replace(regEx, '<span class="u-highlight">$1</span>')
+
+    return new nunjucks.runtime.SafeString(result)
   },
 
   collectionDefault: (collection, defaultValue = 'Not found') => {

--- a/src/apps/investment-projects/views/list.njk
+++ b/src/apps/investment-projects/views/list.njk
@@ -64,7 +64,6 @@
       el: 'header',
       sort: sort,
       filters: filters,
-      selectedFiltersHumanised: selectedFiltersHumanised,
       countLabel: 'project',
       query: QUERY
     }))

--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -4,8 +4,9 @@
  # @param {string} props.id - entity id
  # @param {string} props.name - entity name
  # @param {string} props.type - entity type (e.g. 'date' to format dates)
- # @param {array} [props.metaBadges{}] - an array of metadata item objects
- # @param {array} [props.metaItems{}] - an array of metadata item objects
+ # @param {array}  [props.metaBadges{}] - an array of metadata item objects
+ # @param {array}  [props.metaItems{}] - an array of metadata item objects
+ # @param {string} [props.highlightTerm] - text to use to apply highlight filter
  #}
 {% macro Entity (props) %}
   {% if props.name and props.id and props.type %}
@@ -14,18 +15,18 @@
 
     <div class="c-entity c-entity--{{ props.type }}">
       {% if props.code %}
-        <div class="c-entity__code">{{ props.code }}</div>
+        <div class="c-entity__code">{{ props.code | highlight(props.highlightTerm, true) }}</div>
       {% endif %}
 
       <div class="c-entity__header">
         <h3 class="c-entity__title">
-          <a href="/{{ props.type | pluralise }}/{{ props.id }}">{{ props.name }}</a>
+          <a href="/{{ props.type | pluralise }}/{{ props.id }}">{{ props.name | highlight(props.highlightTerm) }}</a>
         </h3>
 
         {% if metaBadges | length %}
           <div class="c-entity__badges">
             {% for metaBadge in metaBadges %}
-              {{ MetaItem(metaBadge) }}
+              {{ MetaItem(metaBadge | assign({ highlightTerm: props.highlightTerm })) }}
             {% endfor %}
           </div>
         {% endif %}
@@ -34,7 +35,7 @@
       {% if metaItems | length %}
         <div class="c-entity__content">
           {% for metaItem in metaItems %}
-            {{ MetaItem(metaItem) }}
+            {{ MetaItem(metaItem| assign({ highlightTerm: props.highlightTerm })) }}
           {% endfor %}
         </div>
       {% endif %}
@@ -56,6 +57,7 @@
  # @param {string} [props.isBadge] - whether the the CSS c-badge component should be applied to anchor
  # @param {string} [props.isLabelHidden=false] - whether the label should be visually hidden
  # @param {string} [props.badgeModifier] - modifier for badge link if isBadge=true
+ # @param {string} [props.highlightTerm] - text to use to apply highlight filter
  #}
 {% macro MetaItem (props) %}
   {% set badgeModifier = props.badgeModifier | concat('') | reverse | join(' c-badge--') if props.badgeModifier %}
@@ -79,10 +81,10 @@
           class="js-xhr {{ itemValueClass }} {{ 'is-selected' if props.isSelected }}"
           href="{{ props.url }}"
         >
-          {{- metaItemValue -}}
+          {{- metaItemValue  | highlight(props.highlightTerm, true) -}}
         </a>
       {% else %}
-        <span class="{{ itemValueClass }}">{{ metaItemValue }}</span>
+        <span class="{{ itemValueClass }}">{{ metaItemValue | highlight(props.highlightTerm, true) }}</span>
       {% endif %}
     </div>
   {% endif %}

--- a/src/templates/_macros/results.njk
+++ b/src/templates/_macros/results.njk
@@ -101,6 +101,7 @@
  # @param {object}  [props.sort] - object containing selected sorting and sorting options
  # @param {string}  [props.sort.selected] - selected sorting mode
  # @param {array}   [props.sort.options] - sorting options
+ # @param {string}  [props.highlightTerm] - text to use to apply highlight filter
 #}
 {% macro Results(props) %}
   {% set selectedFilters = props.filters | mapValues('value') %}
@@ -140,7 +141,7 @@
       <ol class="c-entity-list">
         {% for project in props.items %}
           <li class="c-entity-list__item">
-            {{ Entity(project) }}
+            {{ Entity(project | assign({ highlightTerm: props.highlightTerm })) }}
           </li>
         {% endfor %}
       </ol>

--- a/test/unit/config/nunjucks/filters.test.js
+++ b/test/unit/config/nunjucks/filters.test.js
@@ -2,13 +2,40 @@ const filters = require('~/config/nunjucks/filters')
 
 describe('nunjucks filters', () => {
   describe('#highlight', () => {
-    it('should render string with highlight', () => {
-      const searchTerm = 'example term'
-      const mockString = `we should see ${searchTerm} highlighted here`
+    it('should not render highlight for empty string', () => {
+      const searchTerm = ''
+      const mockString = 'we should see nothing highlighted here'
 
       const highlightedString = filters.highlight(mockString, searchTerm)
 
-      expect(highlightedString.val).to.equal(`we should see <span class="u-highlight">${searchTerm}</span> highlighted here`)
+      expect(highlightedString).to.equal('we should see nothing highlighted here')
+    })
+
+    it('should not render highlight for string with white space', () => {
+      const searchTerm = ' '
+      const mockString = 'we should see nothing highlighted here'
+
+      const highlightedString = filters.highlight(mockString, searchTerm)
+
+      expect(highlightedString).to.equal('we should see nothing highlighted here')
+    })
+
+    it('should render string with partial highlight (default)', () => {
+      const searchTerm = 'examp'
+      const mockString = 'we should see example term highlighted here'
+
+      const highlightedString = filters.highlight(mockString, searchTerm)
+
+      expect(highlightedString.val).to.equal(`we should see <span class="u-highlight">examp</span>le term highlighted here`)
+    })
+
+    it('should render string only with full word highlight', () => {
+      const searchTerm = 'example term'
+      const mockString = 'we should see example term highlighted here'
+
+      const highlightedString = filters.highlight(mockString, searchTerm, true)
+
+      expect(highlightedString.val).to.equal(`we should see <span class="u-highlight">example term</span> highlighted here`)
     })
 
     it('should render string without highlight', () => {


### PR DESCRIPTION
- remove border from highlight (avoid interfering with potential highlighted element's existing styles
- Allow to restrict to full word match only as search can be configured to match words only
- add highlighters in searchable fields of results macro
- avoid highlighting empty strings

### Before
<img width="973" alt="screen shot 2017-08-05 at 14 40 01" src="https://user-images.githubusercontent.com/203886/28995895-10ac3ad6-79ed-11e7-9522-e34981cc8b49.png">
<img width="976" alt="screen shot 2017-08-05 at 14 40 24" src="https://user-images.githubusercontent.com/203886/28995896-12975682-79ed-11e7-9fb1-c052ccf2aff5.png">

### After
<img width="975" alt="screen shot 2017-08-05 at 14 41 26" src="https://user-images.githubusercontent.com/203886/28995899-188e7fc0-79ed-11e7-9c34-3bf09564a00f.png">
<img width="980" alt="screen shot 2017-08-05 at 14 42 12" src="https://user-images.githubusercontent.com/203886/28995900-1bb43780-79ed-11e7-8382-a0c7901de2c4.png">
