### PR TITLE
Preview order quote

### DIFF
--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -24,6 +24,15 @@
   + * {
     margin-top: $default-spacing-unit;
   }
+
+  * {
+    font-weight: 700;
+  }
+
+  > * + * {
+    margin-top: $default-spacing-unit;
+    margin-bottom: 0;
+  }
 }
 
 .c-messages__close {

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -23,17 +23,30 @@ function setTranslation (req, res, next) {
 }
 
 async function getQuote (req, res, next) {
+  const orderId = get(res.locals, 'order.id')
+
   try {
-    const orderId = get(res.locals, 'order.id')
-    res.locals.quote = await Order.getQuote(req.session.token, orderId)
-    next()
+    res.locals.quote = await Order.previewQuote(req.session.token, orderId)
+    return next()
   } catch (error) {
-    if (error.statusCode === 404) {
-      res.locals.quote = {}
+    // When quote already exists, get it
+    if (error.statusCode === 409) {
+      try {
+        res.locals.quote = await Order.getFullQuote(req.session.token, orderId)
+        return next()
+      } catch (error) {
+        return next(error)
+      }
+    }
+
+    // when preview cannot be generated capture missing data
+    // to render in the view
+    if (error.statusCode === 400) {
+      res.locals.incompleteFields = keys(error.error)
       return next()
     }
 
-    next(error)
+    return next(error)
   }
 }
 
@@ -94,7 +107,11 @@ function setQuoteForm (req, res, next) {
     returnLink: `/omis/${orderId}`,
   }
 
-  if (quote.expires_on) {
+  if (res.locals.incompleteFields) {
+    form.disableFormAction = true
+  }
+
+  if (get(quote, 'created_on')) {
     form.action = `/omis/${orderId}/quote/cancel`
     form.buttonText = 'Cancel quote'
     form.buttonModifiers = 'button-secondary'

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -1,12 +1,25 @@
-const { get } = require('lodash')
+const { get, keys } = require('lodash')
+const path = require('path')
+const i18nFuture = require('i18n-future')
 
 const { setHomeBreadcrumb } = require('../../../middleware')
 const { Order } = require('../../models')
+
+const i18n = i18nFuture({
+  path: path.resolve(__dirname, '../../locales/__lng__/__ns__.json'),
+})
 
 function setOrderBreadcrumb (req, res, next) {
   const reference = get(res.locals, 'order.reference')
 
   return setHomeBreadcrumb(reference)(req, res, next)
+}
+
+function setTranslation (req, res, next) {
+  res.locals.translate = (key) => {
+    return i18n.translate(key)
+  }
+  next()
 }
 
 async function getQuote (req, res, next) {
@@ -103,6 +116,7 @@ function setQuoteForm (req, res, next) {
 
 module.exports = {
   setOrderBreadcrumb,
+  setTranslation,
   getQuote,
   generateQuote,
   cancelQuote,

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,8 +1,15 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
-const { setOrderBreadcrumb, getQuote, setQuoteForm, generateQuote, cancelQuote } = require('./middleware')
 const { renderWorkOrder, renderQuote } = require('./controllers')
+const {
+  setOrderBreadcrumb,
+  setTranslation,
+  getQuote,
+  setQuoteForm,
+  generateQuote,
+  cancelQuote,
+} = require('./middleware')
 
 const LOCAL_NAV = [
   { path: 'work-order', label: 'Work order' },
@@ -12,6 +19,7 @@ const LOCAL_NAV = [
 ]
 
 router.use(setLocalNav(LOCAL_NAV))
+router.use(setTranslation)
 router.use(setOrderBreadcrumb)
 
 router.get('/', redirectToFirstNavItem)

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -1,22 +1,61 @@
 {% extends '_layouts/two-column.njk' %}
 
+{% from "_macros/dev.njk" import Example %}
+
 {% block main_grid_right_column %}
+  {% if incompleteFields %}
+    <ul class="c-messages">
+      <li class="c-messages__item c-messages__item--error">
+        <p>To generate a quote you must enter the following work description information:</p>
+
+        <ul class="list-disc">
+          {% for field in incompleteFields %}
+            <li>{{ translate('fields.' + field + '.label') }}</li>
+          {% endfor %}
+        </ul>
+
+        <p><a href="/omis/{{ order.id }}/edit/work-description">Complete work description</a></p>
+      </li>
+    </ul>
+  {% endif %}
+
   {% if quote %}
+    {# TODO: Remove `if quote.created_on` when API stops returning `created_on` for preview  #}
     {{ MetaList({
       items: [
-        { label: 'Sent on', value: quote.created_on | formatDateTime },
-        { label: 'Sent by', value: quote.created_by },
-        { label: 'Expires on', value: quote.expires_on | formatDateTime }
+        { label: 'Expires on', value: quote.expires_on, type: 'date' },
+        { label: 'Sent on', value: quote.created_on, type: 'datetime' },
+        { label: 'Sent by', value: quote.created_by if quote.created_on }
       ],
       itemModifier: 'stacked'
     }) }}
+
+    {{ MetaList({
+      items: [
+        { label: 'Cancelled on', value: quote.cancelled_on, type: 'datetime' },
+        { label: 'Cancelled by', value: quote.cancelled_by },
+        { label: 'Accepted on', value: quote.accepted_on, type: 'datetime' },
+        { label: 'Accepted by', value: quote.accepted_by }
+      ],
+      itemModifier: 'stacked'
+    }) }}
+
+    {% call Example(tabTitle = 'Preview') %}
+      <div class="l-markdown">
+        {% markdown %}
+          {{ quote.content }}
+        {% endmarkdown %}
+      </div>
+    {% endcall %}
   {% endif %}
 
   {% if destructive %}
-    <div class="infostrip">
-      Editing the order whilst it is out for acceptance will invalidate the
-      current quote and the client will no longer be able to accept it.
-    </div>
+    <ul class="c-messages">
+      <li class="c-messages__item c-messages__item--warning">
+        Editing the order whilst it is out for acceptance will invalidate the
+        current quote and the client will no longer be able to accept it.
+      </li>
+    </ul>
   {% endif %}
 
   {{ Form(quoteForm) }}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -4,7 +4,8 @@ describe('OMIS View middleware', () => {
 
     this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
     this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
-    this.getQuoteStub = this.sandbox.stub()
+    this.previewQuoteStub = this.sandbox.stub()
+    this.getFullQuoteStub = this.sandbox.stub()
     this.createQuoteStub = this.sandbox.stub()
     this.cancelQuoteStub = this.sandbox.stub()
     this.flashSpy = this.sandbox.spy()
@@ -31,7 +32,8 @@ describe('OMIS View middleware', () => {
       },
       '../../models': {
         Order: {
-          getQuote: this.getQuoteStub,
+          previewQuote: this.previewQuoteStub,
+          getFullQuote: this.getFullQuoteStub,
           createQuote: this.createQuoteStub,
           cancelQuote: this.cancelQuoteStub,
         },
@@ -68,73 +70,111 @@ describe('OMIS View middleware', () => {
   })
 
   describe('getQuote()', () => {
-    context('when Order.getQuote resolves', () => {
+    context('when no quote exists', () => {
       beforeEach(() => {
-        this.getQuoteStub.resolves({
+        this.previewQuoteStub.resolves({
           id: '12345',
+          content: 'Quote content',
         })
       })
 
-      it('should set quote on locals object', (done) => {
-        const nextSpy = () => {
-          try {
-            expect(this.resMock.locals).to.have.property('quote')
-            expect(this.resMock.locals.quote).to.deep.equal({
-              id: '12345',
-            })
-            done()
-          } catch (error) {
-            done(error)
-          }
-        }
+      it('should set response as quote property on locals', async () => {
+        await this.middleware.getQuote(this.reqMock, this.resMock, this.nextSpy)
 
-        this.middleware.getQuote(this.reqMock, this.resMock, nextSpy)
+        expect(this.resMock.locals).to.have.property('quote')
+        expect(this.resMock.locals.quote).to.deep.equal({
+          id: '12345',
+          content: 'Quote content',
+        })
+        expect(this.nextSpy).to.have.been.calledWith()
       })
     })
 
-    context('when Order.getQuote returns a 404', () => {
+    context('when quote already exists', () => {
       beforeEach(() => {
         const error = {
-          statusCode: 404,
+          statusCode: 409,
         }
-        this.getQuoteStub.rejects(error)
+        this.previewQuoteStub.rejects(error)
       })
 
-      it('should set an empty quote object on locals object', (done) => {
-        const nextSpy = (error) => {
-          try {
-            expect(this.resMock.locals).to.have.property('quote')
-            expect(this.resMock.locals.quote).to.deep.equal({})
-            expect(error).to.be.undefined
-            done()
-          } catch (error) {
-            done(error)
-          }
-        }
+      context('when quote is returned', () => {
+        beforeEach(() => {
+          this.getFullQuoteStub.resolves({
+            id: '12345',
+            content: 'Quote content',
+          })
+        })
 
-        this.middleware.getQuote(this.reqMock, this.resMock, nextSpy)
+        it('should set response as quote property on locals', async () => {
+          await this.middleware.getQuote(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.resMock.locals).to.have.property('quote')
+          expect(this.resMock.locals.quote).to.deep.equal({
+            id: '12345',
+            content: 'Quote content',
+          })
+          expect(this.nextSpy).to.have.been.calledWith()
+        })
+      })
+
+      context('when quote cannot be returned', () => {
+        beforeEach(() => {
+          this.error = {
+            statusCode: 404,
+          }
+          this.getFullQuoteStub.rejects(this.error)
+        })
+
+        it('should call next with the error', async () => {
+          await this.middleware.getQuote(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.nextSpy).to.have.been.calledWith(this.error)
+        })
+      })
+
+      context('when quote preview generates an unexpected error', () => {
+        beforeEach(() => {
+          this.error = {
+            statusCode: 500,
+          }
+          this.previewQuoteStub.rejects(this.error)
+        })
+
+        it('should call next with the error', async () => {
+          await this.middleware.getQuote(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.nextSpy).to.have.been.calledWith(this.error)
+        })
       })
     })
 
-    context('when Order.getQuote returns any other error', () => {
+    context('when quote cannot be generated because of errors', () => {
       beforeEach(() => {
         const error = {
-          statusCode: 500,
+          statusCode: 400,
+          error: {
+            'service_types': ['Required'],
+            'description': ['Required'],
+          },
         }
-        this.getQuoteStub.rejects(error)
+        this.previewQuoteStub.rejects(error)
       })
 
-      it('should set an empty quote object on locals object', (done) => {
-        const nextSpy = (error) => {
-          try {
-            expect(error.statusCode).to.equal(500)
-            done()
-          } catch (error) {
-            done(error)
-          }
-        }
+      it('should set errors on locals', async () => {
+        await this.middleware.getQuote(this.reqMock, this.resMock, this.nextSpy)
 
-        this.middleware.getQuote(this.reqMock, this.resMock, nextSpy)
+        expect(this.resMock.locals).to.have.property('incompleteFields')
+        expect(this.resMock.locals.incompleteFields).to.deep.equal([
+          'service_types',
+          'description',
+        ])
+      })
+
+      it('should return next without error', async () => {
+        await this.middleware.getQuote(this.reqMock, this.resMock, this.nextSpy)
+
+        expect(this.nextSpy).to.have.been.calledWith()
       })
     })
   })
@@ -359,7 +399,7 @@ describe('OMIS View middleware', () => {
       this.resMock.locals.quote = {}
     })
 
-    context('when quote does not have an expiry date', () => {
+    context('when quote does not exist', () => {
       it('should set default quoteForm object', (done) => {
         const nextSpy = () => {
           try {
@@ -379,9 +419,35 @@ describe('OMIS View middleware', () => {
       })
     })
 
-    context('when quote has an expiry date', () => {
+    context('when quote preview errors exist exist', () => {
       beforeEach(() => {
-        this.resMock.locals.quote.expires_on = '2017-08-01'
+        this.resMock.locals.incompleteFields = ['service_types']
+      })
+
+      it('should set disable the form actions', (done) => {
+        const nextSpy = () => {
+          try {
+            expect(this.resMock.locals).to.have.property('quoteForm')
+
+            expect(this.resMock.locals.quoteForm).to.have.property('buttonText')
+            expect(this.resMock.locals.quoteForm).to.have.property('returnText')
+            expect(this.resMock.locals.quoteForm).to.have.property('returnLink')
+            expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+
+            done()
+          } catch (error) {
+            done(error)
+          }
+        }
+
+        this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+      })
+    })
+
+    context('when quote exists', () => {
+      beforeEach(() => {
+        this.resMock.locals.quote.created_on = '2017-08-01'
+        this.resMock.locals.quote.expires_on = '2017-09-01'
       })
 
       it('should set change quoteForm object', (done) => {
@@ -399,71 +465,71 @@ describe('OMIS View middleware', () => {
 
         this.middleware.setQuoteForm({}, this.resMock, nextSpy)
       })
-    })
 
-    context('when quote has not expired', () => {
-      beforeEach(() => {
-        const mockDate = new Date('2017-08-01')
+      context('when quote has not expired', () => {
+        beforeEach(() => {
+          const mockDate = new Date('2017-08-01')
 
-        this.clock = sinon.useFakeTimers(mockDate.getTime())
-        this.resMock.locals.quote.expires_on = '2017-08-10'
-      })
-
-      afterEach(() => {
-        this.clock.restore()
-      })
-
-      context('when quote has not been accpeted or cancelled', () => {
-        it('should allow destructive cancel', (done) => {
-          const nextSpy = () => {
-            try {
-              expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
-              expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Cancel quote')
-              expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button--destructive')
-
-              done()
-            } catch (error) {
-              done(error)
-            }
-          }
-
-          this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+          this.clock = sinon.useFakeTimers(mockDate.getTime())
+          this.resMock.locals.quote.expires_on = '2017-08-10'
         })
-      })
 
-      context('when quote has been accepted', () => {
-        it('should disable form actions', (done) => {
-          const nextSpy = () => {
-            try {
-              expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
-
-              done()
-            } catch (error) {
-              done(error)
-            }
-          }
-
-          this.resMock.locals.quote.accepted_on = '2017-08-02'
-
-          this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+        afterEach(() => {
+          this.clock.restore()
         })
-      })
 
-      context('when quote has been cancelled', () => {
-        it('should disable form actions', (done) => {
-          const nextSpy = () => {
-            try {
-              expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+        context('when quote has not been accpeted or cancelled', () => {
+          it('should allow destructive cancel', (done) => {
+            const nextSpy = () => {
+              try {
+                expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
+                expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Cancel quote')
+                expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button--destructive')
 
-              done()
-            } catch (error) {
-              done(error)
+                done()
+              } catch (error) {
+                done(error)
+              }
             }
-          }
 
-          this.resMock.locals.quote.cancelled_on = '2017-08-02'
+            this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+          })
+        })
 
-          this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+        context('when quote has been accepted', () => {
+          it('should disable form actions', (done) => {
+            const nextSpy = () => {
+              try {
+                expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+
+                done()
+              } catch (error) {
+                done(error)
+              }
+            }
+
+            this.resMock.locals.quote.accepted_on = '2017-08-02'
+
+            this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+          })
+        })
+
+        context('when quote has been cancelled', () => {
+          it('should disable form actions', (done) => {
+            const nextSpy = () => {
+              try {
+                expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+
+                done()
+              } catch (error) {
+                done(error)
+              }
+            }
+
+            this.resMock.locals.quote.cancelled_on = '2017-08-02'
+
+            this.middleware.setQuoteForm({}, this.resMock, nextSpy)
+          })
         })
       })
     })

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -55,6 +55,18 @@ describe('OMIS View middleware', () => {
     })
   })
 
+  describe('setTranslation()', () => {
+    it('should set a translate method on locals', () => {
+      this.middleware.setTranslation({}, this.resMock, this.nextSpy)
+
+      expect(this.resMock.locals).to.have.property('translate')
+      expect(this.resMock.locals.translate).to.be.a('function')
+      expect(this.nextSpy).to.have.been.calledOnce
+
+      expect(this.resMock.locals.translate('translation.key')).to.equal('translation.key')
+    })
+  })
+
   describe('getQuote()', () => {
     context('when Order.getQuote resolves', () => {
       beforeEach(() => {


### PR DESCRIPTION
This PR includes changes to the quote preview view.

It adds support for previewing the contents of the quote before it is sent and seeing the contents after it has been sent.

## What it looks like

### Quote cannot be generated - missing information

![localhost_3001_omis_3456238e-e94f-4db0-889f-437eb6ac8377_quote](https://user-images.githubusercontent.com/3327997/30123150-eef47962-9328-11e7-9e11-590ba1dba048.png)

### Quote can be generated

![localhost_3001_omis_3456238e-e94f-4db0-889f-437eb6ac8377_quote 1](https://user-images.githubusercontent.com/3327997/30123164-04738c38-9329-11e7-9e7a-cdf5d4da3496.png)

### Cancel quote (not expired)

![localhost_3001_omis_3456238e-e94f-4db0-889f-437eb6ac8377_quote 2](https://user-images.githubusercontent.com/3327997/30123196-1c0d27aa-9329-11e7-884d-f41ab544f300.png)

### Cancel quote (expired)

![localhost_3001_omis_3456238e-e94f-4db0-889f-437eb6ac8377_quote 3](https://user-images.githubusercontent.com/3327997/30123254-481aa4b2-9329-11e7-843a-1c1e2f3e8889.png)
