### PR TITLE
Select current user team by default for interaction service provider

### DIFF
--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -16,6 +16,7 @@ function renderEditPage (req, res) {
     dit_adviser: req.session.user,
     date: transformDateStringToDateObject(new Date()),
     contact: get(res.locals, 'contact.id'),
+    dit_team: get(req, 'session.user.dit_team.id'),
   }
   const mergedInteractionData = pickBy(merge({}, interactionDefaults, interactionData, res.locals.requestBody))
   const interactionForm =

--- a/test/unit/apps/interactions/controllers/edit.test.js
+++ b/test/unit/apps/interactions/controllers/edit.test.js
@@ -1,15 +1,21 @@
-const { assign, merge } = require('lodash')
+const { assign, merge, find } = require('lodash')
 
 const interactionData = require('../../../data/interactions/new-interaction.json')
 
 describe('Interaction edit controller', () => {
+  const currentUserTeam = 'team1'
+
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.controller = require('~/src/apps/interactions/controllers/edit')
     this.req = {
       session: {
         token: 'abcd',
-        user: { },
+        user: {
+          dit_team: {
+            id: currentUserTeam,
+          },
+        },
       },
       query: {
         communication_channel: '1',
@@ -41,36 +47,39 @@ describe('Interaction edit controller', () => {
 
   describe('#renderEditPage', () => {
     context('when rendering the interaction form for a company', () => {
-      it('should render the interaction page', async () => {
+      beforeEach(async () => {
         await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
+      })
 
+      it('should render the interaction page', async () => {
         expect(this.res.render).to.be.calledWith('interactions/views/edit')
         expect(this.res.render).to.have.been.calledOnce
       })
 
       it('should render the interaction page with a return link', async () => {
-        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
         const actual = this.res.render.getCall(0).args[1].interactionForm.returnLink
 
         expect(actual).to.equal('return')
       })
 
       it('should render the interaction page with an interaction form', async () => {
-        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
         const actual = this.res.render.getCall(0).args[1].interactionForm.children
 
         expect(actual).to.be.an('array')
       })
 
       it('should render an interaction form with hidden fields', async () => {
-        await this.controller.renderEditPage(this.req, this.res, this.nextSpy)
-
         const actualHiddenFields = this.res.render.getCall(0).args[1].interactionForm.hiddenFields
 
         expect(actualHiddenFields.company).to.equal('1')
         expect(actualHiddenFields.investment_project).to.be.undefined
+      })
+
+      it('should render an interaction form with the service provider pre-seledcted', async () => {
+        const interactionForm = this.res.render.getCall(0).args[1].interactionForm
+        const actualServiceProvider = find(interactionForm.children, { name: 'dit_team' }).value
+
+        expect(actualServiceProvider).to.equal(currentUserTeam)
       })
     })
 


### PR DESCRIPTION
Change to do as the title says: pre-select the current user's team as the default option for the service provider field on the interaction/service delivery form.

![screen shot 2017-10-16 at 15 21 44](https://user-images.githubusercontent.com/1150417/31616897-e0cf7e96-b285-11e7-9c1e-a1485c60b44b.png)
