### PR TITLE
OMIS order status

### DIFF
--- a/assets/stylesheets/components/_badge.scss
+++ b/assets/stylesheets/components/_badge.scss
@@ -4,6 +4,7 @@
   border: 2px solid rgba($text-colour, .15);
   border-radius: 4px;
   color: inherit;
+  white-space: nowrap;
   transition: 60ms;
   cursor: default;
 

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -2,6 +2,7 @@ const nunjucks = require('nunjucks')
 const moment = require('moment')
 require('moment-duration-format')
 const dateFns = require('date-fns')
+const Case = require('case')
 const {
   assign,
   concat,
@@ -46,6 +47,7 @@ function pluralise (string, count, pluralisedWord) {
 
 const filters = {
   stringify: JSON.stringify,
+  sentenceCase: Case.sentence,
   assign,
   concat,
   filter,
@@ -137,6 +139,10 @@ const filters = {
 
   formatDuration: (value, format = 'hh:mm', measurement = 'minutes') => {
     return moment.duration(value, measurement).format(format, { trim: false })
+  },
+
+  fromNow: (value) => {
+    return moment(value).fromNow()
   },
 
   arrayToLabelValues: (items) => {

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -32,7 +32,11 @@ async function getQuote (req, res, next) {
     // When quote already exists, get it
     if (error.statusCode === 409) {
       try {
-        res.locals.quote = await Order.getFullQuote(req.session.token, orderId)
+        const quote = await Order.getFullQuote(req.session.token, orderId)
+
+        res.locals.quote = Object.assign({}, quote, {
+          expired: new Date(quote.expires_on) < new Date(),
+        })
         return next()
       } catch (error) {
         return next(error)
@@ -102,7 +106,7 @@ function setQuoteForm (req, res, next) {
   const quote = res.locals.quote
   const orderId = get(res.locals, 'order.id')
   const form = {
-    buttonText: 'Generate and send quote',
+    buttonText: 'Send quote',
     returnText: 'Return to order',
     returnLink: `/omis/${orderId}`,
   }

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -23,7 +23,7 @@ router.use(setTranslation)
 router.use(setOrderBreadcrumb)
 
 router.get('/', redirectToFirstNavItem)
-router.get('/work-order', renderWorkOrder)
+router.get('/work-order', getQuote, renderWorkOrder)
 router
   .route('/quote')
   .get(getQuote, setQuoteForm, renderQuote)

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -3,22 +3,28 @@
 {% block local_header %}
   {% set actions %}
     <p class="c-local-header__action">
-      <a href="quote" class="button button--small">Generate quote</a>
+      {% if order.status == 'draft' %}
+        <a href="quote" class="button button--small">Prepare quote</a>
+      {% else %}
+        <a href="quote">View quote</a>
+      {% endif %}
     </p>
   {% endset %}
 
   {% call LocalHeader({
     actions: actions,
     heading: order.reference,
-    modifier: "light-banner"
+    modifier: 'light-banner'
   }) %}
+    {% set status = order.status | sentenceCase %}
+    {% set expires_in = ' (expire' + ('d' if quote.expired else 's') + ' ' + FromNow({ datetime: quote.expires_on }) + ')' %}
 
     {{ MetaList({
       items: [
-        { "label": "Created on", "value": order.created_on | formatDateTime },
-        { "label": "Status", "value": "Draft" }
+        { 'label': 'Created on', 'value': order.created_on | formatDateTime },
+        { 'label': 'Status', 'value': status + (expires_in if order.status === 'quote_awaiting_acceptance'), 'safe': true }
       ],
-      itemModifier: "stacked"
+      itemModifier: 'stacked'
     }) }}
 
   {% endcall %}

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -20,10 +20,15 @@
   {% endif %}
 
   {% if quote %}
-    {# TODO: Remove `if quote.created_on` when API stops returning `created_on` for preview  #}
+    {% if order.status === 'quote_awaiting_acceptance' %}
+      {% set expiryLabel = 'Expire' + ('d' if quote.expired else 's') %}
+    {% else %}
+      {% set expiryLabel = 'Will expire' %}
+    {% endif %}
+
     {{ MetaList({
       items: [
-        { label: 'Expires on', value: quote.expires_on, type: 'date' },
+        { label: expiryLabel, value: quote.expires_on, type: 'fromNow' },
         { label: 'Sent on', value: quote.created_on, type: 'datetime' },
         { label: 'Sent by', value: quote.created_by if quote.created_on }
       ],
@@ -51,7 +56,7 @@
 
   {% if destructive %}
     <ul class="c-messages">
-      <li class="c-messages__item c-messages__item--warning">
+      <li class="c-messages__item c-messages__item--error">
         Editing the order whilst it is out for acceptance will invalidate the
         current quote and the client will no longer be able to accept it.
       </li>

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -76,11 +76,11 @@
   {% call AnswersSummary({
     heading: 'Post advisers',
     actions: [{
-      url: 'edit/assignee-time' if values.assignees.length,
-      text: 'Edit time'
-    }, {
       url: 'edit/assignees',
       text: 'Add or remove'
+    }, {
+      url: 'edit/assignee-time' if values.assignees.length,
+      text: 'Edit time'
     }]
   }) %}
     <tbody>

--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -1,9 +1,11 @@
 /* eslint-disable camelcase */
 const { get } = require('lodash')
+const Case = require('case')
 
 function transformOrderToListItem ({
   id,
   reference,
+  status,
   company,
   contact,
   primary_market,
@@ -18,6 +20,11 @@ function transformOrderToListItem ({
     urlPrefix: 'omis/',
     name: reference,
     meta: [
+      {
+        label: 'Status',
+        type: 'badge',
+        value: Case.sentence(status),
+      },
       {
         label: 'Market',
         type: 'badge',

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -12,7 +12,7 @@
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
 {% from "_macros/common.njk" import LocalHeader with context %}
-{% from "_macros/common.njk" import Pagination, GlobalNav, LocalNav, Progress %}
+{% from "_macros/common.njk" import Pagination, GlobalNav, LocalNav, Progress, FromNow %}
 {% from "_macros/collection.njk" import Collection, CollectionFilters %}
 {% from "_macros/entities.njk" import MetaList %}
 

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -176,3 +176,18 @@
     </div>
   {% endif %}
 {% endmacro %}
+
+{##
+ # Render time element using from now wording
+ # @param {object} props
+ # @param {array} props.datetime - datetime used to generate the time from now
+ #
+ #}
+{% macro FromNow(props) %}
+  {%- if props.datetime -%}
+    <time
+      datetime="{{ props.datetime | formatDateTime('YYYY-MM-DDTHH:mm:ssZ') }}"
+      title="{{ props.datetime | formatDateTime }}"
+    >{{ props.datetime | fromNow }}</time>
+  {%- endif -%}
+{% endmacro %}

--- a/src/templates/_macros/entities.njk
+++ b/src/templates/_macros/entities.njk
@@ -1,3 +1,5 @@
+{% from './common.njk' import FromNow %}
+
 {##
  # Render entity component
  # @param {object} props
@@ -77,6 +79,7 @@
  # @param {string} [props.isLabelHidden=false] - whether the label should be visually hidden
  # @param {string} [props.badgeModifier] - modifier for badge
  # @param {string} [props.highlightTerm] - text to use to apply highlight filter
+ # @param {string} [props.safe] - is a safe string
  #}
 {% macro _MetaItem (props) %}
   {% set badgeModifier = props.badgeModifier | concat('') | reverse | join(' c-badge--') if props.badgeModifier %}
@@ -88,8 +91,16 @@
       {% set metaItemValue = props.value | formatDate %}
     {% elif props.type === 'datetime' %}
       {% set metaItemValue = props.value | formatDateTime %}
+    {% elif props.type === 'fromNow' %}
+      {% set metaItemValue = FromNow({ datetime: props.value }) %}
     {% else %}
       {% set metaItemValue = props.value.name | default(props.value) %}
+    {% endif %}
+
+    {% if props.safe %}
+      {% set safeValue = metaItemValue | highlight(props.highlightTerm, true) | safe %}
+    {% else %}
+      {% set safeValue = metaItemValue | highlight(props.highlightTerm, true) %}
     {% endif %}
 
     <div class="{{ 'c-meta-list__item' | applyClassModifiers(props.modifier) }}">
@@ -103,10 +114,10 @@
           class="js-xhr {{ itemValueClass }} {{ 'is-selected' if props.isSelected }}"
           href="{{ props.url }}"
         >
-          {{- metaItemValue  | highlight(props.highlightTerm, true) -}}
+          {{- safeValue -}}
         </a>
       {% else %}
-        <span class="{{ itemValueClass }}">{{ metaItemValue | highlight(props.highlightTerm, true) }}</span>
+        <span class="{{ itemValueClass }}">{{ safeValue }}</span>
       {% endif %}
     </div>
   {% endif %}

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -33,6 +33,7 @@ describe('OMIS list transformers', function () {
           expect(actual).to.have.property('type', 'order')
           expect(actual).to.have.property('urlPrefix', 'omis/')
           expect(actual).to.have.property('meta').an('array').to.deep.equal([
+            { label: 'Status', type: 'badge', value: 'Draft' },
             { label: 'Market', type: 'badge', value: 'France' },
             { label: 'Company', value: 'Venus Ltd' },
             { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
@@ -51,6 +52,7 @@ describe('OMIS list transformers', function () {
           expect(actual).to.have.property('type', 'order')
           expect(actual).to.have.property('urlPrefix', 'omis/')
           expect(actual).to.have.property('meta').an('array').to.deep.equal([
+            { label: 'Status', type: 'badge', value: 'Draft' },
             { label: 'Market', type: 'badge', value: 'France' },
             { label: 'Company', value: 'Venus Ltd' },
             { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },

--- a/test/unit/data/omis/simple-order.json
+++ b/test/unit/data/omis/simple-order.json
@@ -1,6 +1,7 @@
 {
   "id": "084b934e-9bde-4e2b-88d8-5fbeb17de54d",
   "reference": "XYT113/17",
+  "status": "draft",
   "created_on": "2017-07-26T14:08:36.380979",
   "created_by": null,
   "modified_on": "2017-08-16T14:18:28.328729",

--- a/test/unit/macros/from-now.test.js
+++ b/test/unit/macros/from-now.test.js
@@ -1,0 +1,39 @@
+const { getMacros } = require('~/test/unit/macro-helper')
+const commonMacros = getMacros('common')
+
+describe('FromNow macro', () => {
+  describe('invalid props', () => {
+    it('should not render if props is not given', () => {
+      const component = commonMacros.renderToDom('FromNow')
+      expect(component).to.be.null
+    })
+  })
+
+  describe('valid props', () => {
+    beforeEach(() => {
+      this.component = commonMacros.renderToDom('FromNow', {
+        datetime: '2010-08-01',
+      })
+    })
+
+    it('should render time element', () => {
+      expect(this.component.tagName.toLowerCase()).to.equal('time')
+    })
+
+    it('should contain datetime attribute', () => {
+      expect(this.component.hasAttribute('datetime')).to.equal(true)
+    })
+
+    it('should format datetime attribute to local datetime', () => {
+      expect(this.component.getAttribute('datetime')).to.equal('2010-08-01T00:00:00+01:00')
+    })
+
+    it('should contain title attribute', () => {
+      expect(this.component.hasAttribute('title')).to.equal(true)
+    })
+
+    it('should format title attribute to default datetime format', () => {
+      expect(this.component.getAttribute('title')).to.equal('1 Aug 2010, 12:00am')
+    })
+  })
+})


### PR DESCRIPTION
This adds the status of an order to the OMIS collection and work order views.

It also adds a new `FromNow` macro to support converting datetimes to a from now/time ago wording using the `<time>` element.

👉 [**DEMO**](https://datahub-beta2-pr-572.herokuapp.com/omis/4b0d9b58-57b0-4eb1-941e-d182ea95666c/work-order) 👈 

## What it looks like

### Collection view

![localhost_3001_omis_sortby created_on 3adesc](https://user-images.githubusercontent.com/3327997/30319825-d6cf8532-97a8-11e7-8c04-60285119dd01.png)

### Work order view

#### Draft status

![localhost_3001_omis_4b0d9b58-57b0-4eb1-941e-d182ea95666c_work-order](https://user-images.githubusercontent.com/3327997/30319903-06323608-97a9-11e7-9c4d-4bbac92119ab.png)

#### Awaiting acceptance status (showing time from now)

![localhost_3001_omis_9c9bc8ca-8ea9-4185-95ef-94319e27fafd_work-order](https://user-images.githubusercontent.com/3327997/30319890-fc8454d8-97a8-11e7-8fa2-2561812095d1.png)
