### PR TITLE
add the ability to send in the date field to the DateFieldSet macro

### DIFF
--- a/src/apps/components/middleware.js
+++ b/src/apps/components/middleware.js
@@ -11,6 +11,7 @@ function handleFormPost (req, res, next) {
         averageSalary: ['Select an option'],
         foreignOtherCompany: ['Select a company type'],
         estimated_date: ['Date is required'],
+        land_date: ['Date is required'],
       },
     },
   })

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -191,6 +191,18 @@
           month: form.state.estimated_date_month
         }
       }) }}
+
+      {{ DateFieldset({
+        name: 'land_date',
+        label: 'What is the date?',
+        hint: 'Enter todays date',
+        error: form.errors.messages.land_date,
+        value: {
+          year: form.state.land_date_year,
+          month: form.state.land_date_month,
+          day: form.state.land_date_day
+        }
+      }) }}
     {% endcall %}
   {% endcall %}
 

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -516,18 +516,14 @@
   {% set fieldId = 'field-' + props.name if props.name %}
 
   {% call FormGroup(props | assign({ fieldId: fieldId, element: 'fieldset', modifier: 'inline' })) %}
-    {{ TextField({
-      modifier: ['inline', 'shortest', 'soft'],
-      name: props.name + '_month',
-      value: props.value.month,
-      label: 'Month'
-    }) }}
-
-    {{ TextField({
-      modifier: ['inline', 'shorter', 'soft'],
-      name: props.name + '_year',
-      value: props.value.year,
-      label: 'Year'
-    }) }}
+    {% for key, value in props.value %}
+      {% set name =  props.name + '_' + key %}
+      {{ TextField({
+        modifier: ['inline', 'soft', 'shorter' if key == 'year' else 'shortest'],
+        name: name,
+        value: value,
+        label: key | capitalize
+      }) }}
+    {% endfor %}
   {% endcall %}
 {% endmacro %}

