### PR TITLE
Fix focus outline with highlight utility

### DIFF
--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -30,6 +30,10 @@
     position: relative;
     z-index: -1;
   }
+
+  :focus .u-highlight {
+    position: static;
+  }
 }
 
 .main-content__inner {


### PR DESCRIPTION
When the highlight element was given `position: relative` it was causing the box-shadow outline on elements that have a focus state to jump out of position.

## Before

![image](https://user-images.githubusercontent.com/3327997/29177668-2b57831a-7de7-11e7-816d-27537e058f22.png)

## After

![image](https://user-images.githubusercontent.com/3327997/29177647-2093eac2-7de7-11e7-86bf-8aa3606afe7b.png)
