### PR TITLE
Make contact audit history titles/links consistent with investment

### DIFF
--- a/src/apps/audit/index.js
+++ b/src/apps/audit/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  displayName: 'Audit log',
+  displayName: 'Audit history',
 }

--- a/src/apps/components/views/entity-list.njk
+++ b/src/apps/components/views/entity-list.njk
@@ -87,7 +87,7 @@
     </div>
   {% endcall %}
 
-  {% call Example('Audit log') %}
+  {% call Example('Audit history') %}
     {{ Collection(auditLog) }}
   {% endcall %}
 

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -12,7 +12,7 @@ const { getAudit } = require('./controllers/audit')
 const LOCAL_NAV = [
   { path: 'details', label: 'Details' },
   { path: 'interactions', label: 'Interactions' },
-  { path: 'audit', label: 'Audit log' },
+  { path: 'audit', label: 'Audit history' },
 ]
 
 const DEFAULT_COLLECTION_QUERY = {

--- a/test/unit/apps/audit/transformers.test.js
+++ b/test/unit/apps/audit/transformers.test.js
@@ -28,7 +28,7 @@ describe('Audit transformers', () => {
     expect(this.transformedLog.countLabel).to.equal('log entry')
   })
 
-  it('should return a formatted audit log item when there are changes', () => {
+  it('should return a formatted audit history item when there are changes', () => {
     const item = this.transformedLog.items[0]
 
     expect(item.type).to.equal('audit')


### PR DESCRIPTION
Realised that although the requirements for contact audit log had 'log' as the title, the existing screens use the words 'Audit history'.