### PR TITLE
DH-524 Save event

### DIFF
--- a/src/apps/events/controllers/details.js
+++ b/src/apps/events/controllers/details.js
@@ -1,0 +1,11 @@
+async function renderPage (req, res) {
+  res
+    .breadcrumb('Event details')
+    .render('events/views/details', {
+      title: 'Event details',
+    })
+}
+
+module.exports = {
+  renderPage,
+}

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -1,27 +1,31 @@
 const { eventFormConfig } = require('../macros')
 const { getAdvisers } = require('../../adviser/repos')
 const { transformObjectToOption } = require('../../transformers')
-const { buildFormWithState } = require('../../builders')
-const { get } = require('lodash')
+const { buildFormWithStateAndErrors } = require('../../builders')
+const { assign, get } = require('lodash')
 
 async function renderEventPage (req, res, next) {
   try {
     const advisersResponse = await getAdvisers(req.session.token)
     const advisers = advisersResponse.results.map(transformObjectToOption)
-    const eventForm = eventFormConfig(advisers)
     const emptyDate = { year: '', month: '', day: '' }
-    const body = Object.assign(req.body, {
+    const body = assign({}, req.body, {
       start_date: emptyDate,
       end_date: emptyDate,
       lead_team: get(req, 'session.user.dit_team.id', null),
     })
-    const eventFormWithState = buildFormWithState(eventForm, body)
+    const eventForm =
+      buildFormWithStateAndErrors(
+        eventFormConfig(advisers),
+        body,
+        get(res.locals, 'form.errors.messages')
+      )
 
     res
       .breadcrumb('Add event')
       .render('events/views/edit', {
         title: 'Add event',
-        eventForm: eventFormWithState,
+        eventForm,
       })
   } catch (e) {
     next(e)

--- a/src/apps/events/controllers/index.js
+++ b/src/apps/events/controllers/index.js
@@ -1,0 +1,7 @@
+const details = require('./details')
+const edit = require('./edit')
+
+module.exports = {
+  details,
+  edit,
+}

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -1,15 +1,11 @@
 const { transformToApi } = require('../services/formatting')
 const { createEvent } = require('../repos')
-const { includes, assign, castArray, compact } = require('lodash')
+const { assign, castArray, compact } = require('lodash')
 
 async function handleFormPost (req, res, next) {
   const castToArrayAndRemoveEmpty = (value) => compact(castArray(value))
   req.body.teams = castToArrayAndRemoveEmpty(req.body.teams)
   req.body.related_programmes = castToArrayAndRemoveEmpty(req.body.related_programmes)
-
-  if (!includes(req.body.teams, req.body.lead_team)) {
-    req.body.teams.push(req.body.lead_team)
-  }
 
   if (req.body.add_team || req.body.add_related_programme) {
     return next()

--- a/src/apps/events/middleware/index.js
+++ b/src/apps/events/middleware/index.js
@@ -1,0 +1,5 @@
+const detailsFormMiddleware = require('./details')
+
+module.exports = {
+  detailsFormMiddleware,
+}

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,9 +1,14 @@
 const router = require('express').Router()
 
-const { renderEventPage, postHandler } = require('./controllers/edit')
+const {
+  details,
+  edit,
+} = require('./controllers')
 
 router.route('/create')
   .get(renderEventPage)
   .post(postHandler, renderEventPage)
+router.route('/:id/details')
+  .get(details.renderPage)
 
 module.exports = router

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -4,11 +4,18 @@ const {
   details,
   edit,
 } = require('./controllers')
+const { detailsFormMiddleware } = require('./middleware')
 
 router.route('/create')
-  .get(renderEventPage)
-  .post(postHandler, renderEventPage)
-router.route('/:id/details')
-  .get(details.renderPage)
+  .get(
+    edit.renderEventPage,
+  )
+  .post(
+    detailsFormMiddleware.handleFormPost,
+    edit.postHandler,
+    edit.renderEventPage,
+  )
+
+router.get('/:id/details', details.renderPage)
 
 module.exports = router

--- a/src/apps/events/services/formatting.js
+++ b/src/apps/events/services/formatting.js
@@ -47,6 +47,8 @@ function transformToApi (body) {
   setDate('start_date')
   setDate('end_date')
 
+  formatted.teams.push(formatted.lead_team)
+  formatted.service = '1783ae93-b78f-e611-8c55-e4115bed50dc'
   return assign({}, formatted)
 }
 

--- a/src/apps/events/views/details.njk
+++ b/src/apps/events/views/details.njk
@@ -1,0 +1,7 @@
+{% extends "_layouts/two-column.njk" %}
+
+{% block main_grid_left_column %}{% endblock %}
+
+{% block main_grid_right_column %}
+
+{% endblock %}

--- a/test/unit/apps/events/controllers/details.test.js
+++ b/test/unit/apps/events/controllers/details.test.js
@@ -1,0 +1,41 @@
+describe('Event details controller', () => {
+  beforeEach(() => {
+    this.controller = require('~/src/apps/events/controllers/details')
+
+    this.sandbox = sinon.sandbox.create()
+
+    this.req = { }
+    this.res = {
+      breadcrumb: this.sandbox.stub().returnsThis(),
+      render: this.sandbox.spy(),
+    }
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#renderPage', () => {
+    it('should add a breadcrumb', async () => {
+      this.controller.renderPage(this.req, this.res)
+
+      expect(this.res.breadcrumb).to.be.calledWith('Event details')
+      expect(this.res.breadcrumb).to.have.been.calledOnce
+    })
+
+    it('should render the event details page', async () => {
+      await this.controller.renderPage(this.req, this.res)
+
+      expect(this.res.render).to.be.calledWith('events/views/details')
+      expect(this.res.render).to.have.been.calledOnce
+    })
+
+    it('should render the event details page with a title', async () => {
+      await this.controller.renderPage(this.req, this.res, this.next)
+
+      const actual = this.res.render.getCall(0).args[1].title
+
+      expect(actual).to.equal('Event details')
+    })
+  })
+})

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -139,7 +139,35 @@ describe('Event edit controller', () => {
       })
     })
 
-    context('when there is an error', () => {
+    context('when there are validation errors', () => {
+      it('should prepopulate the errors', async () => {
+        const messages = {
+          name: 'error 1',
+          start_date: 'error 2',
+        }
+        const res = assign({}, this.res, {
+          locals: {
+            form: {
+              errors: {
+                messages,
+              },
+            },
+          },
+        })
+
+        await this.controller.renderEventPage(this.req, res, this.next)
+
+        const actualErrors = this.res.render.getCall(0).args[1].eventForm.errors
+        const expectedErrors = {
+          summary: 'Please correct the following errors:',
+          messages,
+        }
+
+        expect(actualErrors).to.deep.equal(expectedErrors)
+      })
+    })
+
+    context('when there is an exception', () => {
       it('should return an error', async () => {
         const error = Error('error')
         const controller = createEventsEditController(sinon.stub().rejects(error))

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -16,7 +16,7 @@ describe('Event details middleware', () => {
         session: {
           token: 'abcd',
         },
-        body: eventData,
+        body: assign({}, eventData),
       }
       this.res = {
         breadcrumb: this.sandbox.stub().returnsThis(),
@@ -41,6 +41,7 @@ describe('Event details middleware', () => {
         organiser: 'organiser',
         related_programmes: [ 'programme1', 'programme2' ],
         teams: [ 'team1', 'team2', 'lead_team' ],
+        service: '1783ae93-b78f-e611-8c55-e4115bed50dc',
       }
     })
 


### PR DESCRIPTION
This is the final (hopefully!) PR for the saving of an event.

Included in this PR:
- Final changes to event transformation, based upon validation errors received from API
- Including errors when building the form
- Adding a basic view for viewing the event after save.

# Form with errors
<img width="911" alt="screen shot 2017-09-19 at 11 42 46" src="https://user-images.githubusercontent.com/1150417/30588762-e5dd7ba6-9d2f-11e7-8813-718d9199200a.png">

# On successful save
<img width="914" alt="screen shot 2017-09-19 at 11 43 38" src="https://user-images.githubusercontent.com/1150417/30588765-eca55f58-9d2f-11e7-8329-f8a6669db119.png">