### PR TITLE
Cancel quote

### DIFF
--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,7 +1,7 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
-const { setOrderBreadcrumb, getQuote, setQuoteForm, generateQuote } = require('./middleware')
+const { setOrderBreadcrumb, getQuote, setQuoteForm, generateQuote, cancelQuote } = require('./middleware')
 const { renderWorkOrder, renderQuote } = require('./controllers')
 
 const LOCAL_NAV = [
@@ -20,5 +20,7 @@ router
   .route('/quote')
   .get(getQuote, setQuoteForm, renderQuote)
   .post(generateQuote)
+
+router.post('/quote/cancel', cancelQuote)
 
 module.exports = router

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -12,5 +12,12 @@
     }) }}
   {% endif %}
 
+  {% if destructive %}
+    <div class="infostrip">
+      Editing the order whilst it is out for acceptance will invalidate the
+      current quote and the client will no longer be able to accept it.
+    </div>
+  {% endif %}
+
   {{ Form(quoteForm) }}
 {% endblock %}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -6,6 +6,7 @@ describe('OMIS View middleware', () => {
     this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
     this.getQuoteStub = this.sandbox.stub()
     this.createQuoteStub = this.sandbox.stub()
+    this.cancelQuoteStub = this.sandbox.stub()
     this.flashSpy = this.sandbox.spy()
     this.nextSpy = this.sandbox.spy()
 
@@ -32,6 +33,7 @@ describe('OMIS View middleware', () => {
         Order: {
           getQuote: this.getQuoteStub,
           createQuote: this.createQuoteStub,
+          cancelQuote: this.cancelQuoteStub,
         },
       },
     })
@@ -230,18 +232,228 @@ describe('OMIS View middleware', () => {
     })
   })
 
