### PR TITLE
Move CSRF middleware order

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -63,8 +63,6 @@ app.use(sessionStore)
 
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
 
-app.use(csrf())
-app.use(csrfToken())
 app.use(compression())
 app.use(i18n)
 
@@ -89,6 +87,8 @@ app.use(auth)
 app.use(user)
 app.use(headers)
 app.use(store())
+app.use(csrf())
+app.use(csrfToken())
 
 // routing
 app.use(slashify())


### PR DESCRIPTION
It was being loaded before middleware like locals which was causing
it not to be able to display the correct error page as functions from
locals were not being found.

## Before
![localhost_3001_omis_c641586e-fdc9-4ae4-bb6d-bf349a43ecee_quote](https://user-images.githubusercontent.com/3327997/31178814-13b0c0a4-a912-11e7-9cb7-e31b4d0b1d2f.png)

## After
![image](https://user-images.githubusercontent.com/3327997/31178744-e2e048e6-a911-11e7-8db8-b16352bab685.png)
