### PR TITLE
Fix broken interaction detail page

### DIFF
--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -10,7 +10,7 @@ const queryString = require('query-string')
 const metadataRepository = require('../../../lib/metadata')
 
 const { transformObjectToOption } = require('../../transformers')
-const { transformInteractionResponsetoViewRecord } = require('../transformers')
+const { transformInteractionResponseToViewRecord } = require('../transformers')
 
 function renderCreatePage (req, res) {
   const interactionTypes = [...metadataRepository.interactionTypeOptions, { id: 999, name: 'Service delivery' }]
@@ -50,7 +50,7 @@ function renderDetailsPage (req, res, next) {
   try {
     const { interaction } = res.locals
     const breadcrumb = capitalize(lowerCase(interaction.kind))
-    const interactionViewRecord = transformInteractionResponsetoViewRecord(interaction)
+    const interactionViewRecord = transformInteractionResponseToViewRecord(interaction)
 
     return res
       .breadcrumb(breadcrumb)

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -1,8 +1,5 @@
 const { assign, find } = require('lodash')
-const {
-  transformInteractionResponseToViewRecord,
-  transformInteractionFormBodyToApiRequest,
-} = require('../transformers')
+const { transformInteractionFormBodyToApiRequest } = require('../transformers')
 const { fetchInteraction, saveInteraction } = require('../repos')
 const metaDataRepository = require('../../../lib/metadata')
 const { getContactsForCompany } = require('../../contacts/repos')
@@ -37,7 +34,6 @@ async function postDetails (req, res, next) {
 async function getInteractionDetails (req, res, next, interactionId) {
   try {
     res.locals.interaction = await fetchInteraction(req.session.token, interactionId)
-    res.locals.interactionViewRecord = transformInteractionResponseToViewRecord(res.locals.interaction)
     next()
   } catch (err) {
     next(err)

--- a/test/unit/apps/interactions/controllers/details.test.js
+++ b/test/unit/apps/interactions/controllers/details.test.js
@@ -26,11 +26,11 @@ describe('Interaction details controller', () => {
 
     this.transformedInteractionDataMock = {}
 
-    this.transformInteractionResponsetoViewRecordStub = this.sandbox.stub().returns(this.transformedInteractionDataMock)
+    this.transformInteractionResponseToViewRecordStub = this.sandbox.stub().returns(this.transformedInteractionDataMock)
 
     this.controller = proxyquire('~/src/apps/interactions/controllers/details', {
       '../transformers': {
-        transformInteractionResponsetoViewRecord: this.transformInteractionResponsetoViewRecordStub,
+        transformInteractionResponseToViewRecord: this.transformInteractionResponseToViewRecordStub,
       },
     })
   })
@@ -41,7 +41,7 @@ describe('Interaction details controller', () => {
     })
 
     it('should use the interaction details transformer', () => {
-      expect(this.transformInteractionResponsetoViewRecordStub).to.be.calledWith(this.res.locals.interaction)
+      expect(this.transformInteractionResponseToViewRecordStub).to.be.calledWith(this.res.locals.interaction)
     })
 
     it('should render the interaction details template', () => {

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -143,10 +143,7 @@ describe('Interaction details middleware', () => {
     context('when success', () => {
       it('should set interaction data on locals', async () => {
         await this.middleware.getInteractionDetails(this.req, this.res, this.nextSpy, '1')
-
         expect(this.res.locals.interaction).to.deep.equal(interactionData)
-        expect(this.res.locals.interactionViewRecord).to.have.property('id', '1')
-        expect(this.res.locals.interactionViewRecord).to.have.property('data', 'transformed')
       })
     })
   })


### PR DESCRIPTION
The previous commit added transformation of interaction to details view in the middleware, no longer needed, and renamed the transformer but did not update the controller that also used it.