### PR TITLE
Fix error with invalid order ID returning 500

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -3,6 +3,7 @@ const path = require('path')
 const i18nFuture = require('i18n-future')
 
 const { Order } = require('../../models')
+const { getCompany } = require('../../middleware')
 const editSteps = require('../edit/steps')
 
 const i18n = i18nFuture({
@@ -14,6 +15,16 @@ function setTranslation (req, res, next) {
     return i18n.translate(key)
   }
   next()
+}
+
+function setCompany (req, res, next) {
+  const orderId = get(res.locals, 'order.company.id')
+
+  if (!orderId) {
+    return next()
+  }
+
+  getCompany(req, res, next, res.locals.order.company.id)
 }
 
 async function getQuote (req, res, next) {
@@ -146,6 +157,7 @@ function setQuoteForm (req, res, next) {
 
 module.exports = {
   setTranslation,
+  setCompany,
   getQuote,
   generateQuote,
   cancelQuote,

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,10 +1,11 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
-const { getCompany, setOrderBreadcrumb } = require('../../middleware')
+const { setOrderBreadcrumb } = require('../../middleware')
 const { renderWorkOrder, renderQuote } = require('./controllers')
 const {
   setTranslation,
+  setCompany,
   getQuote,
   setQuoteForm,
   generateQuote,
@@ -21,10 +22,7 @@ const LOCAL_NAV = [
 router.use(setLocalNav(LOCAL_NAV))
 router.use(setTranslation)
 router.use(setOrderBreadcrumb)
-
-router.use((req, res, next) => {
-  getCompany(req, res, next, res.locals.order.company.id)
-})
+router.use(setCompany)
 
 router.get('/', redirectToFirstNavItem)
 router.get('/work-order', getQuote, renderWorkOrder)


### PR DESCRIPTION
This change first moves the middleware for setting company data to
locals to the middleware file rather than manually in the router.

It then adds a fix to only call middleware if a company id exists on
the order.