### PR TITLE
Add a medium modifier for form groups

### DIFF
--- a/assets/stylesheets/components/form/_form-control.scss
+++ b/assets/stylesheets/components/form/_form-control.scss
@@ -59,6 +59,10 @@ select.c-form-control {
   border-color: $error-colour;
 }
 
+.c-form-control--medium {
+  max-width: 15em;
+}
+
 .c-form-control--short {
   max-width: 10em;
 }


### PR DESCRIPTION
Adds another modifier in same style as currently exists to support medium width fields.