### PR TITLE
Always cast assignee time to an array

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -1,4 +1,4 @@
-const { filter, pick } = require('lodash')
+const { filter, flatten, pick } = require('lodash')
 
 const { EditController } = require('../../../controllers')
 const { Order } = require('../../../models')
@@ -6,7 +6,8 @@ const { Order } = require('../../../models')
 class EditAssigneeHoursController extends EditController {
   async successHandler (req, res, next) {
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
-    const assignees = data.assignee_time.map((value, index) => {
+    const timeValues = flatten([data.assignee_time])
+    const assignees = timeValues.map((value, index) => {
       if (!value) { return }
 
       const [ hours, minutes ] = value.split(':')


### PR DESCRIPTION
The current code hangs if there is only 1 assignee and the value for
`assignee_time` is then a string rather than an array if there were
multiple values on the step.

This ensures that the value is always what is expected, an array, and
therefore doesn't cause the page to hang.

### Sentry

Fixes a [sentry issue](https://sentry.ci.uktrade.io/dit/data-hub-rhod/issues/1924/).