### PR TITLE
Update form actions to give more breathing space to secondary action

### DIFF
--- a/assets/stylesheets/components/_form.scss
+++ b/assets/stylesheets/components/_form.scss
@@ -1,6 +1,7 @@
 @import "form/form-errors";
 @import "form/form-control";
 @import "form/form-group";
+@import "form/form-actions";
 @import "form/form-fieldset";
 @import "form/multiple-choice";
 @import "form/entity-search";

--- a/assets/stylesheets/components/form/_form-actions.scss
+++ b/assets/stylesheets/components/form/_form-actions.scss
@@ -1,0 +1,23 @@
+@import "../../settings";
+
+.c-form-actions {
+  * {
+    display: block;
+  }
+
+  * + * {
+    margin-top: $default-spacing-unit;
+  }
+
+  @include media(tablet) {
+    * {
+      display: inline-block;
+      vertical-align: baseline;
+    }
+
+    * + * {
+      margin-top: 0;
+      margin-left: $default-spacing-unit;
+    }
+  }
+}

--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -7,6 +7,7 @@
 * + {
   form,
   .c-form-group,
+  .c-form-actions,
   .c-form-fieldset,
   .c-error-summary,
   .results-summary {

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -79,10 +79,10 @@
     {{ children }}
 
     {% if not hideFormActions %}
-      <div class="c-form-group c-form-group--actions {{ props.actionsClass }}">
+      <div class="c-form-actions {{ props.actionsClass }}">
         <button class="button {{ buttonModifiers }}" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
         {% if props.returnLink %}
-          <p><a href="{{ props.returnLink }}">{{ returnText }}</a></p>
+          <a href="{{ props.returnLink }}">{{ returnText }}</a>
         {% endif %}
       </div>
     {% endif %}

--- a/test/unit/macros/form.test.js
+++ b/test/unit/macros/form.test.js
@@ -23,7 +23,7 @@ describe('Nunjucks form macros', () => {
         const component = macros.renderWithCallerToDom('Form')(
           macros.renderToDom('TextField')
         )
-        expect(component.querySelector('.c-form-group--actions')).to.exist
+        expect(component.querySelector('.c-form-actions')).to.exist
         expect(component.querySelector('button.button').textContent).to.equal('Submit')
       })
 
@@ -42,7 +42,7 @@ describe('Nunjucks form macros', () => {
         expect(component.action).to.equal('/form-url')
         expect(component.className).to.equal('c-form-component')
         expect(component.getAttribute('role')).to.equal('search')
-        expect(component.querySelector('.c-form-group--actions').classList.contains('u-js-hidden')).to.be.true
+        expect(component.querySelector('.c-form-actions').classList.contains('u-js-hidden')).to.be.true
       })
 
       it('should render form with custom submit button text', () => {
@@ -62,7 +62,7 @@ describe('Nunjucks form macros', () => {
         const component = macros.renderWithCallerToDom('Form', formProps)(
           macros.renderToDom('TextField')
         )
-        expect(component.querySelector('.c-form-group--actions')).to.not.exist
+        expect(component.querySelector('.c-form-actions')).to.not.exist
       })
 
       it('should render form with button modifier as string', () => {


### PR DESCRIPTION
This uses a sass component to provide some better spacing to the action
within a form.

## Before

![image](https://user-images.githubusercontent.com/3327997/30404025-67167784-98dc-11e7-9cfc-d1a52a2cd0a9.png)

## After

### mobile

![image](https://user-images.githubusercontent.com/3327997/30404018-59ae1e80-98dc-11e7-95a3-ed0fcc328ba6.png)

### > tablet

![image](https://user-images.githubusercontent.com/3327997/30404006-4caae4c0-98dc-11e7-8bdf-7cbb579d329d.png)
