### PR TITLE
CSS: Move layout up the import order

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -5,10 +5,10 @@ $images-dir: "/images/";
 @import "settings";
 @import "tools";
 @import "generic";
+@import "layout";
 @import "elements";
 @import "objects";
 @import "components";
-@import "layout";
 @import "trumps";
 
 //// application specific (deprecated)


### PR DESCRIPTION
As components may have overrides for sibling margins it makes sense to set
layout defaults (specifically assemblies) to order before the overrides.

Example below. See margin between label and radio buttons.
### Before
![image](https://user-images.githubusercontent.com/203886/30786303-b5827ce6-a16b-11e7-96df-18d697cddfaa.png)

### After
![image](https://user-images.githubusercontent.com/203886/30786292-8ae9c304-a16b-11e7-8a7f-a553c2e951f5.png)
