### PR TITLE
Primary navigation

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -9,6 +9,7 @@
 @import "components/collection";
 @import "components/collection-filters";
 @import "components/form";
+@import "components/global-nav";
 @import "components/local-header";
 @import "components/local-nav";
 @import "components/messages";

--- a/assets/stylesheets/_deprecated/components/_button.scss
+++ b/assets/stylesheets/_deprecated/components/_button.scss
@@ -52,6 +52,6 @@
 }
 
 .button--small {
-  @include core-font(16);
+  @include bold-font(16);
   padding: .3em .6em .15em;
 }

--- a/assets/stylesheets/components/_global-nav.scss
+++ b/assets/stylesheets/components/_global-nav.scss
@@ -1,0 +1,44 @@
+.c-global-nav {
+  @include bold-font(16);
+  background: $grey-3;
+  padding: $default-spacing-unit / 4 0;
+
+  @include media(tablet) {
+    padding: 0;
+  }
+}
+
+.c-global-nav__link {
+  display: block;
+  padding: $default-spacing-unit / 4 0;
+  text-decoration: none;
+
+  &:hover,
+  &:link,
+  &:visited,
+  &:active {
+    color: $black;
+  }
+
+  &.is-active {
+    color: $govuk-blue;
+  }
+
+  @include media(tablet) {
+    border-bottom: 5px solid transparent;
+    display: inline-block;
+    padding: ($default-spacing-unit / 2) 0 3px;
+
+    & + & {
+      margin-left: $default-spacing-unit;
+    }
+
+    &:hover {
+      border-bottom-color: $light-blue;
+    }
+
+    &.is-active {
+      border-bottom-color: $govuk-blue;
+    }
+  }
+}

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -2,25 +2,42 @@
 
 .c-local-header {
   @include clearfix;
-  padding-top: $default-spacing-unit * 4;
-  position: relative;
+
+  .l-container {
+    border-top: 1px solid transparent;
+  }
 
   &[class*="c-local-header--"] {
     padding-bottom: $default-spacing-unit * 2;
   }
 
+  .c-entity-search {
+    margin-top: $baseline-grid-unit * 20.5;
+    padding-bottom: $baseline-grid-unit * 6.25;
+  }
+
   .c-breadcrumb {
-    position: absolute;
-    top: $default-spacing-unit;
+    margin-top: $default-spacing-unit / 2;
+
+    & + * {
+      margin-top: $default-spacing-unit * 3;
+    }
+
+    & + .c-entity-search {
+      padding-bottom: 0;
+    }
   }
 
   .c-messages {
-    margin-top: -$default-spacing-unit / 2;
     margin-bottom: $default-spacing-unit;
   }
 
   .c-entity-search__aggregations {
     margin-bottom: -$default-spacing-unit * 2;
+  }
+
+  .c-progress {
+    margin-top: $default-spacing-unit;
   }
 
   .c-progress__stage {
@@ -41,7 +58,6 @@
 
 .c-local-header__heading {
   @include bold-font(36);
-  margin-top: 0;
   margin-bottom: 0;
 }
 
@@ -62,18 +78,26 @@
     margin-top: $default-spacing-unit;
   }
 
+  a {
+    text-decoration: none;
+
+    &:not(.button):hover {
+      text-decoration: underline;
+    }
+  }
+
   @include media(tablet) {
     float: right;
     width: 30%;
 
     * + & {
-      margin-top: 0;
+      margin-top: $default-spacing-unit * 3;
     }
   }
 }
 
 .c-local-header__action {
-  @include core-font(16);
+  @include bold-font(16);
   display: block;
   margin: 0;
 
@@ -88,6 +112,10 @@
 
 .c-local-header--dark-banner {
   background-color: $grey-3;
+
+  .l-container {
+    border-top-color: $grey-2;
+  }
 
   &.c-local-header--keyline {
     border-bottom: 1px solid $grey-2;

--- a/assets/stylesheets/components/_progress.scss
+++ b/assets/stylesheets/components/_progress.scss
@@ -4,11 +4,14 @@
 $_section-width: 25%;
 
 .c-progress {
-  margin: $default-spacing-unit * 2 $default-spacing-unit / 2;
+  margin-left: $default-spacing-unit / 2;
+  margin-right: $default-spacing-unit / 2;
 
   @include media(tablet) {
-    margin: $default-spacing-unit * 2;
+    margin-left: $default-spacing-unit * 2;
+    margin-right: $default-spacing-unit * 2;
     padding-bottom: $default-spacing-unit / 2;
+    padding-top: $default-spacing-unit / 3;
   }
 }
 
@@ -26,6 +29,7 @@ $_section-width: 25%;
   border-color: $grey-3;
   border-width: 0 0 0 2px;
   border-style: solid;
+  padding-bottom: $default-spacing-unit;
 
   @include media(tablet) {
     display: table-cell;
@@ -35,6 +39,7 @@ $_section-width: 25%;
 
   &::before {
     position: absolute;
+    top: 3px;
     left: -8px;
     width: 14px;
     height: 14px;
@@ -69,12 +74,13 @@ $_section-width: 25%;
 
   &:last-child {
     border-color: transparent;
+    padding-bottom: 0;
   }
 }
 
 .c-progress__stage-title {
   display: block;
-  padding: 0 0 $default-spacing-unit $default-spacing-unit;
+  padding: 0 0 0 $default-spacing-unit;
 
   @include media(tablet) {
     position: absolute;

--- a/assets/stylesheets/components/form/_entity-search.scss
+++ b/assets/stylesheets/components/form/_entity-search.scss
@@ -24,7 +24,6 @@ $search-button-width: 50px;
 
 .c-entity-search--global {
   .c-form-group {
-    font-size: 1.1em;
     max-width: none;
   }
 }

--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -6,25 +6,6 @@
   background-color: $white;
   min-height: 60vh;
   flex-grow: 1;
-
-  &::before {
-    content: "";
-    position: absolute;
-    z-index: 10;
-    top: 0;
-    right: 0;
-    left: 0;
-    border-top: 10px solid $govuk-blue;
-    max-width: 100%;
-    width: $site-width;
-    margin: 0 auto;
-
-    @include media($max-width: $site-width) {
-      width: auto;
-      left: $default-spacing-unit;
-      right: $default-spacing-unit;
-    }
-  }
 }
 
 .main-content__inner {

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -5,6 +5,9 @@
     <p class="c-local-header__action">
       <a href="" class="button button--small">Generate order</a>
     </p>
+    <p class="c-local-header__action">
+      <a href="" class="">View quote</a>
+    </p>
   {% endset %}
 
   {% call LocalHeader({

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const logger = require('../../config/logger')
 const config = require('../../config')
 
@@ -7,6 +9,13 @@ try {
 } catch (err) {
   logger.error('Manifest file is not found. Ensure assets are built.')
 }
+
+const globalNavItems = [
+  { path: '/companies', label: 'Companies' },
+  { path: '/contacts', label: 'Contacts' },
+  { path: '/investment-projects', label: 'Investment projects' },
+  { path: '/omis', label: 'OMIS Orders' },
+]
 
 module.exports = function locals (req, res, next) {
   const baseUrl = `${(req.encrypted ? 'https' : req.protocol)}://${req.get('host')}`
@@ -20,6 +29,21 @@ module.exports = function locals (req, res, next) {
     BREADCRUMBS: breadcrumbItems,
     IS_XHR: req.xhr,
     QUERY: req.query,
+    GLOBAL_NAV_ITEMS: globalNavItems.map(item => {
+      const url = path.resolve(req.baseUrl, item.path)
+      let isActive
+
+      if (url === '/') {
+        isActive = req.path === '/'
+      } else {
+        isActive = req.path.startsWith(url)
+      }
+
+      return Object.assign(item, {
+        url,
+        isActive,
+      })
+    }),
 
     getMessages () {
       return req.flash()

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -12,7 +12,7 @@
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/form.njk" import FormGroup, Fieldset, TextField, MultipleChoiceField, HiddenField, DateFieldset %}
 {% from "_macros/common.njk" import LocalHeader with context %}
-{% from "_macros/common.njk" import Pagination, LocalNav, Progress %}
+{% from "_macros/common.njk" import Pagination, GlobalNav, LocalNav, Progress %}
 {% from "_macros/collection.njk" import Collection, CollectionFilters %}
 {% from "_macros/entities.njk" import MetaList %}
 
@@ -40,16 +40,6 @@
 {% block header_menu %}
   <nav aria-label="global nav">
     <ul class="proposition-menu">
-      {% if user %}
-        <li class="proposition-menu__item">
-          <a href="/" class="proposition-menu__link {{ 'is-active' if CURRENT_PATH == '/' }}">Dashboard</a>
-        </li>
-        <li class="proposition-menu__item">
-          <a href="/investment-projects" class="proposition-menu__link {{ 'is-active' if CURRENT_PATH == '/investment-projects' }}">
-            Investment projects
-          </a>
-        </li>
-      {% endif %}
       {% if feedbackLink %}
         <li class="proposition-menu__item">
           <a href="{{ feedbackLink }}" class="proposition-menu__link {{ 'is-active' if CURRENT_PATH and '/support' in CURRENT_PATH }}">Support</a>
@@ -73,6 +63,13 @@
 
 {% block body_main_header %}
   {{ super() }}
+
+  {% if user %}
+    {{ GlobalNav({
+      items: GLOBAL_NAV_ITEMS
+    }) }}
+  {% endif %}
+
   {% block local_header %}
     {% set pageTitle = getPageTitle() %}
     {% set heading = heading or pageTitle[0] %}

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -129,6 +129,28 @@
   {% endif %}
 {% endmacro %}
 
+{##
+ # Render global nav
+ # @param {object} props
+ # @param {string} [props.modifier] - nav modifier
+ # @param {string} [props.items] - nav items
+ #
+ #}
+{% macro GlobalNav(props) %}
+  {% set modifier = props.modifier | concat('') | reverse | join(' c-global-nav--') if props.modifier %}
+  {% set items = [] %}
+
+  {% if props|length %}
+    <nav class="c-global-nav{{ modifier }}" aria-label="global navigation">
+      <div class="c-global-nav__container l-container">
+        {% for item in props.items %}
+          <a class="c-global-nav__link {{ 'is-active' if item.isActive }}" href="{{ item.url }}">{{ item.label }}</a>
+        {% endfor %}
+      </div>
+    </nav>
+  {% endif %}
+{% endmacro %}
+
 
 {##
  # Render progress bar

--- a/test/unit/macros/global-nav.test.js
+++ b/test/unit/macros/global-nav.test.js
@@ -1,0 +1,57 @@
+const { getMacros } = require('~/test/unit/macro-helper')
+const commonMacros = getMacros('common')
+
+describe('GlobalNav macro', () => {
+  describe('invalid props', () => {
+    it('should not render if props is not given', () => {
+      const component = commonMacros.renderToDom('GlobalNav')
+      expect(component).to.be.null
+    })
+  })
+
+  describe('valid props', () => {
+    it('should render local nav', () => {
+      const component = commonMacros.renderToDom('GlobalNav', {
+        items: [
+          { path: '/first-item', label: 'First item' },
+          { path: '/second-item', label: 'Second item' },
+        ],
+      })
+      expect(component.className.trim()).to.equal('c-global-nav')
+      expect(component.querySelectorAll('.c-global-nav__link')).to.have.length(2)
+    })
+
+    it('should render local nav with currently selected item', () => {
+      const component = commonMacros.renderToDom('GlobalNav', {
+        items: [
+          { path: '/first-item', label: 'First item', isActive: true },
+          { path: '/second-item', label: 'Second item' },
+        ],
+      })
+      expect(component.className.trim()).to.equal('c-global-nav')
+      expect(component.querySelectorAll('.c-global-nav__link.is-active')).to.have.length(1)
+    })
+
+    it('should render a string modifier', () => {
+      const component = commonMacros.renderToDom('GlobalNav', {
+        items: [
+          { path: '/first-item', label: 'First item', isActive: true },
+        ],
+        modifier: 'modifier',
+      })
+
+      expect(component.className.trim()).to.equal('c-global-nav c-global-nav--modifier')
+    })
+
+    it('should render an array of modifiers', () => {
+      const component = commonMacros.renderToDom('GlobalNav', {
+        items: [
+          { path: '/first-item', label: 'First item', isActive: true },
+        ],
+        modifier: ['modifier-1', 'modifier-2'],
+      })
+
+      expect(component.className.trim()).to.equal('c-global-nav c-global-nav--modifier-2 c-global-nav--modifier-1')
+    })
+  })
+})


### PR DESCRIPTION
This adds an initial piece of primary navigation to navigate to key areas or collections within the site.

It uses a [similar pattern](https://home-office-digital-patterns.herokuapp.com/patterns/navigation) being developer by the Home Office as a base but using the code style set out in this project.

It creates a basic stacked version on smaller resolutions but a better solution for smaller screens which reduces the navigation might need to be developed further down the line.

**Note:** No _home_ or _dashboard_ link has been added for 2 reasons at the moment. 1) the jump when it was highlight on the homepage to not being highlighted when searching seemed confusing and 2) the breadcrumb provides a clear route back to _Home_ and having the same link duplicated seemed unnecessary.

👉 [**DEMO**](http://datahub-beta2-pr-522.herokuapp.com/investment-projects) 👈 

## What it looks like

![image](https://user-images.githubusercontent.com/3327997/30023906-57f86980-9169-11e7-87ff-93a78614a8aa.png)

---

![image](https://user-images.githubusercontent.com/3327997/30023913-679abcc6-9169-11e7-89f1-cb0cbda7f5a1.png)

---

![image](https://user-images.githubusercontent.com/3327997/30023939-8452d3da-9169-11e7-91b3-b68f252a962d.png)

---

![image](https://user-images.githubusercontent.com/3327997/30023951-93841be8-9169-11e7-89d4-7851165ead93.png)

---

![image](https://user-images.githubusercontent.com/3327997/30023972-a3c4e6d6-9169-11e7-8171-666eff59025a.png)

---

![image](https://user-images.githubusercontent.com/3327997/30023984-b1de3cea-9169-11e7-96d8-193f30f93956.png)
