### PR TITLE
breadcrumb and global nav tweaks

### DIFF
--- a/assets/stylesheets/_deprecated/_dashboard.scss
+++ b/assets/stylesheets/_deprecated/_dashboard.scss
@@ -1,12 +1,11 @@
 @import "../tools/mixins/typography";
 
 .dashboard-section {
-  border-top: 5px solid $black;
   @include core-font(16);
 
   .dashboard-section-title {
     @include bold-font(24);
-    margin: 20px 0;
+    margin: 0 0 20px;
   }
 
   .dashboard-section-intro {

--- a/assets/stylesheets/components/_breadcrumb.scss
+++ b/assets/stylesheets/components/_breadcrumb.scss
@@ -22,13 +22,13 @@
 }
 
 .c-breadcrumb__link {
-  color: $black;
+  color: $light-black;
 
   &:link,
   &:active,
   &:hover,
   &:visited {
-    color: $black;
+    color: $light-black;
     text-decoration: underline;
   }
 

--- a/assets/stylesheets/components/_global-nav.scss
+++ b/assets/stylesheets/components/_global-nav.scss
@@ -1,6 +1,8 @@
+@import "../settings";
+@import "../tools";
+
 .c-global-nav {
-  @include bold-font(16);
-  background: $grey-3;
+  @include bold-font(18);
   padding: $default-spacing-unit / 4 0;
 
   @include media(tablet) {

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -2,18 +2,11 @@
 
 .c-local-header {
   @include clearfix;
-
-  .l-container {
-    border-top: 1px solid transparent;
-  }
-
-  &[class*="c-local-header--"] {
-    padding-bottom: $default-spacing-unit * 2;
-  }
+  padding-bottom: $default-spacing-unit * 2;
 
   .c-entity-search {
-    margin-top: $baseline-grid-unit * 20.5;
-    padding-bottom: $baseline-grid-unit * 6.25;
+    margin-top: $baseline-grid-unit * 10;
+    padding-bottom: $baseline-grid-unit * 8;
   }
 
   .c-breadcrumb {
@@ -104,24 +97,4 @@
   & + & {
     margin-top: $default-spacing-unit / 2;
   }
-}
-
-.c-local-header--light-banner {
-  background-color: $grey-4;
-}
-
-.c-local-header--dark-banner {
-  background-color: $grey-3;
-
-  .l-container {
-    border-top-color: $grey-2;
-  }
-
-  &.c-local-header--keyline {
-    border-bottom: 1px solid $grey-2;
-  }
-}
-
-.c-local-header--keyline {
-  border-bottom: 1px solid $grey-3;
 }

--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -8,6 +8,14 @@
   flex-grow: 1;
 }
 
+.main-content__header {
+  background-color: $grey-4;
+}
+
+.main-content__header--dark {
+  background-color: $grey-3;
+}
+
 .main-content__inner {
   padding-top: $default-spacing-unit * 2;
   padding-bottom: $default-spacing-unit * 4;

--- a/assets/stylesheets/settings/_colours.scss
+++ b/assets/stylesheets/settings/_colours.scss
@@ -3,6 +3,7 @@ $dit-colour: #cf102d;
 
 // Greyscale
 $black: #0b0c0c;
+$light-black: #515151;
 $grey-1: #6f777b;
 $grey-2: #bfc1c3;
 $grey-3: #dee0e2;

--- a/src/apps/companies/views/_layout-edit.njk
+++ b/src/apps/companies/views/_layout-edit.njk
@@ -3,8 +3,7 @@
 {% block local_header %}
   {{
     LocalHeader({
-      heading: 'Edit company' if formData.id else 'Add company',
-      modifier: 'light-banner'
+      heading: 'Edit company' if formData.id else 'Add company'
     })
   }}
 {% endblock %}

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -2,8 +2,7 @@
 
 {% block local_header %}
   {% call LocalHeader({
-      heading: headingName,
-      modifier: 'light-banner'
+      heading: headingName
     })
   %}
     <p class="c-local-header__heading-after">{{ headingAddress }}</p>

--- a/src/apps/components/views/local-header.njk
+++ b/src/apps/components/views/local-header.njk
@@ -9,43 +9,4 @@
       })
     }}
   {% endcall %}
-
-  {% call Example('Light banner', true) %}
-    {{
-      LocalHeader({
-        heading: 'Light banner',
-        modifier: 'light-banner'
-      })
-    }}
-  {% endcall %}
-
-  {% call Example('Light banner + keyline', true) %}
-    {{
-      LocalHeader({
-        headingBefore: '<em>Emphasied text before</em>',
-        heading: 'Light banner with keyline',
-        modifier: ['light-banner', 'keyline']
-      })
-    }}
-  {% endcall %}
-
-  {% call Example('Dark banner', true) %}
-    {{
-      LocalHeader({
-        headingBefore: 'Raw text before',
-        heading: 'Dark banner',
-        modifier: 'dark-banner'
-      })
-    }}
-  {% endcall %}
-
-  {% call Example('Dark banner + keyline', true) %}
-    {{
-      LocalHeader({
-        headingBefore: '<strong>Strong text before</strong>',
-        heading: 'Dark banner with keyline',
-        modifier: ['dark-banner', 'keyline']
-      })
-    }}
-  {% endcall %}
 {% endblock %}

--- a/src/apps/contacts/views/_layout.njk
+++ b/src/apps/contacts/views/_layout.njk
@@ -8,8 +8,7 @@
   {% call LocalHeader({
     headingBefore: headingBefore,
     heading: contact.first_name + ' ' + contact.last_name,
-    headingSuffix: statusbadge('Primary', variation='fuschia') if contact.primary,
-    modifier: 'light-banner'
+    headingSuffix: statusbadge('Primary', variation='fuschia') if contact.primary
   }) %}
     {% if contact.archived %}
       <p class="infostrip">

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -8,8 +8,7 @@
   {{
     LocalHeader({
       headingBefore: headingBefore,
-      heading: 'Edit contact' if formData.id else 'Add contact',
-      modifier: 'light-banner'
+      heading: 'Edit contact' if formData.id else 'Add contact'
     })
   }}
 {% endblock %}

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -1,7 +1,8 @@
 {% extends "_layouts/datahub-base.njk" %}
+{% set mainContentModifier = 'main-content__header--dark' %}
 
 {% block local_header %}
-  {% call LocalHeader({ modifier: 'dark-banner' }) %}
+  {% call LocalHeader() %}
     {{ EntitySearchForm({
       inputName: 'term',
       modifier: 'global',

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -7,8 +7,7 @@
 
   {% call LocalHeader({
     headingBefore: headingBefore,
-    heading: investmentData.name,
-    modifier: 'light-banner'
+    heading: investmentData.name
   }) %}
 
   {{ MetaList({

--- a/src/apps/investment-projects/views/edit.njk
+++ b/src/apps/investment-projects/views/edit.njk
@@ -2,7 +2,7 @@
 
 
 {% block local_header %}
-  {{ LocalHeader({ heading: 'Edit investment project', modifier: 'light-banner' }) }}
+  {{ LocalHeader({ heading: 'Edit investment project' }) }}
 {% endblock %}
 
 {% block main_grid_right_column %}

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -12,8 +12,7 @@
 
   {% call LocalHeader({
     actions: actions,
-    heading: order.reference,
-    modifier: "light-banner"
+    heading: order.reference
   }) %}
 
     {{ MetaList({

--- a/src/apps/search/view.njk
+++ b/src/apps/search/view.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ modifier: 'dark-banner' }) %}
+  {% call LocalHeader() %}
     {{ EntitySearchForm({
       inputName: 'term',
       modifier: 'global',

--- a/src/apps/service-deliveries/views/edit.njk
+++ b/src/apps/service-deliveries/views/edit.njk
@@ -14,8 +14,7 @@
   {{
     LocalHeader({
       headingBefore: headingBefore,
-      heading: 'Edit service delivery' if serviceDelivery.id else 'Add service delivery',
-      modifier: 'light-banner'
+      heading: 'Edit service delivery' if serviceDelivery.id else 'Add service delivery'
     })
   }}
 {% endblock %}

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -73,7 +73,7 @@
   {% block local_header %}
     {% set pageTitle = getPageTitle() %}
     {% set heading = heading or pageTitle[0] %}
-    {{ LocalHeader({ heading: heading, modifier: 'light-banner' }) }}
+    {{ LocalHeader({ heading: heading }) }}
   {% endblock %}
 {% endblock %}
 

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -95,23 +95,25 @@
 
       {% block body_main %}
         <main class="main-content" id="main-content">
-          {% block body_main_header %}
-            {% block body_main_phase_banner %}
-              {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta'] or feedbackLink) %}
-                <div class="phase-banner">
-                  <div class="l-container">
-                    <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
-                    <span class="phase-banner__message">
-                      This is a new service
-                      {% if feedbackLink %}
-                      – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.
-                      {% endif %}
-                    </span>
+          <div class="main-content__header {{ mainContentModifier }}">
+            {% block body_main_header %}
+              {% block body_main_phase_banner %}
+                {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta'] or feedbackLink) %}
+                  <div class="phase-banner">
+                    <div class="l-container">
+                      <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
+                      <span class="phase-banner__message">
+                        This is a new service
+                        {% if feedbackLink %}
+                        – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.
+                        {% endif %}
+                      </span>
+                    </div>
                   </div>
-                </div>
-              {% endif %}
+                {% endif %}
+              {% endblock %}
             {% endblock %}
-          {% endblock %}
+          </div>
           <div class="main-content__inner l-container" id="xhr-outlet">
             {% block body_main_content %}{% endblock %}
           </div>

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -70,7 +70,7 @@
   {% set messages = props.messages | default(getMessages()) %}
   {% set modifier = props.modifier | concat('') | reverse | join(' c-local-header--') if props.modifier %}
 
-  {% if props %}
+  {% if props or caller %}
     <header class="c-local-header {{ modifier }}" aria-label="local header">
       <div class="l-container">
         {% if breadcrumbs|length %}
@@ -113,15 +113,12 @@
 {##
  # Render local nav
  # @param {object} props
- # @param {string} [props.modifier] - nav modifier
  # @param {string} [props.items] - nav items
  #
  #}
 {% macro LocalNav(props) %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-local-nav--') if props.modifier %}
-
   {% if props|length %}
-    <nav class="c-local-nav {{ modifier }}" aria-label="local navigation">
+    <nav class="c-local-nav" aria-label="local navigation">
       {% for item in props.items %}
         <a class="c-local-nav__link {{ 'is-active' if item.isActive }}" href="{{item.url}}">{{ item.label }}</a>
       {% endfor %}

--- a/src/templates/errors.njk
+++ b/src/templates/errors.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/datahub-base.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ heading: statusMessage, modifier: 'light-banner' }) %}
+  {% call LocalHeader({ heading: statusMessage }) %}
     <p>{{ statusCode }}</p>
   {% endcall %}
 {% endblock %}


### PR DESCRIPTION
👉  [Demo here](https://datahub-beta2-pr-532.herokuapp.com/sign-in) 👈 

A few suggestions/tweaks to the styles and markup associated with the breadcrumb and global nav. This removes the need for sending in modifier flags to the macro.

- move setting of background colour for header to wrapper
- make font size for global nav a bit bigger
- remove border underline

![header](https://user-images.githubusercontent.com/2305016/30033733-f56ea38e-9194-11e7-8c38-65523f9cf58c.gif)
