### PR TITLE
Remove entityType from apps transformer

### DIFF
--- a/src/apps/companies/controllers/investments.js
+++ b/src/apps/companies/controllers/investments.js
@@ -12,10 +12,7 @@ async function getAction (req, res, next) {
     const company = await getInflatedDitCompany(token, companyId)
     const results = await getCompanyInvestmentProjects(token, companyId, page)
       .then(transformApiResponseToCollection(
-        {
-          entityType: 'investment_project',
-          query: req.query,
-        },
+        { query: req.query },
         transformInvestmentProjectToListItem,
       ))
 

--- a/src/apps/contacts/middleware.js
+++ b/src/apps/contacts/middleware.js
@@ -5,22 +5,17 @@ const { transformApiResponseToSearchCollection } = require('../search/transforme
 const { transformContactToListItem } = require('./transformers')
 
 async function getContactsCollection (req, res, next) {
-  const searchEntity = 'contact'
-
   try {
     res.locals.results = await search({
       searchTerm: '',
-      searchEntity,
+      searchEntity: 'contact',
       requestBody: req.body,
       token: req.session.token,
       page: req.query.page,
       isAggregation: false,
     })
       .then(transformApiResponseToSearchCollection(
-        {
-          entityType: searchEntity,
-          query: req.query,
-        },
+        { query: req.query },
         transformContactToListItem,
       ))
 

--- a/src/apps/contacts/middleware.js
+++ b/src/apps/contacts/middleware.js
@@ -7,7 +7,6 @@ const { transformContactToListItem } = require('./transformers')
 async function getContactsCollection (req, res, next) {
   try {
     res.locals.results = await search({
-      searchTerm: '',
       searchEntity: 'contact',
       requestBody: req.body,
       token: req.session.token,

--- a/src/apps/investment-projects/middleware/collection.js
+++ b/src/apps/investment-projects/middleware/collection.js
@@ -10,7 +10,6 @@ const {
 async function getInvestmentProjectsCollection (req, res, next) {
   try {
     res.locals.results = await search({
-      searchTerm: '',
       searchEntity: 'investment_project',
       requestBody: req.body,
       token: req.session.token,

--- a/src/apps/investment-projects/middleware/collection.js
+++ b/src/apps/investment-projects/middleware/collection.js
@@ -8,22 +8,17 @@ const {
 } = require('../transformers')
 
 async function getInvestmentProjectsCollection (req, res, next) {
-  const searchEntity = 'investment_project'
-
   try {
     res.locals.results = await search({
       searchTerm: '',
-      searchEntity,
+      searchEntity: 'investment_project',
       requestBody: req.body,
       token: req.session.token,
       page: req.query.page,
       isAggregation: false,
     })
       .then(transformApiResponseToSearchCollection(
-        {
-          entityType: searchEntity,
-          query: req.query,
-        },
+        { query: req.query },
         transformInvestmentProjectToListItem,
         transformInvestmentListItemToHaveMetaLinks(req.query),
       ))

--- a/src/apps/omis/apps/list/middleware.js
+++ b/src/apps/omis/apps/list/middleware.js
@@ -3,21 +3,16 @@ const { transformApiResponseToSearchCollection } = require('../../../search/tran
 const { transformOrderToListItem } = require('../../transformers')
 
 async function getCollection (req, res, next) {
-  const searchEntity = 'order'
-
   try {
     res.locals.results = await search({
-      searchEntity,
+      searchEntity: 'order',
       requestBody: req.body,
       token: req.session.token,
       page: req.query.page,
       isAggregation: false,
     })
       .then(transformApiResponseToSearchCollection(
-        {
-          entityType: searchEntity,
-          query: req.query,
-        },
+        { query: req.query },
         transformOrderToListItem,
       ))
 

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -26,7 +26,6 @@ function searchAction (req, res, next) {
     page: req.query.page,
   })
     .then(transformApiResponseToSearchCollection({
-      entityType: searchEntity,
       searchTerm,
       query: req.query,
     }))
@@ -73,7 +72,6 @@ async function renderSearchResults (req, res) {
   })
     .then(transformApiResponseToSearchCollection(
       {
-        entityType: searchEntity,
         searchTerm,
         query: req.query,
       },

--- a/src/apps/search/transformers.js
+++ b/src/apps/search/transformers.js
@@ -5,7 +5,6 @@ const { buildSearchAggregation } = require('./builders')
 
 /**
  * @param {object} [options] {object}
- * @param {string} [options.entityType] - API entity type
  * @param {string} [options.searchTerm] - search term used for highlighting words in collection macro
  * @param {object} [options.query] - URL query object used in pagination
  * @param {...function} [itemTransformers] - an array of transformer functions to apply for each item in the list

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -43,7 +43,6 @@ function buildMetaDataObj (collection) {
 
 /**
  * @param {object} [options] {object}
- * @param {string} [options.entityType] - API entity type
  * @param {string} [options.searchTerm] - search term used for highlighting words in collection macro
  * @param {object} [options.query] - URL query object used in pagination
  * @param {...function} [itemTransformers] - an array of transformer functions to apply for each item in the list
@@ -55,10 +54,9 @@ function transformApiResponseToCollection (options = {}, ...itemTransformers) {
    * @returns {function}
    */
   return function transformResponseToCollection (response) {
-    if (!isPlainObject(response) || !options.entityType) { return }
+    if (!isPlainObject(response)) { return }
 
-    const pluralisedEntity = options.entityType === 'company' ? 'companies' : `${options.entityType}s`
-    let items = response[pluralisedEntity] || response.items || response.results
+    let items = response.results || response.items
 
     if (!items) { return }
 

--- a/test/unit/apps/search/controllers.test.js
+++ b/test/unit/apps/search/controllers.test.js
@@ -86,7 +86,7 @@ describe('Search Controller #searchAction', () => {
             expect(template).to.equal(`search/views/results-${entityType}`)
             expect(data.searchTerm).to.equal(searchQuery.term)
             expect(data.searchEntity).to.equal(entityType)
-            expect(data.results).to.have.property('items').to.deep.equal(expectedResults.companies)
+            expect(data.results).to.have.property('items').to.deep.equal(expectedResults.results)
             expect(data.results).to.have.property('aggregations').to.deep.equal(expectedSearchEntityResultsData(0))
             done()
           } catch (e) {

--- a/test/unit/apps/search/transformers.test.js
+++ b/test/unit/apps/search/transformers.test.js
@@ -51,7 +51,6 @@ describe('Search transformers', () => {
 
     it('should call transformApiResponseToCollection transformer with entity type and options', () => {
       const options = {
-        entityType: 'contact',
         query: { a: 'A' },
       }
       this.transformers.transformApiResponseToSearchCollection(options)(this.responseMock)
@@ -64,16 +63,14 @@ describe('Search transformers', () => {
       const firstItemTransformerSpy = this.sandbox.spy()
       const secondItemTransformerSpy = this.sandbox.spy()
 
-      const options = { entityType: 'contact' }
-
       this.transformers.transformApiResponseToSearchCollection(
-        options,
+        undefined,
         firstItemTransformerSpy,
         secondItemTransformerSpy
       )(this.responseMock)
 
       expect(this.transformApiResponseToCollectionInnerStub).to.be.calledWith(this.responseMock)
-      expect(this.transformApiResponseToCollectionStub).to.be.calledWith(options, firstItemTransformerSpy, secondItemTransformerSpy)
+      expect(this.transformApiResponseToCollectionStub).to.be.calledWith({}, firstItemTransformerSpy, secondItemTransformerSpy)
     })
 
     it('should return a collection object with aggregation', () => {
@@ -89,10 +86,7 @@ describe('Search transformers', () => {
     })
 
     it('should return a collection object with highlight term', () => {
-      const options = {
-        entityType: 'contact',
-        searchTerm: 'loop',
-      }
+      const options = { searchTerm: 'loop' }
       const itemsMock = [{ a: 'A', b: 'B' }]
       this.transformApiResponseToCollectionInnerStub.returns({ count: 2, items: itemsMock })
       const actual = this.transformers.transformApiResponseToSearchCollection(options)(this.responseMock)

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -94,7 +94,7 @@ describe('Global transformers', () => {
     })
 
     it('should return a collection object with pagination result, count and items array', () => {
-      const actual = this.transformers.transformApiResponseToCollection({ entityType: 'company' })(this.mockResponse)
+      const actual = this.transformers.transformApiResponseToCollection()(this.mockResponse)
 
       expect(actual).to.have.property('count', 2)
       expect(actual).to.have.property('items').to.be.an('array').and.have.length(2)
@@ -108,7 +108,7 @@ describe('Global transformers', () => {
       const itemTransformerOptions = { query: { term: 'bobby' } }
 
       const actual = this.transformers.transformApiResponseToCollection(
-        { entityType: 'company' },
+        undefined,
         itemTransformerSpy(itemTransformerOptions)
       )(this.mockResponse)
 
@@ -122,9 +122,7 @@ describe('Global transformers', () => {
       const secondItemTransformerSpy = this.sandbox.spy()
 
       const actual = this.transformers.transformApiResponseToCollection(
-        {
-          entityType: 'company',
-        },
+        undefined,
         firstItemTransformerSpy,
         secondItemTransformerSpy
       )(this.mockResponse)

--- a/test/unit/data/search/company.json
+++ b/test/unit/data/search/company.json
@@ -17,7 +17,7 @@
       "entity": "order"
     }
   ],
-  "companies": [
+  "results": [
     {
       "account_manager": null,
       "trading_name": null,


### PR DESCRIPTION
Back-end now always returns `results` so there is no need to pass `entityType`
into transformer options.