### PR TITLE
Use shared layout for OMIS order views

### DIFF
--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -1,0 +1,23 @@
+{% extends "_layouts/two-column.njk" %}
+
+{% block local_header %}
+  {% call LocalHeader({
+    heading: order.reference,
+    modifier: "light-banner"
+  }) %}
+
+    {{ MetaList({
+      items: [
+        { "label": "Status", "value": "Draft" },
+        { "label": "Created on", "value": order.created_on | formatDate },
+        { "label": "Created by", "value": order.created_by }
+      ],
+      itemModifier: "stacked"
+    }) }}
+
+  {% endcall %}
+{% endblock %}
+
+{% block main_grid_left_column %}
+  {{ LocalNav({ items: localNavItems }) }}
+{% endblock %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -1,4 +1,4 @@
-{% extends "_layouts/two-column.njk" %}
+{% extends "./_layouts/view.njk" %}
 
 {% macro AnswersSummary(props) %}
   <table class="c-answers-summary">
@@ -33,10 +33,6 @@
     {% endif %}
   </table>
 {% endmacro %}
-
-{% block main_grid_left_column %}
-  {{ LocalNav({ items: localNavItems }) }}
-{% endblock %}
 
 {% block main_grid_right_column %}
   {% set companyLink %}


### PR DESCRIPTION
This creates a shared layout for the view states within OMIS to use.

Uses a new shared local header that starts to support primary and
some basic meta data for the order.