### PR TITLE
DH-590 Add UK region to event form

### DIFF
--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -1,6 +1,7 @@
 const metadataRepo = require('../../../lib/metadata')
 const { globalFields } = require('../../macros')
 const { transformObjectToOption } = require('../../transformers')
+const { assign } = require('lodash')
 
 const eventFormConfig = ({ advisers }) => {
   return {
@@ -81,8 +82,14 @@ const eventFormConfig = ({ advisers }) => {
         label: 'Postcode',
         class: 'u-js-hidden',
       },
-      Object.assign({}, globalFields.countries, {
+      assign({}, globalFields.countries, {
         name: 'address_country',
+      }),
+      assign({}, globalFields.ukRegions, {
+        condition: {
+          name: 'address_country',
+          value: '80756b9a-5d95-e211-a939-e4115bead28a',
+        },
       }),
       {
         macroName: 'TextField',

--- a/src/apps/events/services/formatting.js
+++ b/src/apps/events/services/formatting.js
@@ -15,6 +15,7 @@ function transformToApi (body) {
     address_county: Object,
     postcode: Object,
     address_country: Object,
+    uk_region: Object,
     notes: Object,
     lead_team: Object,
     organiser: Object,

--- a/test/acceptance/features/events/create-event-form.feature
+++ b/test/acceptance/features/events/create-event-form.feature
@@ -22,6 +22,7 @@ Feature: Create an Event in Data hub
     And I verify the event address county field is displayed
     And I verify the event address postcode field is displayed
     And I verify the event address country field is displayed
+    And I verify the event UK region field is not displayed
     And I verify the event notes field is displayed
     And I verify the event Team hosting field is displayed
     And I verify the event organiser field is displayed
@@ -29,6 +30,15 @@ Feature: Create an Event in Data hub
     And I verify the shared teams field is not displayed
     And I verify the event related programmes field is displayed
     And I verify the event save button is displayed
+
+  @events__create-event-form--toggle-uk-region
+  Scenario: Verify event UK region toggling
+
+    When I navigate to the create an event page
+    And I choose the United Kingdom country option
+    Then I verify the event UK region field is displayed
+    When I choose the Afghanistan country option
+    Then I verify the event UK region field is not displayed
 
   @events__create-event-form--toggle-shared
   Scenario: Verify event shared field toggling

--- a/test/acceptance/features/events/page-objects/Events.js
+++ b/test/acceptance/features/events/page-objects/Events.js
@@ -22,6 +22,8 @@ module.exports = {
     addressPostcode: 'input[name="postcode"]',
     addressCountry: 'select[name="address_country"]',
     addressCountryError: 'label[for=field-address_country] span:nth-child(2)',
+    ukRegion: 'select[name="uk_region"]',
+    ukRegionError: 'label[for=field-uk_region] span:nth-child(2)',
     notes: 'textarea[name="notes"]',
     teamHosting: 'select[name="lead_team"]',
     organiser: 'select[name="organiser"]',
@@ -59,6 +61,10 @@ module.exports = {
 
   commands: [
     {
+      selectListOptionByText (listName, text) {
+        return this
+          .click('xpath', `//select[@name="${listName}"]/option[normalize-space(.)="${text}"]`)
+      },
       selectListOption (listName, optionNumber) {
         return this
           .click(`select[name="${listName}"] option:nth-child(${optionNumber})`)

--- a/test/acceptance/features/events/save-new-event.feature
+++ b/test/acceptance/features/events/save-new-event.feature
@@ -27,4 +27,14 @@ Feature: Save a new Event in Data hub
     And I verify the event address country has an error message
     Then I see the error message
 
+  @events__save-new-event--uk-region
+  Scenario: Verify event UK region mandatory field
+
+    When I navigate to the create an event page
+    And I enter all mandatory fields related to the event
+    And I choose the United Kingdom country option
+    And I click the save button
+    And I verify the event UK region has an error message
+    Then I see the error message
+
 

--- a/test/acceptance/features/events/step_definitions/event-create.js
+++ b/test/acceptance/features/events/step_definitions/event-create.js
@@ -10,6 +10,12 @@ defineSupportCode(({ Given, Then, When }) => {
       .navigate()
   })
 
+  When(/^I choose the (.+) country option$/, async (country) => {
+    await Events
+      .setValue('@addressCountry', '')
+      .selectListOptionByText('address_country', country)
+  })
+
   Then(/^I verify the event name field is displayed$/, async () => {
     await Events
       .assert.visible('@eventName')
@@ -76,6 +82,16 @@ defineSupportCode(({ Given, Then, When }) => {
   Then(/^I verify the event address country field is displayed$/, async () => {
     await Events
       .assert.visible('@addressCountry')
+  })
+
+  Then(/^I verify the event UK region field is displayed$/, async () => {
+    await Events
+      .assert.visible('@ukRegion')
+  })
+
+  Then(/^I verify the event UK region field is not displayed$/, async () => {
+    await Events
+      .assert.hidden('@ukRegion')
   })
 
   Then(/^I verify the event notes field is displayed$/, async () => {
@@ -210,6 +226,11 @@ defineSupportCode(({ Given, Then, When }) => {
   Then(/^I verify the event address country has an error message$/, async () => {
     await Events
       .assert.visible('@addressCountryError')
+  })
+
+  Then(/^I verify the event UK region has an error message$/, async () => {
+    await Events
+      .assert.visible('@ukRegionError')
   })
 
   Then(/^I see the event is displayed correctly with all field values$/, async () => {

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -36,6 +36,7 @@ describe('Event details middleware', () => {
         address_county: 'county',
         postcode: 'postcode',
         address_country: 'country',
+        uk_region: 'uk_region',
         notes: 'notes',
         lead_team: 'lead_team',
         organiser: 'organiser',

--- a/test/unit/data/events/event.json
+++ b/test/unit/data/events/event.json
@@ -14,6 +14,7 @@
   "address_county": "county",
   "postcode": "postcode",
   "address_country": "country",
+  "uk_region": "uk_region",
   "notes": "notes",
   "lead_team": "lead_team",
   "organiser": "organiser",


### PR DESCRIPTION
This change adds the UK region to the create event form.

## By default - no UK region
<img width="690" alt="screen shot 2017-09-25 at 14 47 19" src="https://user-images.githubusercontent.com/1150417/30811665-c649884a-a200-11e7-95eb-675b38ec3588.png">

## When United Kingdom is selected
<img width="692" alt="screen shot 2017-09-25 at 14 47 49" src="https://user-images.githubusercontent.com/1150417/30811671-c9ef0cea-a200-11e7-9610-4b75164f76ba.png">

## When submitting the form without selecting a UK region
<img width="691" alt="screen shot 2017-09-25 at 14 48 38" src="https://user-images.githubusercontent.com/1150417/30811676-ce7c1118-a200-11e7-94e3-9435fafad25e.png">
