### PR TITLE
Fix inner content for form wizard

### DIFF
--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -36,11 +36,9 @@
               })) %}
                 {% for value in fieldValues %}
                   {% set removeButton %}
-                    {% if loop.length > 1 %}
-                      <button class="button button--link c-form-group__action" name="remove-item" value="{{ key }}::{{ loop.index0 }}">
-                        {{ translate(removeButtonText) }}
-                      </button>
-                    {% endif %}
+                    <button class="button button--link c-form-group__action" name="remove-item" value="{{ key }}::{{ loop.index0 }}">
+                      {{ translate(removeButtonText) }}
+                    </button>
                   {% endset %}
 
                   {{ callAsMacro(props.fieldType)({} | assign(props, {
@@ -50,7 +48,7 @@
                     label: props.label + " " + loop.index,
                     modifier: 'compact',
                     isLabelHidden: true,
-                    innerContent: removeButton
+                    innerHTML: removeButton if loop.length > 1
                   })) }}
                 {% endfor %}
               {% endcall %}


### PR DESCRIPTION
The structure of macros was changed which meant that the inner content
for the form wizard was no longer being shown.

This uses the new property name to show the correct content.