### PR TITLE
Allow entity macro titles without links and override metalist modifiers

### DIFF
--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -72,3 +72,15 @@
     margin-right: 0;
   }
 }
+
+.c-meta-list--stacked {
+  display: block;
+
+  .c-meta-list__item {
+    display: block;
+  }
+
+  .c-meta-list__item  + .c-meta-list__item {
+    margin-left: 0;
+  }
+}

--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -72,15 +72,3 @@
     margin-right: 0;
   }
 }
-
-.c-meta-list--stacked {
-  display: block;
-
-  .c-meta-list__item {
-    display: block;
-  }
-
-  .c-meta-list__item  + .c-meta-list__item {
-    margin-left: 0;
-  }
-}

--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -1,17 +1,19 @@
 {##
  # Render entity component
  # @param {object} props
- # @param {string} props.id - entity id
  # @param {string} props.name - entity name
  # @param {string} props.type - entity type (e.g. 'date' to format dates)
+ # @param {string} [props.id] - entity id, used to create a link to the entity if provided
  # @param {array}  [props.metaBadges{}] - an array of metadata item objects
  # @param {array}  [props.metaItems{}] - an array of metadata item objects
  # @param {string} [props.highlightTerm] - text to use to apply highlight filter
+ # @param {sting|array} [props.contentMetaModifier] - A modified to apply to metadata to control it's display
  #}
 {% macro Entity (props) %}
-  {% if props.name and props.id and props.type %}
+  {% if props.name and props.type %}
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
     {% set metaTimes = props.meta | filter(['type', 'time']) %}
+    {% set contentMetaModifier = props.contentMetaModifier| default(['inline', 'split']) %}
     {% set metaItems = props.meta
       | reject(['type', 'badge'])
       | reject(['type', 'time'])
@@ -24,7 +26,11 @@
 
       <div class="c-entity__header">
         <h3 class="c-entity__title">
-          <a href="/{{ props.type | pluralise }}/{{ props.id }}">{{ props.name | highlight(props.highlightTerm) }}</a>
+          {% if props.id %}
+            <a href="/{{ props.type | pluralise }}/{{ props.id }}">{{ props.name | highlight(props.highlightTerm) }}</a>
+          {% else %}
+            {{ props.name | highlight(props.highlightTerm) }}
+          {% endif %}
         </h3>
 
         {% if metaBadges | length %}
@@ -45,7 +51,7 @@
             MetaList({
               items: metaItems,
               highlightTerm: props.highlightTerm,
-              modifier: ['inline', 'split']
+              modifier: contentMetaModifier
             })
           }}
         </div>

--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -18,6 +18,7 @@
       | reject(['type', 'badge'])
       | reject(['type', 'time'])
     %}
+    {% set highlightedName = props.name | highlight(props.highlightTerm) %}
 
     <div class="c-entity c-entity--{{ props.type }}">
       {% if props.code %}
@@ -27,9 +28,9 @@
       <div class="c-entity__header">
         <h3 class="c-entity__title">
           {% if props.id %}
-            <a href="/{{ props.type | pluralise }}/{{ props.id }}">{{ props.name | highlight(props.highlightTerm) }}</a>
+            <a href="/{{ props.type | pluralise }}/{{ props.id }}">{{ highlightedName }}</a>
           {% else %}
-            {{ props.name | highlight(props.highlightTerm) }}
+            {{ highlightedName }}
           {% endif %}
         </h3>
 

--- a/test/unit/macros/entities.test.js
+++ b/test/unit/macros/entities.test.js
@@ -46,6 +46,46 @@ describe('Entities macros', () => {
         expect(component.querySelector('.c-entity__content .c-meta-list__item').textContent.replace(/\s+/g, ' ').trim())
           .to.equal('DOB: 10 November 2015')
       })
+
+      it('should render a title without a link if no id passed', () => {
+        const component = entitiesMacros.renderToDom('Entity', {
+          name: 'Horse',
+          type: 'animal',
+        })
+
+        expect(component.querySelector('.c-entity__title').textContent.replace(/\s+/g, ' ').trim())
+          .to.equal('Horse')
+        expect(component.querySelector('.c-entity__title a')).not.to.exist
+      })
+
+      it('should use a default modifier of inline split it no modifier specified', () => {
+        const component = entitiesMacros.renderToDom('Entity', {
+          id: '12345',
+          name: 'Horse',
+          type: 'animal',
+          meta: [
+            { label: 'Colour', value: 'brown', type: 'badge' },
+            { label: 'DOB', value: '2015-11-10', type: 'date', name: 'date_of_birth' },
+          ],
+        })
+        expect(component.querySelector('.c-meta-list.c-meta-list--split.c-meta-list--inline')).to.exist
+      })
+
+      it('should use a content meta modifier if specified', () => {
+        const component = entitiesMacros.renderToDom('Entity', {
+          id: '12345',
+          name: 'Horse',
+          type: 'animal',
+          contentMetaModifier: 'test',
+          meta: [
+            { label: 'Colour', value: 'brown', type: 'badge' },
+            { label: 'DOB', value: '2015-11-10', type: 'date', name: 'date_of_birth' },
+          ],
+        })
+
+        expect(component.querySelector('.c-meta-list.c-meta-list--split.c-meta-list--inline')).not.to.exist
+        expect(component.querySelector('.c-meta-list.c-meta-list--test')).to.exist
+      })
     })
   })
 


### PR DESCRIPTION
Change the entity macro so that it only makes the entity title a link
if an id is passed to it, otherwise make it a plain title.

Add an optional parameter to the entity macro 'contentMetaModifier' to
allow an alternative modifier to applied to the metalist macro call
to allow alernative layouts to be requested when generating entity
collections.