### PR TITLE
Fix focus on global nav

### DIFF
--- a/assets/stylesheets/components/_global-nav.scss
+++ b/assets/stylesheets/components/_global-nav.scss
@@ -4,6 +4,8 @@
   @include bold-font(16);
   background: $grey-3;
   padding: $default-spacing-unit / 4 0;
+  position: relative;
+  z-index: 2;
 
   @include media(tablet) {
     padding: 0;

--- a/assets/stylesheets/components/_global-nav.scss
+++ b/assets/stylesheets/components/_global-nav.scss
@@ -1,3 +1,5 @@
+@import "../tools";
+
 .c-global-nav {
   @include bold-font(16);
   background: $grey-3;


### PR DESCRIPTION
Header, being the next element in document flow overlay on top of global nav which eats the bottom portion of focus outline. Easily fixed by positioning global nav one step up on z-index.

### Before
![image](https://user-images.githubusercontent.com/203886/30755004-da017cc6-9fbc-11e7-8043-f20b5c567be4.png)

### After
![image](https://user-images.githubusercontent.com/203886/30754990-cb9eecf4-9fbc-11e7-833d-e7a2286cb223.png)
