### PR TITLE
Initial quote preview route

### DIFF
--- a/assets/stylesheets/_deprecated/components/_button.scss
+++ b/assets/stylesheets/_deprecated/components/_button.scss
@@ -10,6 +10,10 @@
   }
 }
 
+.button--destructive {
+  @include button($red);
+}
+
 .button-link {
   line-height: 2.5;
   margin-left: 15px;

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -8,12 +8,18 @@ function renderWorkOrder (req, res) {
   })
 
   res
-    .breadcrumb('Work order')
     .render('omis/apps/view/views/work-order', {
       values,
     })
 }
 
+function renderQuote (req, res) {
+  res
+    .breadcrumb('Quote')
+    .render('omis/apps/view/views/quote')
+}
+
 module.exports = {
   renderWorkOrder,
+  renderQuote,
 }

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -1,4 +1,5 @@
 const { setHomeBreadcrumb } = require('../../../middleware')
+const { Order } = require('../../models')
 
 function setOrderBreadcrumb (req, res, next) {
   const order = res.locals.order
@@ -6,6 +7,21 @@ function setOrderBreadcrumb (req, res, next) {
   return setHomeBreadcrumb(order.reference)(req, res, next)
 }
 
+async function getQuote (req, res, next) {
+  try {
+    res.locals.quote = await Order.getQuote(req.session.token, res.locals.order.id)
+    next()
+  } catch (error) {
+    if (error.statusCode === 404) {
+      res.locals.quote = {}
+      return next()
+    }
+
+    next(error)
+  }
+}
+
 module.exports = {
   setOrderBreadcrumb,
+  getQuote,
 }

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,8 +1,8 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
-const { setOrderBreadcrumb } = require('./middleware')
-const { renderWorkOrder } = require('./controllers')
+const { setOrderBreadcrumb, getQuote } = require('./middleware')
+const { renderWorkOrder, renderQuote } = require('./controllers')
 
 const LOCAL_NAV = [
   { path: 'work-order', label: 'Work order' },
@@ -16,5 +16,8 @@ router.use(setOrderBreadcrumb)
 
 router.get('/', redirectToFirstNavItem)
 router.get('/work-order', renderWorkOrder)
+router
+  .route('/quote')
+  .get(getQuote, renderQuote)
 
 module.exports = router

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -3,10 +3,7 @@
 {% block local_header %}
   {% set actions %}
     <p class="c-local-header__action">
-      <a href="" class="button button--small">Generate order</a>
-    </p>
-    <p class="c-local-header__action">
-      <a href="" class="">View quote</a>
+      <a href="quote" class="button button--small">Generate quote</a>
     </p>
   {% endset %}
 
@@ -18,9 +15,8 @@
 
     {{ MetaList({
       items: [
-        { "label": "Status", "value": "Draft" },
-        { "label": "Created on", "value": order.created_on | formatDate },
-        { "label": "Created by", "value": order.created_by }
+        { "label": "Created on", "value": order.created_on | formatDateTime },
+        { "label": "Status", "value": "Draft" }
       ],
       itemModifier: "stacked"
     }) }}

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -1,0 +1,14 @@
+{% extends "_layouts/two-column.njk" %}
+
+{% block main_grid_right_column %}
+  {% if quote %}
+    {{ MetaList({
+      items: [
+        { label: "Sent on", value: quote.created_on | formatDateTime },
+        { label: "Sent by", value: quote.created_by },
+        { label: "Expires on", value: quote.expires_on | formatDateTime }
+      ],
+      itemModifier: "stacked"
+    }) }}
+  {% endif %}
+{% endblock %}

--- a/src/apps/omis/models.js
+++ b/src/apps/omis/models.js
@@ -53,6 +53,28 @@ const Order = {
   getById (token, id) {
     return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}`)
   },
+
+  getQuotePreview (token, id) {
+    return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}/quote/preview`)
+  },
+
+  getQuote (token, id) {
+    return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}/quote`)
+  },
+
+  createQuote (token, id) {
+    return authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/omis/order/${id}/quote`,
+      method: 'POST',
+    })
+  },
+
+  cancelQuote (token, id) {
+    return authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/omis/order/${id}/quote/cancel`,
+      method: 'POST',
+    })
+  },
 }
 
 module.exports = {

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -37,6 +37,7 @@
  # @param {string} [props.role] - Form role attribute value
  # @param {string} [props.actionsClass] - Custom class name for actions container
  # @param {string} [props.buttonText=Submit] - Text for submit button
+ # @param {string, array} [props.buttonModifiers] - Modifiers for the primary button
  # @param {string} [props.returnText=Back] - Text for return link
  # @param {string} [props.returnLink] - Location for return link
  # @param {array}  [props.children] - an array of inner macro configurations
@@ -46,6 +47,7 @@
 {% macro Form(props) %}
   {% set method = props.method or 'POST' -%}
   {% set buttonText = props.buttonText or 'Submit' %}
+  {% set buttonModifiers = props.buttonModifiers | concat('') | join(' ') %}
   {% set returnText = props.returnText or 'Back' %}
   {% set hideFormActions = props.hideFormActions or false %}
   {% set children = caller() if caller else renderAsMacro(props.children) %}
@@ -78,7 +80,7 @@
 
     {% if not hideFormActions %}
       <div class="c-form-group c-form-group--actions {{ props.actionsClass }}">
-        <button class="button" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
+        <button class="button {{ buttonModifiers }}" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
         {% if props.returnLink %}
           <p><a href="{{ props.returnLink }}">{{ returnText }}</a></p>
         {% endif %}

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -1,4 +1,4 @@
-const { renderWorkOrder } = require('~/src/apps/omis/apps/view/controllers')
+const { renderWorkOrder, renderQuote } = require('~/src/apps/omis/apps/view/controllers')
 
 describe('OMIS View controllers', () => {
   beforeEach(() => {
@@ -29,10 +29,10 @@ describe('OMIS View controllers', () => {
       }
     })
 
-    it('should set a breadcrumb option', () => {
+    it('should not set a breadcrumb option', () => {
       renderWorkOrder({}, this.resMock)
 
-      expect(this.breadcrumbSpy).to.have.been.called
+      expect(this.breadcrumbSpy).not.to.have.been.called
     })
 
     it('should render a template', () => {
@@ -54,6 +54,30 @@ describe('OMIS View controllers', () => {
           estimatedTimeSum: 90,
         },
       })
+    })
+  })
+
+  describe('renderQuote()', () => {
+    beforeEach(() => {
+      this.breadcrumbSpy = this.sandbox.stub().returnsThis()
+      this.renderSpy = this.sandbox.spy()
+
+      this.resMock = {
+        breadcrumb: this.breadcrumbSpy,
+        render: this.renderSpy,
+      }
+    })
+
+    it('should set a breadcrumb option', () => {
+      renderQuote({}, this.resMock)
+
+      expect(this.breadcrumbSpy).to.have.been.called
+    })
+
+    it('should render a template', () => {
+      renderQuote({}, this.resMock)
+
+      expect(this.renderSpy).to.have.been.called
     })
   })
 })

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -4,10 +4,25 @@ describe('OMIS View middleware', () => {
 
     this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
     this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
+    this.getQuoteStub = this.sandbox.stub()
+
+    this.resMock = {
+      locals: {
+        order: {
+          id: '123456789',
+          reference: '12345/AS',
+        },
+      },
+    }
 
     this.middleware = proxyquire('~/src/apps/omis/apps/view/middleware', {
       '../../../middleware': {
         setHomeBreadcrumb: this.setHomeBreadcrumbStub,
+      },
+      '../../models': {
+        Order: {
+          getQuote: this.getQuoteStub,
+        },
       },
     })
   })
@@ -18,22 +33,95 @@ describe('OMIS View middleware', () => {
 
   describe('setOrderBreadcrumb()', () => {
     it('should call setHomeBreadcrumb with order reference', () => {
-      const resMock = {
-        locals: {
-          order: {
-            reference: '12345/AS',
-          },
-        },
-      }
       const nextSpy = this.sandbox.spy()
 
-      this.middleware.setOrderBreadcrumb({}, resMock, nextSpy)
+      this.middleware.setOrderBreadcrumb({}, this.resMock, nextSpy)
 
       expect(this.setHomeBreadcrumbStub).to.have.been.calledOnce
       expect(this.setHomeBreadcrumbStub).to.have.been.calledWith('12345/AS')
 
       expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledOnce
-      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, resMock, nextSpy)
+      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, this.resMock, nextSpy)
+    })
+  })
+
+  describe('getQuote()', () => {
+    beforeEach(() => {
+      this.reqMock = {
+        session: {
+          token: '12345',
+        },
+      }
+    })
+
+    context('when Order.getQoute resolves', () => {
+      beforeEach(() => {
+        this.getQuoteStub.resolves({
+          id: '12345',
+        })
+      })
+
+      it('should set quote on locals object', (done) => {
+        const nextSpy = () => {
+          try {
+            expect(this.resMock.locals).to.have.property('quote')
+            expect(this.resMock.locals.quote).to.deep.equal({
+              id: '12345',
+            })
+            done()
+          } catch (error) {
+            done(error)
+          }
+        }
+
+        this.middleware.getQuote(this.reqMock, this.resMock, nextSpy)
+      })
+    })
+
+    context('when Order.getQuote returns a 404', () => {
+      beforeEach(() => {
+        const error = {
+          statusCode: 404,
+        }
+        this.getQuoteStub.rejects(error)
+      })
+
+      it('should set an empty quote object on locals object', (done) => {
+        const nextSpy = (error) => {
+          try {
+            expect(this.resMock.locals).to.have.property('quote')
+            expect(this.resMock.locals.quote).to.deep.equal({})
+            expect(error).to.be.undefined
+            done()
+          } catch (error) {
+            done(error)
+          }
+        }
+
+        this.middleware.getQuote(this.reqMock, this.resMock, nextSpy)
+      })
+    })
+
+    context('when Order.getQuote returns any other error', () => {
+      beforeEach(() => {
+        const error = {
+          statusCode: 500,
+        }
+        this.getQuoteStub.rejects(error)
+      })
+
+      it('should set an empty quote object on locals object', (done) => {
+        const nextSpy = (error) => {
+          try {
+            expect(error.statusCode).to.equal(500)
+            done()
+          } catch (error) {
+            done(error)
+          }
+        }
+
+        this.middleware.getQuote(this.reqMock, this.resMock, nextSpy)
+      })
     })
   })
 })

--- a/test/unit/macros/form.test.js
+++ b/test/unit/macros/form.test.js
@@ -65,6 +65,29 @@ describe('Nunjucks form macros', () => {
         expect(component.querySelector('.c-form-group--actions')).to.not.exist
       })
 
+      it('should render form with button modifier as string', () => {
+        const formProps = {
+          buttonModifiers: 'modifier',
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+        expect(component.querySelector('button.button').classList.contains('modifier')).to.be.true
+      })
+
+      it('should render form with button modifier as array', () => {
+        const formProps = {
+          buttonModifiers: ['modifier-1', 'modifier-2'],
+        }
+        const component = macros.renderWithCallerToDom('Form', formProps)(
+          macros.renderToDom('TextField')
+        )
+        const classList = component.querySelector('button.button').classList
+
+        expect(classList.contains('modifier-1')).to.be.true
+        expect(classList.contains('modifier-2')).to.be.true
+      })
+
       it('should render form with return link', () => {
         const formProps = {
           returnLink: '/previous-page',


### PR DESCRIPTION
This adds a placeholder view and route for the preview and generate
quote logic that will follow.

It makes a few amends to the Order model and existing macros to allow this to happen too.