### PR TITLE
Added a variation to the entity macro

### DIFF
--- a/src/templates/_macros/collection.njk
+++ b/src/templates/_macros/collection.njk
@@ -1,5 +1,5 @@
 {% from './common.njk' import Pagination %}
-{% from './entities.njk' import Entity %}
+{% from './entities.njk' import Entity, PlainEntity %}
 {% from './form.njk' import Form, MultipleChoiceField, TextField %}
 
 {##
@@ -121,16 +121,20 @@
  # @param {object}  [props.sortForm] - object containing sorting form
  # @param {string}  [props.highlightTerm] - text to use to apply highlight filter
  # @param {string}  [props.summaryActionsHTML] - HTML content for actions block
+ # @param {bool}    [props.plainList] - Use a simplified list without support for badges or links
 #}
 {% macro Collection(props) %}
   <article class="c-collection">
     {{ _CollectionHeader(props | assign({ actionsHTML: props.summaryActionsHTML })) }}
-
     {% if props.items | length %}
       <ol class="c-entity-list">
         {% for item in props.items %}
           <li class="c-entity-list__item">
-            {{ Entity(item | assign({ highlightTerm: props.highlightTerm })) }}
+            {% if props.plainList %}
+              {{ PlainEntity(item | assign({ highlightTerm: props.highlightTerm })) }}
+            {% else %}
+              {{ Entity(item | assign({ highlightTerm: props.highlightTerm })) }}
+            {% endif %}
           </li>
         {% endfor %}
       </ol>

--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -123,3 +123,37 @@
     </div>
   {% endif %}
 {% endmacro %}
+
+
+{##
+ # Render entity component
+ # @param {object} props
+ # @param {string} props.name - entity name
+ # @param {array}  [props.metaItems{}] - an array of metadata item objects
+ # @param {string} [props.highlightTerm] - text to use to apply highlight filter
+ #}
+{% macro PlainEntity (props) %}
+  {% set metaItems = props.meta %}
+
+  <div class="c-entity c-entity--anonymous}">
+    {% if props.code %}
+      <div class="c-entity__code">{{ props.code | highlight(props.highlightTerm, true) }}</div>
+    {% endif %}
+
+    <div class="c-entity__header">
+      <h3 class="c-entity__title">{{ props.name | highlight(props.highlightTerm) }}</h3>
+    </div>
+
+    {% if metaItems | length %}
+      <div class="c-entity__content">
+        {{
+          MetaList({
+            items: metaItems,
+            highlightTerm: props.highlightTerm,
+            modifier: ['inline', 'split']
+          })
+        }}
+      </div>
+    {% endif %}
+  </div>
+{% endmacro %}


### PR DESCRIPTION
Created a simplified entity macro that just shows the title and meta
but does not link to a detail screen. The initial use of this is the
audit list.