### PR TITLE
Fix positioning and indexing of header/main content

### DIFF
--- a/assets/stylesheets/components/_global-nav.scss
+++ b/assets/stylesheets/components/_global-nav.scss
@@ -5,7 +5,6 @@
   background: $grey-3;
   padding: $default-spacing-unit / 4 0;
   position: relative;
-  z-index: 2;
 
   @include media(tablet) {
     padding: 0;

--- a/assets/stylesheets/objects/base/_main-content.scss
+++ b/assets/stylesheets/objects/base/_main-content.scss
@@ -1,8 +1,6 @@
 @import "../../settings";
 
 .main-content {
-  position: relative;
-  z-index: 1;
   background-color: $white;
   min-height: 60vh;
   flex-grow: 1;


### PR DESCRIPTION
This addresses an issue with the loading banner not showing when the page is scrolled down and the global nav is at the top of the window.

## Before

![image](https://user-images.githubusercontent.com/3327997/31722182-621c9e00-b413-11e7-8aa0-1868f3494c95.png)

## After

![image](https://user-images.githubusercontent.com/3327997/31722156-54d3e8d4-b413-11e7-8717-3ee6f901d868.png)
