### PR TITLE
Use a leeloo docker image to run UAT tests against

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,22 +67,9 @@ jobs:
     docker:
       - image: ukti/docker-data-hub-base
         environment:
-          API_ROOT: http://localhost:8000
           API_CLIENT_ID: circleCiClientId
           API_CLIENT_SECRET: youAintSeenMeRight
-          AWS_DEFAULT_REGION: eu-west-2
-          AWS_ACCESS_KEY_ID: foo
-          AWS_SECRET_ACCESS_KEY: bar
-          CDMS_AUTH_URL: http://example.com
-          DATABASE_URL: postgresql://postgres@localhost/datahub
-          DATAHUB_SECRET: secret
-          DEBUG: 'True'
-          DJANGO_SECRET_KEY: topSecret
-          DJANGO_SETTINGS_MODULE: config.settings.local
-          DOCUMENTS_BUCKET: baz
-          ES_INDEX: test_index
-          ES5_URL: http://localhost:9200
-          POSTGRES_URL: http://localhost:5432
+          API_ROOT: http://localhost:8000
           QA_HOST: http://localhost:3000
           QA_SELENIUM_HOST: 127.0.0.1
           QA_SELENIUM_PORT: 4444
@@ -93,63 +80,37 @@ jobs:
       - image: redis:3.2.10
       - image: elasticsearch:5.5
       - image: postgres:9.5
+        name: postgres
+        restart: always
         environment:
           POSTGRES_DB: datahub
+      - image: ukti/data-hub-leeloo
+        command: ./setup-uat.sh
+        environment:
+          API_CLIENT_ID: circleCiClientId
+          API_CLIENT_SECRET: youAintSeenMeRight
+          AWS_DEFAULT_REGION: eu-west-2
+          AWS_ACCESS_KEY_ID: foo
+          AWS_SECRET_ACCESS_KEY: bar
+          CDMS_AUTH_URL: http://example.com
+          DATABASE_URL: postgresql://postgres@postgres/datahub
+          DATAHUB_SECRET: secret
+          DEBUG: True
+          DOCUMENTS_BUCKET: baz
+          DJANGO_SECRET_KEY: topSecret
+          DJANGO_SETTINGS_MODULE: config.settings.local
+          ES_INDEX: test_index
+          ES5_URL: http://localhost:9200
+          POSTGRES_URL: tcp://postgres:5432
+          QA_USER_EMAIL: circleci@datahub.com
+          QA_USER_PASSWORD: secretSquiR3L
     parallelism: 4
-#    resource_class: large
     working_directory: ~/data-hub-frontend
     steps:
       - checkout
-       # setup data hub leeloo
       - run:
