### PR TITLE
Add acceptance tests for event search

### DIFF
--- a/test/acceptance/common/date.js
+++ b/test/acceptance/common/date.js
@@ -1,0 +1,9 @@
+const { format } = require('date-fns')
+
+const getDateFor = ({ year, month, day }, formatPattern = 'D MMMM YYYY') => {
+  return format(`${year}-${month}-${day}`, formatPattern)
+}
+
+module.exports = {
+  getDateFor,
+}

--- a/test/acceptance/common/selectors.js
+++ b/test/acceptance/common/selectors.js
@@ -1,0 +1,12 @@
+function getSelectorForElementWithText (text, { el = '//*', className, child } = {}) {
+  const classNameContains = className ? ` and contains(@class, "${className}")` : ''
+
+  return {
+    selector: `${el}[contains(.,"${text}")${classNameContains}]${child || ''}`,
+    locateStrategy: 'xpath',
+  }
+}
+
+module.exports = {
+  getSelectorForElementWithText,
+}

--- a/test/acceptance/features/dashboard/page-objects/Dashboard.js
+++ b/test/acceptance/features/dashboard/page-objects/Dashboard.js
@@ -1,0 +1,7 @@
+module.exports = {
+  url: process.env.QA_HOST,
+  props: {},
+  elements: {
+    term: '#field-term',
+  },
+}

--- a/test/acceptance/features/dashboard/step_definitions/dashboard.js
+++ b/test/acceptance/features/dashboard/step_definitions/dashboard.js
@@ -1,0 +1,12 @@
+const { client } = require('nightwatch-cucumber')
+const { defineSupportCode } = require('cucumber')
+
+defineSupportCode(({ Then, When, Before }) => {
+  const Dashboard = client.page.Dashboard()
+
+  When(/^I navigate to the dashboard/, async () => {
+    await Dashboard
+      .navigate()
+      .waitForElementPresent('@term')
+  })
+})

--- a/test/acceptance/features/events/page-objects/Event.js
+++ b/test/acceptance/features/events/page-objects/Event.js
@@ -1,5 +1,6 @@
 const faker = require('faker')
 const { addWeeks, format } = require('date-fns')
