### PR TITLE
Answers summary macro

### DIFF
--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -7,36 +7,36 @@
     buttonText: 'Create order'
   }) %}
 
-    <table class="c-answers-summary">
-      <caption class="c-answers-summary__heading">Client</caption>
-      <tr>
-        <th class="c-answers-summary__title" scope="row">Company</th>
-        <td class="c-answers-summary__content" colspan="2">{{ values.company.name }}</td>
-      </tr>
-      <tr>
-        <th class="c-answers-summary__title" scope="row">Contact</th>
-        <td class="c-answers-summary__content">{{ values.contact }}</td>
-        <td class="c-answers-summary__control"><a class="button button-secondary" href="client-details/edit">Change</a></td>
-      </tr>
-    </table>
+    {{ AnswersSummary({
+      heading: 'Client details',
+      actions: [{
+        url: 'client-details/edit'
+      }],
+      items: [{
+        label: 'Company',
+        value: values.company.name
+      }, {
+        label: 'Contact',
+        value: values.contact
+      }]
+    }) }}
 
-    <table class="c-answers-summary">
-      <caption class="c-answers-summary__heading">Market of interest</caption>
-      <tr>
-        <th class="c-answers-summary__title" scope="row">Primary market</th>
-        <td class="c-answers-summary__content">{{ values.primary_market.name }}</td>
-        <td class="c-answers-summary__control"><a class="button button-secondary" href="market/edit">Change</a></td>
-      </tr>
-    </table>
+    {{ AnswersSummary({
+      heading: 'Market (country)',
+      actions: [{
+        url: 'market/edit'
+      }],
+      items: [values.primary_market.name]
+    }) }}
 
-    <table class="c-answers-summary">
-      <caption class="c-answers-summary__heading">International Trade Advisers (ITAs)</caption>
-      <tr>
-        <th class="c-answers-summary__title" scope="row">Advisers</th>
-        <td class="c-answers-summary__content">{{ values.subscribers | join(", ") if values.subscribers.length else 'Not added at this stage' }}</td>
-        <td class="c-answers-summary__control"><a class="button button-secondary" href="subscribers/edit">Change</a></td>
-      </tr>
-    </table>
+    {{ AnswersSummary({
+      heading: 'Advisers in the UK',
+      actions: [{
+        url: 'subscribers/edit',
+        label: 'Add or remove'
+      }],
+      items: values.subscribers if values.subscribers.length else ['Not added at this stage']
+    }) }}
 
     <p>Creating the order will notify the following people by email:</p>
 

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -7,40 +7,6 @@
   <a href="/contacts/{{ values.contact.id }}">{{ values.contact.name }}</a>
 {% endset %}
 
-{% macro AnswersSummary(props) %}
-  <table class="c-answers-summary">
-    <caption class="c-answers-summary__heading">
-      {{ props.heading }}
-      {% for action in props.actions %}
-        {% if action.url %}
-          <a class="c-answers-summary__heading-action" href="{{ action.url }}">
-            {{ action.text or 'Edit' }}
-          </a>
-        {% endif %}
-      {% endfor %}
-    </caption>
-
-    {% if caller %}
-      {{ caller() }}
-    {% else %}
-      {% for item in props.items %}
-        {% if not item.value and not item.label %}
-          <tr>
-            <td class="c-answers-summary__title" colspan="2">{{ item }}</td>
-          </tr>
-        {% else %}
-          {% if item.value %}
-            <tr>
-              <th class="c-answers-summary__title" scope="row">{{ item.label }}</th>
-              <td class="c-answers-summary__content">{{ item.value | safe }}</td>
-            </tr>
-          {% endif %}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
-  </table>
-{% endmacro %}
-
 {% block main_grid_right_column %}
   {% if not order.editable %}
     <div class="c-messages__item c-messages__item--info">
@@ -75,7 +41,7 @@
     heading: 'International Trade Advisers (ITAs)',
     actions: [{
       url: 'edit/subscribers' if order.editable,
-      text: 'Add or remove'
+      label: 'Add or remove'
     }],
     items: values.subscribers | map('name') if values.subscribers.length else ['None selected']
   }) }}
