### PR TITLE
Introduce service delivery form config

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -24,6 +24,7 @@ const {
   omit,
   pick,
   lowerCase,
+  kebabCase,
 } = require('lodash')
 
 const { longDateFormat, mediumDateTimeFormat } = require('../../config')
@@ -50,6 +51,7 @@ const filters = {
   stringify: JSON.stringify,
   sentenceCase: Case.sentence,
   lowerCase,
+  kebabCase,
   assign,
   concat,
   filter,

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -20,7 +20,12 @@ function fetchEvent (token, id) {
   return authorisedRequest(token, `${config.apiRoot}/v3/event/${id}`)
 }
 
+function getEvents (token) {
+  return authorisedRequest(token, `${config.apiRoot}/v3/event`)
+}
+
 module.exports = {
   saveEvent,
   fetchEvent,
+  getEvents,
 }

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -1,10 +1,14 @@
 /* eslint camelcase: 0 */
-const { get, merge, pickBy } = require('lodash')
+const { get, merge, pickBy, lowerCase, snakeCase } = require('lodash')
 
 const { transformInteractionResponseToForm } = require('../transformers')
 const { transformDateStringToDateObject } = require('../../transformers')
-const { interactionEditFormConfig } = require('../macros')
+const { interactionFormConfig, serviceDeliveryFormConfig } = require('../macros')
 const { buildFormWithStateAndErrors } = require('../../builders')
+const formConfigs = {
+  'interaction': interactionFormConfig,
+  'service-delivery': serviceDeliveryFormConfig,
+}
 
 function renderEditPage (req, res) {
   const interactionData = transformInteractionResponseToForm(res.locals.interaction)
@@ -16,16 +20,18 @@ function renderEditPage (req, res) {
   const mergedInteractionData = pickBy(merge({}, interactionDefaults, interactionData, res.locals.requestBody))
   const interactionForm =
     buildFormWithStateAndErrors(
-      interactionEditFormConfig(
+      formConfigs[req.params.kind](
         {
           returnLink: res.locals.returnLink,
           advisers: get(res.locals, 'advisers.results'),
           contacts: res.locals.contacts,
           services: res.locals.services,
+          events: get(res.locals, 'events.results'),
           hiddenFields: {
             id: get(res.locals, 'interaction.id'),
             company: res.locals.company.id,
             investment_project: get(res.locals, 'investmentData.id'),
+            kind: snakeCase(req.params.kind),
           },
         }),
       mergedInteractionData,
@@ -35,8 +41,8 @@ function renderEditPage (req, res) {
   const forEntityName = res.locals.entityName ? ` for ${res.locals.entityName}` : ''
 
   res
-    .breadcrumb(`${interactionData ? 'Edit' : 'Add'} interaction`)
-    .title(`${interactionData ? 'Edit' : 'Add'} interaction${forEntityName}`)
+    .breadcrumb(`${interactionData ? 'Edit' : 'Add'} ${lowerCase(req.params.kind)}`)
+    .title(`${interactionData ? 'Edit' : 'Add'} ${lowerCase(req.params.kind) + forEntityName}`)
     .render('interactions/views/edit', {
       interactionForm,
     })

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -1,11 +1,30 @@
-module.exports = {
+const interaction = {
   company: 'Company',
   subject: 'Subject',
-  notes: 'Interaction notes',
+  notes: 'Notes',
   contact: 'Contact',
   date: 'Date of interaction',
   dit_adviser: 'DIT adviser',
   service: 'Service',
   dit_team: 'Service provider',
   communication_channel: 'Communication channel',
+}
+
+const serviceDelivery = {
+  company: 'Company',
+  subject: 'Subject',
+  notes: 'Notes',
+  contact: 'Contact',
+  date: 'Date of service delivery',
+  dit_adviser: 'DIT adviser',
+  service: 'Service',
+  dit_team: 'Service provider',
+  communication_channel: 'Communication channel',
+  is_event: 'Is this an event?',
+  event: 'Event',
+}
+
+module.exports = {
+  interaction,
+  serviceDelivery,
 }

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -58,7 +58,69 @@ const selectKindFormConfig = function ({
   }
 }
 
-const interactionEditFormConfig = function ({
+const interactionFields = {
+  contact (contacts) {
+    return {
+      macroName: 'MultipleChoiceField',
+      name: 'contact',
+      initialOption: '-- Select contact --',
+      options () {
+        return contacts.map(transformContactToOption)
+      },
+    }
+  },
+  provider: {
+    macroName: 'MultipleChoiceField',
+    name: 'dit_team',
+    initialOption: '-- Select provider --',
+    options () {
+      return metaData.teams.map(transformObjectToOption)
+    },
+  },
+  service (services) {
+    return {
+      macroName: 'MultipleChoiceField',
+      name: 'service',
+      initialOption: '-- Select service --',
+      options () {
+        return services.map(transformObjectToOption)
+      },
+    }
+  },
+  subject: {
+    macroName: 'TextField',
+    name: 'subject',
+  },
+  notes: {
+    macroName: 'TextField',
+    type: 'textarea',
+    name: 'notes',
+  },
+  date: {
+    macroName: 'DateFieldset',
+    name: 'date',
+  },
+  adviser (advisers) {
+    return {
+      macroName: 'MultipleChoiceField',
+      name: 'dit_adviser',
+      initialOption: '-- Select adviser --',
+      options () {
+        return advisers.map(transformContactToOption)
+      },
+    }
+  },
+  communicationChannel: {
+    macroName: 'MultipleChoiceField',
+    name: 'communication_channel',
+    initialOption: '-- Select communication channel --',
+    options () {
+      return metaData.communicationChannelOptions.map(transformObjectToOption)
+    },
+  },
+}
+
+const interactionFormConfig = function ({
   returnLink,
   contacts = [],
   advisers = [],
@@ -71,63 +133,77 @@ const interactionEditFormConfig = function ({
     returnText: 'Cancel',
     hiddenFields,
     children: [
-      {
-        macroName: 'MultipleChoiceField',
-        name: 'contact',
-        initialOption: '-- Select contact --',
-        options () {
-          return contacts.map(transformContactToOption)
-        },
-      },
-      {
-        macroName: 'MultipleChoiceField',
-        name: 'dit_team',
-        initialOption: '-- Select provider --',
-        options () {
-          return metaData.teams.map(transformObjectToOption)
-        },
-      },
-      {
-        macroName: 'MultipleChoiceField',
-        name: 'service',
-        initialOption: '-- Select service --',
-        options () {
-          return services.map(transformObjectToOption)
-        },
-      },
-      {
-        macroName: 'TextField',
-        name: 'subject',
-        label: formLabels.subject,
-      },
-      {
-        macroName: 'TextField',
-        type: 'textarea',
-        name: 'notes',
-      },
-      {
-        macroName: 'DateFieldset',
-        name: 'date',
-      },
-      {
-        macroName: 'MultipleChoiceField',
-        name: 'dit_adviser',
-        initialOption: '-- Select adviser --',
-        options () {
-          return advisers.map(transformContactToOption)
-        },
-      },
-      {
-        macroName: 'MultipleChoiceField',
-        name: 'communication_channel',
-        initialOption: '-- Select communication channel --',
-        options () {
-          return metaData.communicationChannelOptions.map(transformObjectToOption)
-        },
-      },
+      interactionFields.contact(contacts),
+      interactionFields.provider,
+      interactionFields.service(services),
+      interactionFields.subject,
+      interactionFields.notes,
+      interactionFields.date,
+      interactionFields.adviser(advisers),
+      interactionFields.communicationChannel,
     ].map(field => {
       return assign(field, {
-        label: formLabels[field.name],
+        label: formLabels.interaction[field.name],
+      })
+    }),
+  }
+}
+
+const serviceDeliveryFormConfig = function ({
+  returnLink,
+  contacts = [],
+  advisers = [],
+  services = [],
+  events = [],
+  hiddenFields,
+}) {
+  return {
+    returnLink,
+    buttonText: 'Save',
+    returnText: 'Cancel',
+    hiddenFields,
+    children: [
+      interactionFields.contact(contacts),
+      interactionFields.provider,
+      // TODO this will be going once interactions are within events
+      {
+        macroName: 'MultipleChoiceField',
+        type: 'radio',
+        name: 'is_event',
+        optional: true,
+        modifier: 'inline',
+        options: [
+          {
+            label: 'Yes',
+            value: 'true',
+          },
+          {
+            label: 'No',
+            value: 'false',
+          },
+        ],
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event',
+        initialOption: '-- Select event --',
+        options () {
+          return events.map(transformObjectToOption)
+        },
+        modifier: 'subfield',
+        condition: {
+          name: 'is_event',
+          value: 'true',
+        },
+      },
+      interactionFields.service(services),
+      interactionFields.subject,
+      interactionFields.notes,
+      interactionFields.date,
+      interactionFields.adviser(advisers),
+    ].map(field => {
+      return assign(field, {
+        label: formLabels.serviceDelivery[field.name],
       })
     }),
   }
@@ -135,6 +211,7 @@ const interactionEditFormConfig = function ({
 
 module.exports = {
   interactionSortForm,
-  interactionEditFormConfig,
   selectKindFormConfig,
+  interactionFormConfig,
+  serviceDeliveryFormConfig,
 }

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -1,10 +1,12 @@
 const { assign } = require('lodash')
+const { sentence } = require('case')
 
 const { transformInteractionFormBodyToApiRequest } = require('../transformers')
 const { fetchInteraction, saveInteraction } = require('../repos')
 const metaDataRepository = require('../../../lib/metadata')
 const { getContactsForCompany } = require('../../contacts/repos')
 const { getAllAdvisers } = require('../../adviser/repos')
+const { getEvents } = require('../../events/repos')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -12,7 +14,7 @@ async function postDetails (req, res, next) {
   try {
     const result = await saveInteraction(req.session.token, res.locals.requestBody)
 
-    req.flash('success', `Interaction ${res.locals.interaction ? 'updated' : 'created'}`)
+    req.flash('success', `${sentence(req.params.kind)} ${res.locals.interaction ? 'updated' : 'created'}`)
 
     if (res.locals.returnLink) {
       return res.redirect(res.locals.returnLink + result.id)
@@ -48,6 +50,7 @@ async function getInteractionOptions (req, res, next) {
     res.locals.advisers = await getAllAdvisers(req.session.token)
     res.locals.contacts = await getContactsForCompany(req.session.token, res.locals.company.id)
     res.locals.services = await metaDataRepository.getServices(req.session.token)
+    res.locals.events = await getEvents(req.session.token)
     next()
   } catch (err) {
     next(err)

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -17,7 +17,7 @@ router.param('interactionId', getInteractionDetails)
 router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getInteractionCollection, renderInteractionList)
 
 router
-  .route('/:interactionId/edit')
+  .route('/:interactionId/:kind/edit')
   .post(
     getInteractionOptions,
     postDetails,

--- a/src/apps/interactions/router.sub-app.js
+++ b/src/apps/interactions/router.sub-app.js
@@ -19,8 +19,8 @@ router
   )
 
 router.route([
-  '/interactions/create/interaction',
-  '/interactions/:interactionId/edit',
+  '/interactions/create/:kind',
+  '/interactions/:interactionId/:kind/edit',
 ])
   .post(
     getInteractionOptions,

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { get, assign } = require('lodash')
+const { get, assign, isUndefined } = require('lodash')
 const { format, isValid } = require('date-fns')
 
 const { transformDateObjectToDateString } = require('../transformers')
@@ -15,6 +15,7 @@ function transformInteractionResponseToForm ({
   dit_adviser,
   company,
   communication_channel,
+  event,
 } = {}) {
   if (!id) return null
 
@@ -35,6 +36,8 @@ function transformInteractionResponseToForm ({
     dit_adviser: get(dit_adviser, 'id'),
     company: get(company, 'id'),
     communication_channel: get(communication_channel, 'id'),
+    is_event: !isUndefined(event),
+    event: get(event, 'id'),
   }
 }
 

--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -2,7 +2,7 @@
 
 {% block main_grid_right_column %}
    {% component 'key-value-table', variant='striped', items=interactionViewRecord %}
-  <a class="button button-secondary" href="{{interaction.id}}/edit">
+  <a class="button button-secondary" href="{{interaction.id}}/{{ interaction.kind | kebabCase }}/edit">
     Edit {{ interaction.kind | lowerCase }}
   </a>
 {% endblock %}

--- a/test/unit/apps/interactions/controllers/edit.test.js
+++ b/test/unit/apps/interactions/controllers/edit.test.js
@@ -9,13 +9,15 @@ describe('Interaction edit controller', () => {
     this.req = {
       session: {
         token: 'abcd',
-        user: {
-        },
+        user: { },
       },
       query: {
         communication_channel: '1',
       },
       body: {},
+      params: {
+        kind: 'interaction',
+      },
     }
     this.res = {
       breadcrumb: this.sandbox.stub().returnsThis(),
@@ -130,34 +132,68 @@ describe('Interaction edit controller', () => {
     })
 
     context('when adding an interaction', () => {
-      it('should add a breadcrumb', async () => {
+      beforeEach(async () => {
         await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
+      })
+      it('should add a breadcrumb', () => {
         expect(this.res.breadcrumb.firstCall).to.be.calledWith('Add interaction')
       })
 
-      it('should add a title', async () => {
-        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
+      it('should add a title', () => {
         expect(this.res.title.firstCall).to.be.calledWith('Add interaction for company')
       })
     })
 
+    context('when adding a service delivery', () => {
+      beforeEach(async () => {
+        const req = merge({}, this.req, {
+          params: {
+            kind: 'service-delivery',
+          },
+        })
+        await this.controller.renderEditPage(req, this.res, this.nextSpy)
+      })
+      it('should add a breadcrumb', () => {
+        expect(this.res.breadcrumb.firstCall).to.be.calledWith('Add service delivery')
+      })
+
+      it('should add a title', () => {
+        expect(this.res.title.firstCall).to.be.calledWith('Add service delivery for company')
+      })
+    })
+
     context('when editing an interaction', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         this.res.locals.interaction = assign({}, interactionData, { id: '1' })
+        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
       })
 
       it('should add a breadcrumb', async () => {
-        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
         expect(this.res.breadcrumb.firstCall).to.be.calledWith('Edit interaction')
       })
 
       it('should add a title', async () => {
-        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
         expect(this.res.title.firstCall).to.be.calledWith('Edit interaction for company')
+      })
+    })
+
+    context('when editing a service delivery', () => {
+      beforeEach(async () => {
+        this.res.locals.interaction = assign({}, interactionData, { id: '1' })
+        const req = merge({}, this.req, {
+          params: {
+            kind: 'service-delivery',
+          },
+        })
+        await this.controller.renderEditPage(req, this.res, this.nextSpy)
+      })
+
+      it('should add a breadcrumb', () => {
+        expect(this.res.breadcrumb.firstCall).to.be.calledWith('Edit service delivery')
+      })
+
+      it('should add a title', () => {
+        expect(this.res.title.firstCall).to.be.calledWith('Edit service delivery for company')
       })
     })
 

--- a/test/unit/apps/interactions/macros.test.js
+++ b/test/unit/apps/interactions/macros.test.js
@@ -22,39 +22,47 @@ describe('Interaction macros', () => {
     })
   })
 
-  describe('#interactionEditFormConfig', () => {
+  describe('#interactionFormConfig', () => {
     it('should return object with specified returnLink present', () => {
-      const actual = this.macros.interactionEditFormConfig({
-        returnLink: 'xxx.yyy.zzz',
-      })
+      const returnLink = '/companies/1/interactions'
+      const actual = this.macros.interactionFormConfig({ returnLink })
 
-      expect(actual.returnLink).to.deep.equal('xxx.yyy.zzz')
+      expect(actual.returnLink).to.deep.equal(returnLink)
     })
 
     it('should return object with transformed contact options', () => {
-      const actual = this.macros.interactionEditFormConfig({ contacts: sampleOptions })
+      const actual = this.macros.interactionFormConfig({ contacts: sampleOptions })
       actual.children.find(x => x.name === 'contact').options()
 
       expect(this.transformContactToOptionSpy).to.have.callCount(2)
     })
 
     it('should return object with transformed dit_adviser options', () => {
-      const actual = this.macros.interactionEditFormConfig({ advisers: sampleOptions })
+      const actual = this.macros.interactionFormConfig({ advisers: sampleOptions })
       actual.children.find(x => x.name === 'dit_adviser').options()
 
       expect(this.transformContactToOptionSpy).to.have.callCount(2)
     })
 
     it('should return object with transformed service options', () => {
-      const actual = this.macros.interactionEditFormConfig({ services: sampleOptions })
+      const actual = this.macros.interactionFormConfig({ services: sampleOptions })
       actual.children.find(x => x.name === 'service').options()
 
       expect(this.transformObjectToOptionSpy).to.have.callCount(2)
     })
 
     it('should return object with transformed dit_team options', () => {
-      const actual = this.macros.interactionEditFormConfig({ dit_team: sampleOptions })
+      const actual = this.macros.interactionFormConfig({ dit_team: sampleOptions })
       actual.children.find(x => x.name === 'dit_team').options()
+
+      expect(this.transformObjectToOptionSpy).to.have.callCount(2)
+    })
+  })
+
+  describe('#serviceDeliveryFormConfig', () => {
+    it('should return object with transformed event options', () => {
+      const actual = this.macros.serviceDeliveryFormConfig({ events: sampleOptions })
+      actual.children.find(x => x.name === 'event').options()
 
       expect(this.transformObjectToOptionSpy).to.have.callCount(2)
     })

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -55,6 +55,9 @@ describe('Interaction details middleware', () => {
       query: {
         company: '299e7412-d9ee-4ab0-a4cb-a8cc00922c91',
       },
+      params: {
+        kind: 'interaction',
+      },
     }
     this.res = {
       breadcrumb: this.sandbox.stub().returnsThis(),

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -2,6 +2,7 @@ const { assign } = require('lodash')
 const mockInteraction = require('~/test/unit/data/interactions/search-interaction.json')
 
 const {
+  transformInteractionResponseToForm,
   transformInteractionToListItem,
   transformInteractionFormBodyToApiRequest,
   transformInteractionResponseToViewRecord,
@@ -9,8 +10,59 @@ const {
 } = require('~/src/apps/interactions/transformers')
 
 describe('Interaction transformers', () => {
+  describe('#transformInteractionResponseToForm', () => {
+    context('when the source is an interaction', () => {
+      beforeEach(() => {
+        this.transformed = transformInteractionResponseToForm(mockInteraction)
+      })
+
+      it('should transform data from interaction response to list item', () => {
+        expect(this.transformed).to.deep.equal({
+          company: 'dcdabbc9-1781-e411-8955-e4115bead28a',
+          contact: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+          dit_adviser: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+          service: '1231231231312',
+          dit_team: '222',
+          communication_channel: '72c226d7-5d95-e211-a939-e4115bead28a',
+          date: { day: '31', month: '05', year: '2017' },
+          is_event: false,
+          event: undefined,
+          id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
+          notes: 'lorem ipsum',
+          subject: 'Test interactions',
+        })
+      })
+    })
+
+    context('when the source is a service delivery', () => {
+      beforeEach(() => {
+        const interaction = assign({}, mockInteraction, {
+          event: { id: '1' },
+        })
+        this.transformed = transformInteractionResponseToForm(interaction)
+      })
+
+      it('should transform data from interaction response to list item', () => {
+        expect(this.transformed).to.deep.equal({
+          company: 'dcdabbc9-1781-e411-8955-e4115bead28a',
+          contact: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+          dit_adviser: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+          service: '1231231231312',
+          dit_team: '222',
+          communication_channel: '72c226d7-5d95-e211-a939-e4115bead28a',
+          date: { day: '31', month: '05', year: '2017' },
+          is_event: true,
+          event: '1',
+          id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
+          notes: 'lorem ipsum',
+          subject: 'Test interactions',
+        })
+      })
+    })
+  })
+
   describe('#transformInteractionToListItem', () => {
-    context('when the source in an interaction', () => {
+    context('when the source is an interaction', () => {
       beforeEach(() => {
         mockInteraction.kind = 'interaction'
         this.transformed = transformInteractionToListItem(mockInteraction)
@@ -62,7 +114,7 @@ describe('Interaction transformers', () => {
       })
     })
 
-    context('when the source in a service delivery', () => {
+    context('when the source is a service delivery', () => {
       beforeEach(() => {
         const serviceDelivery = assign({}, mockInteraction, { kind: 'service_delivery' })
         this.transformed = transformInteractionToListItem(serviceDelivery)


### PR DESCRIPTION
This changes introduces the service delivery form config which displays an edit form when `kind` is `service_delivery`.

![screen shot 2017-10-09 at 22 24 11](https://user-images.githubusercontent.com/1150417/31359141-9d92dff0-ad40-11e7-91c4-3a29efd8f63d.png)
