### PR TITLE
Update OMIS breadcrumbs during edit steps

### DIFF
--- a/src/apps/omis/apps/create/router.js
+++ b/src/apps/omis/apps/create/router.js
@@ -9,7 +9,7 @@ const i18n = i18nFuture({
 const steps = require('./steps')
 const fields = require('../../fields')
 const { FormController } = require('../../controllers')
-const { params } = require('../../middleware')
+const { getCompany } = require('../../middleware')
 
 const config = {
   controller: FormController,
@@ -19,7 +19,7 @@ const config = {
   translate: i18n.translate.bind(i18n),
 }
 
-router.param('companyId', params.getCompany)
+router.param('companyId', getCompany)
 
 router.use('/:companyId?', wizard(steps, fields, config))
 

--- a/src/apps/omis/apps/edit/controllers/edit-handler.js
+++ b/src/apps/omis/apps/edit/controllers/edit-handler.js
@@ -32,6 +32,8 @@ function editHandler (req, res, next) {
   const options = Object.assign(defaults, step, overrides)
   const ControllerClass = options.controller
 
+  res.breadcrumb(options.heading)
+
   new ControllerClass(options).requestHandler()(req, res, next)
 }
 

--- a/src/apps/omis/apps/edit/router.js
+++ b/src/apps/omis/apps/edit/router.js
@@ -1,7 +1,7 @@
 const router = require('express').Router()
 
 const { editRedirect, editHandler, editLeadAssignee } = require('./controllers')
-const { getCompany } = require('../../middleware/params')
+const { getCompany } = require('../../middleware')
 
 router.use((req, res, next) => {
   getCompany(req, res, next, res.locals.order.company.id)

--- a/src/apps/omis/apps/edit/router.js
+++ b/src/apps/omis/apps/edit/router.js
@@ -1,11 +1,13 @@
 const router = require('express').Router()
 
 const { editRedirect, editHandler, editLeadAssignee } = require('./controllers')
-const { getCompany } = require('../../middleware')
+const { getCompany, setOrderBreadcrumb } = require('../../middleware')
 
 router.use((req, res, next) => {
   getCompany(req, res, next, res.locals.order.company.id)
 })
+
+router.use(setOrderBreadcrumb)
 
 router.get('/', editRedirect)
 router.all('/:step', editHandler)

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -9,18 +9,22 @@ const EditWorkDescriptionController = require('./controllers/work-description')
 
 const steps = merge({}, createSteps, {
   '/client-details': {
+    heading: 'Edit client details',
     controller: EditClientDetailsController,
   },
   '/subscribers': {
+    heading: 'Add or remove ITAs',
     controller: EditSubscribersController,
   },
   '/assignees': {
+    heading: 'Add or remove post advisers',
     fields: [
       'assignees',
     ],
     controller: EditAssigneesController,
   },
   '/assignee-time': {
+    heading: 'Edit post adviser time',
     fields: [
       'assignee_time',
     ],
@@ -29,6 +33,7 @@ const steps = merge({}, createSteps, {
     template: 'assignee-time.njk',
   },
   '/work-description': {
+    heading: 'Edit work description',
     fields: [
       'service_types',
       'description',

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -2,18 +2,11 @@ const { get, keys } = require('lodash')
 const path = require('path')
 const i18nFuture = require('i18n-future')
 
-const { setHomeBreadcrumb } = require('../../../middleware')
 const { Order } = require('../../models')
 
 const i18n = i18nFuture({
   path: path.resolve(__dirname, '../../locales/__lng__/__ns__.json'),
 })
-
-function setOrderBreadcrumb (req, res, next) {
-  const reference = get(res.locals, 'order.reference')
-
-  return setHomeBreadcrumb(reference)(req, res, next)
-}
 
 function setTranslation (req, res, next) {
   res.locals.translate = (key) => {
@@ -136,7 +129,6 @@ function setQuoteForm (req, res, next) {
 }
 
 module.exports = {
-  setOrderBreadcrumb,
   setTranslation,
   getQuote,
   generateQuote,

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,9 +1,9 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
+const { setOrderBreadcrumb } = require('../../middleware')
 const { renderWorkOrder, renderQuote } = require('./controllers')
 const {
-  setOrderBreadcrumb,
   setTranslation,
   getQuote,
   setQuoteForm,

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,6 +1,6 @@
-const logger = require('../../../../config/logger')
-const { getInflatedDitCompany } = require('../../companies/services/data')
-const { Order } = require('../models')
+const logger = require('../../../config/logger')
+const { getInflatedDitCompany } = require('../companies/services/data')
+const { Order } = require('./models')
 
 async function getCompany (req, res, next, companyId) {
   try {

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,5 +1,8 @@
+const { get } = require('lodash')
+
 const logger = require('../../../config/logger')
 const { getInflatedDitCompany } = require('../companies/services/data')
+const { setHomeBreadcrumb } = require('../middleware')
 const { Order } = require('./models')
 
 async function getCompany (req, res, next, companyId) {
@@ -27,7 +30,14 @@ async function getOrder (req, res, next, orderId) {
   next()
 }
 
+function setOrderBreadcrumb (req, res, next) {
+  const reference = get(res.locals, 'order.reference')
+
+  return setHomeBreadcrumb(reference)(req, res, next)
+}
+
 module.exports = {
   getCompany,
   getOrder,
+  setOrderBreadcrumb,
 }

--- a/src/apps/omis/middleware/index.js
+++ b/src/apps/omis/middleware/index.js
@@ -1,5 +1,0 @@
-const params = require('./params')
-
-module.exports = {
-  params,
-}

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -1,7 +1,7 @@
 const router = require('express').Router()
 
 const { setHomeBreadcrumb } = require('../middleware')
-const { getOrder } = require('./middleware/params')
+const { getOrder } = require('./middleware')
 const viewApp = require('./apps/view')
 const editApp = require('./apps/edit')
 const createApp = require('./apps/create')

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -10,7 +10,7 @@ const listApp = require('./apps/list')
 router.param('orderId', getOrder)
 
 router.use(createApp.mountpath, setHomeBreadcrumb(createApp.displayName), createApp.router)
-router.use(editApp.mountpath, setHomeBreadcrumb(editApp.displayName), editApp.router)
+router.use(editApp.mountpath, editApp.router)
 router.use(viewApp.mountpath, viewApp.router)
 router.use(listApp.mountpath, listApp.router)
 

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -2,8 +2,6 @@ describe('OMIS View middleware', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
 
-    this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
-    this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
     this.previewQuoteStub = this.sandbox.stub()
     this.getFullQuoteStub = this.sandbox.stub()
     this.createQuoteStub = this.sandbox.stub()
@@ -15,7 +13,6 @@ describe('OMIS View middleware', () => {
       locals: {
         order: {
           id: '123456789',
-          reference: '12345/AS',
         },
       },
     }
@@ -27,9 +24,6 @@ describe('OMIS View middleware', () => {
     }
 
     this.middleware = proxyquire('~/src/apps/omis/apps/view/middleware', {
-      '../../../middleware': {
-        setHomeBreadcrumb: this.setHomeBreadcrumbStub,
-      },
       '../../models': {
         Order: {
           previewQuote: this.previewQuoteStub,
@@ -43,18 +37,6 @@ describe('OMIS View middleware', () => {
 
   afterEach(() => {
     this.sandbox.restore()
-  })
-
-  describe('setOrderBreadcrumb()', () => {
-    it('should call setHomeBreadcrumb with order reference', () => {
-      this.middleware.setOrderBreadcrumb({}, this.resMock, this.nextSpy)
-
-      expect(this.setHomeBreadcrumbStub).to.have.been.calledOnce
-      expect(this.setHomeBreadcrumbStub).to.have.been.calledWith('12345/AS')
-
-      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledOnce
-      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, this.resMock, this.nextSpy)
-    })
   })
 
   describe('setTranslation()', () => {

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -1,0 +1,40 @@
+describe('OMIS middleware', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+
+    this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
+    this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
+    this.nextSpy = this.sandbox.spy()
+
+    this.resMock = {
+      locals: {
+        order: {
+          id: '123456789',
+          reference: '12345/AS',
+        },
+      },
+    }
+
+    this.middleware = proxyquire('~/src/apps/omis/middleware', {
+      '../middleware': {
+        setHomeBreadcrumb: this.setHomeBreadcrumbStub,
+      },
+    })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('setOrderBreadcrumb()', () => {
+    it('should call setHomeBreadcrumb with order reference', () => {
+      this.middleware.setOrderBreadcrumb({}, this.resMock, this.nextSpy)
+
+      expect(this.setHomeBreadcrumbStub).to.have.been.calledOnce
+      expect(this.setHomeBreadcrumbStub).to.have.been.calledWith('12345/AS')
+
+      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledOnce
+      expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, this.resMock, this.nextSpy)
+    })
+  })
+})


### PR DESCRIPTION
This change uses the same breadcrumb middleware to set the work order as a base breadcrumb item for each step.

It also includes moving the location of some middleware so that they can be shared more easily.

## Before

![image](https://user-images.githubusercontent.com/3327997/30334805-8b39e632-97d8-11e7-8b76-de30a527489d.png)

## After

![image](https://user-images.githubusercontent.com/3327997/30334742-66201cd6-97d8-11e7-8f74-3f2d351c2318.png)
