### PR TITLE
Use lodash's get to reference deep properties

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -1,15 +1,18 @@
+const { get } = require('lodash')
+
 const { setHomeBreadcrumb } = require('../../../middleware')
 const { Order } = require('../../models')
 
 function setOrderBreadcrumb (req, res, next) {
-  const order = res.locals.order
+  const reference = get(res.locals, 'order.reference')
 
-  return setHomeBreadcrumb(order.reference)(req, res, next)
+  return setHomeBreadcrumb(reference)(req, res, next)
 }
 
 async function getQuote (req, res, next) {
   try {
-    res.locals.quote = await Order.getQuote(req.session.token, res.locals.order.id)
+    const orderId = get(res.locals, 'order.id')
+    res.locals.quote = await Order.getQuote(req.session.token, orderId)
     next()
   } catch (error) {
     if (error.statusCode === 404) {
@@ -22,7 +25,7 @@ async function getQuote (req, res, next) {
 }
 
 async function generateQuote (req, res, next) {
-  const orderId = res.locals.order.id
+  const orderId = get(res.locals, 'order.id')
 
   try {
     await Order.createQuote(req.session.token, orderId)
@@ -41,25 +44,28 @@ async function generateQuote (req, res, next) {
       req.flash('error', 'Quote could not be generated. A valid quote already exists.')
       return res.redirect(`/omis/${orderId}`)
     }
+
     next(error)
   }
 }
 
 async function cancelQuote (req, res, next) {
+  const orderId = get(res.locals, 'order.id')
+
   try {
-    await Order.cancelQuote(req.session.token, res.locals.order.id)
+    await Order.cancelQuote(req.session.token, orderId)
 
     req.flash('success', 'Quote successfully cancelled.')
-    res.redirect(`/omis/${res.locals.order.id}`)
+    res.redirect(`/omis/${orderId}`)
   } catch (error) {
     if (error.statusCode === 404) {
       req.flash('error', 'The quote does not exist so could not be cancelled.')
-      return res.redirect(`/omis/${res.locals.order.id}/quote`)
+      return res.redirect(`/omis/${orderId}/quote`)
     }
 
     if (error.statusCode === 409) {
       req.flash('error', 'Quote could not be cancelled. It has already been accepted.')
-      return res.redirect(`/omis/${res.locals.order.id}/quote`)
+      return res.redirect(`/omis/${orderId}/quote`)
     }
 
     next(error)
@@ -68,7 +74,7 @@ async function cancelQuote (req, res, next) {
 
 function setQuoteForm (req, res, next) {
   const quote = res.locals.quote
-  const orderId = res.locals.order.id
+  const orderId = get(res.locals, 'order.id')
   const form = {
     buttonText: 'Generate and send quote',
     returnText: 'Return to order',


### PR DESCRIPTION
This is to prevent a `cannot read property of` error as lodash's
get returns undefined if it cannot find the reference.

Fixes this sentry exception: https://sentry.ci.uktrade.io/dit/data-hub-rhod/issues/1937/