### PR TITLE
Fix/multiple choice field component regression

### DIFF
--- a/src/apps/investment-projects/views/_details-form.njk
+++ b/src/apps/investment-projects/views/_details-form.njk
@@ -137,7 +137,7 @@
 
 {% if not investmentData.id %}
   <div class="c-form-group">
-    {% call MultipleChoiceField({
+    {{ MultipleChoiceField({
       type: 'radio',
       name: 'is_relationship_manager',
       label: 'Are you the client relationship manager for this project?',
@@ -152,29 +152,29 @@
           value: 'false',
           label: 'No'
         }
+      ],
+      children:  [
+        {
+          macroName: 'MultipleChoiceField',
+          name: 'client_relationship_manager',
+          label: 'Client relationship manager',
+          error: form.errors.messages['client_relationship_manager'],
+          value: form.state['client_relationship_manager'],
+          options: form.options.advisers,
+          initialOption: '-- Select client relationship manager --',
+          condition: {
+            name: 'is_relationship_manager',
+            value: 'false'
+          },
+          modifier: 'subfield'
+        }
       ]
-    }) %}
-
-      {{ MultipleChoiceField({
-        name: 'client_relationship_manager',
-        label: 'Client relationship manager',
-        error: form.errors.messages['client_relationship_manager'],
-        value: form.state['client_relationship_manager'],
-        options: form.options.advisers,
-        initialOption: '-- Select client relationship manager --',
-        condition: {
-          name: 'is_relationship_manager',
-          value: 'false'
-        },
-        modifier: 'subfield'
-      }) }}
-
-    {% endcall %}
+    }) }}
   </div>
 {% endif %}
 
   <div class="c-form-group">
-    {% call MultipleChoiceField({
+    {{ MultipleChoiceField({
       type: 'radio',
       name: 'is_referral_source',
       label: 'Are you the referral source for this project?',
@@ -189,24 +189,24 @@
           value: 'false',
           label: 'No'
         }
+      ],
+      children:  [
+        {
+          macroName: 'MultipleChoiceField',
+          name: 'referral_source_adviser',
+          label: 'Referral source adviser',
+          error: form.errors.messages['referral_source_adviser'],
+          value: form.state['referral_source_adviser'],
+          options: form.options.advisers,
+          initialOption: '-- Select referral source adviser --',
+          condition: {
+            name: 'is_referral_source',
+            value: 'false'
+          },
+          modifier: 'subfield'
+        }
       ]
-    }) %}
-
-      {{ MultipleChoiceField({
-        name: 'referral_source_adviser',
-        label: 'Referral source adviser',
-        error: form.errors.messages['referral_source_adviser'],
-        value: form.state['referral_source_adviser'],
-        options: form.options.advisers,
-        initialOption: '-- Select referral source adviser --',
-        condition: {
-          name: 'is_referral_source',
-          value: 'false'
-        },
-        modifier: 'subfield'
-      }) }}
-
-    {% endcall %}
+    }) }}
   </div>
 
   <div class="c-form-group">

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -505,9 +505,9 @@
 
         {{ children }}
       </div>
-
-      {{ fieldChildren }}
     {% endfor %}
+
+    {{ fieldChildren }}
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
This PR fixes a regression around the `MultipleChoiceField` component.

- Move optional `MultipleChoicefield` child into parents children property rather than them being provided to `MultipleChoiceField` as `caller()`
- Move the `fieldChildren` variable outside of options for loop so children of the MultipleChoice element can be placed on `props.children` and children for individual multiple choice input elements can be placed inside of option.children
```
options:[
  {
    children:[]
  }
]
```

FYI @tyom 

### Broken
#### Investment Project create
![broken](https://user-images.githubusercontent.com/2305016/29973038-11c2ec14-8f26-11e7-8969-0562a1e64bde.gif)

### Fixed
![fixed](https://user-images.githubusercontent.com/2305016/29973062-1e81ac60-8f26-11e7-85db-1f3fc0d621a7.gif)

### Broken
#### Investment Project edit
![screen shot 2017-09-01 at 14 33 35](https://user-images.githubusercontent.com/2305016/29973079-2721b306-8f26-11e7-974b-567a1449a903.png)

### Fixed
![awesome](https://user-images.githubusercontent.com/2305016/29973084-2bda3cd8-8f26-11e7-9753-143578b051e7.gif)



