### PR TITLE
Revert "Merge pull request #477 from uktrade/patch/form-group-fix"

### DIFF
--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -338,11 +338,11 @@
   {% set element = 'fieldset' if props.type in ['checkbox', 'radio'] %}
   {% set children = caller() if caller else renderAsMacro(props.children) %}
 
-  {% call FormGroup(props | assignCopy({ fieldId: fieldId, caller: caller, children: children, element: element, class: props.groupClass })) %}
+  {% call FormGroup(props | assign({ fieldId: fieldId, caller: caller, children: children, element: element, class: props.groupClass })) %}
     {% if props.type in ['checkbox', 'radio'] %}
-      {{ MultipleChoice(props | assignCopy({ class: inputClass })) }}
+      {{ MultipleChoice(props) }}
     {% else %}
-      {{ SelectBox(props | assignCopy({ class: inputClass })) }}
+      {{ SelectBox(props | assign({ class: inputClass })) }}
     {% endif %}
 
     {{ children }}

--- a/test/unit/macros/form.test.js
+++ b/test/unit/macros/form.test.js
@@ -384,21 +384,4 @@ describe('Nunjucks form macros', () => {
       })
     })
   })
-
-  describe('Formgroup component', () => {
-    it('should allow a class to be specified for use in the form-group wrapper', () => {
-      const component = macros.renderToDom('MultipleChoiceField', {
-        label: 'Test label',
-        name: 'adviser',
-        value: 'wilma',
-        groupClass: 'js-adviser',
-        options: [
-          { label: 'Fred', value: 'fred' },
-          { label: 'Wilma', value: 'wilma' },
-        ],
-      })
-
-      expect(component.className).to.include('js-adviser')
-    })
-  })
 })


### PR DESCRIPTION
This reverts commit dbe588c83015b563f12de25b9e71231055dc65ff, reversing
changes made to b19fb9908c9d1a1a0285ee80dff885f4de5b69c7.

Due to the fact that macros can't get parent context this changes introduces an issue with `fieldId` being lost as well as other props passed down from `MultipleChoiceField` to `FormGroup` caller. Currently we rely on macros mutating the original properties which allows the values to be passed deeper in macro callers.

Reverting to fix the immediate issue of broken filters. Will address the mutation in a separate PR.