### PR TITLE
Enable breadcrumbs only on the third level of hirachy

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -1,6 +1,6 @@
 @import "../tools/mixins";
 
-$_first-element-spacing: $default-spacing-unit * 3;
+$_first-element-spacing: $default-spacing-unit * 4;
 
 .c-local-header {
   @include clearfix;
@@ -22,12 +22,14 @@ $_first-element-spacing: $default-spacing-unit * 3;
   }
 
   .c-entity-search {
-    margin-top: $baseline-grid-unit * 20.5;
-    padding-bottom: $baseline-grid-unit * 6.25;
+    margin-top: $default-spacing-unit * 4;
   }
 
   .c-breadcrumb {
-    margin-top: $default-spacing-unit / 2;
+    padding-top: $default-spacing-unit / 2;
+    padding-bottom: $default-spacing-unit / 2;
+    margin-bottom: -$default-spacing-unit * 2.5;
+    line-height: 1;
 
     & + * {
       margin-top: $_first-element-spacing;

--- a/src/templates/_macros/common/breadcrumbs.njk
+++ b/src/templates/_macros/common/breadcrumbs.njk
@@ -14,7 +14,7 @@
  #}
 
 {% macro Breadcrumbs(props) %}
-  {% if props.items|length > 1 %}
+  {% if props.items|length > 2 %}
     <nav class="c-breadcrumb" aria-label="Breadcrumbs">
       <ul class="c-breadcrumb__list" itemscope itemtype="http://schema.org/BreadcrumbList">
         {% for breadcrumb in props.items %}


### PR DESCRIPTION
I'd like to propose to show breadcrumbs starting from the third level of depth.

I think that the first two levels (Home and global sections) are easily accessible from the header and make it obvious enough to the user where they are which makes the breadcrumb somewhat redundant, adding to UI noise.

### Before

![image](https://user-images.githubusercontent.com/203886/30810840-3a153d94-a1fe-11e7-9c47-44147228d833.png)
![image](https://user-images.githubusercontent.com/203886/30810850-42d597ee-a1fe-11e7-8dcd-d1c59ce1a5d5.png)

### After
![image](https://user-images.githubusercontent.com/203886/30810876-5499214e-a1fe-11e7-9c76-daf3a19838fa.png)
![image](https://user-images.githubusercontent.com/203886/30810898-60b46894-a1fe-11e7-981b-001bfb7a94c0.png)

I encourage people to check out the 💥 [Demo](https://datahub-beta2-pr-680.herokuapp.com/) 💥 to get the feel for how it works.