### PR TITLE
Only show edit time link for assignees if there are some

### DIFF
--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -5,9 +5,11 @@
     <caption class="c-answers-summary__heading">
       {{ props.heading }}
       {% for action in props.actions %}
-        <a class="c-answers-summary__heading-action" href="{{ action.url }}">
-          {{ action.text or 'Edit' }}
-        </a>
+        {% if action.url %}
+          <a class="c-answers-summary__heading-action" href="{{ action.url }}">
+            {{ action.text or 'Edit' }}
+          </a>
+        {% endif %}
       {% endfor %}
     </caption>
 
@@ -72,7 +74,7 @@
   {% call AnswersSummary({
     heading: 'Post advisers',
     actions: [{
-      url: 'edit/assignee-time',
+      url: 'edit/assignee-time' if values.assignees.length,
       text: 'Edit time'
     }, {
       url: 'edit/assignees',


### PR DESCRIPTION
There is no reason to show the edit time link if there aren't any
assignees (post advisers) to assign time to.

## Before

![image](https://user-images.githubusercontent.com/3327997/29559551-b4ef3d06-872f-11e7-8ab6-b8305e23f1ff.png)

## After

![image](https://user-images.githubusercontent.com/3327997/29559571-c05a410e-872f-11e7-97b2-a64a963c55dc.png)