### PR TITLE
Remove getInflatedDitCompany

### DIFF
--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -1,6 +1,7 @@
 const { reject } = require('lodash')
 
-const { getInflatedDitCompany, getCommonTitlesAndlinks } = require('../services/data')
+const { getCommonTitlesAndlinks } = require('../services/data')
+const { getDitCompany } = require('../repos')
 const { transformContactToListItem } = require('../../contacts/transformers')
 
 /**
@@ -12,7 +13,7 @@ const { transformContactToListItem } = require('../../contacts/transformers')
 async function getContacts (req, res, next) {
   try {
     res.locals.tab = 'contacts'
-    const company = res.locals.company = await getInflatedDitCompany(req.session.token, req.params.id)
+    const company = res.locals.company = await getDitCompany(req.session.token, req.params.id)
     getCommonTitlesAndlinks(req, res, company)
 
     const transformedContacts = company.contacts

--- a/src/apps/companies/controllers/exp.js
+++ b/src/apps/companies/controllers/exp.js
@@ -1,6 +1,6 @@
 const metadataRepo = require('../../../lib/metadata')
 const { saveCompany, getDitCompany } = require('../repos')
-const { getInflatedDitCompany, getCommonTitlesAndlinks } = require('../services/data')
+const { getCommonTitlesAndlinks } = require('../services/data')
 const { containsFormData, flattenIdFields } = require('../../../lib/controller-utils')
 
 const exportDetailsLabels = {
@@ -33,7 +33,7 @@ function common (req, res) {
   return new Promise(async (resolve, reject) => {
     try {
       res.locals.tab = 'exports'
-      res.locals.company = await getInflatedDitCompany(req.session.token, req.params.id)
+      res.locals.company = await getDitCompany(req.session.token, req.params.id)
 
       res.breadcrumb(res.locals.company.name, `/viewcompanyresult/${res.locals.company.id}`)
       res.breadcrumb('Exports', `/companies/${res.locals.company.id}/exports`)

--- a/src/apps/companies/controllers/foreign.js
+++ b/src/apps/companies/controllers/foreign.js
@@ -1,6 +1,6 @@
 const { get } = require('lodash')
 
-const companyRepository = require('../repos')
+const { getDitCompany } = require('../repos')
 const companyFormService = require('../services/form')
 const companyService = require('../services/data')
 const companyFormattingService = require('../services/formatting')
@@ -12,7 +12,7 @@ const companyWithoutCHKeys = ['business_type', 'registered_address', 'trading_na
 async function getDetails (req, res, next) {
   try {
     res.locals.tab = 'details'
-    const company = res.locals.company = await companyService.getInflatedDitCompany(req.session.token, req.params.id)
+    const company = res.locals.company = await getDitCompany(req.session.token, req.params.id)
     companyService.getCommonTitlesAndlinks(req, res, company)
     res.locals.companyDetails = companyFormattingService.getDisplayCompany(company)
     res.locals.companyDetailsDisplayOrder = companyWithoutCHKeys
@@ -62,7 +62,7 @@ function addDetails (req, res, next) {
 
 async function editDetails (req, res, next) {
   try {
-    const company = await companyRepository.getDitCompany(req.session.token, req.params.id)
+    const company = await getDitCompany(req.session.token, req.params.id)
     if (containsFormData(req)) {
       res.locals.formData = req.body
     } else {

--- a/src/apps/companies/controllers/investments.js
+++ b/src/apps/companies/controllers/investments.js
@@ -1,5 +1,6 @@
 const { getCompanyInvestmentProjects } = require('../../investment-projects/repos')
-const { getInflatedDitCompany, getCommonTitlesAndlinks } = require('../services/data')
+const { getDitCompany } = require('../repos')
+const { getCommonTitlesAndlinks } = require('../services/data')
 const { transformInvestmentProjectToListItem } = require('../../investment-projects/transformers')
 const { transformApiResponseToCollection } = require('../../transformers')
 
@@ -9,7 +10,7 @@ async function getAction (req, res, next) {
   const page = req.query.page || 1
 
   try {
-    const company = await getInflatedDitCompany(token, companyId)
+    const company = await getDitCompany(token, companyId)
     const results = await getCompanyInvestmentProjects(token, companyId, page)
       .then(transformApiResponseToCollection(
         { query: req.query },

--- a/src/apps/companies/controllers/ltd.js
+++ b/src/apps/companies/controllers/ltd.js
@@ -1,7 +1,7 @@
 const companyService = require('../services/data')
 const companyFormService = require('../services/form')
 const companyFormattingService = require('../services/formatting')
-const companyRepository = require('../repos')
+const { getDitCompany, getCHCompany } = require('../repos')
 const metadataRepository = require('../../../lib/metadata')
 const { companyDetailsLabels, chDetailsLabels, accountManagementDisplayLabels, hqLabels } = require('../labels')
 const { containsFormData, isBlank } = require('../../../lib/controller-utils')
@@ -11,7 +11,7 @@ const chDetailsDisplayOrderLong = ['name', 'company_number', 'registered_address
 async function getDetails (req, res, next) {
   try {
     res.locals.tab = 'details'
-    const company = res.locals.company = await companyService.getInflatedDitCompany(req.session.token, req.params.id)
+    const company = res.locals.company = await getDitCompany(req.session.token, req.params.id)
     companyService.getCommonTitlesAndlinks(req, res, company)
     res.locals.companyDetails = companyFormattingService.getDisplayCompany(company)
     res.locals.companyDetailsDisplayOrder = companyWithCHKeys
@@ -56,7 +56,7 @@ function editCommon (req, res, next) {
 
 async function addDetails (req, res, next) {
   try {
-    res.locals.chCompany = await companyRepository.getCHCompany(req.session.token, req.params.company_number)
+    res.locals.chCompany = await getCHCompany(req.session.token, req.params.company_number)
     res.locals.chDetails = companyFormattingService.getDisplayCH(res.locals.chCompany)
 
     if (containsFormData(req)) {
@@ -80,7 +80,7 @@ async function editDetails (req, res, next) {
       res.locals.formData = req.body
       res.breadcrumb('Edit company')
     } else {
-      const company = await companyRepository.getDitCompany(req.session.token, req.params.id)
+      const company = await getDitCompany(req.session.token, req.params.id)
       res.locals.formData = companyFormService.getLtdCompanyAsFormData(company)
       res.breadcrumb(company.name, `/viewcompanyresult/${company.id}`)
       res.breadcrumb('Edit')

--- a/src/apps/companies/controllers/ukother.js
+++ b/src/apps/companies/controllers/ukother.js
@@ -1,6 +1,6 @@
 const { get } = require('lodash')
 
-const companyRepository = require('../repos')
+const { getDitCompany } = require('../repos')
 const companyFormService = require('../services/form')
 const companyService = require('../services/data')
 const companyFormattingService = require('../services/formatting')
@@ -12,7 +12,7 @@ const companyWithoutCHKeys = ['business_type', 'registered_address', 'trading_na
 async function getDetails (req, res, next) {
   try {
     res.locals.tab = 'details'
-    const company = res.locals.company = await companyService.getInflatedDitCompany(req.session.token, req.params.id)
+    const company = res.locals.company = await getDitCompany(req.session.token, req.params.id)
     companyService.getCommonTitlesAndlinks(req, res, company)
     res.locals.companyDetails = companyFormattingService.getDisplayCompany(company)
     res.locals.companyDetailsDisplayOrder = companyWithoutCHKeys
@@ -63,7 +63,7 @@ function addDetails (req, res, next) {
 
 async function editDetails (req, res, next) {
   try {
-    const company = await companyRepository.getDitCompany(req.session.token, req.params.id)
+    const company = await getDitCompany(req.session.token, req.params.id)
     if (containsFormData(req)) {
       res.locals.formData = req.body
     } else {

--- a/src/apps/companies/services/data.js
+++ b/src/apps/companies/services/data.js
@@ -1,13 +1,6 @@
 /* eslint camelcase: 0 */
 const { get } = require('lodash')
