### PR TITLE
Add home breadcrumb for OMIS order

### DIFF
--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -1,15 +1,17 @@
 const { sumBy } = require('lodash')
 
-function renderWorkOrder (req, res, next) {
+function renderWorkOrder (req, res) {
   const order = res.locals.order
 
   const values = Object.assign({}, order, {
     estimatedTimeSum: sumBy(order.assignees, 'estimated_time'),
   })
 
-  res.render('omis/apps/view/views/work-order', {
-    values,
-  })
+  res
+    .breadcrumb('Work order')
+    .render('omis/apps/view/views/work-order', {
+      values,
+    })
 }
 
 module.exports = {

--- a/src/apps/omis/apps/view/index.js
+++ b/src/apps/omis/apps/view/index.js
@@ -1,7 +1,7 @@
 const router = require('./router')
 
 module.exports = {
-  displayName: 'Order',
+  displayName: 'View order',
   mountpath: '/:orderId',
   router,
 }

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -1,0 +1,11 @@
+const { setHomeBreadcrumb } = require('../../../middleware')
+
+function setOrderBreadcrumb (req, res, next) {
+  const order = res.locals.order
+
+  return setHomeBreadcrumb(order.reference)(req, res, next)
+}
+
+module.exports = {
+  setOrderBreadcrumb,
+}

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
+const { setOrderBreadcrumb } = require('./middleware')
 const { renderWorkOrder } = require('./controllers')
 
 const LOCAL_NAV = [
@@ -11,6 +12,7 @@ const LOCAL_NAV = [
 ]
 
 router.use(setLocalNav(LOCAL_NAV))
+router.use(setOrderBreadcrumb)
 
 router.get('/', redirectToFirstNavItem)
 router.get('/work-order', renderWorkOrder)

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -11,7 +11,7 @@ router.param('orderId', getOrder)
 
 router.use(createApp.mountpath, setHomeBreadcrumb(createApp.displayName), createApp.router)
 router.use(editApp.mountpath, setHomeBreadcrumb(editApp.displayName), editApp.router)
-router.use(viewApp.mountpath, setHomeBreadcrumb(viewApp.displayName), viewApp.router)
+router.use(viewApp.mountpath, viewApp.router)
 router.use(listApp.mountpath, listApp.router)
 
 module.exports = router

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -1,0 +1,59 @@
+const { renderWorkOrder } = require('~/src/apps/omis/apps/view/controllers')
+
+describe('OMIS View controllers', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('renderWorkOrder()', () => {
+    beforeEach(() => {
+      this.breadcrumbSpy = this.sandbox.stub().returnsThis()
+      this.renderSpy = this.sandbox.spy()
+
+      this.resMock = {
+        breadcrumb: this.breadcrumbSpy,
+        render: this.renderSpy,
+        locals: {
+          order: {
+            foo: 'bar',
+            assignees: [
+              { id: '1', estimated_time: 30 },
+              { id: '2', estimated_time: 60 },
+            ],
+          },
+        },
+      }
+    })
+
+    it('should set a breadcrumb option', () => {
+      renderWorkOrder({}, this.resMock)
+
+      expect(this.breadcrumbSpy).to.have.been.called
+    })
+
+    it('should render a template', () => {
+      renderWorkOrder({}, this.resMock)
+
+      expect(this.renderSpy).to.have.been.called
+    })
+
+    it('should send expected data to view', () => {
+      renderWorkOrder({}, this.resMock)
+
+      expect(this.renderSpy).to.have.been.calledWith('omis/apps/view/views/work-order', {
+        values: {
+          foo: 'bar',
+          assignees: [
+            { id: '1', estimated_time: 30 },
+            { id: '2', estimated_time: 60 },
+          ],
+          estimatedTimeSum: 90,
+        },
+      })
+    })
+  })
+})

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -1,0 +1,39 @@
+describe('OMIS View middleware', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+
+    this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
+    this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
+
+    this.middleware = proxyquire('~/src/apps/omis/apps/view/middleware', {
+      '../../../middleware': {
+        setHomeBreadcrumb: this.setHomeBreadcrumbStub,
+      },
+    })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('setOrderBreadcrumb()', () => {
+    it('should call setHomeBreadcrumb with order reference', () => {
+      const resMock = {
+        locals: {
+          order: {
+            reference: '12345/AS',
+          },
+        },
+      }
+      const nextSpy = this.sandbox.spy()
+
+      this.middleware.setOrderBreadcrumb({}, resMock, nextSpy)
+
+      expect(this.setHomeBreadcrumbStub).to.have.been.calledOnce
+      expect(this.setHomeBreadcrumbStub).to.have.been.calledWith('12345/AS')
+
+      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledOnce
+      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, resMock, nextSpy)
+    })
+  })
+})


### PR DESCRIPTION
This makes use of the setHomeBreadcrumb middleware to set the order
reference as the breadcrumb and use another item for the sub-pages
within an order.

## Before

![image](https://user-images.githubusercontent.com/3327997/29926946-c3392438-8e5c-11e7-889b-1164f1c14c39.png)

## After

![image](https://user-images.githubusercontent.com/3327997/29926921-ae062dc2-8e5c-11e7-960d-577c791f9ac6.png)

**Note:** This change also adds some missing tests for the view controllers.