### PR TITLE
Content and spacing updates

### DIFF
--- a/assets/stylesheets/_deprecated/components/_button.scss
+++ b/assets/stylesheets/_deprecated/components/_button.scss
@@ -41,8 +41,3 @@
 .button--compact {
   padding: 0;
 }
-
-.button--small {
-  @include bold-font(16);
-  padding: .3em .6em .15em;
-}

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -84,13 +84,6 @@ $_first-element-spacing: $default-spacing-unit * 3;
   margin-bottom: 0;
 }
 
-.c-local-header__content {
-  @include media(tablet) {
-    float: left;
-    width: 70%;
-  }
-}
-
 .c-local-header__actions {
   * + & {
     margin-top: $default-spacing-unit;
@@ -105,11 +98,10 @@ $_first-element-spacing: $default-spacing-unit * 3;
   }
 
   @include media(tablet) {
-    float: right;
-    width: 30%;
+    text-align: right;
 
     * + & {
-      margin-top: $_first-element-spacing;
+      margin-top: 0;
     }
   }
 }

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -44,7 +44,7 @@ const steps = merge({}, createSteps, {
     controller: EditWorkDescriptionController,
   },
   '/payment': {
-    heading: 'Edit quote and payment details',
+    heading: 'Edit invoice details',
     fields: [
       'vat_status',
       'vat_number',

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -4,7 +4,7 @@
   {% set actions %}
     <p class="c-local-header__action">
       {% if order.status == 'draft' %}
-        <a href="quote" class="button button--small">Prepare quote</a>
+        <a href="quote" class="button">Preview quote</a>
       {% else %}
         <a href="quote">View quote</a>
       {% endif %}

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -1,4 +1,4 @@
-{% extends "_layouts/two-column.njk" %}
+{% extends "_layouts/datahub-base.njk" %}
 
 {% block local_header %}
   {% set actions %}
@@ -30,8 +30,4 @@
     }) }}
 
   {% endcall %}
-{% endblock %}
-
-{% block main_grid_left_column %}
-  {{ LocalNav({ items: localNavItems }) }}
 {% endblock %}

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -1,8 +1,8 @@
-{% extends '_layouts/two-column.njk' %}
+{% extends '_layouts/datahub-base.njk' %}
 
 {% from "_macros/dev.njk" import Example %}
 
-{% block main_grid_right_column %}
+{% block body_main_content %}
   {% if incompleteFields %}
     {% call Message({
       type: 'error',

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -153,7 +153,7 @@
   {% endif %}
 
   {{ AnswersSummary({
-    heading: 'Quote and payment details',
+    heading: 'Invoice details',
     actions: [{
       url: 'edit/payment' if order.editable
     }],

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -7,7 +7,7 @@
   <a href="/contacts/{{ values.contact.id }}">{{ values.contact.name }}</a>
 {% endset %}
 
-{% block main_grid_right_column %}
+{% block body_main_content %}
   {% if not order.editable %}
     {% call Message({ type: 'info', element: 'div' }) %}
       <p>You cannot edit the order whilst a quote is awaiting acceptance.</p>

--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -26,31 +26,29 @@
           {{ MessageList({ items: messages }) }}
         {% endif %}
 
-        {% if props.actions %}
-          <div class="c-local-header__content">
-        {% endif %}
+        <div class="grid-row">
+          <div class="column-{{ 'two-thirds' if props.actions else 'full' }}">
+            {% if props.headingBefore %}
+              <div class="c-local-header__heading-before">
+                {{ props.headingBefore | safe }}
+              </div>
+            {% endif %}
 
-          {% if props.headingBefore %}
-            <div class="c-local-header__heading-before">
-              {{ props.headingBefore | safe }}
+            {% if props.heading %}
+              <h1 class="c-local-header__heading">
+                {{ props.heading }} {{ props.headingSuffix | safe }}
+              </h1>
+            {% endif %}
+
+            {{ caller() if caller }}
+          </div>
+
+          {% if props.actions %}
+            <div class="column-one-third c-local-header__actions">
+              {{ props.actions | safe }}
             </div>
           {% endif %}
-
-          {% if props.heading %}
-            <h1 class="c-local-header__heading">
-              {{ props.heading }} {{ props.headingSuffix | safe }}
-            </h1>
-          {% endif %}
-
-          {{ caller() if caller }}
-
-        {% if props.actions %}
-          </div>
-
-          <div class="c-local-header__actions">
-            {{ props.actions | safe }}
-          </div>
-        {% endif %}
+        </div>
       </div>
     </header>
   {% endif %}


### PR DESCRIPTION
This change combines a few small tweaks to language and spacing on the OMIS work order page.

## 2 column -> full width

### Before
![localhost_3001_omis_78adfc97-a74d-419d-ad8f-b1a28c0bf61a_work-order 1](https://user-images.githubusercontent.com/3327997/31074997-3639cc86-a76b-11e7-95b2-623152d91552.png)

### After
![localhost_3001_omis_78adfc97-a74d-419d-ad8f-b1a28c0bf61a_work-order](https://user-images.githubusercontent.com/3327997/31074959-fce42efe-a76a-11e7-8ff6-ff795b493a01.png)

## Local header spacing

### Before
![image](https://user-images.githubusercontent.com/3327997/31074987-27d8e690-a76b-11e7-9637-e78779039c5f.png)

### After
![image](https://user-images.githubusercontent.com/3327997/31074971-10c9d716-a76b-11e7-9fb0-d93d053ec7a9.png)
