### PR TITLE
Some protection against displaying legacy OMIS orders

### DIFF
--- a/src/apps/omis/apps/edit/controllers/edit-handler.js
+++ b/src/apps/omis/apps/edit/controllers/edit-handler.js
@@ -18,7 +18,7 @@ function editHandler (req, res, next) {
   const defaults = {
     buttonText: 'Save and return',
     returnText: 'Return without saving',
-    disableFormAction: !order.editable,
+    disableFormAction: !order.isEditable,
     journeyName: 'edit',
     name: 'edit',
     route: '/edit',

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -50,13 +50,15 @@
       itemModifier: 'stacked'
     }) }}
 
-    {% call Example(tabTitle = 'Preview') %}
-      <div class="l-markdown">
-        {% markdown %}
-          {{ quote.content }}
-        {% endmarkdown %}
-      </div>
-    {% endcall %}
+    {% if quote.content %}
+      {% call Example(tabTitle = 'Preview') %}
+        <div class="l-markdown">
+          {% markdown %}
+            {{ quote.content }}
+          {% endmarkdown %}
+        </div>
+      {% endcall %}
+    {% endif %}
   {% endif %}
 
   {% if destructive %}

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -61,13 +61,15 @@
     {% endif %}
   {% endif %}
 
-  {% if destructive %}
-    {{ Message({
-      text: 'Editing the order whilst it is out for acceptance will invalidate the
-      current quote and the client will no longer be able to accept it.',
-      type: 'error'
-    }) }}
-  {% endif %}
+  {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
+    {% if destructive %}
+      {{ Message({
+        type: 'error',
+        text: 'Editing the order whilst it is out for acceptance will invalidate the
+        current quote and the client will no longer be able to accept it.'
+      }) }}
+    {% endif %}
 
-  {{ Form(quoteForm) }}
+    {{ Form(quoteForm) }}
+  {% endif %}
 {% endblock %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -8,7 +8,7 @@
 {% endset %}
 
 {% block body_main_content %}
-  {% if not order.editable %}
+  {% if order.status === 'quote_awaiting_acceptance' %}
     {% call Message({ type: 'info', element: 'div' }) %}
       <p>You cannot edit the order whilst a quote is awaiting acceptance.</p>
       <p>You must <a href="quote">cancel the quote</a> to edit the order.</p>

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -18,7 +18,7 @@
   {{ AnswersSummary({
     heading: 'Client details',
     actions: [{
-      url: 'edit/client-details' if order.editable
+      url: 'edit/client-details' if order.isEditable
     }],
     items: [{
       label: 'Company',
@@ -42,10 +42,10 @@
   {% call AnswersSummary({
     heading: 'Advisers in the market',
     actions: [{
-      url: 'edit/assignees' if order.editable,
+      url: 'edit/assignees' if order.isEditable,
       label: 'Add or remove'
     }, {
-      url: 'edit/assignee-time' if values.assignees.length and order.editable,
+      url: 'edit/assignee-time' if values.assignees.length and order.isEditable,
       label: 'Edit time'
     }]
   }) %}
@@ -97,7 +97,7 @@
   {{ AnswersSummary({
     heading: 'Advisers in the UK',
     actions: [{
-      url: 'edit/subscribers' if order.editable,
+      url: 'edit/subscribers' if order.isEditable,
       label: 'Add or remove'
     }],
     items: values.subscribers | map('name') if values.subscribers.length,
@@ -107,7 +107,7 @@
   {{ AnswersSummary({
     heading: 'Work description',
     actions: [{
-      url: 'edit/work-description' if order.editable
+      url: 'edit/work-description' if order.isEditable
     }],
     items: [{
       label: 'Delivery date',
@@ -190,7 +190,7 @@
   {{ AnswersSummary({
     heading: 'Invoice details',
     actions: [{
-      url: 'edit/payment' if order.editable
+      url: 'edit/payment' if order.isEditable
     }],
     items: [{
       label: 'VAT category',

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -23,7 +23,7 @@ async function getOrder (req, res, next, orderId) {
     res.locals.order = Object.assign({}, order, {
       subscribers,
       assignees,
-      editable: order.status === 'draft',
+      isEditable: order.status === 'draft',
     })
   } catch (e) {
     logger.error(e)

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -127,7 +127,7 @@ describe('OMIS middleware', () => {
         const order = Object.assign({}, orderData, {
           subscribers: subscriberData,
           assignees: assigneeData,
-          editable: true,
+          isEditable: true,
         })
         expect(this.resMock.locals).to.have.property('order')
         expect(this.resMock.locals.order).to.deep.equal(order)
@@ -147,10 +147,10 @@ describe('OMIS middleware', () => {
           this.getByIdStub.resolves(draftOrder)
         })
 
-        it('should set editable to true', async () => {
+        it('should set isEditable to true', async () => {
           await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
-          expect(this.resMock.locals.order.editable).to.equal(true)
+          expect(this.resMock.locals.order.isEditable).to.equal(true)
         })
       })
 
@@ -162,10 +162,10 @@ describe('OMIS middleware', () => {
           this.getByIdStub.resolves(quoteOrder)
         })
 
-        it('should set editable to false', async () => {
+        it('should set isEditable to false', async () => {
           await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
-          expect(this.resMock.locals.order.editable).to.equal(false)
+          expect(this.resMock.locals.order.isEditable).to.equal(false)
         })
       })
     })


### PR DESCRIPTION
This makes a few tweaks to work order and quote views to protect against legacy orders and certain states.

See list of commits for changes and explanations.