### PR TITLE
Redirect to event details URL

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -38,7 +38,7 @@ function redirectToDetails (req, res, next) {
   }
 
   req.flash('success', 'Event created')
-  return res.redirect(`/events/${res.locals.resultId}/details`)
+  return res.redirect(`/events/${res.locals.resultId}`)
 }
 
 module.exports = {

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -228,7 +228,7 @@ describe('Event edit controller', () => {
       it('should redirect to the event', () => {
         this.controller.redirectToDetails(this.req, this.res, this.next)
 
-        expect(this.res.redirect).have.been.calledWith('/events/1/details')
+        expect(this.res.redirect).have.been.calledWith('/events/1')
         expect(this.res.redirect).have.been.calledOnce
       })
 


### PR DESCRIPTION
This change corrects the redirect so that once an event has been created the details of the event are visible.