### PR TITLE
Refactor companies middleware

### DIFF
--- a/src/apps/companies/controllers/foreign.js
+++ b/src/apps/companies/controllers/foreign.js
@@ -4,7 +4,7 @@ const { getDitCompany } = require('../repos')
 const companyFormService = require('../services/form')
 const companyService = require('../services/data')
 const companyFormattingService = require('../services/formatting')
-const { companyDetailsLabels, accountManagementDisplayLabels, hqLabels } = require('../labels')
+const { companyDetailsLabels, accountManagementDisplayLabels } = require('../labels')
 const metadataRepository = require('../../../lib/metadata')
 const { containsFormData, isBlank } = require('../../../lib/controller-utils')
 const companyWithoutCHKeys = ['business_type', 'registered_address', 'trading_name', 'trading_address', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range']
@@ -31,18 +31,6 @@ async function getDetails (req, res, next) {
   } catch (error) {
     next(error)
   }
-}
-
-function editCommon (req, res, next) {
-  res.locals.regionOptions = metadataRepository.regionOptions
-  res.locals.sectorOptions = metadataRepository.sectorOptions
-  res.locals.employeeOptions = metadataRepository.employeeOptions
-  res.locals.turnoverOptions = metadataRepository.turnoverOptions
-  res.locals.headquarterOptions = metadataRepository.headquarterOptions
-  res.locals.companyDetailsLabels = companyDetailsLabels
-  res.locals.countryOptions = metadataRepository.countryOptions
-  res.locals.hqLabels = hqLabels
-  if (next) next()
 }
 
 function addDetails (req, res, next) {
@@ -116,5 +104,4 @@ module.exports = {
   editDetails,
   addDetails,
   postDetails,
-  editCommon,
 }

--- a/src/apps/companies/controllers/foreign.js
+++ b/src/apps/companies/controllers/foreign.js
@@ -99,8 +99,6 @@ function postDetails (req, res, next) {
           res.locals.errors = response.errors
         }
 
-        // re-edit the data
-        editCommon(req, res)
         if (req.params.id) {
           editDetails(req, res, next)
         } else {

--- a/src/apps/companies/controllers/foreign.js
+++ b/src/apps/companies/controllers/foreign.js
@@ -71,37 +71,8 @@ async function editDetails (req, res, next) {
   }
 }
 
-function postDetails (req, res, next) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const savedCompany = await companyFormService.saveCompanyForm(req.session.token, req.body)
-      req.flash('success', 'Company record updated')
-      res.redirect(`/companies/view/foreign/${savedCompany.id}`)
-    } catch (response) {
-      if (response.errors) {
-        // Leeloo has inconsistant structure to return errors.
-        // Get the errors and then re-render the edit page.
-        if (response.errors.errors) {
-          res.locals.errors = response.errors.errors
-        } else {
-          res.locals.errors = response.errors
-        }
-
-        if (req.params.id) {
-          editDetails(req, res, next)
-        } else {
-          addDetails(req, res, next)
-        }
-      } else {
-        next(response)
-      }
-    }
-  })
-}
-
 module.exports = {
   getDetails,
   editDetails,
   addDetails,
-  postDetails,
 }

--- a/src/apps/companies/controllers/ltd.js
+++ b/src/apps/companies/controllers/ltd.js
@@ -3,7 +3,7 @@ const companyFormService = require('../services/form')
 const companyFormattingService = require('../services/formatting')
 const { getDitCompany, getCHCompany } = require('../repos')
 const metadataRepository = require('../../../lib/metadata')
-const { companyDetailsLabels, chDetailsLabels, accountManagementDisplayLabels, hqLabels } = require('../labels')
+const { companyDetailsLabels, chDetailsLabels, accountManagementDisplayLabels } = require('../labels')
 const { containsFormData, isBlank } = require('../../../lib/controller-utils')
 const companyWithCHKeys = ['trading_name', 'trading_address', 'uk_region', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range']
 const chDetailsDisplayOrderLong = ['name', 'company_number', 'registered_address', 'business_type', 'company_status', 'incorporation_date', 'sic_code']
@@ -40,22 +40,6 @@ async function getDetails (req, res, next) {
   }
 }
 
