### PR TITLE
Remove interactions from top nav and search

### DIFF
--- a/src/apps/search/services.js
+++ b/src/apps/search/services.js
@@ -26,13 +26,6 @@ const entities = [
     count: 0,
   },
   {
-    entity: 'interaction',
-    path: 'interactions',
-    text: 'Interactions',
-    noun: 'interaction',
-    count: 0,
-  },
-  {
     entity: 'investment_project',
     path: 'investment-projects',
     text: 'Investment projects',

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -12,7 +12,6 @@ const globalNavItems = [
   { path: '/companies', label: 'Companies' },
   { path: '/contacts', label: 'Contacts' },
   { path: '/events', label: 'Events' },
-  { path: '/interactions', label: 'Interactions' },
   { path: '/investment-projects', label: 'Investment projects' },
   { path: '/omis', label: 'OMIS Orders' },
 ]

--- a/test/acceptance/features/search/page-objects/Search.js
+++ b/test/acceptance/features/search/page-objects/Search.js
@@ -32,7 +32,6 @@ module.exports = {
         companies: getSearchResultsTabSelector('Companies'),
         contacts: getSearchResultsTabSelector('Contacts'),
         events: getSearchResultsTabSelector('Events'),
-        interactions: getSearchResultsTabSelector('Interactions'),
         investmentProjects: getSearchResultsTabSelector('Investment projects'),
         orders: getSearchResultsTabSelector('Orders'),
       },

--- a/test/acceptance/features/search/step_definitions/search.js
+++ b/test/acceptance/features/search/step_definitions/search.js
@@ -40,7 +40,6 @@ defineSupportCode(({ Then, When, Before }) => {
       .assert.visible('@companies')
       .assert.visible('@contacts')
       .assert.visible('@events')
-      .assert.visible('@interactions')
       .assert.visible('@investmentProjects')
       .assert.visible('@orders')
   })

--- a/test/unit/apps/search/builders.test.js
+++ b/test/unit/apps/search/builders.test.js
@@ -40,13 +40,6 @@ describe('Search builders', () => {
           count: 31,
         },
         {
-          entity: 'interaction',
-          path: 'interactions',
-          text: 'Interactions',
-          noun: 'interaction',
-          count: 0,
-        },
-        {
           entity: 'investment_project',
           path: 'investment-projects',
           text: 'Investment projects',


### PR DESCRIPTION
Removes the interactions link from the top level navigation and removes the interactions tab from search.

Keeps the interaction list view so breadcrumbs still work in prep for a new sub app pattern.