### PR TITLE
Refactor quote setting logic for OMIS orders

### DIFF
--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -6,7 +6,9 @@ const { renderWorkOrder, renderQuote } = require('./controllers')
 const {
   setTranslation,
   setCompany,
-  getQuote,
+  setQuoteSummary,
+  setQuotePreview,
+  setQuote,
   setQuoteForm,
   generateQuote,
   cancelQuote,
@@ -21,14 +23,15 @@ const LOCAL_NAV = [
 
 router.use(setLocalNav(LOCAL_NAV))
 router.use(setTranslation)
-router.use(setOrderBreadcrumb)
 router.use(setCompany)
+router.use(setOrderBreadcrumb)
+router.use(setQuoteSummary)
 
 router.get('/', redirectToFirstNavItem)
-router.get('/work-order', getQuote, renderWorkOrder)
+router.get('/work-order', renderWorkOrder)
 router
   .route('/quote')
-  .get(getQuote, setQuoteForm, renderQuote)
+  .get(setQuotePreview, setQuote, setQuoteForm, renderQuote)
   .post(generateQuote)
 
 router.post('/quote/cancel', cancelQuote)


### PR DESCRIPTION
This makes the quote logic more logical so that the app only makes
requests when it needs to.

This change also makes handling legacy orders more robust but not
throwing an error when expected cases occur.