### PR TITLE
Fix bug with context in form wrappers

### DIFF
--- a/src/templates/_macros/form/entity-search-form.njk
+++ b/src/templates/_macros/form/entity-search-form.njk
@@ -1,4 +1,4 @@
-{% from "./form.njk" import Form %}
+{% from "./form.njk" import Form with context %}
 {% from "./text-field.njk" import TextField %}
 
 {##

--- a/src/templates/_macros/form/multi-step-form.njk
+++ b/src/templates/_macros/form/multi-step-form.njk
@@ -1,4 +1,4 @@
-{% from "./form.njk" import Form %}
+{% from "./form.njk" import Form with context %}
 
 {##
  # Render multi-step form


### PR DESCRIPTION
As various form flavours are split into separate files we need to pass context when importing `Form` macro from other macros.