### PR TITLE
Extend dev example macro to support custom tab title

### DIFF
--- a/assets/stylesheets/components/_.example.scss
+++ b/assets/stylesheets/components/_.example.scss
@@ -10,7 +10,7 @@
   padding-bottom: $default-spacing-unit / 4;
 
   &::before {
-    content: "Example";
+    content: attr(data-tab-title);
     background-color: $grey-1;
     color: $white;
     text-transform: uppercase;

--- a/src/templates/_macros/dev.njk
+++ b/src/templates/_macros/dev.njk
@@ -1,6 +1,6 @@
-{% macro Example(title, isWide = false) %}
+{% macro Example(title, isWide = false, tabTitle = 'Example') %}
   <article class="example {{ 'example--wide' if isWide }}" {% if title %}id="{{ title | urlencode }}"{% endif %}>
-    <header class="example__header">
+    <header class="example__header" data-tab-title="{{ tabTitle }}">
       {% if title %}
         <h3 class="example__title">{{ title }}</h3>
       {% endif %}


### PR DESCRIPTION
This allows a custom tab title to be passed to the macro instead of
always displaying `Example`.