### PR TITLE
Ability to add multiple ITAs to an OMIS order during creation

### DIFF
--- a/src/apps/omis/apps/create/controllers/assign-ita.js
+++ b/src/apps/omis/apps/create/controllers/assign-ita.js
@@ -1,4 +1,4 @@
-const { sortBy } = require('lodash')
+const { filter, flatten, forEach, sortBy } = require('lodash')
 
 const { FormController } = require('../../../controllers')
 const { getAdvisers } = require('../../../../adviser/repos')
@@ -11,6 +11,44 @@ class AssignItaController extends FormController {
 
     req.form.options.fields.ita.options = sortBy(options, 'label')
     super.configure(req, res, next)
+  }
+
+  process (req, res, next) {
+    const addKey = req.body['add-item']
+    const removeKey = req.body['remove-item']
+
+    if (addKey || removeKey) {
+      if (addKey) {
+        req.form.values[addKey] = flatten([req.form.values[addKey]])
+        // add empty value to array to show add a new add adviser input
+        req.form.values[addKey].push('')
+      }
+
+      if (removeKey) {
+        const [ key, index ] = removeKey.split('::')
+        req.form.values[key].splice(index, 1)
+      }
+
+      return this.saveValues(req, res, () => {
+        res.redirect(req.baseUrl + req.path)
+      })
+    }
+
+    next()
+  }
+
+  saveValues (req, res, next) {
+    if (!req.body['add-item'] && !req.body['remove-item']) {
+      const fields = req.form.options.fields
+
+      forEach(fields, (options, key) => {
+        if (options.repeatable) {
+          req.form.values[key] = filter(flatten([req.form.values[key]]))
+        }
+      })
+    }
+
+    super.saveValues(req, res, next)
   }
 }
 

--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -1,6 +1,7 @@
-const { find, unset } = require('lodash')
+const { filter, find, get, unset } = require('lodash')
 
 const metadataRepo = require('../../../../../lib/metadata')
+const { transformIdToObject } = require('../../../../transformers')
 const { FormController } = require('../../../controllers')
 const { getAdvisers } = require('../../../../adviser/repos')
 const { Order } = require('../../../models')
@@ -16,7 +17,10 @@ class ConfirmController extends FormController {
       values.contact = `${contact.first_name} ${contact.last_name}`
       values.company = company
       values.primary_market = find(metadataRepo.countryOptions, { id: values.primary_market })
-      values.ita = find(advisers.results, { id: values.ita })
+      values.ita = filter(values.ita).map((id) => {
+        const adviser = find(advisers.results, { id })
+        return get(adviser, 'name')
+      })
 
       next(err, values)
     })
@@ -24,6 +28,7 @@ class ConfirmController extends FormController {
 
   async successHandler (req, res, next) {
     const data = req.sessionModel.toJSON()
+    const subscribers = data.ita.map(transformIdToObject)
 
     // clean un-needed properties
     unset(data, 'csrf-secret')
@@ -31,6 +36,8 @@ class ConfirmController extends FormController {
 
     try {
       const order = await Order.save(req.session.token, data)
+
+      await Order.saveSubscribers(req.session.token, order.id, subscribers)
 
       req.journeyModel.reset()
       req.journeyModel.destroy()

--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -30,10 +30,10 @@
     </table>
 
     <table class="c-answers-summary">
-      <caption class="c-answers-summary__heading">Team</caption>
+      <caption class="c-answers-summary__heading">International Trade Advisers (ITAs)</caption>
       <tr>
-        <th class="c-answers-summary__title" scope="row">ITA</th>
-        <td class="c-answers-summary__content">{{ values.ita.name if values.ita else 'Not selected' }}</td>
+        <th class="c-answers-summary__title" scope="row">Advisers</th>
+        <td class="c-answers-summary__content">{{ values.ita | join(", ") if values.ita.length else 'Not added at this stage' }}</td>
         <td class="c-answers-summary__control"><a class="button button-secondary" href="assign-ita/edit">Change</a></td>
       </tr>
     </table>

--- a/src/apps/omis/fields.js
+++ b/src/apps/omis/fields.js
@@ -21,9 +21,11 @@ module.exports = {
   },
   ita: {
     fieldType: 'MultipleChoiceField',
+    legend: 'fields.ita.legend',
     label: 'fields.ita.label',
-    hint: 'fields.ita.hint',
+    addButtonText: 'fields.ita.addButtonText',
     optional: true,
+    repeatable: true,
     initialOption: '-- Select adviser --',
     options: [],
   },

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -9,13 +9,15 @@
       "hint": "The market which should be providing the service"
     },
     "ita": {
-      "label": "International Trade Adviser",
-      "hint": "The ITA responsible for overseeing the work from a UK region"
+      "legend": "International Trade Advisers (ITAs)",
+      "hint": "The adviser(s) responsible for overseeing the work from a UK region",
+      "addButtonText": "Add another adviser",
+      "label": "Adviser"
     }
   },
   "validation": {
     "required": "cannot not be blank",
     "numeric": "can only contain numbers",
-    "default": "question is required"
+    "default": "is required"
   }
 }

--- a/src/apps/omis/models.js
+++ b/src/apps/omis/models.js
@@ -18,6 +18,14 @@ const Order = {
     })
   },
 