-const companyRepository = require('../repos')
 const { getFormattedAddress } = require('../../../lib/address')
-
-// Todo - No longer needed, follow up PR to switch all uses to getDitCompany
-async function getInflatedDitCompany (token, id) {
-  const company = await companyRepository.getDitCompany(token, id)
-  return company
-}
 
 /**
  * Pass an API formatted company record in and return a path to view that company depending on company type
@@ -64,7 +57,6 @@ function getCommonTitlesAndlinks (req, res, company) {
 }
 
 module.exports = {
-  getInflatedDitCompany,
   buildCompanyUrl,
   getCommonTitlesAndlinks,
   getHeadingAddress,

--- a/src/apps/investment-projects/repos.js
+++ b/src/apps/investment-projects/repos.js
@@ -1,6 +1,6 @@
 const config = require('../../../config')
 const authorisedRequest = require('../../lib/authorised-request')
-const { getInflatedDitCompany } = require('../companies/services/data')
+const { getDitCompany } = require('../companies/repos')
 
 function getCompanyInvestmentProjects (token, companyId, page = 1) {
   const limit = 10
@@ -22,7 +22,7 @@ function updateInvestment (token, investmentId, body) {
 
 function getEquityCompanyDetails (token, equityCompanyId) {
   const promises = [
-    getInflatedDitCompany(token, equityCompanyId),
+    getDitCompany(token, equityCompanyId),
     getCompanyInvestmentProjects(token, equityCompanyId),
   ]
 

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,13 +1,13 @@
 const { get } = require('lodash')
 
 const logger = require('../../../config/logger')
-const { getInflatedDitCompany } = require('../companies/services/data')
+const { getDitCompany } = require('../companies/repos')
 const { setHomeBreadcrumb } = require('../middleware')
 const { Order } = require('./models')
 
 async function getCompany (req, res, next, companyId) {
   try {
-    res.locals.company = await getInflatedDitCompany(req.session.token, companyId)
+    res.locals.company = await getDitCompany(req.session.token, companyId)
     next()
   } catch (error) {
     next(error)

--- a/test/unit/apps/companies/controllers/ch.test.js
+++ b/test/unit/apps/companies/controllers/ch.test.js
@@ -3,7 +3,7 @@ const next = function (error) {
 }
 
 describe('Company controller, Companies House', function () {
-  let getInflatedDitCompanyStub
+  let getDitCompanyStub
   let getCHCompanyStub
   let getDisplayCHStub
   let getDisplayCompanyStub
@@ -36,7 +36,7 @@ describe('Company controller, Companies House', function () {
   }
 
   beforeEach(function () {
-    getInflatedDitCompanyStub = sinon.stub().resolves({ company_number: '1234' })
+    getDitCompanyStub = sinon.stub().resolves({ company_number: '1234' })
     getDisplayCHStub = sinon.stub().returns({ company_number: '1234' })
     getDisplayCompanyStub = sinon.stub().returns({ company_number: '1234' })
     getCHCompanyStub = sinon.stub().resolves(chCompany)
@@ -44,9 +44,6 @@ describe('Company controller, Companies House', function () {
     this.breadcrumbStub = function () { return this }
 
     companyControllerCh = proxyquire('~/src/apps/companies/controllers/ch', {
-      '../services/data': {
-        getInflatedDitCompany: getInflatedDitCompanyStub,
-      },
       '../services/formatting': {
         getDisplayCompany: getDisplayCompanyStub,
         getDisplayCH: getDisplayCHStub,
@@ -55,6 +52,7 @@ describe('Company controller, Companies House', function () {
       },
       '../repos': {
         getCHCompany: getCHCompanyStub,
+        getDitCompany: getDitCompanyStub,
       },
     })
   })

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -200,8 +200,10 @@ describe('Company contacts controller', function () {
 
       companyContactController = proxyquire('~/src/apps/companies/controllers/contacts', {
         '../services/data': {
-          getInflatedDitCompany: sinon.stub().resolves(company),
           getCommonTitlesAndLinks: sinon.stub(),
+        },
+        '../repos': {
+          getDitCompany: sinon.stub().resolves(company),
         },
       })
 

--- a/test/unit/apps/companies/controllers/exp.test.js
+++ b/test/unit/apps/companies/controllers/exp.test.js
@@ -13,7 +13,6 @@ describe('Company export controller', () => {
     this.next = function (error) {
       console.log(error)
     }
-    this.getInflatedDitCompany = this.sandbox.stub().resolves(this.company)
     this.getDitCompany = this.sandbox.stub().resolves(this.company)
     this.saveCompany = this.sandbox.stub().resolves(this.company)
     this.flattenIdFields = this.sandbox.spy(controllerUtils, 'flattenIdFields')
@@ -22,7 +21,6 @@ describe('Company export controller', () => {
 
     this.companyExportController = proxyquire('~/src/apps/companies/controllers/exp', {
       '../services/data': {
-        getInflatedDitCompany: this.getInflatedDitCompany,
         getCommonTitlesAndlinks: this.getCommonTitlesAndlinks,
       },
       '../repos': {
@@ -85,7 +83,7 @@ describe('Company export controller', () => {
 
       return this.companyExportController.common(req, res)
         .then(() => {
-          expect(this.getInflatedDitCompany).to.be.calledWith('1234', this.company.id)
+          expect(this.getDitCompany).to.be.calledWith('1234', this.company.id)
           expect(res.locals.company).to.deep.equal(this.company)
         })
     })
@@ -139,11 +137,8 @@ describe('Company export controller', () => {
     it('should return empty strings when no value', (done) => {
       this.company.export_to_countries = []
       this.companyExportController = proxyquire('~/src/apps/companies/controllers/exp', {
-        '../services/data': {
-          getInflatedDitCompany: this.getInflatedDitCompany,
-        },
-        '../../../lib/metadata': {
-          getDitcompany: this.getDitCompany,
+        '../repos': {
+          getDitCompany: this.getDitCompany,
           saveCompany: this.saveCompany,
         },
         '../../../../lib/controller-utils': {
@@ -169,6 +164,8 @@ describe('Company export controller', () => {
           done()
         },
       }
+
+      this.next = function (error) { console.log(error) }
 
       this.companyExportController.view(req, res, this.next)
     })
@@ -374,9 +371,6 @@ describe('Company export controller', () => {
     it('should handle when saving throws error', (done) => {
       const error = new Error('error')
       this.companyExportController = proxyquire('~/src/apps/companies/controllers/exp', {
-        '../services/data': {
-          getInflatedDitCompany: this.getInflatedDitCompany,
-        },
         '../repos': {
           getDitCompany: this.getDitCompany,
           saveCompany: this.saveCompany,

--- a/test/unit/apps/companies/controllers/foreign.test.js
+++ b/test/unit/apps/companies/controllers/foreign.test.js
@@ -6,7 +6,6 @@ const next = function (error) {
 }
 
 describe('Company controller, foreign', function () {
-  let getInflatedDitCompanyStub
   let getCHCompanyStub
   let getDitCompanyStub
   let getDisplayCHStub
@@ -49,7 +48,6 @@ describe('Company controller, foreign', function () {
       registered_address_postcode: 'PR1 0LS',
     }
     fakeCompanyForm = { id: '999', sector: 10 }
-    getInflatedDitCompanyStub = sinon.stub().resolves(company)
     getDisplayCHStub = sinon.stub().returns({ company_number: '1234' })
     getDisplayCompanyStub = sinon.stub().returns({ company_number: '1234' })
     getCHCompanyStub = sinon.stub().resolves(null)
@@ -60,9 +58,6 @@ describe('Company controller, foreign', function () {
     breadcrumbStub = function () { return this }
 
     companyControllerForeign = proxyquire('~/src/apps/companies/controllers/foreign', {
-      '../services/data': {
-        getInflatedDitCompany: getInflatedDitCompanyStub,
-      },
       '../services/formatting': {
         getDisplayCompany: getDisplayCompanyStub,
         getDisplayCH: getDisplayCHStub,
@@ -92,7 +87,7 @@ describe('Company controller, foreign', function () {
         locals: {},
         breadcrumb: breadcrumbStub,
         render: function () {
-          expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
+          expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
         },
       }, next)
@@ -531,9 +526,6 @@ describe('Company controller, foreign', function () {
       })
 
       companyControllerForeign = proxyquire('~/src/apps/companies/controllers/foreign', {
-        '../services/data': {
-          getInflatedDitCompany: getInflatedDitCompanyStub,
-        },
         '../services/formatting': {
           getDisplayCompany: getDisplayCompanyStub,
           getDisplayCH: getDisplayCHStub,

--- a/test/unit/apps/companies/controllers/investments.test.js
+++ b/test/unit/apps/companies/controllers/investments.test.js
@@ -18,7 +18,7 @@ describe('Company investments controller', function () {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
 
-    this.getInflatedDitCompanyStub = this.sandbox.stub().resolves(company)
+    this.getDitCompanyStub = this.sandbox.stub().resolves(company)
     this.getCompanyInvestmentProjectsStub = this.sandbox.stub().resolves(investmentProjects)
     this.getCommonTitlesAndlinksStub = this.sandbox.stub()
     this.nextStub = this.sandbox.stub()
@@ -26,11 +26,13 @@ describe('Company investments controller', function () {
 
     this.controller = proxyquire('~/src/apps/companies/controllers/investments', {
       '../services/data': {
-        getInflatedDitCompany: this.getInflatedDitCompanyStub,
         getCommonTitlesAndlinks: this.getCommonTitlesAndlinksStub,
       },
       '../../investment-projects/repos': {
         getCompanyInvestmentProjects: this.getCompanyInvestmentProjectsStub,
+      },
+      '../repos': {
+        getDitCompany: this.getDitCompanyStub,
       },
     })
   })
@@ -55,7 +57,7 @@ describe('Company investments controller', function () {
           breadcrumb: this.breadcrumbStub,
           render: (template, data) => {
             try {
-              expect(this.getInflatedDitCompanyStub).to.be.calledWith(token, company.id)
+              expect(this.getDitCompanyStub).to.be.calledWith(token, company.id)
               expect(this.getCompanyInvestmentProjectsStub).to.be.calledWith(token, company.id)
               expect(this.getCommonTitlesAndlinksStub).to.be.calledWith(reqStub, resStub, company)
 
@@ -87,7 +89,7 @@ describe('Company investments controller', function () {
 
     describe('when a company is not found', () => {
       beforeEach(() => {
-        this.getInflatedDitCompanyStub.rejects(new Error('Company not found'))
+        this.getDitCompanyStub.rejects(new Error('Company not found'))
       })
 
       it('should call the next function', (done) => {

--- a/test/unit/apps/companies/controllers/ltd.test.js
+++ b/test/unit/apps/companies/controllers/ltd.test.js
@@ -7,7 +7,6 @@ const next = function (error) {
 }
 
 describe('Company controller, ltd', function () {
-  let getInflatedDitCompanyStub
   let getCHCompanyStub
   let getDitCompanyStub
   let getDisplayCHStub
@@ -69,7 +68,6 @@ describe('Company controller, ltd', function () {
 
   beforeEach(function () {
     fakeCompanyForm = { id: '999', sector: 10 }
-    getInflatedDitCompanyStub = sinon.stub().resolves(company)
     getDisplayCHStub = sinon.stub().returns({ company_number: '1234' })
     getDisplayCompanyStub = sinon.stub().returns({ company_number: '1234' })
     getCHCompanyStub = sinon.stub().resolves(chCompany)
@@ -82,9 +80,6 @@ describe('Company controller, ltd', function () {
     this.breadcrumbStub = function () { return this }
 
     companyControllerLtd = proxyquire('~/src/apps/companies/controllers/ltd', {
-      '../services/data': {
-        getInflatedDitCompany: getInflatedDitCompanyStub,
-      },
       '../services/formatting': {
         getDisplayCompany: getDisplayCompanyStub,
         getDisplayCH: getDisplayCHStub,
@@ -115,7 +110,7 @@ describe('Company controller, ltd', function () {
         locals: {},
         breadcrumb: this.breadcrumbStub,
         render: function () {
-          expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
+          expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
         },
       }, next)
@@ -579,9 +574,6 @@ describe('Company controller, ltd', function () {
       })
 
       companyControllerLtd = proxyquire('~/src/apps/companies/controllers/ltd', {
-        '../services/data': {
-          getInflatedDitCompany: getInflatedDitCompanyStub,
-        },
         '../services/formatting': {
           getDisplayCompany: getDisplayCompanyStub,
           getDisplayCH: getDisplayCHStub,

--- a/test/unit/apps/companies/controllers/ukother.test.js
+++ b/test/unit/apps/companies/controllers/ukother.test.js
@@ -6,7 +6,6 @@ const next = function (error) {
 }
 
 describe('Company controller, uk other', function () {
-  let getInflatedDitCompanyStub
   let getCHCompanyStub
   let getDitCompanyStub
   let getDisplayCHStub
@@ -53,7 +52,6 @@ describe('Company controller, uk other', function () {
       registered_address_postcode: 'PR1 0LS',
     }
     fakeCompanyForm = { id: '999', sector: 10 }
-    getInflatedDitCompanyStub = sinon.stub().resolves(company)
     getDisplayCHStub = sinon.stub().returns({ company_number: '1234' })
     getDisplayCompanyStub = sinon.stub().returns({ company_number: '1234' })
     getCHCompanyStub = sinon.stub().resolves(null)
@@ -63,9 +61,6 @@ describe('Company controller, uk other', function () {
     flashStub = sinon.stub()
 
     companyControllerUkOther = proxyquire('~/src/apps/companies/controllers/ukother', {
-      '../services/data': {
-        getInflatedDitCompany: getInflatedDitCompanyStub,
-      },
       '../services/formatting': {
         getDisplayCompany: getDisplayCompanyStub,
         getDisplayCH: getDisplayCHStub,
@@ -95,7 +90,7 @@ describe('Company controller, uk other', function () {
         locals: {},
         breadcrumb: breadcrumbStub,
         render: function () {
-          expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
+          expect(getDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
         },
       }, next)
@@ -551,9 +546,6 @@ describe('Company controller, uk other', function () {
       })
 
       companyControllerUkOther = proxyquire('~/src/apps/companies/controllers/ukother', {
-        '../services/data': {
-          getInflatedDitCompany: getInflatedDitCompanyStub,
-        },
         '../services/formatting': {
           getDisplayCompany: getDisplayCompanyStub,
           getDisplayCH: getDisplayCHStub,

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -9,7 +9,7 @@ describe('OMIS middleware', () => {
 
     this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
     this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
-    this.getInflatedDitCompanyStub = this.sandbox.stub()
+    this.getDitCompanyStub = this.sandbox.stub()
     this.getByIdStub = this.sandbox.stub()
     this.getSubscribersStub = this.sandbox.stub()
     this.getAssigneesStub = this.sandbox.stub()
@@ -26,8 +26,8 @@ describe('OMIS middleware', () => {
     }
 
     this.middleware = proxyquire('~/src/apps/omis/middleware', {
-      '../companies/services/data': {
-        getInflatedDitCompany: this.getInflatedDitCompanyStub,
+      '../companies/repos': {
+        getDitCompany: this.getDitCompanyStub,
       },
       '../../../config/logger': {
         error: this.loggerSpy,
@@ -56,13 +56,13 @@ describe('OMIS middleware', () => {
 
     context('when get company resolves', () => {
       beforeEach(() => {
-        this.getInflatedDitCompanyStub.resolves(companyData)
+        this.getDitCompanyStub.resolves(companyData)
       })
 
-      it('should call getInflatedDitCompany() with correct arguments', async () => {
+      it('should call getDitCompany() with correct arguments', async () => {
         await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
 
-        expect(this.getInflatedDitCompanyStub).to.have.been.calledWith(this.reqMock.session.token, this.companyId)
+        expect(this.getDitCompanyStub).to.have.been.calledWith(this.reqMock.session.token, this.companyId)
       })
 
       it('should set a company property on locals', async () => {
@@ -84,7 +84,7 @@ describe('OMIS middleware', () => {
         this.error = {
           statusCode: 404,
         }
-        this.getInflatedDitCompanyStub.rejects(this.error)
+        this.getDitCompanyStub.rejects(this.error)
       })
 
       it('should call next with an error', async () => {


### PR DESCRIPTION
getInflatedDitCompany was being used throughout the code, and should not have been, it was only designed for the old version of the company pages as it was expanding interactions and combining service deliveries for the interactions screen, this resulted in a high number calls to the back end that wasn't needed.