### PR TITLE
Ensure the event id is set when editing an event

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -18,7 +18,7 @@ async function renderEditPage (req, res, next) {
 
     const eventForm =
       buildFormWithStateAndErrors(
-        eventFormConfig({ advisers }),
+        eventFormConfig({ eventId, advisers }),
         mergedData,
         get(res.locals, 'form.errors.messages'),
       )

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -3,10 +3,13 @@ const { assign } = require('lodash')
 const { globalFields } = require('../../macros')
 const { transformObjectToOption } = require('../../transformers')
 
-const eventFormConfig = ({ advisers }) => {
+const eventFormConfig = ({ eventId, advisers }) => {
   return {
     method: 'post',
     buttonText: 'Save',
+    hiddenFields: {
+      id: eventId,
+    },
     children: [
       {
         macroName: 'TextField',

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -64,7 +64,7 @@ describe('Event edit controller', () => {
 
       const actual = this.res.render.getCall(0).args[1].eventForm
 
-      expect(actual).to.be.an('object')
+      expect(actual).to.be.an('object').and.have.property('hiddenFields').and.have.property('id')
     })
 
     it('should populate the event form with organisers', async () => {


### PR DESCRIPTION
There was a bug which resulted in an existing event being duplicated on each save because event id was not submitted.