### PR TITLE
Fix DateFieldset

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -70,6 +70,12 @@ const filters = {
     return assign({}, ...args)
   },
 
+  split (value, separator) {
+    if (!isString(value)) { return value }
+
+    return value.split(separator)
+  },
+
   highlight (string, searchTerm, shouldMatchFullWord = false) {
     if (!isString(string) || !isString(searchTerm) || !searchTerm.trim()) { return string }
 

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -36,10 +36,11 @@ function transformDateObjectToDateString (key) {
     throw Error('date object key is required to transform date')
   }
   return function transformDateObjectToStringWithKey (props = {}) {
-    return ['year', 'month', 'day']
+    const dateString = ['year', 'month', 'day']
       .map(x => props[`${key}_${x}`])
-      .filter(x => x)
-      .join('-') || null
+      .join('-')
+
+    return dateString === '--' ? null : dateString
   }
 }
 

--- a/src/templates/_macros/form/date-fieldset.njk
+++ b/src/templates/_macros/form/date-fieldset.njk
@@ -12,17 +12,19 @@
  #}
 {% macro DateFieldset(props) %}
   {% set fieldId = 'field-' + props.name if props.name %}
-  {% set value = props.value|default('') %}
-  {% set formattedDate = props.value | formatDate('DD-MM-YYYY') %}
+  {% set value = props.value | default('') %}
 
   {% if value | isPlainObject  %}
     {% set dateObj = props.value %}
-  {% else %}
-    {% set splitDate = formattedDate.split('-') if formattedDate %}
+  {% elif value | isString %}
+    {# Expects YYYY-MM-DD or ISO datetime#}
+    {% set splitDateTime = value | split('T') %}
+    {% set splitDate = splitDateTime[0] | split('-') %}
+
     {% set dateObj = {
-      day: splitDate[0] |  default(''),
+      day: splitDate[2] | default(''),
       month: splitDate[1] | default(''),
-      year: splitDate[2] | default('')
+      year: splitDate[0] | default('')
     } %}
   {% endif %}
 

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -102,8 +102,8 @@ describe('Global transformers', () => {
           start_date_year: '2017',
         })
 
-        expect(actualYearMonth).to.equal('2017-09')
-        expect(actualYear).to.equal('2017')
+        expect(actualYearMonth).to.equal('2017-09-')
+        expect(actualYear).to.equal('2017--')
       })
     })
   })

--- a/test/unit/macros/form/date-fieldset.test.js
+++ b/test/unit/macros/form/date-fieldset.test.js
@@ -130,16 +130,14 @@ describe('DateFieldset component', () => {
     })
 
     describe('datetime ISO 8601 string', () => {
-      beforeEach(() => {
+      it('should render three fields with values from ISO time stamp', () => {
         this.component = macros.renderToDom('DateFieldset', {
           name: 'date',
           label: 'Man in space',
           hint: '20th century',
           value: '2007-03-01T13:00:00',
         })
-      })
 
-      it('should render three fields with values from ISO time stamp', () => {
         const inputsValues = Array.from(this.component.querySelectorAll('input')).map(x => x.value)
         const labels = Array.from(this.component.querySelectorAll('label')).map(x => x.textContent.trim())
 
@@ -150,6 +148,25 @@ describe('DateFieldset component', () => {
         expect(labels[2]).to.equal('Year')
         expect(inputsValues[2]).to.equal('2007')
       })
+    })
+
+    it('should render three fields with values from ISO time stamp', () => {
+      this.component = macros.renderToDom('DateFieldset', {
+        name: 'date',
+        label: 'Man in space',
+        hint: '20th century',
+        value: '-03-',
+      })
+
+      const inputsValues = Array.from(this.component.querySelectorAll('input')).map(x => x.value)
+      const labels = Array.from(this.component.querySelectorAll('label')).map(x => x.textContent.trim())
+
+      expect(labels[0]).to.equal('Day')
+      expect(inputsValues[0]).to.equal('')
+      expect(labels[1]).to.equal('Month')
+      expect(inputsValues[1]).to.equal('03')
+      expect(labels[2]).to.equal('Year')
+      expect(inputsValues[2]).to.equal('')
     })
   })
 


### PR DESCRIPTION
DateFieldset was not great with handling partial dates so when a form error occurred because the date was not in the right format the missing fields would be prefilled to unexpected values.