+  saveSubscribers (token, id, body) {
+    return authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/omis/order/${id}/subscriber-list`,
+      method: 'PUT',
+      body,
+    })
+  },
+
   getById (token, id) {
     return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}`)
   },

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -22,6 +22,12 @@ function transformContactToOption ({ id, first_name, last_name }) {
   }
 }
 
+function transformIdToObject (id) {
+  return {
+    id,
+  }
+}
+
 /**
  * Utility to build an object from a transformed metadata array of objects so you can reference properties
  * by key rather than array index. Helpful when the array length changes.
@@ -38,4 +44,5 @@ module.exports = {
   transformObjectToOption,
   transformStringToOption,
   transformContactToOption,
+  transformIdToObject,
 }

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -10,7 +10,7 @@
 {% from "_macros/_deprecated/trade-elements/textbox.njk" import textbox %}
 
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
-{% from "_macros/form.njk" import Fieldset, TextField, MultipleChoiceField, HiddenField, DateFieldset %}
+{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, MultipleChoiceField, HiddenField, DateFieldset %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Pagination, LocalNav, Progress %}
 {% from "_macros/results.njk" import Results, ResultsFilters %}

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -15,15 +15,54 @@
     })) %}
 
       {% block fields %}
-        {% for key, props in options.fields %}
+        {% for key, fieldOptions in options.fields %}
+          {% set props = {} | assign(fieldOptions, {
+            name: key,
+            label: translate(fieldOptions.label),
+            hint: translate(fieldOptions.hint),
+            value: values[key],
+            error: errors[key].message
+          }) %}
+
           {% if props.fieldType %}
-            {{ callAsMacro(props.fieldType)(props | assign({
-              name: key,
-              label: translate(props.label),
-              hint: translate(props.hint),
-              value: values[key],
-              error: errors[key].message
-            })) }}
+            {% if props.repeatable %}
+              {% set fieldValues = values[key] if values[key].length else [''] %}
+              {% set addButtonText = props.addButtonText or 'Add another' %}
+              {% set removeButtonText = props.removeButtonText or 'Remove' %}
+
+              {% call FormGroup({} | assign(props, {
+                element: 'fieldset',
+                label: translate(props.legend)
+              })) %}
+                {% for value in fieldValues %}
+                  {% set removeButton %}
+                    {% if loop.length > 1 %}
+                      <button class="button button--link c-form-group__action" name="remove-item" value="{{ key }}::{{ loop.index0 }}">
+                        {{ translate(removeButtonText) }}
+                      </button>
+                    {% endif %}
+                  {% endset %}
+
+                  {{ callAsMacro(props.fieldType)({} | assign(props, {
+                    idSuffix: loop.index,
+                    value: value,
+                    optional: false,
+                    label: props.label + " " + loop.index,
+                    modifier: 'compact',
+                    isLabelHidden: true,
+                    innerContent: removeButton
+                  })) }}
+                {% endfor %}
+              {% endcall %}
+
+              <p class="c-form-group c-form-group--compact">
+                <button class="button button-secondary" name="add-item" value="{{ key }}">
+                  {{ translate(addButtonText) }}
+                </button>
+              </p>
+            {% else %}
+              {{ callAsMacro(props.fieldType)(props) }}
+            {% endif %}
           {% endif %}
         {% endfor %}
       {% endblock %}

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -27,6 +27,7 @@ describe('OMIS create confirm controller', () => {
     this.nextSpy = this.sandbox.spy()
     this.getAdvisersStub = this.sandbox.stub().resolves(getAdvisersMockData)
     this.orderSaveStub = this.sandbox.stub()
+    this.saveSubscribersStub = this.sandbox.stub()
 
     this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/confirm', {
       '../../../../adviser/repos': {
@@ -38,6 +39,7 @@ describe('OMIS create confirm controller', () => {
       '../../../models': {
         Order: {
           save: this.orderSaveStub,
+          saveSubscribers: this.saveSubscribersStub,
         },
       },
     })
@@ -62,7 +64,7 @@ describe('OMIS create confirm controller', () => {
       this.valuesMock = {
         contact: '1',
         company: 'company-12345',
-        ita: '0513453c-86bc-e211-a646-e4115bead28a',
+        ita: ['0513453c-86bc-e211-a646-e4115bead28a'],
         primary_market: '2',
       }
     })
@@ -85,7 +87,7 @@ describe('OMIS create confirm controller', () => {
               },
               contact: 'Fred Stevens',
               primary_market: metadataCountryMockData[1],
-              ita: getAdvisersMockData.results[0],
+              ita: [getAdvisersMockData.results[0].name],
             })
             done()
           } catch (err) {
@@ -112,6 +114,7 @@ describe('OMIS create confirm controller', () => {
             errors: {},
             foo: 'bar',
             fizz: 'buzz',
+            ita: ['12345', '67890'],
           }),
           reset: this.resetSpy,
           destroy: this.destroySpy,
@@ -126,6 +129,7 @@ describe('OMIS create confirm controller', () => {
     describe('when the order save was successful', () => {
       beforeEach(() => {
         this.orderSaveStub.resolves(saveMockData)
+        this.saveSubscribersStub.resolves([])
       })
 
       it('should save an order', (done) => {
@@ -135,7 +139,12 @@ describe('OMIS create confirm controller', () => {
               expect(this.orderSaveStub).to.have.been.calledWith('token-12345', {
                 foo: 'bar',
                 fizz: 'buzz',
+                ita: ['12345', '67890'],
               })
+              expect(this.saveSubscribersStub).to.have.been.calledWith('token-12345', '1234567890', [
+                { id: '12345' },
+                { id: '67890' },
+              ])
               expect(this.resetSpy).to.have.been.calledTwice
               expect(this.destroySpy).to.have.been.calledTwice
               expect(this.nextSpy).not.to.have.been.called

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -41,4 +41,14 @@ describe('Global transformers', () => {
       })
     })
   })
+
+  describe('transformIdToObject()', () => {
+    it('should return an object with id', () => {
+      const option = transformers.transformIdToObject('123456')
+
+      expect(option).to.deep.equal({
+        id: '123456',
+      })
+    })
+  })
 })


### PR DESCRIPTION
This adds the ability to add multiple ITAs to an OMIS order.

It's tries to create a generic _add another_ functionality for the form wizard that could be replicated elsewhere.

👉  [DEMO](https://datahub-beta2-pr-436.herokuapp.com/omis/create/dcdabbc9-1781-e411-8955-e4115bead28a) 👈 

## What it looks like

![add-another](https://user-images.githubusercontent.com/3327997/29215683-d9ec08c6-7ea3-11e7-9d64-47fbf703e982.gif)
