### PR TITLE
Fix spacing issue within local header

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -7,6 +7,10 @@ $_first-element-spacing: $default-spacing-unit * 3;
 
   .l-container {
     border-top: 1px solid transparent;
+
+    > .c-local-header__heading:first-child {
+      margin-top: $_first-element-spacing;
+    }
   }
 
   &[class*="c-local-header--"] {
@@ -61,10 +65,6 @@ $_first-element-spacing: $default-spacing-unit * 3;
 .c-local-header__heading {
   @include bold-font(36);
   margin-bottom: 0;
-
-  &:first-child {
-    margin-top: $_first-element-spacing;
-  }
 }
 
 * + .c-local-header__heading-after {


### PR DESCRIPTION
This tweaks a fix for the spacing of elements within the local header.

Mainly when the heading is the first element and no breadcrumb is
present.

## Before

![image](https://user-images.githubusercontent.com/3327997/30108358-ef1c7d4c-92f9-11e7-9d66-b98f793eb854.png)

## After

![image](https://user-images.githubusercontent.com/3327997/30108340-de0fdcba-92f9-11e7-9980-39ab6f831e69.png)
