### PR TITLE
Avoid removing empty values in request body

### DIFF
--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -1,11 +1,11 @@
-const { assign, pickBy } = require('lodash')
+const { assign } = require('lodash')
 
 const { fetchEvent } = require('../repos')
 const { transformEventResponseToViewRecord, transformEventFormBodyToApiRequest } = require('../transformers')
 const { saveEvent } = require('../repos')
 
 async function postDetails (req, res, next) {
-  res.locals.requestBody = pickBy(transformEventFormBodyToApiRequest(req.body))
+  res.locals.requestBody = transformEventFormBodyToApiRequest(req.body)
 
   if (req.body.add_team || req.body.add_related_programme) {
     return next()


### PR DESCRIPTION
This removes the logic to remove empty values from request body as empty values are used to set `null` in the API.