### PR TITLE
Fix error displaying all contacts as the 'Primary'

### DIFF
--- a/src/apps/contacts/views/_layout.njk
+++ b/src/apps/contacts/views/_layout.njk
@@ -8,7 +8,7 @@
   {% call LocalHeader({
     headingBefore: headingBefore,
     heading: contact.first_name + ' ' + contact.last_name,
-    headingSuffix: '<span class="c-badge c-badge--secondary">Primary</span>',
+    headingSuffix: '<span class="c-badge c-badge--secondary">Primary</span>' if contact.primary,
     modifier: 'light-banner'
   }) %}
     {% if contact.archived %}


### PR DESCRIPTION
Not sure how we missed this but every contact had the 'Primary' badge showing.