@@ -84,10 +50,10 @@
     heading: 'Post advisers',
     actions: [{
       url: 'edit/assignees' if order.editable,
-      text: 'Add or remove'
+      label: 'Add or remove'
     }, {
       url: 'edit/assignee-time' if values.assignees.length and order.editable,
-      text: 'Edit time'
+      label: 'Edit time'
     }]
   }) %}
     <tbody>

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -12,7 +12,7 @@
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
 {% from "_macros/common.njk" import LocalHeader with context %}
-{% from "_macros/common.njk" import Pagination, GlobalNav, LocalNav, Progress, FromNow %}
+{% from "_macros/common.njk" import Pagination, GlobalNav, LocalNav, Progress, FromNow, AnswersSummary %}
 {% from "_macros/collection.njk" import Collection, CollectionFilters %}
 {% from "_macros/entities.njk" import MetaList %}
 

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -191,3 +191,55 @@
     >{{ props.datetime | fromNow }}</time>
   {%- endif -%}
 {% endmacro %}
+
+{##
+ # Render answers summary table
+ #
+ # @param {object} props
+ # @param {object|string[]} props.items - array of ojects or strings to display in table body
+ # @param {string} props.items.value - item value
+ # @param {string} props.items.label - item label
+ # @param {string} [props.heading] - heading to use as caption for the table
+ # @param {object[]} [props.actions] - array of actions to display
+ # @param {string} [props.actions.url] - URL for the action
+ # @param {string} [props.actions.label=Edit] - Text for the action
+ # @param {caller} [caller()] - Alternative body to use
+ #
+ #}
+{% macro AnswersSummary(props) %}
+  {% if props.items %}
+    <table class="c-answers-summary">
+      {% if props.heading or props.actions.length %}
+        <caption class="c-answers-summary__heading">
+          {{ props.heading }}
+          {% for action in props.actions %}
+            {% if action.url %}
+              <a class="c-answers-summary__heading-action" href="{{ action.url }}">
+                {{ action.label or 'Edit' }}
+              </a>
+            {% endif %}
+          {% endfor %}
+        </caption>
+      {% endif %}
+
+      {% if caller %}
+        {{ caller() }}
+      {% else %}
+        {% for item in props.items %}
+          {% if not item.value and not item.label %}
+            <tr>
+              <td class="c-answers-summary__title" colspan="2">{{ item }}</td>
+            </tr>
+          {% else %}
+            {% if item.value %}
+              <tr>
+                <th class="c-answers-summary__title" scope="row">{{ item.label }}</th>
+                <td class="c-answers-summary__content">{{ item.value | safe }}</td>
+              </tr>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+    </table>
+  {% endif %}
+{% endmacro %}

--- a/test/unit/macros/answers-summary.test.js
+++ b/test/unit/macros/answers-summary.test.js
@@ -1,0 +1,159 @@
+const { getMacros } = require('~/test/unit/macro-helper')
+const commonMacros = getMacros('common')
+
+const items = [
+  { label: 'Foo', value: 'Bar' },
+  { label: 'Fizz', value: 'Buzz' },
+]
+
+describe('Answers Summary macro', () => {
+  context('invalid props', () => {
+    it('should not render if items object is not given', () => {
+      const component = commonMacros.renderToDom('AnswersSummary')
+      expect(component).to.be.null
+    })
+  })
+
+  context('minimum props', () => {
+    beforeEach(() => {
+      this.component = commonMacros.renderToDom('AnswersSummary', {
+        items,
+      })
+    })
+
+    it('should render list of items', () => {
+      const rows = this.component.querySelectorAll('tr')
+
+      expect(rows).to.have.lengthOf(2)
+      expect(rows[0].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Foo')
+      expect(rows[0].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Bar')
+      expect(rows[1].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Fizz')
+      expect(rows[1].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Buzz')
+    })
+
+    it('should not display a caption', () => {
+      expect(this.component.querySelector('caption')).to.be.null
+    })
+  })
+
+  context('customise component', () => {
+    context('with heading', () => {
+      it('should display heading element', () => {
+        const component = commonMacros.renderToDom('AnswersSummary', {
+          heading: 'Table heading',
+          items,
+        })
+
+        expect(component.querySelector('.c-answers-summary__heading').textContent.trim()).to.equal('Table heading')
+      })
+    })
+
+    context('with actions', () => {
+      beforeEach(() => {
+        this.component = commonMacros.renderToDom('AnswersSummary', {
+          actions: [{
+            url: '/edit',
+          }],
+          items,
+        })
+      })
+
+      it('should display summary heading', () => {
+        expect(this.component.querySelectorAll('.c-answers-summary__heading')).to.have.lengthOf(1)
+      })
+
+      it('should display action with default text', () => {
+        const action = this.component.querySelector('.c-answers-summary__heading-action')
+
+        expect(action.textContent.trim()).to.equal('Edit')
+        expect(action.getAttribute('href').trim()).to.equal('/edit')
+      })
+
+      context('with multiple actions', () => {
+        beforeEach(() => {
+          this.component = commonMacros.renderToDom('AnswersSummary', {
+            actions: [{
+              url: '/edit-1',
+            }, {
+              url: '/edit-2',
+            }, {
+              url: '/edit-3',
+            }],
+            items,
+          })
+        })
+
+        it('should render the correct amount', () => {
+          const actions = this.component.querySelectorAll('.c-answers-summary__heading-action')
+
+          expect(actions).to.have.lengthOf(3)
+        })
+      })
+
+      context('with custom label', () => {
+        beforeEach(() => {
+          this.component = commonMacros.renderToDom('AnswersSummary', {
+            actions: [{
+              url: '/edit',
+              label: 'Edit this item',
+            }],
+            items,
+          })
+        })
+
+        it('should render the correct amount', () => {
+          const action = this.component.querySelector('.c-answers-summary__heading-action')
+
+          expect(action.textContent.trim()).to.equal('Edit this item')
+        })
+      })
+
+      context('with no url', () => {
+        beforeEach(() => {
+          this.component = commonMacros.renderToDom('AnswersSummary', {
+            actions: [{
+              url: '/edit-1',
+            }, {
+              label: 'No url value',
+            }, {
+              url: '/edit-2',
+            }],
+            items,
+          })
+        })
+
+        it('should not render ', () => {
+          const actions = this.component.querySelectorAll('.c-answers-summary__heading-action')
+
+          expect(actions).to.have.lengthOf(2)
+          expect(actions[0].getAttribute('href')).to.equal('/edit-1')
+          expect(actions[1].getAttribute('href')).to.equal('/edit-2')
+        })
+      })
+    })
+  })
+
+  context('items as list of strings', () => {
+    beforeEach(() => {
+      this.component = commonMacros.renderToDom('AnswersSummary', {
+        items: ['Item one', 'Item two', 'Item three'],
+      })
+    })
+
+    it('should only render 1 column', () => {
+      const rows = this.component.querySelectorAll('tr')
+
+      expect(rows[0].querySelector('.c-answers-summary__content')).to.be.null
+      expect(rows[0].querySelector('.c-answers-summary__title').getAttribute('colspan')).to.equal('2')
+    })
+
+    it('should render all items', () => {
+      const rows = this.component.querySelectorAll('tr')
+
+      expect(rows).to.have.lengthOf(3)
+      expect(rows[0].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Item one')
+      expect(rows[1].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Item two')
+      expect(rows[2].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Item three')
+    })
+  })
+})


### PR DESCRIPTION
This change moves the summary macro used within the work order in to its own macro that can be shared across other views.

It then uses this shared macro for the OMIS create journey summary to keep consistency with the work order.

👀 [**DEMO**](http://datahub-beta2-pr-592.herokuapp.com/omis/create/dcdabbc9-1781-e411-8955-e4115bead28a) 👀 

## Create journey summary

### Before

![localhost_3001_omis_create_dcdabbc9-1781-e411-8955-e4115bead28a_confirm 1](https://user-images.githubusercontent.com/3327997/30424566-3e4b6078-993e-11e7-97da-0581bce39036.png)

### After

![localhost_3001_omis_create_dcdabbc9-1781-e411-8955-e4115bead28a_confirm](https://user-images.githubusercontent.com/3327997/30424553-356d3b7a-993e-11e7-99ce-61e36cee6c52.png)

## Work order summary

![localhost_3001_omis_389ef312-f6c7-4c41-8ed1-0e48ada0acb0_work-order](https://user-images.githubusercontent.com/3327997/30424619-6747ccdc-993e-11e7-8cbe-ec042aa1334c.png)
