### PR TITLE
Feature/add another js

### DIFF
--- a/assets/javascripts/_deprecated/lib/element-stuff.js
+++ b/assets/javascripts/_deprecated/lib/element-stuff.js
@@ -183,6 +183,29 @@ function regenIds (wrapper) {
     })
 }
 
+function closest (element, selector) {
+  if (!element) {
+    return
+  }
+
+  if (!element.matches) {
+    element.prototype.matches = element.prototype.msMatchesSelector || element.prototype.webkitMatchesSelector
+  }
+
+  let parent
+
+  // traverse parents
+  while (element) {
+    parent = element.parentElement
+    if (parent && parent.matches(selector)) {
+      return parent
+    }
+    element = parent
+  }
+
+  return null
+}
+
 module.exports = {
   addClass,
   removeClass,
@@ -199,4 +222,5 @@ module.exports = {
   toggleVisible,
   regenIds,
   resetFieldValues,
+  closest,
 }

--- a/assets/javascripts/_deprecated/lib/element-stuff.js
+++ b/assets/javascripts/_deprecated/lib/element-stuff.js
@@ -58,13 +58,18 @@ function toggleVisible (element) {
   }
 }
 
-function generateID () {
-  let d = new Date().getTime()
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (d + Math.random() * 16) % 16 | 0
-    d = Math.floor(d / 16)
-    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16)
-  })
+/**
+ * generateId
+ *
+ * Create an ID string unique enough to use as an element ID in a page.
+ * The prefix is required as ID's cannot start with a number or a hyphen
+ *
+ * @param {string} prefix
+ * @returns {string} a unique string to use to indentify an element
+ */
+function generateID (prefix) {
+  const _prefix = (prefix && prefix.length > 0) ? prefix : 'dh'
+  return `${_prefix}-${Math.floor(Math.random() * 1000000) + 1}`
 }
 
 function isNodeList (nodes) {
@@ -119,6 +124,65 @@ function removeElement (element) {
   element.parentNode.removeChild(element)
 }
 
+/**
+ * resetFieldValues
+ *
+ * Scans the content of a dom fragment for fields
+ * and resets their values back to nothing.
+ *
+ * Useful when copying fields to use as new fields
+ *
+ * @param {nodeElement} fragment
+ */
+function resetFieldValues (fragment) {
+  Array
+    .from(fragment.querySelectorAll('option:checked'))
+    .forEach(selectedElement => {
+      selectedElement.selected = false
+    })
+
+  Array
+    .from(fragment.querySelectorAll('input:checked'))
+    .forEach(checkedElement => {
+      checkedElement.checked = false
+    })
+
+  Array
+    .from(fragment.querySelectorAll('input[type="text"], textarea'))
+    .forEach(textField => {
+      textField.value = ''
+    })
+}
+
+/**
+ * regenIds
+ * *
+ * Get all the all the elements in a fragment that have an ID
+ * attribute, generate a new one to replace it and look for related
+ * label tags to update their 'for' attribute
+ *
+ * @param {nodeElement} wrapper
+ *
+ */
+function regenIds (wrapper) {
+  Array
+    .from(wrapper.querySelectorAll('*[id]'))
+    .forEach((element) => {
+      const oldId = element.id
+
+      // If the element has a name, use that as part of the new ID
+      const name = element.name || ''
+      const newId = generateID(name)
+
+      element.id = newId
+
+      const relatedLabel = wrapper.querySelector(`[for="${oldId}"]`)
+      if (relatedLabel) {
+        relatedLabel.setAttribute('for', newId)
+      }
+    })
+}
+
 module.exports = {
   addClass,
   removeClass,
@@ -133,4 +197,6 @@ module.exports = {
   createElementFromMarkup,
   removeElement,
   toggleVisible,
+  regenIds,
+  resetFieldValues,
 }

--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -11,6 +11,7 @@ const Messages = require('./modules/messages')
 const FormErrors = require('./modules/form-errors')
 const AutoSubmit = require('./modules/auto-submit')
 const XhrLink = require('./modules/xhr-link')
+const AddAnotherFragment = require('./modules/add-another-fragment')
 
 const AddAnotherField = require('./_deprecated/add-another-field')
 const CompanyAdd = require('./_deprecated/company-add')
@@ -28,6 +29,7 @@ Messages.init()
 FormErrors.init()
 AutoSubmit.init()
 XhrLink.init()
+AddAnotherFragment.init()
 
 // Deprecated
 AddAnotherField.init()

--- a/assets/javascripts/modules/add-another-fragment.js
+++ b/assets/javascripts/modules/add-another-fragment.js
@@ -1,0 +1,291 @@
+const {
+  insertAfter,
+  resetFieldValues,
+  regenIds,
+  closest,
+  hide,
+  show,
+} = require('../_deprecated/lib/element-stuff')
+
+const wrapperClass = 'js-addanother'
+const defaultAddButtonClass = 'js-addanother__add'
+const defaultRemoveButtonClass = 'js-addanother__remove'
+
+/**
+ * AddAnotherFragment
+ *
+ * Component that scans markup to find elements that require a 'add another' button
+ * The target element defines a selector to define what page fragment should be duplicated
+ * when the user preses add another. The contents of the cloned fragment will have it's fields reset.
+ * The component also inserts a 'remove' button that will allow values to also be removed.
+ *
+ * The selector used to activate the component is 'js-add-another-fragment'
+ *
+ * The element that includes the activation class must also provide data attributes to define
+ * it's behaviour
+ *
+ * data-fragment-selector: The css selector that defines the element to clone.
+ * data-fragment-allow-remove-all: (Optional) By default the component won't let the user delete the last instance
+ *                                 of the defined element. If the user needs to be able to delete all instances
+ *                                 then provide a value 'yes'
+ * data-fragment-add-button-selector: (Optional) By default the component will add a 'add another' button
+ *                                 to the end of the wrapper fragment. If an add button already exists
+ *                                 within the markup then the css selector to that button can be specified.
+ * data-fragment-add-button-text: (Optional) Allow the text for the 'add another' button to be specified
+ * data-fragment-remove-selector: (Optional) If the initial markup includes a remove button then this
+ *                                selector will attach the remove event handler to it intead of adding a button
+ * data-fragment-remove-button-text: (Optional) Allow the text for the 'add another' button to be specified
+ *
+ * e.g.
+ * <div class="js-add-another-fragment" data-fragment-selector=".js-adviser">
+ *   <div class="c-form-group js-adviser">
+ *     <label for="adviser">Adviser</label>
+ *     <select name="adviser">
+ *       <option value="">---Select Adviser--</option>
+ *       ...
+ *     </select>
+ *   </div>
+ * </div>
+ */
+const AddAnotherFragment = {}
+
+AddAnotherFragment.prototype = {
+  /**
+   * init
+   *
+   * Main setup method
+   * Gets params, generates a template for new fragments
+   * and adds and activates add and delete buttons
+   */
+  init () {
+    this.parseProperties()
+    this.lastFragment = this.wrapper.querySelector(`${this.fragmentSelector}:last-of-type`)
+    this.getTemplate()
+    this.addPlaceholder()
+    this.setupAddAndRemoveButtons()
+    this.bindEvents()
+  },
+
+  /**
+   * setupAddAndRemoveButtons
+   *
+   * Parse the content and render additional markup,
+   * or decorate existing markup if required
+   */
+  setupAddAndRemoveButtons () {
+    if (!this.overrideAddButton) {
+      this.insertAddButton()
+    }
+    this.decorateAddButton()
+
+    if (!this.overrideRemoveButton) {
+      this.insertRemoveButtons()
+    }
+    this.decorateRemoveButtons()
+    this.updateRemoveButtonVisibility()
+  },
+
+  /**
+   * parseProperties
+   *
+   * Look at the wrapper element for parameters and properties
+   * that describe the behaviour of the component
+   */
+  parseProperties () {
+    this.fragmentSelector = this.wrapper.getAttribute('data-selector')
+
+    this.allowRemoveAll = this.wrapper.hasAttribute('data-allow-remove-all')
+
+    this.overrideAddButton = this.wrapper.hasAttribute('data-add-button-selector')
+    this.addButtonSelector = this.wrapper.getAttribute('data-add-button-selector') || `.${defaultAddButtonClass} a`
+    this.addText = this.wrapper.getAttribute('data-add-button-text') || 'Add another'
+
+    this.overrideRemoveButton = this.wrapper.hasAttribute('data-remove-button-selector')
+    this.removeButtonSelector = this.wrapper.getAttribute('data-remove-button-selector') || `.${defaultRemoveButtonClass} a`
+    this.removeText = this.wrapper.getAttribute('data-remove-button-text') || 'Remove'
+  },
+
+  /**
+   * addEventListeners
+   *
+   * Attach an event listener to the wrapper
+   * element that waits for the use to click on
+   * the add and remove buttons, and intercept and redirects
+   * those events, so events don't have to be attached to each
+   * link
+   */
+  bindEvents () {
+    this.wrapper.addEventListener('click', this.clickHandler.bind(this))
+  },
+
+  /**
+   * getTemplate
+   *
+   * Takes a copy of a fragment and resets the field values
+   * so it can be used as a blueprint for a new fragment
+   *
+   */
+  getTemplate () {
+    this.templateFragment = this.lastFragment
+    resetFieldValues(this.templateFragment)
+  },
+
+  /**
+   * addPlaceholder
+   *
+   * Insert a placeholder under the last existing fragment,
+   * so new fragments are always inserted in to the corect place
+   * even when adding a new fragment when there are none.
+   */
+  addPlaceholder () {
+    this.placeHolder = this.document.createElement('div')
+    insertAfter(this.placeHolder, this.lastFragment)
+  },
+
+  /**
+   * decorateAddButton
+   *
+   * Adds a data attribute to the add button so the event handler
+   * recognises it is an add button for this component.
+   */
+  decorateAddButton () {
+    const addButton = this.wrapper.querySelector(this.addButtonSelector)
+    if (addButton) {
+      addButton.setAttribute('data-method', 'add')
+    }
+  },
+
+  /**
+   * decorateRemoveButton
+   *
+   * Adds a data attribute to all remove buttons so the event handler
+   * recognises them as a remove button for this component.
+   */
+  decorateRemoveButtons () {
+    Array
+      .from(this.wrapper.querySelectorAll(this.removeButtonSelector))
+      .forEach((element) => {
+        element.setAttribute('data-method', 'remove')
+      })
+  },
+
+  /**
+   * insertAddButton
+   *
+   * Creates a new button to 'add another' and appends it after the
+   * placeholder that indicates the end of the fragments
+   */
+  insertAddButton () {
+    const addButtonElement = this.document.createElement('a')
+    addButtonElement.href = '#'
+    addButtonElement.innerHTML = this.addText
+
+    const addButtonWrapper = this.document.createElement('p')
+    addButtonWrapper.className = `c-form-group c-form-group--actions ${defaultAddButtonClass}`
+    addButtonWrapper.appendChild(addButtonElement)
+
+    insertAfter(addButtonWrapper, this.placeHolder)
+  },
+
+  /**
+   * insertRemoveButtons
+   *
+   * Adds a 'remove' button to the each of each of the fragments.
+   */
+  insertRemoveButtons () {
+    Array.from(this.wrapper.querySelectorAll(this.fragmentSelector))
+      .forEach((fragment) => {
+        const removeButtonElement = this.document.createElement('a')
+        removeButtonElement.innerHTML = this.removeText
+        removeButtonElement.href = '#'
+
+        const p = this.document.createElement('p')
+        p.className = `c-form-group c-form-group--actions ${defaultRemoveButtonClass}`
+        p.appendChild(removeButtonElement)
+
+        fragment.appendChild(p)
+      })
+  },
+
+  /**
+   * updateRemoveButtonVisibility
+   *
+   * Determines if remove buttons can be seen based on rules around
+   * allowing a user to delete, or not delete all fragments
+   */
+  updateRemoveButtonVisibility () {
+    const removeButtons = Array.from(this.wrapper.querySelectorAll(this.removeButtonSelector))
+
+    // Don't allow the last fragment to be deleted unless it's the desired behaviour
+    if (removeButtons.length === 1 && !this.allowRemoveAll) {
+      hide(removeButtons[0])
+    } else {
+      removeButtons.forEach((fragment) => show(fragment))
+    }
+  },
+
+  // When the user presses 'add another', clone a template
+  // Then reset any fields id's within it
+  addClickHandler (event) {
+    event.preventDefault()
+    event.target.blur()
+
+    const clonedFragment = this.templateFragment.cloneNode(true)
+    regenIds(clonedFragment)
+
+    // Add the fragment below the last one, unless there are none left,
+    // in which case add it before the 'add another' button
+    this.wrapper.insertBefore(clonedFragment, this.placeHolder)
+
+    this.updateRemoveButtonVisibility()
+  },
+
+  // Handle when a user clicks on a 'remove' link
+  // Gets the selector for the fragment to remove and removes it.
+  // Then updates the last fragment in case we just deleted it.
+  removeClickHandler (event) {
+    event.preventDefault()
+    event.target.blur()
+
+    // Remove the fragment that contains the remove button
+    const fragment = closest(event.target, this.fragmentSelector)
+    this.wrapper.removeChild(fragment)
+
+    this.updateRemoveButtonVisibility()
+  },
+
+  // Listen for button clicks on the wrapper and direct events to the correct
+  // handler if they are to add or remove
+  clickHandler (event) {
+    const target = event.target
+    if (!target.hasAttribute('data-method')) {
+      return
+    }
+
+    switch (target.getAttribute('data-method')) {
+      case 'add':
+        this.addClickHandler(event)
+        break
+      case 'remove':
+        this.removeClickHandler(event)
+        break
+    }
+  },
+}
+
+module.exports = {
+  init (page = document) {
+    const targetElements = Array.from(page.querySelectorAll(`.${wrapperClass}`))
+    targetElements.forEach((targetElement) => {
+      const addAnotherFragment = Object.create(AddAnotherFragment.prototype, {
+        wrapper: {
+          value: targetElement,
+        },
+        document: {
+          value: page,
+        },
+      })
+      addAnotherFragment.init()
+    })
+  },
+}

--- a/src/apps/investment-projects/views/team/edit-team-members.njk
+++ b/src/apps/investment-projects/views/team/edit-team-members.njk
@@ -7,25 +7,28 @@
     {% if form.errors.team_members %}
       <div class="error">{{ form.errors.team_members }}</div>
     {% endif %}
+    <div class="js-add-another-fragment"
+      data-selector=".c-form-fieldset"
+      data-allow-remove>
+      {% for teamMember in form.state.teamMembers %}
+        {% call Fieldset({ legend: 'Team member' }) %}
+          {{ MultipleChoiceField({
+            name: 'adviser',
+            label: form.labels.adviser,
+            options: form.options.advisers,
+            value: teamMember.adviser,
+            idSuffix: loop.index,
+            initialOption: '-- Select an adviser --'
+          }) }}
 
-    {% for teamMember in form.state.teamMembers %}
-      {% call Fieldset({ legend: 'Team member' }) %}
-        {{ MultipleChoiceField({
-          name: 'adviser',
-          label: form.labels.adviser,
-          options: form.options.advisers,
-          value: teamMember.adviser,
-          idSuffix: loop.index,
-          initialOption: '-- Select an adviser --'
-        }) }}
-
-        {{ TextField({
-          name: 'role',
-          label: form.labels.role,
-          value: teamMember.role,
-          idSuffix: loop.index
-        }) }}
-      {% endcall %}
+          {{ TextField({
+            name: 'role',
+            label: form.labels.role,
+            value: teamMember.role,
+            idSuffix: loop.index
+          }) }}
+        {% endcall %}
       {% endfor %}
+    </div>
   {% endcall %}
 {% endblock %}

--- a/test/unit/components/add-another-fragment.test.js
+++ b/test/unit/components/add-another-fragment.test.js
@@ -1,0 +1,510 @@
+const AddAnotherFragment = require('~/assets/javascripts/modules/add-another-fragment')
+const { getMacros } = require('~/test/unit/macro-helper')
+const formMacros = getMacros('form')
+const jsdom = require('jsdom')
+const { JSDOM } = jsdom
+
+const selectMarkup = `<div id="group-field-adviser" class="c-form-group js-adviser">
+  <label class="c-form-group__label " for="field-adviser">
+    <span class="c-form-group__label-text">Test label</span>
+  </label>
+  <div class="c-form-group__inner">
+    <select id="field-adviser" name="adviser" class="c-form-control">
+      <option value="fred">Fred</option>
+      <option value="wilma" selected>Wilma</option>
+    </select>
+  </div>
+</div>`
+
+function makeSingleFieldset (allowDeleteAll = false) {
+  const fieldset = formMacros.renderWithCallerToDom('Fieldset')(
+    formMacros.render('MultipleChoiceField', {
+      label: 'Test label',
+      name: 'adviser',
+      value: 'wilma',
+      options: [
+        { label: 'Fred', value: 'fred' },
+        { label: 'Wilma', value: 'wilma' },
+      ],
+    }),
+    formMacros.render('TextField', {
+      label: 'Role',
+      name: 'role',
+      value: 'Fred Smith',
+    })
+  ).outerHTML
+
+  const HTML = `
+    <div class="js-addanother"
+      data-selector=".c-form-fieldset"
+      ${allowDeleteAll ? 'data-allow-remove-all' : ''}>${fieldset}</div>`
+
+  const { window } = new JSDOM(HTML)
+  const document = window.document
+  const wrapper = document.querySelector('.js-addanother')
+  AddAnotherFragment.init(document)
+
+  return { document, wrapper }
+}
+
+function makeMultipleFieldset (allowDeleteAll = false) {
+  const fieldset = formMacros.renderWithCallerToDom('Fieldset')(
+    formMacros.render('MultipleChoiceField', {
+      label: 'Test label',
+      name: 'adviser',
+      value: 'wilma',
+      options: [
+        { label: 'Fred', value: 'fred' },
+        { label: 'Wilma', value: 'wilma' },
+      ],
+    }),
+    formMacros.render('TextField', {
+      label: 'Role',
+      name: 'role',
+      value: 'Fred Smith',
+    })
+  ).outerHTML
+
+  const HTML = `
+    <div class="js-addanother"
+      data-selector=".c-form-fieldset"
+      ${allowDeleteAll ? 'data-allow-remove-all' : ''}>${fieldset}${fieldset}</div>`
+
+  const { window } = new JSDOM(HTML)
+  const document = window.document
+  const wrapper = document.querySelector('.js-addanother')
+  AddAnotherFragment.init(document)
+
+  return { document, wrapper }
+}
+
+function makeSingleSelect (allowDeleteAll = false) {
+  const HTML = `
+    <div class="js-addanother"
+      data-selector=".js-adviser"
+      ${allowDeleteAll ? 'data-allow-remove-all' : ''}>${selectMarkup}</div>`
+
+  const { window } = new JSDOM(HTML)
+  const document = window.document
+  const wrapper = document.querySelector('.js-addanother')
+  AddAnotherFragment.init(document)
+
+  return { document, wrapper }
+}
+
+function makeMultipleSelect (allowDeleteAll = false) {
+  const HTML = `
+    <div class="js-addanother"
+      data-selector=".js-adviser"
+      ${allowDeleteAll ? 'data-allow-remove-all' : ''}>${selectMarkup}${selectMarkup}</div>`
+
+  const { window } = new JSDOM(HTML)
+  const document = window.document
+  const wrapper = document.querySelector('.js-addanother')
+  AddAnotherFragment.init(document)
+
+  return { document, wrapper }
+}
+
+function getVisibleRemoveButtons (wrapper, selector = '.js-addanother__remove a') {
+  return Array
+  .from(wrapper.querySelectorAll(selector))
+  .filter((removeLink) => !Array.from(removeLink.classList).includes('u-hidden'))
+}
+
+describe('Add another', () => {
+  describe('<fieldset>', () => {
+    describe('add', () => {
+      beforeEach(() => {
+        const { document, wrapper } = makeSingleFieldset()
+        this.document = document
+        this.wrapper = wrapper
+      })
+
+      it('should add a button to add more fragments', () => {
+        const addButtonElement = this.wrapper.querySelector('.js-addanother__add a')
+        expect(addButtonElement.innerHTML).to.contain('Add another')
+      })
+
+      it('should create a 2nd fieldset after the first if the add button is pressed', () => {
+        const addButtonElement = this.wrapper.querySelector('.js-addanother__add a')
+        addButtonElement.click()
+        const fieldsets = this.wrapper.querySelectorAll('fieldset')
+        expect(fieldsets).to.have.length(2)
+      })
+
+      it('should create a new ID for elements with an existing ID', () => {
+        const addButtonElement = this.wrapper.querySelector('.js-addanother__add a')
+        addButtonElement.click()
+        const fieldsets = Array.from(this.wrapper.querySelectorAll('fieldset'))
+
+        const firstTextField = fieldsets[0].querySelector('input')
+        const secondTextField = fieldsets[1].querySelector('input')
+
+        expect(secondTextField.id).to.have.length.above(0)
+        expect(secondTextField.id).to.not.equal(firstTextField.id)
+      })
+
+      it('should re-assign "for" attributes to their associated new field', () => {
+        const addButtonElement = this.wrapper.querySelector('.js-addanother__add a')
+        addButtonElement.click()
+
+        const fieldset = Array.from(this.wrapper.querySelectorAll('fieldset'))[1]
+        const secondTextField = fieldset.querySelector('input')
+        const label = fieldset.querySelector(`[for="${secondTextField.id}"]`)
+        expect(label.innerHTML).to.contain('Role')
+      })
+    })
+
+    describe('remove', () => {
+      describe('default behaviour', () => {
+        it('should not show a remove button if there is only 1 initial fragment by default', () => {
+          const { document, wrapper } = makeSingleFieldset()
+          this.document = document
+          this.wrapper = wrapper
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(0)
+        })
+
+        it('should add a remove button at the end of each fragment if there is more than one', () => {
+          const { document, wrapper } = makeMultipleFieldset()
+          this.document = document
+          this.wrapper = wrapper
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
+        })
+
+        it('should remove an element if the remove button is pressed', () => {
+          const { document, wrapper } = makeMultipleFieldset()
+          this.document = document
+          this.wrapper = wrapper
+
+          this.wrapper.querySelector('.c-form-fieldset .js-addanother__remove a:not(.u-hidden)').click()
+
+          expect(this.wrapper.querySelectorAll('.c-form-fieldset')).to.have.length(1)
+        })
+
+        it('should delete the remove button if you remove a fragment and there is only 1 left', () => {
+          const { document, wrapper } = makeMultipleFieldset()
+          this.document = document
+          this.wrapper = wrapper
+          this.wrapper.querySelector('.c-form-fieldset .js-addanother__remove a:not(.u-hidden)').click()
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(0)
+        })
+
+        it('should add a remove button to existing fragments if they go from 1 to 2 fragments', () => {
+          const { document, wrapper } = makeSingleFieldset()
+          this.document = document
+          this.wrapper = wrapper
+
+          this.wrapper.querySelector('.js-addanother__add a').click()
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
+        })
+      })
+
+      describe('(allow remove all)', () => {
+        beforeEach(() => {
+          const { document, wrapper } = makeMultipleFieldset(true)
+          this.document = document
+          this.wrapper = wrapper
+        })
+
+        it('should add a remove button when there is only one fragment', () => {
+          const { document, wrapper } = makeSingleFieldset(true)
+          this.document = document
+          this.wrapper = wrapper
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(1)
+        })
+
+        it('should add a remove button when there is more than one fragment', () => {
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
+        })
+
+        it('should remove an element if the remove button is pressed', () => {
+          this.wrapper.querySelector('.js-addanother__remove a').click()
+          expect(this.wrapper.querySelectorAll('.c-form-fieldset')).to.have.length(1)
+        })
+
+        it('should not delete the remove button if you remove a fragment and there is only 1 left', () => {
+          this.wrapper.querySelector('.c-form-fieldset .js-addanother__remove a').click()
+          expect(getVisibleRemoveButtons(this.wrapper)).have.length(1)
+        })
+
+        it('should add a remove button to any new fragments', () => {
+          const addButtonElement = this.wrapper.querySelector('.js-addanother__add a')
+          addButtonElement.click()
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(3)
+        })
+      })
+    })
+  })
+
+  describe('<select>', () => {
+    describe('add', () => {
+      beforeEach(() => {
+        const { document, wrapper } = makeSingleSelect()
+        this.document = document
+        this.wrapper = wrapper
+      })
+
+      it('should add a button to add more fragments', () => {
+        const addButtonElement = this.wrapper.querySelector('.js-addanother__add a')
+        expect(addButtonElement.innerHTML).to.contain('Add another')
+      })
+
+      it('should create a 2nd textfield after the first if the add button is pressed', () => {
+        const addButtonElement = this.wrapper.querySelector('.js-addanother__add a')
+        addButtonElement.click()
+
+        const inputs = this.wrapper.querySelectorAll('.js-adviser')
+        expect(inputs).to.have.length(2)
+      })
+    })
+
+    describe('remove', () => {
+      describe('default behaviour', () => {
+        it('should not add a remove button if there is only 1 initial form group by default', () => {
+          const { document, wrapper } = makeSingleSelect()
+          this.document = document
+          this.wrapper = wrapper
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(0)
+        })
+
+        it('should add a remove button at the end of each form group if there is more than one', () => {
+          const { document, wrapper } = makeMultipleSelect()
+          this.document = document
+          this.wrapper = wrapper
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
+        })
+
+        it('should remove a form group if the remove button is pressed', () => {
+          const { document, wrapper } = makeMultipleSelect()
+          this.document = document
+          this.wrapper = wrapper
+
+          this.wrapper.querySelector('.js-adviser .js-addanother__remove a').click()
+
+          expect(this.wrapper.querySelectorAll('.js-adviser')).to.have.length(1)
+        })
+
+        it('should delete the remove button if you remove a form group and there is only 1 left', () => {
+          const { document, wrapper } = makeMultipleSelect()
+          this.document = document
+          this.wrapper = wrapper
+
+          this.wrapper.querySelector('.js-adviser .js-addanother__remove a').click()
+          expect(getVisibleRemoveButtons(this.wrapper)).to.be.length(0)
+        })
+
+        it('should add a remove button to existing fragments if they go from 1 to 2 fragments', () => {
+          const { document, wrapper } = makeSingleSelect()
+          this.document = document
+          this.wrapper = wrapper
+
+          this.wrapper.querySelector('.js-addanother__add a').click()
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
+        })
+      })
+
+      describe('(allow remove all)', () => {
+        beforeEach(() => {
+          const { document, wrapper } = makeMultipleSelect(true)
+          this.document = document
+          this.wrapper = wrapper
+        })
+
+        it('should add a remove button when there is only one fragment', () => {
+          const { document, wrapper } = makeSingleSelect(true)
+          this.document = document
+          this.wrapper = wrapper
+
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(1)
+        })
+
+        it('should add a remove button when there is more than one fragment', () => {
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
+        })
+
+        it('should remove an element if the remove button is pressed', () => {
+          this.wrapper.querySelector('.js-adviser .js-addanother__remove a').click()
+          expect(this.wrapper.querySelectorAll('.js-adviser')).to.have.length(1)
+        })
+
+        it('should not delete the remove button if you remove a fragment and there is only 1 left', () => {
+          this.wrapper.querySelector('.js-adviser .js-addanother__remove a').click()
+          expect(getVisibleRemoveButtons(this.wrapper)).have.length(1)
+        })
+
+        it('should add a remove button to any new fragments', () => {
+          this.wrapper.querySelector('.js-addanother__add a').click()
+          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(3)
+        })
+      })
+    })
+  })
+
+  describe('decorate existing add button', () => {
+    beforeEach(() => {
+      const fieldset = formMacros.renderWithCallerToDom('Fieldset')(
+        formMacros.render('MultipleChoiceField', {
+          label: 'Test label',
+          name: 'adviser',
+          value: 'wilma',
+          options: [
+            { label: 'Fred', value: 'fred' },
+            { label: 'Wilma', value: 'wilma' },
+          ],
+        }),
+        formMacros.render('TextField', {
+          label: 'Role',
+          name: 'role',
+          value: 'Fred Smith',
+        })
+      ).outerHTML
+
+      const HTML = `
+        <div class="js-addanother"
+          data-selector=".c-form-fieldset"
+          data-add-button-selector="#add"
+          >
+
+          ${fieldset}
+
+          <p>
+            <a id="add" href="page">Add more stuff</a>
+          </p>
+        </div>`
+
+      const { window } = new JSDOM(HTML)
+      this.document = window.document
+      AddAnotherFragment.init(this.document)
+    })
+
+    it('should not add a new add button if one is specified', () => {
+      expect(this.document.querySelector('.js-addanother__add')).to.equal(null)
+    })
+
+    it('should add a fragment when the add button is pressed', () => {
+      this.document.getElementById('add').click()
+      expect(this.document.querySelectorAll('.c-form-fieldset')).to.have.length(2)
+    })
+  })
+
+  describe('decorate existing remove button', () => {
+    beforeEach(() => {
+      const selectMarkup = formMacros.render('MultipleChoiceField', {
+        label: 'Test label',
+        name: 'adviser',
+        value: 'wilma',
+        groupClass: 'js-adviser',
+        options: [
+          { label: 'Fred', value: 'fred' },
+          { label: 'Wilma', value: 'wilma' },
+        ],
+      })
+
+      const HTML = `
+        <div class="js-addanother"
+          data-selector=".my-fragment"
+          data-remove-button-selector=".js-remove-thing">
+          <div class="my-fragment">
+            ${selectMarkup}
+            <p>
+              <a href="/thing" class="js-remove-thing">delete</a>
+            </p>
+          </div>
+          <div class="my-fragment">
+            ${selectMarkup}
+            <p>
+              <a href="/thing" class="js-remove-thing">delete</a>
+            </p>
+          </div>
+        </div>`
+
+      const { window } = new JSDOM(HTML)
+      this.document = window.document
+      this.wrapper = this.document.querySelector('.js-addanother')
+      AddAnotherFragment.init(this.document)
+    })
+
+    it('should not add a new remove button if one is specified to existing markup', () => {
+      expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(0)
+    })
+
+    it('should remove a fragment when the decorated remove button is pressed', () => {
+      this.document.querySelector('.js-remove-thing').click()
+      expect(this.document.querySelectorAll('.my-fragment')).to.have.length(1)
+    })
+  })
+
+  it('should allow add another button text to be overriden', () => {
+    const fieldset = formMacros.renderWithCallerToDom('Fieldset')(
+      formMacros.render('MultipleChoiceField', {
+        label: 'Test label',
+        name: 'adviser',
+        value: 'wilma',
+        options: [
+          { label: 'Fred', value: 'fred' },
+          { label: 'Wilma', value: 'wilma' },
+        ],
+      }),
+      formMacros.render('TextField', {
+        label: 'Role',
+        name: 'role',
+        value: 'Fred Smith',
+      })
+    ).outerHTML
+
+    const HTML = `
+      <div class="js-addanother"
+        data-selector=".c-form-fieldset"
+        data-add-button-text="Add new adviser"
+        >
+        ${fieldset}
+      </div>`
+
+    const { window } = new JSDOM(HTML)
+    const document = window.document
+    AddAnotherFragment.init(document)
+
+    expect(document.querySelector('.js-addanother__add a').innerHTML).to.contain('Add new adviser')
+  })
+
+  it('should allow remove button text to be overridden', () => {
+    const fieldset = formMacros.renderWithCallerToDom('Fieldset')(
+      formMacros.render('MultipleChoiceField', {
+        label: 'Test label',
+        name: 'adviser',
+        value: 'wilma',
+        options: [
+          { label: 'Fred', value: 'fred' },
+          { label: 'Wilma', value: 'wilma' },
+        ],
+      }),
+      formMacros.render('TextField', {
+        label: 'Role',
+        name: 'role',
+        value: 'Fred Smith',
+      })
+    ).outerHTML
+
+    const HTML = `
+      <div class="js-addanother"
+        data-selector=".c-form-fieldset"
+        data-remove-button-text="Delete thing"
+        >
+        ${fieldset}
+      </div>`
+
+    const { window } = new JSDOM(HTML)
+    const document = window.document
+    AddAnotherFragment.init(document)
+
+    expect(document.querySelector('.js-addanother__remove a').innerHTML).to.contain('Delete thing')
+  })
+})


### PR DESCRIPTION
Component that scans markup to find elements that require a 'add another' button
The target element defines a selector to define what page fragment should be duplicated when the user presses add another. The contents of the cloned fragment will have it's fields reset. The component also inserts a 'remove' button that will allow values to also be removed.