### PR TITLE
add organiser to filters and tidy up UAT tests a little

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -1,40 +1,32 @@
 /* eslint camelcase: 0 */
 const { eventFormConfig } = require('../macros')
-const { getAdvisers } = require('../../adviser/repos')
 const { transformEventResponseToFormBody } = require('../transformers')
 const { buildFormWithStateAndErrors } = require('../../builders')
 const { assign, merge, get, pickBy } = require('lodash')
 
-async function renderEditPage (req, res, next) {
+function renderEditPage (req, res) {
   const eventData = transformEventResponseToFormBody(res.locals.event)
+  const advisers = get(res.locals, 'advisers.results')
   const eventId = get(eventData, 'id', '')
   const eventName = get(eventData, 'name')
   const lead_team = eventData.lead_team || get(req, 'session.user.dit_team.id')
+  const mergedData = pickBy(merge({}, eventData, { lead_team }, res.locals.requestBody))
+  const eventForm =
+    buildFormWithStateAndErrors(
+      eventFormConfig({ eventId, advisers }),
+      mergedData,
+      get(res.locals, 'form.errors.messages'),
+    )
 
-  try {
-    const advisersResponse = await getAdvisers(req.session.token)
-    const advisers = advisersResponse.results
-    const mergedData = pickBy(merge({}, eventData, { lead_team }, res.locals.requestBody))
-
-    const eventForm =
-      buildFormWithStateAndErrors(
-        eventFormConfig({ eventId, advisers }),
-        mergedData,
-        get(res.locals, 'form.errors.messages'),
-      )
-
-    res
-      .breadcrumb(eventName, `/events/${eventId}`)
-      .breadcrumb(`${eventId ? 'Edit' : 'Add'} event`)
-      .render('events/views/edit', {
-        eventForm: assign(eventForm, {
-          returnLink: `/events/${eventId}`,
-          returnText: 'Cancel',
-        }),
-      })
-  } catch (e) {
-    next(e)
-  }
+  res
+    .breadcrumb(eventName, `/events/${eventId}`)
+    .breadcrumb(`${eventId ? 'Edit' : 'Add'} event`)
+    .render('events/views/edit', {
+      eventForm: assign(eventForm, {
+        returnLink: `/events/${eventId}`,
+        returnText: 'Cancel',
+      }),
+    })
 }
 
 module.exports = {

--- a/src/apps/events/controllers/list.js
+++ b/src/apps/events/controllers/list.js
@@ -1,15 +1,16 @@
 const { get, omit, merge, assign } = require('lodash')
-const { eventFiltersFields: filtersFields, eventSortForm } = require('../macros')
+const { eventFiltersFields, eventSortForm } = require('../macros')
 const { buildSelectedFiltersSummary } = require('../../builders')
 
 function renderEventList (req, res) {
+  const advisers = get(res.locals, 'advisers.results')
   const sortForm = merge({}, eventSortForm, {
     hiddenFields: assign({}, omit(req.query, 'sortby')),
     children: [
       { value: req.query.sortby },
     ],
   })
-
+  const filtersFields = eventFiltersFields({ advisers })
   const selectedFilters = buildSelectedFiltersSummary(filtersFields, req.query)
   const isUKSelected = get(selectedFilters, 'address_country.valueLabel') === 'United Kingdom'
 

--- a/src/apps/events/labels.js
+++ b/src/apps/events/labels.js
@@ -5,6 +5,7 @@ const labels = {
       event_type: 'Type of event',
       address_country: 'Country',
       uk_region: 'Region',
+      organiser: 'Organiser',
       start_date: 'Starts on or after',
       end_date: 'Ends on',
     },

--- a/src/apps/events/macros/event-filters-fields.js
+++ b/src/apps/events/macros/event-filters-fields.js
@@ -1,44 +1,54 @@
 const { assign } = require('lodash')
 const { globalFields } = require('../../macros')
 const { collectionFilterLabels } = require('../labels')
+const { transformObjectToOption } = require('../../transformers')
 
 const currentYear = (new Date()).getFullYear()
 
-const eventFiltersFields = [
-  {
-    macroName: 'TextField',
-    name: 'name',
-    hint: 'At least three characters',
-  },
-  assign({}, globalFields.eventTypes, {
-    name: 'event_type',
-    initialOption: 'All types',
-  }),
-  assign({}, globalFields.countries, {
-    name: 'address_country',
-    initialOption: 'All countries',
-  }),
-  assign({}, globalFields.ukRegions, {
-    name: 'uk_region',
-    initialOption: 'All UK regions',
-  }),
-  {
-    macroName: 'TextField',
-    name: 'start_date',
-    hint: 'YYYY-MM-DD',
-    placeholder: `e.g. ${currentYear}-07-18`,
-  },
-  {
-    macroName: 'TextField',
-    name: 'end_date',
-    hint: 'YYYY-MM-DD',
-    placeholder: `e.g. ${currentYear}-07-21`,
-  },
-].map(filter => {
-  return assign(filter, {
-    label: collectionFilterLabels.edit[filter.name],
-    modifier: ['smaller', 'light'],
+const eventFiltersFields = ({ advisers }) => {
+  return [
+    {
+      macroName: 'TextField',
+      name: 'name',
+      hint: 'At least three characters',
+    },
+    assign({}, globalFields.eventTypes, {
+      name: 'event_type',
+      initialOption: 'All types',
+    }),
+    assign({}, globalFields.countries, {
+      name: 'address_country',
+      initialOption: 'All countries',
+    }),
+    assign({}, globalFields.ukRegions, {
+      name: 'uk_region',
+      initialOption: 'All UK regions',
+    }),
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'organiser',
+      label: 'Organiser',
+      initialOption: '-- Select organiser --',
+      options: advisers.map(transformObjectToOption),
+    },
+    {
+      macroName: 'TextField',
+      name: 'start_date',
+      hint: 'YYYY-MM-DD',
+      placeholder: `e.g. ${currentYear}-07-18`,
+    },
+    {
+      macroName: 'TextField',
+      name: 'end_date',
+      hint: 'YYYY-MM-DD',
+      placeholder: `e.g. ${currentYear}-07-21`,
+    },
+  ].map(filter => {
+    return assign(filter, {
+      label: collectionFilterLabels.edit[filter.name],
+      modifier: ['smaller', 'light'],
+    })
   })
-})
+}
 
 module.exports = eventFiltersFields

--- a/src/apps/events/middleware/collection.js
+++ b/src/apps/events/middleware/collection.js
@@ -28,6 +28,7 @@ function getRequestBody (req, res, next) {
   const selectedFiltersQuery = pick(req.query, [
     'name',
     'event_type',
+    'organiser',
     'address_country',
     'uk_region',
     'start_date',

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -1,8 +1,8 @@
 const { assign } = require('lodash')
 
-const { fetchEvent } = require('../repos')
 const { transformEventResponseToViewRecord, transformEventFormBodyToApiRequest } = require('../transformers')
-const { saveEvent } = require('../repos')
+const { fetchEvent, saveEvent } = require('../repos')
+const { getAdvisers } = require('../../adviser/repos')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformEventFormBodyToApiRequest(req.body)
@@ -37,12 +37,22 @@ async function getEventDetails (req, res, next, eventId) {
     res.locals.event = await fetchEvent(req.session.token, eventId)
     res.locals.eventViewRecord = transformEventResponseToViewRecord(res.locals.event)
     next()
-  } catch (error) {
-    next(error)
+  } catch (err) {
+    next(err)
+  }
+}
+
+async function getAdviserDetails (req, res, next) {
+  try {
+    res.locals.advisers = await getAdvisers(req.session.token)
+    next()
+  } catch (err) {
+    next(err)
   }
 }
 
 module.exports = {
-  postDetails,
   getEventDetails,
+  getAdviserDetails,
+  postDetails,
 }

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -3,7 +3,7 @@ const router = require('express').Router()
 const { setDefaultQuery } = require('../middleware')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderEditPage } = require('./controllers/edit')
-const { postDetails, getEventDetails } = require('./middleware/details')
+const { postDetails, getEventDetails, getAdviserDetails } = require('./middleware/details')
 const { getRequestBody, getEventsCollection } = require('./middleware/collection')
 const { renderEventList } = require('./controllers/list')
 
@@ -15,14 +15,16 @@ router.param('id', getEventDetails)
 
 router.get('/',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
+  getAdviserDetails,
   getRequestBody,
   getEventsCollection,
   renderEventList,
 )
 
 router.route(['/create', '/:id/edit'])
-  .post(postDetails)
-  .all(renderEditPage)
+  .all(getAdviserDetails)
+  .post(postDetails, renderEditPage)
+  .get(renderEditPage)
 
 router.get('/:id', renderDetailsPage)
 

--- a/test/acceptance/commands/clickListOption.js
+++ b/test/acceptance/commands/clickListOption.js
@@ -1,0 +1,9 @@
+/**
+ * Utility to click a specific option by textContent in a named select element
+ * @param name
+ * @param textContent
+ * @returns this
+ */
+exports.command = function clickListOption (name, textContent) {
+  return this.click('xpath', `//select[@name="${name}"]/option[normalize-space(.)="${textContent}"]`)
+}

--- a/test/acceptance/features/events/list.feature
+++ b/test/acceptance/features/events/list.feature
@@ -42,11 +42,17 @@ Feature: View a list of events
     And I click the save button
     Then I see the success message
     When I navigate to the event list page
-    And I filter the events list
+    And I filter the events list by name
+    Then I can view the event
+    And I filter the events list by organiser
+    Then I can view the event
+    And I filter the events list by event type
+    Then I can view the event
+    And I filter the events list by country
     Then I can view the event
 
-  @events-list--sort-a-z
-  Scenario: Sort event list A-Z
+  @events-list--sort-a-z-and-z-a
+  Scenario: Sort event list A-Z and Z-A
     And I navigate to the event list page
     When I click the add an event link
     And I populate the create event form
@@ -60,20 +66,6 @@ Feature: View a list of events
     When I navigate to the event list page
     And I sort the events list name A-Z
     Then I see the list in A-Z alphabetical order
-
-  @events-list--sort-z-a
-  Scenario: Sort event list Z-A
-    And I navigate to the event list page
-    When I click the add an event link
-    And I populate the create event form
-    And I click the save button
-    Then I see the success message
-    When I navigate to the event list page
-    And I click the add an event link
-    And I populate the create event form
-    When I click the save button
-    Then I see the success message
-    When I navigate to the event list page
     And I sort the events list name Z-A
     Then I see the list in Z-A alphabetical order
 

--- a/test/acceptance/features/events/page-objects/Event.js
+++ b/test/acceptance/features/events/page-objects/Event.js
@@ -65,10 +65,6 @@ module.exports = {
   },
   commands: [
     {
-      selectListOptionByText (listName, text) {
-        return this
-          .click('xpath', `//select[@name="${listName}"]/option[normalize-space(.)="${text}"]`)
-      },
       selectListOption (listName, optionNumber) {
         return this
           .click(`select[name="${listName}"] option:nth-child(${optionNumber})`)

--- a/test/acceptance/features/events/page-objects/Event.js
+++ b/test/acceptance/features/events/page-objects/Event.js
@@ -41,7 +41,7 @@ module.exports = {
     relatedProgrammes: '#field-related_programmes',
     addAnotherProgramme: 'input[name="add_related_programme"]',
     saveButton: {
-      selector: '//button[text() = \'Save and Continue\']',
+      selector: '//button[text()[normalize-space()="Save"]]',
       locateStrategy: 'xpath',
     },
     // Event details page
@@ -94,7 +94,7 @@ module.exports = {
           end_date_year: format(futureDate, 'YYYY'),
           end_date_month: format(futureDate, 'MM'),
           end_date_day: format(futureDate, 'D'),
-          notes: faker.lorem.paragraph(),
+          notes: faker.lorem.sentence(),
           location_type: null,
           service: null,
           event_type: null,

--- a/test/acceptance/features/events/page-objects/EventList.js
+++ b/test/acceptance/features/events/page-objects/EventList.js
@@ -52,6 +52,15 @@ module.exports = {
         nameInput: {
           selector: '#field-name',
         },
+        organiser: {
+          selector: 'select[name="organiser"]',
+        },
+        country: {
+          selector: 'select[name="address_country"]',
+        },
+        eventType: {
+          selector: 'select[name="event_type"]',
+        },
       },
     },
   },

--- a/test/acceptance/features/events/step_definitions/create.js
+++ b/test/acceptance/features/events/step_definitions/create.js
@@ -13,7 +13,7 @@ defineSupportCode(({ Given, Then, When }) => {
   When(/^I choose the (.+) country option$/, async (country) => {
     await Event
       .setValue('@addressCountry', '')
-      .selectListOptionByText('address_country', country)
+      .clickListOption('address_country', country)
   })
 
   Then(/^I verify the event name field is displayed$/, async () => {

--- a/test/acceptance/features/events/step_definitions/list.js
+++ b/test/acceptance/features/events/step_definitions/list.js
@@ -75,7 +75,7 @@ defineSupportCode(({ Then, When, Before }) => {
       .assert.containsText('@region', Event.state.countryDetails.uk_region)
   })
 
-  Then(/^I filter the events list$/, async () => {
+  Then(/^I filter the events list by name$/, async () => {
     await EventList.section.filters
       .waitForElementPresent('@nameInput')
       .setValue('@nameInput', Event.state.eventDetails.name)
@@ -85,6 +85,39 @@ defineSupportCode(({ Then, When, Before }) => {
     await EventList.section.firstEventInList
       .waitForElementVisible('@header')
       .assert.containsText('@header', Event.state.eventDetails.name)
+  })
+
+  Then(/^I filter the events list by organiser$/, async () => {
+    await EventList.section.filters
+      .waitForElementPresent('@organiser')
+      .clickListOption('organiser', Event.state.eventDetails.organiser)
+      .wait() // wait for xhr
+
+    await EventList.section.firstEventInList
+      .waitForElementVisible('@organiser')
+      .assert.containsText('@organiser', Event.state.eventDetails.organiser)
+  })
+
+  Then(/^I filter the events list by country/, async () => {
+    await EventList.section.filters
+      .waitForElementPresent('@country')
+      .clickListOption('address_country', Event.state.eventDetails.address_country)
+      .wait() // wait for xhr
+
+    await EventList.section.firstEventInList
+      .waitForElementVisible('@country')
+      .assert.containsText('@country', Event.state.eventDetails.address_country)
+  })
+
+  Then(/^I filter the events list by event type/, async () => {
+    await EventList.section.filters
+      .waitForElementPresent('@eventType')
+      .clickListOption('event_type', Event.state.eventDetails.event_type)
+      .wait() // wait for xhr
+
+    await EventList.section.firstEventInList
+      .waitForElementVisible('@eventType')
+      .assert.containsText('@eventType', Event.state.eventDetails.event_type)
   })
 
   Then(/^I sort the events list name A-Z$/, async () => {

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -1,31 +1,14 @@
 const { assign, find } = require('lodash')
 
 const eventData = require('../../../data/events/event.json')
+const advisersResponse = require('../../../data/advisers/advisers')
 
 describe('Event edit controller', () => {
-  const createEventsEditController = (getAdvisers) => {
-    return proxyquire('~/src/apps/events/controllers/edit', {
-      '../../adviser/repos': {
-        getAdvisers: getAdvisers,
-      },
-    })
-  }
   const currentUserTeam = 'team1'
 
   beforeEach(() => {
-    const advisersResponse = {
-      results: [
-        { name: 'advisor 1', id: 'advisor1' },
-        { name: 'advisor 2', id: 'advisor2' },
-        { name: 'advisor 3', id: 'advisor3' },
-      ],
-    }
-    const getAdvisersStub = sinon.stub().resolves(advisersResponse)
-
-    this.controller = createEventsEditController(getAdvisersStub)
-
     this.sandbox = sinon.sandbox.create()
-
+    this.controller = require('~/src/apps/events/controllers/edit')
     this.req = {
       session: {
         token: 'abcd',
@@ -42,7 +25,9 @@ describe('Event edit controller', () => {
       breadcrumb: this.sandbox.stub().returnsThis(),
       render: this.sandbox.spy(),
       redirect: this.sandbox.spy(),
-      locals: {},
+      locals: {
+        advisers: advisersResponse,
+      },
     }
     this.next = this.sandbox.spy()
   })
@@ -73,9 +58,26 @@ describe('Event edit controller', () => {
       const eventForm = this.res.render.getCall(0).args[1].eventForm
       const actual = find(eventForm.children, { name: 'organiser' }).options
       const expected = [
-        { value: 'advisor1', label: 'advisor 1' },
-        { value: 'advisor2', label: 'advisor 2' },
-        { value: 'advisor3', label: 'advisor 3' },
+        {
+          label: 'Jeff Smith',
+          value: 'a0dae366-1134-e411-985c-e4115bead28a',
+        },
+        {
+          label: 'Aaron Mr',
+          value: 'e13209b8-8d61-e311-8255-e4115bead28a',
+        },
+        {
+          label: 'Mr Benjamin',
+          value: 'b9d6b3dc-7af4-e411-bcbe-e4115bead28a',
+        },
+        {
+          label: 'George Chan',
+          value: '0119a99e-9798-e211-a939-e4115bead28a',
+        },
+        {
+          label: 'Fred Rafters',
+          value: '0919a99e-9798-e211-a939-e4115bead28a',
+        },
       ]
 
       expect(actual).to.deep.equal(expected)
@@ -113,7 +115,7 @@ describe('Event edit controller', () => {
     })
 
     context('when there are validation errors', () => {
-      it('should prepopulate the errors', async () => {
+      it('should pre populate the errors', async () => {
         const messages = {
           name: 'error 1',
           start_date: 'error 2',
@@ -131,6 +133,7 @@ describe('Event edit controller', () => {
                 messages,
               },
             },
+            advisers: advisersResponse,
           },
         })
 
@@ -144,18 +147,6 @@ describe('Event edit controller', () => {
         }
 
         expect(actualErrors).to.deep.equal(expectedErrors)
-      })
-    })
-
-    context('when there is an exception', () => {
-      it('should return an error', async () => {
-        const error = Error('error')
-        const controller = createEventsEditController(sinon.stub().rejects(error))
-
-        await controller.renderEditPage(this.req, this.res, this.next)
-
-        expect(this.next).to.be.calledWith(sinon.match({ message: error.message }))
-        expect(this.next).to.have.been.calledOnce
       })
     })
   })

--- a/test/unit/apps/events/controllers/list.test.js
+++ b/test/unit/apps/events/controllers/list.test.js
@@ -1,29 +1,49 @@
+const advisersData = require('../../../data/advisers/advisers')
+
+const standardMacros = [
+  { macroName: 'useful' },
+  { macroName: 'exciting' },
+]
+const countryAndUkRegionMacros = [
+  {
+    macroName: 'MultipleChoiceField',
+    name: 'address_country',
+    options: [
+      { value: 'non-uk', label: 'Albania' },
+      { value: 'uk', label: 'United Kingdom' },
+    ],
+  },
+  {
+    macroName: 'MultipleChoiceField',
+    name: 'uk_region',
+    options: [
+      { value: '1', label: 'England' },
+      { value: '2', label: 'Scotland' },
+    ],
+  },
+]
+
 describe('Event list controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
-    this.req = {
+    this.nextSpy = this.sandbox.spy()
+    this.reqMock = {
       session: {
         token: 'abcd',
       },
       query: {},
     }
-    this.res = {
+    this.resMock = {
       render: this.sandbox.spy(),
       query: {},
-    }
-
-    this.buildSelectedFiltersSummaryStub = this.sandbox.spy()
-
-    this.controller = proxyquire('~/src/apps/events/controllers/list', {
-      '../../builders': {
-        buildSelectedFiltersSummary: this.buildSelectedFiltersSummaryStub,
+      locals: {
+        advisers: advisersData,
       },
+    }
+    this.eventFiltersFieldsStub = this.sandbox.stub()
+    this.controller = proxyquire('~/src/apps/events/controllers/list', {
       '../macros': {
-        eventFiltersFields: [
-          { macroName: 'useful' },
-          { macroName: 'exciting' },
-        ],
+        eventFiltersFields: this.eventFiltersFieldsStub,
       },
     })
   })
@@ -33,70 +53,54 @@ describe('Event list controller', () => {
   })
 
   describe('#renderEventList', () => {
-    it('should render collection page with expected locals', () => {
-      this.controller.renderEventList(this.req, this.res, this.next)
-      expect(this.res.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('title'))
-      expect(this.res.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
-      expect(this.res.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('filtersFields'))
-      expect(this.res.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
-      expect(this.buildSelectedFiltersSummaryStub).to.have.been.calledWith([
-        { macroName: 'useful' },
-        { macroName: 'exciting' },
-      ], this.req.query)
+    beforeEach(() => {
+      this.eventFiltersFieldsStub.returns(standardMacros)
+    })
+
+    it('should render collection page as expected', () => {
+      this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('title'))
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('filtersFields'))
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
     })
   })
 
-  describe('Conditional field', () => {
+  describe('Uk region conditional field', () => {
     beforeEach(() => {
-      this.controller = proxyquire('~/src/apps/events/controllers/list', {
-        '../macros': {
-          eventFiltersFields: [
-            {
-              macroName: 'MultipleChoiceField',
-              name: 'address_country',
-              options: [
-                { value: 'non-uk', label: 'Albania' },
-                { value: 'uk', label: 'United Kingdom' },
-              ],
-            },
-            {
-              macroName: 'MultipleChoiceField',
-              name: 'uk_region',
-              options: [
-                { value: '1', label: 'England' },
-                { value: '2', label: 'Scotland' },
-              ],
-            },
-          ],
-        },
-      })
+      this.eventFiltersFieldsStub.returns(countryAndUkRegionMacros)
     })
 
     it('should render collection without region if non-UK country is selected', () => {
-      this.req.query = { address_country: 'non-uk' }
-      this.controller.renderEventList(this.req, this.res, this.next)
+      this.reqMock.query = { address_country: 'non-uk' }
+      this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
 
-      expect(this.res.render).to.have.been.calledWith(
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('title'))
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
+      expect(this.resMock.render).to.have.been.calledWith(
         'events/views/list',
         sinon.match.hasOwn(
           'filtersFields',
-          sinon.match(fields => fields.length === 1 && fields[0].name === 'address_country' && fields[0].value === 'non-uk')
+          sinon.match(fields => fields.length === 1 && fields[0].name === 'address_country')
         )
       )
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
     })
 
     it('should render collection with region if UK is selected', () => {
-      this.req.query = { address_country: 'uk' }
-      this.controller.renderEventList(this.req, this.res, this.next)
+      this.reqMock.query = { address_country: 'uk' }
+      this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
 
-      expect(this.res.render).to.have.been.calledOnce
-      expect(this.res.render).to.have.been.calledWith(
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('title'))
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
+      expect(this.resMock.render).to.have.been.calledWith(
         'events/views/list',
         sinon.match.hasOwn(
           'filtersFields',
           sinon.match(fields => fields.length === 2 && fields[1].name === 'uk_region')
         )
       )
+      expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
     })
   })
 })

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -1,3 +1,4 @@
+const advisersData = require('../../../data/advisers/advisers')
 const eventData = require('../../../data/events/event.json')
 const { merge, assign } = require('lodash')
 
@@ -35,6 +36,7 @@ describe('Event details middleware', () => {
     this.sandbox = sinon.sandbox.create()
     this.saveEventStub = this.sandbox.stub()
     this.fetchEventStub = this.sandbox.stub()
+    this.getAdvisersStub = this.sandbox.stub()
     this.transformEventFormBodyToApiRequestStub = this.sandbox.stub()
     this.transformEventResponseToViewRecordStub = this.sandbox.stub()
     this.middleware = proxyquire('~/src/apps/events/middleware/details', {
@@ -48,6 +50,9 @@ describe('Event details middleware', () => {
           id: '2',
           data: 'transformed',
         }),
+      },
+      '../../adviser/repos': {
+        getAdvisers: this.getAdvisersStub.resolves(advisersData),
       },
     })
     this.req = {
@@ -254,12 +259,13 @@ describe('Event details middleware', () => {
       })
     })
 
-    context('when error', () => {
-      it('should call next middleware', async () => {
-        this.fetchEventStub.rejects({ status: 500 })
-        await this.middleware.getEventDetails(this.req, this.res, this.nextSpy, eventData.id)
+    describe('#getAdviserDetails', () => {
+      context('when success', () => {
+        it('should set event data on locals', async () => {
+          await this.middleware.getAdviserDetails(this.req, this.res, this.nextSpy)
 
-        expect(this.nextSpy).to.be.calledWith({ status: 500 })
+          expect(this.res.locals.advisers).to.deep.equal(advisersData)
+        })
       })
     })
   })

--- a/test/unit/data/advisers/advisers.json
+++ b/test/unit/data/advisers/advisers.json
@@ -1,0 +1,90 @@
+{
+  "count": 5,
+  "results": [
+    {
+      "id": "a0dae366-1134-e411-985c-e4115bead28a",
+      "name": "Jeff Smith",
+      "last_login": null,
+      "first_name": "Jeff",
+      "last_name": "Smith",
+      "email": "jeff.smith@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "4348318c-9698-e211-a939-e4115bead28a",
+        "name": "Team A",
+        "role": "66329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": "874cd12a-6095-e211-a939-e4115bead28a",
+        "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "e13209b8-8d61-e311-8255-e4115bead28a",
+      "name": "Aaron Mr",
+      "last_login": null,
+      "first_name": "Aaron",
+      "last_name": "Mr",
+      "email": "aaron.mr@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "f57d43ce-9698-e211-a939-e4115bead28a",
+        "name": "Team B",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "81756b9a-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "b9d6b3dc-7af4-e411-bcbe-e4115bead28a",
+      "name": "Mr Benjamin",
+      "last_login": null,
+      "first_name": "Mr",
+      "last_name": "Benjamin",
+      "email": "mr.benjamin@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "1a8433c8-9698-e211-a939-e4115bead28a",
+        "name": "Team C",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "5161b8be-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "0119a99e-9798-e211-a939-e4115bead28a",
+      "name": "George Chan",
+      "last_login": null,
+      "first_name": "George",
+      "last_name": "Chan",
+      "email": "george.chan@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "ab4d24c2-9698-e211-a939-e4115bead28a",
+        "name": "Team D",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "1f0be5c4-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "0919a99e-9798-e211-a939-e4115bead28a",
+      "name": "Fred Rafters",
+      "last_login": null,
+      "first_name": "Fred",
+      "last_name": "Rafters",
+      "email": "fred.rafters@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "346e1abc-9698-e211-a939-e4115bead28a",
+        "name": "Team E",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "955f66a0-5d95-e211-a939-e4115bead28a"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Add organiser to `/event` list filters
- UAT tests
- Unit tests
- Move selectListOptionByText over to commands for global use and rename to clickListOption

<img width="1134" alt="screen shot 2017-09-27 at 17 07 45" src="https://user-images.githubusercontent.com/2305016/30924702-6c6f4302-a3a7-11e7-99a8-52f098f90edd.png">


![organiser](https://user-images.githubusercontent.com/2305016/30925547-1a5732b6-a3aa-11e7-867f-8274a5be4fa9.gif)
