### PR TITLE
Return all advisers from API in OMIS

### DIFF
--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -6,6 +6,12 @@ function getAdvisers (token) {
   return authorisedRequest(token, `${config.apiRoot}/adviser/`)
 }
 
+// TODO: Make sure this is removed and replaced with a better way to
+// filter/select advisers
+function getAllAdvisers (token) {
+  return authorisedRequest(token, `${config.apiRoot}/adviser/?limit=100000&offset=0`)
+}
+
 function getAdviser (token, id) {
   return authorisedRequest(token, `${config.apiRoot}/adviser/${id}/`)
 }
@@ -51,6 +57,7 @@ function adviserSearch (token, term) {
 
 module.exports = {
   getAdvisers,
+  getAllAdvisers,
   getAdviser,
   adviserSearch,
 }

--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -3,12 +3,12 @@ const { filter, find, get, unset } = require('lodash')
 const metadataRepo = require('../../../../../lib/metadata')
 const { transformIdToObject } = require('../../../../transformers')
 const { FormController } = require('../../../controllers')
-const { getAdvisers } = require('../../../../adviser/repos')
+const { getAllAdvisers } = require('../../../../adviser/repos')
 const { Order } = require('../../../models')
 
 class ConfirmController extends FormController {
   async getValues (req, res, next) {
-    const advisers = await getAdvisers(req.session.token)
+    const advisers = await getAllAdvisers(req.session.token)
 
     super.getValues(req, res, (err, values) => {
       const company = res.locals.company

--- a/src/apps/omis/apps/create/controllers/subscribers.js
+++ b/src/apps/omis/apps/create/controllers/subscribers.js
@@ -1,12 +1,12 @@
 const { sortBy } = require('lodash')
 
 const { FormController } = require('../../../controllers')
-const { getAdvisers } = require('../../../../adviser/repos')
+const { getAllAdvisers } = require('../../../../adviser/repos')
 const { transformObjectToOption } = require('../../../../transformers')
 
 class SubscribersController extends FormController {
   async configure (req, res, next) {
-    const advisers = await getAdvisers(req.session.token)
+    const advisers = await getAllAdvisers(req.session.token)
     const options = advisers.results.map(transformObjectToOption)
 
     req.form.options.fields.subscribers.options = sortBy(options, 'label')

--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -1,13 +1,13 @@
 const { pick, sortBy } = require('lodash')
 
 const { EditController } = require('../../../controllers')
-const { getAdvisers } = require('../../../../adviser/repos')
+const { getAllAdvisers } = require('../../../../adviser/repos')
 const { transformObjectToOption } = require('../../../../transformers')
 const { Order } = require('../../../models')
 
 class EditAssigneesController extends EditController {
   async configure (req, res, next) {
-    const advisers = await getAdvisers(req.session.token)
+    const advisers = await getAllAdvisers(req.session.token)
     const options = advisers.results.map(transformObjectToOption)
 
     req.form.options.fields.assignees.options = sortBy(options, 'label')

--- a/src/apps/omis/apps/edit/controllers/subscribers.js
+++ b/src/apps/omis/apps/edit/controllers/subscribers.js
@@ -1,13 +1,13 @@
 const { sortBy, pick } = require('lodash')
 
 const { EditController } = require('../../../controllers')
-const { getAdvisers } = require('../../../../adviser/repos')
+const { getAllAdvisers } = require('../../../../adviser/repos')
 const { transformObjectToOption, transformIdToObject } = require('../../../../transformers')
 const { Order } = require('../../../models')
 
 class EditSubscribersController extends EditController {
   async configure (req, res, next) {
-    const advisers = await getAdvisers(req.session.token)
+    const advisers = await getAllAdvisers(req.session.token)
     const options = advisers.results.map(transformObjectToOption)
 
     req.form.options.fields.subscribers.options = sortBy(options, 'label')

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -31,7 +31,7 @@ describe('OMIS create confirm controller', () => {
 
     this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/confirm', {
       '../../../../adviser/repos': {
-        getAdvisers: this.getAdvisersStub,
+        getAllAdvisers: this.getAdvisersStub,
       },
       '../../../../../lib/metadata': {
         countryOptions: metadataCountryMockData,

--- a/test/unit/apps/omis/apps/create/controllers/subscribers.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/subscribers.test.js
@@ -9,7 +9,7 @@ describe('OMIS create subscribers controller', () => {
 
     this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/subscribers', {
       '../../../../adviser/repos': {
-        getAdvisers: this.getAdvisersStub,
+        getAllAdvisers: this.getAdvisersStub,
       },
     })
 


### PR DESCRIPTION
This uses a different method to return all the advisers rather than
a limited amount for OMIS.

This is not an ideal solution as it can add a lot of time to API
requests but it avoids advisers not being found in the list for
existing orders that are being migrated over.

## Problems this adds

- Long page request times when returning all advisers

## Problems it solves

- Being able to select advisers that aren't in the first 100 results
- Migrated orders not having the correct adviser selected as it is not in the list, then on save it removes the advisers from the order

## What hasn't been done

This has only been done in OMIS for now to test legacy orders so won't effect other parts of data hub.