### PR TITLE
[DH-419] Fix error displaying company interactions page for some companies

### DIFF
--- a/src/apps/interactions/services/formatting.js
+++ b/src/apps/interactions/services/formatting.js
@@ -36,12 +36,13 @@ function getDisplayInteraction (interaction) {
  * @returns {Object} A formatted service delivery or interaction
  */
 function getDisplayCompanyInteraction (interaction) {
-  const type = (interaction.interaction_type.name === 'Service delivery') ? 'service-deliveries' : 'interactions'
+  const interactionType = get(interaction, 'interaction_type.name')
+  const entityType = (interactionType === 'Service delivery') ? 'service-deliveries' : 'interactions'
 
   const result = {
     id: interaction.id,
-    url: `/${type}/${interaction.id}`,
-    interaction_type: interaction.interaction_type.name,
+    url: `/${entityType}/${interaction.id}`,
+    interaction_type: interactionType,
     subject: interaction.subject,
     date: formatMediumDate(interaction.date),
     adviser: getPropertyName(interaction, 'dit_adviser'),

--- a/test/unit/apps/interactions/services/formatting.service.test.js
+++ b/test/unit/apps/interactions/services/formatting.service.test.js
@@ -41,6 +41,24 @@ describe('Interaction formatting service', function () {
       const actualDisplayInteraction = interactionFormattingService.getDisplayCompanyInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
     })
+    it('handles missing interaction types', () => {
+      interaction.interaction_type = null
+      const expectedDisplayInteraction = {
+        id: '22651151-2149-465e-871b-ac45bc568a62',
+        url: '/interactions/22651151-2149-465e-871b-ac45bc568a62',
+        interaction_type: undefined,
+        subject: 'Subject 1234',
+        date: '14 Feb 2017',
+        adviser: 'John Brown',
+        contact: '<a href="/contacts/444">Fred Smith</a>',
+        service: 'service name',
+        notes: 'Here are some notes<br/>line 2.',
+        dit_team: 'team name',
+      }
+      const actualDisplayInteraction = interactionFormattingService.getDisplayCompanyInteraction(interaction)
+
+      expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
+    })
     it('should handle a missing adviser', function () {
       interaction.dit_adviser = null
       const expectedDisplayInteraction = {


### PR DESCRIPTION
Fixes the 500 error on the company interactions page when there are interactions with a null interaction_type.