### PR TITLE
Update res.locals `trans()` to `translate()`

### DIFF
--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -56,7 +56,7 @@ module.exports = function locals (req, res, next) {
       return res.locals[key]
     },
 
-    trans (key) {
+    translate (key) {
       return req.translate(key)
     },
   })

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -19,8 +19,8 @@
           {% if props.fieldType %}
             {{ callAsMacro(props.fieldType)(props | assign({
               name: key,
-              label: trans(props.label),
-              hint: trans(props.hint),
+              label: translate(props.label),
+              hint: translate(props.hint),
               value: values[key],
               error: errors[key].message
             })) }}


### PR DESCRIPTION
Using `translate()` means it is much clearer to understand what the
function is doing and allows it to be scanned quicker when looking
at the code of a view.