### PR TITLE
Skip step 1 when adding interaction to investment project

### DIFF
--- a/src/apps/investment-projects/views/interactions.njk
+++ b/src/apps/investment-projects/views/interactions.njk
@@ -1,7 +1,7 @@
 {% extends "./_layout.njk" %}
 
 {% set addButton %}
-  <a href="/investment-projects/{{ investmentData.id }}/interactions/create" class="button button-secondary">Add interaction</a>
+  <a href="/investment-projects/{{ investmentData.id }}/interactions/create/interaction" class="button button-secondary">Add interaction</a>
 {% endset %}
 
 {% block main_grid_right_column %}


### PR DESCRIPTION
This change will skip step 1 when adding an interaction for an investment project. When adding an interaction to a contact or company the user will need to choose whether they want to add an interaction or service delivery. Investment projects will default to adding interactions.