### PR TITLE
Rename OMIS nav item

### DIFF
--- a/src/apps/omis/index.js
+++ b/src/apps/omis/index.js
@@ -1,7 +1,7 @@
 const router = require('./router')
 
 module.exports = {
-  displayName: 'OMIS orders',
+  displayName: 'Orders (OMIS)',
   mountpath: '/omis',
   router,
 }

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -14,7 +14,7 @@ const globalNavItems = [
   { path: '/events', label: 'Events' },
   { path: '/interactions', label: 'Interactions' },
   { path: '/investment-projects', label: 'Investment projects' },
-  { path: '/omis', label: 'OMIS Orders' },
+  { path: '/omis', label: 'Orders (OMIS)' },
 ]
 
 module.exports = function locals (req, res, next) {


### PR DESCRIPTION
Rather than using `OMIS` as the lead word use `Orders` which better
describes what it is a list of but keep the legacy name that people
still refer to in the description for now.

## Before
![image](https://user-images.githubusercontent.com/3327997/31451833-168a4780-aea5-11e7-9f14-5b8888c71ecf.png)

## After
![image](https://user-images.githubusercontent.com/3327997/31451798-fb2076cc-aea4-11e7-977f-2d0ffb05d5ff.png)