+const { compact } = require('lodash')
 
 module.exports = {
   url: process.env.QA_HOST + '/events/create',
@@ -41,7 +42,7 @@ module.exports = {
     relatedProgrammes: '#field-related_programmes',
     addAnotherProgramme: 'input[name="add_related_programme"]',
     saveButton: {
-      selector: '//button[text()[normalize-space()="Save"]]',
+      selector: '//button[. = "Save"]',
       locateStrategy: 'xpath',
     },
     // Event details page
@@ -77,13 +78,13 @@ module.exports = {
         return this
           .assert.visible('#group-field-related_programmes #group-field-related_programmes:nth-child(' + listNumber + ') select')
       },
-      populateCreateEventForm () {
+      populateCreateEventForm ({ eventNameSuffix }) {
         const today = new Date()
         const futureDate = addWeeks(today, 1)
 
         // Store created event details
         this.state.eventDetails = {
-          name: faker.company.companyName(),
+          name: compact([ faker.company.companyName(), eventNameSuffix ]).join(' '),
           address_1: faker.address.streetName(),
           address_2: faker.address.secondaryAddress(),
           address_town: faker.address.city(),

--- a/test/acceptance/features/search/page-objects/Search.js
+++ b/test/acceptance/features/search/page-objects/Search.js
@@ -1,0 +1,58 @@
+const { getSelectorForElementWithText } = require('../../../common/selectors')
+
+const getSearchResultsTabSelector = (text) =>
+  getSelectorForElementWithText(
+    text,
+    {
+      el: '//ul//li',
+      className: 'c-entity-search__aggregations-item',
+    }
+  )
+const getSearchResultSelector = (text) =>
+  getSelectorForElementWithText(
+    text,
+    {
+      el: '//span',
+      className: 'c-meta-list__item-label',
+      child: '/following-sibling::span',
+    }
+  )
+
+module.exports = {
+  url: process.env.QA_HOST,
+  props: {},
+  elements: {
+    term: '#field-term',
+    resultsCount: '.c-collection__result-count',
+  },
+  sections: {
+    tabs: {
+      selector: '.c-entity-search__aggregations',
+      elements: {
+        companies: getSearchResultsTabSelector('Companies'),
+        contacts: getSearchResultsTabSelector('Contacts'),
+        events: getSearchResultsTabSelector('Events'),
+        interactions: getSearchResultsTabSelector('Interactions'),
+        investmentProjects: getSearchResultsTabSelector('Investment projects'),
+        orders: getSearchResultsTabSelector('Orders'),
+      },
+    },
+    firstEventSearchResult: {
+      selector: '.c-entity-list li:first-child',
+      elements: {
+        header: {
+          selector: '.c-entity__header a',
+        },
+        eventType: getSearchResultSelector('Type'),
+        country: getSearchResultSelector('Country'),
+        eventStart: getSearchResultSelector('Begins'),
+        eventEnd: getSearchResultSelector('Ends'),
+        organiser: getSearchResultSelector('Organiser'),
+        leadTeam: getSearchResultSelector('Lead team'),
+      },
+    },
+  },
+  commands: [
+    {},
+  ],
+}

--- a/test/acceptance/features/search/search.feature
+++ b/test/acceptance/features/search/search.feature
@@ -1,0 +1,25 @@
+@search
+Feature: Search
+  As an existing user
+  I would like to search the data hub
+  So search for entities
+
+  Background:
+    Given I am an authenticated user on the data hub website
+
+  @search--events
+  Scenario: Search events
+    And I navigate to the event list page
+    When I click the add an event link
+    And I populate the create event form to search
+    And I click the save button
+    Then I see the success message
+    When I navigate to the dashboard
+    And I search for the event
+    Then I verify the tabs are displayed
+    And I verify the Companies tab is active
+    And I verify there is a results count 0
+    When I click the Events tab
+    Then I verify the Events tab is active
+    And I verify there is a results count 1
+    And I can view the event in the search results

--- a/test/acceptance/features/search/step_definitions/search.js
+++ b/test/acceptance/features/search/step_definitions/search.js
@@ -1,0 +1,87 @@
+/* eslint-disable camelcase */
+const { client } = require('nightwatch-cucumber')
+const { defineSupportCode } = require('cucumber')
+const faker = require('faker')
+const { getDateFor } = require('../../../common/date')
+
+defineSupportCode(({ Then, When, Before }) => {
+  const Event = client.page.Event()
+  const Search = client.page.Search()
+
+  Before(() => {
+    Event.state = {
+      eventDetails: {},
+    }
+    Search.state = {
+      eventNameSuffix: faker.random.uuid(),
+    }
+  })
+
+  When(/^I populate the create event form to search$/, async () => {
+    await Event
+      .populateCreateEventForm({ eventNameSuffix: Search.state.eventNameSuffix })
+  })
+
+  When(/^I search for the event$/, async () => {
+    await Search
+      .waitForElementPresent('@term')
+      .setValue('@term', Search.state.eventNameSuffix)
+      .sendKeys('@term', [ client.Keys.ENTER ])
+      .wait() // wait for xhr
+  })
+
+  When(/^I click the Events tab/, async () => {
+    await Search.section.tabs
+      .click('@events')
+  })
+
+  Then(/^I verify the tabs are displayed$/, async () => {
+    await Search.section.tabs
+      .assert.visible('@companies')
+      .assert.visible('@contacts')
+      .assert.visible('@events')
+      .assert.visible('@interactions')
+      .assert.visible('@investmentProjects')
+      .assert.visible('@orders')
+  })
+
+  Then(/^I verify the Companies tab is active/, async () => {
+    await Search.section.tabs
+      .assert.cssClassPresent('@companies', 'is-active')
+  })
+
+  Then(/^I verify the Events tab is active/, async () => {
+    await Search.section.tabs
+      .assert.cssClassPresent('@events', 'is-active')
+  })
+
+  Then(/^I verify there is a results count ([0-9]+)/, async (resultsCount) => {
+    await Search
+      .assert.visible('@resultsCount')
+      .assert.containsText('@resultsCount', resultsCount)
+  })
+
+  Then(/^I can view the event in the search results/, async () => {
+    const {
+      start_date_year,
+      start_date_month,
+      start_date_day,
+      end_date_year,
+      end_date_month,
+      end_date_day,
+    } = Event.state.eventDetails
+
+    const expectedStartDate = getDateFor({ year: start_date_year, month: start_date_month, day: start_date_day })
+    const expectedEndDate = getDateFor({ year: end_date_year, month: end_date_month, day: end_date_day })
+
+    await Search.section.firstEventSearchResult
+      .waitForElementPresent('@header')
+      .assert.containsText('@header', Event.state.eventDetails.name)
+      .assert.containsText('@eventType', Event.state.eventDetails.event_type)
+      .assert.containsText('@country', Event.state.eventDetails.address_country)
+      .assert.containsText('@eventStart', expectedStartDate)
+      .assert.containsText('@eventEnd', expectedEndDate)
+      .assert.containsText('@organiser', Event.state.eventDetails.organiser)
+      .assert.containsText('@leadTeam', Event.state.eventDetails.lead_team)
+  })
+})


### PR DESCRIPTION
This change adds an acceptance test for seeing events in the search results. As we build out the other entity types we can add to the search tests.

![screen shot 2017-09-29 at 11 32 36](https://user-images.githubusercontent.com/1150417/31012494-ed70e966-a509-11e7-97bb-ddb45ae28834.png)