-          name: Clone data hub leeloo branch
-          command: |
-            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-            if [ ${CIRCLE_BRANCH} = "master" ]; then
-              BRANCH="master"
-            else
-              BRANCH="develop"
-            fi
-            git clone --depth 1 -b ${BRANCH} --single-branch git@github.com:uktrade/data-hub-leeloo.git ~/app
-            echo "Data hub leelo - \"${BRANCH}\" branch cloned"
-      - restore_cache:
-          name: Restore pip cache
-          key: pip-dependencies-{{ checksum "~/app/requirements.txt" }}
-          paths:
-            - ~/cache/pip
-      - run:
-          name: Install pip dependencies
-          command: pip install --cache-dir ~/cache/pip -r ~/app/requirements.txt
-      - save_cache:
-          name: Save pip cache
-          key: pip-dependencies-{{ checksum "~/app/requirements.txt" }}
-          paths:
-            - ~/cache/pip
-      - run:
-          name: Configure and populate postgres db
-          command: |
-            ~/app/manage.py migrate
-            ~/app/manage.py loadmetadata
-            ~/app/manage.py load_omis_metadata
-            ~/app/manage.py createinitialrevisions
-      - run:
-          name: Create data hub leeloo application
-          command: |
-            echo "from oauth2_provider.models import Application; from datahub.oauth.models import OAuthApplicationScope; app = Application.objects.create(name='circleci', client_id='${API_CLIENT_ID}', client_secret='${API_CLIENT_SECRET}', client_type=Application.CLIENT_CONFIDENTIAL, authorization_grant_type=Application.GRANT_PASSWORD); OAuthApplicationScope.objects.create(application=app, scopes=['internal-front-end'])" | ~/app/manage.py shell
-      - run:
-          name: Create data hub leeloo test user
-          command: |
-            echo "from datahub.company.models import Advisor; Advisor.objects.create_user(email='${QA_USER_EMAIL}', password='${QA_USER_PASSWORD}', first_name='Circle', last_name='Ci')" | ~/app/manage.py shell
-      - run: ~/app/manage.py loaddata ~/app/fixtures/test_data.yaml
-      - run: ~/app/manage.py sync_es
-      - run:
-          name: Run data hub leeloo
-          command: ~/app/manage.py runserver
-          background: true
-      - run:
-          name: Wait for postgres db, Elasticsearch and data hub leeloo
-          command: dockerize -wait ${POSTGRES_URL} -wait ${ES5_URL} -wait ${API_ROOT}/admin/ -timeout 60s
-      # setup data hub frontend
+          name: Wait for data hub leeloo
+          command: dockerize -wait ${API_ROOT}/admin/ -timeout 240s
       - restore_cache:
           name: Restore yarn dependencies cache
           key: yarn-dependencies-{{ checksum "~/data-hub-frontend/yarn.lock" }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ and be provided with a back end server to provide the API, data storage and sear
 
     - [Ignoring features](#ignoring-features)
 - [Continuous Integration](#continuous-integration)
-  - [Docker image](#docker-image)
+  - [Base docker image](#base-docker-image)
+  - [Data hub backend docker image](#data-hub-backend-docker-image)
   - [Job failure](#job-failure)
 - [Deployment](#deployment)
 
@@ -337,15 +338,18 @@ You can tell `nightwatch.js` not to run a feature by adding the tag `@ignore`.
 ## Continuous Integration
 Data hub uses [CircleCI](https://circleci.com/) for continuous integration. 
 
-### Docker image
-The acceptance tests use the docker image `ukti/docker-data-hub-base` 
+### Base docker image
+The acceptance tests `user_acceptance_tests` job uses the docker image `ukti/docker-data-hub-base` as a base for running a selenium server and data hub frontend 
 Details can be found in the [GitHub](https://github.com/uktrade/docker-data-hub-base) and [docker](https://hub.docker.com/r/ukti/docker-data-hub-base/) repositories.
+
+### Data hub backend docker image
+The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo). The `uktrade/data-hub-leeloo:latest` docker image that is used is automatically built via a Docker hub automated job. Details can be found [https://hub.docker.com/r/ukti/data-hub-leeloo](https://hub.docker.com/r/ukti/data-hub-leeloo).
 
 ### Job failure
 CircleCI has been configured to show you a summary report of what has failed on the following workflows:
 - `unit_tests`
 - `lint_code`
-- `acceptance_tests`
+- `user_acceptance_tests`
 
 When acceptance tests fail you can also have a look at the `Nightwatch.js` html report found in the jobs artifacts folder. 
 This can be accessed by logging in to [CircleCI](https://circleci.com/)


### PR DESCRIPTION
- Use an automated local https://hub.docker.com/r/ukti/data-hub-leeloo to run UAT tests against
- update README with information around the various repos used

The `./setup-uat.sh` can be found in [#533](https://github.com/uktrade/data-hub-leeloo/pull/533)
The updated `docker-data-hub-base` work can be found in [#1](https://github.com/uktrade/docker-data-hub-base/pull/1) 

![screen shot 2017-10-10 at 15 23 30](https://user-images.githubusercontent.com/2305016/31391637-04b111aa-adcf-11e7-8d9b-9dfebd789987.png)

