### PR TITLE
Fix an OMIS edit controller so that it doesn't treat true as a date

### DIFF
--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -2,7 +2,9 @@ const {
   find,
   flatten,
   get,
+  isNull,
   isPlainObject,
+  isUndefined,
   map,
   mapValues,
   pick,
@@ -65,17 +67,22 @@ class EditController extends FormController {
     // combine order values and error values
     let combinedValues = Object.assign({}, orderValues, sessionValues, errorValues)
     // convert dates to default format
-    combinedValues = mapValues(combinedValues, (value) => {
-      const parsedDate = dateFns.parse(value)
-
-      if (value && dateFns.isValid(parsedDate)) {
-        return dateFns.format(parsedDate, longDateFormat)
+    combinedValues = mapValues(combinedValues, (value, key) => {
+      if (typeof value === 'string') {
+        const parsedDate = dateFns.parse(value.toString())
+        if (dateFns.isValid(parsedDate)) {
+          return dateFns.format(parsedDate, longDateFormat)
+        }
       }
 
       return value
     })
 
-    next(null, pickBy(combinedValues))
+    const filtered = pickBy(combinedValues, (value) => {
+      return !isUndefined(value) && !isNull(value)
+    })
+
+    next(null, filtered)
   }
 }
 

--- a/test/unit/apps/omis/controllers/edit.test.js
+++ b/test/unit/apps/omis/controllers/edit.test.js
@@ -340,6 +340,44 @@ describe('OMIS EditController', () => {
       })
     })
 
+    context('when a value contains a boolean', () => {
+      it('should return true', (done) => {
+        const resMock = {
+          locals: {
+            order: {
+              foo: true,
+            },
+          },
+        }
+        const nextMock = (e, values) => {
+          expect(values).to.deep.equal({
+            foo: true,
+          })
+          done()
+        }
+
+        this.controller.getValues(this.reqMock, resMock, nextMock)
+      })
+
+      it('should return false', (done) => {
+        const resMock = {
+          locals: {
+            order: {
+              foo: false,
+            },
+          },
+        }
+        const nextMock = (e, values) => {
+          expect(values).to.deep.equal({
+            foo: false,
+          })
+          done()
+        }
+
+        this.controller.getValues(this.reqMock, resMock, nextMock)
+      })
+    })
+
     context('when returning order keys', () => {
       context('when the value is a plain object', () => {
         it('should return the id property', (done) => {
@@ -436,6 +474,42 @@ describe('OMIS EditController', () => {
 
           this.controller.getValues(this.reqMock, resMock, nextMock)
         })
+      })
+    })
+
+    describe('filtering', () => {
+      it('should only filter null and undefined', (done) => {
+        const resMock = {
+          locals: {
+            order: {
+              false: false,
+              undefined: undefined,
+              null: null,
+              empty: '',
+            },
+          },
+        }
+        const reqMock = Object.assign({}, this.reqMock, {
+          form: {
+            options: {
+              fields: {
+                false: {},
+                undefined: {},
+                null: {},
+                empty: {},
+              },
+            },
+          },
+        })
+        const nextMock = (e, values) => {
+          expect(values).to.deep.equal({
+            false: false,
+            empty: '',
+          })
+          done()
+        }
+
+        this.controller.getValues(reqMock, resMock, nextMock)
       })
     })
   })


### PR DESCRIPTION
If true was passed to the datefns parse function it would treat it
as a date and therefore parse the value as a date.