### PR TITLE
Set lead adviser

### DIFF
--- a/assets/stylesheets/_deprecated/components/_button.scss
+++ b/assets/stylesheets/_deprecated/components/_button.scss
@@ -23,6 +23,7 @@
   margin: 30px 0;
 }
 
+// modifiers
 .button--link {
   background: transparent;
   border: 0;
@@ -44,4 +45,8 @@
   &:hover {
     color: $link-hover-colour;
   }
+}
+
+.button--compact {
+  padding: 0;
 }

--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -71,7 +71,7 @@
     text-align: right;
   }
 
-  .button {
+  .button--secondary {
     @include core-font(16);
     margin-bottom: $default-spacing-unit / 2;
 

--- a/assets/stylesheets/components/_badge.scss
+++ b/assets/stylesheets/components/_badge.scss
@@ -37,6 +37,10 @@
   text-decoration: none;
   font-weight: 600;
 
+  .c-answers-summary & {
+    font-size: 14px;
+  }
+
   &:link,
   &:visited {
     background-color: $white;

--- a/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
+++ b/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
@@ -1,0 +1,32 @@
+const { find, get } = require('lodash')
+
+const { Order } = require('../../../models')
+
+async function editLeadAssignee (req, res, next) {
+  const adviserId = req.body.adviserId
+  const orderId = req.body.orderId
+  const returnUrl = req.body.returnUrl || req.header('Referer')
+
+  if (!adviserId || !orderId) {
+    return res.redirect(returnUrl)
+  }
+
+  try {
+    const allAssignees = await Order.getAssignees(req.session.token, orderId)
+    const assignees = allAssignees.map(assignee => {
+      return Object.assign(assignee, {
+        is_lead: assignee.adviser.id === adviserId,
+      })
+    })
+    const leadAdviser = find(assignees, { adviser: { id: adviserId } })
+
+    await Order.saveAssignees(req.session.token, orderId, assignees)
+
+    req.flash('success', `Lead post adviser set to ${get(leadAdviser, 'adviser.name')}`)
+    res.redirect(returnUrl)
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = editLeadAssignee

--- a/src/apps/omis/apps/edit/controllers/index.js
+++ b/src/apps/omis/apps/edit/controllers/index.js
@@ -4,6 +4,7 @@ const EditClientDetailsController = require('./client-details')
 const EditSubscribersController = require('./subscribers')
 const EditWorkDescriptionController = require('./work-description')
 const editHandler = require('./edit-handler')
+const editLeadAssignee = require('./edit-lead-assignee')
 const editRedirect = require('./edit-redirect')
 
 module.exports = {
@@ -13,5 +14,6 @@ module.exports = {
   EditSubscribersController,
   EditWorkDescriptionController,
   editHandler,
+  editLeadAssignee,
   editRedirect,
 }

--- a/src/apps/omis/apps/edit/router.js
+++ b/src/apps/omis/apps/edit/router.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const { editRedirect, editHandler } = require('./controllers')
+const { editRedirect, editHandler, editLeadAssignee } = require('./controllers')
 const { getCompany } = require('../../middleware/params')
 
 router.use((req, res, next) => {
@@ -9,5 +9,7 @@ router.use((req, res, next) => {
 
 router.get('/', editRedirect)
 router.all('/:step', editHandler)
+
+router.post('/lead-assignee', editLeadAssignee)
 
 module.exports = router

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -91,8 +91,25 @@
       {% for assignee in values.assignees %}
         <tr>
           <th class="c-answers-summary__title" scope="row">
-            {{ assignee.adviser.name }}
+            {{ assignee.adviser.name }} {{ '(you)' if assignee.adviser.id === user.id }}
+            {% if assignee.is_lead %}
+              <span class="c-badge">Lead adviser</span>
+            {% endif %}
           </th>
+          <td class="c-answers-summary__content c-answers-summary__control">
+            {% if not assignee.is_lead %}
+              {% call Form ({
+                action: 'edit/lead-assignee',
+                hideFormActions: true,
+                hiddenFields: {
+                  adviserId: assignee.adviser.id,
+                  orderId: order.id
+                }
+              }) %}
+                <button type="submit" class="button button--link button--compact">Set as lead adviser</button>
+              {% endcall %}
+            {% endif %}
+          </td>
           <td class="c-answers-summary__content c-answers-summary__content--number">
             {{ assignee.estimated_time  | humanizeDuration if assignee.estimated_time else 'No time estimated' }}
           </td>
@@ -107,7 +124,7 @@
     {% if values.estimatedTimeSum and values.assignees.length %}
       <tfoot>
         <tr>
-          <td class="c-answers-summary__footer" colspan="2">
+          <td class="c-answers-summary__footer" colspan="3">
             <span class="c-answers-summary__footer-value">{{ values.estimatedTimeSum | humanizeDuration }}</span> total estimated time
           </td>
         </tr>


### PR DESCRIPTION
This change adds the ability to set who the lead adviser on an order is.

It adds an extra post handler to the edit sub-app which handles unsetting the previous lead and setting the new lead.

**Note:** Needs to be merged and rebased after #475 

👉 [**DEMO**](https://datahub-beta2-pr-478.herokuapp.com/omis/ebad867d-2527-4439-b5fb-d39fb7095392/work-order) 👈

## What it looks like

![localhost_3001_omis_5325ad09-0dd4-480e-94be-9a4a3cde0eb9_work-order](https://user-images.githubusercontent.com/3327997/29457936-f8cd25d0-841c-11e7-8a79-f0d34067993b.png)
