### PR TITLE
Form macro/element updates

### DIFF
--- a/assets/stylesheets/_deprecated/_shame.scss
+++ b/assets/stylesheets/_deprecated/_shame.scss
@@ -93,15 +93,6 @@
   }
 }
 
-.button--link {
-  background-color: $white;
-  border: 0;
-  color: $link-colour;
-  cursor: pointer;
-  text-decoration: underline;
-  margin-left: 0;
-}
-
 .js-enabled .block-label.selection-button-radio,
 .js-enabled .block-label.selection-button-checkbox {
   &::before,

--- a/assets/stylesheets/_deprecated/components/_button.scss
+++ b/assets/stylesheets/_deprecated/components/_button.scss
@@ -22,3 +22,26 @@
   clear: both;
   margin: 30px 0;
 }
+
+.button--link {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  color: $link-colour;
+  cursor: pointer;
+  padding: .4em 0;
+  text-align: left;
+  text-decoration: underline;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background: transparent;
+    color: $link-colour;
+    top: 0;
+  }
+
+  &:hover {
+    color: $link-hover-colour;
+  }
+}

--- a/assets/stylesheets/components/form/_form-group.scss
+++ b/assets/stylesheets/components/form/_form-group.scss
@@ -1,4 +1,5 @@
 @import "../../tools";
+@import "../../settings";
 
 .c-form-group {
   max-width: 40em;
@@ -36,6 +37,15 @@
   color: $error-colour;
   font-weight: 600;
   display: block;
+}
+
+.c-form-group__action {
+  @include media(desktop) {
+    position: absolute;
+    left: 100%;
+    margin-left: $default-spacing-unit;
+    top: 0;
+  }
 }
 
 // States

--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -12,6 +12,10 @@
     margin-top: $default-spacing-unit * 2;
   }
 
+  .c-form-group--compact {
+    margin-top: $default-spacing-unit;
+  }
+
   .c-multiple-choice {
     margin-top: $default-spacing-unit / 2;
   }

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -313,4 +313,48 @@
     {% endcall %}
   {% endcall %}
 
+  {% call Example('Fields with actions') %}
+    {% set removeButton %}
+      <button class="button button--link c-form-group__action">Remove</button>
+    {% endset %}
+
+    {% call Form(form) %}
+      {{ MultipleChoiceField({
+        name: 'averageSalary-light',
+        label: 'Average salary range',
+        options: form.options.averageSalaryRange,
+        error: form.errors.messages.averageSalaryLight,
+        selected: form.state.averageSalaryLight,
+        innerContent: removeButton
+      }) }}
+
+      {{ MultipleChoiceField({
+        name: 'averageSalary-light',
+        label: 'Average salary range',
+        options: form.options.averageSalaryRange,
+        error: form.errors.messages.averageSalaryLight,
+        selected: form.state.averageSalaryLight,
+        innerContent: removeButton
+      }) }}
+
+      {{ TextField({
+        name: 'name-small',
+        label: 'Company name',
+        placeholder: 'e.g. Hooli',
+        error: form.errors.messages.name,
+        value: form.state.name,
+        innerContent: removeButton
+      }) }}
+
+      {{ TextField({
+        name: 'name-small',
+        label: 'Company name',
+        placeholder: 'e.g. Hooli',
+        error: form.errors.messages.name,
+        value: form.state.name,
+        innerContent: removeButton
+      }) }}
+    {% endcall %}
+  {% endcall %}
+
 {% endblock %}

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -278,4 +278,39 @@
     {% endcall %}
   {% endcall %}
 
+  {% call Example('Compact version') %}
+    {% call Form(form) %}
+      {{ TextField({
+        name: 'name-small',
+        label: 'Company name',
+        placeholder: 'e.g. Hooli',
+        error: form.errors.messages.name,
+        value: form.state.name,
+        modifier: 'compact'
+      }) }}
+
+      {{ MultipleChoiceField({
+          type: 'radio',
+          name: 'gender',
+          label: 'Gender',
+          initialOption: 'Unspecified',
+          options: [
+            { label: 'Male' },
+            { label: 'Female' }
+          ],
+          selected: form.state.gender,
+          modifier: 'compact'
+      }) }}
+
+      {{ MultipleChoiceField({
+          name: 'averageSalary-light',
+          label: 'Average salary range',
+          options: form.options.averageSalaryRange,
+          error: form.errors.messages.averageSalaryLight,
+          selected: form.state.averageSalaryLight,
+          modifier: 'compact'
+      }) }}
+    {% endcall %}
+  {% endcall %}
+
 {% endblock %}

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -138,7 +138,7 @@
     fieldModifier: props.fieldModifier
   })) %}
 
-    {% call TextField({
+    {{ TextField({
       type: 'search',
       inputClass: 'c-entity-search__input',
       name: props.inputName,
@@ -147,10 +147,9 @@
       label: props.inputLabel,
       placeholder: props.inputPlaceholder,
       isLabelHidden: props.isLabelHidden,
-      modifier: props.fieldModifier
-    }) %}
-      <button class="c-entity-search__button">Search</button>
-    {% endcall %}
+      modifier: props.fieldModifier,
+      innerContent: '<button class="c-entity-search__button">Search</button>'
+    }) }}
 
     {% if props.aggregations|length %}
       <nav class="c-entity-search__aggregations" aria-label="search results aggregation options">
@@ -230,7 +229,7 @@
 
       <div class="c-form-group__inner">
         {{ caller() }}
-        {{ props.innerContent }}
+        {{ props.innerContent | safe }}
       </div>
     </{{ groupElement }}>
   {%- endif %}
@@ -289,9 +288,8 @@
  #}
 {% macro TextField(props) %}
   {% set fieldId = 'field-' + props.name + ('-' + props.idSuffix if props.idSuffix) if props.name %}
-  {% set innerContent = caller() if caller else null %}
 
-  {% call FormGroup(props | assign({ fieldId: fieldId, modifier: props.modifier, innerContent: innerContent, class: props.groupClass })) %}
+  {% call FormGroup(props | assign({ fieldId: fieldId, modifier: props.modifier, class: props.groupClass })) %}
     {% if props.type === 'textarea' %}
       {{ TextArea(props | assign({ class: props.inputClass })) }}
     {% else %}


### PR DESCRIPTION
This PR extracts a few updates that will be needed for the _add another_ functionality being added to the OMIS form wizard. In summary:

- Tweak link modifier on `button` component
- Add a [compact style](https://datahub-beta2-pr-441.herokuapp.com/components/form#Compact%20version) as a modifier to `.form-group`
- Support for an [action to be attached](https://datahub-beta2-pr-441.herokuapp.com/components/form#Fields%20with%20actions) to a `.form-group`