### PR TITLE
Rename ita to subscribers

### DIFF
--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -17,7 +17,7 @@ class ConfirmController extends FormController {
       values.contact = `${contact.first_name} ${contact.last_name}`
       values.company = company
       values.primary_market = find(metadataRepo.countryOptions, { id: values.primary_market })
-      values.ita = filter(values.ita).map((id) => {
+      values.subscribers = filter(values.subscribers).map((id) => {
         const adviser = find(advisers.results, { id })
         return get(adviser, 'name')
       })
@@ -28,7 +28,7 @@ class ConfirmController extends FormController {
 
   async successHandler (req, res, next) {
     const data = req.sessionModel.toJSON()
-    const subscribers = data.ita.map(transformIdToObject)
+    const subscribers = data.subscribers.map(transformIdToObject)
 
     // clean un-needed properties
     unset(data, 'csrf-secret')

--- a/src/apps/omis/apps/create/controllers/index.js
+++ b/src/apps/omis/apps/create/controllers/index.js
@@ -1,10 +1,10 @@
-const AssignItaController = require('./assign-ita')
+const SubscribersController = require('./subscribers')
 const ClientDetailsController = require('./client-details')
 const MarketController = require('./market')
 const ConfirmController = require('./confirm')
 
 module.exports = {
-  AssignItaController,
+  SubscribersController,
   ClientDetailsController,
   MarketController,
   ConfirmController,

--- a/src/apps/omis/apps/create/controllers/subscribers.js
+++ b/src/apps/omis/apps/create/controllers/subscribers.js
@@ -4,12 +4,12 @@ const { FormController } = require('../../../controllers')
 const { getAdvisers } = require('../../../../adviser/repos')
 const { transformObjectToOption } = require('../../../../transformers')
 
-class AssignItaController extends FormController {
+class SubscribersController extends FormController {
   async configure (req, res, next) {
     const advisers = await getAdvisers(req.session.token)
     const options = advisers.results.map(transformObjectToOption)
 
-    req.form.options.fields.ita.options = sortBy(options, 'label')
+    req.form.options.fields.subscribers.options = sortBy(options, 'label')
     super.configure(req, res, next)
   }
 
@@ -52,4 +52,4 @@ class AssignItaController extends FormController {
   }
 }
 
-module.exports = AssignItaController
+module.exports = SubscribersController

--- a/src/apps/omis/apps/create/steps.js
+++ b/src/apps/omis/apps/create/steps.js
@@ -1,5 +1,5 @@
 const {
-  AssignItaController,
+  SubscribersController,
   ClientDetailsController,
   MarketController,
   ConfirmController,
@@ -22,15 +22,15 @@ module.exports = {
   },
   '/market': {
     editable: true,
-    next: 'assign-ita',
+    next: 'subscribers',
     fields: ['primary_market'],
     controller: MarketController,
   },
-  '/assign-ita': {
+  '/subscribers': {
     editable: true,
     next: 'confirm',
-    fields: ['ita'],
-    controller: AssignItaController,
+    fields: ['subscribers'],
+    controller: SubscribersController,
   },
   '/confirm': {
     backLink: null,

--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -33,8 +33,8 @@
       <caption class="c-answers-summary__heading">International Trade Advisers (ITAs)</caption>
       <tr>
         <th class="c-answers-summary__title" scope="row">Advisers</th>
-        <td class="c-answers-summary__content">{{ values.ita | join(", ") if values.ita.length else 'Not added at this stage' }}</td>
-        <td class="c-answers-summary__control"><a class="button button-secondary" href="assign-ita/edit">Change</a></td>
+        <td class="c-answers-summary__content">{{ values.subscribers | join(", ") if values.subscribers.length else 'Not added at this stage' }}</td>
+        <td class="c-answers-summary__control"><a class="button button-secondary" href="subscribers/edit">Change</a></td>
       </tr>
     </table>
 

--- a/src/apps/omis/apps/edit/controllers/index.js
+++ b/src/apps/omis/apps/edit/controllers/index.js
@@ -1,12 +1,12 @@
 const EditClientDetailsController = require('./client-details')
-const EditAssignItaController = require('./assign-ita')
+const EditSubscribersController = require('./subscribers')
 const EditWorkDescriptionController = require('./work-description')
 const editHandler = require('./edit-handler')
 const editRedirect = require('./edit-redirect')
 
 module.exports = {
   EditClientDetailsController,
-  EditAssignItaController,
+  EditSubscribersController,
   EditWorkDescriptionController,
   editHandler,
   editRedirect,

--- a/src/apps/omis/apps/edit/controllers/subscribers.js
+++ b/src/apps/omis/apps/edit/controllers/subscribers.js
@@ -4,14 +4,14 @@ const { EditController } = require('../../../controllers')
 const { getAdvisers } = require('../../../../adviser/repos')
 const { transformObjectToOption } = require('../../../../transformers')
 
-class EditAssignItaController extends EditController {
+class EditSubscribersController extends EditController {
   async configure (req, res, next) {
     const advisers = await getAdvisers(req.session.token)
     const options = advisers.results.map(transformObjectToOption)
 
-    req.form.options.fields.ita.options = sortBy(options, 'label')
+    req.form.options.fields.subscribers.options = sortBy(options, 'label')
     super.configure(req, res, next)
   }
 }
 
-module.exports = EditAssignItaController
+module.exports = EditSubscribersController

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -2,15 +2,15 @@ const { merge } = require('lodash')
 
 const createSteps = require('../create/steps')
 const EditClientDetailsController = require('./controllers/client-details')
-const EditAssignItaController = require('./controllers/assign-ita')
+const EditSubscribersController = require('./controllers/subscribers')
 const EditWorkDescriptionController = require('./controllers/work-description')
 
 const steps = merge({}, createSteps, {
   '/client-details': {
     controller: EditClientDetailsController,
   },
-  '/assign-ita': {
-    controller: EditAssignItaController,
+  '/subscribers': {
+    controller: EditSubscribersController,
   },
   '/work-description': {
     fields: [

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -49,11 +49,11 @@
 
   {{ AnswersSummary({
     heading: 'International Trade Advisers (ITAs)',
-    editUrl: 'edit/assign-ita',
+    editUrl: 'edit/subscribers',
     editText: 'Add or remove',
     items: [{
       label: 'Advisers',
-      value: values.ita.name if values.ita else 'None selected'
+      value: values.subscribers.name if values.subscribers else 'None selected'
     }]
   }) }}
 

--- a/src/apps/omis/fields.js
+++ b/src/apps/omis/fields.js
@@ -19,11 +19,11 @@ module.exports = {
     initialOption: '-- Select market --',
     options: [],
   },
-  ita: {
+  subscribers: {
     fieldType: 'MultipleChoiceField',
-    legend: 'fields.ita.legend',
-    label: 'fields.ita.label',
-    addButtonText: 'fields.ita.addButtonText',
+    legend: 'fields.subscribers.legend',
+    label: 'fields.subscribers.label',
+    addButtonText: 'fields.subscribers.addButtonText',
     optional: true,
     repeatable: true,
     initialOption: '-- Select adviser --',

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -8,7 +8,7 @@
       "label": "Primary market",
       "hint": "The market which should be providing the service"
     },
-    "ita": {
+    "subscribers": {
       "legend": "International Trade Advisers (ITAs)",
       "hint": "The adviser(s) responsible for overseeing the work from a UK region",
       "addButtonText": "Add another adviser",

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -64,7 +64,7 @@ describe('OMIS create confirm controller', () => {
       this.valuesMock = {
         contact: '1',
         company: 'company-12345',
-        ita: ['0513453c-86bc-e211-a646-e4115bead28a'],
+        subscribers: ['0513453c-86bc-e211-a646-e4115bead28a'],
         primary_market: '2',
       }
     })
@@ -87,7 +87,7 @@ describe('OMIS create confirm controller', () => {
               },
               contact: 'Fred Stevens',
               primary_market: metadataCountryMockData[1],
-              ita: [getAdvisersMockData.results[0].name],
+              subscribers: [getAdvisersMockData.results[0].name],
             })
             done()
           } catch (err) {
@@ -114,7 +114,7 @@ describe('OMIS create confirm controller', () => {
             errors: {},
             foo: 'bar',
             fizz: 'buzz',
-            ita: ['12345', '67890'],
+            subscribers: ['12345', '67890'],
           }),
           reset: this.resetSpy,
           destroy: this.destroySpy,
@@ -139,7 +139,7 @@ describe('OMIS create confirm controller', () => {
               expect(this.orderSaveStub).to.have.been.calledWith('token-12345', {
                 foo: 'bar',
                 fizz: 'buzz',
-                ita: ['12345', '67890'],
+                subscribers: ['12345', '67890'],
               })
               expect(this.saveSubscribersStub).to.have.been.calledWith('token-12345', '1234567890', [
                 { id: '12345' },

--- a/test/unit/apps/omis/apps/create/controllers/subscribers.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/subscribers.test.js
@@ -2,12 +2,12 @@ const FormController = require('hmpo-form-wizard').Controller
 
 const getAdvisersMock = require('~/test/unit/data/investment/interaction/advisers')
 
-describe('OMIS create assign controller', () => {
+describe('OMIS create subscribers controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.getAdvisersStub = this.sandbox.stub().resolves(getAdvisersMock)
 
-    this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/assign-ita', {
+    this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/subscribers', {
       '../../../../adviser/repos': {
         getAdvisers: this.getAdvisersStub,
       },
@@ -26,7 +26,7 @@ describe('OMIS create assign controller', () => {
         form: {
           options: {
             fields: {
-              ita: {},
+              subscribers: {},
             },
           },
         },
@@ -48,7 +48,7 @@ describe('OMIS create assign controller', () => {
 
       const nextSpy = () => {
         try {
-          expect(this.reqMock.form.options.fields.ita.options).to.deep.equal([
+          expect(this.reqMock.form.options.fields.subscribers.options).to.deep.equal([
             {
               value: '0513453c-86bc-e211-a646-e4115bead28a',
               label: 'Tom Thumb',


### PR DESCRIPTION
This is to better describe what is actually going on in the app.

The backend is treating "ITAs" as subscribers and all the logic is
using a subscribers methodology so this rename brings the frontend app
in line with what it is doing with the API.