### PR TITLE
move between investment project stages

### DIFF
--- a/src/apps/investment-projects/middleware/forms/index.js
+++ b/src/apps/investment-projects/middleware/forms/index.js
@@ -3,6 +3,7 @@ const detailsFormMiddleware = require('./details')
 const interactionsFormMiddleware = require('./interactions')
 const investmentTypeFormMiddleware = require('./investment-type')
 const projectManagementFormMiddleware = require('./project-management')
+const projectStageFormMiddleware = require('./project-stage')
 const requirementsFormMiddleware = require('./requirements')
 const teamMembersFormMiddleware = require('./team-members')
 const valueFormMiddleware = require('./value')
@@ -13,6 +14,7 @@ module.exports = {
   interactionsFormMiddleware,
   investmentTypeFormMiddleware,
   projectManagementFormMiddleware,
+  projectStageFormMiddleware,
   requirementsFormMiddleware,
   teamMembersFormMiddleware,
   valueFormMiddleware,

--- a/src/apps/investment-projects/middleware/forms/project-stage.js
+++ b/src/apps/investment-projects/middleware/forms/project-stage.js
@@ -1,0 +1,26 @@
+const logger = require('../../../../../config/logger')
+const { updateInvestment } = require('../../repos')
+
+function handleFormPost (req, res, next, projectId = req.params.id) {
+  updateInvestment(req.session.token, projectId, {
+    stage: {
+      id: req.body.next_project_stage,
+    },
+  })
+    .then(() => {
+      req.flash('success', `Investment project moved to ${res.locals.investmentStatus.nextStage.name} stage`)
+      res.redirect(`/investment-projects/${res.locals.investmentData.id}/details`)
+    })
+    .catch((err) => {
+      if (err.statusCode === 400) {
+        logger.error(err)
+        req.flash('error', 'Something has gone wrong')
+        return res.redirect(`/investment-projects/${res.locals.investmentData.id}/details`)
+      }
+      next(err)
+    })
+}
+
+module.exports = {
+  handleFormPost,
+}

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -1,5 +1,6 @@
 const { get } = require('lodash')
 
+const metadata = require('../../../lib/metadata')
 const { isValidGuid } = require('../../../lib/controller-utils')
 const { getDitCompany } = require('../../companies/repos')
 const { getInteraction } = require('../../interactions/repos')
@@ -7,6 +8,17 @@ const { getAdviser } = require('../../adviser/repos')
 const { transformFromApi } = require('../../interactions/services/formatting')
 const { buildCompanyUrl } = require('../../companies/services/data')
 const { getInvestment } = require('../repos')
+
+function projectPosition (currentStage, projectStages) {
+  const projectStageIndex = projectStages.findIndex((projectStage) => {
+    return projectStage.name.toLowerCase() === currentStage.toLowerCase()
+  })
+
+  return {
+    currentStageIndex: projectStageIndex,
+    nextStage: projectStages[projectStageIndex + 1],
+  }
+}
 
 function getCompanyDetails (req, res, next) {
   getDitCompany(req.session.token, req.params.companyId)
@@ -22,9 +34,11 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
     return next()
   }
   try {
+    const investmentProjectStages = metadata.investmentProjectStage
     const investmentData = await getInvestment(req.session.token, req.params.id)
     const investorCompany = await getDitCompany(req.session.token, get(investmentData, 'investor_company.id'))
     const ukCompanyId = get(investmentData, 'uk_company.id')
+    const { currentStageIndex, nextStage } = projectPosition(investmentData.stage.name, investmentProjectStages)
 
     investmentData.investor_company = Object.assign({}, investmentData.investor_company, investorCompany)
 
@@ -38,6 +52,7 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
 
     res.locals.investmentData = investmentData
     res.locals.equityCompany = investmentData.investor_company
+    res.locals.investmentProjectStages = investmentProjectStages
 
     res.locals.investmentStatus = {
       id: investmentData.id,
@@ -51,11 +66,16 @@ async function getInvestmentDetails (req, res, next, id = req.params.id) {
           value: investmentData.value_complete ? 'Project valued' : 'Not yet valued',
         },
       ],
-      stageName: investmentData.stage.name,
       company: {
         name: investmentData.investor_company.name,
         url: buildCompanyUrl(investmentData.investor_company),
       },
+      currentStage: {
+        name: investmentData.stage.name,
+        index: currentStageIndex,
+        isComplete: investmentData.team_complete && investmentData.requirements_complete && investmentData.value_complete,
+      },
+      nextStage,
     }
 
     res.breadcrumb({

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -23,6 +23,7 @@ const {
   interactionsFormMiddleware,
   investmentTypeFormMiddleware,
   projectManagementFormMiddleware,
+  projectStageFormMiddleware,
   requirementsFormMiddleware,
   valueFormMiddleware,
   teamMembersFormMiddleware,
@@ -170,5 +171,7 @@ router
     interactions.edit.editPostInteractionHandler,
     interactions.edit.editGetInteractionHandler
   )
+
+router.post('/:id/change-project-stage', projectStageFormMiddleware.handleFormPost)
 
 module.exports = router

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -28,6 +28,23 @@
 {% endblock %}
 
 {% block main_grid_right_column %}
+  {% call Form({
+    buttonText: 'Move to ' + investmentStatus.nextStage.name + ' stage',
+    action: 'change-project-stage',
+    class: 'flash flash--info',
+    disableFormActions: true if not investmentStatus.currentStage.isComplete,
+    hiddenFields: {
+      next_project_stage: investmentStatus.nextStage.id
+    }
+  }) %}
+    <p>
+      {% if investmentStatus.currentStage.isComplete %}
+        You have added all required information to complete this stage.
+        {% else %}
+        Complete this stage to move to the {{ investmentStatus.nextStage.name }} stage.
+      {% endif %}
+    </p>
+  {% endcall %}
 {% endblock %}
 
 {% block main_grid_left_column %}

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -79,6 +79,7 @@ const metadataItems = [
   ['referral-source-website', 'referralSourceWebsiteOptions'],
   ['investment-business-activity', 'businessActivityOptions'],
   ['investment-type', 'investmentTypeOptions'],
+  ['investment-project-stage', 'investmentProjectStage'],
   ['fdi-type', 'fdiOptions'],
   ['non-fdi-type', 'nonFdiOptions'],
   ['salary-range', 'salaryRangeOptions'],


### PR DESCRIPTION
Add the ability to move to the next Investment project stage once all qualifications have been met

Multipart PR, part of base branch`feature/investment-project-stages` and PR #395

### Project stage progress component
![move-stage](https://user-images.githubusercontent.com/2305016/29043352-b9f8a0e0-7bb2-11e7-855e-153c0a1e9b75.gif)


### Error state
Of note this is a total edge case and in the gif I have had to manipulate the api flags.
If for whatever reason the flags are incorrect and the user tries to move stage and can't they will be met with this flash error. **very unlikely to happen but is covered if it does**

![move-stage-error](https://user-images.githubusercontent.com/2305016/29043434-15cdac58-7bb3-11e7-9afc-b6881f6ce9da.gif)


