### PR TITLE
Add default local header spacing to first heading element

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -1,5 +1,7 @@
 @import "../tools/mixins";
 
+$_first-element-spacing: $default-spacing-unit * 3;
+
 .c-local-header {
   @include clearfix;
 
@@ -20,7 +22,7 @@
     margin-top: $default-spacing-unit / 2;
 
     & + * {
-      margin-top: $default-spacing-unit * 3;
+      margin-top: $_first-element-spacing;
     }
 
     & + .c-entity-search {
@@ -59,6 +61,10 @@
 .c-local-header__heading {
   @include bold-font(36);
   margin-bottom: 0;
+
+  &:first-child {
+    margin-top: $_first-element-spacing;
+  }
 }
 
 * + .c-local-header__heading-after {
@@ -91,7 +97,7 @@
     width: 30%;
 
     * + & {
-      margin-top: $default-spacing-unit * 3;
+      margin-top: $_first-element-spacing;
     }
   }
 }


### PR DESCRIPTION
When there is no breadcrumb and the heading is the first child add
the default local header spacing amount.

## Before

![localhost_3001_sign-in 2](https://user-images.githubusercontent.com/3327997/30055877-a689c1e2-9228-11e7-8692-a297eb89ff5e.png)

## After

![localhost_3001_sign-in 1](https://user-images.githubusercontent.com/3327997/30055836-902d7420-9228-11e7-9adb-f4094559b167.png)
