### PR TITLE
DH-664 save event acceptance tests

### DIFF
--- a/test/acceptance/features/events/create-event-form.feature
+++ b/test/acceptance/features/events/create-event-form.feature
@@ -10,7 +10,7 @@ Feature: Create an Event in Data hub
   @create-event-form-fields
   Scenario: Verify event form fields
 
-    When I navigate to create an event page
+    When I navigate to the create an event page
     Then I verify the event name field is displayed
     And I verify the event type field is displayed
     And I verify the event start date fields are displayed
@@ -33,7 +33,7 @@ Feature: Create an Event in Data hub
   @create-event-form-shared-toggle
   Scenario: Verify event shared field toggling
 
-    When I navigate to create an event page
+    When I navigate to the create an event page
     And I choose the Yes option
     Then I verify the shared teams field is displayed
     When I choose the No option
@@ -42,7 +42,7 @@ Feature: Create an Event in Data hub
   @create-event-form-add-teams
   Scenario: Verify event shared teams field
 
-    When I navigate to create an event page
+    When I navigate to the create an event page
     And I choose the Yes option
     And I select shared team 2
     And I add it to the shared teams list
@@ -52,7 +52,7 @@ Feature: Create an Event in Data hub
   @create-event-form-add-related-programmes
   Scenario: Verify event related programmes field
 
-    When I navigate to create an event page
+    When I navigate to the create an event page
     And I select programme 2
     And I add it to the programmes list
     Then I verify there should be 2 programmes lists

--- a/test/acceptance/features/events/create-event-form.feature
+++ b/test/acceptance/features/events/create-event-form.feature
@@ -1,4 +1,4 @@
-@create-event-form
+@events__create-event-form
 Feature: Create an Event in Data hub
   As an Event organiser
   I would like to add an event record to data hub
@@ -7,7 +7,7 @@ Feature: Create an Event in Data hub
   Background:
     Given I am an authenticated user on the data hub website
 
-  @create-event-form-fields
+  @events__create-event-form--fields
   Scenario: Verify event form fields
 
     When I navigate to the create an event page
@@ -30,7 +30,7 @@ Feature: Create an Event in Data hub
     And I verify the event related programmes field is displayed
     And I verify the event save button is displayed
 
-  @create-event-form-shared-toggle
+  @events__create-event-form--toggle-shared
   Scenario: Verify event shared field toggling
 
     When I navigate to the create an event page
@@ -39,7 +39,7 @@ Feature: Create an Event in Data hub
     When I choose the No option
     Then I verify the shared teams field is not displayed
 
-  @create-event-form-add-teams
+  @events__create-event-form--add-teams
   Scenario: Verify event shared teams field
 
     When I navigate to the create an event page
@@ -49,7 +49,7 @@ Feature: Create an Event in Data hub
     Then I verify there should be 2 shared teams lists
     And I verify there is the option to add another shared team
 
-  @create-event-form-add-related-programmes
+  @events__create-event-form--add-related-programmes
   Scenario: Verify event related programmes field
 
     When I navigate to the create an event page

