### PR TITLE
Update interaction lists to support service delivery

### DIFF
--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -33,7 +33,7 @@ function transformInteractionResponseToForm ({
 function transformInteractionToListItem ({
   id,
   subject,
-  interaction_type,
+  kind,
   contact,
   company,
   date,
@@ -47,7 +47,7 @@ function transformInteractionToListItem ({
       {
         label: 'Type',
         type: 'badge',
-        value: interaction_type,
+        value: (kind === 'interaction') ? 'Interaction' : 'Service delivery',
       },
       {
         label: 'Contact',

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -6,56 +6,108 @@ const {
 
 describe('Interaction transformers', () => {
   describe('#transformInteractionToListItem', () => {
-    it('should transform data from interaction response to list item', () => {
-      const expected = {
-        id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
-        type: 'interaction',
-        name: 'Test interactionss',
-        meta: [
-          {
-            label: 'Type',
-            type: 'badge',
-            value: {
-              id: '72c226d7-5d95-e211-a939-e4115bead28a',
-              name: 'Telephone',
-            },
-          },
-          {
-            label: 'Contact',
-            value: {
-              id: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
-              first_name: 'Jackson',
-              last_name: 'Whitfield',
-              name: 'Jackson Whitfield',
-            },
-          },
-          {
-            label: 'Company',
-            value: {
-              id: 'dcdabbc9-1781-e411-8955-e4115bead28a',
-              name: 'Samsung',
-            },
-          },
-          {
-            label: 'Date',
-            type: 'date',
-            value: '2017-05-31T00:00:00',
-          },
-          {
-            label: 'Adviser',
-            value: {
-              id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
-              first_name: 'Test',
-              last_name: 'CMU 1',
-              name: 'Test CMU 1',
-            },
-          },
-        ],
-      }
+    context('when the source in an interaction', () => {
+      beforeEach(() => {
+        interactionData.kind = 'interaction'
+        this.transformed = transformInteractionToListItem(interactionData)
+      })
 
-      const actual = transformInteractionToListItem(interactionData)
+      it('should transform data from interaction response to list item', () => {
+        expect(this.transformed).to.deep.equal({
+          id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
+          type: 'interaction',
+          name: 'Test interactionss',
+          meta: [
+            {
+              label: 'Type',
+              type: 'badge',
+              value: 'Interaction',
+            },
+            {
+              label: 'Contact',
+              value: {
+                id: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+                first_name: 'Jackson',
+                last_name: 'Whitfield',
+                name: 'Jackson Whitfield',
+              },
+            },
+            {
+              label: 'Company',
+              value: {
+                id: 'dcdabbc9-1781-e411-8955-e4115bead28a',
+                name: 'Samsung',
+              },
+            },
+            {
+              label: 'Date',
+              type: 'date',
+              value: '2017-05-31T00:00:00',
+            },
+            {
+              label: 'Adviser',
+              value: {
+                id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+                first_name: 'Test',
+                last_name: 'CMU 1',
+                name: 'Test CMU 1',
+              },
+            },
+          ],
+        })
+      })
+    })
 
-      expect(actual).to.deep.equal(expected)
+    context('when the source in a service delivery', () => {
+      beforeEach(() => {
+        interactionData.kind = 'service_delivery'
+        this.transformed = transformInteractionToListItem(interactionData)
+      })
+
+      it('should transform data from interaction response to list item', () => {
+        expect(this.transformed).to.deep.equal({
+          id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
+          type: 'interaction',
+          name: 'Test interactionss',
+          meta: [
+            {
+              label: 'Type',
+              type: 'badge',
+              value: 'Service delivery',
+            },
+            {
+              label: 'Contact',
+              value: {
+                id: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+                first_name: 'Jackson',
+                last_name: 'Whitfield',
+                name: 'Jackson Whitfield',
+              },
+            },
+            {
+              label: 'Company',
+              value: {
+                id: 'dcdabbc9-1781-e411-8955-e4115bead28a',
+                name: 'Samsung',
+              },
+            },
+            {
+              label: 'Date',
+              type: 'date',
+              value: '2017-05-31T00:00:00',
+            },
+            {
+              label: 'Adviser',
+              value: {
+                id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+                first_name: 'Test',
+                last_name: 'CMU 1',
+                name: 'Test CMU 1',
+              },
+            },
+          ],
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Changes the behaviour of the interaction list transformer so that the badge now indicates if the item is a service delivery or an interaction.