### PR TITLE
Move the global nav outside of the main container

### DIFF
--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -62,7 +62,7 @@
   </nav>
 {% endblock %}
 
-{% block body_main_header %}
+{% block body_site_header %}
   {{ super() }}
 
   {% if user %}
@@ -70,6 +70,10 @@
       items: GLOBAL_NAV_ITEMS
     }) }}
   {% endif %}
+{% endblock %}
+
+{% block body_main_header %}
+  {{ super() }}
 
   {% block local_header %}
     {% set pageTitle = getPageTitle() %}


### PR DESCRIPTION
The global nav shouldn't sit within the main content area. This moves
it to outside in the DOM.