### PR TITLE
Fix meta item value output syntax

### DIFF
--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -83,17 +83,15 @@
   {% set isLabelHidden = props.isLabelHidden | default(false) %}
   {% set itemValueClass = 'c-badge ' + badgeModifier if props.type === 'badge' else 'c-meta-list__item-value'%}
 
-  {% if props.type %}
+  {% if props.value %}
     {% if props.type === 'date' %}
-      {% set date = props.value | formatDate %}
+      {% set metaItemValue = props.value | formatDate %}
     {% elif props.type === 'datetime' %}
-      {% set date = props.value | formatDateTime %}
+      {% set metaItemValue = props.value | formatDateTime %}
+    {% else %}
+      {% set metaItemValue = props.value.name | default(props.value) %}
     {% endif %}
-  {% endif %}
 
-  {% set metaItemValue = date or props.value.name | default(props.value)  %}
-
-  {% if metaItemValue %}
     <div class="{{ 'c-meta-list__item' | applyClassModifiers(props.modifier) }}">
       {% if props.label %}
         <span class="c-meta-list__item-label {{ 'u-visually-hidden' if isLabelHidden or props.type === 'badge' }}">

--- a/test/unit/macros/entities.test.js
+++ b/test/unit/macros/entities.test.js
@@ -159,6 +159,25 @@ describe('Entities macros', () => {
         expect(component.querySelector('.c-meta-list__item-value').textContent).to.equal('26 July 2017')
       })
 
+      it('should not render item formatted as date if it has no value', () => {
+        const component = entitiesMacros.renderToDom('MetaList', {
+          items: [{
+            label: 'Land date',
+            type: 'date',
+            name: 'land_date',
+            value: '2017-07-26',
+          }, {
+            label: 'Expiry date',
+            type: 'date',
+            name: 'expiry_date',
+          }],
+        })
+
+        expect(component.querySelector('.c-meta-list__item-value').textContent).to.equal('26 July 2017')
+        expect(component.querySelectorAll('.c-meta-list__item')).to.have.length(1)
+        expect(component.textContent).not.to.contain('Expiry date')
+      })
+
       it('should render item with link', () => {
         const component = entitiesMacros.renderToDom('MetaList', {
           items: [{


### PR DESCRIPTION
Previously if the value was empty but a type was specified it would
still output the item as the filter was being applied before the
check.