### PR TITLE
Fix spacing around local header

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -7,23 +7,31 @@ $_first-element-spacing: $default-spacing-unit * 3;
 
   .l-container {
     border-top: 1px solid transparent;
+  }
 
-    > .c-local-header__heading:first-child {
-      margin-top: $_first-element-spacing;
-    }
+  .c-message-list:first-child {
+    margin-top: $default-spacing-unit;
+  }
 
-    > .c-message-list:first-child {
-      margin-top: $default-spacing-unit;
-    }
+  .c-local-header__heading:first-child {
+    margin-top: $_first-element-spacing;
   }
 
   &[class*="c-local-header--"] {
     padding-bottom: $default-spacing-unit * 2;
   }
 
+  .c-message-list {
+    margin-bottom: $default-spacing-unit;
+  }
+
   .c-entity-search {
     margin-top: $baseline-grid-unit * 20.5;
     padding-bottom: $baseline-grid-unit * 6.25;
+  }
+
+  .c-entity-search__aggregations {
+    margin-bottom: -$baseline-grid-unit * 14.25;
   }
 
   .c-breadcrumb {
@@ -33,17 +41,15 @@ $_first-element-spacing: $default-spacing-unit * 3;
       margin-top: $_first-element-spacing;
     }
 
-    & + .c-entity-search {
-      padding-bottom: 0;
+    & + .grid-row {
+      .c-entity-search {
+        margin-top: 0;
+      }
+
+      .c-local-header__heading:first-child {
+        margin-top: 0;
+      }
     }
-  }
-
-  .c-message-list {
-    margin-bottom: $default-spacing-unit;
-  }
-
-  .c-entity-search__aggregations {
-    margin-bottom: -$default-spacing-unit * 2;
   }
 
   .c-progress {


### PR DESCRIPTION
There were some changes which adjusted the spacing of the entity
search and the main heading when there was no breadcrumb.

## Before
![localhost_3001_sign-in 1](https://user-images.githubusercontent.com/3327997/31451465-16cbba7c-aea4-11e7-8132-3d3abc90e9d3.png)

![localhost_3001_ 1](https://user-images.githubusercontent.com/3327997/31451441-074d8058-aea4-11e7-8f3d-96f0623095a9.png)

![localhost_3001_search_companies_term samsung 1](https://user-images.githubusercontent.com/3327997/31451446-0b6dc7f6-aea4-11e7-88e3-fb731fcf89a1.png)

## After
![localhost_3001_sign-in](https://user-images.githubusercontent.com/3327997/31451390-deff11de-aea3-11e7-968b-2c74035c7d87.png)

![localhost_3001_](https://user-images.githubusercontent.com/3327997/31451403-ec0b17f6-aea3-11e7-8a8f-d10f00224307.png)

![localhost_3001_search_companies_term samsung](https://user-images.githubusercontent.com/3327997/31451415-f44ce28c-aea3-11e7-9e5b-c82aa86f542d.png)
