### PR TITLE
Use Sentry for error reporting in Node.js layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This file expects the following environment variables:
 | ZEN_BROWSER | Zendesk browser ID |
 | ZEN_IMPACT | Zendesk impact ID |
 | ZEN_SERVICE | Zendesk service ID |
+| SENTRY_DSN | Sentry DSN (optional) |
 | WEBPACK_ENV | Optionally select the webpack configuration variation to use, the default will correctly pick a production or development config based on NODE_ENV. Valid values include `prod`, `develop` and `docker` |
 
 Either set these variables manually or why not look at [autoenv](https://github.com/kennethreitz/autoenv).

--- a/config/index.js
+++ b/config/index.js
@@ -41,6 +41,7 @@ const config = {
   zenBrowser: process.env.ZEN_BROWSER,
   zenImpact: process.env.ZEN_IMPACT,
   zenService: process.env.ZEN_SERVICE,
+  sentryDsn: process.env.SENTRY_DSN,
   longDateFormat: 'D MMMM YYYY',
   mediumDateFormat: 'D MMM YYYY',
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "postcss-loader": "^2.0.6",
     "proxyquire": "^1.7.10",
     "query-string": "^5.0.0",
+    "raven": "^2.1.1",
     "reqres": "^1.3.0",
     "request": "^2.74.0",
     "request-promise": "^4.1.1",

--- a/sample.env
+++ b/sample.env
@@ -21,3 +21,6 @@ QA_USER_PASSWORD=
 QA_SELENIUM_PORT=4444
 QA_SELENIUM_HOST=127.0.0.1
 QA_HOST=http://localhost:3000
+
+# Not used for local development
+SENTRY_DSN=

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ const bodyParser = require('body-parser')
 const compression = require('compression')
 const config = require('../config')
 const express = require('express')
+const raven = require('raven')
 const flash = require('connect-flash')
 const csrf = require('csurf')
 const slashify = require('slashify')
@@ -32,6 +33,19 @@ const routers = require('./apps/routers')
 const app = express()
 
 app.disable('x-powered-by')
+
+if (config.sentryDsn) {
+  logger.info('Sentry DSN detected. Raven will be enabled.')
+  // See https://docs.sentry.io/clients/node/config/
+  // and https://docs.sentry.io/clients/node/usage/
+  // for info on Raven config options
+  raven.config(config.sentryDsn, {
+    autoBreadcrumbs: true,
+    captureUnhandledRejections: true,
+  }).install()
+  // Raven request handler must be the first middleware
+  app.use(raven.requestHandler())
+}
 
 if (!config.ci) {
   app.use(churchill(logger))
@@ -79,6 +93,11 @@ app.use(store())
 // routing
 app.use(slashify())
 app.use(routers)
+
+// Raven error handler must come before other error middleware
+if (config.sentryDsn) {
+  app.use(raven.errorHandler())
+}
 
 app.use(errors.notFound)
 app.use(errors.catchAll)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4782,7 +4782,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -5306,6 +5306,10 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lsmod@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
 
 macaddress@^0.2.8:
   version "0.2.8"
@@ -6883,6 +6887,17 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/raven/-/raven-2.1.1.tgz#b3a974c6c29315c677c079e168435ead196525cd"
+  dependencies:
+    cookie "0.3.1"
+    json-stringify-safe "5.0.1"
+    lsmod "1.0.0"
+    stack-trace "0.0.9"
+    timed-out "4.0.1"
+    uuid "3.0.0"
+
 raw-body@2, raw-body@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"
@@ -7902,6 +7917,10 @@ stack-generator@^2.0.1:
   dependencies:
     stackframe "^1.0.3"
 
+stack-trace@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
+
 stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
@@ -8305,13 +8324,13 @@ time-stamp@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
 
+timed-out@4.0.1, timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
 timed-out@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-2.0.0.tgz#f38b0ae81d3747d628001f41dafc652ace671c0a"
-
-timed-out@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timers-browserify@^2.0.2:
   version "2.0.2"
@@ -8649,6 +8668,10 @@ util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
 utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
+
+uuid@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
 uuid@^2.0.1:
   version "2.0.3"


### PR DESCRIPTION
DHE-549

Adds Sentry to Express to report unhandled errors, along the lines of:
https://docs.sentry.io/clients/node/integrations/express/

Technically:
* `if (config.sentryDsn)` isn't required as Raven won't do anything if a DSN isn't configured
* Adding sentryDsn to config/index.js isn't needed as Raven will use the SENTRY_DSN environment variable automatically

Reporting JS errors in the browser should also be looked at, but that can be done separately and isn't as important right now.