### PR TITLE
Add/remove post advisers (assignees)

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -1,0 +1,43 @@
+const { pick, sortBy } = require('lodash')
+
+const { EditController } = require('../../../controllers')
+const { getAdvisers } = require('../../../../adviser/repos')
+const { transformObjectToOption } = require('../../../../transformers')
+const { Order } = require('../../../models')
+
+class EditAssigneesController extends EditController {
+  async configure (req, res, next) {
+    const advisers = await getAdvisers(req.session.token)
+    const options = advisers.results.map(transformObjectToOption)
+
+    req.form.options.fields.assignees.options = sortBy(options, 'label')
+    super.configure(req, res, next)
+  }
+
+  async successHandler (req, res, next) {
+    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
+    const assignees = data.assignees.map((id) => {
+      return {
+        adviser: {
+          id,
+        },
+      }
+    })
+
+    try {
+      await Order.saveAssignees(req.session.token, res.locals.order.id, assignees)
+
+      req.journeyModel.reset()
+      req.journeyModel.destroy()
+      req.sessionModel.reset()
+      req.sessionModel.destroy()
+
+      req.flash('success', 'Order updated')
+      res.redirect(`/omis/${res.locals.order.id}`)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = EditAssigneesController

--- a/src/apps/omis/apps/edit/controllers/index.js
+++ b/src/apps/omis/apps/edit/controllers/index.js
@@ -1,3 +1,4 @@
+const EditAssigneesController = require('./assignees')
 const EditClientDetailsController = require('./client-details')
 const EditSubscribersController = require('./subscribers')
 const EditWorkDescriptionController = require('./work-description')
@@ -5,6 +6,7 @@ const editHandler = require('./edit-handler')
 const editRedirect = require('./edit-redirect')
 
 module.exports = {
+  EditAssigneesController,
   EditClientDetailsController,
   EditSubscribersController,
   EditWorkDescriptionController,

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -32,6 +32,16 @@ const editFields = Object.assign({}, globalFields, {
     label: 'fields.contacts_not_to_approach.label',
     optional: true,
   },
+  assignees: {
+    fieldType: 'MultipleChoiceField',
+    legend: 'fields.assignees.legend',
+    label: 'fields.assignees.label',
+    addButtonText: 'fields.assignees.addButtonText',
+    optional: true,
+    repeatable: true,
+    initialOption: '-- Select adviser --',
+    options: [],
+  },
 })
 
 module.exports = editFields

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -1,6 +1,7 @@
 const { merge } = require('lodash')
 
 const createSteps = require('../create/steps')
+const EditAssigneesController = require('./controllers/assignees')
 const EditClientDetailsController = require('./controllers/client-details')
 const EditSubscribersController = require('./controllers/subscribers')
 const EditWorkDescriptionController = require('./controllers/work-description')
@@ -11,6 +12,12 @@ const steps = merge({}, createSteps, {
   },
   '/subscribers': {
     controller: EditSubscribersController,
+  },
+  '/assignees': {
+    fields: [
+      'assignees',
+    ],
+    controller: EditAssigneesController,
   },
   '/work-description': {
     fields: [

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -62,12 +62,9 @@
 
   {{ AnswersSummary({
     heading: 'Post advisers',
-    editUrl: 'edit/post-adviser',
+    editUrl: 'edit/assignees',
     editText: 'Add or remove',
-    items: [{
-      label: 'Advisers',
-      value: values.post_adviser.name if values.post_adviser else 'None selected'
-    }]
+    items: values.assignees | map('adviser.name') if values.assignees.length else ['None selected']
   }) }}
 
   {{ AnswersSummary({

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -50,6 +50,10 @@ class EditController extends FormController {
         return map(newValue, 'id')
       }
 
+      if (find(newValue, 'adviser')) {
+        return map(newValue, 'adviser.id')
+      }
+
       if (fieldOptions.repeatable) {
         return flatten([newValue])
       }

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -29,6 +29,11 @@
     },
     "contacts_not_to_approach": {
       "label": "Contacts not to approach"
+    },
+    "assignees": {
+      "legend": "Post advisers",
+      "addButtonText": "Add another adviser",
+      "label": "Adviser"
     }
   },
   "validation": {

--- a/src/apps/omis/middleware/params.js
+++ b/src/apps/omis/middleware/params.js
@@ -15,9 +15,11 @@ async function getOrder (req, res, next, orderId) {
   try {
     const order = await Order.getById(req.session.token, orderId)
     const subscribers = await Order.getSubscribers(req.session.token, orderId)
+    const assignees = await Order.getAssignees(req.session.token, orderId)
 
     res.locals.order = Object.assign({}, order, {
       subscribers,
+      assignees,
     })
   } catch (e) {
     logger.error(e)

--- a/src/apps/omis/models.js
+++ b/src/apps/omis/models.js
@@ -26,6 +26,18 @@ const Order = {
     })
   },
 
+  getAssignees (token, id) {
+    return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}/assignee`)
+  },
+
+  saveAssignees (token, id, body) {
+    return authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/omis/order/${id}/assignee`,
+      method: 'PATCH',
+      body,
+    })
+  },
+
   getSubscribers (token, id) {
     return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}/subscriber-list`)
   },


### PR DESCRIPTION
This change adds the ability to add/remove post advisers to an OMIS order. On the backend we call these _assignees_.

👉 [**DEMO**](https://datahub-beta2-pr-463.herokuapp.com/omis/bcc2e419-0870-48d7-9f9e-a0028bf09dd8/work-order) 👈 

## What it looks like

![localhost_3001_omis_5325ad09-0dd4-480e-94be-9a4a3cde0eb9_work-order](https://user-images.githubusercontent.com/3327997/29365571-c84c556a-8297-11e7-8b75-23a7a62e1060.png)

![localhost_3001_omis_5325ad09-0dd4-480e-94be-9a4a3cde0eb9_edit_assignees](https://user-images.githubusercontent.com/3327997/29365605-e41b55fc-8297-11e7-8a1b-40b6c1b88c5d.png)