### PR TITLE
Save event, add lead team if populated

### DIFF
--- a/src/apps/events/services/formatting.js
+++ b/src/apps/events/services/formatting.js
@@ -47,7 +47,9 @@ function transformToApi (body) {
   setDate('start_date')
   setDate('end_date')
 
-  formatted.teams.push(formatted.lead_team)
+  if (formatted.lead_team) {
+    formatted.teams.push(formatted.lead_team)
+  }
   formatted.service = '1783ae93-b78f-e611-8c55-e4115bed50dc'
   return assign({}, formatted)
 }

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -111,6 +111,26 @@ describe('Event details middleware', () => {
       })
     })
 
+    context('when not selecting the lead team', () => {
+      it('should not add to the teams', async () => {
+        const req = merge({}, this.req, {
+          body: {
+            lead_team: null,
+          },
+        })
+
+        await this.middleware.postDetails(req, this.res, this.next)
+
+        const expectedBody = assign({}, this.expectedBody, {
+          teams: [ 'team1', 'team2' ],
+          lead_team: undefined,
+        })
+
+        expect(this.createEventStub).to.have.been.calledWith(this.req.session.token, expectedBody)
+        expect(this.createEventStub).to.have.been.calledOnce
+      })
+    })
+
     context('when selecting one event shared team', () => {
       it('should set teams as an array', async () => {
         const req = merge({}, this.req, {


### PR DESCRIPTION
This change makes sure we only add the `lead_team` to the `teams` when it is populated. Without this check the code was adding an `undefined` element to the array.