-function editCommon (req, res, next) {
-  res.locals.chDetailsLabels = chDetailsLabels
-  res.locals.chDetailsDisplayOrder = chDetailsDisplayOrderLong
-
-  res.locals.regionOptions = metadataRepository.regionOptions
-  res.locals.sectorOptions = metadataRepository.sectorOptions
-  res.locals.employeeOptions = metadataRepository.employeeOptions
-  res.locals.turnoverOptions = metadataRepository.turnoverOptions
-  res.locals.headquarterOptions = metadataRepository.headquarterOptions
-  res.locals.companyDetailsLabels = companyDetailsLabels
-  res.locals.countryOptions = metadataRepository.countryOptions
-  res.locals.hqLabels = hqLabels
-
-  if (next) next()
-}
-
 async function addDetails (req, res, next) {
   try {
     res.locals.chCompany = await getCHCompany(req.session.token, req.params.company_number)
@@ -66,6 +50,8 @@ async function addDetails (req, res, next) {
     } else {
       res.locals.formData = companyFormService.getDefaultLtdFormForCH(res.locals.chCompany)
     }
+    res.locals.chDetailsLabels = chDetailsLabels
+    res.locals.chDetailsDisplayOrder = chDetailsDisplayOrderLong
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
     res.locals.businessTypeName = 'Limited company'
     res.locals.isCompaniesHouse = true
@@ -89,6 +75,8 @@ async function editDetails (req, res, next) {
       res.breadcrumb(company.name, `/viewcompanyresult/${company.id}`)
       res.breadcrumb('Edit')
     }
+    res.locals.chDetailsLabels = chDetailsLabels
+    res.locals.chDetailsDisplayOrder = chDetailsDisplayOrderLong
     res.locals.showTradingAddress = !isBlank(res.locals.formData.trading_address_country)
     res.locals.businessTypeName = 'Limited company'
     res.locals.isCompaniesHouse = true
@@ -98,40 +86,8 @@ async function editDetails (req, res, next) {
   }
 }
 
-function postDetails (req, res, next) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const savedCompany = await companyFormService.saveCompanyForm(req.session.token, req.body)
-      req.flash('success', 'Company record updated')
-      res.redirect(`/companies/view/ltd/${savedCompany.id}`)
-    } catch (response) {
-      if (response.errors) {
-        // Leeloo has inconsistant structure to return errors.
-        // Get the errors and then re-render the edit page.
-        if (response.errors.errors) {
-          res.locals.errors = response.errors.errors
-        } else {
-          res.locals.errors = response.errors
-        }
-
-        // re-edit the data
-        editCommon(req, res)
-        if (req.params.id) {
-          editDetails(req, res, next)
-        } else {
-          addDetails(req, res, next)
-        }
-      } else {
-        next(response)
-      }
-    }
-  })
-}
-
 module.exports = {
   getDetails,
   editDetails,
   addDetails,
-  postDetails,
-  editCommon,
 }

--- a/src/apps/companies/controllers/ukother.js
+++ b/src/apps/companies/controllers/ukother.js
@@ -4,7 +4,7 @@ const { getDitCompany } = require('../repos')
 const companyFormService = require('../services/form')
 const companyService = require('../services/data')
 const companyFormattingService = require('../services/formatting')
-const { companyDetailsLabels, accountManagementDisplayLabels, hqLabels } = require('../labels')
+const { companyDetailsLabels, accountManagementDisplayLabels } = require('../labels')
 const metadataRepository = require('../../../lib/metadata')
 const { containsFormData, isBlank } = require('../../../lib/controller-utils')
 const companyWithoutCHKeys = ['business_type', 'registered_address', 'trading_name', 'trading_address', 'uk_region', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range']
@@ -32,19 +32,6 @@ async function getDetails (req, res, next) {
   } catch (error) {
     next(error)
   }
-}
-
-function editCommon (req, res, next) {
-  res.locals.regionOptions = metadataRepository.regionOptions
-  res.locals.sectorOptions = metadataRepository.sectorOptions
-  res.locals.employeeOptions = metadataRepository.employeeOptions
-  res.locals.turnoverOptions = metadataRepository.turnoverOptions
-  res.locals.headquarterOptions = metadataRepository.headquarterOptions
-  res.locals.companyDetailsLabels = companyDetailsLabels
-  res.locals.countryOptions = metadataRepository.countryOptions
-  res.locals.hqLabels = hqLabels
-
-  if (next) next()
 }
 
 function addDetails (req, res, next) {
@@ -83,40 +70,8 @@ async function editDetails (req, res, next) {
   }
 }
 
