### PR TITLE
Search-driven navigation

### DIFF
--- a/assets/stylesheets/components/_global-nav.scss
+++ b/assets/stylesheets/components/_global-nav.scss
@@ -31,7 +31,7 @@
   @include media(tablet) {
     border-bottom: 5px solid transparent;
     display: inline-block;
-    padding: ($default-spacing-unit / 2) 0 3px;
+    padding: $default-spacing-unit 0 ($default-spacing-unit - 5);
 
     & + & {
       margin-left: $default-spacing-unit;
@@ -45,4 +45,9 @@
       border-bottom-color: $govuk-blue;
     }
   }
+}
+
+.c-global-nav__count {
+  @include core-font(14);
+  color: $grey-1;
 }

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -22,8 +22,7 @@ $_first-element-spacing: $default-spacing-unit * 3;
   }
 
   .c-entity-search {
-    margin-top: $baseline-grid-unit * 20.5;
-    padding-bottom: $baseline-grid-unit * 6.25;
+    margin-top: $default-spacing-unit * 2;
   }
 
   .c-breadcrumb {

--- a/assets/stylesheets/components/form/_entity-search.scss
+++ b/assets/stylesheets/components/form/_entity-search.scss
@@ -46,3 +46,24 @@ $search-button-width: 50px;
 .c-entity-search__aggregations-item.is-active {
   background-color: $white;
 }
+
+// Modifiers
+
+.c-entity-search--header {
+  display: block;
+  margin-top: $default-spacing-unit;
+  margin-bottom: $default-spacing-unit;
+
+  @include media(tablet) {
+    display: inline-block;
+    margin: 0 $default-spacing-unit * 2;
+  }
+
+  @include media(desktop) {
+    width: 280px;
+  }
+
+  .c-form-control {
+    height: 1.8em;
+  }
+}

--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -7,6 +7,7 @@ const { transformCompanyToListItem } = require('../transformers')
 async function getCompanyCollection (req, res, next) {
   try {
     res.locals.results = await search({
+      searchTerm: req.query.term,
       searchEntity: 'company',
       requestBody: req.body,
       token: req.session.token,

--- a/src/apps/companies/views/list.njk
+++ b/src/apps/companies/views/list.njk
@@ -15,11 +15,11 @@
   {% endset %}
 
   {{
-    Collection(results | assign({
+    Collection(searchResults | assign({
       countLabel: 'company',
       sortForm: sortForm,
       selectedFilters: selectedFilters,
-      highlightTerm: selectedFilters.company_name.valueLabel,
+      highlightTerm: searchTerm,
       query: QUERY,
       summaryActionsHTML: addCompanyButton
     }))

--- a/src/apps/contacts/middleware/collection.js
+++ b/src/apps/contacts/middleware/collection.js
@@ -7,6 +7,7 @@ const { transformContactToListItem } = require('../transformers')
 async function getContactsCollection (req, res, next) {
   try {
     res.locals.results = await search({
+      searchTerm: req.query.term,
       searchEntity: 'contact',
       requestBody: req.body,
       token: req.session.token,

--- a/src/apps/contacts/views/list.njk
+++ b/src/apps/contacts/views/list.njk
@@ -11,11 +11,11 @@
 
 {% block main_grid_right_column %}
   {{
-    Collection(results | assign({
+    Collection(searchResults | assign({
       countLabel: 'contact',
       sortForm: sortForm,
       selectedFilters: selectedFilters,
-      highlightTerm: selectedFilters.company_name.valueLabel,
+      highlightTerm: searchTerm,
       query: QUERY
     }))
   }}

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -5,7 +5,7 @@
     {{ EntitySearchForm({
       inputName: 'term',
       modifier: 'global',
-      action: '/search/companies',
+      action: '/companies',
       inputLabel: 'Search for company, contact, investment project or OMIS order'
     }) }}
   {% endcall %}

--- a/src/apps/events/middleware/collection.js
+++ b/src/apps/events/middleware/collection.js
@@ -8,6 +8,7 @@ async function getEventsCollection (req, res, next) {
   try {
     res.locals.results = await search({
       searchEntity: 'event',
+      searchTerm: req.query.term,
       requestBody: req.body,
       token: req.session.token,
       page: req.query.page,

--- a/src/apps/events/views/list.njk
+++ b/src/apps/events/views/list.njk
@@ -15,7 +15,7 @@
   {% endset %}
 
   {{
-    Collection(results | assign({
+    Collection(searchResults | assign({
       countLabel: 'event',
       sortForm: sortForm,
       selectedFilters: selectedFilters,

--- a/src/apps/interactions/views/list.njk
+++ b/src/apps/interactions/views/list.njk
@@ -2,7 +2,7 @@
 
 {% block main_grid_right_column %}
   {{
-    Collection(results | assign({
+    Collection(searchResults | assign({
       countLabel: 'interaction',
       sortForm: sortForm,
       query: QUERY

--- a/src/apps/investment-projects/middleware/collection.js
+++ b/src/apps/investment-projects/middleware/collection.js
@@ -11,6 +11,7 @@ async function getInvestmentProjectsCollection (req, res, next) {
   try {
     res.locals.results = await search({
       searchEntity: 'investment_project',
+      searchTerm: req.query.term,
       requestBody: req.body,
       token: req.session.token,
       page: req.query.page,

--- a/src/apps/investment-projects/views/list.njk
+++ b/src/apps/investment-projects/views/list.njk
@@ -13,9 +13,10 @@
 
 {% block main_grid_right_column %}
   {{
-    Collection(results | assign({
+    Collection(searchResults | assign({
       sortForm: sortForm,
       selectedFilters: selectedFilters,
+      highlightTerm: searchTerm,
       countLabel: 'project',
       query: QUERY
     }))

--- a/src/apps/omis/apps/list/middleware.js
+++ b/src/apps/omis/apps/list/middleware.js
@@ -6,6 +6,7 @@ async function getCollection (req, res, next) {
   try {
     res.locals.results = await search({
       searchEntity: 'order',
+      searchTerm: req.query.term,
       requestBody: req.body,
       token: req.session.token,
       page: req.query.page,

--- a/src/apps/omis/apps/list/views/list.njk
+++ b/src/apps/omis/apps/list/views/list.njk
@@ -2,9 +2,10 @@
 
 {% block main_grid_right_column %}
   {{
-    Collection(results | assign({
+    Collection(searchResults | assign({
       countLabel: 'order',
       sortForm: sortForm,
+      highlightTerm: searchTerm,
       query: QUERY
     }))
   }}

--- a/src/apps/search/services.js
+++ b/src/apps/search/services.js
@@ -18,6 +18,13 @@ const entities = [
     count: 0,
   },
   {
+    entity: 'event',
+    path: 'events',
+    text: 'Events',
+    noun: 'event',
+    count: 0,
+  },
+  {
     entity: 'interaction',
     path: 'interactions',
     text: 'Interactions',

--- a/src/apps/search/view.njk
+++ b/src/apps/search/view.njk
@@ -1,17 +1,6 @@
 {% extends "_layouts/two-column.njk" %}
 
-{% block local_header %}
-  {% call LocalHeader({ modifier: 'dark-banner' }) %}
-    {{ EntitySearchForm({
-      inputName: 'term',
-      modifier: 'global',
-      searchTerm: searchTerm,
-      entityType: searchEntity,
-      inputLabel: 'Search for company, contact, investment project or OMIS order',
-      aggregations: results.aggregations
-    }) }}
-  {% endcall %}
-{% endblock %}
+{% block local_header %}{% endblock %}
 
 {% block main_grid_right_column %}
   {% set summaryAction %}

--- a/src/middleware/global-search.js
+++ b/src/middleware/global-search.js
@@ -1,0 +1,92 @@
+const { get, find } = require('lodash')
+
+const { entities, search } = require('../apps/search/services')
+
+const { transformApiResponseToSearchCollection } = require('../apps/search/transformers')
+const { transformCompanyToListItem } = require('../apps/companies/transformers')
+const { transformContactToListItem } = require('../apps/contacts/transformers')
+const { transformEventToListItem } = require('../apps/events/transformers')
+const { transformInvestmentProjectToListItem } = require('../apps/investment-projects/transformers')
+const { transformOrderToListItem } = require('../apps/omis/transformers')
+const { transformInteractionToListItem } = require('../apps/interactions/transformers')
+
+async function searchMiddleware (req, res, next) {
+  const entityPathExtract = req.path.replace(/^\/([a-z-]+).*/, '$1')
+  const entityPath = entityPathExtract === '/' ? 'companies' : entityPathExtract
+  const entity = find(entities, ['path', entityPath])
+
+  console.log(entityPath)
+
+  res.locals = Object.assign({}, res.locals, {
+    globalSearchFormConfig: {
+      searchTerm: req.query.term,
+      action: `/${entityPath}`,
+      inputName: 'term',
+      inputLabel: 'Search',
+      modifier: 'header',
+      fieldModifier: 'light',
+      hiddenFields: { global: true },
+    },
+  })
+
+  if (!entity) {
+    return next()
+  }
+
+  const actionButton = { text: null, url: null }
+  const searchTerm = get(req, 'query.term', '').trim()
+  const searchEntity = entity.entity
+  const itemTransformers = []
+  let searchResults
+
+  if (searchEntity === 'investment_project') {
+    itemTransformers.push(transformInvestmentProjectToListItem)
+  }
+  if (searchEntity === 'contact') {
+    itemTransformers.push(transformContactToListItem)
+  }
+  if (searchEntity === 'event') {
+    itemTransformers.push(transformEventToListItem)
+  }
+  if (searchEntity === 'order') {
+    itemTransformers.push(transformOrderToListItem)
+  }
+
+  if (searchEntity === 'company') {
+    itemTransformers.push(transformCompanyToListItem)
+    actionButton.text = 'Add company'
+    actionButton.url = '/companies/add-step-1'
+  }
+
+  if (searchEntity === 'interaction') {
+    itemTransformers.push(transformInteractionToListItem)
+  }
+
+  try {
+    searchResults = await search({
+      searchTerm,
+      searchEntity,
+      requestBody: req.body,
+      token: req.session.token,
+      page: req.query.page,
+    })
+      .then(transformApiResponseToSearchCollection(
+        {
+          searchTerm,
+          query: req.query,
+        },
+        ...itemTransformers,
+      ))
+  } catch (error) {
+    next(error)
+  }
+
+  res.locals = Object.assign({}, res.locals, {
+    searchResults,
+    searchTerm,
+  })
+
+  next()
+}
+
+module.exports = searchMiddleware

--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,7 @@ const auth = require('./middleware/auth')
 const store = require('./middleware/store')
 const csrfToken = require('./middleware/csrf-token')
 const errors = require('./middleware/errors')
+const globalSearch = require('./middleware/global-search')
 const sessionStore = require('./middleware/session-store')
 const logger = require('../config/logger')
 
@@ -89,6 +90,7 @@ app.use(auth)
 app.use(user)
 app.use(headers)
 app.use(store())
+app.use(globalSearch)
 
 // routing
 app.use(slashify())

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -38,6 +38,8 @@
 
 {% block header_menu %}
   <nav aria-label="global nav">
+    {{ EntitySearchForm(globalSearchFormConfig) if user and CURRENT_PATH != '/' }}
+
     <ul class="proposition-menu">
       {% if feedbackLink %}
         <li class="proposition-menu__item">
@@ -64,7 +66,7 @@
 {% block body_site_header %}
   {{ super() }}
 
-  {{ GlobalNav({ items: GLOBAL_NAV_ITEMS }) if user }}
+  {{ GlobalNav({ items: GLOBAL_NAV_ITEMS, searchAggregations: searchResults.aggregations, searchTerm: searchTerm }) if user }}
 {% endblock %}
 
 {% block body_main_header %}

--- a/src/templates/_macros/common/global-nav.njk
+++ b/src/templates/_macros/common/global-nav.njk
@@ -13,7 +13,15 @@
     <nav class="c-global-nav{{ modifier }}" aria-label="global navigation">
       <div class="c-global-nav__container l-container">
         {% for item in props.items %}
-          <a class="c-global-nav__link {{ 'is-active' if item.isActive }}" href="{{ item.url }}">{{ item.label }}</a>
+          {% set aggregationCount  = (props.searchAggregations | filter(['path', item.path.replace('/', '') ]))[0].count %}
+          {% set url = item.url + ('?term=' + props.searchTerm if props.searchTerm) %}
+
+          <a class="c-global-nav__link {{ 'is-active' if item.isActive }}" href="{{ url }}">
+            {{ item.label }}
+            <span class="c-global-nav__count">
+              ({{ aggregationCount | default(0) }})
+            </span>
+          </a>
         {% endfor %}
       </div>
     </nav>


### PR DESCRIPTION
This is a prototype where search takes central stage. The data flows from the top (search query), then split into sections (global nav), further narrowed down by filters.

Unfortunately filters don't work in this version. Try to imagine 🙂 

### 💥 [Demo](https://datahub-beta2-pr-669.herokuapp.com/companies?term=pizza) 💥

![localhost_3001_companies_global true term pizza](https://user-images.githubusercontent.com/203886/30765690-e2718028-9fe8-11e7-9dbc-52c5832835f5.png)
