### PR TITLE
Remove console log from interactions

### DIFF
--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -55,7 +55,6 @@ async function renderEditPage (req, res, next) {
         interactionTypeLabel: interaction.interaction_type.name,
       })
   } catch (error) {
-    console.log(error)
     next(error)
   }
 }


### PR DESCRIPTION
There was a left over console log logging the error which caused
it to show up in unit tests.

## Before
![image](https://user-images.githubusercontent.com/3327997/30856033-f4cc30f6-a2ae-11e7-990b-9f0185c46c7d.png)

## After
![image](https://user-images.githubusercontent.com/3327997/30855992-d98951de-a2ae-11e7-929e-da507527349d.png)