-  describe('setQuoteForm()', () => {
-    it('should set quoteForm on locals object', (done) => {
-      const nextSpy = () => {
-        try {
-          expect(this.resMock.locals).to.have.property('quoteForm')
-          done()
-        } catch (error) {
-          done(error)
-        }
-      }
+  describe('cancelQuote()', () => {
+    context('when Order.cancelQuote resolves', () => {
+      beforeEach(() => {
+        this.cancelQuoteStub.resolves({
+          created_on: '2017-08-31T15:10:41.119609',
+          created_by: {
+            'name': 'Rebecca Bah',
+            'id': '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+          },
+          cancelled_on: '2017-09-02T15:10:41.119609',
+          cancelled_by: {
+            'name': 'Rebecca Bah',
+            'id': '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+          },
+        })
+      })
 
-      this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+      it('should redirect back to order page', (done) => {
+        const resMock = Object.assign({}, this.resMock, {
+          redirect: (path) => {
+            try {
+              expect(this.nextSpy).not.to.have.been.called
+              expect(this.flashSpy).to.have.been.calledOnce
+              expect(path).to.equal('/omis/123456789')
+              done()
+            } catch (error) {
+              done(error)
+            }
+          },
+        })
+
+        this.middleware.cancelQuote(this.reqMock, resMock, this.nextSpy)
+      })
+    })
+
+    context('when Order.cancelQuote returns a 404', () => {
+      beforeEach(() => {
+        const error = {
+          statusCode: 404,
+        }
+        this.cancelQuoteStub.rejects(error)
+      })
+
+      it('should set flash and redirect', (done) => {
+        const resMock = Object.assign({}, this.resMock, {
+          redirect: (path) => {
+            try {
+              expect(this.nextSpy).not.to.have.been.called
+              expect(this.flashSpy).to.have.been.calledOnce
+              expect(path).to.equal('/omis/123456789/quote')
+              done()
+            } catch (error) {
+              done(error)
+            }
+          },
+        })
+
+        this.middleware.cancelQuote(this.reqMock, resMock, this.nextSpy)
+      })
+    })
+
+    context('when Order.cancelQuote returns a 409', () => {
+      beforeEach(() => {
+        const error = {
+          statusCode: 409,
+        }
+        this.cancelQuoteStub.rejects(error)
+      })
+
+      it('should set flash and redirect', (done) => {
+        const resMock = Object.assign({}, this.resMock, {
+          redirect: (path) => {
+            try {
+              expect(this.nextSpy).not.to.have.been.called
+              expect(this.flashSpy).to.have.been.calledOnce
+              expect(path).to.equal('/omis/123456789/quote')
+              done()
+            } catch (error) {
+              done(error)
+            }
+          },
+        })
+
+        this.middleware.cancelQuote(this.reqMock, resMock, this.nextSpy)
+      })
+    })
+
+    context('when Order.cancelQuote returns any other error', () => {
+      beforeEach(() => {
+        this.error = new Error('Server error')
+        this.error.statusCode = 500
+
+        this.cancelQuoteStub.rejects(this.error)
+      })
+
+      it('should set an empty quote object on locals object', (done) => {
+        const nextSpy = (error) => {
+          try {
+            expect(error).to.deep.equal(this.error)
+            done()
+          } catch (error) {
+            done(error)
+          }
+        }
+
+        this.middleware.cancelQuote(this.reqMock, this.resMock, nextSpy)
+      })
+    })
+  })
+
+  describe('setQuoteForm()', () => {
+    beforeEach(() => {
+      this.resMock.locals.quote = {}
+    })
+
+    context('when quote does not have an expiry date', () => {
+      it('should set default quoteForm object', (done) => {
+        const nextSpy = () => {
+          try {
+            expect(this.resMock.locals).to.have.property('quoteForm')
+
+            expect(this.resMock.locals.quoteForm).to.have.property('buttonText')
+            expect(this.resMock.locals.quoteForm).to.have.property('returnText')
+            expect(this.resMock.locals.quoteForm).to.have.property('returnLink')
+
+            done()
+          } catch (error) {
+            done(error)
+          }
+        }
+
+        this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+      })
+    })
+
+    context('when quote has an expiry date', () => {
+      beforeEach(() => {
+        this.resMock.locals.quote.expires_on = '2017-08-01'
+      })
+
+      it('should set change quoteForm object', (done) => {
+        const nextSpy = () => {
+          try {
+            expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
+            expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Cancel quote')
+            expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button-secondary')
+
+            done()
+          } catch (error) {
+            done(error)
+          }
+        }
+
+        this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+      })
+    })
+
+    context('when quote has not expired', () => {
+      beforeEach(() => {
+        const mockDate = new Date('2017-08-01')
+
+        this.clock = sinon.useFakeTimers(mockDate.getTime())
+        this.resMock.locals.quote.expires_on = '2017-08-10'
+      })
+
+      afterEach(() => {
+        this.clock.restore()
+      })
+
+      context('when quote has not been accpeted or cancelled', () => {
+        it('should allow destructive cancel', (done) => {
+          const nextSpy = () => {
+            try {
+              expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
+              expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Cancel quote')
+              expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button--destructive')
+
+              done()
+            } catch (error) {
+              done(error)
+            }
+          }
+
+          this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+        })
+      })
+
+      context('when quote has been accepted', () => {
+        it('should disable form actions', (done) => {
+          const nextSpy = () => {
+            try {
+              expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+
+              done()
+            } catch (error) {
+              done(error)
+            }
+          }
+
+          this.resMock.locals.quote.accepted_on = '2017-08-02'
+
+          this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+        })
+      })
+
+      context('when quote has been cancelled', () => {
+        it('should disable form actions', (done) => {
+          const nextSpy = () => {
+            try {
+              expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+
+              done()
+            } catch (error) {
+              done(error)
+            }
+          }
+
+          this.resMock.locals.quote.cancelled_on = '2017-08-02'
+
+          this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
This change adds the initial journey for cancelling a quote that has been sent for approval.

It can be cancelled as long as it hasn't been accepted or previously cancelled. There are 2 slightly different variations to the cancellation too: 

1) **Not expired**: Can be cancelled but a warning is provided that it will notify the client and they will no longer be able to accept that quote
2) **Expired**: Can be cancelled without major consequence as client can no longer accept anyway

**Note:** The API doesn't currently return the `expires_on` property of the quote object so the functionality won't work on the demo link at this point.

## What it looks like

### Not expired

![localhost_3001_omis_6c4f3d1b-b9ad-4d27-a2ff-94a53167f86f_quote](https://user-images.githubusercontent.com/3327997/30065949-65149edc-924e-11e7-8a31-90594173a330.png)

### Expired

![localhost_3001_omis_6c4f3d1b-b9ad-4d27-a2ff-94a53167f86f_quote 1](https://user-images.githubusercontent.com/3327997/30065970-71ae1f06-924e-11e7-8f1c-8549e0345b35.png)
