### PR TITLE
Fix issue importing interaction controllers

### DIFF
--- a/src/apps/interactions/controllers/index.js
+++ b/src/apps/interactions/controllers/index.js
@@ -1,7 +1,9 @@
-const details = require('./details')
-const edit = require('./edit')
+const detailsController = require('./details')
+const editController = require('./edit')
+const listController = require('./list')
 
 module.exports = {
-  details,
-  edit,
+  detailsController,
+  editController,
+  listController,
 }


### PR DESCRIPTION
The updated require statements in the investment router did not take into account the naming of controllers in investment/controllers/index, or include the list controller.