### PR TITLE
Edit assignee time allocated

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -113,12 +113,16 @@ const filters = {
     return dateFns.format(parsedDate, format)
   },
 
-  formatDuration: (value, format = longDateFormat, measurement = 'minutes') => {
+  humanizeDuration: (value, measurement = 'minutes') => {
     const duration = moment.duration(value, measurement)
-    const hoursSuffix = pluralise('hour', duration.hours())
-    const minutesSuffix = pluralise('minute', duration.minutes())
+    const hrsSuffix = pluralise('hour', duration.hours())
+    const minsSuffix = pluralise('minute', duration.minutes())
 
-    return duration.format(`h [${hoursSuffix}], m [${minutesSuffix}]`)
+    return duration.format(`h [${hrsSuffix}], m [${minsSuffix}]`)
+  },
+
+  formatDuration: (value, format = 'hh:mm', measurement = 'minutes') => {
+    return moment.duration(value, measurement).format(format, { trim: false })
   },
 
   arrayToLabelValues: (items) => {

--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -1,0 +1,38 @@
+const { filter, pick } = require('lodash')
+
+const { EditController } = require('../../../controllers')
+const { Order } = require('../../../models')
+
+class EditAssigneeHoursController extends EditController {
+  async successHandler (req, res, next) {
+    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
+    const assignees = data.assignee_time.map((value, index) => {
+      if (!value) { return }
+
+      const [ hours, minutes ] = value.split(':')
+
+      return {
+        adviser: {
+          id: res.locals.order.assignees[index].adviser.id,
+        },
+        estimated_time: parseInt((hours * 60)) + parseInt(minutes),
+      }
+    })
+
+    try {
+      await Order.saveAssignees(req.session.token, res.locals.order.id, filter(assignees))
+
+      req.journeyModel.reset()
+      req.journeyModel.destroy()
+      req.sessionModel.reset()
+      req.sessionModel.destroy()
+
+      req.flash('success', 'Order updated')
+      res.redirect(`/omis/${res.locals.order.id}`)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = EditAssigneeHoursController

--- a/src/apps/omis/apps/edit/controllers/index.js
+++ b/src/apps/omis/apps/edit/controllers/index.js
@@ -1,4 +1,5 @@
 const EditAssigneesController = require('./assignees')
+const EditAssigneeTimeController = require('./assignee-time')
 const EditClientDetailsController = require('./client-details')
 const EditSubscribersController = require('./subscribers')
 const EditWorkDescriptionController = require('./work-description')
@@ -7,6 +8,7 @@ const editRedirect = require('./edit-redirect')
 
 module.exports = {
   EditAssigneesController,
+  EditAssigneeTimeController,
   EditClientDetailsController,
   EditSubscribersController,
   EditWorkDescriptionController,

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -1,4 +1,27 @@
+const { isArray } = require('lodash')
+
 const globalFields = require('../../fields')
+
+function isDuration (value) {
+  const regex = /^\d+:\d{2}$/
+
+  if (!isArray(value)) {
+    if (!value) { return true }
+
+    return !!value.match(regex)
+  }
+
+  let valid = true
+  value.forEach(itemValue => {
+    if (!itemValue) { return }
+
+    if (!itemValue.match(regex)) {
+      valid = false
+    }
+  })
+
+  return valid
+}
 
 const editFields = Object.assign({}, globalFields, {
   service_types: {
@@ -41,6 +64,12 @@ const editFields = Object.assign({}, globalFields, {
     repeatable: true,
     initialOption: '-- Select adviser --',
     options: [],
+  },
+  assignee_time: {
+    fieldType: 'TextField',
+    label: 'fields.assignee_time.label',
+    modifier: ['shorter', 'soft'],
+    validate: [isDuration],
   },
 })
 

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -2,6 +2,7 @@ const { merge } = require('lodash')
 
 const createSteps = require('../create/steps')
 const EditAssigneesController = require('./controllers/assignees')
+const EditAssigneeTimeController = require('./controllers/assignee-time')
 const EditClientDetailsController = require('./controllers/client-details')
 const EditSubscribersController = require('./controllers/subscribers')
 const EditWorkDescriptionController = require('./controllers/work-description')
@@ -18,6 +19,14 @@ const steps = merge({}, createSteps, {
       'assignees',
     ],
     controller: EditAssigneesController,
+  },
+  '/assignee-time': {
+    fields: [
+      'assignee_time',
+    ],
+    controller: EditAssigneeTimeController,
+    templatePath: 'omis/apps/edit/views',
+    template: 'assignee-time.njk',
   },
   '/work-description': {
     fields: [

--- a/src/apps/omis/apps/edit/views/assignee-time.njk
+++ b/src/apps/omis/apps/edit/views/assignee-time.njk
@@ -1,0 +1,30 @@
+{% extends "_layouts/form-wizard-step.njk" %}
+
+{% block fields %}
+  {% set key = 'assignee_time' %}
+  {% set defaultProps = options.fields[key] %}
+
+  <table class="c-answers-summary">
+    <thead>
+      <tr>
+        <th class="c-answers-summary__control" colspan="2">Estimated time (HH:MM)</th>
+      </tr>
+    </thead>
+    {% for assignee in order.assignees %}
+      {% set props = {} | assign(defaultProps, {
+        name: key,
+        idSuffix: assignee.adviser.id,
+        label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
+        value: values[key][loop.index0] or assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time,
+        error: errors[key].message,
+        isLabelHidden: true
+      }) %}
+      <tr>
+        <td class="c-answers-summary__title">{{ assignee.adviser.name }}</td>
+        <td class="c-answers-summary__control">
+          {{ callAsMacro(props.fieldType)(props) }}
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -86,7 +86,7 @@
             {{ assignee.adviser.name }}
           </th>
           <td class="c-answers-summary__content c-answers-summary__content--number">
-            {{ assignee.estimated_time  | formatDuration if assignee.estimated_time else 'No time estimated' }}
+            {{ assignee.estimated_time  | humanizeDuration if assignee.estimated_time else 'No time estimated' }}
           </td>
         </tr>
       </tbody>
@@ -96,7 +96,7 @@
     <tfoot>
       <tr>
         <td class="c-answers-summary__footer" colspan="2">
-          <span class="c-answers-summary__footer-value">{{ values.estimatedTimeSum | formatDuration }}</span> total estimated time
+          <span class="c-answers-summary__footer-value">{{ values.estimatedTimeSum | humanizeDuration }}</span> total estimated time
         </td>
       </tr>
     </tfoot>

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -34,6 +34,9 @@
       "legend": "Post advisers",
       "addButtonText": "Add another adviser",
       "label": "Adviser"
+    },
+    "assignee_time": {
+      "label": "Estimated time"
     }
   },
   "validation": {
@@ -41,6 +44,7 @@
     "numeric": "can only contain numbers",
     "date": "must be a valid date",
     "after": "must be in the future",
+    "isDuration": "must be a valid duration format, for example 01:30",
     "default": "is required"
   }
 }


### PR DESCRIPTION
This adds support for editing the time assignees spend on an order.

It creates the step, controller and custom view needed to edit this data.

👉 [**DEMO**](https://datahub-beta2-pr-471.herokuapp.com/omis/ebad867d-2527-4439-b5fb-d39fb7095392/edit/assignee-time) 👈

## What it looks like

![localhost_3001_omis_5325ad09-0dd4-480e-94be-9a4a3cde0eb9_edit_assignee-time](https://user-images.githubusercontent.com/3327997/29453831-5672f1b8-840b-11e7-953a-cac122577c1b.png)
