### PR TITLE
Add detail view to event sub app

### DIFF
--- a/src/apps/events/controllers/details.js
+++ b/src/apps/events/controllers/details.js
@@ -1,9 +1,20 @@
-async function renderDetailsPage (req, res) {
-  res
-    .breadcrumb('Event details')
-    .render('events/views/details', {
-      title: 'Event details',
-    })
+const { fetchEvent } = require('../repos')
+const { transformEventResponseToViewRecord } = require('../transformers')
+
+async function renderDetailsPage (req, res, next) {
+  try {
+    const event = await fetchEvent(req.session.token, req.params.id)
+    const eventViewRecord = transformEventResponseToViewRecord(event)
+
+    res
+      .breadcrumb(event.name)
+      .render('events/views/details', {
+        eventViewRecord,
+        eventId: req.params.id,
+      })
+  } catch (error) {
+    next(error)
+  }
 }
 
 module.exports = {

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -9,6 +9,11 @@ function createEvent (token, body) {
   })
 }
 
+function fetchEvent (token, id) {
+  return authorisedRequest(token, `${config.apiRoot}/v3/event/${id}`)
+}
+
 module.exports = {
   createEvent,
+  fetchEvent,
 }

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -22,6 +22,6 @@ router.route('/create')
   .get(renderEditPage)
   .post(postDetails, redirectToDetails, renderEditPage)
 
-router.get('/:id/details', renderDetailsPage)
+router.get('/:id', renderDetailsPage)
 
 module.exports = router

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -1,6 +1,8 @@
 /* eslint-disable camelcase */
 const { get } = require('lodash')
 
