### PR TITLE
DH-545 Add another to event shared teams and programmes

### DIFF
--- a/assets/javascripts/modules/conditional-subfields.js
+++ b/assets/javascripts/modules/conditional-subfields.js
@@ -136,8 +136,10 @@ const ConditionalSubfields = {
       const children = subField.querySelectorAll('input, select, checkbox, textarea')
 
       Array.from(children).forEach((field) => {
-        field.value = ''
-        field.checked = false
+        if (!field.getAttribute('data-persist-values')) {
+          field.value = ''
+          field.checked = false
+        }
 
         const event = this.wrapper.createEvent('HTMLEvents')
         event.initEvent('change', true, false)

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -196,4 +196,33 @@
     {% endcall %}
   {% endcall %}
 
+  {% call Example('Add another (macro)') %}
+    {% call Form(form) %}
+
+      {{ AddAnother({
+
+        buttonName: 'add_country',
+        name: 'country',
+        label: 'Country',
+        children: [
+          {
+            macroName: 'MultipleChoiceField',
+            name: 'country',
+            label: 'Country',
+            isLabelHidden: true,
+            optional: true,
+            initialOption: '-- Select country --',
+            options: [
+              { value: 1, label: 'country 1' },
+              { value: 2, label: 'country 2' },
+              { value: 3, label: 'country 3' }
+            ]
+          }
+        ]
+
+      }) }}
+
+    {% endcall %}
+  {% endcall %}
+
 {% endblock %}

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -31,8 +31,9 @@ async function renderEventPage (req, res, next) {
 function postHandler (req, res, next) {
   const setAddAnotherField = (value) => compact(castArray(value))
   req.body.event_shared_teams = setAddAnotherField(req.body.event_shared_teams)
+  req.body.event_programmes = setAddAnotherField(req.body.event_programmes)
 
-  if (req.body.add_event_shared_team) {
+  if (req.body.add_event_shared_team || req.body.add_event_programme) {
     return next()
   }
 }

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -2,7 +2,7 @@ const { eventFormConfig } = require('../macros')
 const { getAdvisers } = require('../../adviser/repos')
 const { transformObjectToOption } = require('../../transformers')
 const { buildFormWithState } = require('../../builders')
-const { castArray, compact } = require('lodash')
+const { get, castArray, compact } = require('lodash')
 
 async function renderEventPage (req, res, next) {
   try {
@@ -10,12 +10,12 @@ async function renderEventPage (req, res, next) {
     const advisers = advisersResponse.results.map(transformObjectToOption)
     const eventForm = eventFormConfig(advisers)
     const emptyDate = { year: '', month: '', day: '' }
-    const requestBody = {
-      'event-start-date': emptyDate,
-      'event-end-date': emptyDate,
-      'event-team-hosting': req.session.user.dit_team.id,
-    }
-    const eventFormWithState = buildFormWithState(eventForm, requestBody)
+    const body = Object.assign(req.body, {
+      event_start_date: emptyDate,
+      event_end_date: emptyDate,
+      event_team_hosting: get(req, 'session.user.dit_team.id', null),
+    })
+    const eventFormWithState = buildFormWithState(eventForm, body)
 
     res
       .breadcrumb('Add event')

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -2,6 +2,7 @@ const { eventFormConfig } = require('../macros')
 const { getAdvisers } = require('../../adviser/repos')
 const { transformObjectToOption } = require('../../transformers')
 const { buildFormWithState } = require('../../builders')
+const { castArray, compact } = require('lodash')
 
 async function renderEventPage (req, res, next) {
   try {
@@ -27,6 +28,16 @@ async function renderEventPage (req, res, next) {
   }
 }
 
+function postHandler (req, res, next) {
+  const setAddAnotherField = (value) => compact(castArray(value))
+  req.body.event_shared_teams = setAddAnotherField(req.body.event_shared_teams)
+
+  if (req.body.add_event_shared_team) {
+    return next()
+  }
+}
+
 module.exports = {
   renderEventPage,
+  postHandler,
 }

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -150,14 +150,23 @@ const eventFormConfig = (organisers) => {
         },
       },
       {
-        macroName: 'MultipleChoiceField',
-        name: 'event-related-programmes',
+        macroName: 'AddAnother',
+        buttonName: 'add_event_programme',
+        name: 'event_programmes',
         label: 'Related programmes',
-        optional: true,
-        initialOption: '-- Select programme --',
-        options () {
-          return metadataRepo.programmeOptions.map(transformObjectToOption)
-        },
+        children: [
+          {
+            macroName: 'MultipleChoiceField',
+            name: 'event_programmes',
+            label: 'Related programmes',
+            isLabelHidden: true,
+            optional: true,
+            initialOption: '-- Select programme --',
+            options () {
+              return metadataRepo.programmeOptions.map(transformObjectToOption)
+            },
+          },
+        ],
       },
     ],
   }

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -110,7 +110,7 @@ const eventFormConfig = (organisers) => {
       {
         macroName: 'MultipleChoiceField',
         type: 'radio',
-        name: 'event-shared',
+        name: 'event_shared',
         label: 'Is this a shared event',
         optional: true,
         modifier: 'inline',
@@ -126,16 +126,26 @@ const eventFormConfig = (organisers) => {
         ],
       },
       {
-        macroName: 'MultipleChoiceField',
-        name: 'event-teams',
+        macroName: 'AddAnother',
+        buttonName: 'add_event_shared_team',
+        name: 'event_shared_teams',
         label: 'Teams',
-        initialOption: '-- Select team --',
         isLabelHidden: true,
-        options () {
-          return metadataRepo.teams.map(transformObjectToOption)
-        },
+        children: [
+          {
+            macroName: 'MultipleChoiceField',
+            name: 'event_shared_teams',
+            label: 'Teams',
+            isLabelHidden: true,
+            optional: true,
+            initialOption: '-- Select team --',
+            options () {
+              return metadataRepo.teams.map(transformObjectToOption)
+            },
+          },
+        ],
         condition: {
-          name: 'event-shared',
+          name: 'event_shared',
           value: 'Yes',
         },
       },

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -9,12 +9,12 @@ const eventFormConfig = (organisers) => {
     children: [
       {
         macroName: 'TextField',
-        name: 'event-name',
+        name: 'event_name',
         label: 'Event name',
       },
       {
         macroName: 'MultipleChoiceField',
-        name: 'event-type',
+        name: 'event_type',
         label: 'Event type',
         initialOption: '-- Select event type --',
         options () {
@@ -23,7 +23,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'DateFieldset',
-        name: 'event-start-date',
+        name: 'event_start_date',
         label: 'Event start date',
         optional: true,
         value: {
@@ -34,7 +34,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'DateFieldset',
-        name: 'event-end-date',
+        name: 'event_end_date',
         label: 'Event end date',
         optional: true,
         value: {
@@ -45,7 +45,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'MultipleChoiceField',
-        name: 'event-location-type',
+        name: 'event_location_type',
         label: 'Event location type',
         optional: true,
         initialOption: '-- Select location type --',
@@ -85,13 +85,13 @@ const eventFormConfig = (organisers) => {
       {
         macroName: 'TextField',
         type: 'textarea',
-        name: 'event-notes',
+        name: 'event_notes',
         label: 'Event notes',
         optional: true,
       },
       {
         macroName: 'MultipleChoiceField',
-        name: 'event-team-hosting',
+        name: 'event_team_hosting',
         label: 'Team hosting the event',
         optional: true,
         initialOption: '-- Select team --',
@@ -101,7 +101,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'MultipleChoiceField',
-        name: 'event-organiser',
+        name: 'event_organiser',
         label: 'Organiser',
         optional: true,
         initialOption: '-- Select organiser --',

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,7 +1,9 @@
 const router = require('express').Router()
 
-const { renderEventPage } = require('./controllers/edit')
+const { renderEventPage, postHandler } = require('./controllers/edit')
 
-router.get('/create', renderEventPage)
+router.route('/create')
+  .get(renderEventPage)
+  .post(postHandler, renderEventPage)
 
 module.exports = router

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -10,7 +10,7 @@
 {% from "_macros/_deprecated/trade-elements/textbox.njk" import textbox %}
 
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
-{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, MultipleChoiceField, HiddenField, DateFieldset %}
+{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Pagination, GlobalNav, LocalNav, Progress %}
 {% from "_macros/collection.njk" import Collection, CollectionFilters %}

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -352,6 +352,32 @@
 {% endmacro %}
 
 {##
+ # Render a collection for multiple fields for add another functionality
+ # @param {object} props - An object containing field properties
+ # @param {array} [props.value] - Input values
+ #}
+{% macro AddAnother(props) %}
+  {% set fieldId = 'field-' + props.name + ('-' + props.idSuffix if props.idSuffix) if props.name %}
+
+  {% call FormGroup(props | assign({ fieldId: fieldId })) %}
+    {% for individualValue in props.value %}
+      {{ renderAsMacro(props.children, { value: individualValue }) }}
+    {% endfor %}
+
+    {{ renderAsMacro(props.children, { value: null } ) }}
+
+    <p class="c-form-group c-form-group--compact">
+      <input
+        class="button button-secondary"
+        type="submit"
+        name="{{ props.buttonName }}"
+        value="Add another"
+        data-persist-values="true" />
+    </p>
+  {% endcall %}
+{% endmacro %}
+
+{##
  # Render hidden input field
  # @param {object} props - An object containing field properties
  # @param {string} props.name - Field name

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -115,6 +115,20 @@ describe('Event edit controller', () => {
       })
     })
 
+    context('when there are event programmes', () => {
+      it('should prepopulate the event programmes', async () => {
+        const eventProgrammes = [ 'programme1', 'programme2' ]
+        this.req.body['event_programmes'] = eventProgrammes
+
+        await this.controller.renderEventPage(this.req, this.res, this.next)
+
+        const eventForm = this.res.render.getCall(0).args[1].eventForm
+        const actual = find(eventForm.children, { name: 'event_programmes' }).value
+
+        expect(actual).to.deep.equal(eventProgrammes)
+      })
+    })
+
     context('when there is an error', () => {
       it('should return an error', async () => {
         const error = Error('error')
@@ -154,6 +168,58 @@ describe('Event edit controller', () => {
         const actual = this.req.body['event_shared_teams']
 
         expect(actual).to.deep.equal(teams)
+      })
+
+      it('should not add empty values to the event programmes', () => {
+        this.req.body.addEventSharedTeam = true
+        this.req.body['event_shared_teams'] = [ 'team1', 'team2' ]
+        this.req.body['event_programmes'] = [ 'programme1', '' ]
+
+        this.controller.postHandler(this.req, this.res, this.next)
+
+        const actual = this.req.body['event_programmes']
+
+        expect(actual).to.deep.equal([ 'programme1' ])
+      })
+    })
+
+    context('when adding an event programme for the first time', () => {
+      it('should set the event programmes', () => {
+        const programme = 'programme1'
+        this.req.body.addEventProgramme = true
+        this.req.body['event_programmes'] = programme
+
+        this.controller.postHandler(this.req, this.res, this.next)
+
+        const actual = this.req.body['event_programmes']
+
+        expect(actual).to.deep.equal([ programme ])
+      })
+    })
+
+    context('when adding subsequent event programmes', () => {
+      it('should add to the event programmes', () => {
+        const programmes = [ 'programme1', 'programme2' ]
+        this.req.body.addEventSharedTeam = true
+        this.req.body['event_programmes'] = programmes
+
+        this.controller.postHandler(this.req, this.res, this.next)
+
+        const actual = this.req.body['event_programmes']
+
+        expect(actual).to.deep.equal(programmes)
+      })
+
+      it('should not add empty values to the event shared teams', () => {
+        this.req.body.addEventSharedTeam = true
+        this.req.body['event_shared_teams'] = [ 'team1', '' ]
+        this.req.body['event_programmes'] = [ 'programme1', 'programme2' ]
+
+        this.controller.postHandler(this.req, this.res, this.next)
+
+        const actual = this.req.body['event_shared_teams']
+
+        expect(actual).to.deep.equal([ 'team1' ])
       })
     })
   })

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -81,7 +81,7 @@ describe('Event edit controller', () => {
       await this.controller.renderEventPage(this.req, this.res, this.next)
 
       const eventForm = this.res.render.getCall(0).args[1].eventForm
-      const actual = find(eventForm.children, { name: 'event-organiser' }).options
+      const actual = find(eventForm.children, { name: 'event_organiser' }).options
       const expected = [
         { value: 'advisor1', label: 'advisor 1' },
         { value: 'advisor2', label: 'advisor 2' },
@@ -95,7 +95,7 @@ describe('Event edit controller', () => {
       await this.controller.renderEventPage(this.req, this.res, this.next)
 
       const eventForm = this.res.render.getCall(0).args[1].eventForm
-      const actual = find(eventForm.children, { name: 'event-team-hosting' }).value
+      const actual = find(eventForm.children, { name: 'event_team_hosting' }).value
       const expected = currentUserTeam
 
       expect(actual).to.equal(expected)

--- a/test/unit/macros/form.test.js
+++ b/test/unit/macros/form.test.js
@@ -407,4 +407,49 @@ describe('Nunjucks form macros', () => {
       })
     })
   })
+
+  describe('AddAnother component', () => {
+    beforeEach(() => {
+      this.component = macros.renderToDom('AddAnother', {
+        buttonName: 'add_another',
+        name: 'add_another',
+        label: 'Add another',
+        children: [
+          {
+            macroName: 'MultipleChoiceField',
+            name: 'add_another',
+            label: 'Add another',
+            isLabelHidden: true,
+            optional: true,
+            initialOption: '-- Select another --',
+            options: [
+              { value: 1, label: 'another 1' },
+              { value: 2, label: 'another 2' },
+              { value: 3, label: 'another 3' },
+            ],
+          },
+        ],
+        value: [ 1, 2 ],
+      })
+    })
+
+    it('should render a component with 2 preselected drop downs', () => {
+      const selectedElements = this.component.getElementsByTagName('select')
+
+      expect(selectedElements[0].value).to.equal('1')
+      expect(selectedElements[1].value).to.equal('2')
+    })
+
+    it('should render a component with 1 unselected drop down', () => {
+      const selectElements = this.component.getElementsByTagName('select')
+
+      expect(selectElements[2].value).to.equal('')
+    })
+
+    it('should render a component with an "Add another" button', () => {
+      const addAnotherButton = this.component.querySelectorAll('input[type=submit]')
+
+      expect(addAnotherButton[0].value).to.equal('Add another')
+    })
+  })
 })


### PR DESCRIPTION
<img width="670" alt="screen shot 2017-09-08 at 16 13 10" src="https://user-images.githubusercontent.com/1150417/30218314-aa9d2c4e-94b0-11e7-9153-ed661bdc0153.png">

Changes give the ability to add another for fields:
- Event shared teams
- Programmes

Note this is a no JS version.

I was feeling confident, so special attention needs to be given to:
- `MultipleChoiceFieldAddAnother`
- My change to `conditional-subfields.js` - this was required because there is a conditional input that was losing its value each time visibility was toggled