### PR TITLE
OMIS Work order amends

### DIFF
--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -117,6 +117,10 @@
   }
 }
 
+.c-answers-summary__content--muted {
+  color: $grey-1;
+}
+
 .c-answers-summary__title--unstyled {
   border: 0;
 }

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -59,9 +59,10 @@ const filters = {
   omit,
   pick,
   mapValues,
-  isFunction,
   isArray,
+  isFunction,
   isNull,
+  isString,
   pluralise,
 
   assignCopy (...args) {

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -78,7 +78,7 @@
         </tr>
       {% else %}
         <tr>
-          <td class="c-answers-summary__content" colspan="3">None selected</td>
+          <td class="c-answers-summary__content c-answers-summary__content--muted" colspan="3">None added</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -100,7 +100,8 @@
       url: 'edit/subscribers' if order.editable,
       label: 'Add or remove'
     }],
-    items: values.subscribers | map('name') if values.subscribers.length else ['None selected']
+    items: values.subscribers | map('name') if values.subscribers.length,
+    fallbackText: 'None added'
   }) }}
 
   {{ AnswersSummary({
@@ -110,19 +111,24 @@
     }],
     items: [{
       label: 'Delivery date',
-      value: values.delivery_date | formatDate if values.delivery_date else 'Not set'
+      value: values.delivery_date | formatDate if values.delivery_date,
+      fallbackText: 'Not set'
     }, {
       label: 'Service type' | pluralise(values.service_types.length),
-      value: values.service_types | map('name') | join(', ') if values.service_types.length else 'None added'
+      value: values.service_types | map('name') | join(', ') if values.service_types.length,
+      fallbackText: 'None selected'
     }, {
       label: 'Sector',
-      value: values.sector.name or 'Not selected'
+      value: values.sector.name,
+      fallbackText: 'Not selected'
     }, {
       label: 'Description of the activity',
-      value: values.description or 'Not added'
+      value: values.description,
+      fallbackText: 'Not added'
     }, {
       label: 'Contacts not to approach',
-      value: values.contacts_not_to_approach or 'None added'
+      value: values.contacts_not_to_approach,
+      fallbackText: 'None added'
     }, {
       label: 'Existing representatives',
       value: values.existing_agents
@@ -153,13 +159,15 @@
     }],
     items: [{
       label: 'VAT category',
-      value: translate('fields.vat_status.options.' + values.vat_status) if values.vat_status else 'Not set'
+      value: translate('fields.vat_status.options.' + values.vat_status) if values.vat_status,
+      fallbackText: 'Not set'
     }, {
       label: 'VAT number',
       value: values.vat_number + ' (' + verifiedState + ')' if values.vat_number
     }, {
       label: 'Purchase Order (PO) number',
-      value: values.po_number or 'Not set'
+      value: values.po_number,
+      fallbackText: 'Not added'
     }]
   }) }}
 

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -122,7 +122,7 @@
       value: values.description or 'Not added'
     }, {
       label: 'Contacts not to approach',
-      value: values.contacts_not_to_approach
+      value: values.contacts_not_to_approach or 'None added'
     }, {
       label: 'Existing representatives',
       value: values.existing_agents

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -28,7 +28,7 @@
     },
     "delivery_date": {
       "label": "Delivery date of first activity",
-      "hint": "Try tomorrow, next month or 28/10/2017"
+      "hint": "Try next week, next month or 28/10/2017"
     },
     "contacts_not_to_approach": {
       "label": "Contacts not to approach"

--- a/src/templates/_macros/common.njk
+++ b/src/templates/_macros/common.njk
@@ -196,9 +196,11 @@
  # Render answers summary table
  #
  # @param {object} props
- # @param {object|string[]} props.items - array of ojects or strings to display in table body
+ # @param {object[]|string[]} props.items - array of ojects or strings to display in table body
  # @param {string} props.items.value - item value
  # @param {string} props.items.label - item label
+ # @param {string} [props.items.fallbackText] - fallback text if value is empty
+ # @param {string} [props.fallbackText] - component level fallback when items is a list of strings
  # @param {string} [props.heading] - heading to use as caption for the table
  # @param {object[]} [props.actions] - array of actions to display
  # @param {string} [props.actions.url] - URL for the action
@@ -207,7 +209,7 @@
  #
  #}
 {% macro AnswersSummary(props) %}
-  {% if props.items or caller %}
+  {% if props.items or props.fallbackText or caller %}
     <table class="c-answers-summary">
       {% if props.heading or props.actions.length %}
         <caption class="c-answers-summary__heading">
@@ -225,20 +227,30 @@
       {% if caller %}
         {{ caller() }}
       {% else %}
-        {% for item in props.items %}
-          {% if not item.value and not item.label %}
-            <tr>
-              <td class="c-answers-summary__title" colspan="2">{{ item }}</td>
-            </tr>
-          {% else %}
-            {% if item.value %}
+        <tbody>
+          {% for item in props.items %}
+            {% if item | isString %}
               <tr>
-                <th class="c-answers-summary__title" scope="row">{{ item.label }}</th>
-                <td class="c-answers-summary__content">{{ item.value | safe }}</td>
+                <td class="c-answers-summary__content" colspan="2">{{ item }}</td>
               </tr>
+            {% else %}
+              {% if item.value or item.fallbackText %}
+                <tr>
+                  <th class="c-answers-summary__title" scope="row">{{ item.label }}</th>
+                  <td class="c-answers-summary__content {{ 'c-answers-summary__content--muted' if not item.value }}">
+                    {{ item.value | safe if item.value else item.fallbackText }}
+                  </td>
+                </tr>
+              {% endif %}
             {% endif %}
-          {% endif %}
-        {% endfor %}
+          {% else %}
+            <tr>
+              <td class="c-answers-summary__content c-answers-summary__content--muted" colspan="2">
+                {{ props.fallbackText }}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
       {% endif %}
     </table>
   {% endif %}

--- a/test/unit/macros/common/answers-summary.test.js
+++ b/test/unit/macros/common/answers-summary.test.js
@@ -8,7 +8,7 @@ const items = [
 
 describe('Answers Summary macro', () => {
   context('invalid props', () => {
-    it('should not render if no items or caller is not provided', () => {
+    it('should not render if nothing is provided', () => {
       const component = commonMacros.renderToDom('AnswersSummary')
       expect(component).to.be.null
     })
@@ -50,12 +50,69 @@ describe('Answers Summary macro', () => {
         )
       })
 
-      it('should render list of items', () => {
+      it('should render row of items', () => {
         expect(this.component.querySelector('tbody').textContent.trim()).to.equal('Custom body')
       })
 
       it('should not display a caption', () => {
         expect(this.component.querySelector('caption')).to.be.null
+      })
+    })
+
+    context('fallback', () => {
+      beforeEach(() => {
+        this.component = commonMacros.renderToDom('AnswersSummary', {
+          fallbackText: 'Fallback text',
+        })
+      })
+
+      it('should render 1 row', () => {
+        const rows = this.component.querySelectorAll('tr')
+
+        expect(rows).to.have.lengthOf(1)
+      })
+
+      it('should render fallback row', () => {
+        const rowContent = this.component.querySelector('.c-answers-summary__content').textContent.trim()
+
+        expect(rowContent).to.equal('Fallback text')
+      })
+
+      it('should render fallback with modifier class', () => {
+        const className = this.component.querySelector('.c-answers-summary__content').className
+
+        expect(className).to.contain('c-answers-summary__content--muted')
+      })
+
+      it('should not display a caption', () => {
+        expect(this.component.querySelector('caption')).to.be.null
+      })
+
+      context('with items', () => {
+        beforeEach(() => {
+          this.component = commonMacros.renderToDom('AnswersSummary', {
+            fallbackText: 'Fallback text',
+            items,
+          })
+        })
+
+        it('should render 2 rows', () => {
+          const rows = this.component.querySelectorAll('tr')
+
+          expect(rows).to.have.lengthOf(2)
+        })
+
+        it('should not render fallback row', () => {
+          const rows = this.component.querySelectorAll('tr')
+
+          expect(rows[0].querySelector('.c-answers-summary__content').textContent.trim()).not.to.equal('Fallback text')
+        })
+
+        it('should not contain modifier class', () => {
+          const className = this.component.querySelector('.c-answers-summary__content').className
+
+          expect(className).not.to.contain('c-answers-summary__content--muted')
+        })
       })
     })
   })
@@ -157,6 +214,37 @@ describe('Answers Summary macro', () => {
     })
   })
 
+  context('items with a fallback', () => {
+    beforeEach(() => {
+      this.component = commonMacros.renderToDom('AnswersSummary', {
+        items: [
+          { label: 'Foo', value: '', fallbackText: 'Fallback value' },
+          { label: 'Foo', value: '' },
+          { label: 'Fizz', value: 'Buzz' },
+        ],
+      })
+    })
+
+    it('should only render items with a value or feedback', () => {
+      const rows = this.component.querySelectorAll('tr')
+
+      expect(rows).to.have.lengthOf(2)
+    })
+
+    it('should render fallback text as value', () => {
+      const rows = this.component.querySelectorAll('tr')
+
+      expect(rows[0].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Foo')
+      expect(rows[0].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Fallback value')
+    })
+
+    it('should apply modifier class to fallback row', () => {
+      const className = this.component.querySelector('.c-answers-summary__content').className
+
+      expect(className).to.contain('c-answers-summary__content--muted')
+    })
+  })
+
   context('items as list of strings', () => {
     beforeEach(() => {
       this.component = commonMacros.renderToDom('AnswersSummary', {
@@ -167,17 +255,17 @@ describe('Answers Summary macro', () => {
     it('should only render 1 column', () => {
       const rows = this.component.querySelectorAll('tr')
 
-      expect(rows[0].querySelector('.c-answers-summary__content')).to.be.null
-      expect(rows[0].querySelector('.c-answers-summary__title').getAttribute('colspan')).to.equal('2')
+      expect(rows[0].querySelector('.c-answers-summary__title')).to.be.null
+      expect(rows[0].querySelector('.c-answers-summary__content').getAttribute('colspan')).to.equal('2')
     })
 
     it('should render all items', () => {
       const rows = this.component.querySelectorAll('tr')
 
       expect(rows).to.have.lengthOf(3)
-      expect(rows[0].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Item one')
-      expect(rows[1].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Item two')
-      expect(rows[2].querySelector('.c-answers-summary__title').textContent.trim()).to.equal('Item three')
+      expect(rows[0].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Item one')
+      expect(rows[1].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Item two')
+      expect(rows[2].querySelector('.c-answers-summary__content').textContent.trim()).to.equal('Item three')
     })
   })
 })


### PR DESCRIPTION
This amends one of the work description fields to always be displayed on the work order whether or not it has value and to use a fallback if it doesn't.

It also includes changes to how fallback text is output to allow the component to control it. This means it can have a different visual style applied to allow it to be distinguished from user generated content.

## Before

![localhost_3001_omis_10613433-3b9f-4e2d-9617-02769a84e876_work-order 1](https://user-images.githubusercontent.com/3327997/30596030-df04ab86-9d4a-11e7-8919-fefd73b812e9.png)

![localhost_3001_omis_10613433-3b9f-4e2d-9617-02769a84e876_work-order 3](https://user-images.githubusercontent.com/3327997/30596130-2b0ac308-9d4b-11e7-88d1-52aa2f7f25f1.png)

## After

![localhost_3001_omis_10613433-3b9f-4e2d-9617-02769a84e876_work-order](https://user-images.githubusercontent.com/3327997/30596008-cbef4dda-9d4a-11e7-89c5-ec4764463747.png)

![localhost_3001_omis_10613433-3b9f-4e2d-9617-02769a84e876_work-order 2](https://user-images.githubusercontent.com/3327997/30596112-1ebc1c32-9d4b-11e7-9d55-a9cad1e3a53a.png)
