### PR TITLE
DH-524 Set teams and related programmes before POST to API

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -2,7 +2,7 @@ const { eventFormConfig } = require('../macros')
 const { getAdvisers } = require('../../adviser/repos')
 const { transformObjectToOption } = require('../../transformers')
 const { buildFormWithState } = require('../../builders')
-const { get, castArray, compact } = require('lodash')
+const { get } = require('lodash')
 
 async function renderEventPage (req, res, next) {
   try {
@@ -29,14 +29,6 @@ async function renderEventPage (req, res, next) {
 }
 
 function postHandler (req, res, next) {
-  const setAddAnotherField = (value) => compact(castArray(value))
-  req.body.teams = setAddAnotherField(req.body.teams)
-  req.body.related_programmes = setAddAnotherField(req.body.related_programmes)
-
-  if (req.body.add_team || req.body.add_related_programme) {
-    return next()
-  }
-
   if (get(res.locals, 'form.errors')) {
     return next()
   }

--- a/src/apps/events/services/formatting.js
+++ b/src/apps/events/services/formatting.js
@@ -1,4 +1,4 @@
-const { mapValues, isPlainObject } = require('lodash')
+const { mapValues, isPlainObject, some, assign } = require('lodash')
 
 function transformToApi (body) {
   if (!isPlainObject(body)) { return }
@@ -33,17 +33,21 @@ function transformToApi (body) {
   })
 
   const setDate = (key) => {
-    formatted[key] = [
+    const dateParts = [
       body[`${key}_year`],
       body[`${key}_month`],
       body[`${key}_day`],
-    ].join('-')
+    ]
+
+    if (some(dateParts)) {
+      formatted[key] = dateParts.join('-')
+    }
   }
 
   setDate('start_date')
   setDate('end_date')
 
-  return Object.assign({}, formatted)
+  return assign({}, formatted)
 }
 
 module.exports = {

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -1,4 +1,4 @@
-const { find } = require('lodash')
+const { assign, find, set } = require('lodash')
 
 describe('Event edit controller', () => {
   const createEventsEditController = (getAdvisers) => {
@@ -34,10 +34,12 @@ describe('Event edit controller', () => {
         },
       },
       body: {},
+      flash: this.sandbox.spy(),
     }
     this.res = {
       breadcrumb: this.sandbox.stub().returnsThis(),
       render: this.sandbox.spy(),
+      redirect: this.sandbox.spy(),
     }
     this.next = this.sandbox.spy()
   })
@@ -104,9 +106,13 @@ describe('Event edit controller', () => {
     context('when there are event shared teams', () => {
       it('should prepopulate the event shared teams', async () => {
         const teams = [ 'team1', 'team2' ]
-        this.req.body.teams = teams
+        const req = assign({}, this.req, {
+          body: {
+            teams: teams,
+          },
+        })
 
-        await this.controller.renderEventPage(this.req, this.res, this.next)
+        await this.controller.renderEventPage(req, this.res, this.next)
 
         const eventForm = this.res.render.getCall(0).args[1].eventForm
         const actual = find(eventForm.children, { name: 'teams' }).value
@@ -118,9 +124,13 @@ describe('Event edit controller', () => {
     context('when there are event programmes', () => {
       it('should prepopulate the event programmes', async () => {
         const relatedProgrammes = [ 'programme1', 'programme2' ]
-        this.req.body.related_programmes = relatedProgrammes
+        const req = assign({}, this.req, {
+          body: {
+            related_programmes: relatedProgrammes,
+          },
+        })
 
-        await this.controller.renderEventPage(this.req, this.res, this.next)
+        await this.controller.renderEventPage(req, this.res, this.next)
 
         const eventForm = this.res.render.getCall(0).args[1].eventForm
         const actual = find(eventForm.children, { name: 'related_programmes' }).value
@@ -143,83 +153,54 @@ describe('Event edit controller', () => {
   })
 
   describe('#postHandler', () => {
-    context('when adding an event shared team for the first time', () => {
-      it('should set the event shared teams', () => {
-        const team = 'team1'
-        this.req.body.add_team = true
-        this.req.body.teams = team
+    context('when there are errors', () => {
+      beforeEach(() => {
+        set(this.res, 'locals.form.errors', [ 'error' ])
+      })
 
+      it('should not flash a success message', () => {
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body.teams
+        expect(this.req.flash).have.not.been.called
+      })
 
-        expect(actual).to.deep.equal([ team ])
+      it('should not redirect to the event', () => {
+        this.controller.postHandler(this.req, this.res, this.next)
+
+        expect(this.res.redirect).have.not.been.calledOnce
+      })
+
+      it('should call next', () => {
+        this.controller.postHandler(this.req, this.res, this.next)
+
+        expect(this.next).have.been.calledWith()
+        expect(this.next).have.been.calledOnce
       })
     })
 
-    context('when adding subsequent event shared teams', () => {
-      it('should add to the event shared teams', () => {
-        const teams = [ 'team1', 'team2' ]
-        this.req.body.add_team = true
-        this.req.body.teams = teams
-
-        this.controller.postHandler(this.req, this.res, this.next)
-
-        const actual = this.req.body.teams
-
-        expect(actual).to.deep.equal(teams)
+    context('when creating was successful', () => {
+      beforeEach(() => {
+        set(this.res, 'locals.resultId', 1)
       })
 
-      it('should not add empty values to the event programmes', () => {
-        this.req.body.add_team = true
-        this.req.body.teams = [ 'team1', 'team2' ]
-        this.req.body.related_programmes = [ 'programme1', '' ]
-
+      it('should flash a success message', () => {
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body.related_programmes
-
-        expect(actual).to.deep.equal([ 'programme1' ])
-      })
-    })
-
-    context('when adding an event programme for the first time', () => {
-      it('should set the event programmes', () => {
-        const relatedProgramme = 'programme1'
-        this.req.body.add_related_programme = true
-        this.req.body.related_programmes = relatedProgramme
-
-        this.controller.postHandler(this.req, this.res, this.next)
-
-        const actual = this.req.body.related_programmes
-
-        expect(actual).to.deep.equal([ relatedProgramme ])
-      })
-    })
-
-    context('when adding subsequent event programmes', () => {
-      it('should add to the event programmes', () => {
-        const relatedProgrammes = [ 'programme1', 'programme2' ]
-        this.req.body.add_team = true
-        this.req.body.related_programmes = relatedProgrammes
-
-        this.controller.postHandler(this.req, this.res, this.next)
-
-        const actual = this.req.body.related_programmes
-
-        expect(actual).to.deep.equal(relatedProgrammes)
+        expect(this.req.flash).have.been.calledWith('success', 'Event created')
+        expect(this.req.flash).have.been.calledOnce
       })
 
-      it('should not add empty values to the event shared teams', () => {
-        this.req.body.add_team = true
-        this.req.body.teams = [ 'team1', '' ]
-        this.req.body.related_programmes = [ 'programme1', 'programme2' ]
-
+      it('should redirect to the event', () => {
         this.controller.postHandler(this.req, this.res, this.next)
 
-        const actual = this.req.body.teams
+        expect(this.res.redirect).have.been.calledWith('/events/1/details')
+        expect(this.res.redirect).have.been.calledOnce
+      })
 
-        expect(actual).to.deep.equal([ 'team1' ])
+      it('should not call next', () => {
+        this.controller.postHandler(this.req, this.res, this.next)
+
+        expect(this.next).have.not.been.called
       })
     })
   })

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -1,10 +1,12 @@
 const eventData = require('../../../data/events/event.json')
+const { merge, assign } = require('lodash')
 
 describe('Event details middleware', () => {
   describe('#handleFormPost', () => {
     beforeEach(() => {
       this.sandbox = sinon.sandbox.create()
       this.createEventStub = this.sandbox.stub()
+      this.createEventStub.resolves({ id: '1' })
       this.middleware = proxyquire('~/src/apps/events/middleware/details', {
         '../repos': {
           createEvent: this.createEventStub,
@@ -22,6 +24,24 @@ describe('Event details middleware', () => {
         locals: {},
       }
       this.next = this.sandbox.spy()
+      this.expectedBody = {
+        name: 'name',
+        event_type: 'event_type',
+        start_date: '2018-01-01',
+        end_date: '2018-02-02',
+        location_type: 'location_type',
+        address_1: 'address 1',
+        address_2: 'address 2',
+        address_town: 'town',
+        address_county: 'county',
+        postcode: 'postcode',
+        address_country: 'country',
+        notes: 'notes',
+        lead_team: 'lead_team',
+        organiser: 'organiser',
+        related_programmes: [ 'programme1', 'programme2' ],
+        teams: [ 'team1', 'team2', 'lead_team' ],
+      }
     })
 
     afterEach(() => {
@@ -29,33 +49,10 @@ describe('Event details middleware', () => {
     })
 
     context('when all fields are valid', () => {
-      beforeEach(() => {
-        this.createEventStub.resolves({ id: '1' })
-      })
-
       it('should post to the API', async () => {
         await this.middleware.handleFormPost(this.req, this.res, this.next)
 
-        const expectedBody = {
-          name: 'name',
-          event_type: 'event_type',
-          start_date: '2018-01-01',
-          end_date: '2018-02-02',
-          location_type: 'location_type',
-          address_1: 'address 1',
-          address_2: 'address 2',
-          address_town: 'town',
-          address_county: 'county',
-          postcode: 'postcode',
-          address_country: 'country',
-          notes: 'notes',
-          lead_team: 'lead_team',
-          organiser: 'organiser',
-          related_programmes: [ 'programme1', 'programme2' ],
-          teams: [ 'team1', 'team2' ],
-        }
-
-        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, this.expectedBody)
         expect(this.createEventStub).to.have.been.calledOnce
       })
 
@@ -66,6 +63,166 @@ describe('Event details middleware', () => {
         const expectedResultId = '1'
 
         expect(actualResultId).to.equal(expectedResultId)
+      })
+    })
+
+    context('when start and end dates have not been entered', () => {
+      it('should not attempt to set start and end date', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            start_date_day: '',
+            start_date_month: '',
+            start_date_year: '',
+            end_date_day: '',
+            end_date_month: '',
+            end_date_year: '',
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        const expectedBody = assign({}, this.expectedBody, { start_date: undefined, end_date: undefined })
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+    })
+
+    context('when start and end dates have not been partially entered', () => {
+      it('should attempt to set start and end date', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            start_date_day: '01',
+            start_date_month: '',
+            start_date_year: '',
+            end_date_day: '02',
+            end_date_month: '',
+            end_date_year: '',
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        const expectedBody = assign({}, this.expectedBody, { start_date: '--01', end_date: '--02' })
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+    })
+
+    context('when selecting one event shared team', () => {
+      it('should set teams as an array', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            teams: 'team 1',
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        const expectedBody = assign({}, this.expectedBody, { teams: [ 'team 1', 'lead_team' ] })
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+
+      it('should not add empty values to the event shared teams', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            teams: [ 'team 1', '' ],
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        const expectedBody = assign({}, this.expectedBody, { teams: [ 'team 1', 'lead_team' ] })
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+    })
+
+    context('when adding another event shared team', () => {
+      it('should not POST to the API', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            add_team: true,
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        expect(this.createEventStub).to.not.have.been.called
+      })
+
+      it('should call next', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            add_team: true,
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        expect(this.next).to.have.been.calledOnce
+      })
+    })
+
+    context('when selecting one related programme', () => {
+      it('should set related programmes as an array', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            related_programmes: 'programme 1',
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        const expectedBody = assign({}, this.expectedBody, { related_programmes: [ 'programme 1' ] })
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+
+      it('should not add empty values to the event shared teams', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            related_programmes: [ 'programme 1', '' ],
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        const expectedBody = assign({}, this.expectedBody, { related_programmes: [ 'programme 1' ] })
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+    })
+
+    context('when adding another related programme', () => {
+      it('should not POST to the API', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            add_related_programme: true,
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        expect(this.createEventStub).to.not.have.been.called
+      })
+
+      it('should call next', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            add_related_programme: true,
+          },
+        })
+
+        await this.middleware.handleFormPost(req, this.res, this.next)
+
+        expect(this.next).to.have.been.calledOnce
       })
     })
 


### PR DESCRIPTION
This changes moves the setting of the `teams` and `related_programmes` to before POST to create event. If the user is attempting to add another then the POST will not happen.

In future PRs:
- Tidy up edit controller to be consistent with new patterns
- Check presentation of errors (fingers crossed this should just work)