### PR TITLE
Fix issues around editing interactions

### DIFF
--- a/src/apps/interactions/controllers/create.js
+++ b/src/apps/interactions/controllers/create.js
@@ -1,5 +1,4 @@
-const { pick, kebabCase } = require('lodash')
-const queryString = require('query-string')
+const { kebabCase } = require('lodash')
 const { selectKindFormConfig } = require('../macros')
 
 function postCreate (req, res, next) {
@@ -13,11 +12,7 @@ function postCreate (req, res, next) {
     }
     return next()
   }
-
-  const interactionData = pick(req.query, 'contact', 'company', 'investment', 'returnLink')
-  const createQueryString = queryString.stringify(interactionData)
-
-  return res.redirect(`/interactions/create/${kebabCase(kind)}?${createQueryString}`)
+  return res.redirect(`${res.locals.returnLink}create/${kebabCase(kind)}`)
 }
 
 function renderCreate (req, res) {

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -23,6 +23,7 @@ function renderEditPage (req, res) {
           contacts: res.locals.contacts,
           services: res.locals.services,
           hiddenFields: {
+            id: get(res.locals, 'interaction.id'),
             company: res.locals.company.id,
             investment_project: get(res.locals, 'investmentData.id'),
           },
@@ -31,9 +32,11 @@ function renderEditPage (req, res) {
       get(res.locals, 'form.errors.messages'),
     )
 
+  const forEntityName = res.locals.entityName ? ` for ${res.locals.entityName}` : ''
+
   res
     .breadcrumb(`${interactionData ? 'Edit' : 'Add'} interaction`)
-    .title(`${interactionData ? 'Edit' : 'Add'} interaction for ${res.locals.entityName}`)
+    .title(`${interactionData ? 'Edit' : 'Add'} interaction${forEntityName}`)
     .render('interactions/views/edit', {
       interactionForm,
     })

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -11,6 +11,7 @@ function renderEditPage (req, res) {
   const interactionDefaults = {
     dit_adviser: req.session.user,
     date: transformDateStringToDateObject(new Date()),
+    contact: get(res.locals, 'contact.id'),
   }
   const mergedInteractionData = pickBy(merge({}, interactionDefaults, interactionData, res.locals.requestBody))
   const interactionForm =

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -22,6 +22,10 @@ function renderEditPage (req, res) {
           advisers: get(res.locals, 'advisers.results'),
           contacts: res.locals.contacts,
           services: res.locals.services,
+          hiddenFields: {
+            company: res.locals.company.id,
+            investment_project: get(res.locals, 'investmentData.id'),
+          },
         }),
       mergedInteractionData,
       get(res.locals, 'form.errors.messages'),

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -110,7 +110,6 @@ const interactionEditFormConfig = function ({
       {
         macroName: 'MultipleChoiceField',
         name: 'dit_adviser',
-        optional: true,
         initialOption: '-- Select adviser --',
         options () {
           return advisers.map(transformContactToOption)

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -63,11 +63,13 @@ const interactionEditFormConfig = function ({
   contacts = [],
   advisers = [],
   services = [],
+  hiddenFields,
 }) {
   return {
     returnLink,
     buttonText: 'Save',
     returnText: 'Cancel',
+    hiddenFields,
     children: [
       {
         macroName: 'MultipleChoiceField',

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -4,7 +4,7 @@ const { transformInteractionFormBodyToApiRequest } = require('../transformers')
 const { fetchInteraction, saveInteraction } = require('../repos')
 const metaDataRepository = require('../../../lib/metadata')
 const { getContactsForCompany } = require('../../contacts/repos')
-const { getAdvisers } = require('../../adviser/repos')
+const { getAllAdvisers } = require('../../adviser/repos')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -39,7 +39,7 @@ async function getInteractionDetails (req, res, next, interactionId) {
 
 async function getInteractionOptions (req, res, next) {
   try {
-    res.locals.advisers = await getAdvisers(req.session.token)
+    res.locals.advisers = await getAllAdvisers(req.session.token)
     res.locals.contacts = await getContactsForCompany(req.session.token, res.locals.company.id)
     res.locals.services = await metaDataRepository.getServices(req.session.token)
     next()

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -13,7 +13,12 @@ async function postDetails (req, res, next) {
     const result = await saveInteraction(req.session.token, res.locals.requestBody)
 
     req.flash('success', `Interaction ${res.locals.interaction ? 'updated' : 'created'}`)
-    return res.redirect(res.locals.returnLink + result.id)
+
+    if (res.locals.returnLink) {
+      return res.redirect(res.locals.returnLink + result.id)
+    }
+
+    return res.redirect(`/interactions/${result.id}`)
   } catch (err) {
     if (err.statusCode === 400) {
       res.locals.form = assign({}, res.locals.form, {
@@ -31,6 +36,7 @@ async function postDetails (req, res, next) {
 async function getInteractionDetails (req, res, next, interactionId) {
   try {
     res.locals.interaction = await fetchInteraction(req.session.token, interactionId)
+    res.locals.company = res.locals.interaction.company
     next()
   } catch (err) {
     next(err)

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -7,11 +7,7 @@ const { getContactsForCompany } = require('../../contacts/repos')
 const { getAdvisers } = require('../../adviser/repos')
 
 async function postDetails (req, res, next) {
-  res.locals.requestBody = transformInteractionFormBodyToApiRequest({
-    props: req.body,
-    company: res.locals.company.id,
-    communicationChannel: res.locals.interactionType.id,
-  })
+  res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
 
   try {
     const result = await saveInteraction(req.session.token, res.locals.requestBody)

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -1,10 +1,12 @@
 const router = require('express').Router()
 
-const { setDefaultQuery } = require('../middleware')
-const { getInteractionCollection } = require('./middleware/collection')
-const { getInteractionDetails } = require('../interactions/middleware/details')
+const { renderEditPage } = require('./controllers/edit')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderInteractionList } = require('./controllers/list')
+
+const { setDefaultQuery } = require('../middleware')
+const { getInteractionCollection } = require('./middleware/collection')
+const { postDetails, getInteractionOptions, getInteractionDetails } = require('./middleware/details')
 
 const DEFAULT_COLLECTION_QUERY = {
   sortby: 'date:desc',
@@ -13,6 +15,18 @@ const DEFAULT_COLLECTION_QUERY = {
 router.param('interactionId', getInteractionDetails)
 
 router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getInteractionCollection, renderInteractionList)
+
+router
+  .route('/:interactionId/edit')
+  .post(
+    getInteractionOptions,
+    postDetails,
+    renderEditPage,
+  )
+  .get(
+    getInteractionOptions,
+    renderEditPage,
+  )
 
 router.get('/:interactionId', renderDetailsPage)
 

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -134,9 +134,8 @@ function transformInteractionResponseToViewRecord ({
   return viewRecord
 }
 
-function transformInteractionFormBodyToApiRequest ({ props, company }) {
+function transformInteractionFormBodyToApiRequest (props) {
   return assign({}, props, {
-    company,
     date: transformDateObjectToDateString('date')(props),
   })
 }

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -6,12 +6,14 @@ const { transformDateObjectToDateString } = require('../transformers')
 
 function transformInteractionResponseToForm ({
   id,
-  date,
-  company,
   contact,
-  dit_adviser,
-  service,
   dit_team,
+  service,
+  subject,
+  notes,
+  date,
+  dit_adviser,
+  company,
   communication_channel,
 } = {}) {
   if (!id) return null
@@ -19,17 +21,20 @@ function transformInteractionResponseToForm ({
   const isValidDate = isValid(new Date(date))
 
   return {
-    company: get(company, 'id'),
+    id: id,
     contact: get(contact, 'id'),
-    dit_adviser: get(dit_adviser, 'id'),
-    service: get(service, 'id'),
     dit_team: get(dit_team, 'id'),
-    communication_channel: get(communication_channel, 'id'),
+    service: get(service, 'id'),
+    subject: subject,
+    notes: notes,
     date: {
       day: isValidDate ? format(date, 'DD') : '',
       month: isValidDate ? format(date, 'MM') : '',
       year: isValidDate ? format(date, 'YYYY') : '',
     },
+    dit_adviser: get(dit_adviser, 'id'),
+    company: get(company, 'id'),
+    communication_channel: get(communication_channel, 'id'),
   }
 }
 

--- a/test/unit/apps/interactions/controllers/create.test.js
+++ b/test/unit/apps/interactions/controllers/create.test.js
@@ -24,14 +24,16 @@ describe('Create interaction, step 1', () => {
       breadcrumb: this.sandbox.stub().returnsThis(),
       redirect: this.sandbox.spy(),
       render: this.sandbox.spy(),
-      locals: {},
+      locals: {
+        returnLink: '/return/',
+      },
     }
 
     this.next = this.sandbox.spy()
   })
 
   describe('#postcreate', () => {
-    context('when a request is made to add an interaction from a company contact', () => {
+    context('when a request is made to add an interaction', () => {
       beforeEach(() => {
         this.req = assign({}, this.req, {
           body: {
@@ -49,94 +51,11 @@ describe('Create interaction, step 1', () => {
 
       it('should forward the user to the create interaction page', () => {
         const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('/interactions/create/interaction?')
-      })
-
-      it('should pass on the company id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('company=1234')
-      })
-
-      it('should pass on the contact id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('contact=4321')
-      })
-
-      it('should pass on the return url, correctly encoded', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('returnLink=%2Fcontacts%2F4321%2Finteractions')
+        expect(redirectUrl).to.contain('/return/create/interaction')
       })
     })
 
-    context('whan a request is made to add an interaction from a company', () => {
-      beforeEach(() => {
-        this.req = assign({}, this.req, {
-          body: {
-            kind: 'interaction',
-          },
-          query: {
-            company: '1234',
-            returnLink: '/companies/1234/interactions',
-          },
-        })
-
-        this.create.postCreate(this.req, this.res, this.next)
-      })
-
-      it('should forward the user to the create interaction page', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('/interactions/create/interaction?')
-      })
-
-      it('should pass on the company id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('company=1234')
-      })
-
-      it('should pass on the return url, correctly encoded', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('returnLink=%2Fcompanies%2F1234%2Finteractions')
-      })
-    })
-
-    context('when a request is made to add an interaction from an investment project', () => {
-      beforeEach(() => {
-        this.req = assign({}, this.req, {
-          body: {
-            kind: 'interaction',
-          },
-          query: {
-            investment: '4444',
-            company: '1234',
-            returnLink: '/investment-projects/444/interactions',
-          },
-        })
-
-        this.create.postCreate(this.req, this.res, this.next)
-      })
-
-      it('should forward the user to the create interaction page', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('/interactions/create/interaction?')
-      })
-
-      it('should pass on the company id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('company=1234')
-      })
-
-      it('should pass on the investment id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('investment=4444')
-      })
-
-      it('should pass on the return url, correctly encoded', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('returnLink=%2Finvestment-projects%2F444%2Finteractions')
-      })
-    })
-
-    context('when a request is made to add a service delivery from a company contact', () => {
+    context('when a request is made to add a service delivery', () => {
       beforeEach(() => {
         this.req = assign({}, this.req, {
           body: {
@@ -154,53 +73,7 @@ describe('Create interaction, step 1', () => {
 
       it('should forward the user to the create service delivery page', () => {
         const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('/interactions/create/service-delivery?')
-      })
-
-      it('should pass on the company id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('company=1234')
-      })
-
-      it('should pass on the contact id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('contact=4321')
-      })
-
-      it('should pass on the return url, correctly encoded', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('returnLink=%2Fcontacts%2F4321%2Finteractions')
-      })
-    })
-
-    context('when a request is made to add a service delivery from a company', () => {
-      beforeEach(() => {
-        this.req = assign({}, this.req, {
-          body: {
-            kind: 'service_delivery',
-          },
-          query: {
-            company: '1234',
-            returnLink: '/companies/1234/interactions',
-          },
-        })
-
-        this.create.postCreate(this.req, this.res, this.next)
-      })
-
-      it('should forward the user to the create service delivery page', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('/interactions/create/service-delivery?')
-      })
-
-      it('should pass on the company id in the url', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('company=1234')
-      })
-
-      it('should pass on the return url, correctly encoded', () => {
-        const redirectUrl = this.res.redirect.firstCall.args[0]
-        expect(redirectUrl).to.contain('returnLink=%2Fcompanies%2F1234%2Finteractions')
+        expect(redirectUrl).to.contain('/return/create/service-delivery')
       })
     })
 

--- a/test/unit/apps/interactions/controllers/edit.test.js
+++ b/test/unit/apps/interactions/controllers/edit.test.js
@@ -28,6 +28,9 @@ describe('Interaction edit controller', () => {
         interactionType: {
           name: 'interaction type',
         },
+        company: {
+          id: '1',
+        },
       },
     }
     this.nextSpy = this.sandbox.spy()
@@ -38,27 +41,56 @@ describe('Interaction edit controller', () => {
   })
 
   describe('#renderEditPage', () => {
-    it('should render the interaction page', async () => {
-      await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
+    context('when rendering the interaction form for a company', () => {
+      it('should render the interaction page', async () => {
+        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
 
-      expect(this.res.render).to.be.calledWith('interactions/views/edit')
-      expect(this.res.render).to.have.been.calledOnce
+        expect(this.res.render).to.be.calledWith('interactions/views/edit')
+        expect(this.res.render).to.have.been.calledOnce
+      })
+
+      it('should render the interaction page with a return link', async () => {
+        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
+
+        const actual = this.res.render.getCall(0).args[1].interactionForm.returnLink
+
+        expect(actual).to.equal('return')
+      })
+
+      it('should render the interaction page with an interaction form', async () => {
+        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
+
+        const actual = this.res.render.getCall(0).args[1].interactionForm.children
+
+        expect(actual).to.be.an('array')
+      })
+
+      it('should render an interaction form with hidden fields', async () => {
+        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
+
+        const actualHiddenFields = this.res.render.getCall(0).args[1].interactionForm.hiddenFields
+
+        expect(actualHiddenFields.company).to.equal('1')
+        expect(actualHiddenFields.investment_project).to.be.undefined
+      })
     })
 
-    it('should render the interaction page with a return link', async () => {
-      await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
+    context('when rendering the interaction form for an investment project', () => {
+      it('should render an interaction form with hidden fields', async () => {
+        const res = merge({}, this.res, {
+          locals: {
+            investmentData: {
+              id: '2',
+            },
+          },
+        })
+        await this.controller.renderEditPage(this.req, res, this.nextSpy)
 
-      const actual = this.res.render.getCall(0).args[1].interactionForm.returnLink
+        const actualHiddenFields = this.res.render.getCall(0).args[1].interactionForm.hiddenFields
 
-      expect(actual).to.equal('return')
-    })
-
-    it('should render the interaction page with an interaction form', async () => {
-      await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
-      const actual = this.res.render.getCall(0).args[1].interactionForm.children
-
-      expect(actual).to.be.an('array')
+        expect(actualHiddenFields.company).to.equal('1')
+        expect(actualHiddenFields.investment_project).to.equal('2')
+      })
     })
 
     context('when adding an interaction', () => {

--- a/test/unit/apps/interactions/controllers/edit.test.js
+++ b/test/unit/apps/interactions/controllers/edit.test.js
@@ -93,6 +93,42 @@ describe('Interaction edit controller', () => {
       })
     })
 
+    context('when rendering the interaction form for editing an interaction found from top level navigation', () => {
+      it('should render an interaction form with hidden fields', async () => {
+        const res = assign({}, this.res, {
+          locals: {
+            company: {
+              id: '1',
+            },
+            interaction: {
+              id: '3',
+            },
+          },
+        })
+        await this.controller.renderEditPage(this.req, res, this.nextSpy)
+
+        const actualHiddenFields = this.res.render.getCall(0).args[1].interactionForm.hiddenFields
+
+        expect(actualHiddenFields.company).to.equal('1')
+        expect(actualHiddenFields.id).to.equal('3')
+        expect(actualHiddenFields.investment_project).to.be.undefined
+      })
+
+      it('should add a title without entity name', async () => {
+        const res = assign({}, this.res, {
+          locals: {
+            company: {
+              id: '1',
+            },
+          },
+        })
+
+        await this.controller.renderEditPage(this.req, res, this.nextSpy)
+
+        expect(this.res.title.firstCall).to.be.calledWith('Add interaction')
+      })
+    })
+
     context('when adding an interaction', () => {
       it('should add a breadcrumb', async () => {
         await this.controller.renderEditPage(this.req, this.res, this.nextSpy)

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -113,6 +113,21 @@ describe('Interaction details middleware', () => {
       })
     })
 
+    context('when all fields are valid for updating an interaction found from the top level navigation', () => {
+      it('should redirect on success', async () => {
+        const res = assign({}, this.res, {
+          breadcrumb: this.sandbox.stub().returnsThis(),
+          render: this.sandbox.spy(),
+          redirect: this.sandbox.spy(),
+          locals: {},
+        })
+
+        await this.middleware.postDetails(this.req, res, this.nextSpy)
+
+        expect(res.redirect).to.be.calledWith('/interactions/1')
+      })
+    })
+
     context('when there is a 400', () => {
       beforeEach(async () => {
         this.saveInteractionStub.rejects({ statusCode: 400, error: 'error' })
@@ -151,6 +166,11 @@ describe('Interaction details middleware', () => {
       it('should set interaction data on locals', async () => {
         await this.middleware.getInteractionDetails(this.req, this.res, this.nextSpy, '1')
         expect(this.res.locals.interaction).to.deep.equal(interactionData)
+      })
+
+      it('should set company data on locals', async () => {
+        await this.middleware.getInteractionDetails(this.req, this.res, this.nextSpy, '1')
+        expect(this.res.locals.company).to.deep.equal(interactionData.company)
       })
     })
   })

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -22,7 +22,7 @@ describe('Interaction details middleware', () => {
     this.sandbox = sinon.sandbox.create()
     this.saveInteractionStub = this.sandbox.stub()
     this.fetchInteractionStub = this.sandbox.stub()
-    this.getAdvisersStub = this.sandbox.stub()
+    this.getAllAdvisersStub = this.sandbox.stub()
     this.transformInteractionFormBodyToApiRequestStub = this.sandbox.stub()
     this.transformInteractionResponseToViewRecordStub = this.sandbox.stub()
     this.getContactsForCompanyStub = this.sandbox.stub()
@@ -36,7 +36,7 @@ describe('Interaction details middleware', () => {
         transformInteractionResponseToViewRecord: this.transformInteractionResponseToViewRecordStub.returns(transformed),
       },
       '../../adviser/repos': {
-        getAdvisers: this.getAdvisersStub.resolves(advisersData),
+        getAllAdvisers: this.getAllAdvisersStub.resolves(advisersData),
       },
       '../../../lib/metadata': {
         getServices: () => { return servicesData },

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -117,24 +117,13 @@ describe('Interaction transformers', () => {
 
   describe('#transformInteractionFormBodyToApiRequest', () => {
     it('should set the date', () => {
-      const actual = transformInteractionFormBodyToApiRequest(
-        {
-          props: {
-            date_year: '2018',
-            date_month: '01',
-            date_day: '02',
-          },
-        }
-      )
+      const actual = transformInteractionFormBodyToApiRequest({
+        date_year: '2018',
+        date_month: '01',
+        date_day: '02',
+      })
 
       expect(actual.date).to.equal('2018-01-02')
-    })
-
-    it('should set the company', () => {
-      const expected = 'company'
-      const actual = transformInteractionFormBodyToApiRequest({ company: expected })
-
-      expect(actual.company).to.equal(expected)
     })
   })
 


### PR DESCRIPTION
This change will fix the majority of issues around editing interactions, including:
- Using data set on `res.locals` rather than depending on the query string
- Displaying all data when editing
- Adding investment project ID for POST to API when editing an investment project interaction
- Selecting contact when adding an interaction for contact

Not covered:
- Editing interactions from the top-level `Interactions` list view