### PR TITLE
Avoid changing window location when not needed

### DIFF
--- a/assets/javascripts/lib/xhr.js
+++ b/assets/javascripts/lib/xhr.js
@@ -8,7 +8,7 @@ history.listen((location, action) => {
   if (action === 'POP') {
     if (location.state) {
       XHR.injectResponseInHtml(location.state.data)
-    } else {
+    } else if (window.location.pathname !== location.pathname && window.location.search !== location.search) {
       window.location.href = location.pathname + location.search
     }
   }


### PR DESCRIPTION
The module was changing window location every time any part of it was updated which caused page refresh on fragment update (e.g. focus on error field).