### PR TITLE
Break three quarter column at same breakpoint as one column

### DIFF
--- a/assets/stylesheets/_deprecated/_shame.scss
+++ b/assets/stylesheets/_deprecated/_shame.scss
@@ -81,7 +81,7 @@ strong {
 }
 
 .column-three-quarters {
-  @include grid-column(3 / 4);
+  @include grid-column(3 / 4, tablet);
 }
 
 .table--readonly {


### PR DESCRIPTION
This is a quick fix to only float the three quarter column class
when the one column class floats. This stops an overlap in columns
between tablet and desktop.

## Before
![localhost_3001_contacts_sortby modified_on 3adesc 1](https://user-images.githubusercontent.com/3327997/30925098-aada1800-a3a8-11e7-874f-7f885d1dd542.png)

## After
![localhost_3001_contacts_sortby modified_on 3adesc](https://user-images.githubusercontent.com/3327997/30925092-9ec4b3a4-a3a8-11e7-995b-0d3d6fab76ed.png)
