### PR TITLE
Don't show error border on form group if label isn't visible

### DIFF
--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -208,7 +208,7 @@
       id="group-{{ props.fieldId }}"
       class="
         c-form-group
-        {{ 'has-error' if props.error }}
+        {{ 'has-error' if props.error and not isLabelHidden }}
         {{ 'js-ConditionalSubfield' if isConditional }}
         {{ modifier }}
         {{ props.class if props.class }}


### PR DESCRIPTION
Currently if we hide the label the border seems like its floating
so visually looks a odd.

When the field errors we still highlight the field and provide an error
summary so this enough for now. 

One example of where this causes strangeness is repeated fields:

## Before

<img width="727" alt="screen shot 2017-08-18 at 11 27 00" src="https://user-images.githubusercontent.com/3327997/29453609-84106124-840a-11e7-8812-fe9c810b7cf7.png">

## After

<img width="728" alt="screen shot 2017-08-18 at 11 11 51" src="https://user-images.githubusercontent.com/3327997/29453614-8986992a-840a-11e7-88d7-88aaee37753e.png">
