### PR TITLE
Fix issue with disappearing text in select box in Firefox

### DIFF
--- a/assets/stylesheets/components/form/_form-control.scss
+++ b/assets/stylesheets/components/form/_form-control.scss
@@ -42,10 +42,6 @@ select.c-form-control {
   background-size: .8em;
   padding-right: $default-spacing-unit * 2;
 
-  &:-moz-focusring {
-    color: transparent;
-  }
-
   &::-ms-expand {
     display: none;
   }


### PR DESCRIPTION
Remove focusring style overides in Firefox which was there to remove the dotted line around select focus. It was also making text transparent in Firefox when select box was focused before it was opened.

### Before
![image](https://user-images.githubusercontent.com/203886/29069340-7f8b6a2a-7c32-11e7-95c5-3b091d1e97a2.png)

### After
![image](https://user-images.githubusercontent.com/203886/29069322-6906d578-7c32-11e7-9f33-23d7ed2ba3b1.png)