--- a/test/acceptance/features/events/page-objects/Events.js
+++ b/test/acceptance/features/events/page-objects/Events.js
@@ -3,7 +3,9 @@ module.exports = {
   props: {},
   elements: {
     eventName: 'input[name="name"]',
+    eventNameError: 'label[for=field-name] span:nth-child(2)',
     eventType: 'select[name="event_type"]',
+    eventTypeError: 'label[for=field-event_type] span:nth-child(2)',
     startDateYear: 'input[name="start_date_year"]',
     startDateMonth: 'input[name="start_date_month"]',
     startDateDay: 'input[name="start_date_day"]',
@@ -12,11 +14,14 @@ module.exports = {
     endDateDay: 'input[name="end_date_day"]',
     locationType: 'select[name="location_type"]',
     addressLine1: 'input[name="address_1"]',
+    addressLine1Error: 'label[for=field-address_1] span:nth-child(2)',
     addressLine2: 'input[name="address_2"]',
     addressTown: 'input[name="address_town"]',
+    addressTownError: 'label[for=field-address_town] span:nth-child(2)',
     addressCounty: 'input[name="address_county"]',
     addressPostcode: 'input[name="postcode"]',
     addressCountry: 'select[name="address_country"]',
+    addressCountryError: 'label[for=field-address_country] span:nth-child(2)',
     notes: 'textarea[name="notes"]',
     teamHosting: 'select[name="lead_team"]',
     organiser: 'select[name="organiser"]',
@@ -54,19 +59,15 @@ module.exports = {
 
   commands: [
     {
-      selectTeam (optionNumber) {
+      selectListOption (listName, optionNumber) {
         return this
-          .click('select[name="teams"] option:nth-child(' + optionNumber + ')')
+          .click(`select[name="${listName}"] option:nth-child(${optionNumber})`)
       },
-      assertVisibleSharedTeamList (listNumber) {
+      assertVisibleTeamsList (listNumber) {
         return this
           .assert.visible('#group-field-teams #group-field-teams:nth-child(' + listNumber + ') select')
       },
-      selectRelatedProgramme (optionNumber) {
-        return this
-          .click('select[name="related_programmes"] option:nth-child(' + optionNumber + ')')
-      },
-      assertVisibleProgrammesList (listNumber) {
+      assertVisibleRelatedProgrammesList (listNumber) {
         return this
           .assert.visible('#group-field-related_programmes #group-field-related_programmes:nth-child(' + listNumber + ') select')
       },

--- a/test/acceptance/features/events/save-new-event.feature
+++ b/test/acceptance/features/events/save-new-event.feature
@@ -1,4 +1,4 @@
-@save-new-event
+@events__save-new-event
 Feature: Save a new Event in Data hub
   As an Event organiser
   I would like to add an event record to data hub
@@ -7,22 +7,24 @@ Feature: Save a new Event in Data hub
   Background:
     Given I am an authenticated user on the data hub website
 
-  @save-new-event-submit @ignore
+  @events__save-new-event--submit
   Scenario: Verify event is submitted
 
     When I navigate to the create an event page
     And I enter all mandatory fields related to the event
-    And I click on save button
-    Then I see the Added new event confirmation message
+    And I click the save button
+    Then I see the success message
 
-  @save-new-event-mandatory-fields @ignore
+  @events__save-new-event--mandatory-fields
   Scenario: Verify event mandatory fields
 
-    And I click on save button
-    Then I verify error message displayed for event name field
-    And I verify error message displayed for event type field
-    And I verify error message displayed for Address fields
-    And I see the Added new event confirmation message is not displayed
     When I navigate to the create an event page
+    And I click the save button
+    Then I verify the event name has an error message
+    And I verify the event type has an error message
+    And I verify the event address line 1 has an error message
+    And I verify the event address town has an error message
+    And I verify the event address country has an error message
+    Then I see the error message
 
 

--- a/test/acceptance/features/events/save-new-event.feature
+++ b/test/acceptance/features/events/save-new-event.feature
@@ -25,11 +25,4 @@ Feature: Save a new Event in Data hub
     And I verify error message displayed for Address fields
     And I see the Added new event confirmation message is not displayed
 
-  @save-new-event-display @ignore
-  Scenario: Verify event is displayed
 
-    When I navigate to create an event page
-    And I enter all mandatory fields related to the event
-    And I click on save button
-    Then I see the Added new event confirmation message
-    And I see the event is displayed correctly with all field values

--- a/test/acceptance/features/events/save-new-event.feature
+++ b/test/acceptance/features/events/save-new-event.feature
@@ -10,7 +10,7 @@ Feature: Save a new Event in Data hub
   @save-new-event-submit @ignore
   Scenario: Verify event is submitted
 
-    When I navigate to create an event page
+    When I navigate to the create an event page
     And I enter all mandatory fields related to the event
     And I click on save button
     Then I see the Added new event confirmation message
@@ -18,11 +18,11 @@ Feature: Save a new Event in Data hub
   @save-new-event-mandatory-fields @ignore
   Scenario: Verify event mandatory fields
 
-    When I navigate to create an event page
     And I click on save button
     Then I verify error message displayed for event name field
     And I verify error message displayed for event type field
     And I verify error message displayed for Address fields
     And I see the Added new event confirmation message is not displayed
+    When I navigate to the create an event page
 
 

--- a/test/acceptance/features/events/step_definitions/event-create.js
+++ b/test/acceptance/features/events/step_definitions/event-create.js
@@ -3,10 +3,9 @@ const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
 defineSupportCode(({ Given, Then, When }) => {
-  const Company = client.page.Company()
   const Events = client.page.Events()
 
-  When(/^I navigate to create an event page$/, async () => {
+  When(/^I navigate to the create an event page$/, async () => {
     await Events
       .navigate()
   })

--- a/test/acceptance/features/events/step_definitions/event-create.js
+++ b/test/acceptance/features/events/step_definitions/event-create.js
@@ -95,7 +95,6 @@ defineSupportCode(({ Given, Then, When }) => {
 
   Then(/^I verify the event is shared or not field is displayed$/, async () => {
     await Events
-      // .waitForElementVisible('@sharedYes', 1000)
       .assert.visible('@sharedYes')
       .assert.visible('@sharedNo')
   })
@@ -125,7 +124,7 @@ defineSupportCode(({ Given, Then, When }) => {
   When(/^I select shared team ([0-9])$/, async (optionNumber) => {
     await Events
       .setValue('@sharedTeams', '')
-      .selectTeam(optionNumber)
+      .selectListOption('teams', optionNumber)
   })
 
   When(/^I add it to the shared teams list$/, async () => {
@@ -135,7 +134,7 @@ defineSupportCode(({ Given, Then, When }) => {
 
   Then(/^I verify there should be ([0-9]) shared teams lists$/, async (expected) => {
     await Events
-      .assertVisibleSharedTeamList(expected)
+      .assertVisibleTeamsList(expected)
   })
 
   Then(/^I verify there is the option to add another shared team$/, async () => {
@@ -151,7 +150,7 @@ defineSupportCode(({ Given, Then, When }) => {
   When(/^I select programme ([0-9])$/, async (optionNumber) => {
     await Events
       .setValue('@sharedTeams', '')
-      .selectRelatedProgramme(optionNumber)
+      .selectListOption('related_programmes', optionNumber)
   })
 
   When(/^I add it to the programmes list$/, async () => {
@@ -159,9 +158,23 @@ defineSupportCode(({ Given, Then, When }) => {
       .click('@addAnotherProgramme')
   })
 
+  When(/^I enter all mandatory fields related to the event$/, async () => {
+    await Events
+      .setValue('@eventName', faker.company.companyName())
+      .selectListOption('event_type', 2)
+      .setValue('@addressLine1', faker.address.streetName())
+      .setValue('@addressTown', faker.address.city())
+      .setValue('@addressPostcode', faker.address.zipCode())
+      .setValue('@addressCountry', faker.address.country())
+  })
+
+  When(/^I click the save button$/, async () => {
+    await Events.submitForm('form')
+  })
+
   Then(/^I verify there should be ([0-9]) programmes lists$/, async (expected) => {
     await Events
-      .assertVisibleProgrammesList(expected)
+      .assertVisibleRelatedProgrammesList(expected)
   })
 
   Then(/^I verify there is the option to add another programme/, async () => {
@@ -174,37 +187,29 @@ defineSupportCode(({ Given, Then, When }) => {
       .assert.visible('@saveButton')
   })
 
-  When(/^I enter all mandatory fields related to the event$/, async () => {
+  Then(/^I verify the event name has an error message$/, async () => {
     await Events
-      .setValue('@eventName', faker.company.companyName())
-      .click('@eventTypeList')
-      .setValue('@addressLine1', faker.address.streetName())
-      .setValue('@addressTown', faker.address.city())
-      .setValue('@addressPostcode', faker.address.zipCode())
-      .setValue('@addressCountry', faker.address.country())
+      .assert.visible('@eventNameError')
   })
 
-  Then(/^I verify error message displayed for event name field$/, async () => {
+  Then(/^I verify the event type has an error message$/, async () => {
     await Events
-      .assert.visible('@errorEventName')
+      .assert.visible('@eventTypeError')
   })
 
-  Then(/^I verify error message displayed for event type field$/, async () => {
+  Then(/^I verify the event address line 1 has an error message$/, async () => {
     await Events
-      .assert.visible('@errorEventType')
+      .assert.visible('@addressLine1Error')
   })
 
-  Then(/^I verify error message displayed for Address fields$/, async () => {
+  Then(/^I verify the event address town has an error message$/, async () => {
     await Events
-      .assert.visible('@errorAddressLine1')
-      .assert.visible('@errorAddressTown')
-      .assert.visible('@errorAddressPostcode')
-      .assert.visible('@errorAddressCountry')
+      .assert.visible('@addressTownError')
   })
 
-  Then(/^I see the Added new event confirmation message is not displayed$/, async () => {
-    await Company
-      .assert.elementNotVisible('@flashInfo')
+  Then(/^I verify the event address country has an error message$/, async () => {
+    await Events
+      .assert.visible('@addressCountryError')
   })
 
   Then(/^I see the event is displayed correctly with all field values$/, async () => {


### PR DESCRIPTION
This change hooks up the acceptance tests for saving an event. Included:
- General tidy up of scenarios and steps
- Save event acceptance tests

Still to come:
- Refactor code further

<img width="627" alt="screen shot 2017-09-22 at 14 08 13" src="https://user-images.githubusercontent.com/1150417/30745971-02615c80-9fa0-11e7-8059-53e2eac07b7c.png">