### PR TITLE
Use force-delete query string to also delete assignees

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -25,7 +25,7 @@ class EditAssigneesController extends EditController {
     })
 
     try {
-      await Order.saveAssignees(req.session.token, res.locals.order.id, assignees)
+      await Order.forceSaveAssignees(req.session.token, res.locals.order.id, assignees)
 
       req.journeyModel.reset()
       req.journeyModel.destroy()

--- a/src/apps/omis/models.js
+++ b/src/apps/omis/models.js
@@ -38,6 +38,14 @@ const Order = {
     })
   },
 
+  forceSaveAssignees (token, id, body) {
+    return authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/omis/order/${id}/assignee?force-delete=1`,
+      method: 'PATCH',
+      body,
+    })
+  },
+
   getSubscribers (token, id) {
     return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}/subscriber-list`)
   },


### PR DESCRIPTION
By default the assignees PATCH endpoint doesn't delete assignees
that are not passed. During the add/remove stages we need this to
be true so that if assignees are removed from the list, they are
removed from the API.