### PR TITLE
DH-594 Add service to event form

### DIFF
--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -108,6 +108,7 @@ const eventFormConfig = ({ advisers }) => {
           return metadataRepo.teams.map(transformObjectToOption)
         },
       },
+      globalFields.serviceDeliveryServices,
       {
         macroName: 'MultipleChoiceField',
         name: 'organiser',

--- a/src/apps/events/services/formatting.js
+++ b/src/apps/events/services/formatting.js
@@ -18,6 +18,7 @@ function transformToApi (body) {
     uk_region: Object,
     notes: Object,
     lead_team: Object,
+    service: Object,
     organiser: Object,
     related_programmes: Array,
     teams: Array,
@@ -51,7 +52,7 @@ function transformToApi (body) {
   if (formatted.lead_team) {
     formatted.teams.push(formatted.lead_team)
   }
-  formatted.service = '1783ae93-b78f-e611-8c55-e4115bed50dc'
+
   return assign({}, formatted)
 }
 

--- a/src/apps/macros.js
+++ b/src/apps/macros.js
@@ -100,6 +100,16 @@ const globalFields = {
       return metadata.serviceDeliveryStatusOptions.map(transformObjectToOption)
     },
   },
+
+  serviceDeliveryServices: {
+    macroName: 'MultipleChoiceField',
+    name: 'service',
+    label: 'Service',
+    initialOption: '-- Select service --',
+    options () {
+      return metadata.serviceDeliveryServiceOptions.map(transformObjectToOption)
+    },
+  },
 }
 
 module.exports = {

--- a/test/acceptance/features/events/create-event-form.feature
+++ b/test/acceptance/features/events/create-event-form.feature
@@ -25,6 +25,7 @@ Feature: Create an Event in Data hub
     And I verify the event UK region field is not displayed
     And I verify the event notes field is displayed
     And I verify the event Team hosting field is displayed
+    And I verify the event services field is displayed
     And I verify the event organiser field is displayed
     And I verify the event is shared or not field is displayed
     And I verify the shared teams field is not displayed

--- a/test/acceptance/features/events/page-objects/Events.js
+++ b/test/acceptance/features/events/page-objects/Events.js
@@ -26,6 +26,8 @@ module.exports = {
     ukRegionError: 'label[for=field-uk_region] span:nth-child(2)',
     notes: 'textarea[name="notes"]',
     teamHosting: 'select[name="lead_team"]',
+    services: 'select[name="service"]',
+    servicesError: 'label[for=field-service] span:nth-child(2)',
     organiser: 'select[name="organiser"]',
     sharedYesContainer: '#group-field-event_shared div div',
     sharedNoContainer: '#group-field-event_shared div div:nth-child(2)',

--- a/test/acceptance/features/events/save-new-event.feature
+++ b/test/acceptance/features/events/save-new-event.feature
@@ -25,7 +25,8 @@ Feature: Save a new Event in Data hub
     And I verify the event address line 1 has an error message
     And I verify the event address town has an error message
     And I verify the event address country has an error message
-    Then I see the error message
+    And I verify the event services has an error message
+    Then I see the error summary
 
   @events__save-new-event--uk-region
   Scenario: Verify event UK region mandatory field
@@ -35,6 +36,6 @@ Feature: Save a new Event in Data hub
     And I choose the United Kingdom country option
     And I click the save button
     And I verify the event UK region has an error message
-    Then I see the error message
+    Then I see the error summary
 
 

--- a/test/acceptance/features/events/step_definitions/event-create.js
+++ b/test/acceptance/features/events/step_definitions/event-create.js
@@ -104,6 +104,11 @@ defineSupportCode(({ Given, Then, When }) => {
       .assert.visible('@teamHosting')
   })
 
+  Then(/^I verify the event services field is displayed$/, async () => {
+    await Events
+      .assert.visible('@services')
+  })
+
   Then(/^I verify the event organiser field is displayed$/, async () => {
     await Events
       .assert.visible('@organiser')
@@ -182,6 +187,7 @@ defineSupportCode(({ Given, Then, When }) => {
       .setValue('@addressTown', faker.address.city())
       .setValue('@addressPostcode', faker.address.zipCode())
       .setValue('@addressCountry', faker.address.country())
+      .selectListOption('service', 2)
   })
 
   When(/^I click the save button$/, async () => {
@@ -226,6 +232,11 @@ defineSupportCode(({ Given, Then, When }) => {
   Then(/^I verify the event address country has an error message$/, async () => {
     await Events
       .assert.visible('@addressCountryError')
+  })
+
+  Then(/^I verify the event services has an error message$/, async () => {
+    await Events
+      .assert.visible('@servicesError')
   })
 
   Then(/^I verify the event UK region has an error message$/, async () => {

--- a/test/acceptance/features/form/page-objects/Form.js
+++ b/test/acceptance/features/form/page-objects/Form.js
@@ -1,0 +1,5 @@
+module.exports = {
+  elements: {
+    errorSummary: '.c-error-summary li:first-child',
+  },
+}

--- a/test/acceptance/features/form/step_definitions/form.js
+++ b/test/acceptance/features/form/step_definitions/form.js
@@ -1,0 +1,11 @@
+const { client } = require('nightwatch-cucumber')
+const { defineSupportCode } = require('cucumber')
+
+defineSupportCode(({ Then }) => {
+  const Form = client.page.Form()
+
+  Then(/^I see the error summary$/, async () => {
+    await Form
+      .assert.visible('@errorSummary')
+  })
+})

--- a/test/acceptance/features/messages/step_definitions/messages.js
+++ b/test/acceptance/features/messages/step_definitions/messages.js
@@ -9,10 +9,4 @@ defineSupportCode(({ Then }) => {
       .waitForElementPresent('@flashMessage')
       .assert.cssClassPresent('@flashMessage', 'c-message--success')
   })
-
-  Then(/^I see the error message$/, () => {
-    Messages
-      .waitForElementPresent('@flashMessage')
-      .assert.cssClassPresent('@flashMessage', 'c-message--error')
-  })
 })

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -39,10 +39,10 @@ describe('Event details middleware', () => {
         uk_region: 'uk_region',
         notes: 'notes',
         lead_team: 'lead_team',
+        service: 'service',
         organiser: 'organiser',
         related_programmes: [ 'programme1', 'programme2' ],
         teams: [ 'team1', 'team2', 'lead_team' ],
-        service: '1783ae93-b78f-e611-8c55-e4115bed50dc',
       }
     })
 

--- a/test/unit/data/events/event.json
+++ b/test/unit/data/events/event.json
@@ -17,6 +17,7 @@
   "uk_region": "uk_region",
   "notes": "notes",
   "lead_team": "lead_team",
+  "service": "service",
   "organiser": "organiser",
   "teams": [ "team1", "team2" ],
   "related_programmes": [ "programme1", "programme2" ]


### PR DESCRIPTION
This change adds the service field to the create event form.

## New service field
<img width="680" alt="screen shot 2017-09-25 at 15 06 33" src="https://user-images.githubusercontent.com/1150417/30812652-40ce3a46-a203-11e7-9007-78aeb8e1a15b.png">

## Validation on service field
<img width="680" alt="screen shot 2017-09-25 at 15 07 00" src="https://user-images.githubusercontent.com/1150417/30812657-44785de8-a203-11e7-9a15-209a666d213c.png">
