### PR TITLE
Rename form prop and add disableFormAction prop

### DIFF
--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -37,7 +37,7 @@
     buttonText: 'Move to ' + investmentStatus.nextStage.name + ' stage',
     action: 'change-project-stage',
     class: 'flash flash--info',
-    disableFormActions: true if not investmentStatus.currentStage.isComplete,
+    disableFormAction: true if not investmentStatus.currentStage.isComplete,
     hiddenFields: {
       next_project_stage: investmentStatus.nextStage.id
     }

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -31,7 +31,8 @@
  # @param {string} [props.action] - Form action url
  # @param {object} [props.errors] - Object containing form errors
  # @param {object} [props.hiddenFields] - Custom fields to be added as hidden inputs
- # @param {boolean} [props.disableFormActions] - Avoid rendering form actions
+ # @param {boolean} [props.hideFormActions] - Hide form actions
+ # @param {boolean} [props.disableFormAction] - Disable form submit button
  # @param {string} [props.class] - Form class name
  # @param {string} [props.role] - Form role attribute value
  # @param {string} [props.actionsClass] - Custom class name for actions container
@@ -45,6 +46,7 @@
   {% set method = props.method or 'POST' -%}
   {% set buttonText = props.buttonText or 'Submit' %}
   {% set returnText = props.returnText or 'Back' %}
+  {% set hideFormActions = props.hideFormActions or false %}
 
   <form
     method="{{ method }}"
@@ -72,9 +74,9 @@
 
     {{ caller() }}
 
-    {% if not props.disableFormActions %}
+    {% if not hideFormActions %}
       <div class="c-form-group c-form-group--actions {{ props.actionsClass }}">
-        <button class="button">{{ buttonText }}</button>
+        <button class="button" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
         {% if props.returnLink %}
           <p><a href="{{ props.returnLink }}">{{ returnText }}</a></p>
         {% endif %}
@@ -130,7 +132,7 @@
     class: 'c-entity-search ' + modifier,
     role: 'search',
     method: method,
-    disableFormActions: true,
+    hideFormActions: true,
     inputName: inputName,
     inputPlaceholder: inputPlaceholder,
     isLabelHidden: isLabelHidden,

--- a/src/templates/_macros/results.njk
+++ b/src/templates/_macros/results.njk
@@ -130,7 +130,7 @@
           {% call Form({
             method: 'get',
             class: 'c-results__sort-form js-AutoSubmit',
-            disableFormActions: true,
+            hideFormActions: true,
             hiddenFields: selectedFilters | assign({ custom: true })
           }) %}
             {{ MultipleChoiceField({

--- a/test/unit/macros/form.test.js
+++ b/test/unit/macros/form.test.js
@@ -57,7 +57,7 @@ describe('Nunjucks form macros', () => {
 
       it('should render form without submit button', () => {
         const formProps = {
-          disableFormActions: true,
+          hideFormActions: true,
         }
         const component = macros.renderWithCallerToDom('Form', formProps)(
           macros.renderToDom('TextField')


### PR DESCRIPTION
This work:
- Renames `disableFormActions` form prop to `hideFormActions` form prop to align more with what it is doing
- Add `disableFormAction` prop to add `disabled` attribute to form action
- This resolves #439 

### Example disabled form button
![screen shot 2017-08-11 at 14 54 37](https://user-images.githubusercontent.com/2305016/29216073-4a5d6df6-7ea5-11e7-815e-afa99fe0cffd.png)
