### PR TITLE
Add ability to set a custom billing address for an OMIS order

### DIFF
--- a/src/apps/omis/apps/edit/controllers/billing-address.js
+++ b/src/apps/omis/apps/edit/controllers/billing-address.js
@@ -1,0 +1,12 @@
+const { EditController } = require('../../../controllers')
+const { transformObjectToOption } = require('../../../../transformers')
+const metadataRepo = require('../../../../../lib/metadata')
+
+class EditBillingAddressController extends EditController {
+  configure (req, res, next) {
+    req.form.options.fields.billing_address_country.options = metadataRepo.countryOptions.map(transformObjectToOption)
+    super.configure(req, res, next)
+  }
+}
+
+module.exports = EditBillingAddressController

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -131,6 +131,41 @@ const editFields = merge({}, globalFields, {
     modifier: 'medium',
     optional: true,
   },
+  billing_address_1: {
+    fieldType: 'TextField',
+    label: 'fields.billing_address_1.label',
+    validate: 'required',
+  },
+  billing_address_2: {
+    fieldType: 'TextField',
+    label: 'fields.billing_address_2.label',
+    optional: true,
+    isLabelHidden: true,
+    modifier: 'compact',
+  },
+  billing_address_town: {
+    fieldType: 'TextField',
+    label: 'fields.billing_address_town.label',
+    validate: 'required',
+  },
+  billing_address_county: {
+    fieldType: 'TextField',
+    label: 'fields.billing_address_county.label',
+    optional: true,
+  },
+  billing_address_postcode: {
+    fieldType: 'TextField',
+    label: 'fields.billing_address_postcode.label',
+    modifier: 'short',
+    validate: 'required',
+  },
+  billing_address_country: {
+    fieldType: 'MultipleChoiceField',
+    label: 'fields.billing_address_country.label',
+    initialOption: '-- Select country --',
+    options: [],
+    validate: 'required',
+  },
 })
 
 module.exports = editFields

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -6,6 +6,7 @@ const EditAssigneeTimeController = require('./controllers/assignee-time')
 const EditClientDetailsController = require('./controllers/client-details')
 const EditSubscribersController = require('./controllers/subscribers')
 const EditWorkDescriptionController = require('./controllers/work-description')
