### PR TITLE
Feature/redis tls and crypto phase out

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -25,10 +25,11 @@ const config = {
     url: process.env.REDIS_URL || process.env.REDISTOGO_URL,
     port: process.env.REDIS_PORT || 6379,
     host: process.env.REDIS_HOST || 'redis',
+    metadataTtl: (process.env.METADATA_TTL || (15 * 60)),
     sentinel: process.env.REDIS_SENTINEL,
     sentinelPort: process.env.REDIS_SENTINEL_PORT || 26379,
     sentinelMaster: process.env.REDIS_SENTINEL_MASTER || 'master',
-    metadataTtl: (process.env.METADATA_TTL || (15 * 60)),
+    useTLS: process.env.REDIS_USE_TLS,
   },
   googleTagManagerKey: process.env.GOOGLE_TAG_MANAGER_KEY,
   session: {

--- a/config/redis-store.js
+++ b/config/redis-store.js
@@ -1,17 +1,18 @@
 const Redis = require('ioredis')
-const redisCrypto = require('connect-redis-crypto')
+// TODO remove crypto and rename plain when migration to Gov PaaS is complete
+const redisConnectPlain = require('connect-redis')
+const redisConnectCrypto = require('connect-redis-crypto')
 const session = require('express-session')
 const url = require('url')
-
 const logger = require('./logger')
 const config = require('./')
-
-const RedisStore = redisCrypto(session)
 
 let redisConfig = {
   port: config.redis.port,
   host: config.redis.host,
 }
+
+let RedisStore
 
 if (config.redis.url) {
   const redisURL = url.parse(config.redis.url)
@@ -34,6 +35,15 @@ if (config.redis.url) {
   if (redisURL.auth) {
     redisConfig.password = redisURL.auth.split(':')[1]
   }
+}
+if (config.redis.useTLS) {
+  redisConfig.tls = {
+    // allows self-signed certificates
+    rejectUnauthorized: false,
+  }
+  RedisStore = redisConnectPlain(session)
+} else {
+  RedisStore = redisConnectCrypto(session)
 }
 
 const client = new Redis(redisConfig)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "classlist.js": "^1.1.20150312",
     "compression": "^1.6.2",
     "connect-flash": "0.1.1",
+    "connect-redis": "^3.3.0",
     "connect-redis-crypto": "3.1.1",
     "cookie-parser": "^1.4.3",
     "core-js": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,6 +1752,13 @@ connect-redis-crypto@3.1.1:
     debug "^2.2.0"
     redis "^2.1.0"
 
+connect-redis@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-3.3.0.tgz#c9510c1a567ff710eb2510e6a7509fa92b2232df"
+  dependencies:
+    debug "^2.2.0"
+    redis "^2.1.0"
+
 connect@1.x:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/connect/-/connect-1.9.2.tgz#42880a22e9438ae59a8add74e437f58ae8e52807"


### PR DESCRIPTION
(Had to kill previous PR as I mucked up Git)

This allows us to start Redis in TLS mode which requires a new env var called REDIS_USE_TLS set to true

It also *starts* the process of removing `connect-redis-crypto` module - if the Redis is TLS enabled it will be encrypted as well, but if not we need to rely on the old module. Once everything is on Gov PaaS then we can remove it 