### PR TITLE
Revert RenderAsMacros

### DIFF
--- a/src/apps/interactions/views/edit.njk
+++ b/src/apps/interactions/views/edit.njk
@@ -8,5 +8,5 @@
     itemModifier: 'stacked'
   }) }}
 
-  {{ RenderAsMacros(interactionForm) }}
+  {{ Form(interactionForm) }}
 {% endblock %}


### PR DESCRIPTION
Reverting `RenderAsMacros` back to `Form`. This was mistakenly left in for the last PR.