### PR TITLE
DH-524 Add middleware for event POST to API

### DIFF
--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -1,0 +1,40 @@
+const { transformToApi } = require('../services/formatting')
+const { createEvent } = require('../repos')
+
+async function populateForm (req, res, next) {
+  // todo
+}
+
+async function handleFormPost (req, res, next) {
+  const formattedBody = transformToApi(Object.assign({}, req.body))
+
+  try {
+    await createEvent(req.session.token, formattedBody)
+
+    res.locals.resultId = '1'
+
+    next()
+  } catch (err) {
+    if (err.statusCode === 400) {
+      res.locals.form = Object.assign({}, res.locals.form, {
+        state: req.body,
+        errors: {
+          messages: err.error,
+        },
+      })
+      next()
+    } else {
+      next(err)
+    }
+  }
+}
+
+function validateForm (req, res, next) {
+  // todo
+}
+
+module.exports = {
+  populateForm,
+  handleFormPost,
+  validateForm,
+}

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -1,10 +1,6 @@
 const { transformToApi } = require('../services/formatting')
 const { createEvent } = require('../repos')
 
-async function populateForm (req, res, next) {
-  // todo
-}
-
 async function handleFormPost (req, res, next) {
   const formattedBody = transformToApi(Object.assign({}, req.body))
 
@@ -27,10 +23,6 @@ async function handleFormPost (req, res, next) {
       next(err)
     }
   }
