### PR TITLE
DH-524 Rename event fields for simplified transformation

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -11,9 +11,9 @@ async function renderEventPage (req, res, next) {
     const eventForm = eventFormConfig(advisers)
     const emptyDate = { year: '', month: '', day: '' }
     const body = Object.assign(req.body, {
-      event_start_date: emptyDate,
-      event_end_date: emptyDate,
-      event_team_hosting: get(req, 'session.user.dit_team.id', null),
+      start_date: emptyDate,
+      end_date: emptyDate,
+      lead_team: get(req, 'session.user.dit_team.id', null),
     })
     const eventFormWithState = buildFormWithState(eventForm, body)
 
@@ -30,12 +30,19 @@ async function renderEventPage (req, res, next) {
 
 function postHandler (req, res, next) {
   const setAddAnotherField = (value) => compact(castArray(value))
-  req.body.event_shared_teams = setAddAnotherField(req.body.event_shared_teams)
-  req.body.event_programmes = setAddAnotherField(req.body.event_programmes)
+  req.body.teams = setAddAnotherField(req.body.teams)
+  req.body.related_programmes = setAddAnotherField(req.body.related_programmes)
 
-  if (req.body.add_event_shared_team || req.body.add_event_programme) {
+  if (req.body.add_team || req.body.add_related_programme) {
     return next()
   }
+
+  if (get(res.locals, 'form.errors')) {
+    return next()
+  }
+
+  req.flash('success', 'Event created')
+  return res.redirect(`/events/${res.locals.resultId}/details`)
 }
 
 module.exports = {

--- a/src/apps/events/macros.js
+++ b/src/apps/events/macros.js
@@ -9,7 +9,7 @@ const eventFormConfig = (organisers) => {
     children: [
       {
         macroName: 'TextField',
-        name: 'event_name',
+        name: 'name',
         label: 'Event name',
       },
       {
@@ -23,7 +23,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'DateFieldset',
-        name: 'event_start_date',
+        name: 'start_date',
         label: 'Event start date',
         optional: true,
         value: {
@@ -34,7 +34,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'DateFieldset',
-        name: 'event_end_date',
+        name: 'end_date',
         label: 'Event end date',
         optional: true,
         value: {
@@ -45,7 +45,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'MultipleChoiceField',
-        name: 'event_location_type',
+        name: 'location_type',
         label: 'Event location type',
         optional: true,
         initialOption: '-- Select location type --',
@@ -77,21 +77,23 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'TextField',
-        name: 'address_postcode',
+        name: 'postcode',
         label: 'Postcode',
         class: 'u-js-hidden',
       },
-      globalFields.countries,
+      Object.assign({}, globalFields.countries, {
+        name: 'address_country',
+      }),
       {
         macroName: 'TextField',
         type: 'textarea',
-        name: 'event_notes',
+        name: 'notes',
         label: 'Event notes',
         optional: true,
       },
       {
         macroName: 'MultipleChoiceField',
-        name: 'event_team_hosting',
+        name: 'lead_team',
         label: 'Team hosting the event',
         optional: true,
         initialOption: '-- Select team --',
@@ -101,7 +103,7 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'MultipleChoiceField',
-        name: 'event_organiser',
+        name: 'organiser',
         label: 'Organiser',
         optional: true,
         initialOption: '-- Select organiser --',
@@ -127,14 +129,14 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'AddAnother',
-        buttonName: 'add_event_shared_team',
-        name: 'event_shared_teams',
+        buttonName: 'add_team',
+        name: 'teams',
         label: 'Teams',
         isLabelHidden: true,
         children: [
           {
             macroName: 'MultipleChoiceField',
-            name: 'event_shared_teams',
+            name: 'teams',
             label: 'Teams',
             isLabelHidden: true,
             optional: true,
@@ -151,13 +153,13 @@ const eventFormConfig = (organisers) => {
       },
       {
         macroName: 'AddAnother',
-        buttonName: 'add_event_programme',
-        name: 'event_programmes',
+        buttonName: 'add_related_programme',
+        name: 'related_programmes',
         label: 'Related programmes',
         children: [
           {
             macroName: 'MultipleChoiceField',
-            name: 'event_programmes',
+            name: 'related_programmes',
             label: 'Related programmes',
             isLabelHidden: true,
             optional: true,

--- a/test/acceptance/page_objects/Events.js
+++ b/test/acceptance/page_objects/Events.js
@@ -24,10 +24,10 @@ module.exports = {
     sharedNoContainer: '#group-field-event_shared div div:nth-child(2)',
     sharedYes: 'label[for=field-event_shared-1]',
     sharedNo: 'label[for=field-event_shared-2]',
-    sharedTeams: '#field-event_shared_teams',
-    addAnotherSharedTeam: 'input[name="add_event_shared_team"]',
-    relatedProgrammes: '#field-event_programmes',
-    addAnotherProgramme: 'input[name="add_event_programme"]',
+    sharedTeams: '#field-teams',
+    addAnotherSharedTeam: 'input[name="add_team"]',
+    relatedProgrammes: '#field-related_programmes',
+    addAnotherProgramme: 'input[name="add_related_programme"]',
     saveButton: {
       selector: '//button[text() = \'Save and Continue\']',
       locateStrategy: 'xpath',
@@ -56,19 +56,19 @@ module.exports = {
     {
       selectSharedTeam (optionNumber) {
         return this
-          .click('select[name="event_shared_teams"] option:nth-child(' + optionNumber + ')')
+          .click('select[name="teams"] option:nth-child(' + optionNumber + ')')
       },
       verifyVisibleSharedTeamList (listNumber) {
         return this
-          .verify.visible('#group-field-event_shared_teams #group-field-event_shared_teams:nth-child(' + listNumber + ') select')
+          .verify.visible('#group-field-teams #group-field-teams:nth-child(' + listNumber + ') select')
       },
       selectProgramme (optionNumber) {
         return this
-          .click('select[name="event_programmes"] option:nth-child(' + optionNumber + ')')
+          .click('select[name="related_programmes"] option:nth-child(' + optionNumber + ')')
       },
       verifyVisibleProgrammesList (listNumber) {
         return this
-          .verify.visible('#group-field-event_programmes #group-field-event_programmes:nth-child(' + listNumber + ') select')
+          .verify.visible('#group-field-related_programmes #group-field-related_programmes:nth-child(' + listNumber + ') select')
       },
     },
   ],

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -81,7 +81,7 @@ describe('Event edit controller', () => {
       await this.controller.renderEventPage(this.req, this.res, this.next)
 
       const eventForm = this.res.render.getCall(0).args[1].eventForm
-      const actual = find(eventForm.children, { name: 'event_organiser' }).options
+      const actual = find(eventForm.children, { name: 'organiser' }).options
       const expected = [
         { value: 'advisor1', label: 'advisor 1' },
         { value: 'advisor2', label: 'advisor 2' },
@@ -95,7 +95,7 @@ describe('Event edit controller', () => {
       await this.controller.renderEventPage(this.req, this.res, this.next)
 
       const eventForm = this.res.render.getCall(0).args[1].eventForm
-      const actual = find(eventForm.children, { name: 'event_team_hosting' }).value
+      const actual = find(eventForm.children, { name: 'lead_team' }).value
       const expected = currentUserTeam
 
       expect(actual).to.equal(expected)
@@ -103,29 +103,29 @@ describe('Event edit controller', () => {
 
     context('when there are event shared teams', () => {
       it('should prepopulate the event shared teams', async () => {
-        const eventSharedTeams = [ 'team1', 'team2' ]
-        this.req.body['event_shared_teams'] = eventSharedTeams
+        const teams = [ 'team1', 'team2' ]
+        this.req.body.teams = teams
 
         await this.controller.renderEventPage(this.req, this.res, this.next)
 
         const eventForm = this.res.render.getCall(0).args[1].eventForm
-        const actual = find(eventForm.children, { name: 'event_shared_teams' }).value
+        const actual = find(eventForm.children, { name: 'teams' }).value
 
-        expect(actual).to.deep.equal(eventSharedTeams)
+        expect(actual).to.deep.equal(teams)
       })
     })
 
     context('when there are event programmes', () => {
       it('should prepopulate the event programmes', async () => {
-        const eventProgrammes = [ 'programme1', 'programme2' ]
-        this.req.body['event_programmes'] = eventProgrammes
+        const relatedProgrammes = [ 'programme1', 'programme2' ]
+        this.req.body.related_programmes = relatedProgrammes
 
         await this.controller.renderEventPage(this.req, this.res, this.next)
 
         const eventForm = this.res.render.getCall(0).args[1].eventForm
-        const actual = find(eventForm.children, { name: 'event_programmes' }).value
+        const actual = find(eventForm.children, { name: 'related_programmes' }).value
 
-        expect(actual).to.deep.equal(eventProgrammes)
+        expect(actual).to.deep.equal(relatedProgrammes)
       })
     })
 
@@ -146,12 +146,12 @@ describe('Event edit controller', () => {
     context('when adding an event shared team for the first time', () => {
       it('should set the event shared teams', () => {
         const team = 'team1'
-        this.req.body.addEventSharedTeam = true
-        this.req.body['event_shared_teams'] = team
+        this.req.body.add_team = true
+        this.req.body.teams = team
 
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body['event_shared_teams']
+        const actual = this.req.body.teams
 
         expect(actual).to.deep.equal([ team ])
       })
@@ -160,24 +160,24 @@ describe('Event edit controller', () => {
     context('when adding subsequent event shared teams', () => {
       it('should add to the event shared teams', () => {
         const teams = [ 'team1', 'team2' ]
-        this.req.body.addEventSharedTeam = true
-        this.req.body['event_shared_teams'] = teams
+        this.req.body.add_team = true
+        this.req.body.teams = teams
 
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body['event_shared_teams']
+        const actual = this.req.body.teams
 
         expect(actual).to.deep.equal(teams)
       })
 
       it('should not add empty values to the event programmes', () => {
-        this.req.body.addEventSharedTeam = true
-        this.req.body['event_shared_teams'] = [ 'team1', 'team2' ]
-        this.req.body['event_programmes'] = [ 'programme1', '' ]
+        this.req.body.add_team = true
+        this.req.body.teams = [ 'team1', 'team2' ]
+        this.req.body.related_programmes = [ 'programme1', '' ]
 
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body['event_programmes']
+        const actual = this.req.body.related_programmes
 
         expect(actual).to.deep.equal([ 'programme1' ])
       })
@@ -185,39 +185,39 @@ describe('Event edit controller', () => {
 
     context('when adding an event programme for the first time', () => {
       it('should set the event programmes', () => {
-        const programme = 'programme1'
-        this.req.body.addEventProgramme = true
-        this.req.body['event_programmes'] = programme
+        const relatedProgramme = 'programme1'
+        this.req.body.add_related_programme = true
+        this.req.body.related_programmes = relatedProgramme
 
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body['event_programmes']
+        const actual = this.req.body.related_programmes
 
-        expect(actual).to.deep.equal([ programme ])
+        expect(actual).to.deep.equal([ relatedProgramme ])
       })
     })
 
     context('when adding subsequent event programmes', () => {
       it('should add to the event programmes', () => {
-        const programmes = [ 'programme1', 'programme2' ]
-        this.req.body.addEventSharedTeam = true
-        this.req.body['event_programmes'] = programmes
+        const relatedProgrammes = [ 'programme1', 'programme2' ]
+        this.req.body.add_team = true
+        this.req.body.related_programmes = relatedProgrammes
 
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body['event_programmes']
+        const actual = this.req.body.related_programmes
 
-        expect(actual).to.deep.equal(programmes)
+        expect(actual).to.deep.equal(relatedProgrammes)
       })
 
       it('should not add empty values to the event shared teams', () => {
-        this.req.body.addEventSharedTeam = true
-        this.req.body['event_shared_teams'] = [ 'team1', '' ]
-        this.req.body['event_programmes'] = [ 'programme1', 'programme2' ]
+        this.req.body.add_team = true
+        this.req.body.teams = [ 'team1', '' ]
+        this.req.body.related_programmes = [ 'programme1', 'programme2' ]
 
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body['event_shared_teams']
+        const actual = this.req.body.teams
 
         expect(actual).to.deep.equal([ 'team1' ])
       })


### PR DESCRIPTION
This is a simple change that renames the fields so that the transformation before POST to API is simpler.