### PR TITLE
Send null for empty date in date transformer

### DIFF
--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -39,7 +39,7 @@ function transformDateObjectToDateString (key) {
     return ['year', 'month', 'day']
       .map(x => props[`${key}_${x}`])
       .filter(x => x)
-      .join('-')
+      .join('-') || null
   }
 }
 

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -75,11 +75,11 @@ describe('Global transformers', () => {
 
     context('when valid key with inner call', () => {
       it('should return empty string for incorrect object', () => {
-        expect(this.transformers.transformDateObjectToDateString('start_date')()).to.equal('')
-        expect(this.transformers.transformDateObjectToDateString('start_date')({})).to.equal('')
-        expect(this.transformers.transformDateObjectToDateString('start_date')({ a: 'v' })).to.equal('')
-        expect(this.transformers.transformDateObjectToDateString('start_date')({ year: '123124' })).to.equal('')
-        expect(this.transformers.transformDateObjectToDateString('start_date')({ year: '2017' })).to.equal('')
+        expect(this.transformers.transformDateObjectToDateString('start_date')()).to.be.null
+        expect(this.transformers.transformDateObjectToDateString('start_date')({})).to.be.null
+        expect(this.transformers.transformDateObjectToDateString('start_date')({ a: 'v' })).to.be.null
+        expect(this.transformers.transformDateObjectToDateString('start_date')({ year: '123124' })).to.be.null
+        expect(this.transformers.transformDateObjectToDateString('start_date')({ year: '2017' })).to.be.null
       })
 
       it('should return date string for correct object', () => {


### PR DESCRIPTION
API expects `null` for undefined date. We were sending empty string.

Fixes acceptance tests for events.

<img width="948" alt="screen shot 2017-09-29 at 13 26 38" src="https://user-images.githubusercontent.com/203886/31015886-42ff51e6-a51a-11e7-938f-e04e193a699d.png">
