### PR TITLE
Limit pagination results to 10,000 items paginated

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -44,6 +44,7 @@ const config = {
   sentryDsn: process.env.SENTRY_DSN,
   longDateFormat: 'D MMMM YYYY',
   mediumDateFormat: 'D MMM YYYY',
+  paginationMaxResults: 10000,
 }
 
 module.exports = config

--- a/src/lib/pagination.js
+++ b/src/lib/pagination.js
@@ -1,5 +1,6 @@
 const { range, take, get, omitBy } = require('lodash')
 const queryString = require('query-string')
+const config = require('../../config')
 
 function getPageLink (page, query = {}) {
   const newQuery = Object.assign({}, query, {
@@ -55,16 +56,17 @@ function truncatePages (pagination, blockSize) {
 function buildPagination (query = {}, results, truncate = 4) {
   const limit = results.limit || Math.max(get(results, 'results.length', 10), 10)
   const totalPages = results.count ? Math.ceil(results.count / limit) : 0
+  const totalPagesLimited = Math.round(Math.min(totalPages, config.paginationMaxResults / limit))
   results.page = parseInt(results.page, 10)
 
   if (!results.page || totalPages < 2) { return null }
 
   const pagination = {
-    totalPages,
+    totalPages: totalPagesLimited,
     currentPage: results.page,
     prev: results.page > 1 ? getPageLink(results.page - 1, query) : null,
     next: results.page === totalPages ? null : getPageLink(results.page + 1, query),
-    pages: range(0, totalPages).map((page, idx) => {
+    pages: range(0, totalPagesLimited).map((page, idx) => {
       return {
         label: idx + 1,
         url: getPageLink(idx + 1, query),

--- a/test/unit/lib/pagination.test.js
+++ b/test/unit/lib/pagination.test.js
@@ -123,5 +123,13 @@ describe('Pagination', () => {
       }
       expect(actual).to.deep.equal(expected)
     })
+
+    it('should return pagination object with a maximum of 10000 results paginated', () => {
+      const limited1 = buildPagination(query, { count: 20000, limit: 10, page: 1 })
+      const limited2 = buildPagination(query, { count: 20000, limit: 3, page: 1 })
+
+      expect(limited1).to.have.property('totalPages', 1000)
+      expect(limited2).to.have.property('totalPages', 3333)
+    })
   })
 })


### PR DESCRIPTION
As ElasticSearch is only limited to provide up to 10,000 results and because there is not much value for user in showing pagination beyond 10,000 items we should limit the number of results that can be pagination to 10,000.