### PR TITLE
Only use lodash reject if lead team is defined

### DIFF
--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -132,6 +132,8 @@ function transformEventResponseToViewRecord ({
     }
   }
 
+  const otherTeams = lead_team ? reject(teams, lead_team) : teams
+
   return Object.assign(transformedEvent, {
     'Event location type': location_type,
     'Address': getFormattedAddress({
@@ -146,7 +148,7 @@ function transformEventResponseToViewRecord ({
     'Notes': notes,
     'Lead team': lead_team,
     'Organiser': organiser,
-    'Other teams': reject(teams, lead_team).map(x => x.name),
+    'Other teams': otherTeams.map(x => x.name),
     'Related programmes': related_programmes
       .map(item => item.name),
     'Service': service,

--- a/test/unit/apps/events/transformers.test.js
+++ b/test/unit/apps/events/transformers.test.js
@@ -279,6 +279,27 @@ describe('Event transformers', () => {
           expect(this.transformedEvent['Other teams']).to.deep.equal(['Team 2', 'Team 3'])
         })
       })
+
+      context('when there is no lead team', () => {
+        beforeEach(() => {
+          const eventWithThreeTeams = Object.assign({}, mockEvent, {
+            lead_team: null,
+            teams: [{
+              id: '2',
+              name: 'Team 2',
+            }, {
+              id: '3',
+              name: 'Team 3',
+            }],
+          })
+
+          this.transformedEvent = transformEventResponseToViewRecord(eventWithThreeTeams)
+        })
+
+        it('should include a list of other teams', () => {
+          expect(this.transformedEvent['Other teams']).to.deep.equal(['Team 2', 'Team 3'])
+        })
+      })
     })
 
     describe('programmes transformer', () => {


### PR DESCRIPTION
If falsey value is given as second argument to `reject` it will return empty array. We want to actually return teams even if no lead team is defined, hence the fix.