### PR TITLE
Copy props to FormGroup to avoid mutation

### DIFF
--- a/src/templates/_macros/form/text-field.njk
+++ b/src/templates/_macros/form/text-field.njk
@@ -23,9 +23,9 @@
 
   {% call FormGroup(props | assign({ fieldId: fieldId, modifier: props.modifier, class: props.groupClass })) %}
     {% if props.type === 'textarea' %}
-      {{ TextArea(props | assign({ class: props.inputClass })) }}
+      {{ TextArea(props | assignCopy({ class: props.inputClass })) }}
     {% else %}
-      {{ Input(props | assign({ class: props.inputClass })) }}
+      {{ Input(props | assignCopy({ class: props.inputClass })) }}
     {% endif %}
   {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
`props` passed to Input were affecting `FormGroup` as they were assigned on `props`.