### PR TITLE
start date filters events

### DIFF
--- a/src/apps/events/labels.js
+++ b/src/apps/events/labels.js
@@ -6,8 +6,8 @@ const labels = {
       address_country: 'Country',
       uk_region: 'Region',
       organiser: 'Organiser',
-      start_date: 'Starts on or after',
-      end_date: 'Ends on',
+      start_date_after: 'From',
+      start_date_before: 'To',
     },
   },
 }

--- a/src/apps/events/macros/event-filters-fields.js
+++ b/src/apps/events/macros/event-filters-fields.js
@@ -33,13 +33,13 @@ const eventFiltersFields = ({ advisers }) => {
     },
     {
       macroName: 'TextField',
-      name: 'start_date',
+      name: 'start_date_after',
       hint: 'YYYY-MM-DD',
       placeholder: `e.g. ${currentYear}-07-18`,
     },
     {
       macroName: 'TextField',
-      name: 'end_date',
+      name: 'start_date_before',
       hint: 'YYYY-MM-DD',
       placeholder: `e.g. ${currentYear}-07-21`,
     },

--- a/src/apps/events/macros/event-sort-form.js
+++ b/src/apps/events/macros/event-sort-form.js
@@ -16,8 +16,6 @@ const eventSortForm = {
         { value: 'modified_on:asc', label: 'Least recently updated' },
         { value: 'start_date:asc', label: 'Earliest start date' },
         { value: 'start_date:desc', label: 'Latest start date' },
-        { value: 'end_date:asc', label: 'Earliest end date' },
-        { value: 'end_date:desc', label: 'Latest end date' },
       ],
     },
   ],

--- a/src/apps/events/middleware/collection.js
+++ b/src/apps/events/middleware/collection.js
@@ -31,8 +31,8 @@ function getRequestBody (req, res, next) {
     'organiser',
     'address_country',
     'uk_region',
-    'start_date',
-    'end_date',
+    'start_date_after',
+    'start_date_before',
   ])
 
   const selectedSortBy = req.query.sortby ? { sortby: req.query.sortby } : null

--- a/test/acceptance/features/events/list.feature
+++ b/test/acceptance/features/events/list.feature
@@ -50,9 +50,11 @@ Feature: View a list of events
     Then I can view the event
     And I filter the events list by country
     Then I can view the event
+    And I filter the events list by start date
+    Then I can view the event
 
-  @events-list--sort-a-z-and-z-a
-  Scenario: Sort event list A-Z and Z-A
+  @events-list--sort
+  Scenario: Sort event list
     And I navigate to the event list page
     When I click the add an event link
     And I populate the create event form
@@ -68,4 +70,8 @@ Feature: View a list of events
     Then I see the list in A-Z alphabetical order
     And I sort the events list name Z-A
     Then I see the list in Z-A alphabetical order
+    And I sort the events list by recently updated
+    Then I see the list in descending recently updated order
+    And I sort the events list by least recently updated
+    Then I see the list in ascending recently updated order
 

--- a/test/acceptance/features/events/page-objects/EventList.js
+++ b/test/acceptance/features/events/page-objects/EventList.js
@@ -1,3 +1,22 @@
+const { getSelectorForElementWithText } = require('../../../common/selectors')
+
+const getFilterTagRemoveBtnSelector = (text) => getSelectorForElementWithText(
+  text,
+  {
+    el: '//span',
+    className: 'c-collection__filter-label',
+    child: '/following-sibling::a',
+  }
+)
+const getMetaListItemValueSelector = (text) => getSelectorForElementWithText(
+  text,
+  {
+    el: '//span',
+    className: 'c-meta-list__item-label',
+    child: '/following-sibling::span',
+  }
+)
+
 module.exports = {
   url: process.env.QA_HOST + '/events',
   props: {},
@@ -5,45 +24,43 @@ module.exports = {
     h1Element: '.c-local-header__heading',
     addEventButton: '#add-event-link',
     sortBy: '#field-sortby',
-    firstHeaderInList: '.c-entity-list li:first-child .c-entity__header a',
-    secondHeaderInList: '.c-entity-list li:nth-child(2) .c-entity__header a',
     xhrTargetElement: '#xhr-outlet',
   },
   sections: {
+    filterTags: {
+      selector: '.c-collection__filter-summary',
+      elements: {
+        eventName: getFilterTagRemoveBtnSelector('Event name'),
+        organiser: getFilterTagRemoveBtnSelector('Organiser'),
+        eventType: getFilterTagRemoveBtnSelector('Type of event'),
+        country: getFilterTagRemoveBtnSelector('Country'),
+        fromDate: getFilterTagRemoveBtnSelector('From'),
+      },
+    },
     firstEventInList: {
       selector: '.c-entity-list li:first-child',
       elements: {
         header: {
           selector: '.c-entity__header a',
         },
-        eventType: {
-          selector: '//span[contains(@class,"c-meta-list__item-label")][text()[normalize-space()="Type"]]/following-sibling::span',
-          locateStrategy: 'xpath',
+        eventType: getMetaListItemValueSelector('Type'),
+        country: getMetaListItemValueSelector('Country'),
+        region: getMetaListItemValueSelector('Region'),
+        eventStart: getMetaListItemValueSelector('Begins'),
+        eventEnd: getMetaListItemValueSelector('Ends'),
+        organiser: getMetaListItemValueSelector('Organiser'),
+        leadTeam: getMetaListItemValueSelector('Lead team'),
+        updated: getMetaListItemValueSelector('Updated'),
+      },
+    },
+    secondEventInList: {
+      selector: '.c-entity-list li:nth-child(2)',
+      elements: {
+        header: {
+          selector: '.c-entity__header a',
         },
-        country: {
-          selector: '//span[contains(@class,"c-meta-list__item-label")][text()[normalize-space()="Country"]]/following-sibling::span',
-          locateStrategy: 'xpath',
-        },
-        region: {
-          selector: '//span[contains(@class,"c-meta-list__item-label")][text()[normalize-space()="Region"]]/following-sibling::span',
-          locateStrategy: 'xpath',
-        },
-        eventStart: {
-          selector: '//span[contains(@class,"c-meta-list__item-label")][text()[normalize-space()="Begins"]]/following-sibling::span',
-          locateStrategy: 'xpath',
-        },
-        eventEnd: {
-          selector: '//span[contains(@class,"c-meta-list__item-label")][text()[normalize-space()="Ends"]]/following-sibling::span',
-          locateStrategy: 'xpath',
-        },
-        organiser: {
-          selector: '//span[contains(@class,"c-meta-list__item-label")][text()[normalize-space()="Organiser"]]/following-sibling::span',
-          locateStrategy: 'xpath',
-        },
-        leadTeam: {
-          selector: '//span[contains(@class,"c-meta-list__item-label")][text()[normalize-space()="Lead team"]]/following-sibling::span',
-          locateStrategy: 'xpath',
-        },
+        eventStart: getMetaListItemValueSelector('Begins'),
+        updated: getMetaListItemValueSelector('Updated'),
       },
     },
     filters: {
@@ -60,6 +77,9 @@ module.exports = {
         },
         eventType: {
           selector: 'select[name="event_type"]',
+        },
+        startDateAfter: {
+          selector: '#field-start_date_after',
         },
       },
     },


### PR DESCRIPTION
- Work around making the start date filters work with `start_date_after` and `start_date_before`
- Improve UAT coverage around filters and sort for events
- Update event filter labels

![start_date](https://user-images.githubusercontent.com/2305016/31029028-0f38c6e8-a548-11e7-8f9b-59e743774015.gif)

