### PR TITLE
Rename events controller and middleware functions

### DIFF
--- a/src/apps/events/controllers/details.js
+++ b/src/apps/events/controllers/details.js
@@ -1,4 +1,4 @@
-async function renderPage (req, res) {
+async function renderDetailsPage (req, res) {
   res
     .breadcrumb('Event details')
     .render('events/views/details', {
@@ -7,5 +7,5 @@ async function renderPage (req, res) {
 }
 
 module.exports = {
-  renderPage,
+  renderDetailsPage,
 }

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -4,7 +4,7 @@ const { transformObjectToOption } = require('../../transformers')
 const { buildFormWithStateAndErrors } = require('../../builders')
 const { assign, get } = require('lodash')
 
-async function renderEventPage (req, res, next) {
+async function renderEditPage (req, res, next) {
   try {
     const advisersResponse = await getAdvisers(req.session.token)
     const advisers = advisersResponse.results.map(transformObjectToOption)
@@ -32,7 +32,7 @@ async function renderEventPage (req, res, next) {
   }
 }
 
-function postHandler (req, res, next) {
+function redirectToDetails (req, res, next) {
   if (get(res.locals, 'form.errors')) {
     return next()
   }
@@ -42,6 +42,6 @@ function postHandler (req, res, next) {
 }
 
 module.exports = {
-  renderEventPage,
-  postHandler,
+  renderEditPage,
+  redirectToDetails,
 }

--- a/src/apps/events/controllers/index.js
+++ b/src/apps/events/controllers/index.js
@@ -1,7 +1,0 @@
-const details = require('./details')
-const edit = require('./edit')
-
-module.exports = {
-  details,
-  edit,
-}

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -2,7 +2,7 @@ const { transformToApi } = require('../services/formatting')
 const { createEvent } = require('../repos')
 const { assign, castArray, compact } = require('lodash')
 
-async function handleFormPost (req, res, next) {
+async function postDetails (req, res, next) {
   const castToArrayAndRemoveEmpty = (value) => compact(castArray(value))
   req.body.teams = castToArrayAndRemoveEmpty(req.body.teams)
   req.body.related_programmes = castToArrayAndRemoveEmpty(req.body.related_programmes)
@@ -35,5 +35,5 @@ async function handleFormPost (req, res, next) {
 }
 
 module.exports = {
-  handleFormPost,
+  postDetails,
 }

--- a/src/apps/events/middleware/index.js
+++ b/src/apps/events/middleware/index.js
@@ -1,5 +1,0 @@
-const detailsFormMiddleware = require('./details')
-
-module.exports = {
-  detailsFormMiddleware,
-}

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,21 +1,13 @@
 const router = require('express').Router()
 
-const {
-  details,
-  edit,
-} = require('./controllers')
-const { detailsFormMiddleware } = require('./middleware')
+const { renderDetailsPage } = require('./controllers/details')
+const { redirectToDetails, renderEditPage } = require('./controllers/edit')
+const { postDetails } = require('./middleware/details')
 
 router.route('/create')
-  .get(
-    edit.renderEventPage,
-  )
-  .post(
-    detailsFormMiddleware.handleFormPost,
-    edit.postHandler,
-    edit.renderEventPage,
-  )
+  .get(renderEditPage)
+  .post(postDetails, redirectToDetails, renderEditPage)
 
-router.get('/:id/details', details.renderPage)
+router.get('/:id/details', renderDetailsPage)
 
 module.exports = router

--- a/test/unit/apps/events/controllers/details.test.js
+++ b/test/unit/apps/events/controllers/details.test.js
@@ -15,23 +15,23 @@ describe('Event details controller', () => {
     this.sandbox.restore()
   })
 
-  describe('#renderPage', () => {
+  describe('#renderDetailsPage', () => {
     it('should add a breadcrumb', async () => {
-      this.controller.renderPage(this.req, this.res)
+      this.controller.renderDetailsPage(this.req, this.res)
 
       expect(this.res.breadcrumb).to.be.calledWith('Event details')
       expect(this.res.breadcrumb).to.have.been.calledOnce
     })
 
     it('should render the event details page', async () => {
-      await this.controller.renderPage(this.req, this.res)
+      await this.controller.renderDetailsPage(this.req, this.res)
 
       expect(this.res.render).to.be.calledWith('events/views/details')
       expect(this.res.render).to.have.been.calledOnce
     })
 
     it('should render the event details page with a title', async () => {
-      await this.controller.renderPage(this.req, this.res, this.next)
+      await this.controller.renderDetailsPage(this.req, this.res, this.next)
 
       const actual = this.res.render.getCall(0).args[1].title
 

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -48,23 +48,23 @@ describe('Event edit controller', () => {
     this.sandbox.restore()
   })
 
-  describe('#renderEventPage', () => {
+  describe('#renderEditPage', () => {
     it('should add a breadcrumb', async () => {
-      await this.controller.renderEventPage(this.req, this.res, this.next)
+      await this.controller.renderEditPage(this.req, this.res, this.next)
 
       expect(this.res.breadcrumb).to.be.calledWith('Add event')
       expect(this.res.breadcrumb).to.have.been.calledOnce
     })
 
     it('should render the event page', async () => {
-      await this.controller.renderEventPage(this.req, this.res, this.next)
+      await this.controller.renderEditPage(this.req, this.res, this.next)
 
       expect(this.res.render).to.be.calledWith('events/views/edit')
       expect(this.res.render).to.have.been.calledOnce
     })
 
     it('should render the event page with a title', async () => {
-      await this.controller.renderEventPage(this.req, this.res, this.next)
+      await this.controller.renderEditPage(this.req, this.res, this.next)
 
       const actual = this.res.render.getCall(0).args[1].title
 
@@ -72,7 +72,7 @@ describe('Event edit controller', () => {
     })
 
     it('should render the event page with an event form', async () => {
-      await this.controller.renderEventPage(this.req, this.res, this.next)
+      await this.controller.renderEditPage(this.req, this.res, this.next)
 
       const actual = this.res.render.getCall(0).args[1].eventForm
 
@@ -80,7 +80,7 @@ describe('Event edit controller', () => {
     })
 
     it('should populate the event form with organisers', async () => {
-      await this.controller.renderEventPage(this.req, this.res, this.next)
+      await this.controller.renderEditPage(this.req, this.res, this.next)
 
       const eventForm = this.res.render.getCall(0).args[1].eventForm
       const actual = find(eventForm.children, { name: 'organiser' }).options
@@ -94,7 +94,7 @@ describe('Event edit controller', () => {
     })
 
     it('should prepopulate the team hosting the event with the current user team', async () => {
-      await this.controller.renderEventPage(this.req, this.res, this.next)
+      await this.controller.renderEditPage(this.req, this.res, this.next)
 
       const eventForm = this.res.render.getCall(0).args[1].eventForm
       const actual = find(eventForm.children, { name: 'lead_team' }).value
@@ -112,7 +112,7 @@ describe('Event edit controller', () => {
           },
         })
 
-        await this.controller.renderEventPage(req, this.res, this.next)
+        await this.controller.renderEditPage(req, this.res, this.next)
 
         const eventForm = this.res.render.getCall(0).args[1].eventForm
         const actual = find(eventForm.children, { name: 'teams' }).value
@@ -130,7 +130,7 @@ describe('Event edit controller', () => {
           },
         })
 
-        await this.controller.renderEventPage(req, this.res, this.next)
+        await this.controller.renderEditPage(req, this.res, this.next)
 
         const eventForm = this.res.render.getCall(0).args[1].eventForm
         const actual = find(eventForm.children, { name: 'related_programmes' }).value
@@ -155,7 +155,7 @@ describe('Event edit controller', () => {
           },
         })
 
-        await this.controller.renderEventPage(this.req, res, this.next)
+        await this.controller.renderEditPage(this.req, res, this.next)
 
         const actualErrors = this.res.render.getCall(0).args[1].eventForm.errors
         const expectedErrors = {
@@ -172,7 +172,7 @@ describe('Event edit controller', () => {
         const error = Error('error')
         const controller = createEventsEditController(sinon.stub().rejects(error))
 
-        await controller.renderEventPage(this.req, this.res, this.next)
+        await controller.renderEditPage(this.req, this.res, this.next)
 
         expect(this.next).to.be.calledWith(sinon.match({ message: error.message }))
         expect(this.next).to.have.been.calledOnce
@@ -180,26 +180,26 @@ describe('Event edit controller', () => {
     })
   })
 
-  describe('#postHandler', () => {
+  describe('#redirectToDetails', () => {
     context('when there are errors', () => {
       beforeEach(() => {
         set(this.res, 'locals.form.errors', [ 'error' ])
       })
 
       it('should not flash a success message', () => {
-        this.controller.postHandler(this.req, this.res, this.next)
+        this.controller.redirectToDetails(this.req, this.res, this.next)
 
         expect(this.req.flash).have.not.been.called
       })
 
       it('should not redirect to the event', () => {
-        this.controller.postHandler(this.req, this.res, this.next)
+        this.controller.redirectToDetails(this.req, this.res, this.next)
 
         expect(this.res.redirect).have.not.been.calledOnce
       })
 
       it('should call next', () => {
-        this.controller.postHandler(this.req, this.res, this.next)
+        this.controller.redirectToDetails(this.req, this.res, this.next)
 
         expect(this.next).have.been.calledWith()
         expect(this.next).have.been.calledOnce
@@ -212,21 +212,21 @@ describe('Event edit controller', () => {
       })
 
       it('should flash a success message', () => {
-        this.controller.postHandler(this.req, this.res, this.next)
+        this.controller.redirectToDetails(this.req, this.res, this.next)
 
         expect(this.req.flash).have.been.calledWith('success', 'Event created')
         expect(this.req.flash).have.been.calledOnce
       })
 
       it('should redirect to the event', () => {
-        this.controller.postHandler(this.req, this.res, this.next)
+        this.controller.redirectToDetails(this.req, this.res, this.next)
 
         expect(this.res.redirect).have.been.calledWith('/events/1/details')
         expect(this.res.redirect).have.been.calledOnce
       })
 
       it('should not call next', () => {
-        this.controller.postHandler(this.req, this.res, this.next)
+        this.controller.redirectToDetails(this.req, this.res, this.next)
 
         expect(this.next).have.not.been.called
       })

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -51,14 +51,14 @@ describe('Event details middleware', () => {
 
     context('when all fields are valid', () => {
       it('should post to the API', async () => {
-        await this.middleware.handleFormPost(this.req, this.res, this.next)
+        await this.middleware.postDetails(this.req, this.res, this.next)
 
         expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, this.expectedBody)
         expect(this.createEventStub).to.have.been.calledOnce
       })
 
       it('should set the result ID', async () => {
-        await this.middleware.handleFormPost(this.req, this.res, this.next)
+        await this.middleware.postDetails(this.req, this.res, this.next)
 
         const actualResultId = this.res.locals.resultId
         const expectedResultId = '1'
@@ -80,7 +80,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         const expectedBody = assign({}, this.expectedBody, { start_date: undefined, end_date: undefined })
 
@@ -102,7 +102,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         const expectedBody = assign({}, this.expectedBody, { start_date: '--01', end_date: '--02' })
 
@@ -119,7 +119,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         const expectedBody = assign({}, this.expectedBody, { teams: [ 'team 1', 'lead_team' ] })
 
@@ -134,7 +134,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         const expectedBody = assign({}, this.expectedBody, { teams: [ 'team 1', 'lead_team' ] })
 
@@ -151,7 +151,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         expect(this.createEventStub).to.not.have.been.called
       })
@@ -163,7 +163,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         expect(this.next).to.have.been.calledOnce
       })
@@ -177,7 +177,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         const expectedBody = assign({}, this.expectedBody, { related_programmes: [ 'programme 1' ] })
 
@@ -192,7 +192,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         const expectedBody = assign({}, this.expectedBody, { related_programmes: [ 'programme 1' ] })
 
@@ -209,7 +209,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         expect(this.createEventStub).to.not.have.been.called
       })
@@ -221,7 +221,7 @@ describe('Event details middleware', () => {
           },
         })
 
-        await this.middleware.handleFormPost(req, this.res, this.next)
+        await this.middleware.postDetails(req, this.res, this.next)
 
         expect(this.next).to.have.been.calledOnce
       })
@@ -233,19 +233,19 @@ describe('Event details middleware', () => {
       })
 
       it('should set the state', async () => {
-        await this.middleware.handleFormPost(this.req, this.res, this.next)
+        await this.middleware.postDetails(this.req, this.res, this.next)
 
         expect(this.res.locals.form.state).to.deep.equal(this.req.body)
       })
 
       it('should set the errors', async () => {
-        await this.middleware.handleFormPost(this.req, this.res, this.next)
+        await this.middleware.postDetails(this.req, this.res, this.next)
 
         expect(this.res.locals.form.errors.messages).to.equal('error')
       })
 
       it('should not call next with errors', async () => {
-        await this.middleware.handleFormPost(this.req, this.res, this.next)
+        await this.middleware.postDetails(this.req, this.res, this.next)
 
         expect(this.next).have.been.calledWith()
         expect(this.next).have.been.calledOnce
@@ -258,13 +258,13 @@ describe('Event details middleware', () => {
       })
 
       it('should not set form', async () => {
-        await this.middleware.handleFormPost(this.req, this.res, this.next)
+        await this.middleware.postDetails(this.req, this.res, this.next)
 
         expect(this.res.locals.form).to.be.undefined
       })
 
       it('should call next with errors', async () => {
-        await this.middleware.handleFormPost(this.req, this.res, this.next)
+        await this.middleware.postDetails(this.req, this.res, this.next)
 
         expect(this.next).have.been.calledWith({ statusCode: 500, error: 'error' })
         expect(this.next).have.been.calledOnce


### PR DESCRIPTION
The events `router` was becoming difficult to read. This change aligns the naming with the contacts `router`.