### PR TITLE
Support custom URL within entity macro

### DIFF
--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -4,6 +4,7 @@
  # @param {string} props.name - entity name
  # @param {string} props.type - entity type (e.g. 'date' to format dates)
  # @param {string} [props.id] - entity id, used to create a link to the entity if provided
+ # @param {string} [props.urlPrefix] - base URL for linking to an entity, by default it will pluralise props.type
  # @param {array}  [props.metaBadges{}] - an array of metadata item objects
  # @param {array}  [props.metaItems{}] - an array of metadata item objects
  # @param {string} [props.highlightTerm] - text to use to apply highlight filter
@@ -11,6 +12,7 @@
  #}
 {% macro Entity (props) %}
   {% if props.name and props.type %}
+    {% set urlPrefix = props.urlPrefix or props.type | pluralise + '/' %}
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
     {% set metaTimes = props.meta | filter(['type', 'time']) %}
     {% set contentMetaModifier = props.contentMetaModifier| default(['inline', 'split']) %}
@@ -28,7 +30,7 @@
       <div class="c-entity__header">
         <h3 class="c-entity__title">
           {% if props.id %}
-            <a href="/{{ props.type | pluralise }}/{{ props.id }}">{{ highlightedName }}</a>
+            <a href="/{{ urlPrefix }}{{ props.id }}">{{ highlightedName }}</a>
           {% else %}
             {{ highlightedName }}
           {% endif %}

--- a/test/unit/macros/entities.test.js
+++ b/test/unit/macros/entities.test.js
@@ -58,6 +58,17 @@ describe('Entities macros', () => {
         expect(component.querySelector('.c-entity__title a')).not.to.exist
       })
 
+      it('should render a custom url if passed', () => {
+        const component = entitiesMacros.renderToDom('Entity', {
+          id: '12345',
+          name: 'Horse',
+          type: 'animal',
+          urlPrefix: 'horses/',
+        })
+
+        expect(component.querySelector('.c-entity__title a')).to.have.property('href', '/horses/12345')
+      })
+
       it('should use a default modifier of inline split it no modifier specified', () => {
         const component = entitiesMacros.renderToDom('Entity', {
           id: '12345',


### PR DESCRIPTION
In some cases we don't want to just use a plural of the type so this
adds support for a custom URL to be passed to the macro.