### PR TITLE
Add contact to summary

### DIFF
--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -16,9 +16,9 @@ function editRequirementsGet (req, res) {
   res.render('investment-projects/views/requirements-edit')
 }
 
-function editDetailsPost (req, res) {
-  if (res.locals.form.errors) {
-    return res.render('investment-projects/views/details-edit')
+function editDetailsPost (req, res, next) {
+  if (res.locals.form.errors || req.body.add_contact) {
+    return next()
   }
   req.flash('success', 'Investment details updated')
   return res.redirect(`/investment-projects/${res.locals.resultId}/details`)

--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -17,7 +17,7 @@ function editRequirementsGet (req, res) {
 }
 
 function editDetailsPost (req, res, next) {
-  if (res.locals.form.errors || req.body.add_contact) {
+  if (res.locals.form.errors || req.body['add-item']) {
     return next()
   }
   req.flash('success', 'Investment details updated')

--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -11,6 +11,7 @@ const labels = {
       investment_type: 'Type of investment',
       sector: 'Primary sector',
       business_activities: 'Business activity',
+      client_contacts: 'Client contacts',
       description: 'Project description',
       nda_signed: 'Non-disclosure agreement',
       estimated_land_date: 'Estimated land date',

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 const { get, isEmpty } = require('lodash')
 
 const { transformToApi, transformFromApi } = require('../../services/formatting')
@@ -84,6 +85,24 @@ function handleFormPost (req, res, next) {
   const formattedBody = transformToApi(Object.assign({}, req.body))
   const projectId = res.locals.projectId || req.params.investmentId
   let saveMethod
+
+  if (req.body.add_contact) {
+    res.locals.form = Object.assign({}, res.locals.form, {
+      state: req.body,
+    })
+
+    let client_contacts = res.locals.form.state.client_contacts
+
+    if (Array.isArray(client_contacts)) {
+      client_contacts.push('')
+    } else {
+      client_contacts = [client_contacts, '']
+    }
+
+    res.locals.form.state.client_contacts = client_contacts
+
+    return next()
+  }
 
   if (projectId) {
     saveMethod = updateInvestment(req.session.token, projectId, formattedBody)

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -1,5 +1,4 @@
-/* eslint-disable camelcase */
-const { get, isEmpty } = require('lodash')
+const { flatten, get, isEmpty } = require('lodash')
 
 const { transformToApi, transformFromApi } = require('../../services/formatting')
 const { isValidGuid } = require('../../../../lib/controller-utils')
@@ -84,22 +83,18 @@ async function populateForm (req, res, next) {
 function handleFormPost (req, res, next) {
   const formattedBody = transformToApi(Object.assign({}, req.body))
   const projectId = res.locals.projectId || req.params.investmentId
+  const addKey = req.body['add-item']
   let saveMethod
 
-  if (req.body.add_contact) {
+  // Todo - currently only supports add with non-js,
+  // add remove action for non-js later, for now the user just sets the value to nothing.
+  if (addKey) {
+    req.body[addKey] = flatten([req.body[addKey]])
+    req.body[addKey].push('')
+
     res.locals.form = Object.assign({}, res.locals.form, {
       state: req.body,
     })
-
-    let client_contacts = res.locals.form.state.client_contacts
-
-    if (Array.isArray(client_contacts)) {
-      client_contacts.push('')
-    } else {
-      client_contacts = [client_contacts, '']
-    }
-
-    res.locals.form.state.client_contacts = client_contacts
 
     return next()
   }

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -108,7 +108,7 @@ router.get('/:investmentId/details', details.detailsGetHandler)
 router
   .route('/:investmentId/edit-details')
   .get(detailsFormMiddleware.populateForm, edit.editDetailsGet)
-  .post(detailsFormMiddleware.populateForm, detailsFormMiddleware.handleFormPost, edit.editDetailsPost)
+  .post(detailsFormMiddleware.populateForm, detailsFormMiddleware.handleFormPost, edit.editDetailsPost, edit.editDetailsGet)
 
 router
   .route('/:investmentId/edit-value')

--- a/src/apps/investment-projects/services/formatting.js
+++ b/src/apps/investment-projects/services/formatting.js
@@ -55,9 +55,9 @@ function transformToApi (body) {
         return value.map(item => {
           return { id: item }
         })
-      } else {
-        return [{ id: value }]
       }
+
+      return [{ id: value }]
     } else if (type === Boolean) {
       return value === 'true' | false
     }
@@ -135,6 +135,7 @@ function transformInvestmentDataForView (data) {
     investment_type: getInvestmentTypeDetails(),
     sector: get(data, 'sector.name', null),
     business_activities: data.business_activities.map(i => i.name).join(', '),
+    client_contacts: data.client_contacts.map(i => i.name).join(', '),
     nda_signed: data.nda_signed ? 'Signed' : 'Not signed',
     estimated_land_date: data.estimated_land_date ? moment(data.estimated_land_date).format('MMMM YYYY') : null,
   })

--- a/src/apps/investment-projects/services/formatting.js
+++ b/src/apps/investment-projects/services/formatting.js
@@ -51,7 +51,13 @@ function transformToApi (body) {
     }
 
     if (type === Array) {
-      return [{ id: value }]
+      if (Array.isArray(value)) {
+        return value.map(item => {
+          return { id: item }
+        })
+      } else {
+        return [{ id: value }]
+      }
     } else if (type === Boolean) {
       return value === 'true' | false
     }
@@ -90,7 +96,9 @@ function transformFromApi (body) {
 
   const formatted = mapValues(schema, (type, key) => {
     if (type === Array) {
-      return get(body, `${key}[0].id`, '')
+      const items = get(body, key, [])
+      const ids = items.map(item => item.id)
+      return ids
     } else if (type === Boolean) {
       const value = get(body, key, '')
       return value.toString()

--- a/src/apps/investment-projects/views/_details-form.njk
+++ b/src/apps/investment-projects/views/_details-form.njk
@@ -96,23 +96,21 @@
     initialOption: '-- Choose a business activity --',
     options: form.options.businessActivities,
     error: form.errors.messages['business_activities'],
-    value: form.state['business_activities']
+    value: form.state['business_activities'][0]
   }) }}
 
- {{ TextField({
-    name: 'other_business_activity',
-    label: 'Other business activity (please specify)',
-    placeholder: 'e.g meet and greet dinner',
-    error: form.errors.messages['other_business_activity'],
-    value: form.state['other_business_activity'],
-    condition: {
-      name: 'business_activities',
-      value: form.options.businessActivities[8].value
-    },
-    modifier: 'subfield'
-  }) }}
-
-
+  {{ TextField({
+      name: 'other_business_activity',
+      label: 'Other business activity (please specify)',
+      placeholder: 'e.g meet and greet dinner',
+      error: form.errors.messages['other_business_activity'],
+      value: form.state['other_business_activity'],
+      condition: {
+        name: 'business_activities',
+        value: form.options.businessActivities[8].value
+      },
+      modifier: 'subfield'
+    }) }}
 
   <fieldset
     class="c-form-fieldset js-AddItems"
@@ -136,7 +134,7 @@
 
 
     <p class="c-form-fieldset__add-another">
-      <input class="button button-secondary js-AddItems__add" type="submit" name="add_contact" value="Add another" data-persist-values="true" data-method="add">
+      <button class="button button-secondary js-AddItems__add" type="submit" name="add-item" value="client_contacts" data-persist-values="true">Add another</button>
     </p>
   </fieldset>
 

--- a/src/apps/investment-projects/views/_details-form.njk
+++ b/src/apps/investment-projects/views/_details-form.njk
@@ -112,14 +112,33 @@
     modifier: 'subfield'
   }) }}
 
-  {{ MultipleChoiceField({
-    name: 'client_contacts',
-    label: 'Client contact',
-    initialOption: '-- Pick a contact --',
-    options: form.options.contacts,
-    error: form.errors.messages['client_contacts'],
-    value: form.state['client_contacts']
-  }) }}
+
+
+  <fieldset
+    class="c-form-fieldset js-AddItems"
+    data-item-selector=".c-form-group"
+    data-add-button-selector=".js-AddItems__add">
+
+    <legend class="c-form-fieldset__legend">
+      <span class="c-form-fieldset__legend-text">Client contact</span>
+    </legend>
+
+    {% for client_contact in form.state['client_contacts'] %}
+      {{ MultipleChoiceField({
+        name: 'client_contacts',
+        label: 'Client contact',
+        isLabelHidden: true,
+        initialOption: '-- Pick a contact --',
+        options: form.options.contacts,
+        value: client_contact
+      }) }}
+    {% endfor %}
+
+
+    <p class="c-form-fieldset__add-another">
+      <input class="button button-secondary js-AddItems__add" type="submit" name="add_contact" value="Add another" data-persist-values="true" data-method="add">
+    </p>
+  </fieldset>
 
 {% if not investmentData.id %}
   {{ MultipleChoiceField({


### PR DESCRIPTION
![add contact](https://user-images.githubusercontent.com/56056/31656963-19edf0c8-b325-11e7-8542-4c3e3a730375.gif)

Add the ability to add multiple client contacts to an investment project through editing the summary.

Also, fixes an issue not showing the investment contact value on the details page.