### PR TITLE
Fallback on <label> element for label for FormGroup macro

### DIFF
--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -193,7 +193,7 @@
  #}
 {% macro FormGroup(props) %}
   {% set groupElement = props.element or 'div' %}
-  {% set labelElement = 'label' if groupElement == 'div' else 'legend' %}
+  {% set labelElement = 'legend' if groupElement == 'fieldset' else 'label' %}
   {% set isLabelHidden = props.isLabelHidden | default(false) %}
   {% set isConditional = props.condition %}
   {% set modifier = props.modifier | concat('') | reverse | join(' c-form-group--') if props.modifier %}


### PR DESCRIPTION
It currently checks for a `<div>` as the form group element and if not it uses a `<legend>` for the label element.

`<label>` feels like a better default and would still be used if the wrapper was a `<p>` for example.

`<legend>` is only permitted within a `<fieldset>` so checking for fieldset first feels a better choice.