### PR TITLE
Fix strong override

### DIFF
--- a/assets/stylesheets/_deprecated/_shame.scss
+++ b/assets/stylesheets/_deprecated/_shame.scss
@@ -106,3 +106,15 @@ select.form-control {
 fieldset.error {
   margin-bottom: 20px;
 }
+
+strong {
+  font-weight: 700;
+}
+
+.column-three-quarters {
+  @include grid-column(3 / 4);
+}
+
+.table--readonly {
+  border-left-width: 5px;
+}

--- a/assets/stylesheets/_deprecated/trade-elements.scss
+++ b/assets/stylesheets/_deprecated/trade-elements.scss
@@ -24,14 +24,6 @@ $asset-path: "../" !default;
 @import "../settings/layout";
 @import "../settings/colours";
 
-strong {
-  @include bold-font(20);
-}
-
-.column-three-quarters {
-  @include grid-column(3 / 4);
-}
-
 // Component styles
 @import "components/autocomplete";
 @import "components/backlink";

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -17,10 +17,6 @@ $images-dir: "/images/";
 @import "_deprecated/flash";
 @import "_deprecated/errors";
 @import "_deprecated/search";
-@import "_deprecated/shame";
 @import "_deprecated/splitheader";
 @import "_deprecated/tables";
-
-.table--readonly {
-  border-left-width: 5px;
-}
+@import "_deprecated/shame";


### PR DESCRIPTION
There is an override for the strong tag which dictates the font
size as well as the font weight. This can be problematic in other
areas so it has been switched to only override font-weight.

It has also been moved to the shame file so that we can address it as
part of that clean-up.