### PR TITLE
Add link to edit advisers from OMIS time edit

### DIFF
--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -116,3 +116,7 @@
     text-align: right;
   }
 }
+
+.c-answers-summary__title--unstyled {
+  border: 0;
+}

--- a/src/apps/omis/apps/edit/views/assignee-time.njk
+++ b/src/apps/omis/apps/edit/views/assignee-time.njk
@@ -10,21 +10,30 @@
         <th class="c-answers-summary__control" colspan="2">Estimated time (HH:MM)</th>
       </tr>
     </thead>
-    {% for assignee in order.assignees %}
-      {% set props = {} | assign(defaultProps, {
-        name: key,
-        idSuffix: assignee.adviser.id,
-        label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
-        value: values[key][loop.index0] or assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time,
-        error: errors[key].message,
-        isLabelHidden: true
-      }) %}
+    <tbody>
+      {% for assignee in order.assignees %}
+        {% set props = {} | assign(defaultProps, {
+          name: key,
+          idSuffix: assignee.adviser.id,
+          label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
+          value: values[key][loop.index0] or assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time,
+          error: errors[key].message,
+          isLabelHidden: true
+        }) %}
+        <tr>
+          <th class="c-answers-summary__title">{{ assignee.adviser.name }}</th>
+          <td class="c-answers-summary__control">
+            {{ callAsMacro(props.fieldType)(props) }}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    <tfoot>
       <tr>
-        <td class="c-answers-summary__title">{{ assignee.adviser.name }}</td>
-        <td class="c-answers-summary__control">
-          {{ callAsMacro(props.fieldType)(props) }}
+        <td class="c-answers-summary__title c-answers-summary__title--unstyled">
+          <a href="assignees">Edit advisers</a>
         </td>
       </tr>
-    {% endfor %}
+    </tfoot>
   </table>
 {% endblock %}


### PR DESCRIPTION
This allows a direct link back to changing the advisers when a
user is editing the estimated time for advisers.

## Before

![localhost_3001_omis_698f449e-9c86-428f-b674-f86174d67897_edit_assignee-time 1](https://user-images.githubusercontent.com/3327997/30404134-f8b458fa-98dc-11e7-890d-277cc0fe0c27.png)

## After

![localhost_3001_omis_698f449e-9c86-428f-b674-f86174d67897_edit_assignee-time](https://user-images.githubusercontent.com/3327997/30404126-f0415092-98dc-11e7-9e36-4b97666aa0f7.png)
