### PR TITLE
rename the docker image used for running nightwatch tests on circleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           path: coverage
   acceptance_tests:
     docker:
-      - image: ukti/docker-nightwatch-base
+      - image: ukti/docker-selenium-base
         environment:
           TZ: "/usr/share/zoneinfo/Europe/London"
           REDIS_HOST: localhost

--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ You can tell `nightwatch.js` not to run a feature by adding the tag `@ignore`.
 Data hub uses [CircleCI](https://circleci.com/) for continuous integration. 
 
 ### Docker image
-The acceptance tests use the docker image `ukti/docker-nightwatch-base`. 
-Details can be found in the [GitHub](https://github.com/uktrade/docker-nightwatch-base) repo.
+The acceptance tests use the docker image `ukti/docker-selenium-base`. 
+Details can be found in the [GitHub](https://github.com/uktrade/docker-selenium-base) repo.
 
 ### Job failure
 CircleCI has been configured to show you a summary report of what has failed on the following workflows:


### PR DESCRIPTION
Rename the docker image to a more semantic name

Repos also updated:

[docker docker-selenium-base](https://hub.docker.com/r/ukti/docker-selenium-base)
[GitHub docker-selenium-base](https://github.com/uktrade/docker-selenium-base)