### PR TITLE
Only list markets where OMIS is supplied

### DIFF
--- a/src/apps/omis/apps/create/controllers/market.js
+++ b/src/apps/omis/apps/create/controllers/market.js
@@ -1,10 +1,14 @@
+const { filter } = require('lodash')
+
 const metadataRepo = require('../../../../../lib/metadata')
 const { FormController } = require('../../../controllers')
 const { transformObjectToOption } = require('../../../../transformers')
 
 class MarketController extends FormController {
   configure (req, res, next) {
-    req.form.options.fields.primary_market.options = metadataRepo.countryOptions.map(transformObjectToOption)
+    const filterMarkets = filter(metadataRepo.omisMarketOptions, market => !market.disabled_on)
+
+    req.form.options.fields.primary_market.options = filterMarkets.map(transformObjectToOption)
     super.configure(req, res, next)
   }
 }

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -86,6 +86,7 @@ const metadataItems = [
   ['investment-strategic-driver', 'strategicDriverOptions'],
   ['investment-project-stage', 'investmentStageOptions'],
   ['order-service-type', 'orderServiceTypesOptions'],
+  ['omis-market', 'omisMarketOptions'],
 ]
 
 const restrictedServiceKeys = [

--- a/test/unit/apps/omis/apps/create/controllers/market.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/market.test.js
@@ -2,12 +2,18 @@ const FormController = require('hmpo-form-wizard').Controller
 
 const Controller = proxyquire('~/src/apps/omis/apps/create/controllers/market', {
   '../../../../../lib/metadata': {
-    countryOptions: [{
+    omisMarketOptions: [{
       id: '1',
       name: 'One',
+      disabled_on: null,
     }, {
       id: '2',
       name: 'Two',
+      disabled_on: '2010-01-01T00:00:00',
+    }, {
+      id: '3',
+      name: 'Three',
+      disabled_on: null,
     }],
   },
 })
@@ -47,8 +53,8 @@ describe('OMIS create market controller', () => {
           label: 'One',
         },
         {
-          value: '2',
-          label: 'Two',
+          value: '3',
+          label: 'Three',
         },
       ])
       expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, globalRes, this.nextSpy)


### PR DESCRIPTION
Previously we were using all countries in the market choice step
but OMIS is only supplied in selected markets so this changes that
list to the correct options.