### PR TITLE
Add ability to edit payment fields for an OMIS order

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -71,6 +71,62 @@ const editFields = Object.assign({}, globalFields, {
     modifier: ['shorter', 'soft'],
     validate: [isDuration],
   },
+  vat_status: {
+    fieldType: 'MultipleChoiceField',
+    type: 'radio',
+    label: 'fields.vat_status.label',
+    options: [
+      {
+        value: 'outside_eu',
+        label: 'non-EU company',
+        hint: 'No VAT charged',
+      },
+      {
+        value: 'uk',
+        label: 'UK company',
+        hint: '20% VAT charged',
+      },
+      {
+        value: 'eu',
+        label: 'EU company',
+        hint: 'No VAT charged if validated. 20% VAT charged if not validated.',
+      },
+    ],
+  },
+  vat_number: {
+    fieldType: 'TextField',
+    label: 'fields.vat_number.label',
+    modifier: ['subfield', 'medium'],
+    condition: {
+      name: 'vat_status',
+      value: 'eu',
+    },
+    innerHTML: '<p><a href="http://ec.europa.eu/taxation_customs/vies/">Validate the EU VAT number</a></p>',
+  },
+  vat_verified: {
+    fieldType: 'MultipleChoiceField',
+    type: 'radio',
+    modifier: ['inline', 'subfield'],
+    label: 'fields.vat_verified.label',
+    options: [{
+      value: 'true',
+      label: 'Yes',
+    },
+    {
+      value: 'false',
+      label: 'No',
+    }],
+    condition: {
+      name: 'vat_status',
+      value: 'eu',
+    },
+  },
+  po_number: {
+    fieldType: 'TextField',
+    label: 'fields.po_number.label',
+    modifier: 'medium',
+    optional: true,
+  },
 })
 
 module.exports = editFields

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -43,6 +43,15 @@ const steps = merge({}, createSteps, {
     ],
     controller: EditWorkDescriptionController,
   },
+  '/payment': {
+    heading: 'Edit quote and payment details',
+    fields: [
+      'vat_status',
+      'vat_number',
+      'vat_verified',
+      'po_number',
+    ],
+  },
 })
 
 // Market cannot be edited after creation

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -136,4 +136,29 @@
     }]
   }) }}
 
+  {% if values.vat_verified === true %}
+    {% set verifiedState = translate('fields.vat_verified.options.valid') %}
+  {% elif values.vat_verified === false %}
+    {% set verifiedState = translate('fields.vat_verified.options.invalid') %}
+  {% else %}
+    {% set verifiedState = translate('fields.vat_verified.options.unverified') %}
+  {% endif %}
+
+  {{ AnswersSummary({
+    heading: 'Quote and payment details',
+    actions: [{
+      url: 'edit/payment' if order.editable
+    }],
+    items: [{
+      label: 'VAT category',
+      value: translate('fields.vat_status.options.' + values.vat_status) if values.vat_status else 'Not set'
+    }, {
+      label: 'VAT number',
+      value: values.vat_number + ' (' + verifiedState + ')' if values.vat_number
+    }, {
+      label: 'Purchase Order (PO) number',
+      value: values.po_number or 'Not set'
+    }]
+  }) }}
+
 {% endblock %}

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -64,11 +64,12 @@ class EditController extends FormController {
       return newValue
     })
 
+    const exemptFields = ['vat_number']
     // combine order values and error values
     let combinedValues = Object.assign({}, orderValues, sessionValues, errorValues)
     // convert dates to default format
     combinedValues = mapValues(combinedValues, (value, key) => {
-      if (typeof value === 'string') {
+      if (typeof value === 'string' && !exemptFields.includes(key)) {
         const parsedDate = dateFns.parse(value.toString())
         if (dateFns.isValid(parsedDate)) {
           return dateFns.format(parsedDate, longDateFormat)

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -37,6 +37,28 @@
     },
     "assignee_time": {
       "label": "Estimated time"
+    },
+    "vat_status": {
+      "label": "VAT category",
+      "options": {
+        "uk": "Inside UK",
+        "eu": "Inside EU",
+        "outside_eu": "Outside EU"
+      }
+    },
+    "vat_number": {
+      "label": "VAT number"
+    },
+    "vat_verified": {
+      "label": "Is the VAT number valid?",
+      "options": {
+        "unverified": "Not verified",
+        "valid": "Valid",
+        "invalid": "Invalid"
+      }
+    },
+    "po_number": {
+      "label": "Purchase Order (PO) number"
     }
   },
   "validation": {

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -231,7 +231,7 @@
           <span class="c-form-group__error-message">{{ props.error }}</span>
         {% endif %}
         {% if props.hint %}
-          <span class="c-form-group__hint" id="hint-{{ props.fieldId }}">{{ props.hint }}</span>
+          <span class="c-form-group__hint" id="hint-{{ props.fieldId }}">{{ props.hint | safe }}</span>
         {% endif %}
       </{{ labelElement }}>
 


### PR DESCRIPTION
This adds the ability to edit the payment details around an order.

💣 [**DEMO**](https://datahub-beta2-pr-562.herokuapp.com/omis/5f9d37d9-0399-472e-a600-35effa7eec2f) 💣 

## What it looks like

### Work order overview

![localhost_3001_omis_096a1499-d142-4cf6-9da2-234ba542bd3a_work-order](https://user-images.githubusercontent.com/3327997/30438914-59a292e8-996a-11e7-83c4-8c8b0f573e52.png)

### Edit payment details

![localhost_3001_omis_096a1499-d142-4cf6-9da2-234ba542bd3a_edit_payment](https://user-images.githubusercontent.com/3327997/30438900-507e0fa8-996a-11e7-9dd1-44cb71068802.png)
