### PR TITLE
Only allow an order to be edited in draft

### DIFF
--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -18,7 +18,9 @@
   background-color: $white;
 
   @include media(tablet) {
-    padding-right: 90px;
+    .js-Messages & {
+      padding-right: 90px;
+    }
   }
 
   + * {
@@ -26,7 +28,12 @@
   }
 
   * {
-    font-weight: 700;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    &:not(button) {
+      font-weight: 700;
+    }
   }
 
   > * + * {

--- a/src/apps/omis/apps/edit/controllers/edit-handler.js
+++ b/src/apps/omis/apps/edit/controllers/edit-handler.js
@@ -10,12 +10,14 @@ const i18n = i18nFuture({
 
 function editHandler (req, res, next) {
   const step = steps[`/${req.params.step}`]
+  const order = res.locals.order
 
-  if (!step) { return next() }
+  if (!step || !order) { return next() }
 
   const defaults = {
     buttonText: 'Save and return',
     returnText: 'Return without saving',
+    disableFormAction: !order.editable,
     journeyName: 'edit',
     name: 'edit',
     route: '/edit',

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -1,5 +1,12 @@
 {% extends "./_layouts/view.njk" %}
 
+{% set companyLink %}
+  <a href="/viewcompanyresult/{{ values.company.id }}">{{ values.company.name }}</a>
+{% endset %}
+{% set contactLink %}
+  <a href="/contacts/{{ values.contact.id }}">{{ values.contact.name }}</a>
+{% endset %}
+
 {% macro AnswersSummary(props) %}
   <table class="c-answers-summary">
     <caption class="c-answers-summary__heading">
@@ -35,17 +42,17 @@
 {% endmacro %}
 
 {% block main_grid_right_column %}
-  {% set companyLink %}
-    <a href="/viewcompanyresult/{{ values.company.id }}">{{ values.company.name }}</a>
-  {% endset %}
-  {% set contactLink %}
-    <a href="/contacts/{{ values.contact.id }}">{{ values.contact.name }}</a>
-  {% endset %}
+  {% if not order.editable %}
+    <div class="c-messages__item c-messages__item--info">
+      <p>You cannot edit the order whilst a quote is awaiting acceptance.</p>
+      <p>You must <a href="quote">cancel the quote</a> to edit the order.</p>
+    </div>
+  {% endif %}
 
   {{ AnswersSummary({
     heading: 'Client details',
     actions: [{
-      url: 'edit/client-details'
+      url: 'edit/client-details' if order.editable
     }],
     items: [{
       label: 'Company',
@@ -67,7 +74,7 @@
   {{ AnswersSummary({
     heading: 'International Trade Advisers (ITAs)',
     actions: [{
-      url: 'edit/subscribers',
+      url: 'edit/subscribers' if order.editable,
       text: 'Add or remove'
     }],
     items: values.subscribers | map('name') if values.subscribers.length else ['None selected']
@@ -76,10 +83,10 @@
   {% call AnswersSummary({
     heading: 'Post advisers',
     actions: [{
-      url: 'edit/assignees',
+      url: 'edit/assignees' if order.editable,
       text: 'Add or remove'
     }, {
-      url: 'edit/assignee-time' if values.assignees.length,
+      url: 'edit/assignee-time' if values.assignees.length and order.editable,
       text: 'Edit time'
     }]
   }) %}
@@ -131,7 +138,7 @@
   {{ AnswersSummary({
     heading: 'Work description',
     actions: [{
-      url: 'edit/work-description'
+      url: 'edit/work-description' if order.editable
     }],
     items: [{
       label: 'Delivery date',

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -23,6 +23,7 @@ async function getOrder (req, res, next, orderId) {
     res.locals.order = Object.assign({}, order, {
       subscribers,
       assignees,
+      editable: order.status === 'draft',
     })
   } catch (e) {
     logger.error(e)

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -1,23 +1,46 @@
+const companyData = require('~/test/unit/data/company.json')
+const orderData = require('~/test/unit/data/omis/simple-order.json')
+const subscriberData = require('~/test/unit/data/omis/subscribers.json')
+const assigneeData = require('~/test/unit/data/omis/assignees.json')
+
 describe('OMIS middleware', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
 
     this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
     this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
+    this.getInflatedDitCompanyStub = this.sandbox.stub()
+    this.getByIdStub = this.sandbox.stub()
+    this.getSubscribersStub = this.sandbox.stub()
+    this.getAssigneesStub = this.sandbox.stub()
+    this.loggerSpy = this.sandbox.spy()
     this.nextSpy = this.sandbox.spy()
 
     this.resMock = {
-      locals: {
-        order: {
-          id: '123456789',
-          reference: '12345/AS',
-        },
+      locals: {},
+    }
+    this.reqMock = {
+      session: {
+        token: 'session-12345',
       },
     }
 
     this.middleware = proxyquire('~/src/apps/omis/middleware', {
+      '../companies/services/data': {
+        getInflatedDitCompany: this.getInflatedDitCompanyStub,
+      },
+      '../../../config/logger': {
+        error: this.loggerSpy,
+      },
       '../middleware': {
         setHomeBreadcrumb: this.setHomeBreadcrumbStub,
+      },
+      './models': {
+        Order: {
+          getById: this.getByIdStub,
+          getSubscribers: this.getSubscribersStub,
+          getAssignees: this.getAssigneesStub,
+        },
       },
     })
   })
@@ -26,7 +49,163 @@ describe('OMIS middleware', () => {
     this.sandbox.restore()
   })
 
+  describe('getCompany()', () => {
+    beforeEach(() => {
+      this.companyId = 'c-1234567890'
+    })
+
+    context('when get company resolves', () => {
+      beforeEach(() => {
+        this.getInflatedDitCompanyStub.resolves(companyData)
+      })
+
+      it('should call getInflatedDitCompany() with correct arguments', async () => {
+        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+
+        expect(this.getInflatedDitCompanyStub).to.have.been.calledWith(this.reqMock.session.token, this.companyId)
+      })
+
+      it('should set a company property on locals', async () => {
+        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+
+        expect(this.resMock.locals).to.have.property('company')
+        expect(this.resMock.locals.company).to.deep.equal(companyData)
+      })
+
+      it('should call next with no errors', async () => {
+        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
+    context('when a company rejects', () => {
+      beforeEach(() => {
+        this.error = {
+          statusCode: 404,
+        }
+        this.getInflatedDitCompanyStub.rejects(this.error)
+      })
+
+      it('should call next with an error', async () => {
+        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+
+      it('should not set a company property on locals', async () => {
+        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+
+        expect(this.resMock.locals).to.not.have.property('company')
+      })
+    })
+  })
+
+  describe('getOrder()', () => {
+    beforeEach(() => {
+      this.orderId = 'o-1234567890'
+    })
+
+    context('when model methods resolve', () => {
+      beforeEach(() => {
+        this.getByIdStub.resolves(orderData)
+        this.getSubscribersStub.resolves(subscriberData)
+        this.getAssigneesStub.resolves(assigneeData)
+      })
+
+      it('should call model methods with correct arguments', async () => {
+        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+        expect(this.getByIdStub).to.have.been.calledWith(this.reqMock.session.token, this.orderId)
+        expect(this.getSubscribersStub).to.have.been.calledWith(this.reqMock.session.token, this.orderId)
+        expect(this.getAssigneesStub).to.have.been.calledWith(this.reqMock.session.token, this.orderId)
+      })
+
+      it('should set a order property on locals', async () => {
+        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+        const order = Object.assign({}, orderData, {
+          subscribers: subscriberData,
+          assignees: assigneeData,
+          editable: true,
+        })
+        expect(this.resMock.locals).to.have.property('order')
+        expect(this.resMock.locals.order).to.deep.equal(order)
+      })
+
+      it('should call next with no errors', async () => {
+        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+
+      context('when order is in draft', () => {
+        beforeEach(() => {
+          const draftOrder = Object.assign({}, orderData, {
+            status: 'draft',
+          })
+          this.getByIdStub.resolves(draftOrder)
+        })
+
+        it('should set editable to true', async () => {
+          await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+          expect(this.resMock.locals.order.editable).to.equal(true)
+        })
+      })
+
+      context('when order is not in draft', () => {
+        beforeEach(() => {
+          const quoteOrder = Object.assign({}, orderData, {
+            status: 'quote_awaiting_acceptance',
+          })
+          this.getByIdStub.resolves(quoteOrder)
+        })
+
+        it('should set editable to false', async () => {
+          await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+          expect(this.resMock.locals.order.editable).to.equal(false)
+        })
+      })
+    })
+
+    context('when a model method rejects', () => {
+      beforeEach(() => {
+        this.error = {
+          statusCode: 404,
+        }
+        this.getByIdStub.rejects(this.error)
+      })
+
+      it('should not set an order property on locals', async () => {
+        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+        expect(this.resMock.locals).to.not.have.property('order')
+      })
+
+      it('should log the error', async () => {
+        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+        expect(this.loggerSpy).to.have.been.calledWith(this.error)
+      })
+
+      it('should call next without an error', async () => {
+        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+  })
+
   describe('setOrderBreadcrumb()', () => {
+    beforeEach(() => {
+      this.resMock.locals.order = {
+        id: '123456789',
+        reference: '12345/AS',
+      }
+    })
+
     it('should call setHomeBreadcrumb with order reference', () => {
       this.middleware.setOrderBreadcrumb({}, this.resMock, this.nextSpy)
 

--- a/test/unit/data/omis/assignees.json
+++ b/test/unit/data/omis/assignees.json
@@ -1,0 +1,22 @@
+[
+  {
+    "adviser": {
+      "first_name": "Joe",
+      "last_name": "Doe",
+      "name": "Joe Doe",
+      "id": "33736be0-3e6b-4d4e-9fa8-32f23d0ba55e"
+    },
+    "estimated_time": 200,
+    "is_lead": true
+  },
+  {
+    "adviser": {
+      "first_name": "Rebecca",
+      "last_name": "Bah",
+      "name": "Rebecca Bah",
+      "id": "3cfad090-8f7e-4a8b-beb0-14c909d6f052"
+    },
+    "estimated_time": 250,
+    "is_lead": false
+  }
+]

--- a/test/unit/data/omis/subscribers.json
+++ b/test/unit/data/omis/subscribers.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "name": "Puck Head",
+    "dit_team": {
+      "name": "CBBC North EAST",
+      "id": "602b971d-5df6-e511-888e-e4115bead28a"
+    }
+  },
+  {
+    "id": "25628b23-c75b-4aef-b120-dac2d64c0696",
+    "first_name": "",
+    "last_name": "",
+    "name": "",
+    "dit_team": null
+  }
+]


### PR DESCRIPTION
This change stops an order being edited unless it is in draft status.

It removes the option to link to an edit step and also disables the form actions in case a user ends up back on this page by mistake.

💯 [**DEMO**](http://datahub-beta2-pr-582.herokuapp.com/omis) 💯 

## What it looks like

### When editable

![localhost_3001_omis_4a7575c2-245e-450d-babf-902126a9ee7d_work-order](https://user-images.githubusercontent.com/3327997/30373443-406848f0-9879-11e7-84f9-b279c227f5fd.png)

### When not editable

![localhost_3001_omis_d13e34ca-4aa2-4e50-b1db-459219cc1c08_work-order](https://user-images.githubusercontent.com/3327997/30373420-2b565056-9879-11e7-9c0d-0bd5ecd3aeef.png)

### If user accidentally lands on edit route (eg bookmarked or logged out whilst editing)

![localhost_3001_omis_9c9bc8ca-8ea9-4185-95ef-94319e27fafd_edit_client-details](https://user-images.githubusercontent.com/3327997/30374004-3c8f2e22-987b-11e7-8235-4177244f40e2.png)
