### PR TITLE
add primary contact badge to contacts

### DIFF
--- a/src/apps/contacts/transformers.js
+++ b/src/apps/contacts/transformers.js
@@ -13,6 +13,7 @@ function transformContactToListItem ({
   archived_on,
   archived_reason,
   company_sector,
+  primary,
 } = {}) {
   if (!id || !first_name || !last_name) { return }
 
@@ -35,13 +36,25 @@ function transformContactToListItem ({
         label: 'Sector',
         value: get(company_sector, 'name'),
       },
-      {
-        label: 'Country',
-        type: 'badge',
-        value: get(address_country, 'name'),
-      },
     ],
   }
+
+  // Add Contact type as first badge to be displayed
+  if (primary) {
+    item.meta.push({
+      label: 'Contact type',
+      value: 'Primary',
+      type: 'badge',
+      badgeModifier: 'secondary',
+    })
+  }
+
+  item.meta.push(
+    {
+      label: 'Country',
+      type: 'badge',
+      value: get(address_country, 'name'),
+    })
 
   if (archived_reason) {
     item.meta.push({

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -221,7 +221,7 @@ describe('Company contacts controller', function () {
       expect(contact).to.have.property('id')
       expect(contact).to.have.property('type', 'contact')
       expect(contact).to.have.property('name', 'Fred Smith')
-      expect(contact).to.have.property('meta').to.be.an('array').to.have.length(3)
+      expect(contact).to.have.property('meta').to.be.an('array').to.have.length(4)
     })
 
     it('should return the required fields to list archived contacts', function () {
@@ -230,7 +230,7 @@ describe('Company contacts controller', function () {
       expect(contact).to.have.property('type', 'contact')
       expect(contact).to.have.property('name', 'Jane Smith')
       expect(contact).to.have.property('isArchived').to.be.true
-      expect(contact).to.have.property('meta').to.be.an('array').to.have.length(5)
+      expect(contact).to.have.property('meta').to.be.an('array').to.have.length(6)
     })
 
     it('should return a link to add a new contact', function () {

--- a/test/unit/apps/contacts/transformers.test.js
+++ b/test/unit/apps/contacts/transformers.test.js
@@ -24,6 +24,7 @@ describe('Contact transformers', function () {
         { label: 'Company', value: 'Fred ltd' },
         { label: 'Updated', type: 'datetime', value: '2017-02-14T14:49:17' },
         { label: 'Sector', value: 'Aerospace' },
+        { label: 'Contact type', type: 'badge', value: 'Primary', badgeModifier: 'secondary' },
         { label: 'Country', type: 'badge', value: 'United Kingdom' },
       ])
     })
@@ -45,6 +46,7 @@ describe('Contact transformers', function () {
         { label: 'Company', value: 'Fred ltd' },
         { label: 'Archived', type: 'datetime', value: '2017-03-14T14:49:17' },
         { label: 'Sector', value: 'Aerospace' },
+        { label: 'Contact type', type: 'badge', value: 'Primary', badgeModifier: 'secondary' },
         { label: 'Country', type: 'badge', value: 'United Kingdom' },
         { label: 'Reason to archive', value: 'Left job' },
         { label: 'Archived by', value: 'Sam Smith' },


### PR DESCRIPTION
Add the primary contact badge to contacts search results and collections list.

### Contacts search Results
![screen shot 2017-09-04 at 18 12 11](https://user-images.githubusercontent.com/2305016/30034936-a178a3da-919c-11e7-8648-3618a479846b.png)

### Contacts collection list
![screen shot 2017-09-04 at 18 11 45](https://user-images.githubusercontent.com/2305016/30034940-a62526c4-919c-11e7-8537-662f7be61bcb.png)

