### PR TITLE
DH-538 Add create event form

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -1,8 +1,11 @@
+const { eventForm } = require('../macros')
+
 function renderEventPage (req, res) {
   res
     .breadcrumb('Add event')
     .render('events/views/edit', {
       title: 'Add event',
+      eventForm,
     })
 }
 

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -1,12 +1,21 @@
 const { eventForm } = require('../macros')
+const { getAdvisers } = require('../../adviser/repos')
+const { transformObjectToOption } = require('../../transformers')
 
-function renderEventPage (req, res) {
-  res
-    .breadcrumb('Add event')
-    .render('events/views/edit', {
-      title: 'Add event',
-      eventForm,
-    })
+async function renderEventPage (req, res, next) {
+  try {
+    const advisersResponse = await getAdvisers(req.session.token)
+    const advisers = advisersResponse.results.map(transformObjectToOption)
+
+    res
+      .breadcrumb('Add event')
+      .render('events/views/edit', {
+        title: 'Add event',
+        eventForm: eventForm(advisers),
+      })
+  } catch (e) {
+    next(e)
+  }
 }
 
 module.exports = {

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -1,17 +1,26 @@
-const { eventForm } = require('../macros')
+const { eventFormConfig } = require('../macros')
 const { getAdvisers } = require('../../adviser/repos')
 const { transformObjectToOption } = require('../../transformers')
+const { buildFormWithState } = require('../../builders')
 
 async function renderEventPage (req, res, next) {
   try {
     const advisersResponse = await getAdvisers(req.session.token)
     const advisers = advisersResponse.results.map(transformObjectToOption)
+    const eventForm = eventFormConfig(advisers)
+    const emptyDate = { year: '', month: '', day: '' }
+    const requestBody = {
+      'event-start-date': emptyDate,
+      'event-end-date': emptyDate,
+      'event-team-hosting': req.session.user.dit_team.id,
+    }
+    const eventFormWithState = buildFormWithState(eventForm, requestBody)
 
     res
       .breadcrumb('Add event')
       .render('events/views/edit', {
         title: 'Add event',
-        eventForm: eventForm(advisers),
+        eventForm: eventFormWithState,
       })
   } catch (e) {
     next(e)

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -2,7 +2,7 @@ const metadataRepo = require('../../lib/metadata')
 const { transformObjectToOption } = require('../transformers')
 const { globalFields } = require('../macros')
 
-const eventForm = (organisers) => {
+const eventFormConfig = (organisers) => {
   return {
     method: 'post',
     buttonText: 'Save and Continue',
@@ -92,7 +92,7 @@ const eventForm = (organisers) => {
       {
         macroName: 'MultipleChoiceField',
         name: 'event-team-hosting',
-        label: 'Team hosting the event', // todo: pre select current user team
+        label: 'Team hosting the event',
         optional: true,
         initialOption: '-- Select team --',
         options () {
@@ -154,5 +154,5 @@ const eventForm = (organisers) => {
 }
 
 module.exports = {
-  eventForm,
+  eventFormConfig,
 }

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -2,164 +2,164 @@ const metadataRepo = require('../../lib/metadata')
 const { transformObjectToOption } = require('../transformers')
 const { globalFields } = require('../macros')
 
-const eventForm = {
-  method: 'post',
-  buttonText: 'Save and Continue',
-  children: [
-    {
-      macroName: 'TextField',
-      name: 'event-name',
-      label: 'Event name',
-    },
-    {
-      macroName: 'MultipleChoiceField',
-      name: 'event-type',
-      label: 'Event type',
-      initialOption: '-- Select event type --',
-      options: [ // todo: meta data endpoint
-        { label: 'event type 1' },
-        { label: 'event type 2' },
-        { label: 'event type 3' },
-        { label: 'event type 4' },
-        { label: 'event type 5' },
-      ],
-    },
-    {
-      macroName: 'DateFieldset',
-      name: 'event-start-date',
-      label: 'Event start date',
-      optional: true,
-      value: {
-        year: '',
-        month: '',
-        day: '',
+const eventForm = (organisers) => {
+  return {
+    method: 'post',
+    buttonText: 'Save and Continue',
+    children: [
+      {
+        macroName: 'TextField',
+        name: 'event-name',
+        label: 'Event name',
       },
-    },
-    {
-      macroName: 'DateFieldset',
-      name: 'event-end-date',
-      label: 'Event end date',
-      optional: true,
-      value: {
-        year: '',
-        month: '',
-        day: '',
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event-type',
+        label: 'Event type',
+        initialOption: '-- Select event type --',
+        options: [ // todo: meta data endpoint
+          { label: 'event type 1' },
+          { label: 'event type 2' },
+          { label: 'event type 3' },
+          { label: 'event type 4' },
+          { label: 'event type 5' },
+        ],
       },
-    },
-    {
-      macroName: 'MultipleChoiceField',
-      name: 'event-location-type',
-      label: 'Event location type',
-      optional: true,
-      initialOption: '-- Select location type --',
-      options: [ // todo: meta data endpoint
-        { label: 'location type 1' },
-        { label: 'location type 2' },
-        { label: 'location type 3' },
-        { label: 'location type 4' },
-      ],
-    },
-    {
-      macroName: 'TextField',
-      name: 'address_1',
-      label: 'Business and street',
-    },
-    {
-      macroName: 'TextField',
-      name: 'address_2',
-      label: 'Second line of address',
-      isLabelHidden: true,
-      optional: true,
-    },
-    {
-      macroName: 'TextField',
-      name: 'address_town',
-      label: 'Town or city',
-    },
-    {
-      macroName: 'TextField',
-      name: 'address_county',
-      label: 'County',
-    },
-    {
-      macroName: 'TextField',
-      name: 'address_postcode',
-      label: 'Postcode',
-      class: 'u-js-hidden',
-    },
-    globalFields.countries,
-    {
-      macroName: 'TextField',
-      type: 'textarea',
-      name: 'event-notes',
-      label: 'Event notes',
-      optional: true,
-    },
-    {
-      macroName: 'MultipleChoiceField',
-      name: 'event-team-hosting',
-      label: 'Team hosting the event', // todo: pre select current user team
-      optional: true,
-      initialOption: '-- Select team --',
-      options () {
-        return metadataRepo.teams.map(transformObjectToOption)
+      {
+        macroName: 'DateFieldset',
+        name: 'event-start-date',
+        label: 'Event start date',
+        optional: true,
+        value: {
+          year: '',
+          month: '',
+          day: '',
+        },
       },
-    },
-    {
-      macroName: 'MultipleChoiceField',
-      name: 'event-organiser',
-      label: 'Organiser',
-      optional: true,
-      initialOption: '-- Select organiser --',
-      options () {
-        return [ '1', '2' ]
+      {
+        macroName: 'DateFieldset',
+        name: 'event-end-date',
+        label: 'Event end date',
+        optional: true,
+        value: {
+          year: '',
+          month: '',
+          day: '',
+        },
       },
-    },
-    {
-      macroName: 'MultipleChoiceField',
-      type: 'radio',
-      name: 'event-shared',
-      label: 'Is this a shared event',
-      optional: true,
-      modifier: 'inline',
-      options: [
-        {
-          label: 'Yes',
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event-location-type',
+        label: 'Event location type',
+        optional: true,
+        initialOption: '-- Select location type --',
+        options: [ // todo: meta data endpoint
+          { label: 'location type 1' },
+          { label: 'location type 2' },
+          { label: 'location type 3' },
+          { label: 'location type 4' },
+        ],
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_1',
+        label: 'Business and street',
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_2',
+        label: 'Second line of address',
+        isLabelHidden: true,
+        optional: true,
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_town',
+        label: 'Town or city',
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_county',
+        label: 'County',
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_postcode',
+        label: 'Postcode',
+        class: 'u-js-hidden',
+      },
+      globalFields.countries,
+      {
+        macroName: 'TextField',
+        type: 'textarea',
+        name: 'event-notes',
+        label: 'Event notes',
+        optional: true,
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event-team-hosting',
+        label: 'Team hosting the event', // todo: pre select current user team
+        optional: true,
+        initialOption: '-- Select team --',
+        options () {
+          return metadataRepo.teams.map(transformObjectToOption)
+        },
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event-organiser',
+        label: 'Organiser',
+        optional: true,
+        initialOption: '-- Select organiser --',
+        options: organisers,
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        type: 'radio',
+        name: 'event-shared',
+        label: 'Is this a shared event',
+        optional: true,
+        modifier: 'inline',
+        options: [
+          {
+            label: 'Yes',
+            value: 'Yes',
+          },
+          {
+            label: 'No',
+            value: 'No',
+          },
+        ],
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event-teams',
+        label: 'Teams',
+        initialOption: '-- Select team --',
+        isLabelHidden: true,
+        options () {
+          return metadataRepo.teams.map(transformObjectToOption)
+        },
+        condition: {
+          name: 'event-shared',
           value: 'Yes',
         },
-        {
-          label: 'No',
-          value: 'No',
-        },
-      ],
-    },
-    {
-      macroName: 'MultipleChoiceField',
-      name: 'event-teams',
-      label: 'Teams',
-      initialOption: '-- Select team --',
-      isLabelHidden: true,
-      options () {
-        return metadataRepo.teams.map(transformObjectToOption)
       },
-      condition: {
-        name: 'event-shared',
-        value: 'Yes',
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event-related-programmes',
+        label: 'Related programmes',
+        optional: true,
+        initialOption: '-- Select programme --',
+        options: [ // todo: meta data endpoint
+          { label: 'programme 1' },
+          { label: 'programme 2' },
+          { label: 'programme 3' },
+        ],
       },
-    },
-    {
-      macroName: 'MultipleChoiceField',
-      name: 'event-related-programmes',
-      label: 'Related programmes',
-      optional: true,
-      initialOption: '-- Select programme --',
-      options: [ // todo: meta data endpoint
-        { label: 'programme 1' },
-        { label: 'programme 2' },
-        { label: 'programme 3' },
-      ],
-    },
-  ],
+    ],
+  }
 }
 
 module.exports = {

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -17,13 +17,9 @@ const eventForm = (organisers) => {
         name: 'event-type',
         label: 'Event type',
         initialOption: '-- Select event type --',
-        options: [ // todo: meta data endpoint
-          { label: 'event type 1' },
-          { label: 'event type 2' },
-          { label: 'event type 3' },
-          { label: 'event type 4' },
-          { label: 'event type 5' },
-        ],
+        options () {
+          metadataRepo.eventTypeOptions.map(transformObjectToOption)
+        },
       },
       {
         macroName: 'DateFieldset',
@@ -53,12 +49,9 @@ const eventForm = (organisers) => {
         label: 'Event location type',
         optional: true,
         initialOption: '-- Select location type --',
-        options: [ // todo: meta data endpoint
-          { label: 'location type 1' },
-          { label: 'location type 2' },
-          { label: 'location type 3' },
-          { label: 'location type 4' },
-        ],
+        options () {
+          metadataRepo.locationTypeOptions.map(transformObjectToOption)
+        },
       },
       {
         macroName: 'TextField',
@@ -152,11 +145,9 @@ const eventForm = (organisers) => {
         label: 'Related programmes',
         optional: true,
         initialOption: '-- Select programme --',
-        options: [ // todo: meta data endpoint
-          { label: 'programme 1' },
-          { label: 'programme 2' },
-          { label: 'programme 3' },
-        ],
+        options () {
+          return metadataRepo.programmeOptions.map(transformObjectToOption)
+        },
       },
     ],
   }

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -1,0 +1,167 @@
+const metadataRepo = require('../../lib/metadata')
+const { transformObjectToOption } = require('../transformers')
+const { globalFields } = require('../macros')
+
+const eventForm = {
+  method: 'post',
+  buttonText: 'Save and Continue',
+  children: [
+    {
+      macroName: 'TextField',
+      name: 'event-name',
+      label: 'Event name',
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'event-type',
+      label: 'Event type',
+      initialOption: '-- Select event type --',
+      options: [ // todo: meta data endpoint
+        { label: 'event type 1' },
+        { label: 'event type 2' },
+        { label: 'event type 3' },
+        { label: 'event type 4' },
+        { label: 'event type 5' },
+      ],
+    },
+    {
+      macroName: 'DateFieldset',
+      name: 'event-start-date',
+      label: 'Event start date',
+      optional: true,
+      value: {
+        year: '',
+        month: '',
+        day: '',
+      },
+    },
+    {
+      macroName: 'DateFieldset',
+      name: 'event-end-date',
+      label: 'Event end date',
+      optional: true,
+      value: {
+        year: '',
+        month: '',
+        day: '',
+      },
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'event-location-type',
+      label: 'Event location type',
+      optional: true,
+      initialOption: '-- Select location type --',
+      options: [ // todo: meta data endpoint
+        { label: 'location type 1' },
+        { label: 'location type 2' },
+        { label: 'location type 3' },
+        { label: 'location type 4' },
+      ],
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_1',
+      label: 'Business and street',
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_2',
+      label: 'Second line of address',
+      isLabelHidden: true,
+      optional: true,
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_town',
+      label: 'Town or city',
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_county',
+      label: 'County',
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_postcode',
+      label: 'Postcode',
+      class: 'u-js-hidden',
+    },
+    globalFields.countries,
+    {
+      macroName: 'TextField',
+      type: 'textarea',
+      name: 'event-notes',
+      label: 'Event notes',
+      optional: true,
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'event-team-hosting',
+      label: 'Team hosting the event', // todo: pre select current user team
+      optional: true,
+      initialOption: '-- Select team --',
+      options () {
+        return metadataRepo.teams.map(transformObjectToOption)
+      },
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'event-organiser',
+      label: 'Organiser',
+      optional: true,
+      initialOption: '-- Select organiser --',
+      options () {
+        return [ '1', '2' ]
+      },
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      type: 'radio',
+      name: 'event-shared',
+      label: 'Is this a shared event',
+      optional: true,
+      modifier: 'inline',
+      options: [
+        {
+          label: 'Yes',
+          value: 'Yes',
+        },
+        {
+          label: 'No',
+          value: 'No',
+        },
+      ],
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'event-teams',
+      label: 'Teams',
+      initialOption: '-- Select team --',
+      isLabelHidden: true,
+      options () {
+        return metadataRepo.teams.map(transformObjectToOption)
+      },
+      condition: {
+        name: 'event-shared',
+        value: 'Yes',
+      },
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'event-related-programmes',
+      label: 'Related programmes',
+      optional: true,
+      initialOption: '-- Select programme --',
+      options: [ // todo: meta data endpoint
+        { label: 'programme 1' },
+        { label: 'programme 2' },
+        { label: 'programme 3' },
+      ],
+    },
+  ],
+}
+
+module.exports = {
+  eventForm,
+}

--- a/src/apps/events/views/edit.njk
+++ b/src/apps/events/views/edit.njk
@@ -4,6 +4,6 @@
 
 {% block main_grid_right_column %}
 
+  {{ Form(eventForm) }}
 
-  
 {% endblock %}

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -62,6 +62,9 @@ module.exports.getMetadataItem = function (table, id) {
 }
 
 const metadataItems = [
+  ['programme', 'programmeOptions'],
+  ['event-type', 'eventTypeOptions'],
+  ['location-type', 'locationTypeOptions'],
   ['sector', 'sectorOptions'],
   ['turnover', 'turnoverOptions'],
   ['uk-region', 'regionOptions'],

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -41,21 +41,21 @@ describe('Event edit controller', () => {
     })
 
     it('should add a breadcrumb', async () => {
-      await this.controller.renderEventPage(this.req, this.res)
+      await this.controller.renderEventPage(this.req, this.res, this.next)
 
       expect(this.res.breadcrumb).to.be.calledWith('Add event')
       expect(this.res.breadcrumb).to.have.been.calledOnce
     })
 
     it('should render the event page', async () => {
-      await this.controller.renderEventPage(this.req, this.res)
+      await this.controller.renderEventPage(this.req, this.res, this.next)
 
       expect(this.res.render).to.be.calledWith('events/views/edit')
       expect(this.res.render).to.have.been.calledOnce
     })
 
     it('should render the event page with a title', async () => {
-      await this.controller.renderEventPage(this.req, this.res)
+      await this.controller.renderEventPage(this.req, this.res, this.next)
 
       const actual = this.res.render.getCall(0).args[1].title
 
@@ -63,7 +63,7 @@ describe('Event edit controller', () => {
     })
 
     it('should render the event page with an event form', async () => {
-      await this.controller.renderEventPage(this.req, this.res)
+      await this.controller.renderEventPage(this.req, this.res, this.next)
 
       const actual = this.res.render.getCall(0).args[1].eventForm
 
@@ -71,7 +71,7 @@ describe('Event edit controller', () => {
     })
 
     it('should populate the event form with organisers', async () => {
-      await this.controller.renderEventPage(this.req, this.res)
+      await this.controller.renderEventPage(this.req, this.res, this.next)
 
       const eventForm = this.res.render.getCall(0).args[1].eventForm
       const actual = find(eventForm.children, { name: 'event-organiser' }).options

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -9,6 +9,7 @@ describe('Event edit controller', () => {
         },
       })
     }
+    const currentUserTeam = 'team1'
 
     beforeEach(() => {
       const advisersResponse = {
@@ -27,6 +28,11 @@ describe('Event edit controller', () => {
       this.req = {
         session: {
           token: 'abcd',
+          user: {
+            dit_team: {
+              id: currentUserTeam,
+            },
+          },
         },
       }
       this.res = {
@@ -82,6 +88,16 @@ describe('Event edit controller', () => {
       ]
 
       expect(actual).to.deep.equal(expected)
+    })
+
+    it('should prepopulate the team hosting the event with the current user team', async () => {
+      await this.controller.renderEventPage(this.req, this.res, this.next)
+
+      const eventForm = this.res.render.getCall(0).args[1].eventForm
+      const actual = find(eventForm.children, { name: 'event-team-hosting' }).value
+      const expected = currentUserTeam
+
+      expect(actual).to.equal(expected)
     })
 
     it('should return an error when there is an error', async () => {

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -1,49 +1,97 @@
+const { find } = require('lodash')
+
 describe('Event edit controller', () => {
   describe('#renderEventPage', () => {
+    const createEventsEditController = (getAdvisers) => {
+      return proxyquire('~/src/apps/events/controllers/edit', {
+        '../../adviser/repos': {
+          getAdvisers: getAdvisers,
+        },
+      })
+    }
+
     beforeEach(() => {
+      const advisersResponse = {
+        results: [
+          { name: 'advisor 1', id: 'advisor1' },
+          { name: 'advisor 2', id: 'advisor2' },
+          { name: 'advisor 3', id: 'advisor3' },
+        ],
+      }
+      const getAdvisersStub = sinon.stub().resolves(advisersResponse)
+
+      this.controller = createEventsEditController(getAdvisersStub)
+
       this.sandbox = sinon.sandbox.create()
 
-      this.controller = require('~/src/apps/events/controllers/edit')
-
-      this.req = {}
+      this.req = {
+        session: {
+          token: 'abcd',
+        },
+      }
       this.res = {
         breadcrumb: this.sandbox.stub().returnsThis(),
         render: this.sandbox.spy(),
       }
+      this.next = this.sandbox.spy()
     })
 
     afterEach(() => {
       this.sandbox.restore()
     })
 
-    it('should add a breadcrumb', () => {
-      this.controller.renderEventPage(this.req, this.res)
+    it('should add a breadcrumb', async () => {
+      await this.controller.renderEventPage(this.req, this.res)
 
       expect(this.res.breadcrumb).to.be.calledWith('Add event')
       expect(this.res.breadcrumb).to.have.been.calledOnce
     })
 
-    it('should render the event page', () => {
-      this.controller.renderEventPage(this.req, this.res)
+    it('should render the event page', async () => {
+      await this.controller.renderEventPage(this.req, this.res)
 
       expect(this.res.render).to.be.calledWith('events/views/edit')
       expect(this.res.render).to.have.been.calledOnce
     })
 
-    it('should render the event page with a title', () => {
-      this.controller.renderEventPage(this.req, this.res)
+    it('should render the event page with a title', async () => {
+      await this.controller.renderEventPage(this.req, this.res)
 
       const actual = this.res.render.getCall(0).args[1].title
 
       expect(actual).to.equal('Add event')
     })
 
-    it('should render the event page with an event form', () => {
-      this.controller.renderEventPage(this.req, this.res)
+    it('should render the event page with an event form', async () => {
+      await this.controller.renderEventPage(this.req, this.res)
 
       const actual = this.res.render.getCall(0).args[1].eventForm
 
       expect(actual).to.not.be.undefined
+    })
+
+    it('should populate the event form with organisers', async () => {
+      await this.controller.renderEventPage(this.req, this.res)
+
+      const eventForm = this.res.render.getCall(0).args[1].eventForm
+      const actual = find(eventForm.children, { name: 'event-organiser' }).options
+      const expected = [
+        { value: 'advisor1', label: 'advisor 1' },
+        { value: 'advisor2', label: 'advisor 2' },
+        { value: 'advisor3', label: 'advisor 3' },
+      ]
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('should return an error when there is an error', async () => {
+      const error = Error('error')
+      const controller = createEventsEditController(sinon.stub().rejects(error))
+
+      await controller.renderEventPage(this.req, this.res, this.next)
+
+      expect(this.next).to.be.calledWith(sinon.match({ message: error.message }))
+      expect(this.next).to.have.been.calledOnce
     })
   })
 })

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -26,8 +26,24 @@ describe('Event edit controller', () => {
     it('should render the event page', () => {
       this.controller.renderEventPage(this.req, this.res)
 
-      expect(this.res.render).to.be.calledWith('events/views/edit', { title: 'Add event' })
+      expect(this.res.render).to.be.calledWith('events/views/edit')
       expect(this.res.render).to.have.been.calledOnce
+    })
+
+    it('should render the event page with a title', () => {
+      this.controller.renderEventPage(this.req, this.res)
+
+      const actual = this.res.render.getCall(0).args[1].title
+
+      expect(actual).to.equal('Add event')
+    })
+
+    it('should render the event page with an event form', () => {
+      this.controller.renderEventPage(this.req, this.res)
+
+      const actual = this.res.render.getCall(0).args[1].eventForm
+
+      expect(actual).to.not.be.undefined
     })
   })
 })


### PR DESCRIPTION
Browsing to `/events/create` presents a form for creating an event.

Work completed in this PR:
- Create new event form
- Integration with new meta data endpoints
- Preselecting the current user's team for `Team hosting the event`

Work to be done in the next PR:
- Add another for shared event teams
- Add another for programmes

<img width="910" alt="screen shot 2017-09-06 at 11 55 51" src="https://user-images.githubusercontent.com/1150417/30108496-7f419222-92fa-11e7-8367-ee2243211c2c.png">