### PR TITLE
Remove legacy button class names

### DIFF
--- a/assets/javascripts/modules/archive-form.js
+++ b/assets/javascripts/modules/archive-form.js
@@ -67,7 +67,6 @@ const ArchiveForm = {
 
   createCancelButton () {
     const hideArchiveFormButton = this.document.createElement('a')
-    hideArchiveFormButton.classList.add('button-link')
     hideArchiveFormButton.href = '#'
     hideArchiveFormButton.textContent = 'Cancel'
 

--- a/assets/stylesheets/_deprecated/_shame.scss
+++ b/assets/stylesheets/_deprecated/_shame.scss
@@ -24,10 +24,6 @@
   margin-bottom: 30px;
 }
 
-.form-label-bold .button-link {
-  @include core-font(20)
-}
-
 .column-three-quarters .form-control {
   width: 100%;
 }

--- a/assets/stylesheets/_deprecated/components/_button.scss
+++ b/assets/stylesheets/_deprecated/components/_button.scss
@@ -10,24 +10,11 @@
   }
 }
 
+// modifiers
 .button--destructive {
   @include button($red);
 }
 
-.button-link {
-  line-height: 2.5;
-  margin-left: 15px;
-  top: 1px;
-  position: relative;
-}
-
-.button-bar {
-  float: none;
-  clear: both;
-  margin: 30px 0;
-}
-
-// modifiers
 .button--link {
   background: transparent;
   border: 0;

--- a/src/apps/companies/views/add-step-2.njk
+++ b/src/apps/companies/views/add-step-2.njk
@@ -2,10 +2,13 @@
 
 {% block main_grid_right_column %}
   <div class="key-value key-value--vertical">
-    <div id="business-type" class="key-value__key form-label-bold">Business type
-      <a href="/companies/add-step-1" class="button-link">Change</a>
+    <div id="business-type" class="key-value__key form-label-bold">
+      Business type
     </div>
-    <div class="key-value__value" aria-labelledby="business-type">{{ companyTypeOptions[businessType] }}</div>
+    <div class="key-value__value" aria-labelledby="business-type">
+      {{ companyTypeOptions[businessType] }}
+      <a href="/companies/add-step-1">Change</a>
+    </div>
   </div>
 
   {{ EntitySearchForm({

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -7,12 +7,14 @@
 {% block main_grid_right_column %}
   <div class="section">
     <div class="for-control key-value key-value--vertical">
-      <div id="business-type" class="key-value__key form-label-bold">Business type
-        <a href="/companies/add-step-1" class="button-link">Change</a>
+      <div id="business-type" class="key-value__key form-label-bold">
+        Business type
       </div>
       <div class="key-value__value" aria-labelledby="business-type">
         {{ 'Foreign' if isForeign else 'UK' }}
         {{ 'limited company' if isCompaniesHouse else businessType or '(type of organisation not known)' }}
+
+        <a href="/companies/add-step-1">Change</a>
       </div>
     </div>
   </div>

--- a/src/templates/_components/archive-form.njk
+++ b/src/templates/_components/archive-form.njk
@@ -12,7 +12,7 @@
  #  } %}
  #
 #}
-{% from "_macros/form.njk" import MultipleChoiceField %}
+{% from "_macros/form.njk" import TextField, MultipleChoiceField %}
 
 {% set radioOptions = options | concat('Other') | arrayToLabelValues %}
 {% set radioOptionsPrefix = optionsPrefix %}
@@ -28,14 +28,16 @@
     hint: radioOptionsPrefix
   }) }}
 
-  <div class="js-ConditionalSubfield" data-controlled-by="archived_reason" data-control-value="Other">
-    <div class="form-group">
-      <label class="form-label-bold">Other</label>
-      <input class="form-control" type="text" name="archived_reason_other">
-    </div>
-  </div>
+  {{ TextField({
+    label: 'Other',
+    name: 'archived_reason_other',
+    condition: {
+      name: 'archived_reason',
+      value: 'Other'
+    }
+  }) }}
 
-  <div class="save-bar">
+  <div class="c-form-actions">
     <button class="button button--save" type="submit">Archive</button>
   </div>
 </form>


### PR DESCRIPTION
This removes the use of `button-link`. It was only being used in
a couple of places so was removed in favour of a style that fits
in with newer components.

## Before
![localhost_3001_companies_add-step-2_business_type ltd country uk 1](https://user-images.githubusercontent.com/3327997/30978007-2f91cc6e-a471-11e7-9f6c-f09a73cadb48.png)

## After
![localhost_3001_companies_add-step-2_business_type ltd country uk](https://user-images.githubusercontent.com/3327997/30978000-22ef34c4-a471-11e7-8654-7069e329986e.png)
