### PR TITLE
run uat master against leeloo master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,10 @@ jobs:
           path: coverage
       - store_artifacts:
           path: coverage
-  user_acceptance_tests:
+  user_acceptance_tests: &user_acceptance_tests
     docker:
-      - image: ukti/docker-data-hub-base
+      - &docker_dat_hub_base
+        image: ukti/docker-data-hub-base
         environment:
           API_CLIENT_ID: circleCiClientId
           API_CLIENT_SECRET: youAintSeenMeRight
@@ -77,14 +78,18 @@ jobs:
           QA_USER_PASSWORD: secretSquiR3L
           REDIS_HOST: localhost
           TZ: "/usr/share/zoneinfo/Europe/London"
-      - image: redis:3.2.10
-      - image: elasticsearch:5.5
-      - image: postgres:9.5
+      - &docker_redis
+        image: redis:3.2.10
+      - &docker_elasticsearch
+        image: elasticsearch:5.5
+      - &docker_postgres
+        image: postgres:9.5
         name: postgres
         restart: always
         environment:
           POSTGRES_DB: datahub
-      - image: ukti/data-hub-leeloo
+      - &docker_data_hub_leeloo
+        image: ukti/data-hub-leeloo
         command: ./setup-uat.sh
         environment:
           API_CLIENT_ID: circleCiClientId
@@ -155,6 +160,16 @@ jobs:
           path: cucumber
       - store_artifacts:
           path: cucumber
+  user_acceptance_tests_master:
+    <<: *user_acceptance_tests
+    docker:
+      - *docker_dat_hub_base
+      - *docker_redis
+      - *docker_elasticsearch
+      - *docker_postgres
+      - <<: *docker_data_hub_leeloo
+        image: ukti/data-hub-leeloo:master
+
 workflows:
   version: 2
   datahub:
@@ -180,3 +195,14 @@ workflows:
       - user_acceptance_tests:
           requires:
             - start_uat
+          filters:
+            branches:
+              ignore:
+                - master
+      - user_acceptance_tests_master:
+          requires:
+            - start_uat
+          filters:
+            branches:
+              only:
+                - master

--- a/README.md
+++ b/README.md
@@ -343,7 +343,11 @@ The acceptance tests `user_acceptance_tests` job uses the docker image `ukti/doc
 Details can be found in the [GitHub](https://github.com/uktrade/docker-data-hub-base) and [docker](https://hub.docker.com/r/ukti/docker-data-hub-base/) repositories.
 
 ### Data hub backend docker image
-The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo). The `uktrade/data-hub-leeloo:latest` docker image that is used is automatically built via a Docker hub automated job. Details can be found [https://hub.docker.com/r/ukti/data-hub-leeloo](https://hub.docker.com/r/ukti/data-hub-leeloo).
+The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo). 
+The `uktrade/data-hub-leeloo` docker image and tags that is used is automatically built via a Docker hub automated job. Details can be found [https://hub.docker.com/r/ukti/data-hub-leeloo](https://hub.docker.com/r/ukti/data-hub-leeloo).
+
+- `user_acceptance_tests` job uses `ukti/data-hub-leeloo:latest`
+- `user_acceptance_tests_master` job uses `ukti/data-hub-leeloo:master`
 
 ### Job failure
 CircleCI has been configured to show you a summary report of what has failed on the following workflows:


### PR DESCRIPTION
This work enables a `user_acceptance_tests_master` job that will run the `master` branch of Data hub frontend against the `master` tag of [ukti/data-hub-leeloo:master](https://hub.docker.com/r/ukti/data-hub-leeloo/) (which is an automated build of the repos `master` branch)

I have also updated the documentation to reflect this and update info in the [leeloo docker repo](https://hub.docker.com/r/ukti/data-hub-leeloo/)


- Data hub frontend `master` branch runs against Data hub leeloo `master` tagged docker image, which is an automated build of the repos `master` branch

- Data hub frontend `!master` branch runs against Data hub leeloo `latest` tagged docker image which is an automated build of the repos `develop` branch

@reupen FYI ☝️ 