+const { getFormattedAddress } = require('../../lib/address')
+
 function transformEventToListItem ({
   id,
   name,
@@ -85,6 +87,72 @@ function transformEventToListItem ({
   return item
 }
 
+function transformEventResponseToViewRecord ({
+  event_type,
+  start_date,
+  end_date,
+  location_type,
+  address_1,
+  address_2,
+  address_town,
+  address_county,
+  address_postcode,
+  address_country,
+  uk_region,
+  notes,
+  lead_team,
+  organiser,
+  teams,
+  related_programmes,
+  service,
+}) {
+  teams = teams || []
+  related_programmes = related_programmes || []
+
+  const transformedEvent = {
+    'Type of event': event_type,
+  }
+
+  if (start_date === end_date) {
+    transformedEvent['Event date'] = {
+      type: 'date',
+      name: start_date,
+    }
+  } else {
+    transformedEvent['Event start date'] = {
+      type: 'date',
+      name: start_date,
+    }
+    transformedEvent['Event end date'] = {
+      type: 'date',
+      name: end_date,
+    }
+  }
+
+  return Object.assign(transformedEvent, {
+    'Event location type': location_type,
+    'Address': getFormattedAddress({
+      address_1,
+      address_2,
+      address_town,
+      address_county,
+      address_postcode,
+      address_country,
+    }),
+    'Region': uk_region,
+    'Notes': notes,
+    'Lead team': lead_team,
+    'Organiser': organiser,
+    'Other teams': teams
+      .filter(team => team.id !== lead_team.id)
+      .map(item => item.name),
+    'Related programmes': related_programmes
+      .map(item => item.name),
+    'Service': service,
+  })
+}
+
 module.exports = {
   transformEventToListItem,
+  transformEventResponseToViewRecord,
 }

--- a/src/apps/events/views/details.njk
+++ b/src/apps/events/views/details.njk
@@ -1,7 +1,6 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block main_grid_left_column %}{% endblock %}
-
 {% block main_grid_right_column %}
-
+  {% component 'key-value-table', variant='striped', items=eventViewRecord %}
+  <a class="button button-secondary" href="{{ eventId }}/edit">Edit Event</a>
 {% endblock %}

--- a/test/unit/apps/events/controllers/details.test.js
+++ b/test/unit/apps/events/controllers/details.test.js
@@ -1,41 +1,85 @@
+const eventData = require('~/test/unit/data/events/event-data')
+
 describe('Event details controller', () => {
   beforeEach(() => {
-    this.controller = require('~/src/apps/events/controllers/details')
-
+    this.transformedData = {}
     this.sandbox = sinon.sandbox.create()
 
-    this.req = { }
+    this.fetchEventStub = this.sandbox
+      .stub()
+      .withArgs('4321', '1234')
+      .resolves(eventData)
+
+    this.controller = proxyquire('~/src/apps/events/controllers/details', {
+      '../transformers': {
+        transformEventResponseToViewRecord: this.sandbox
+          .stub()
+          .withArgs(eventData)
+          .returns(this.transformedData),
+      },
+      '../repos': {
+        fetchEvent: this.fetchEventStub,
+      },
+    })
+
+    this.req = {
+      params: {
+        id: '1234',
+      },
+      session: {
+        token: '4321',
+      },
+    }
+
     this.res = {
       breadcrumb: this.sandbox.stub().returnsThis(),
       render: this.sandbox.spy(),
     }
+
+    this.next = this.sandbox.spy()
   })
 
   afterEach(() => {
     this.sandbox.restore()
   })
 
-  describe('#renderDetailsPage', () => {
-    it('should add a breadcrumb', async () => {
-      this.controller.renderDetailsPage(this.req, this.res)
+  describe('#renderDetailsPage', async () => {
+    context('when there are no errors', () => {
+      beforeEach(async () => {
+        await this.controller.renderDetailsPage(this.req, this.res, this.next)
+      })
 
-      expect(this.res.breadcrumb).to.be.calledWith('Event details')
-      expect(this.res.breadcrumb).to.have.been.calledOnce
+      it('should add a breadcrumb', () => {
+        expect(this.res.breadcrumb).to.be.calledWith(eventData.name)
+        expect(this.res.breadcrumb).to.have.been.calledOnce
+      })
+
+      it('should render the event details template', () => {
+        expect(this.res.render).to.be.calledWith('events/views/details')
+        expect(this.res.render).to.have.been.calledOnce
+      })
+
+      it('should return transformed events data', () => {
+        const options = this.res.render.firstCall.args[1]
+        expect(options.eventViewRecord).to.deep.equal(this.transformedData)
+      })
+
+      it('should return the event id', () => {
+        const options = this.res.render.firstCall.args[1]
+        expect(options.eventId).to.equal('1234')
+      })
     })
 
-    it('should render the event details page', async () => {
-      await this.controller.renderDetailsPage(this.req, this.res)
+    context('when there are errors fetching data', async () => {
+      beforeEach(async () => {
+        this.error = new Error()
+        this.fetchEventStub.rejects(this.error)
+        await this.controller.renderDetailsPage(this.req, this.res, this.next)
+      })
 
-      expect(this.res.render).to.be.calledWith('events/views/details')
-      expect(this.res.render).to.have.been.calledOnce
-    })
-
-    it('should render the event details page with a title', async () => {
-      await this.controller.renderDetailsPage(this.req, this.res, this.next)
-
-      const actual = this.res.render.getCall(0).args[1].title
-
-      expect(actual).to.equal('Event details')
+      it('should pass the error to the error page', () => {
+        expect(this.next).to.be.calledWith(this.error)
+      })
     })
   })
 })

--- a/test/unit/apps/events/transformers.test.js
+++ b/test/unit/apps/events/transformers.test.js
@@ -1,11 +1,14 @@
+/* eslint camelcase: 0 */
+
 const {
   transformEventToListItem,
+  transformEventResponseToViewRecord,
 } = require('~/src/apps/events/transformers')
 
 describe('Event transformers', function () {
-  describe('#transformEventToListItem', () => {
-    const mockEvent = require('~/test/unit/data/events/event-data')
+  const mockEvent = require('~/test/unit/data/events/event-data')
 
+  describe('#transformEventToListItem', () => {
     it('should return undefined when no arguments', () => {
       expect(transformEventToListItem({})).to.be.undefined
     })
@@ -43,12 +46,270 @@ describe('Event transformers', function () {
           { label: 'Type', value: 'Outward mission' },
           { label: 'Updated', type: 'datetime', value: '2017-09-19T15:20:26.834094' },
           { label: 'Begins', type: 'date', value: '2017-11-10' },
-          { label: 'Ends', type: 'date', value: '2017-11-10' },
+          { label: 'Ends', type: 'date', value: '2017-11-11' },
           { label: 'Organiser', value: 'Jeff Smith' },
           { label: 'Country', type: 'badge', value: 'United Kingdom' },
           { label: 'Lead team', value: 'Association of Cats' },
           { label: 'Region', type: 'badge', value: 'FDI Hub' },
         ])
+      })
+    })
+  })
+
+  describe('#transformEventToDisplayEvent', () => {
+    context('when all event fields are populated', () => {
+      beforeEach(() => {
+        this.transformedEvent = transformEventResponseToViewRecord(mockEvent)
+      })
+
+      it('should transform to a display event', () => {
+        expect(this.transformedEvent).to.deep.equal({
+          'Address': '1 Uk Street, The Lane, Plymouth, Devon, PL1 3FG, United Kingdom',
+          'Event end date': {
+            type: 'date',
+            name: '2017-11-11',
+          },
+          'Type of event': {
+            id: '6031f993-a689-49af-9a11-942a8413a779',
+            name: 'Outward mission',
+          },
+          'Lead team': {
+            id: '32f12898-9698-e211-a939-e4115bead28a',
+            name: 'Association of Cats',
+          },
+          'Event location type': {
+            id: 'cf45bf02-8ea7-4e53-af0e-b5676a30cb96',
+            name: 'Other',
+          },
+          'Notes': 'An example event for testing',
+          'Organiser': {
+            id: '0919a99e-9798-e211-a939-e4115bead28a',
+            first_name: 'Jeff',
+            last_name: 'Smith',
+            name: 'Jeff Smith',
+          },
+          'Related programmes': ['Example Programme'],
+          'Event start date': {
+            type: 'date',
+            name: '2017-11-10',
+          },
+          'Other teams': [],
+          'Region': {
+            id: '804cd12a-6095-e211-a939-e4115bead28a',
+            name: 'FDI Hub',
+          },
+          'Service': {
+            id: '9484b82b-3499-e211-a939-e4115bead28a',
+            name: 'Account Management',
+          },
+        })
+      })
+    })
+
+    context('when the event contains minimal data', () => {
+      beforeEach(() => {
+        const minimalEvent = require('~/test/unit/data/events/minimal-event.json')
+        this.transformedEvent = transformEventResponseToViewRecord(minimalEvent)
+      })
+
+      it('should transform to a display event', () => {
+        expect(this.transformedEvent).to.deep.equal({
+          'Address': '1 Uk Street, Plymouth, Devon, PL1 3FG, United Kingdom',
+          'Type of event': {
+            id: '6031f993-a689-49af-9a11-942a8413a779',
+            name: 'Outward mission',
+          },
+          'Lead team': null,
+          'Event location type': null,
+          'Notes': null,
+          'Organiser': null,
+          'Related programmes': [],
+          'Event date': {
+            type: 'date',
+            name: null,
+          },
+          'Other teams': [],
+          'Region': null,
+          'Service': null,
+        })
+      })
+    })
+
+    describe('date transformer', () => {
+      context('when start and end date are identical', () => {
+        beforeEach(() => {
+          const eventWithDates = Object.assign({}, mockEvent, {
+            start_date: '2017-11-11',
+            end_date: '2017-11-11',
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithDates)
+        })
+
+        it('should include a single date', () => {
+          expect(this.transformedEvent['Event date']).to.deep.equal({
+            type: 'date',
+            name: '2017-11-11',
+          })
+          expect(this.transformedEvent).to.not.have.property('Start date')
+          expect(this.transformedEvent).to.not.have.property('End date')
+        })
+      })
+
+      context('when there is only a start date', () => {
+        beforeEach(() => {
+          const eventWithNoEndDate = Object.assign({}, mockEvent, {
+            start_date: '2017-11-10',
+            end_date: null,
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithNoEndDate)
+        })
+
+        it('should format the start date', () => {
+          expect(this.transformedEvent['Event start date']).to.deep.equal({
+            type: 'date',
+            name: '2017-11-10',
+          })
+        })
+
+        it('should return a blank end date', () => {
+          expect(this.transformedEvent['Event end date']).to.deep.equal({
+            type: 'date',
+            name: null,
+          })
+        })
+      })
+
+      context('when there is only an end date', () => {
+        beforeEach(() => {
+          const eventWithNoStartDate = Object.assign({}, mockEvent, {
+            start_date: null,
+            end_date: '2017-11-11',
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithNoStartDate)
+        })
+
+        it('should format the end date', () => {
+          expect(this.transformedEvent['Event end date']).to.deep.equal({
+            type: 'date',
+            name: '2017-11-11',
+          })
+        })
+        it('should return a blank start date', () => {
+          expect(this.transformedEvent['Event start date']).to.deep.equal({
+            type: 'date',
+            name: null,
+          })
+        })
+      })
+    })
+
+    describe('team transformer', () => {
+      context('when there is only one team involved', () => {
+        beforeEach(() => {
+          const lead_team = {
+            id: '1',
+            name: 'Team 1',
+          }
+
+          const eventWithNoTeams = Object.assign({}, mockEvent, {
+            lead_team,
+            teams: [lead_team],
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithNoTeams)
+        })
+
+        it('should indicate there are no other teams', () => {
+          expect(this.transformedEvent['Other teams']).to.deep.equal([])
+        })
+      })
+
+      context('when there are two teams', () => {
+        beforeEach(() => {
+          const lead_team = {
+            id: '1',
+            name: 'Team 1',
+          }
+
+          const eventWithTwoTeams = Object.assign({}, mockEvent, {
+            lead_team,
+            teams: [lead_team, {
+              id: '2',
+              name: 'Team 2',
+            }],
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithTwoTeams)
+        })
+
+        it('should display the other team', () => {
+          expect(this.transformedEvent['Other teams']).to.deep.equal(['Team 2'])
+        })
+      })
+
+      context('when there is more than two teams', () => {
+        beforeEach(() => {
+          const lead_team = {
+            id: '1',
+            name: 'Team 1',
+          }
+
+          const eventWithThreeTeams = Object.assign({}, mockEvent, {
+            lead_team,
+            teams: [lead_team, {
+              id: '2',
+              name: 'Team 2',
+            }, {
+              id: '3',
+              name: 'Team 3',
+            }],
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithThreeTeams)
+        })
+
+        it('should include a list of other teams', () => {
+          expect(this.transformedEvent['Other teams']).to.deep.equal(['Team 2', 'Team 3'])
+        })
+      })
+    })
+
+    describe('programmes transformer', () => {
+      context('when there are no related programmes', () => {
+        beforeEach(() => {
+          const eventWithNoProgrammes = Object.assign({}, mockEvent, {
+            related_programmes: [],
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithNoProgrammes)
+        })
+
+        it('should indicate there are no related programmes', () => {
+          expect(this.transformedEvent['Related programmes']).to.deep.equal([])
+        })
+      })
+
+      context('when there are related programmes', () => {
+        beforeEach(() => {
+          const eventWithNoProgrammes = Object.assign({}, mockEvent, {
+            related_programmes: [{
+              id: '1',
+              name: 'Programme 1',
+            }, {
+              id: '2',
+              name: 'Programme 2',
+            }],
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithNoProgrammes)
+        })
+
+        it('should include the related programme', () => {
+          expect(this.transformedEvent['Related programmes']).to.deep.equal(['Programme 1', 'Programme 2'])
+        })
       })
     })
   })

--- a/test/unit/data/events/event-data.json
+++ b/test/unit/data/events/event-data.json
@@ -28,8 +28,8 @@
   },
   "teams": [
     {
-      "id": "574049e6-9698-e211-a939-e4115bead28a",
-      "name": "The cat collective"
+      "id": "32f12898-9698-e211-a939-e4115bead28a",
+      "name": "Association of Cats"
     }
   ],
   "related_programmes": [
@@ -46,7 +46,7 @@
   "modified_on": "2017-09-19T15:20:26.834094",
   "name": "A United Kingdom Get together",
   "start_date": "2017-11-10",
-  "end_date": null,
+  "end_date": "2017-11-11",
   "address_1": "1 uk street",
   "address_2": "the lane",
   "address_town": "plymouth",

--- a/test/unit/data/events/minimal-event.json
+++ b/test/unit/data/events/minimal-event.json
@@ -1,0 +1,29 @@
+{
+  "id": "31a9f8bd-7796-4af4-8f8c-25450860e2d1",
+  "event_type": {
+    "id": "6031f993-a689-49af-9a11-942a8413a779",
+    "name": "Outward mission"
+  },
+  "location_type": null,
+  "address_country": {
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+    "name": "United Kingdom"
+  },
+  "uk_region": null,
+  "organiser": null,
+  "lead_team": null,
+  "teams": [],
+  "related_programmes": [],
+  "service": null,
+  "created_on": "2017-09-19T15:20:26.834080",
+  "modified_on": "2017-09-19T15:20:26.834094",
+  "name": "A United Kingdom Get together",
+  "start_date": null,
+  "end_date": null,
+  "address_1": "1 uk street",
+  "address_2": "",
+  "address_town": "plymouth",
+  "address_county": "devon",
+  "address_postcode": "PL1 3FG",
+  "notes": null
+}


### PR DESCRIPTION
Adds the detail view to the events section to view an event.

![capture](https://user-images.githubusercontent.com/56056/30777600-faf586b2-a0b5-11e7-8938-4bf8e3bb8aec.PNG)
(updated capture to show almost fully populated and using updated component)

Transforms raw event data into the key/value style for viewing, with some simple modifications to handle dates and 'other teams'.

- [x] Refactor tests to use context
- [x] Switch to use component for key-value-table
- [x] Update key-value-table to support date type, and format it, e.g. 12 January 2017 (details have long dates compared to lists
- [x] Refine transformer to use ideas from Tyom and not format date
- [x] Expand parameters like collections transformers
