### PR TITLE
Fix adding companies house company

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/uktrade/data-hub-frontend"
   },
   "dependencies": {
+    "asyncro": "^2.0.1",
     "autoprefixer": "^7.1.1",
     "axios": "^0.16.2",
     "babel-core": "^6.23.1",

--- a/src/apps/companies/views/add-step-2.njk
+++ b/src/apps/companies/views/add-step-2.njk
@@ -16,56 +16,68 @@
     searchTerm: searchTerm,
     isLabelHidden: false,
     hiddenFields: {
-      business_type: businessType,
-      country: country
+      business_type: businessType
     },
     action: '/companies/add-step-2'
   }) }}
 
-  {% if companies %}
-    <ol class="results-list result-list--expandable">
-      {% for company in companies %}
-        <li class="results-list__result">
-          {% set isSelected = currentlySelected and (company.id == currentlySelected or company.company_number == currentlySelected) %}
+  {% if companies.results | length %}
+    <ol class="c-entity-list">
+      {% for company in companies.results %}
+        {% if company.company_number %}
+          {% set createLink = '/companies/add/ltd/' + company.company_number %}
+        {% else %}
+          {% set createLink = '/companies/edit/ltd/' + company.id %}
+        {% endif %}
 
-          {% if isSelected %}
-            <a class="open" href="/companies/add-step-2/?term={{ searchTerm }}&business_type={{ businessType }}&country={{ country }}">
-              <h3 class="result-title">{{company.name}}</h3>
-            </a>
-          {% else %}
-            <a class="closed" href="/companies/add-step-2/?term={{ searchTerm }}&business_type={{ businessType }}&country={{ country }}&selected={{ company.company_number if company.company_number else company.id }}">
-              <h3 class="result-title">{{ company.name }}</h3>
-            </a>
-          {% endif %}
+        <li class="c-entity-list__item">
+          <a href="{{ createLink }}" class="c-entity-list__link">
+            <h3 class="c-entity-list__item-header">{{ company.name | highlight(searchTerm) }}</h3>
 
-          {% if isSelected %}
-            <div class="panel panel-border-wide">
-                {{ keyvaluetable(
-                  displayDetails,
-                  labels=labels,
-                  keyorder=[
-                    'business_type',
-                    'company_status',
-                    'incorporation_date',
-                    'sic_code'
-                  ],
-                  class="table--small"
-                ) }}
+            {% if company.company_number %}
+              <dl class="metadata-list">
+                <dt class="metadata-list__term u-visually-hidden">Registered address</dt>
+                <dd class="metadata-list__value metadata-list__value--block">
+                  {% set comma = joiner() %}
+                  {% for part in [company.registered_address_1, company.registered_address_2, company.registered_address_town, company.registered_address_postcode] -%}
+                    {% if part -%}
+                      {%- set address = part -%}
 
-                {% if company.company_number %}
-                  {% set href = '/companies/add/ltd/' + company.company_number %}
-                  {% set label = 'Choose company' %}
-                {% else %}
-                  {% set href = '/companies/edit/ltd/' + company.id %}
-                  {% set label = 'Go to company record' %}
-                {% endif %}
+                      {{ comma() }}
+                      {% if loop.last -%}
+                        {{ address | upper }}
+                      {% else -%}
+                        {{ address | capitalize }}
+                      {%- endif %}
+                    {%- endif %}
+                  {%- endfor %}
+                </dd>
 
