### PR TITLE
Removed use of Path library when generating URL's

### DIFF
--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const { isEmpty } = require('lodash')
 const queryString = require('query-string')
 
@@ -17,7 +16,7 @@ function setHomeBreadcrumb (name) {
 function setLocalNav (items = []) {
   return function buildLocalNav (req, res, next) {
     res.locals.localNavItems = items.map(item => {
-      const url = path.resolve(req.baseUrl, item.path)
+      const url = `${req.baseUrl}/${item.path}`
       return Object.assign(item, {
         url,
         isActive: res.locals.CURRENT_PATH === url,

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -1,5 +1,3 @@
-const path = require('path')
-
 const logger = require('../../config/logger')
 const config = require('../../config')
 
@@ -30,10 +28,10 @@ module.exports = function locals (req, res, next) {
     BREADCRUMBS: breadcrumbItems,
     IS_XHR: req.xhr,
     QUERY: req.query,
-    GLOBAL_NAV_ITEMS: globalNavItems.map(item => {
-      const url = path.resolve(req.baseUrl, item.path)
+    GLOBAL_NAV_ITEMS: globalNavItems.map(globalNavItem => {
+      const url = globalNavItem.path
 
-      return Object.assign(item, {
+      return Object.assign(globalNavItem, {
         url,
         isActive: req.path.startsWith(url),
       })


### PR DESCRIPTION
The path library is designed to generate file system paths,
not HTTP URL's. When the service is run on windows the urls
generated come out as 'c:\'.