-function postDetails (req, res, next) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const savedCompany = await companyFormService.saveCompanyForm(req.session.token, req.body)
-      req.flash('success', 'Company record updated')
-      res.redirect(`/companies/view/ukother/${savedCompany.id}`)
-    } catch (response) {
-      if (response.errors) {
-        // Leeloo has inconsistant structure to return errors.
-        // Get the errors and then re-render the edit page.
-        if (response.errors.errors) {
-          res.locals.errors = response.errors.errors
-        } else {
-          res.locals.errors = response.errors
-        }
-
-        // re-edit the data
-        editCommon(req, res)
-        if (req.params.id) {
-          editDetails(req, res, next)
-        } else {
-          addDetails(req, res, next)
-        }
-      } else {
-        next(response)
-      }
-    }
-  })
-}
-
 module.exports = {
   getDetails,
   editDetails,
   addDetails,
-  postDetails,
-  editCommon,
 }

--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -2,6 +2,7 @@ const { assign } = require('lodash')
 
 const metadataRepository = require('../../../lib/metadata')
 const { companyDetailsLabels, hqLabels } = require('../labels')
+const companyFormService = require('../services/form')
 
 function populateForm (req, res, next) {
   res.locals = assign({}, res.locals, {
@@ -18,6 +19,29 @@ function populateForm (req, res, next) {
   next()
 }
 
+async function handleFormPost (req, res, next) {
+  try {
+    const savedCompany = await companyFormService.saveCompanyForm(req.session.token, req.body)
+
+    req.flash('success', 'Company record updated')
+    res.redirect(`/viewcompanyresult/${savedCompany.id}`)
+  } catch (response) {
+    if (response.errors) {
+      // Leeloo has inconsistant structure to return errors.
+      // Get the errors and then re-render the edit page.
+      if (response.errors.errors) {
+        res.locals.errors = response.errors.errors
+      } else {
+        res.locals.errors = response.errors
+      }
+      next()
+    } else {
+      next(response)
+    }
+  }
+}
+
 module.exports = {
   populateForm,
+  handleFormPost,
 }

--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -1,0 +1,23 @@
+const { assign } = require('lodash')
+
+const metadataRepository = require('../../../lib/metadata')
+const { companyDetailsLabels, hqLabels } = require('../labels')
+
+function populateForm (req, res, next) {
+  res.locals = assign({}, res.locals, {
+    hqLabels,
+    companyDetailsLabels,
+    regionOptions: metadataRepository.regionOptions,
+    sectorOptions: metadataRepository.sectorOptions,
+    employeeOptions: metadataRepository.employeeOptions,
+    turnoverOptions: metadataRepository.turnoverOptions,
+    headquarterOptions: metadataRepository.headquarterOptions,
+    countryOptions: metadataRepository.countryOptions,
+  })
+
+  next()
+}
+
+module.exports = {
+  populateForm,
+}

--- a/src/apps/companies/middleware/index.js
+++ b/src/apps/companies/middleware/index.js
@@ -1,9 +1,11 @@
 const collection = require('./collection')
 const details = require('./details')
+const form = require('./form')
 const interactions = require('./interactions')
 
 module.exports = {
   collection,
+  form,
   details,
   interactions,
 }

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -52,41 +52,41 @@ router.get('/view/ltd/:id', ltdController.getDetails)
 router
   .route('/edit/ltd/:id')
   .get(foreignController.editCommon, ltdController.editDetails)
-  .post(foreignController.postDetails)
+  .post(foreignController.editCommon, foreignController.postDetails)
 
 router
   .route('/add/ltd/:company_number')
   .get(foreignController.editCommon, ltdController.addDetails)
-  .post(foreignController.postDetails)
+  .post(foreignController.editCommon, foreignController.postDetails)
 
 router
   .route('/add/ltd')
   .get(foreignController.editCommon, ltdController.addDetails)
-  .post(foreignController.postDetails)
+  .post(foreignController.editCommon, foreignController.postDetails)
 
 router.get('/view/ukother/:id', ukotherController.getDetails)
 
 router
   .route('/edit/ukother/:id')
   .get(foreignController.editCommon, ukotherController.editDetails)
-  .post(foreignController.postDetails)
+  .post(foreignController.editCommon, foreignController.postDetails)
 
 router
   .route('/add/ukother')
   .get(foreignController.editCommon, ukotherController.addDetails)
-  .post(foreignController.postDetails)
+  .post(foreignController.editCommon, foreignController.postDetails)
 
 router.get('/view/foreign/:id', foreignController.getDetails)
 
 router
   .route('/edit/foreign/:id')
   .get(foreignController.editCommon, foreignController.editDetails)
-  .post(foreignController.postDetails)
+  .post(foreignController.editCommon, foreignController.postDetails)
 
 router
   .route('/add/foreign')
   .get(foreignController.editCommon, foreignController.addDetails)
-  .post(foreignController.postDetails)
+  .post(foreignController.editCommon, foreignController.postDetails)
 
 router.get('/:id/investments', investmentsController.getAction)
 router.get('/:id/audit', auditController.getAudit)

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -19,7 +19,7 @@ const {
 
 const { renderCompanyList } = require('./controllers/list')
 const { getRequestBody, getCompanyCollection } = require('./middleware/collection')
-const { populateForm } = require('./middleware/form')
+const { populateForm, handleFormPost } = require('./middleware/form')
 const { setDefaultQuery } = require('../middleware')
 
 const DEFAULT_COLLECTION_QUERY = {
@@ -53,41 +53,41 @@ router.get('/view/ltd/:id', ltdController.getDetails)
 router
   .route('/edit/ltd/:id')
   .get(populateForm, ltdController.editDetails)
-  .post(populateForm, foreignController.postDetails)
+  .post(populateForm, handleFormPost, ltdController.editDetails)
 
 router
   .route('/add/ltd/:company_number')
   .get(populateForm, ltdController.addDetails)
-  .post(populateForm, foreignController.postDetails)
+  .post(populateForm, handleFormPost, ltdController.addDetails)
 
 router
   .route('/add/ltd')
   .get(populateForm, ltdController.addDetails)
-  .post(populateForm, foreignController.postDetails)
+  .post(populateForm, handleFormPost, ltdController.addDetails)
 
 router.get('/view/ukother/:id', ukotherController.getDetails)
 
 router
   .route('/edit/ukother/:id')
   .get(populateForm, ukotherController.editDetails)
-  .post(populateForm, foreignController.postDetails)
+  .post(populateForm, handleFormPost, ukotherController.editDetails)
 
 router
   .route('/add/ukother')
   .get(populateForm, ukotherController.addDetails)
-  .post(populateForm, foreignController.postDetails)
+  .post(populateForm, handleFormPost, ukotherController.addDetails)
 
 router.get('/view/foreign/:id', foreignController.getDetails)
 
 router
   .route('/edit/foreign/:id')
   .get(populateForm, foreignController.editDetails)
-  .post(populateForm, foreignController.postDetails)
+  .post(populateForm, handleFormPost, foreignController.editDetails)
 
 router
   .route('/add/foreign')
   .get(populateForm, foreignController.addDetails)
-  .post(populateForm, foreignController.postDetails)
+  .post(populateForm, handleFormPost, foreignController.addDetails)
 
 router.get('/:id/investments', investmentsController.getAction)
 router.get('/:id/audit', auditController.getAudit)

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -19,6 +19,7 @@ const {
 
 const { renderCompanyList } = require('./controllers/list')
 const { getRequestBody, getCompanyCollection } = require('./middleware/collection')
+const { populateForm } = require('./middleware/form')
 const { setDefaultQuery } = require('../middleware')
 
 const DEFAULT_COLLECTION_QUERY = {
@@ -51,42 +52,42 @@ router.get('/view/ltd/:id', ltdController.getDetails)
 
 router
   .route('/edit/ltd/:id')
-  .get(foreignController.editCommon, ltdController.editDetails)
-  .post(foreignController.editCommon, foreignController.postDetails)
+  .get(populateForm, ltdController.editDetails)
+  .post(populateForm, foreignController.postDetails)
 
 router
   .route('/add/ltd/:company_number')
-  .get(foreignController.editCommon, ltdController.addDetails)
-  .post(foreignController.editCommon, foreignController.postDetails)
+  .get(populateForm, ltdController.addDetails)
+  .post(populateForm, foreignController.postDetails)
 
 router
   .route('/add/ltd')
-  .get(foreignController.editCommon, ltdController.addDetails)
-  .post(foreignController.editCommon, foreignController.postDetails)
+  .get(populateForm, ltdController.addDetails)
+  .post(populateForm, foreignController.postDetails)
 
 router.get('/view/ukother/:id', ukotherController.getDetails)
 
 router
   .route('/edit/ukother/:id')
-  .get(foreignController.editCommon, ukotherController.editDetails)
-  .post(foreignController.editCommon, foreignController.postDetails)
+  .get(populateForm, ukotherController.editDetails)
+  .post(populateForm, foreignController.postDetails)
 
 router
   .route('/add/ukother')
-  .get(foreignController.editCommon, ukotherController.addDetails)
-  .post(foreignController.editCommon, foreignController.postDetails)
+  .get(populateForm, ukotherController.addDetails)
+  .post(populateForm, foreignController.postDetails)
 
 router.get('/view/foreign/:id', foreignController.getDetails)
 
 router
   .route('/edit/foreign/:id')
-  .get(foreignController.editCommon, foreignController.editDetails)
-  .post(foreignController.editCommon, foreignController.postDetails)
+  .get(populateForm, foreignController.editDetails)
+  .post(populateForm, foreignController.postDetails)
 
 router
   .route('/add/foreign')
-  .get(foreignController.editCommon, foreignController.addDetails)
-  .post(foreignController.editCommon, foreignController.postDetails)
+  .get(populateForm, foreignController.addDetails)
+  .post(populateForm, foreignController.postDetails)
 
 router.get('/:id/investments', investmentsController.getAction)
 router.get('/:id/audit', auditController.getAudit)

--- a/test/unit/apps/companies/controllers/foreign.test.js
+++ b/test/unit/apps/companies/controllers/foreign.test.js
@@ -14,7 +14,6 @@ describe('Company controller, foreign', function () {
   let companyControllerForeign
   let fakeCompanyForm
   let saveCompanyFormStub
-  let flashStub
   let breadcrumbStub
   let company
   const metadataRepositoryStub = {
@@ -54,7 +53,6 @@ describe('Company controller, foreign', function () {
     getDitCompanyStub = sinon.stub().resolves(company)
     getForeignCompanyAsFormDataStub = sinon.stub().returns(fakeCompanyForm)
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
-    flashStub = sinon.stub()
     breadcrumbStub = function () {
       return this
     }
@@ -471,135 +469,6 @@ describe('Company controller, foreign', function () {
       }
 
       companyControllerForeign.editDetails(req, res, next)
-    })
-  })
-  describe('post details', function () {
-    it('call the company repository to save the company', function (done) {
-      const body = {
-        id: '1234',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function () {
-          expect(saveCompanyFormStub).to.be.calledWith('1234', body)
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerForeign.postDetails(req, res, next)
-    })
-    it('should forward to the detail screen if save is good', function (done) {
-      const body = {
-        id: '999',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function (url) {
-          expect(url).to.equal('/companies/view/foreign/999')
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerForeign.postDetails(req, res, next)
-    })
-    it('should re-render the edit form with form data on error', function (done) {
-      saveCompanyFormStub = sinon.stub().rejects({
-        errors: { name: ['test'] },
-      })
-
-      companyControllerForeign = proxyquire('~/src/apps/companies/controllers/foreign', {
-        '../services/formatting': {
-          getDisplayCompany: getDisplayCompanyStub,
-          getDisplayCH: getDisplayCHStub,
-        },
-        '../services/form': {
-          getForeignCompanyAsFormData: getForeignCompanyAsFormDataStub,
-          saveCompanyForm: saveCompanyFormStub,
-        },
-        '../repos': {
-          getCHCompany: getCHCompanyStub,
-          getDitCompany: getDitCompanyStub,
-        },
-        '../../../lib/metadata': metadataRepositoryStub,
-      })
-
-      const body = {
-        id: '999',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        query: { business_type: 'charity' },
-        params: {},
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function () {
-          throw Error('error')
-        },
-        render: function (template) {
-          try {
-            expect(template).to.equal('companies/views/edit')
-            expect(res.locals).to.have.property('errors')
-            done()
-          } catch (e) {
-            done(e)
-          }
-        },
-      }
-      companyControllerForeign.postDetails(req, res, next)
-    })
-    it('should flash a message to let people know they did something', function (done) {
-      const body = {
-        id: '1234',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function () {
-          expect(flashStub).to.be.calledWith('success', 'Company record updated')
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerForeign.postDetails(req, res, next)
     })
   })
 })

--- a/test/unit/apps/companies/controllers/foreign.test.js
+++ b/test/unit/apps/companies/controllers/foreign.test.js
@@ -602,36 +602,4 @@ describe('Company controller, foreign', function () {
       companyControllerForeign.postDetails(req, res, next)
     })
   })
-  describe('edit common', function () {
-    let req
-    let res
-
-    beforeEach(function () {
-      req = {
-        session: {
-          token: '1234',
-        },
-      }
-      res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-      }
-    })
-    it('should include the require properties in the response', function () {
-      companyControllerForeign.editCommon(req, res)
-      expect(res.locals).to.have.property('regionOptions')
-      expect(res.locals).to.have.property('sectorOptions')
-      expect(res.locals).to.have.property('employeeOptions')
-      expect(res.locals).to.have.property('turnoverOptions')
-      expect(res.locals).to.have.property('headquarterOptions')
-      expect(res.locals).to.have.property('hqLabels')
-      expect(res.locals).to.have.property('companyDetailsLabels')
-    })
-
-    it('should goto the next function if there is one', function () {
-      const next = sinon.stub()
-      companyControllerForeign.editCommon(req, res, next)
-      expect(next).to.be.called
-    })
-  })
 })

--- a/test/unit/apps/companies/controllers/ltd.test.js
+++ b/test/unit/apps/companies/controllers/ltd.test.js
@@ -16,7 +16,6 @@ describe('Company controller, ltd', function () {
   let getDefaultLtdFormForCHStub
   let fakeCompanyForm
   let saveCompanyFormStub
-  let flashStub
 
   const chCompany = {
     id: '972173',
@@ -75,7 +74,6 @@ describe('Company controller, ltd', function () {
     getLtdCompanyAsFormDataStub = sinon.stub().returns(fakeCompanyForm)
     getDefaultLtdFormForCHStub = sinon.stub().returns(fakeCompanyForm)
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
-    flashStub = sinon.stub()
 
     this.breadcrumbStub = function () {
       return this
@@ -518,169 +516,6 @@ describe('Company controller, ltd', function () {
       }
 
       companyControllerLtd.editDetails(req, res, next)
-    })
-  })
-  describe('post details', function () {
-    it('call the company repository to save the company', function (done) {
-      const body = {
-        id: '1234',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: this.breadcrumbStub,
-        redirect: function () {
-          expect(saveCompanyFormStub).to.be.calledWith('1234', body)
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerLtd.postDetails(req, res, next)
-    })
-    it('should forward to the detail screen if save is good', function (done) {
-      const body = {
-        id: '999',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: this.breadcrumbStub,
-        redirect: function (url) {
-          expect(url).to.equal('/companies/view/ltd/999')
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerLtd.postDetails(req, res, next)
-    })
-    it('should re-render the edit form with form data on error', function (done) {
-      saveCompanyFormStub = sinon.stub().rejects({
-        errors: { name: ['test'] },
-      })
-
-      companyControllerLtd = proxyquire('~/src/apps/companies/controllers/ltd', {
-        '../services/formatting': {
-          getDisplayCompany: getDisplayCompanyStub,
-          getDisplayCH: getDisplayCHStub,
-        },
-        '../repos': {
-          getCHCompany: getCHCompanyStub,
-          getDitCompany: getDitCompanyStub,
-        },
-        '../services/form': {
-          getLtdCompanyAsFormData: getLtdCompanyAsFormDataStub,
-          getDefaultLtdFormForCH: getDefaultLtdFormForCHStub,
-          saveCompanyForm: saveCompanyFormStub,
-        },
-        '../../../lib/metadata': metadataRepositoryStub,
-      })
-
-      const body = {
-        id: '999',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        params: {},
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: this.breadcrumbStub,
-        redirect: function () {
-          throw Error('error')
-        },
-        render: function (template) {
-          try {
-            expect(template).to.equal('companies/views/edit')
-            expect(res.locals).to.have.property('errors')
-            done()
-          } catch (e) {
-            done(e)
-          }
-        },
-      }
-      companyControllerLtd.postDetails(req, res, next)
-    })
-    it('should flash a message to let people know they did something', function (done) {
-      const body = {
-        id: '1234',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: this.breadcrumbStub,
-        redirect: function () {
-          expect(flashStub).to.be.calledWith('success', 'Company record updated')
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerLtd.postDetails(req, res, next)
-    })
-  })
-  describe('edit common', function () {
-    let req
-    let res
-
-    beforeEach(function () {
-      req = {
-        session: {
-          token: '1234',
-        },
-      }
-      res = {
-        locals: {},
-        breadcrumb: this.breadcrumbStub,
-      }
-    })
-    it('should include the require properties in the response', function () {
-      companyControllerLtd.editCommon(req, res)
-      expect(res.locals).to.have.property('chDetailsLabels')
-      expect(res.locals).to.have.property('chDetailsDisplayOrder')
-      expect(res.locals).to.have.property('regionOptions')
-      expect(res.locals).to.have.property('sectorOptions')
-      expect(res.locals).to.have.property('employeeOptions')
-      expect(res.locals).to.have.property('turnoverOptions')
-      expect(res.locals).to.have.property('headquarterOptions')
-      expect(res.locals).to.have.property('hqLabels')
-      expect(res.locals).to.have.property('companyDetailsLabels')
-    })
-
-    it('should goto the next function if there is one', function () {
-      const next = sinon.stub()
-      companyControllerLtd.editCommon(req, res, next)
-      expect(next).to.be.called
     })
   })
 })

--- a/test/unit/apps/companies/controllers/ukother.test.js
+++ b/test/unit/apps/companies/controllers/ukother.test.js
@@ -14,7 +14,6 @@ describe('Company controller, uk other', function () {
   let companyControllerUkOther
   let fakeCompanyForm
   let saveCompanyFormStub
-  let flashStub
 
   let company
   const metadataRepositoryStub = {
@@ -58,7 +57,6 @@ describe('Company controller, uk other', function () {
     getDitCompanyStub = sinon.stub().resolves(company)
     getUkOtherCompanyAsFormDataStub = sinon.stub().returns(fakeCompanyForm)
     saveCompanyFormStub = sinon.stub().returns(fakeCompanyForm)
-    flashStub = sinon.stub()
 
     companyControllerUkOther = proxyquire('~/src/apps/companies/controllers/ukother', {
       '../services/formatting': {
@@ -487,172 +485,4 @@ describe('Company controller, uk other', function () {
       companyControllerUkOther.editDetails(req, res, next)
     })
   })
-  describe('post details', function () {
-    it('call the company repository to save the company', function (done) {
-      const body = {
-        id: '1234',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        query: { business_type: 'charity' },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function () {
-          expect(saveCompanyFormStub).to.be.calledWith('1234', body)
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerUkOther.postDetails(req, res, next)
-    })
-    it('should forward to the detail screen if save is good', function (done) {
-      const body = {
-        id: '999',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        query: { business_type: 'charity' },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function (url) {
-          expect(url).to.equal('/companies/view/ukother/999')
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerUkOther.postDetails(req, res, next)
-    })
-    it('should re-render the edit form with form data on error', function (done) {
-      saveCompanyFormStub = sinon.stub().rejects({
-        errors: { name: ['test'] },
-      })
-
-      companyControllerUkOther = proxyquire('~/src/apps/companies/controllers/ukother', {
-        '../services/formatting': {
-          getDisplayCompany: getDisplayCompanyStub,
-          getDisplayCH: getDisplayCHStub,
-        },
-        '../services/form': {
-          getUkOtherCompanyAsFormData: getUkOtherCompanyAsFormDataStub,
-          saveCompanyForm: saveCompanyFormStub,
-        },
-        '../repos': {
-          getCHCompany: getCHCompanyStub,
-          getDitCompany: getDitCompanyStub,
-        },
-        '../../../lib/metadata': metadataRepositoryStub,
-      })
-
-      const body = {
-        id: '999',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        params: {},
-        query: {
-          business_type: 'Charity',
-        },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function () {
-          throw Error('error')
-        },
-        render: function (template) {
-          try {
-            expect(template).to.equal('companies/views/edit')
-            expect(res.locals).to.have.property('errors')
-            done()
-          } catch (e) {
-            done(e)
-          }
-        },
-      }
-      companyControllerUkOther.postDetails(req, res, next)
-    })
-    it('should flash a message to let people know they did something', function (done) {
-      const body = {
-        id: '1234',
-        name: 'freds',
-      }
-      const req = {
-        session: {
-          token: '1234',
-        },
-        query: { business_type: 'charity' },
-        flash: flashStub,
-        body,
-      }
-      const res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-        redirect: function () {
-          expect(flashStub).to.be.calledWith('success', 'Company record updated')
-          done()
-        },
-        render: function () {
-          throw Error('error')
-        },
-      }
-      companyControllerUkOther.postDetails(req, res, next)
-    })
-  })
-  describe('edit common', function () {
-    let req
-    let res
-
-    beforeEach(function () {
-      req = {
-        session: {
-          token: '1234',
-        },
-      }
-      res = {
-        locals: {},
-        breadcrumb: breadcrumbStub,
-      }
-    })
-    it('should include the require properties in the response', function () {
-      companyControllerUkOther.editCommon(req, res)
-      expect(res.locals).to.have.property('regionOptions')
-      expect(res.locals).to.have.property('sectorOptions')
-      expect(res.locals).to.have.property('employeeOptions')
-      expect(res.locals).to.have.property('turnoverOptions')
-      expect(res.locals).to.have.property('headquarterOptions')
-      expect(res.locals).to.have.property('hqLabels')
-      expect(res.locals).to.have.property('companyDetailsLabels')
-    })
-
-    it('should goto the next function if there is one', function () {
-      const next = sinon.stub()
-      companyControllerUkOther.editCommon(req, res, next)
-      expect(next).to.be.called
-    })
-  })
 })
-
-// Show Trading

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -1,0 +1,37 @@
+const { populateForm } = require('~/src/apps/companies/middleware/form')
+
+describe('Companies form middleware', function () {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+
+    this.nextSpy = this.sandbox.spy()
+    this.reqMock = {}
+    this.resMock = {
+      locals: {},
+    }
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('populateForm()', () => {
+    it('should include the required properties in the response', () => {
+      populateForm(this.reqMock, this.resMock, this.nextSpy)
+
+      expect(this.resMock.locals).to.have.property('regionOptions')
+      expect(this.resMock.locals).to.have.property('sectorOptions')
+      expect(this.resMock.locals).to.have.property('employeeOptions')
+      expect(this.resMock.locals).to.have.property('turnoverOptions')
+      expect(this.resMock.locals).to.have.property('headquarterOptions')
+      expect(this.resMock.locals).to.have.property('hqLabels')
+      expect(this.resMock.locals).to.have.property('companyDetailsLabels')
+    })
+
+    it('should call next with no arguments', () => {
+      populateForm(this.reqMock, this.resMock, this.nextSpy)
+
+      expect(this.nextSpy).to.be.calledWith()
+    })
+  })
+})


### PR DESCRIPTION
This change tries to reduce some more of the duplication currently in company middleware.

It consolidates the setting of form data and moves the post handler to shared form middleware.