-                {% if company.company_number %}
-                  <div class="table_footnote">Data from <strong>Companies House</strong></div>
-                {% endif %}
-                <a class="button" href="{{ href }}">{{ label }}</a>
-            </div>
-          {% endif %}
+                <dt class="metadata-list__term">Company number</dt>
+                <dd class="metadata-list__value">{{ company.company_number }}</dd>
+
+                <dt class="metadata-list__term">Type</dt>
+                <dd class="metadata-list__value">{{ company.companies_house_data.company_category }}</dd>
+
+                <dt class="metadata-list__term">Status</dt>
+                <dd class="metadata-list__value">{{ company.companies_house_data.company_status }}</dd>
+
+                <dt class="metadata-list__term">Incorporated on</dt>
+                <dd class="metadata-list__value">{{ company.companies_house_data.incorporation_date | formatDate }}</dd>
+
+                <dt class="metadata-list__term">Nature of bussines (SIC)</dt>
+                <dd class="metadata-list__value">
+                  {% set codes = [company.companies_house_data.sic_code_1, company.companies_house_data.sic_code_2, company.companies_house_data.sic_code_3, company.companies_house_data.sic_code_4] | removeNilAndEmpty %}
+
+                  {{ codes | join(', ')}}
+                </dd>
+              </dl>
+
+              <p class="table_footnote">
+                Data from <strong>Companies House</strong>
+              </p>
+            {% endif %}
+          </a>
         </li>
       {% endfor %}
     </ol>

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -205,7 +205,6 @@ describe('Company add controller', function () {
         const req = {
           query: {
             business_type: 'ltd',
-            country: 'uk',
           },
           session: {},
         }
@@ -222,7 +221,6 @@ describe('Company add controller', function () {
         const req = {
           query: {
             business_type: 'ltd',
-            country: 'uk',
           },
           session: {},
         }
@@ -245,7 +243,6 @@ describe('Company add controller', function () {
         const req = {
           query: {
             business_type: 'ltd',
-            country: 'uk',
           },
           session: {},
         }
@@ -254,7 +251,6 @@ describe('Company add controller', function () {
           render: function (template, options) {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.businessType).to.equal('ltd')
-            expect(allOptions.country).to.equal('uk')
             done()
           },
         }
@@ -269,7 +265,6 @@ describe('Company add controller', function () {
           },
           query: {
             business_type: 'ltd',
-            country: 'uk',
             term: 'test',
           },
         }
@@ -289,17 +284,20 @@ describe('Company add controller', function () {
           },
           query: {
             business_type: 'ltd',
-            country: 'uk',
             term: 'test',
           },
         }
         const res = {
           locals: {},
           render: function (template, options) {
-            const allOptions = mergeLocals(res, options)
-            const company = allOptions.companies[0]
-            expect(company.name).to.equal('ACHME LIMITED')
-            done()
+            try {
+              const allOptions = mergeLocals(res, options)
+              const company = allOptions.companies.results[0]
+              expect(company.name).to.equal('ACHME LIMITED')
+              done()
+            } catch (error) {
+              done(error)
+            }
           },
         }
         companyAddController.getAddStepTwo(req, res, next)
@@ -311,7 +309,6 @@ describe('Company add controller', function () {
           },
           query: {
             business_type: 'ltd',
-            country: 'uk',
             term: 'test',
             selected: '',
           },
@@ -319,11 +316,14 @@ describe('Company add controller', function () {
         const res = {
           locals: {},
           render: function (template, options) {
-            const allOptions = mergeLocals(res, options)
-            expect(allOptions.businessType).to.equal('ltd')
-            expect(allOptions.country).to.equal('uk')
-            expect(allOptions.searchTerm).to.equal('test')
-            done()
+            try {
+              const allOptions = mergeLocals(res, options)
+              expect(allOptions.businessType).to.equal('ltd')
+              expect(allOptions.searchTerm).to.equal('test')
+              done()
+            } catch (error) {
+              done(error)
+            }
           },
         }
         companyAddController.getAddStepTwo(req, res, next)
@@ -335,7 +335,6 @@ describe('Company add controller', function () {
           },
           query: {
             business_type: 'ltd',
-            country: 'uk',
             term: 'test',
             selected: '9999',
           },
@@ -343,11 +342,14 @@ describe('Company add controller', function () {
         const res = {
           locals: {},
           render: function (template, options) {
-            const allOptions = mergeLocals(res, options)
-            expect(allOptions.businessType).to.equal('ltd')
-            expect(allOptions.country).to.equal('uk')
-            expect(allOptions.searchTerm).to.equal('test')
-            done()
+            try {
+              const allOptions = mergeLocals(res, options)
+              expect(allOptions.businessType).to.equal('ltd')
+              expect(allOptions.searchTerm).to.equal('test')
+              done()
+            } catch (error) {
+              done(error)
+            }
           },
         }
         companyAddController.getAddStepTwo(req, res, next)
@@ -361,7 +363,6 @@ describe('Company add controller', function () {
           },
           query: {
             business_type: 'ltd',
-            country: 'uk',
             term: 'test',
             selected: '08311441',
           },
@@ -370,49 +371,6 @@ describe('Company add controller', function () {
           locals: {},
           render: function (template, options) {
             expect(getCHCompanyStub).to.be.calledWith('1234', '08311441')
-            done()
-          },
-        }
-        companyAddController.getAddStepTwo(req, res, next)
-      })
-      it('should parse the CH details for display', function (done) {
-        const req = {
-          session: {
-            token: '1234',
-          },
-          query: {
-            business_type: 'ltd',
-            country: 'uk',
-            term: 'test',
-            selected: '08311441',
-          },
-        }
-        const res = {
-          locals: {},
-          render: function (template, options) {
-            expect(getDisplayCHStub).to.have.been.called
-            done()
-          },
-        }
-        companyAddController.getAddStepTwo(req, res, next)
-      })
-      it('should include labels and display order for the table', function (done) {
-        const req = {
-          session: {
-            token: '1234',
-          },
-          query: {
-            business_type: 'ltd',
-            country: 'uk',
-            term: 'test',
-            selected: '08311441',
-          },
-        }
-        const res = {
-          locals: {},
-          render: function (template, options) {
-            const allOptions = mergeLocals(res, options)
-            expect(allOptions.displayDetails).to.deep.equal(displayHouseCompany)
             done()
           },
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,6 +353,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+asyncro@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/asyncro/-/asyncro-2.0.1.tgz#441783c134d0e13588af894bd4f8d1c834630d5d"
+
 atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"


### PR DESCRIPTION
This was previously not working due to using a legacy way of moving to the next step. This refactor makes it more in line with the way companies are searched for when adding an investment project.

#### Out of scope of this PR

- **Style issues affecting results list** - This component needs some changes to prevent double border displaying but that's out of scope of this change
- **Change metadata list to new component** - This uses a legacy version of the metadata list that could be swapped for `c-meta-list` instead

## Before

![before](https://user-images.githubusercontent.com/3327997/30656976-ce9df098-9e2d-11e7-9e7e-a7816a9c2fbd.gif)

## After

![after](https://user-images.githubusercontent.com/3327997/30656978-d1def248-9e2d-11e7-90e9-e57a88e97ef9.gif)
