### PR TITLE
Update audit logs to use generic collection

### DIFF
--- a/src/apps/audit/transformers.js
+++ b/src/apps/audit/transformers.js
@@ -1,8 +1,6 @@
 /* eslint camelcase: 0 */
-const { isArray, isPlainObject } = require('lodash')
 const dateFns = require('date-fns')
 const { mediumDateTimeFormat } = require('../../../config')
-const { buildPagination } = require('../../lib/pagination')
 
 function transformChanges (changes, labels) {
   return Object.keys(changes)
@@ -22,44 +20,29 @@ function getChangeCountDisplay (changeCount) {
   return `${changeCount} changes`
 }
 
-function transformAuditLogToListItem (logEntry, labels = {}) {
-  const changeCount = (logEntry.changes && Object.keys(logEntry.changes).length) || 0
+function transformAuditLogToListItem (labels = {}) {
+  return function transformAuditLogItem (logEntry) {
+    const changeCount = (logEntry.changes && Object.keys(logEntry.changes).length) || 0
 
-  return {
-    type: 'audit',
-    name: dateFns.format(logEntry.timestamp, mediumDateTimeFormat),
-    contentMetaModifier: 'stacked',
-    meta: [{
-      label: 'Adviser',
-      value: logEntry.user.name,
-    }, {
-      label: 'Change count',
-      type: 'badge',
-      value: getChangeCountDisplay(changeCount),
-    }, {
-      label: 'Fields',
-      value: transformChanges(logEntry.changes, labels),
-    }],
-  }
-}
-
-function transformAuditLogToCollection (auditData, labels = {}, options = {}) {
-  if (!isPlainObject(auditData)) { return }
-  const resultItems = auditData.results
-  if (!isArray(resultItems)) { return }
-
-  const items = resultItems.map((resultItem) => {
-    return transformAuditLogToListItem(resultItem, labels)
-  })
-
-  return {
-    items,
-    count: items.length,
-    countLabel: 'log entry',
-    pagination: buildPagination(options.query, auditData),
+    return {
+      type: 'audit',
+      name: dateFns.format(logEntry.timestamp, mediumDateTimeFormat),
+      contentMetaModifier: 'stacked',
+      meta: [{
+        label: 'Adviser',
+        value: logEntry.user.name,
+      }, {
+        label: 'Change count',
+        type: 'badge',
+        value: getChangeCountDisplay(changeCount),
+      }, {
+        label: 'Fields',
+        value: transformChanges(logEntry.changes, labels),
+      }],
+    }
   }
 }
 
 module.exports = {
-  transformAuditLogToCollection,
+  transformAuditLogToListItem,
 }

--- a/src/apps/companies/controllers/audit.js
+++ b/src/apps/companies/controllers/audit.js
@@ -1,7 +1,8 @@
 const { getCompanyAuditLog, getDitCompany } = require('../repos')
 const { getCommonTitlesAndlinks } = require('../services/data')
-const { transformAuditLogToCollection } = require('../../audit/transformers')
+const { transformAuditLogToListItem } = require('../../audit/transformers')
 const { companyDetailsLabels } = require('../labels')
+const { transformApiResponseToCollection } = require('../../transformers')
 
 async function getAudit (req, res, next) {
   try {
@@ -13,7 +14,10 @@ async function getAudit (req, res, next) {
     getCommonTitlesAndlinks(req, res, company)
 
     const auditLog = await getCompanyAuditLog(token, companyId, page)
-      .then(result => transformAuditLogToCollection(result, companyDetailsLabels))
+      .then(transformApiResponseToCollection(
+        { entityType: 'audit' },
+        transformAuditLogToListItem(companyDetailsLabels)
+      ))
 
     return res
       .breadcrumb('Audit history')

--- a/src/apps/contacts/controllers/audit.js
+++ b/src/apps/contacts/controllers/audit.js
@@ -1,5 +1,6 @@
 const { getContactAuditLog } = require('../repos')
-const { transformAuditLogToCollection } = require('../../audit/transformers')
+const { transformApiResponseToCollection } = require('../../transformers')
+const { transformAuditLogToListItem } = require('../../audit/transformers')
 const { contactDetailsLabels } = require('../labels')
 
 async function getAudit (req, res, next) {
@@ -9,7 +10,10 @@ async function getAudit (req, res, next) {
     const page = req.query.page || 1
 
     const auditLog = await getContactAuditLog(token, contactId, page)
-      .then(result => transformAuditLogToCollection(result, contactDetailsLabels))
+      .then(transformApiResponseToCollection(
+        { entityType: 'audit' },
+        transformAuditLogToListItem(contactDetailsLabels)
+      ))
 
     return res
       .breadcrumb('Audit history')

--- a/test/unit/apps/audit/transformers.test.js
+++ b/test/unit/apps/audit/transformers.test.js
@@ -15,31 +15,27 @@ describe('Audit transformers', () => {
       query: {},
     }
 
-    this.transformedLog = this.transformers.transformAuditLogToCollection(auditLog, contactDetailsLabels, this.options)
+    this.transformer = this.transformers.transformAuditLogToListItem(contactDetailsLabels)
   })
 
   afterEach(() => {
     this.sandbox.restore()
   })
 
-  it('should return an object for use in collections', () => {
-    expect(this.transformedLog).to.have.property('items')
-    expect(this.transformedLog.count).to.equal(7)
-    expect(this.transformedLog.countLabel).to.equal('log entry')
-  })
-
   it('should return a formatted audit history item when there are changes', () => {
-    const item = this.transformedLog.items[0]
+    const transformedItem = this.transformer(auditLog.results[0])
 
-    expect(item.type).to.equal('audit')
-    expect(item.name).to.equal('9 Jun 2017, 4:11pm')
-    expect(item.contentMetaModifier).to.equal('stacked')
-    expect(item.meta[0].label).to.equal('Adviser')
-    expect(item.meta[0].value).to.equal('Reupen Shah')
+    expect(transformedItem.type).to.equal('audit')
+    expect(transformedItem.name).to.equal('9 Jun 2017, 4:11pm')
+    expect(transformedItem.contentMetaModifier).to.equal('stacked')
+    expect(transformedItem.meta[0].label).to.equal('Adviser')
+    expect(transformedItem.meta[0].value).to.equal('Reupen Shah')
   })
 
   it('should transform the list of changes to a list of fields and use the labels', () => {
-    expect(this.transformedLog.items[1].meta[2]).to.deep.equal({
+    const transformedItem = this.transformer(auditLog.results[1])
+
+    expect(transformedItem.meta[2]).to.deep.equal({
       label: 'Fields',
       value: 'Address same as company, Address line 1, Address line 2, Town, County, Country, Postcode',
     })
@@ -47,7 +43,9 @@ describe('Audit transformers', () => {
 
   describe('change count', () => {
     it('should describe multiple of changes', () => {
-      expect(this.transformedLog.items[1].meta[1]).to.deep.equal({
+      const transformedItem = this.transformer(auditLog.results[1])
+
+      expect(transformedItem.meta[1]).to.deep.equal({
         label: 'Change count',
         type: 'badge',
         value: '7 changes',
@@ -55,7 +53,8 @@ describe('Audit transformers', () => {
     })
 
     it('should describe a single change', () => {
-      expect(this.transformedLog.items[2].meta[1]).to.deep.equal({
+      const transformedItem = this.transformer(auditLog.results[2])
+      expect(transformedItem.meta[1]).to.deep.equal({
         label: 'Change count',
         type: 'badge',
         value: '1 change',
@@ -63,15 +62,13 @@ describe('Audit transformers', () => {
     })
 
     it('should describe a zero changes', () => {
-      expect(this.transformedLog.items[0].meta[1]).to.deep.equal({
+      const transformedItem = this.transformer(auditLog.results[0])
+
+      expect(transformedItem.meta[1]).to.deep.equal({
         label: 'Change count',
         type: 'badge',
         value: 'No changes saved',
       })
     })
-  })
-
-  it('should build pagination information in the collection', () => {
-    expect(this.buildPaginationStub).to.be.calledWith(this.options.query, auditLog)
   })
 })


### PR DESCRIPTION
Updates the audit transformer to be compatible with new generic collection handlers.

Changed company and contact audit controllers to use new generic collections

