### PR TITLE
OMIS edit return url support

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -22,6 +22,7 @@ class EditAssigneeHoursController extends EditController {
 
     try {
       await Order.saveAssignees(req.session.token, res.locals.order.id, filter(assignees))
+      const nextUrl = req.form.options.next || `/omis/${res.locals.order.id}`
 
       req.journeyModel.reset()
       req.journeyModel.destroy()
@@ -29,7 +30,7 @@ class EditAssigneeHoursController extends EditController {
       req.sessionModel.destroy()
 
       req.flash('success', 'Order updated')
-      res.redirect(`/omis/${res.locals.order.id}`)
+      res.redirect(nextUrl)
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -26,6 +26,7 @@ class EditAssigneesController extends EditController {
 
     try {
       await Order.forceSaveAssignees(req.session.token, res.locals.order.id, assignees)
+      const nextUrl = req.form.options.next || `/omis/${res.locals.order.id}`
 
       req.journeyModel.reset()
       req.journeyModel.destroy()
@@ -33,7 +34,7 @@ class EditAssigneesController extends EditController {
       req.sessionModel.destroy()
 
       req.flash('success', 'Order updated')
-      res.redirect(`/omis/${res.locals.order.id}`)
+      res.redirect(nextUrl)
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/apps/edit/controllers/subscribers.js
+++ b/src/apps/omis/apps/edit/controllers/subscribers.js
@@ -20,6 +20,7 @@ class EditSubscribersController extends EditController {
 
     try {
       await Order.saveSubscribers(req.session.token, res.locals.order.id, subscribers)
+      const nextUrl = req.form.options.next || `/omis/${res.locals.order.id}`
 
       req.journeyModel.reset()
       req.journeyModel.destroy()
@@ -27,7 +28,7 @@ class EditSubscribersController extends EditController {
       req.sessionModel.destroy()
 
       req.flash('success', 'Order updated')
-      res.redirect(`/omis/${res.locals.order.id}`)
+      res.redirect(nextUrl)
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/apps/edit/controllers/work-description.js
+++ b/src/apps/omis/apps/edit/controllers/work-description.js
@@ -27,7 +27,7 @@ class EditWorkDescriptionController extends EditController {
 
     req.form.options.fields.sector.options = metadataRepo.sectorOptions.map(transformObjectToOption)
     req.form.options.fields.service_types.options = filteredServiceTypes.map(transformObjectToOption)
-    next()
+    super.configure(req, res, next)
   }
 
   process (req, res, next) {

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -22,6 +22,7 @@ class EditController extends FormController {
 
     try {
       const order = await Order.update(req.session.token, res.locals.order.id, data)
+      const nextUrl = req.form.options.next || `/omis/${order.id}`
 
       req.journeyModel.reset()
       req.journeyModel.destroy()
@@ -29,7 +30,7 @@ class EditController extends FormController {
       req.sessionModel.destroy()
 
       req.flash('success', 'Order updated')
-      res.redirect(`/omis/${order.id}`)
+      res.redirect(nextUrl)
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/controllers/form.js
+++ b/src/apps/omis/controllers/form.js
@@ -9,6 +9,11 @@ class FormController extends Controller {
       res.breadcrumb(heading)
     }
 
+    if (req.query.returnUrl) {
+      req.form.options.backLink = req.query.returnUrl
+      req.form.options.next = req.query.returnUrl
+    }
+
     next()
   }
 

--- a/test/unit/apps/omis/controllers/edit.test.js
+++ b/test/unit/apps/omis/controllers/edit.test.js
@@ -137,6 +137,26 @@ describe('OMIS EditController', () => {
         this.controller.successHandler(this.reqMock, resMock, this.nextSpy)
       })
 
+      context('when next is set', () => {
+        it('should redirect back to returnUrl', (done) => {
+          const reqMock = Object.assign({}, this.reqMock)
+          const resMock = Object.assign({}, this.resMock, {
+            redirect: (url) => {
+              try {
+                expect(url).to.equal('/custom-return-url')
+                done()
+              } catch (error) {
+                done(error)
+              }
+            },
+          })
+
+          reqMock.form.options.next = '/custom-return-url'
+
+          this.controller.successHandler(reqMock, resMock, this.nextSpy)
+        })
+      })
+
       it('should not call the next method', (done) => {
         const resMock = Object.assign({}, this.resMock, {
           redirect: () => {

--- a/test/unit/apps/omis/controllers/form.test.js
+++ b/test/unit/apps/omis/controllers/form.test.js
@@ -36,6 +36,29 @@ describe('OMIS FormController', () => {
       })
     })
 
+    context('when a returnUrl query exists', () => {
+      beforeEach(() => {
+        this.returnUrl = '/custom-return-url'
+
+        this.reqMock = Object.assign({}, this.reqMock, {
+          query: {
+            returnUrl: this.returnUrl,
+          },
+        })
+        this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set backLink to the returnUrl value', () => {
+        expect(this.reqMock.form.options.backLink).to.equal(this.returnUrl)
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+
+      it('should set next to the returnUrl value', () => {
+        expect(this.reqMock.form.options.next).to.equal(this.returnUrl)
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
     context('when a step heading exists', () => {
       it('should set append a breadcrumb item', () => {
         this.reqMock.form.options.heading = 'Step heading'


### PR DESCRIPTION
This uses the `returnURL` query string param and sets the backLink and
next properties on the form options object so that they can be used
to change the destinations.