### PR TITLE
Fix datetime format in configuration

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -44,7 +44,7 @@ const config = {
   sentryDsn: process.env.SENTRY_DSN,
   longDateFormat: 'D MMMM YYYY',
   mediumDateFormat: 'D MMM YYYY',
-  mediumDateTimeFormat: 'D MMM YYYY, h:MMa',
+  mediumDateTimeFormat: 'D MMM YYYY, h:mma',
   paginationMaxResults: 10000,
 }
 

--- a/test/unit/apps/audit/transformers.test.js
+++ b/test/unit/apps/audit/transformers.test.js
@@ -32,7 +32,7 @@ describe('Audit transformers', () => {
     const item = this.transformedLog.items[0]
 
     expect(item.type).to.equal('audit')
-    expect(item.name).to.equal('9 Jun 2017, 4:06pm')
+    expect(item.name).to.equal('9 Jun 2017, 4:11pm')
     expect(item.contentMetaModifier).to.equal('stacked')
     expect(item.meta[0].label).to.equal('Adviser')
     expect(item.meta[0].value).to.equal('Reupen Shah')


### PR DESCRIPTION
The datetime format was actually using the month value for minutes.