### PR TITLE
Use investmentId as parameter name instead of id

### DIFF
--- a/src/apps/investment-projects/controllers/archive.js
+++ b/src/apps/investment-projects/controllers/archive.js
@@ -6,7 +6,7 @@ async function archiveInvestmentProjectHandler (req, res, next) {
   try {
     // Archive the project.
     const reason = (req.body.archived_reason === 'Other') ? req.body.archived_reason_other : req.body.archived_reason
-    await investmentRepository.archiveInvestmentProject(req.session.token, req.params.id, reason)
+    await investmentRepository.archiveInvestmentProject(req.session.token, req.params.investmentId, reason)
 
     res.locals.investmentData = Object.assign({}, res.locals.investmentData, {
       archived: true,
@@ -29,7 +29,7 @@ async function archiveInvestmentProjectHandler (req, res, next) {
 
 async function unarchiveInvestmentProjectHandler (req, res, next) {
   try {
-    await investmentRepository.unarchiveInvestmentProject(req.session.token, req.params.id)
+    await investmentRepository.unarchiveInvestmentProject(req.session.token, req.params.investmentId)
     req.flash('success', 'Investment project updated')
     res.redirect('details')
   } catch (error) {

--- a/src/apps/investment-projects/controllers/audit.js
+++ b/src/apps/investment-projects/controllers/audit.js
@@ -14,7 +14,7 @@ function formatAuditLog (logEntry) {
 async function getInvestmentAudit (req, res, next) {
   try {
     if (get(res, 'locals.investmentData')) {
-      const rawAuditLog = await getInvestmentProjectAuditLog(req.session.token, req.params.id)
+      const rawAuditLog = await getInvestmentProjectAuditLog(req.session.token, req.params.investmentId)
       const auditLog = rawAuditLog.map(formatAuditLog)
 
       return res

--- a/src/apps/investment-projects/controllers/interactions.js
+++ b/src/apps/investment-projects/controllers/interactions.js
@@ -9,7 +9,7 @@ async function renderInteractionList (req, res, next) {
   try {
     const token = req.session.token
     const page = req.query.page || '1'
-    const investmentId = req.params.id
+    const investmentId = req.params.investmentId
 
     const interactions = await getInteractionsForInvestment(token, investmentId, page)
       .then(transformApiResponseToCollection(

--- a/src/apps/investment-projects/middleware/forms/client-relationship-management.js
+++ b/src/apps/investment-projects/middleware/forms/client-relationship-management.js
@@ -36,7 +36,7 @@ async function populateForm (req, res, next) {
 
 async function handleFormPost (req, res, next) {
   try {
-    res.locals.projectId = req.params.id
+    res.locals.projectId = req.params.investmentId
     await updateCompany(req.session.token, req.body.investor_company, { account_manager: req.body.account_manager })
     await updateInvestment(req.session.token, res.locals.projectId, { client_relationship_manager: req.body.client_relationship_manager })
     next()

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -82,7 +82,7 @@ async function populateForm (req, res, next) {
 
 function handleFormPost (req, res, next) {
   const formattedBody = transformToApi(Object.assign({}, req.body))
-  const projectId = res.locals.projectId || req.params.id
+  const projectId = res.locals.projectId || req.params.investmentId
   let saveMethod
 
   if (projectId) {

--- a/src/apps/investment-projects/middleware/forms/project-management.js
+++ b/src/apps/investment-projects/middleware/forms/project-management.js
@@ -32,7 +32,7 @@ async function populateForm (req, res, next) {
 }
 
 function handleFormPost (req, res, next) {
-  res.locals.projectId = req.params.id
+  res.locals.projectId = req.params.investmentId
   updateInvestment(req.session.token, res.locals.projectId, req.body)
     .then(() => next())
     .catch((err) => {

--- a/src/apps/investment-projects/middleware/forms/project-stage.js
+++ b/src/apps/investment-projects/middleware/forms/project-stage.js
@@ -1,7 +1,7 @@
 const logger = require('../../../../../config/logger')
 const { updateInvestment } = require('../../repos')
 
-function handleFormPost (req, res, next, projectId = req.params.id) {
+function handleFormPost (req, res, next, projectId = req.params.investmentId) {
   updateInvestment(req.session.token, projectId, {
     stage: {
       id: req.body.next_project_stage,

--- a/src/apps/investment-projects/middleware/forms/requirements.js
+++ b/src/apps/investment-projects/middleware/forms/requirements.js
@@ -19,7 +19,7 @@ function populateForm (req, res, next) {
 }
 
 function handleFormPost (req, res, next) {
-  res.locals.projectId = req.params.id
+  res.locals.projectId = req.params.investmentId
 
   const formattedBody = assign({}, req.body, {
     strategic_drivers: flatten([req.body.strategic_drivers]),

--- a/src/apps/investment-projects/middleware/forms/team-members.js
+++ b/src/apps/investment-projects/middleware/forms/team-members.js
@@ -57,9 +57,9 @@ async function populateForm (req, res, next) {
 
 async function handleFormPost (req, res, next) {
   try {
-    res.locals.projectId = req.params.id
+    res.locals.projectId = req.params.investmentId
     const teamMembers = transformDataToTeamMemberArray(req.body)
-    await updateInvestmentTeamMembers(req.session.token, req.params.id, teamMembers)
+    await updateInvestmentTeamMembers(req.session.token, req.params.investmentId, teamMembers)
     next()
   } catch (err) {
     if (err.statusCode === 400) {

--- a/src/apps/investment-projects/middleware/forms/value.js
+++ b/src/apps/investment-projects/middleware/forms/value.js
@@ -19,7 +19,7 @@ function populateForm (req, res, next) {
 }
 
 function handleFormPost (req, res, next) {
-  res.locals.projectId = req.params.id
+  res.locals.projectId = req.params.investmentId
 
   const formattedBody = Object.assign({}, req.body, {
     average_salary: {

--- a/src/apps/investment-projects/middleware/interactions.js
+++ b/src/apps/investment-projects/middleware/interactions.js
@@ -7,7 +7,7 @@ async function getInteractionCollection (req, res, next) {
   try {
     const token = req.session.token
     const page = req.query.page || '1'
-    const investmentId = req.params.id
+    const investmentId = req.params.investmentId
 
     res.locals.interactions = await getInteractionsForInvestment(token, investmentId, page)
       .then(transformApiResponseToCollection(
@@ -22,7 +22,7 @@ async function getInteractionCollection (req, res, next) {
 }
 
 function setInteractionsReturnUrl (req, res, next) {
-  res.locals.returnLink = `/investment-projects/${req.params.id}/interactions/`
+  res.locals.returnLink = `/investment-projects/${req.params.investmentId}/interactions/`
   next()
 }
 
@@ -33,7 +33,7 @@ function setInteractionsEntityName (req, res, next) {
 
 async function setCompanyDetails (req, res, next) {
   try {
-    const investment = await getInvestment(req.session.token, req.params.id)
+    const investment = await getInvestment(req.session.token, req.params.investmentId)
     res.locals.company = investment.investor_company
     next()
   } catch (error) {

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -22,13 +22,13 @@ function getCompanyDetails (req, res, next) {
     .catch(next)
 }
 
-async function getInvestmentDetails (req, res, next, id = req.params.id) {
-  if (!isValidGuid(id)) {
+async function getInvestmentDetails (req, res, next, investmentId = req.params.investmentId) {
+  if (!isValidGuid(investmentId)) {
     return next()
   }
   try {
     const investmentProjectStages = metadata.investmentProjectStage
-    const investmentData = await getInvestment(req.session.token, req.params.id)
+    const investmentData = await getInvestment(req.session.token, investmentId)
     const investorCompany = await getDitCompany(req.session.token, get(investmentData, 'investor_company.id'))
     const ukCompanyId = get(investmentData, 'uk_company.id')
 

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -22,7 +22,9 @@ function getCompanyDetails (req, res, next) {
     .catch(next)
 }
 
-async function getInvestmentDetails (req, res, next, investmentId = req.params.investmentId) {
+async function getInvestmentDetails (req, res, next) {
+  const investmentId = req.params.investmentId
+
   if (!isValidGuid(investmentId)) {
     return next()
   }

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -51,17 +51,17 @@ const DEFAULT_COLLECTION_QUERY = {
   sortby: 'estimated_land_date:asc',
 }
 
-router.use('/:id/', setLocalNav(LOCAL_NAV))
+router.use('/:investmentId/', setLocalNav(LOCAL_NAV))
 
-router.param('id', shared.getInvestmentDetails)
+router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)
 
 router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getRequestBody, getInvestmentProjectsCollection, renderInvestmentList)
 
-router.post('/:id/details', archive.archiveInvestmentProjectHandler, details.detailsGetHandler)
-router.get('/:id/unarchive', archive.unarchiveInvestmentProjectHandler)
+router.post('/:investmentId/details', archive.archiveInvestmentProjectHandler, details.detailsGetHandler)
+router.get('/:investmentId/unarchive', archive.unarchiveInvestmentProjectHandler)
 
-router.get('/:id/audit', audit.getInvestmentAudit)
+router.get('/:investmentId/audit', audit.getInvestmentAudit)
 
 router.get('/create/:companyId?', create.start.redirectHandler, create.start.renderCreatePage)
 
@@ -102,28 +102,28 @@ router
     create.project.renderCreateProjectPage
   )
 
-router.get('/:id', redirectToFirstNavItem)
-router.get('/:id/details', details.detailsGetHandler)
+router.get('/:investmentId', redirectToFirstNavItem)
+router.get('/:investmentId/details', details.detailsGetHandler)
 
 router
-  .route('/:id/edit-details')
+  .route('/:investmentId/edit-details')
   .get(detailsFormMiddleware.populateForm, edit.editDetailsGet)
   .post(detailsFormMiddleware.populateForm, detailsFormMiddleware.handleFormPost, edit.editDetailsPost)
 
 router
-  .route('/:id/edit-value')
+  .route('/:investmentId/edit-value')
   .get(valueFormMiddleware.populateForm, edit.editValueGet)
   .post(valueFormMiddleware.populateForm, valueFormMiddleware.handleFormPost, edit.editValuePost)
 
 router
-  .route('/:id/edit-requirements')
+  .route('/:investmentId/edit-requirements')
   .get(requirementsFormMiddleware.populateForm, edit.editRequirementsGet)
   .post(requirementsFormMiddleware.populateForm, requirementsFormMiddleware.handleFormPost, edit.editRequirementsPost)
 
-router.get('/:id/team', expandTeamMembers, team.details.getDetailsHandler)
+router.get('/:investmentId/team', expandTeamMembers, team.details.getDetailsHandler)
 
 router
-  .route('/:id/edit-project-management')
+  .route('/:investmentId/edit-project-management')
   .get(getBriefInvestmentSummary, projectManagementFormMiddleware.populateForm, team.editProjectManagement.getHandler)
   .post(
     getBriefInvestmentSummary,
@@ -134,7 +134,7 @@ router
   )
 
 router
-  .route('/:id/edit-client-relationship-management')
+  .route('/:investmentId/edit-client-relationship-management')
   .get(
     clientRelationshipManagementFormMiddleware.populateForm,
     team.editClientRelationshipManagement.getHandler
@@ -147,7 +147,7 @@ router
   )
 
 router
-  .route('/:id/edit-team-members')
+  .route('/:investmentId/edit-team-members')
   .get(
     teamMembersFormMiddleware.populateForm,
     team.editTeamMembers.getHandler
@@ -159,12 +159,12 @@ router
     team.editTeamMembers.getHandler
   )
 
-router.get('/:id/interactions', setInteractionsReturnUrl, renderInteractionList)
+router.get('/:investmentId/interactions', setInteractionsReturnUrl, renderInteractionList)
 
-router.get('/:id/evaluation', evaluation.renderEvaluationPage)
+router.get('/:investmentId/evaluation', evaluation.renderEvaluationPage)
 
-router.post('/:id/change-project-stage', projectStageFormMiddleware.handleFormPost)
+router.post('/:investmentId/change-project-stage', projectStageFormMiddleware.handleFormPost)
 
-router.use('/:id', setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails, interactionsRouter)
+router.use('/:investmentId', setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails, interactionsRouter)
 
 module.exports = router

--- a/test/unit/apps/investment-projects/controllers/archive.test.js
+++ b/test/unit/apps/investment-projects/controllers/archive.test.js
@@ -33,7 +33,7 @@ describe('Investment archive controller', function () {
           archived_reason,
         },
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
       }, {
         locals: {},
@@ -53,7 +53,7 @@ describe('Investment archive controller', function () {
           archived_reason_other,
         },
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
       }, {
         locals: {},
@@ -74,7 +74,7 @@ describe('Investment archive controller', function () {
           archived_reason,
         },
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
       }, {
         locals,
@@ -100,7 +100,7 @@ describe('Investment archive controller', function () {
           archived_reason_other,
         },
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
       }, {
         locals,
@@ -134,7 +134,7 @@ describe('Investment archive controller', function () {
         session: this.session,
         body,
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
       }, {
         locals,
@@ -163,7 +163,7 @@ describe('Investment archive controller', function () {
         session: this.session,
         body,
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
       }, {
         locals,
@@ -181,7 +181,7 @@ describe('Investment archive controller', function () {
           token: this.token,
         },
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
         flash: this.flashStub,
       }, {
@@ -201,7 +201,7 @@ describe('Investment archive controller', function () {
           archived_reason: 'test',
         },
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
         flash: this.flashStub,
       }, {
@@ -222,7 +222,7 @@ describe('Investment archive controller', function () {
           token: this.token,
         },
         params: {
-          id: investmentData.id,
+          investmentId: investmentData.id,
         },
         flash: this.flashStub,
       }, {

--- a/test/unit/apps/investment-projects/controllers/audit.test.js
+++ b/test/unit/apps/investment-projects/controllers/audit.test.js
@@ -22,7 +22,7 @@ describe('Investment audit controller', () => {
         token,
       },
       params: {
-        id: '9999',
+        investmentId: '9999',
       },
     }, {
       locals: {
@@ -55,7 +55,7 @@ describe('Investment audit controller', () => {
         token,
       },
       params: {
-        id: '9999',
+        investmentId: '9999',
       },
     }, {
       locals: {
@@ -104,7 +104,7 @@ describe('Investment audit controller', () => {
         token,
       },
       params: {
-        id: '9999',
+        investmentId: '9999',
       },
     }, {
       locals: {
@@ -151,7 +151,7 @@ describe('Investment audit controller', () => {
         token,
       },
       params: {
-        id: '9999',
+        investmentId: '9999',
       },
     }, {
       locals: {
@@ -198,7 +198,7 @@ describe('Investment audit controller', () => {
         token,
       },
       params: {
-        id: '9999',
+        investmentId: '9999',
       },
     }, {
       locals: {

--- a/test/unit/apps/investment-projects/controllers/interactions.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions.test.js
@@ -25,7 +25,7 @@ describe('Investment Interactions controller', () => {
       },
       query: { },
       params: {
-        id: 'example-id-1234',
+        investmentId: 'example-id-1234',
       },
     }
 

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -156,7 +156,7 @@ describe('Investment form middleware - client relationship management', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, () => {
@@ -171,7 +171,7 @@ describe('Investment form middleware - client relationship management', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, () => {
@@ -186,7 +186,7 @@ describe('Investment form middleware - client relationship management', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {
@@ -239,7 +239,7 @@ describe('Investment form middleware - client relationship management', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {
@@ -262,7 +262,7 @@ describe('Investment form middleware - client relationship management', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {

--- a/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
@@ -105,7 +105,7 @@ describe('Investment form middleware - project magement', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, () => {
@@ -120,7 +120,7 @@ describe('Investment form middleware - project magement', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {
@@ -166,7 +166,7 @@ describe('Investment form middleware - project magement', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {
@@ -189,7 +189,7 @@ describe('Investment form middleware - project magement', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -169,7 +169,7 @@ describe('Investment form middleware - team members', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, () => {
@@ -190,7 +190,7 @@ describe('Investment form middleware - team members', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {
@@ -216,7 +216,7 @@ describe('Investment form middleware - team members', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {
@@ -239,7 +239,7 @@ describe('Investment form middleware - team members', () => {
             token: 'mock-token',
           },
           params: {
-            id: investmentData.id,
+            investmentId: investmentData.id,
           },
           body: this.body,
         }, this.resMock, (error) => {

--- a/test/unit/apps/investment-projects/middleware/interactions.test.js
+++ b/test/unit/apps/investment-projects/middleware/interactions.test.js
@@ -11,7 +11,7 @@ describe('Investment projects interactions middleware', () => {
     })
     this.req = {
       params: {
-        id: '1',
+        investmentId: '1',
       },
       session: {
         token: 'abcd',


### PR DESCRIPTION
In order to add a field to the investment summary form I first need to refactor the investment project code to use the form macros and the middleware pattern found in events and interactions.

This is the first step in that direction, renaming the parameter used in the investment project to `investmentId` instead of the generic name `id`

There are still places in investment that have inconsistent naming for the parameter, these will slow be refactored out in upcoming PR's