### PR TITLE
Remove unused meta item filter from entity macro

### DIFF
--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -12,11 +12,9 @@
 {% macro Entity (props) %}
   {% if props.name and props.type %}
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
-    {% set metaTimes = props.meta | filter(['type', 'time']) %}
     {% set contentMetaModifier = props.contentMetaModifier| default(['inline', 'split']) %}
     {% set metaItems = props.meta
       | reject(['type', 'badge'])
-      | reject(['type', 'time'])
     %}
     {% set highlightedName = props.name | highlight(props.highlightTerm) %}
 


### PR DESCRIPTION
The entity macro was filtering out `time` meta items but not doing
anything with them so this has been removed.