-}
-
-function validateForm (req, res, next) {
-  // todo
 }
 
 module.exports = {

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -5,9 +5,9 @@ async function handleFormPost (req, res, next) {
   const formattedBody = transformToApi(Object.assign({}, req.body))
 
   try {
-    await createEvent(req.session.token, formattedBody)
+    const result = await createEvent(req.session.token, formattedBody)
 
-    res.locals.resultId = '1'
+    res.locals.resultId = result.id
 
     next()
   } catch (err) {
@@ -26,7 +26,5 @@ async function handleFormPost (req, res, next) {
 }
 
 module.exports = {
-  populateForm,
   handleFormPost,
-  validateForm,
 }

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -1,0 +1,14 @@
+const config = require('../../../config')
+const authorisedRequest = require('../../lib/authorised-request')
+
+function createEvent (token, body) {
+  return authorisedRequest(token, {
+    url: `${config.apiRoot}/v3/event`,
+    method: 'POST',
+    body,
+  })
+}
+
+module.exports = {
+  createEvent,
+}

--- a/src/apps/events/services/formatting.js
+++ b/src/apps/events/services/formatting.js
@@ -1,0 +1,51 @@
+const { mapValues, isPlainObject } = require('lodash')
+
+function transformToApi (body) {
+  if (!isPlainObject(body)) { return }
+
+  const schema = {
+    name: Object,
+    event_type: Object,
+    start_date: Object,
+    end_date: Object,
+    location_type: Object,
+    address_1: Object,
+    address_2: Object,
+    address_town: Object,
+    address_county: Object,
+    postcode: Object,
+    address_country: Object,
+    notes: Object,
+    lead_team: Object,
+    organiser: Object,
+    related_programmes: Array,
+    teams: Array,
+  }
+
+  const formatted = mapValues(schema, (type, key) => {
+    const value = body[key]
+
+    if (!value) {
+      return
+    }
+
+    return value
+  })
+
+  const setDate = (key) => {
+    formatted[key] = [
+      body[`${key}_year`],
+      body[`${key}_month`],
+      body[`${key}_day`],
+    ].join('-')
+  }
+
+  setDate('start_date')
+  setDate('end_date')
+
+  return Object.assign({}, formatted)
+}
+
+module.exports = {
+  transformToApi,
+}

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -1,0 +1,116 @@
+const eventData = require('../../../data/events/event.json')
+
+describe('Event details middleware', () => {
+  describe('#handleFormPost', () => {
+    beforeEach(() => {
+      this.sandbox = sinon.sandbox.create()
+      this.createEventStub = this.sandbox.stub()
+      this.middleware = proxyquire('~/src/apps/events/middleware/details', {
+        '../repos': {
+          createEvent: this.createEventStub,
+        },
+      })
+      this.req = {
+        session: {
+          token: 'abcd',
+        },
+        body: eventData,
+      }
+      this.res = {
+        breadcrumb: this.sandbox.stub().returnsThis(),
+        render: this.sandbox.spy(),
+        locals: {},
+      }
+      this.next = this.sandbox.spy()
+    })
+
+    afterEach(() => {
+      this.sandbox.restore()
+    })
+
+    context('when all fields are valid', () => {
+      beforeEach(() => {
+        this.createEventStub.resolves({ id: '1' })
+      })
+
+      it('should post to the API', async () => {
+        await this.middleware.handleFormPost(this.req, this.res, this.next)
+
+        const expectedBody = {
+          name: 'name',
+          event_type: 'event_type',
+          start_date: '2018-01-01',
+          end_date: '2018-02-02',
+          location_type: 'location_type',
+          address_1: 'address 1',
+          address_2: 'address 2',
+          address_town: 'town',
+          address_county: 'county',
+          postcode: 'postcode',
+          address_country: 'country',
+          notes: 'notes',
+          lead_team: 'lead_team',
+          organiser: 'organiser',
+          related_programmes: [ 'programme1', 'programme2' ],
+          teams: [ 'team1', 'team2' ],
+        }
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+
+      it('should set the result ID', async () => {
+        await this.middleware.handleFormPost(this.req, this.res, this.next)
+
+        const actualResultId = this.res.locals.resultId
+        const expectedResultId = '1'
+
+        expect(actualResultId).to.equal(expectedResultId)
+      })
+    })
+
+    context('when there is a 400', () => {
+      beforeEach(() => {
+        this.createEventStub.rejects({ statusCode: 400, error: 'error' })
+      })
+
+      it('should set the state', async () => {
+        await this.middleware.handleFormPost(this.req, this.res, this.next)
+
+        expect(this.res.locals.form.state).to.deep.equal(this.req.body)
+      })
+
+      it('should set the errors', async () => {
+        await this.middleware.handleFormPost(this.req, this.res, this.next)
+
+        expect(this.res.locals.form.errors.messages).to.equal('error')
+      })
+
+      it('should not call next with errors', async () => {
+        await this.middleware.handleFormPost(this.req, this.res, this.next)
+
+        expect(this.next).have.been.calledWith()
+        expect(this.next).have.been.calledOnce
+      })
+    })
+
+    context('when there is an error other than 400', () => {
+      beforeEach(() => {
+        this.createEventStub.rejects({ statusCode: 500, error: 'error' })
+      })
+
+      it('should not set form', async () => {
+        await this.middleware.handleFormPost(this.req, this.res, this.next)
+
+        expect(this.res.locals.form).to.be.undefined
+      })
+
+      it('should call next with errors', async () => {
+        await this.middleware.handleFormPost(this.req, this.res, this.next)
+
+        expect(this.next).have.been.calledWith({ statusCode: 500, error: 'error' })
+        expect(this.next).have.been.calledOnce
+      })
+    })
+  })
+})

--- a/test/unit/data/events/event.json
+++ b/test/unit/data/events/event.json
@@ -1,0 +1,22 @@
+{
+  "name": "name",
+  "event_type": "event_type",
+  "start_date_year": "2018",
+  "start_date_month": "01",
+  "start_date_day": "01",
+  "end_date_year": "2018",
+  "end_date_month": "02",
+  "end_date_day": "02",
+  "location_type": "location_type",
+  "address_1": "address 1",
+  "address_2": "address 2",
+  "address_town": "town",
+  "address_county": "county",
+  "postcode": "postcode",
+  "address_country": "country",
+  "notes": "notes",
+  "lead_team": "lead_team",
+  "organiser": "organiser",
+  "teams": [ "team1", "team2" ],
+  "related_programmes": [ "programme1", "programme2" ]
+}


### PR DESCRIPTION
This is the first in a series of PRs for DH-524 Save an event.

This PR includes:
- middleware for handling the form POST
- tests covering middleware