### PR TITLE
Break OMIS quote incomplete fields down into steps

### DIFF
--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -6,15 +6,19 @@
   {% if incompleteFields %}
     <ul class="c-messages">
       <li class="c-messages__item c-messages__item--error">
-        <p>To generate a quote you must enter the following work description information:</p>
+        <p>To generate a quote you must complete the following information:</p>
 
         <ul class="list-disc">
-          {% for field in incompleteFields %}
-            <li>{{ translate('fields.' + field + '.label') }}</li>
+          {% for stepUrl, stepData in incompleteFields %}
+            {% for field in stepData.errors %}
+              <li>
+                <a href="/omis/{{ order.id }}/edit{{ stepUrl }}?returnUrl=/omis/{{ order.id }}/quote#field-{{ field }}">
+                  {{ translate('errors.quote.' + field) }}
+                </a>
+              </li>
+            {% endfor %}
           {% endfor %}
         </ul>
-
-        <p><a href="/omis/{{ order.id }}/edit/work-description">Complete work description</a></p>
       </li>
     </ul>
   {% endif %}

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -65,6 +65,16 @@
       "label": "Purchase Order (PO) number"
     }
   },
+  "errors": {
+    "quote": {
+      "service_types": "Service types the order covers",
+      "description": "Description of the work or activity",
+      "delivery_date": "Delivery date at least 21 days from now",
+      "assignees": "At least one adviser in the market",
+      "assignee_time": "Some time allocated to an adviser in market",
+      "vat_status": "VAT category"
+    }
+  },
   "validation": {
     "required": "cannot not be blank",
     "numeric": "can only contain numbers",

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -32,6 +32,28 @@ describe('OMIS View middleware', () => {
           cancelQuote: this.cancelQuoteStub,
         },
       },
+      '../edit/steps': {
+        '/one': {
+          heading: 'Step one',
+          fields: [
+            'service_types',
+          ],
+        },
+        '/two': {
+          heading: 'Step two',
+          fields: [
+            'foo',
+            'bar',
+          ],
+        },
+        '/three': {
+          heading: 'Step three',
+          fields: [
+            'description',
+          ],
+        },
+        '@noCallThru': true,
+      },
     })
   })
 
@@ -197,10 +219,20 @@ describe('OMIS View middleware', () => {
         await this.middleware.getQuote(this.reqMock, this.resMock, this.nextSpy)
 
         expect(this.resMock.locals).to.have.property('incompleteFields')
-        expect(this.resMock.locals.incompleteFields).to.deep.equal([
-          'service_types',
-          'description',
-        ])
+        expect(this.resMock.locals.incompleteFields).to.deep.equal({
+          '/one': {
+            heading: 'Step one',
+            errors: [
+              'service_types',
+            ],
+          },
+          '/three': {
+            heading: 'Step three',
+            errors: [
+              'description',
+            ],
+          },
+        })
       })
 
       it('should return next without error', async () => {


### PR DESCRIPTION
New errors that are coming back from the API don't all sit on the same edit url now so they need to be broken down into separate steps and handled individually.

## Before

![localhost_3001_omis_10613433-3b9f-4e2d-9617-02769a84e876_quote 1](https://user-images.githubusercontent.com/3327997/30603677-2ad2dbcc-9d60-11e7-818e-ae5b639487c1.png)

## After

![localhost_3001_omis_10613433-3b9f-4e2d-9617-02769a84e876_quote](https://user-images.githubusercontent.com/3327997/30603660-1c881e10-9d60-11e7-8046-462f60db9222.png)
