### PR TITLE
update glob to work with new folder structure for Acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           name: Split tests for parallelisation and run acceptance tests
           command: |
             # split .features for parallelisation
-            FEATURES="$(circleci tests glob "test/acceptance/features/*.feature" | circleci tests split --split-by=filesize)"
+            FEATURES="$(circleci tests glob "test/acceptance/features/**/*.feature" | circleci tests split --split-by=filesize)"
 
             # move groups of .features to folder
             mkdir -p test/acceptance/features_${CIRCLE_NODE_INDEX}


### PR DESCRIPTION
This work updates the features glob to match the new Acceptance tests folder layout. Confirmed as running as intended on [CircleCi](https://circleci.com/gh/uktrade/data-hub-frontend/5031)

## Box 1
<img width="783" alt="screen shot 2017-09-21 at 15 34 03" src="https://user-images.githubusercontent.com/2305016/30701568-8327f57c-9ee2-11e7-8486-e216620dce9f.png">

## Box 2
<img width="788" alt="screen shot 2017-09-21 at 15 34 19" src="https://user-images.githubusercontent.com/2305016/30701582-89963a54-9ee2-11e7-84df-10cb4b57b33f.png">

## Box 3
<img width="789" alt="screen shot 2017-09-21 at 15 34 27" src="https://user-images.githubusercontent.com/2305016/30701589-8dffde24-9ee2-11e7-8556-3a29edd97321.png">

## Box 4
<img width="784" alt="screen shot 2017-09-21 at 15 34 40" src="https://user-images.githubusercontent.com/2305016/30701597-9335ca34-9ee2-11e7-9dfe-b003fd360469.png">


