### PR TITLE
Remove surplus global navigation logic

### DIFF
--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -31,17 +31,10 @@ module.exports = function locals (req, res, next) {
     QUERY: req.query,
     GLOBAL_NAV_ITEMS: globalNavItems.map(item => {
       const url = path.resolve(req.baseUrl, item.path)
-      let isActive
-
-      if (url === '/') {
-        isActive = req.path === '/'
-      } else {
-        isActive = req.path.startsWith(url)
-      }
 
       return Object.assign(item, {
         url,
-        isActive,
+        isActive: req.path.startsWith(url),
       })
     }),
 


### PR DESCRIPTION
This was missed during #522 when it was meant to be removed.

This logic isn't needed as the global navigation doesn't provide
a link back to _Home_ at this stage as it appears in the breadcrumb
when navigating through the levels.