+const EditBillingAddressController = require('./controllers/billing-address')
 
 const steps = merge({}, createSteps, {
   '/client-details': {
@@ -51,6 +52,20 @@ const steps = merge({}, createSteps, {
       'vat_verified',
       'po_number',
     ],
+    templatePath: 'omis/apps/edit/views',
+    template: 'payment.njk',
+  },
+  '/billing-address': {
+    heading: 'Edit billing address',
+    fields: [
+      'billing_address_1',
+      'billing_address_2',
+      'billing_address_town',
+      'billing_address_county',
+      'billing_address_postcode',
+      'billing_address_country',
+    ],
+    controller: EditBillingAddressController,
   },
 })
 

--- a/src/apps/omis/apps/edit/views/payment.njk
+++ b/src/apps/omis/apps/edit/views/payment.njk
@@ -1,0 +1,77 @@
+{% extends "_layouts/form-wizard-step.njk" %}
+
+{% block fields %}
+  {{ super() }}
+
+  {% set billingContact = [
+    order.billing_contact_name,
+    order.billing_email,
+    order.billing_phone
+  ] | removeNilAndEmpty %}
+
+  {% if billingContact | length %}
+    <div class="c-form-group">
+      <p class="c-form-group__label">
+        <span class="c-form-group__label-text">
+          Billing contact
+        </span>
+      </p>
+
+      <p>
+        {{ billingContact | join('<br>') | safe }}
+      </p>
+    </div>
+  {% endif %}
+
+  {% set billingAddress = [
+    order.billing_address_1,
+    order.billing_address_2,
+    order.billing_address_town,
+    order.billing_address_county,
+    order.billing_address_postcode,
+    order.billing_address_country.name
+  ] | removeNilAndEmpty %}
+
+  {% set registeredAddress = [
+    company.registered_address_1,
+    company.registered_address_2,
+    company.registered_address_town,
+    company.registered_address_county,
+    company.registered_address_postcode,
+    company.registered_address_country.name
+  ] | removeNilAndEmpty %}
+
+  {% set tradingAddress = [
+    company.trading_address_1,
+    company.trading_address_2,
+    company.trading_address_town,
+    company.trading_address_county,
+    company.trading_address_postcode,
+    company.trading_address_country.name
+  ] | removeNilAndEmpty %}
+
+  <div class="c-form-group">
+    <p class="c-form-group__label">
+      <span class="c-form-group__label-text">
+        Billing address
+      </span>
+    </p>
+
+    <div>
+      {% if billingAddress | length %}
+        {{ billingAddress | join('<br>') | safe }}
+        <br>
+        <a href="billing-address?returnUrl={{ CURRENT_PATH }}">Change address</a>
+      {% else %}
+        {{ (tradingAddress if tradingAddress|length else registeredAddress) | join('<br>') | safe }}
+        {% call Message({ type: 'muted' }) %}
+          The company's {{ 'trading' if tradingAddress|length else 'registered' }} address is currently being used for the invoice.
+          <br>
+          <a href="billing-address?returnUrl={{ CURRENT_PATH }}">Add billing address</a>
+        {% endcall %}
+      {% endif %}
+    </div>
+  </div>
+
+  {# {{company|dump}} #}
+{% endblock %}

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,7 +1,7 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
-const { setOrderBreadcrumb } = require('../../middleware')
+const { getCompany, setOrderBreadcrumb } = require('../../middleware')
 const { renderWorkOrder, renderQuote } = require('./controllers')
 const {
   setTranslation,
@@ -21,6 +21,10 @@ const LOCAL_NAV = [
 router.use(setLocalNav(LOCAL_NAV))
 router.use(setTranslation)
 router.use(setOrderBreadcrumb)
+
+router.use((req, res, next) => {
+  getCompany(req, res, next, res.locals.order.company.id)
+})
 
 router.get('/', redirectToFirstNavItem)
 router.get('/work-order', getQuote, renderWorkOrder)

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -152,6 +152,41 @@
     {% set verifiedState = translate('fields.vat_verified.options.unverified') %}
   {% endif %}
 
+  {% set billingContact = [
+    values.billing_contact_name,
+    values.billing_email,
+    values.billing_phone
+  ] | removeNilAndEmpty | join('<br>') %}
+
+  {% set billingAddress = [
+    values.billing_address_1,
+    values.billing_address_2,
+    values.billing_address_town,
+    values.billing_address_county,
+    values.billing_address_postcode,
+    values.billing_address_country.name
+  ] | removeNilAndEmpty %}
+
+  {% set registeredAddress = [
+    company.registered_address_1,
+    company.registered_address_2,
+    company.registered_address_town,
+    company.registered_address_county,
+    company.registered_address_postcode,
+    company.registered_address_country.name
+  ] | removeNilAndEmpty %}
+
+  {% set tradingAddress = [
+    company.trading_address_1,
+    company.trading_address_2,
+    company.trading_address_town,
+    company.trading_address_county,
+    company.trading_address_postcode,
+    company.trading_address_country.name
+  ] | removeNilAndEmpty %}
+
+  {% set companyAddress = tradingAddress if tradingAddress|length else registeredAddress %}
+
   {{ AnswersSummary({
     heading: 'Invoice details',
     actions: [{
@@ -168,7 +203,20 @@
       label: 'Purchase Order (PO) number',
       value: values.po_number,
       fallbackText: 'Not added'
+    }, {
+      label: 'Billing contact',
+      value: billingContact
+    }, {
+      label: 'Billing address',
+      value: billingAddress | join(', ') if billingAddress|length else companyAddress | join(', '),
+      fallbackText: 'Not added'
     }]
   }) }}
+
+  {% if not billingAddress | length %}
+    {% call Message({ type: 'muted' }) %}
+      The company's {{ 'trading' if tradingAddress|length else 'registered' }} address is currently being used for the invoice.
+    {% endcall %}
+  {% endif %}
 
 {% endblock %}

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -65,7 +65,7 @@ class EditController extends FormController {
       return newValue
     })
 
-    const exemptFields = ['vat_number']
+    const exemptFields = ['vat_number', 'po_number']
     // combine order values and error values
     let combinedValues = Object.assign({}, orderValues, sessionValues, errorValues)
     // convert dates to default format

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -63,6 +63,24 @@
     },
     "po_number": {
       "label": "Purchase Order (PO) number"
+    },
+    "billing_address_1": {
+      "label": "Business and street"
+    },
+    "billing_address_2": {
+      "label": "Business and street continued"
+    },
+    "billing_address_town": {
+      "label": "Town or city"
+    },
+    "billing_address_county": {
+      "label": "County"
+    },
+    "billing_address_postcode": {
+      "label": "Postcode"
+    },
+    "billing_address_country": {
+      "label": "Country"
     }
   },
   "errors": {


### PR DESCRIPTION
This adds a separate edit step for setting a billing address as
well as the fields required for this step.

[**DEMO**](https://datahub-beta2-pr-736.herokuapp.com/omis)

## What it looks like

### Work order
![localhost_3001_omis_c459a635-1c0c-471e-bd40-931851d33f09_work-order](https://user-images.githubusercontent.com/3327997/31237697-98273d08-a9ef-11e7-814c-d899cfe53458.png)

![localhost_3001_omis_4f63e457-beb1-4e7f-95c1-0b9936387ea2_work-order](https://user-images.githubusercontent.com/3327997/31238147-e29fd862-a9f0-11e7-9599-e98f5aab6f6d.png)

### Edit invoice details
![localhost_3001_omis_c459a635-1c0c-471e-bd40-931851d33f09_edit_payment](https://user-images.githubusercontent.com/3327997/31237722-aaad8d56-a9ef-11e7-8cf5-9db3f52ac7ee.png)

![localhost_3001_omis_4f63e457-beb1-4e7f-95c1-0b9936387ea2_edit_payment 1](https://user-images.githubusercontent.com/3327997/31237766-c79ebfa2-a9ef-11e7-83d7-b3e318afede4.png)

### Edit billing address
![localhost_3001_omis_c459a635-1c0c-471e-bd40-931851d33f09_edit_billing-address_returnurl _omis_c459a635-1c0c-471e-bd40-931851d33f09_edit_payment](https://user-images.githubusercontent.com/3327997/31237732-b344e93c-a9ef-11e7-87df-1059caaba06a.png)
