### PR TITLE
Firefox issue with highlighter

### DIFF
--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -25,15 +25,6 @@
       right: $default-spacing-unit;
     }
   }
-
-  .u-highlight {
-    position: relative;
-    z-index: -1;
-  }
-
-  :focus .u-highlight {
-    position: static;
-  }
 }
 
 .main-content__inner {

--- a/assets/stylesheets/trumps/_utility.scss
+++ b/assets/stylesheets/trumps/_utility.scss
@@ -28,8 +28,6 @@
 
 .u-highlight {
   background-color: $yellow-25;
-  padding: 2px;
-  margin: -2px;
 }
 
 .u-clearfix {

--- a/config/nunjucks/trade-elements-filters.js
+++ b/config/nunjucks/trade-elements-filters.js
@@ -51,17 +51,6 @@ filter.toHyphenated = function toHyphenated (string) {
   return string.trim().toLowerCase().replace(/\s+/g, '-')
 }
 
-/**
- * Highlights a phrase in a source piece of text
- * @param  {String} text    The original text to be updated
- * @param  {String} phrase  The phrase to highlight in the original text
- * @return {String}     The resulting text with highlights using <strong>
- */
-filter.highlight = function highlight (text, phrase) {
-  const regex = new RegExp('(' + phrase + ')', 'gi')
-  return text.replace(regex, '<strong>$1</strong>')
-}
-
 filter.attributeArray = function attributeArray (list) {
   if (!Array.isArray(list)) {
     return filter.attributeObject(list)


### PR DESCRIPTION
Firefox has issues with applying negative margin to inline elements. It forces them to drop to the new line. This fix means the small padding around the highlighter had to be removed.

### Before
![image](https://user-images.githubusercontent.com/203886/29359287-f9508720-8275-11e7-89f7-8b451e136e4e.png)

### After
![image](https://user-images.githubusercontent.com/203886/29359268-e525c580-8275-11e7-8120-6de689e29ec4.png)
