### PR TITLE
Provide fallback when no assignees have been added

### DIFF
--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -79,8 +79,8 @@
       text: 'Add or remove'
     }]
   }) %}
-    {% for assignee in values.assignees %}
-      <tbody>
+    <tbody>
+      {% for assignee in values.assignees %}
         <tr>
           <th class="c-answers-summary__title" scope="row">
             {{ assignee.adviser.name }}
@@ -89,17 +89,21 @@
             {{ assignee.estimated_time  | humanizeDuration if assignee.estimated_time else 'No time estimated' }}
           </td>
         </tr>
-      </tbody>
-    {% endfor %}
+      {% else %}
+        <tr>
+          <td class="c-answers-summary__content" colspan="3">None selected</td>
+        </tr>
+      {% endfor %}
+    </tbody>
 
     {% if values.estimatedTimeSum and values.assignees.length %}
-    <tfoot>
-      <tr>
-        <td class="c-answers-summary__footer" colspan="2">
-          <span class="c-answers-summary__footer-value">{{ values.estimatedTimeSum | humanizeDuration }}</span> total estimated time
-        </td>
-      </tr>
-    </tfoot>
+      <tfoot>
+        <tr>
+          <td class="c-answers-summary__footer" colspan="2">
+            <span class="c-answers-summary__footer-value">{{ values.estimatedTimeSum | humanizeDuration }}</span> total estimated time
+          </td>
+        </tr>
+      </tfoot>
     {% endif %}
   {% endcall %}
 


### PR DESCRIPTION
This provides a default value when there are no assignees on an
OMIS order.

It also fixes a bug where the loop was creating a new `tbody` element
for each item.

## Before

![image](https://user-images.githubusercontent.com/3327997/29505896-2a499818-8649-11e7-8294-7341006736e3.png)

## After

![image](https://user-images.githubusercontent.com/3327997/29505881-15d7a6d6-8649-11e7-96a3-df043119022f.png)
