### PR TITLE
Handle expected session expiry error

### DIFF
--- a/src/apps/omis/apps/create/views/timeout.njk
+++ b/src/apps/omis/apps/create/views/timeout.njk
@@ -1,0 +1,8 @@
+{% extends "_layouts/form-wizard-step.njk" %}
+
+{% block form %}
+  <p>Your session has timed out due to a long period of inactivity.</p>
+  <p>
+    <a href="{{ baseUrl }}" class="button">Restart</a>
+  </p>
+{% endblock %}

--- a/src/apps/omis/controllers/form.js
+++ b/src/apps/omis/controllers/form.js
@@ -75,6 +75,14 @@ class FormController extends Controller {
       return res.redirect(lastStep.path)
     }
 
+    if (get(err, 'code') === 'SESSION_TIMEOUT') {
+      return res
+        .breadcrumb('Session expired')
+        .render('omis/apps/create/views/timeout', {
+          baseUrl: req.baseUrl,
+        })
+    }
+
     super.errorHandler(err, req, res, next)
   }
 }


### PR DESCRIPTION
The session expiry should be an expected error that is handled differently. It shouldn't be triggering sentry alerts for example.

This change adds it to the OMIS form controller error handler method.