--- a/test/unit/macros/form.test.js
+++ b/test/unit/macros/form.test.js
@@ -250,58 +250,121 @@ describe('Nunjucks form macros', () => {
     })
 
     describe('valid props', () => {
-      beforeEach(() => {
-        this.component = macros.renderToDom('DateFieldset', {
-          name: 'estimated_date',
-          label: 'What is your favourite day?',
-          hint: 'A day you really like',
-          value: {
-            month: '08',
-            year: '1977',
-          },
+      describe('month and year', () => {
+        beforeEach(() => {
+          this.component = macros.renderToDom('DateFieldset', {
+            name: 'estimated_date',
+            label: 'What is your favourite day?',
+            hint: 'A day you really like',
+            value: {
+              month: '04',
+              year: '2017',
+            },
+          })
+        })
+
+        it('should render a component with group id', () => {
+          expect(this.component.id).to.equal('group-field-estimated_date')
+        })
+
+        it('should render a component with correct group class name and modifier', () => {
+          expect(this.component.className.trim()).to.contain('c-form-group')
+          expect(this.component.className.trim()).to.contain('c-form-group--inline')
+        })
+
+        it('should render a component with correct legend, labels and input fields', () => {
+          const inputElems = this.component.querySelectorAll('input')
+          const labelElems = this.component.querySelectorAll('label')
+
+          expect(this.component.querySelector('legend').firstElementChild.textContent.trim()).to.equal('What is your favourite day?')
+          expect(inputElems.length).to.equal(2)
+          expect(labelElems.length).to.equal(2)
+          expect(labelElems[0].textContent.trim()).to.equal('Month')
+          expect(labelElems[1].textContent.trim()).to.equal('Year')
+        })
+
+        it('should render a component which has inputs with names and ids based on its name', () => {
+          const inputElems = this.component.querySelectorAll('input')
+
+          expect(inputElems[0].name).to.equal('estimated_date_month')
+          expect(inputElems[1].name).to.equal('estimated_date_year')
+          expect(inputElems[0].id).to.equal('field-estimated_date_month')
+          expect(inputElems[1].id).to.equal('field-estimated_date_year')
+        })
+
+        it('should render a component with text input by default', () => {
+          this.component.querySelectorAll('input').forEach((input) => {
+            expect(input.type).to.equal('text')
+          })
+        })
+
+        it('should render a field with value given', () => {
+          const inputElems = this.component.querySelectorAll('input')
+
+          expect(inputElems[0].value).to.equal('04')
+          expect(inputElems[1].value).to.equal('2017')
         })
       })
 
-      it('should render a component with group id', () => {
-        expect(this.component.id).to.equal('group-field-estimated_date')
-      })
-
-      it('should render a component with correct group class name and modifier', () => {
-        expect(this.component.className.trim()).to.contain('c-form-group')
-        expect(this.component.className.trim()).to.contain('c-form-group--inline')
-      })
-
-      it('should render a component with correct legend, labels and input fields', () => {
-        const inputElems = this.component.querySelectorAll('input')
-        const labelElems = this.component.querySelectorAll('label')
-
-        expect(this.component.querySelector('legend').firstElementChild.textContent.trim()).to.equal('What is your favourite day?')
-        expect(inputElems.length).to.equal(2)
-        expect(labelElems.length).to.equal(2)
-        expect(labelElems[0].textContent.trim()).to.equal('Month')
-        expect(labelElems[1].textContent.trim()).to.equal('Year')
-      })
-
-      it('should render a component which has inputs with names and ids based on its name', () => {
-        const inputElems = this.component.querySelectorAll('input')
-
-        expect(inputElems[0].name).to.equal('estimated_date_month')
-        expect(inputElems[1].name).to.equal('estimated_date_year')
-        expect(inputElems[0].id).to.equal('field-estimated_date_month')
-        expect(inputElems[1].id).to.equal('field-estimated_date_year')
-      })
-
-      it('should render a component with text input by default', () => {
-        this.component.querySelectorAll('input').forEach((input) => {
-          expect(input.type).to.equal('text')
+      describe('month, year and day', () => {
+        beforeEach(() => {
+          this.component = macros.renderToDom('DateFieldset', {
+            name: 'estimated_date',
+            label: 'What is your favourite day?',
+            hint: 'A day you really like',
+            value: {
+              month: '02',
+              year: '2013',
+              day: '19',
+            },
+          })
         })
-      })
 
-      it('should render a field with value given', () => {
-        const inputElems = this.component.querySelectorAll('input')
+        it('should render a component with group id', () => {
+          expect(this.component.id).to.equal('group-field-estimated_date')
+        })
 
-        expect(inputElems[0].value).to.equal('08')
-        expect(inputElems[1].value).to.equal('1977')
+        it('should render a component with correct group class name and modifier', () => {
+          expect(this.component.className.trim()).to.contain('c-form-group')
+          expect(this.component.className.trim()).to.contain('c-form-group--inline')
+        })
+
+        it('should render a component with correct legend, labels and input fields', () => {
+          const inputElems = this.component.querySelectorAll('input')
+          const labelElems = this.component.querySelectorAll('label')
+
+          expect(this.component.querySelector('legend').firstElementChild.textContent.trim()).to.equal('What is your favourite day?')
+          expect(inputElems.length).to.equal(3)
+          expect(labelElems.length).to.equal(3)
+          expect(labelElems[0].textContent.trim()).to.equal('Month')
+          expect(labelElems[1].textContent.trim()).to.equal('Year')
+          expect(labelElems[2].textContent.trim()).to.equal('Day')
+        })
+
+        it('should render a component which has inputs with names and ids based on its name', () => {
+          const inputElems = this.component.querySelectorAll('input')
+
+          expect(inputElems[0].name).to.equal('estimated_date_month')
+          expect(inputElems[1].name).to.equal('estimated_date_year')
+          expect(inputElems[2].name).to.equal('estimated_date_day')
+          expect(inputElems[0].id).to.equal('field-estimated_date_month')
+          expect(inputElems[1].id).to.equal('field-estimated_date_year')
+          expect(inputElems[2].id).to.equal('field-estimated_date_day')
+        })
+
+        it('should render a component with text input by default', () => {
+          this.component.querySelectorAll('input').forEach((input) => {
+            expect(input.type).to.equal('text')
+          })
+        })
+
+        it('should render a field with value given', () => {
+          const inputElems = this.component.querySelectorAll('input')
+
+          expect(inputElems[0].value).to.equal('02')
+          expect(inputElems[1].value).to.equal('2013')
+          expect(inputElems[2].value).to.equal('19')
+        })
       })
     })
 
@@ -312,8 +375,8 @@ describe('Nunjucks form macros', () => {
           label: 'What is your favourite day?',
           hint: 'A day you really like',
           value: {
-            month: '08',
-            year: '1977',
+            month: '03',
+            year: '2016',
           },
           error: 'Please enter a valid date',
         })


### PR DESCRIPTION
There is a need to provide `day` for investment project interactions field. This work enables the DateFieldSet pattern to build date inputs dependant on the `props.value` object:
```
value: {
  year: form.state.land_date_year,
  month: form.state.land_date_month,
  day: form.state.land_date_day
}
```
![screen shot 2017-08-14 at 16 59 45](https://user-images.githubusercontent.com/2305016/29280161-090b9cbe-8112-11e7-8cc6-27be52e1a96e.png)
