### PR TITLE
Move middleware for redirecting to default query to generic

### DIFF
--- a/src/apps/investment-projects/middleware/collection.js
+++ b/src/apps/investment-projects/middleware/collection.js
@@ -1,5 +1,4 @@
-const { pick, isEmpty, pickBy } = require('lodash')
-const queryString = require('query-string')
+const { pick, pickBy } = require('lodash')
 
 const { buildPagination } = require('../../../lib/pagination')
 const { searchInvestmentProjects } = require('../../search/services')
@@ -7,20 +6,6 @@ const {
   transformInvestmentProjectToListItem,
   transformInvestmentListItemToHaveMetaLinks,
 } = require('../transformers')
-
-function handleDefaultFilters (req, res, next) {
-  const currentYear = (new Date()).getFullYear()
-  const defaultQuery = {
-    estimated_land_date_after: `${currentYear}-04-05`,
-    estimated_land_date_before: `${currentYear + 1}-04-06`,
-  }
-
-  if (isEmpty(req.query)) {
-    return res.redirect(`${req.baseUrl}?${queryString.stringify(defaultQuery)}`)
-  }
-
-  next()
-}
 
 async function getInvestmentProjectsCollection (req, res, next) {
   const page = parseInt(req.query.page, 10) || 1
@@ -67,7 +52,6 @@ function getRequestBody (req, res, next) {
 }
 
 module.exports = {
-  handleDefaultFilters,
   getRequestBody,
   getInvestmentProjectsCollection,
 }

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const { setLocalNav, redirectToFirstNavItem } = require('../middleware')
+const { setLocalNav, setDefaultQuery, redirectToFirstNavItem } = require('../middleware')
 const { shared } = require('./middleware')
 const {
   getBriefInvestmentSummary,
@@ -27,7 +27,7 @@ const projectManagementFormMiddleware = require('./middleware/forms/project-mana
 const clientRelationshipManagementFormMiddleware = require('./middleware/forms/client-relationship-management')
 const teamMembersFormMiddleware = require('./middleware/forms/team-members')
 const { renderInvestmentList } = require('./controllers/list')
-const { handleDefaultFilters, getInvestmentProjectsCollection, getRequestBody } = require('./middleware/collection')
+const { getInvestmentProjectsCollection, getRequestBody } = require('./middleware/collection')
 
 const LOCAL_NAV = [
   { path: 'details', label: 'Project details' },
@@ -37,12 +37,18 @@ const LOCAL_NAV = [
   { path: 'audit', label: 'Audit history' },
 ]
 
+const currentYear = (new Date()).getFullYear()
+const DEFAULT_COLLECTION_QUERY = {
+  estimated_land_date_after: `${currentYear}-04-05`,
+  estimated_land_date_before: `${currentYear + 1}-04-06`,
+}
+
 router.use('/:id/', setLocalNav(LOCAL_NAV))
 
 router.param('id', shared.getInvestmentDetails)
 router.param('interactionId', shared.getInteractionDetails)
 
-router.get('/', handleDefaultFilters, getRequestBody, getInvestmentProjectsCollection, renderInvestmentList)
+router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getRequestBody, getInvestmentProjectsCollection, renderInvestmentList)
 
 router.post('/:id/details', archive.archiveInvestmentProjectHandler, details.detailsGetHandler)
 router.get('/:id/unarchive', archive.unarchiveInvestmentProjectHandler)

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -1,4 +1,6 @@
 const path = require('path')
+const { isEmpty } = require('lodash')
+const queryString = require('query-string')
 
 function setHomeBreadcrumb (name) {
   return function (req, res, next) {
@@ -25,6 +27,15 @@ function setLocalNav (items = []) {
   }
 }
 
+function setDefaultQuery (query = {}) {
+  return function handleDefaultRedirect (req, res, next) {
+    if (isEmpty(req.query)) {
+      return res.redirect(`${req.baseUrl}?${queryString.stringify(query)}`)
+    }
+    next()
+  }
+}
+
 function redirectToFirstNavItem (req, res) {
   return res.redirect(res.locals.localNavItems[0].url)
 }
@@ -33,4 +44,5 @@ module.exports = {
   setHomeBreadcrumb,
   setLocalNav,
   redirectToFirstNavItem,
+  setDefaultQuery,
 }

--- a/test/unit/apps/investment-projects/middleware/collection.test.js
+++ b/test/unit/apps/investment-projects/middleware/collection.test.js
@@ -22,30 +22,6 @@ describe('Investment projects collection middleware', () => {
     this.sandbox.restore()
   })
 
-  describe('#handleDefaultFilters', () => {
-    it('should redirect to url with default query string when initial query is empty', () => {
-      const resMock = {
-        redirect: this.sandbox.spy(),
-      }
-      const currentYear = (new Date()).getFullYear()
-
-      this.controller.handleDefaultFilters(this.req, resMock, this.next)
-
-      expect(resMock.redirect).to.be.calledWith(`/?estimated_land_date_after=${currentYear}-04-05&estimated_land_date_before=${currentYear + 1}-04-06`)
-      expect(this.next).to.not.be.called
-    })
-
-    it('should redirect to url with default query string when initial query is empty', () => {
-      this.req.query = {
-        stage: 'i1',
-        sector: 's1',
-      }
-      this.controller.handleDefaultFilters(this.req, this.res, this.next)
-
-      expect(this.next).to.be.called
-    })
-  })
-
   describe('#getInvestmentProjectsCollection', () => {
     beforeEach(async () => {
       this.req.query = {

--- a/test/unit/apps/middleware.test.js
+++ b/test/unit/apps/middleware.test.js
@@ -77,4 +77,43 @@ describe('Apps middleware', () => {
       expect(redirectMock).to.have.been.calledWith('/base-url/first')
     })
   })
+
+  describe('setDefaultQuery()', () => {
+    beforeEach(() => {
+      this.resMock = {
+        redirect: this.sandbox.spy(),
+      }
+    })
+
+    it('should redirect to default query if initial query is empty', () => {
+      const reqMock = {
+        query: {},
+        baseUrl: '/sub-app',
+      }
+      this.middleware.setDefaultQuery({
+        filter: 'apple',
+        sortby: 'sweetness',
+      })(reqMock, this.resMock, this.nextSpy)
+
+      expect(this.nextSpy).to.not.have.been.called
+      expect(this.resMock.redirect).to.be.calledWith('/sub-app?filter=apple&sortby=sweetness')
+    })
+
+    it('should not redirect if query contains properties', () => {
+      const reqMock = {
+        query: {
+          filter: 'pear',
+        },
+        baseUrl: '/sub-app',
+      }
+
+      this.middleware.setDefaultQuery({
+        filter: 'apple',
+        sortby: 'sweetness',
+      })(reqMock, this.resMock, this.nextSpy)
+
+      expect(this.nextSpy).to.have.been.called
+      expect(this.resMock.redirect).to.not.have.been.called
+    })
+  })
 })


### PR DESCRIPTION
The middleware used to redirect to a given default query string if no query
is set can be generic enough to be used in different parts of application.