### PR TITLE
Add "add company" button to search and collection

### DIFF
--- a/src/apps/companies/views/list.njk
+++ b/src/apps/companies/views/list.njk
@@ -10,13 +10,18 @@
 {% endblock %}
 
 {% block main_grid_right_column %}
+  {% set addCompanyButton %}
+    <a id="add-contact-link" class="button button-secondary" href="/companies/add-step-1">Add company</a>
+  {% endset %}
+
   {{
     Collection(results | assign({
       countLabel: 'company',
       sortForm: sortForm,
       selectedFilters: selectedFilters,
       highlightTerm: selectedFilters.company_name.valueLabel,
-      query: QUERY
+      query: QUERY,
+      summaryActionsHTML: addCompanyButton
     }))
   }}
 {% endblock %}

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -14,6 +14,7 @@ async function renderSearchResults (req, res) {
     return res.render('search/view')
   }
 
+  const actionButton = { text: null, url: null }
   const searchTerm = get(req, 'query.term', '').trim()
   const searchEntity = entity.entity
   const itemTransformers = []
@@ -30,6 +31,8 @@ async function renderSearchResults (req, res) {
 
   if (searchEntity === 'company') {
     itemTransformers.push(transformCompanyToListItem)
+    actionButton.text = 'Add company'
+    actionButton.url = '/companies/add-step-1'
   }
 
   const results = await search({
@@ -50,6 +53,7 @@ async function renderSearchResults (req, res) {
   res
     .breadcrumb(entity.text)
     .render('search/view', {
+      actionButton,
       searchEntity,
       searchTerm,
       results,

--- a/src/apps/search/view.njk
+++ b/src/apps/search/view.njk
@@ -14,5 +14,15 @@
 {% endblock %}
 
 {% block main_grid_right_column %}
-  {{ Collection(results) }}
+  {% set summaryAction %}
+    {% if actionButton.url %}
+      <a id="add-contact-link" class="button button-secondary" href="{{ actionButton.url }}">{{ actionButton.text }}</a>
+    {% endif %}
+  {% endset %}
+
+  {{
+    Collection(results | assign({
+      summaryActionsHTML: summaryAction
+    }))
+  }}
 {% endblock %}


### PR DESCRIPTION
This work adds the "add company" button to `/companies` collection and to the companies search results `/search/companies?term=<searchTerm>` 

## Companies collection
![screen shot 2017-09-04 at 11 14 00](https://user-images.githubusercontent.com/2305016/30024855-96e261ba-916d-11e7-817c-648648ccffa2.png)

## Company search results
![screen shot 2017-09-04 at 12 28 41](https://user-images.githubusercontent.com/2305016/30024858-9a7d70b2-916d-11e7-8047-1323f27e52a3.png)

FYI @venureddy95 
