### PR TITLE
Add communication channel to interaction

### DIFF
--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -7,5 +7,5 @@ module.exports = {
   dit_adviser: 'DIT adviser',
   service: 'Service',
   dit_team: 'Service provider',
-  interaction_type: 'Interaction type',
+  communication_channel: 'Communication channel',
 }

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -1,3 +1,5 @@
+const { assign } = require('lodash')
+
 const formLabels = require('./labels')
 const metaData = require('../../lib/metadata')
 const { transformContactToOption, transformObjectToOption } = require('../transformers')
@@ -70,7 +72,6 @@ const interactionEditFormConfig = function ({
       {
         macroName: 'MultipleChoiceField',
         name: 'contact',
-        label: formLabels.contact,
         initialOption: '-- Select contact --',
         options () {
           return contacts.map(transformContactToOption)
@@ -79,7 +80,6 @@ const interactionEditFormConfig = function ({
       {
         macroName: 'MultipleChoiceField',
         name: 'dit_team',
-        label: formLabels.dit_team,
         initialOption: '-- Select provider --',
         options () {
           return metaData.teams.map(transformObjectToOption)
@@ -88,7 +88,6 @@ const interactionEditFormConfig = function ({
       {
         macroName: 'MultipleChoiceField',
         name: 'service',
-        label: formLabels.service,
         initialOption: '-- Select service --',
         options () {
           return services.map(transformObjectToOption)
@@ -103,17 +102,14 @@ const interactionEditFormConfig = function ({
         macroName: 'TextField',
         type: 'textarea',
         name: 'notes',
-        label: formLabels.notes,
       },
       {
         macroName: 'DateFieldset',
         name: 'date',
-        label: formLabels.date,
       },
       {
         macroName: 'MultipleChoiceField',
         name: 'dit_adviser',
-        label: formLabels.dit_adviser,
         optional: true,
         initialOption: '-- Select adviser --',
         options () {
@@ -123,13 +119,16 @@ const interactionEditFormConfig = function ({
       {
         macroName: 'MultipleChoiceField',
         name: 'communication_channel',
-        label: formLabels.communication_channel,
         initialOption: '-- Select communication channel --',
         options () {
           return metaData.communicationChannelOptions.map(transformObjectToOption)
         },
       },
-    ],
+    ].map(field => {
+      return assign(field, {
+        label: formLabels[field.name],
+      })
+    }),
   }
 }
 

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -120,6 +120,15 @@ const interactionEditFormConfig = function ({
           return advisers.map(transformContactToOption)
         },
       },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'communication_channel',
+        label: formLabels.communication_channel,
+        initialOption: '-- Select communication channel --',
+        options () {
+          return metaData.communicationChannelOptions.map(transformObjectToOption)
+        },
+      },
     ],
   }
 }

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -1,4 +1,5 @@
-const { assign, find } = require('lodash')
+const { assign } = require('lodash')
+
 const { transformInteractionFormBodyToApiRequest } = require('../transformers')
 const { fetchInteraction, saveInteraction } = require('../repos')
 const metaDataRepository = require('../../../lib/metadata')
@@ -9,7 +10,6 @@ async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest({
     props: req.body,
     company: req.query.company,
-    communicationChannel: req.query.interaction_type,
   })
 
   try {
@@ -58,9 +58,8 @@ async function getAdviserDetails (req, res, next) {
   }
 }
 
-async function getInteractionTypeAndService (req, res, next) {
+async function getServices (req, res, next) {
   try {
-    res.locals.interactionType = find(metaDataRepository.interactionTypeOptions, { id: req.query.interaction_type })
     res.locals.services = await metaDataRepository.getServices(req.session.token)
     next()
   } catch (err) {
@@ -73,5 +72,5 @@ module.exports = {
   postDetails,
   getCompanyDetails,
   getAdviserDetails,
-  getInteractionTypeAndService,
+  getServices,
 }

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -5,7 +5,7 @@ const { getInteractionCollection } = require('./middleware/collection')
 const {
   postDetails,
   getInteractionDetails,
-  getInteractionTypeAndService,
+  getServices,
   getCompanyDetails,
   getAdviserDetails,
 } = require('../interactions/middleware/details')
@@ -54,7 +54,7 @@ router.route(['/create/interaction', '/:interactionId/edit'])
     },
     getAdviserDetails,
     getCompanyDetails,
-    getInteractionTypeAndService,
+    getServices,
     renderEditPage
   )
 

--- a/src/apps/interactions/services/form.js
+++ b/src/apps/interactions/services/form.js
@@ -13,7 +13,7 @@ function getInteractionAsFormData (interaction) {
     id: interaction.id || null,
     company: getPropertyId(interaction, 'company'),
     contact: getPropertyId(interaction, 'contact'),
-    interaction_type: getPropertyId(interaction, 'interaction_type'),
+    communication_channel: getPropertyId(interaction, 'communication_channel'),
     subject: interaction.subject || null,
     notes: interaction.notes || null,
     date: interaction.date || null,

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -12,7 +12,7 @@ function transformInteractionResponseToForm ({
   dit_adviser,
   service,
   dit_team,
-  interaction_type,
+  communication_channel,
 } = {}) {
   if (!id) return null
 
@@ -24,7 +24,7 @@ function transformInteractionResponseToForm ({
     dit_adviser: get(dit_adviser, 'id'),
     service: get(service, 'id'),
     dit_team: get(dit_team, 'id'),
-    interaction_type: get(interaction_type, 'id'),
+    communication_channel: get(communication_channel, 'id'),
     date: {
       day: isValidDate ? format(date, 'DD') : '',
       month: isValidDate ? format(date, 'MM') : '',
@@ -129,11 +129,10 @@ function transformInteractionResponseToViewRecord ({
   return viewRecord
 }
 
-function transformInteractionFormBodyToApiRequest ({ props, company, communicationChannel }) {
+function transformInteractionFormBodyToApiRequest ({ props, company }) {
   return assign({}, props, {
+    company,
     date: transformDateObjectToDateString('date')(props),
-    company: company,
-    communication_channel: communicationChannel,
   })
 }
 

--- a/test/unit/apps/interactions/controllers/edit.test.js
+++ b/test/unit/apps/interactions/controllers/edit.test.js
@@ -13,7 +13,7 @@ describe('Interaction edit controller', () => {
         },
       },
       query: {
-        interaction_type: '1',
+        communication_channel: '1',
       },
       body: {},
     }

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -54,7 +54,6 @@ describe('Interaction details middleware', () => {
       body: assign({}, interactionData),
       query: {
         company: '299e7412-d9ee-4ab0-a4cb-a8cc00922c91',
-        interaction_type: 'a5d71fdd-5d95-e211-a939-e4115bead28a',
       },
     }
     this.res = {
@@ -169,12 +168,10 @@ describe('Interaction details middleware', () => {
     })
   })
 
-  describe('#getInteractionTypeAndService', () => {
+  describe('#getServices', () => {
     context('when success', () => {
       it('should set type and service data on locals', async () => {
-        await this.middleware.getInteractionTypeAndService(this.req, this.res, this.nextSpy)
-
-        expect(this.res.locals.interactionType).to.deep.equal(interactionTypeOptionsData[1])
+        await this.middleware.getServices(this.req, this.res, this.nextSpy)
         expect(this.res.locals.services).to.deep.equal(servicesData)
       })
     })

--- a/test/unit/apps/interactions/services/form.service.test.js
+++ b/test/unit/apps/interactions/services/form.service.test.js
@@ -5,7 +5,7 @@ describe('interaction form service', function () {
   let company
   let contact
   let dit_adviser
-  let interaction_type
+  let communication_channel
   let interaction
   let service
   let dit_team
@@ -15,14 +15,14 @@ describe('interaction form service', function () {
     company = { id: '1234', name: 'Fred ltd' }
     contact = { id: '3321', name: 'Fred Smith', first_name: 'Fred', last_name: 'Smith', company }
     dit_adviser = { id: '4455', name: 'Fred Jones', first_name: 'Fred', last_name: 'Jones' }
-    interaction_type = { id: '1234', name: 'Email' }
+    communication_channel = { id: '1234', name: 'Email' }
     service = { id: '6654', name: 'Significant Assist' }
     dit_team = { id: '90934', name: 'North East' }
     interaction = {
       id: '999',
       company,
       contact,
-      interaction_type,
+      communication_channel,
       subject: 'Test subject',
       notes: 'Test notes',
       date: '2017-01-02:T00:00:00.00Z',
@@ -51,7 +51,7 @@ describe('interaction form service', function () {
         id: '999',
         company: company.id,
         contact: contact.id,
-        interaction_type: interaction_type.id,
+        communication_channel: communication_channel.id,
         subject: 'Test subject',
         notes: 'Test notes',
         date: '2017-01-02:T00:00:00.00Z',
@@ -65,7 +65,7 @@ describe('interaction form service', function () {
       const freshInteraction = {
         company,
         contact: null,
-        interaction_type: interaction_type,
+        communication_channel: communication_channel,
         dit_adviser,
         date: '2017-01-02:T00:00:00.00Z',
         service: {
@@ -81,7 +81,7 @@ describe('interaction form service', function () {
         id: null,
         company: company.id,
         contact: null,
-        interaction_type: interaction_type.id,
+        communication_channel: communication_channel.id,
         subject: null,
         notes: null,
         date: '2017-01-02:T00:00:00.00Z',

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -135,13 +135,6 @@ describe('Interaction transformers', () => {
 
       expect(actual.company).to.equal(expected)
     })
-
-    it('should set the communication channel', () => {
-      const expected = 'communication channel'
-      const actual = transformInteractionFormBodyToApiRequest({ communicationChannel: expected })
-
-      expect(actual.communication_channel).to.equal(expected)
-    })
   })
 
   describe('#transformInteractionResponsetoViewRecord', () => {


### PR DESCRIPTION
- Adds the 'communication_channel' to the interaction form
- Removes the use of interaction type when posting an interaction
- No longer fetches interaction types for the edit form