### PR TITLE
Fix JS error in IE11

### DIFF
--- a/assets/javascripts/modules/add-items.js
+++ b/assets/javascripts/modules/add-items.js
@@ -1,3 +1,4 @@
+const assign = require('lodash/assign')
 const pickBy = require('lodash/pickBy')
 const {
   insertAfter,
@@ -52,7 +53,7 @@ const AddItems = {
 
   init (wrapper = document, options) {
     this.wrapper = wrapper
-    this.settings = Object.assign({}, this.defaults, options)
+    this.settings = assign({}, this.defaults, options)
 
     this.cacheEls()
     this.bindEvents()

--- a/assets/javascripts/modules/add-items.js
+++ b/assets/javascripts/modules/add-items.js
@@ -1,4 +1,4 @@
-const { pickBy } = require('lodash')
+const pickBy = require('lodash/pickBy')
 const {
   insertAfter,
   resetFieldValues,

--- a/assets/javascripts/modules/sortable-table.js
+++ b/assets/javascripts/modules/sortable-table.js
@@ -1,4 +1,4 @@
-const { uniqueId } = require('lodash')
+const uniqueId = require('lodash/uniqueId')
 
 const { parseDateString } = require('../../../common/date')
 const { addClass, removeClass } = require('../_deprecated/lib/element-stuff')


### PR DESCRIPTION
- `Object.assign` is not available in IE11
- Destructuring imports loads the whole library. On server it doesn't matter but on client we need to watch the build size. Use specific lodash modules by importing them directly.

### Before
![image](https://user-images.githubusercontent.com/203886/31014112-3799f3e6-a511-11e7-938b-4f6315e240f1.png)

### After
![image](https://user-images.githubusercontent.com/203886/31014080-1cad35ca-a511-11e7-94f2-7bd568e5f116.png)

(Size is for uncompressed JS)