### PR TITLE
Local header actions

### DIFF
--- a/assets/stylesheets/_deprecated/components/_button.scss
+++ b/assets/stylesheets/_deprecated/components/_button.scss
@@ -50,3 +50,8 @@
 .button--compact {
   padding: 0;
 }
+
+.button--small {
+  @include core-font(16);
+  padding: .3em .6em .15em;
+}

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -1,6 +1,7 @@
 @import "../tools/mixins";
 
 .c-local-header {
+  @include clearfix;
   padding-top: $default-spacing-unit * 4;
   position: relative;
 
@@ -47,6 +48,38 @@
 * + .c-local-header__heading-after {
   margin-top: $default-spacing-unit / 2;
   margin-bottom: 0;
+}
+
+.c-local-header__content {
+  @include media(tablet) {
+    float: left;
+    width: 70%;
+  }
+}
+
+.c-local-header__actions {
+  * + & {
+    margin-top: $default-spacing-unit;
+  }
+
+  @include media(tablet) {
+    float: right;
+    width: 30%;
+
+    * + & {
+      margin-top: 0;
+    }
+  }
+}
+
+.c-local-header__action {
+  @include core-font(16);
+  display: block;
+  margin: 0;
+
+  & + & {
+    margin-top: $default-spacing-unit / 2;
+  }
 }
 
 .c-local-header--light-banner {

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -1,7 +1,14 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block local_header %}
+  {% set actions %}
+    <p class="c-local-header__action">
+      <a href="" class="button button--small">Generate order</a>
+    </p>
+  {% endset %}
+
   {% call LocalHeader({
+    actions: actions,
     heading: order.reference,
     modifier: "light-banner"
   }) %}

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -60,6 +60,7 @@
  # @param {string} [props.heading] - page heading
  # @param {string} [props.headingBefore] - a string before heading (safe to render HTML)
  # @param {string} [props.headingSuffix] - a string suffix for heading (safe to render HTML)
+ # @param {object} [props.actions] - an area to display actions for an entity
  # @param {object} [props.breadcrumbs] - an object containing page breadcrumbs
  # @param {object} [props.messages] - an object containing flash messages
  # @param {function} [props.caller] - Optional inner contents
@@ -79,19 +80,31 @@
           {% component 'messages', { messages: messages } %}
         {% endif %}
 
-        {% if props.headingBefore %}
-          <div class="c-local-header__heading-before">
-            {{ props.headingBefore | safe }}
+        {% if props.actions %}
+          <div class="c-local-header__content">
+        {% endif %}
+
+          {% if props.headingBefore %}
+            <div class="c-local-header__heading-before">
+              {{ props.headingBefore | safe }}
+            </div>
+          {% endif %}
+
+          {% if props.heading %}
+            <h1 class="c-local-header__heading">
+              {{ props.heading }} {{ props.headingSuffix | safe }}
+            </h1>
+          {% endif %}
+
+          {{ caller() if caller }}
+
+        {% if props.actions %}
+          </div>
+
+          <div class="c-local-header__actions">
+            {{ props.actions | safe }}
           </div>
         {% endif %}
-
-        {% if props.heading %}
-          <h1 class="c-local-header__heading">
-            {{ props.heading }} {{ props.headingSuffix | safe }}
-          </h1>
-        {% endif %}
-
-        {{ caller() if caller }}
       </div>
     </header>
   {% endif %}
@@ -141,5 +154,3 @@
     </div>
   {% endif %}
 {% endmacro %}
-
-


### PR DESCRIPTION
This change adds support for an _actions_ area on the right hand side of the local header component.

## Example

![image](https://user-images.githubusercontent.com/3327997/29927102-4051f80a-8e5d-11e7-8194-1d74fb5b919a.png)
