### PR TITLE
Add support to key value table for dates and properties with name

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -62,6 +62,7 @@ const filters = {
   isArray,
   isFunction,
   isNull,
+  isPlainObject,
   isString,
   pluralise,
 
@@ -115,14 +116,20 @@ const filters = {
   },
 
   formatDate: (value, format = longDateFormat) => {
+    if (!value) {
+      return value
+    }
     const parsedDate = dateFns.parse(value)
 
     if (!dateFns.isValid(parsedDate)) { return value }
-
     return dateFns.format(parsedDate, format)
   },
 
   formatDateTime: (value, format = mediumDateTimeFormat) => {
+    if (!value) {
+      return value
+    }
+
     const parsedDate = dateFns.parse(value)
 
     if (!dateFns.isValid(parsedDate)) { return value }

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -27,6 +27,12 @@
                 <li>{{ item }}{{ "," if not loop.last }}</li>
                {% endfor %}
               </ul>
+            {% elif data | isPlainObject %}
+              {% if data.type == "date" %}
+                {{ data.name | formatDate }}
+              {% else %}
+                {{ data.name }}
+              {% endif %}
             {% else %}
               {{ data }}
             {% endif %}

--- a/test/unit/components/key-value-table.test.js
+++ b/test/unit/components/key-value-table.test.js
@@ -44,6 +44,74 @@ describe('Key/value table component', () => {
       .to.equal('<a href="/label-1">#1 label content</a>')
   })
 
+  it('should render a table with an object with a name', () => {
+    const component = renderComponentToDom(
+      'key-value-table',
+      {
+        items: {
+          'Adviser': {
+            name: 'Fred Smith',
+          },
+          'Second label': '#2 label content',
+        },
+      }
+    )
+
+    expect(component.className).to.contain('table--key-value')
+    const rows = component.querySelectorAll('tr')
+    expect(rows.length).to.equal(2)
+    expect(rows[0].querySelector('th').textContent).to.equal('Adviser')
+    expect(rows[0].querySelector('td').textContent).to.equal('Fred Smith')
+    expect(rows[1].querySelector('th').textContent).to.equal('Second label')
+    expect(rows[1].querySelector('td').textContent).to.equal('#2 label content')
+  })
+
+  it('it sould render a table with an object with a null name', () => {
+    const component = renderComponentToDom(
+      'key-value-table',
+      {
+        items: {
+          'Start date': {
+            type: 'date',
+            name: null,
+          },
+          'Second label': '#2 label content',
+        },
+      }
+    )
+
+    expect(component.className).to.contain('table--key-value')
+    const rows = component.querySelectorAll('tr')
+    expect(rows.length).to.equal(2)
+    expect(rows[0].querySelector('th').textContent).to.equal('Start date')
+    expect(rows[0].querySelector('td').textContent).to.equal('')
+    expect(rows[1].querySelector('th').textContent).to.equal('Second label')
+    expect(rows[1].querySelector('td').textContent).to.equal('#2 label content')
+  })
+
+  it('should render a table with a date', () => {
+    const component = renderComponentToDom(
+      'key-value-table',
+      {
+        items: {
+          'Start date': {
+            type: 'date',
+            name: '1971-01-07',
+          },
+          'Second label': '#2 label content',
+        },
+      }
+    )
+
+    expect(component.className).to.contain('table--key-value')
+    const rows = component.querySelectorAll('tr')
+    expect(rows.length).to.equal(2)
+    expect(rows[0].querySelector('th').textContent).to.equal('Start date')
+    expect(rows[0].querySelector('td').textContent).to.equal('7 January 1971')
+    expect(rows[1].querySelector('th').textContent).to.equal('Second label')
+    expect(rows[1].querySelector('td').textContent).to.equal('#2 label content')
+  })
+
   it('should render one section title', () => {
     const component = renderComponentToDom(
       'key-value-table',


### PR DESCRIPTION
The key value component can show text and links, this pr adds 2 features to that:

- Support date 'type'
- Pass properties that contain a name and display that name

This is really usefully for showing entity details without having to put presentation logic or a lot of boilerplate in the transformer.