### PR TITLE
Fix answers summary not being display when called with a caller

### DIFF
--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -207,7 +207,7 @@
  #
  #}
 {% macro AnswersSummary(props) %}
-  {% if props.items %}
+  {% if props.items or caller %}
     <table class="c-answers-summary">
       {% if props.heading or props.actions.length %}
         <caption class="c-answers-summary__heading">

--- a/test/unit/macros/answers-summary.test.js
+++ b/test/unit/macros/answers-summary.test.js
@@ -8,31 +8,55 @@ const items = [
 
 describe('Answers Summary macro', () => {
   context('invalid props', () => {
-    it('should not render if items object is not given', () => {
+    it('should not render if no items or caller is not provided', () => {
       const component = commonMacros.renderToDom('AnswersSummary')
       expect(component).to.be.null
     })
   })
 
   context('minimum props', () => {
-    beforeEach(() => {
-      this.component = commonMacros.renderToDom('AnswersSummary', {
-        items,
+    context('items prop', () => {
+      beforeEach(() => {
+        this.component = commonMacros.renderToDom('AnswersSummary', {
+          items,
+        })
+      })
+
+      it('should render list of items', () => {
+        const rows = this.component.querySelectorAll('tr')
+
+        expect(rows).to.have.lengthOf(2)
+        expect(rows[0].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Foo')
+        expect(rows[0].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Bar')
+        expect(rows[1].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Fizz')
+        expect(rows[1].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Buzz')
+      })
+
+      it('should not display a caption', () => {
+        expect(this.component.querySelector('caption')).to.be.null
       })
     })
 
-    it('should render list of items', () => {
-      const rows = this.component.querySelectorAll('tr')
+    context('caller', () => {
+      beforeEach(() => {
+        this.component = commonMacros.renderWithCallerToDom('AnswersSummary')(
+          `
+          <tbody>
+            <tr>
+              <th>Custom body</th>
+            </tr>
+          </tbody>
+          `
+        )
+      })
 
-      expect(rows).to.have.lengthOf(2)
-      expect(rows[0].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Foo')
-      expect(rows[0].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Bar')
-      expect(rows[1].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Fizz')
-      expect(rows[1].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Buzz')
-    })
+      it('should render list of items', () => {
+        expect(this.component.querySelector('tbody').textContent.trim()).to.equal('Custom body')
+      })
 
-    it('should not display a caption', () => {
-      expect(this.component.querySelector('caption')).to.be.null
+      it('should not display a caption', () => {
+        expect(this.component.querySelector('caption')).to.be.null
+      })
     })
   })
 


### PR DESCRIPTION
The answers summary macro was looking for props.items to exist
before displayed the component but as it can be called with a caller
it should also support that too.