### PR TITLE
Collection filtering

### DIFF
--- a/src/apps/omis/apps/list/controllers.js
+++ b/src/apps/omis/apps/list/controllers.js
@@ -1,5 +1,23 @@
+const { assign, merge, omit } = require('lodash')
+
+const { buildSelectedFiltersSummary } = require('../../../builders')
+const { collectionFiltersFields, collectionSortForm } = require('./macros')
+
 function renderCollectionList (req, res) {
-  res.render('omis/apps/list/views/list-collection')
+  const sortForm = merge({}, collectionSortForm, {
+    hiddenFields: assign({}, omit(req.query, 'sortby')),
+    children: [
+      { value: req.query.sortby },
+    ],
+  })
+
+  const selectedFilters = buildSelectedFiltersSummary(collectionFiltersFields, req.query)
+
+  res.render('omis/apps/list/views/list-collection', {
+    sortForm,
+    selectedFilters,
+    filtersFields: collectionFiltersFields,
+  })
 }
 
 function renderReconciliationList (req, res) {

--- a/src/apps/omis/apps/list/macros.js
+++ b/src/apps/omis/apps/list/macros.js
@@ -1,0 +1,73 @@
+const { assign, flatten } = require('lodash')
+
+const { ORDER_STATES } = require('../../constants')
+const metadataRepo = require('../../../../lib/metadata')
+const { transformObjectToOption } = require('../../../transformers')
+
+const filterFields = [
+  {
+    macroName: 'MultipleChoiceField',
+    label: 'Order status',
+    name: 'status',
+    type: 'radio',
+    options: ORDER_STATES,
+  },
+  {
+    macroName: 'TextField',
+    label: 'Order reference',
+    name: 'reference',
+    hint: 'At least three characters',
+  },
+  {
+    macroName: 'TextField',
+    label: 'Company name',
+    name: 'company_name',
+    hint: 'At least three characters',
+  },
+]
+
+const collectionFiltersFields = flatten([filterFields, [
+  {
+    macroName: 'TextField',
+    label: 'Contact name',
+    name: 'contact_name',
+    hint: 'At least three characters',
+  },
+  {
+    macroName: 'MultipleChoiceField',
+    label: 'Market (country)',
+    name: 'primary_market',
+    initialOption: 'All countries',
+    options () {
+      return metadataRepo.omisMarketOptions.map(transformObjectToOption)
+    },
+  },
+]]).map(filter => {
+  return assign({}, filter, {
+    modifier: ['smaller', 'light'],
+  })
+})
+
+const collectionSortForm = {
+  method: 'get',
+  class: 'c-collection__sort-form js-AutoSubmit',
+  hideFormActions: true,
+  hiddenFields: { custom: true },
+  children: [
+    {
+      macroName: 'MultipleChoiceField',
+      label: 'Sort by',
+      name: 'sortby',
+      modifier: ['small', 'inline', 'light'],
+      options: [
+        { value: 'created_on:desc', label: 'Newest' },
+        { value: 'created_on:asc', label: 'Oldest' },
+      ],
+    },
+  ],
+}
+
+module.exports = {
+  collectionFiltersFields,
+  collectionSortForm,
+}

--- a/src/apps/omis/apps/list/middleware.js
+++ b/src/apps/omis/apps/list/middleware.js
@@ -1,3 +1,5 @@
+const { assign, pick, pickBy } = require('lodash')
+
 const { search } = require('../../../search/services')
 const { transformApiResponseToSearchCollection } = require('../../../search/transformers')
 const { transformOrderToListItem, transformOrderToTableItem } = require('../../transformers')
@@ -45,7 +47,15 @@ async function setReconciliationResults (req, res, next) {
 function setRequestBody (req, res, next) {
   const selectedSortBy = req.query.sortby ? { sortby: req.query.sortby } : null
 
-  req.body = Object.assign({}, req.body, selectedSortBy)
+  const selectedFiltersQuery = pick(req.query, [
+    'status',
+    'company_name',
+    'contact_name',
+    'primary_market',
+    'reference',
+  ])
+
+  req.body = assign({}, req.body, selectedSortBy, pickBy(selectedFiltersQuery))
   next()
 }
 

--- a/src/apps/omis/apps/list/views/list-collection.njk
+++ b/src/apps/omis/apps/list/views/list-collection.njk
@@ -1,10 +1,20 @@
 {% extends "_layouts/two-column.njk" %}
 
+{% block main_grid_left_column %}
+  {{
+    CollectionFilters({
+      query: QUERY,
+      filtersFields: filtersFields
+    })
+  }}
+{% endblock %}
+
 {% block main_grid_right_column %}
   {{
     Collection(results | assign({
       countLabel: 'order',
       sortForm: sortForm,
+      selectedFilters: selectedFilters,
       query: QUERY
     }))
   }}

--- a/src/apps/omis/constants.js
+++ b/src/apps/omis/constants.js
@@ -1,0 +1,30 @@
+const ORDER_STATES = [
+  {
+    value: 'draft',
+    label: 'Draft',
+  },
+  {
+    value: 'quote_awaiting_acceptance',
+    label: 'Quote awaiting acceptance',
+  },
+  {
+    value: 'quote_accepted',
+    label: 'Quote accepted',
+  },
+  {
+    value: 'paid',
+    label: 'Paid',
+  },
+  {
+    value: 'complete',
+    label: 'Complete',
+  },
+  {
+    value: 'cancelled',
+    label: 'Cancelled',
+  },
+]
+
+module.exports = {
+  ORDER_STATES,
+}

--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -11,6 +11,7 @@ function transformOrderToListItem ({
   primary_market,
   delivery_date,
   modified_on,
+  created_on,
 } = {}) {
   if (!id || !reference) { return }
 
@@ -35,13 +36,18 @@ function transformOrderToListItem ({
         value: get(company, 'name'),
       },
       {
-        label: 'Updated',
+        label: 'Created',
         type: 'datetime',
-        value: modified_on,
+        value: created_on,
       },
       {
         label: 'Contact',
         value: get(contact, 'name'),
+      },
+      {
+        label: 'Updated',
+        type: 'datetime',
+        value: modified_on,
       },
     ],
   }

--- a/test/unit/apps/omis/apps/list/controllers.test.js
+++ b/test/unit/apps/omis/apps/list/controllers.test.js
@@ -1,27 +1,66 @@
-const { renderCollectionList, renderReconciliationList } = require('~/src/apps/omis/apps/list/controllers')
-
 describe('OMIS list controllers', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+
+    this.req = {
+      session: {
+        token: 'abcd',
+      },
+      query: {},
+    }
+    this.res = {
+      render: this.sandbox.spy(),
+      query: {},
+    }
+    this.buildSelectedFiltersSummaryStub = this.sandbox.spy()
+
+    this.controller = proxyquire('~/src/apps/omis/apps/list/controllers', {
+      '../../../builders': {
+        buildSelectedFiltersSummary: this.buildSelectedFiltersSummaryStub,
+      },
+      './macros': {
+        collectionFiltersFields: [
+          { macroName: 'useful' },
+          { macroName: 'exciting' },
+        ],
+      },
+    })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
   describe('renderCollectionList()', () => {
-    it('should render a template', () => {
-      const res = {
-        render: sinon.spy(),
-      }
+    beforeEach(() => {
+      this.controller.renderCollectionList(this.req, this.res)
+    })
 
-      renderCollectionList({}, res)
+    it('should call render method', () => {
+      expect(this.res.render).to.have.been.calledOnce
+    })
 
-      expect(res.render).to.have.been.calledOnce
+    it('should pass the correct data to the view', () => {
+      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('sortForm'))
+      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('filtersFields'))
+      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('selectedFilters'))
+    })
+
+    it('should build filters summary', () => {
+      expect(this.buildSelectedFiltersSummaryStub).to.have.been.calledWith([
+        { macroName: 'useful' },
+        { macroName: 'exciting' },
+      ], this.req.query)
     })
   })
 
   describe('renderReconciliationList()', () => {
-    it('should render a template', () => {
-      const res = {
-        render: sinon.spy(),
-      }
+    beforeEach(() => {
+      this.controller.renderReconciliationList(this.req, this.res)
+    })
 
-      renderReconciliationList({}, res)
-
-      expect(res.render).to.have.been.calledOnce
+    it('should call render method', () => {
+      expect(this.res.render).to.have.been.calledOnce
     })
   })
 })

--- a/test/unit/apps/omis/apps/list/middleware.test.js
+++ b/test/unit/apps/omis/apps/list/middleware.test.js
@@ -1,0 +1,85 @@
+const nock = require('nock')
+const { assign } = require('lodash')
+
+const config = require('~/config')
+const orderCollectionData = require('~/test/unit/data/omis/collection.json')
+
+describe('OMIS list middleware', () => {
+  beforeEach(() => {
+    nock(config.apiRoot)
+      .post(`/v3/search/order`)
+      .reply(200, orderCollectionData)
+
+    this.sandbox = sinon.sandbox.create()
+    this.next = this.sandbox.spy()
+    this.req = assign({}, globalReq, {
+      session: { token: 'abcd' },
+    })
+    this.res = assign({}, globalRes)
+
+    this.controller = require('~/src/apps/omis/apps/list/middleware')
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#setCollectionResults', () => {
+    beforeEach(async () => {
+      this.req.query = {
+        status: 'draft',
+        company_name: 'samsung',
+        sortby: 'name:asc',
+      }
+      await this.controller.setCollectionResults(this.req, this.res, this.next)
+    })
+
+    it('should set results property on locals with pagination', () => {
+      const actual = this.res.locals.results
+      expect(actual).to.have.property('count')
+      expect(actual).to.have.property('items')
+      expect(actual).to.have.property('pagination')
+      expect(actual.count).to.equal(3)
+      expect(this.next).to.have.been.calledOnce
+    })
+  })
+
+  describe('#setRequestBody', () => {
+    it('should not set req.body for empty query', async () => {
+      await this.controller.setRequestBody(this.req, this.res, this.next)
+
+      expect(this.req.body).to.be.an('object').and.empty
+      expect(this.next).to.have.been.calledOnce
+    })
+
+    it('should set req.body for valid query items', async () => {
+      this.req.query = {
+        status: 'draft',
+        company_name: 'samsung',
+        sortby: 'name:asc',
+        random: 'query',
+      }
+
+      await this.controller.setRequestBody(this.req, this.res, this.next)
+
+      expect(this.req.body).to.deep.equal({
+        status: 'draft',
+        company_name: 'samsung',
+        sortby: 'name:asc',
+      })
+      expect(this.next).to.have.been.calledOnce
+    })
+
+    it('should not set req.body invalid items', async () => {
+      this.req.query = {
+        random: 'query',
+        some: 'more',
+      }
+
+      await this.controller.setRequestBody(this.req, this.res, this.next)
+
+      expect(this.req.body).to.be.an('object').and.empty
+      expect(this.next).to.have.been.calledOnce
+    })
+  })
+})

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -36,8 +36,9 @@ describe('OMIS list transformers', function () {
             { label: 'Status', type: 'badge', value: 'Draft' },
             { label: 'Market', type: 'badge', value: 'France' },
             { label: 'Company', value: 'Venus Ltd' },
-            { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
+            { label: 'Created', type: 'datetime', value: '2017-07-26T14:08:36.380979' },
             { label: 'Contact', value: 'Jenny Cakeman' },
+            { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
           ])
         })
       })
@@ -55,8 +56,9 @@ describe('OMIS list transformers', function () {
             { label: 'Status', type: 'badge', value: 'Draft' },
             { label: 'Market', type: 'badge', value: 'France' },
             { label: 'Company', value: 'Venus Ltd' },
-            { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
+            { label: 'Created', type: 'datetime', value: '2017-07-26T14:08:36.380979' },
             { label: 'Contact', value: 'Jenny Cakeman' },
+            { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
             { label: 'Delivery date', type: 'date', value: '2018-10-16T14:18:28.328729' },
           ])
         })

--- a/test/unit/data/omis/collection.json
+++ b/test/unit/data/omis/collection.json
@@ -1,0 +1,182 @@
+{
+  "count": 3,
+  "results": [
+    {
+      "id": "084b934e-9bde-4e2b-88d8-5fbeb17de54d",
+      "reference": "XYT113/17",
+      "status": "draft",
+      "created_on": "2017-07-26T14:08:36.380979",
+      "created_by": null,
+      "modified_on": "2017-08-16T14:18:28.328729",
+      "modified_by": {
+        "name": "Test CMU 1",
+        "id": "8036f207-ae3e-e611-8d53-e4115bed50dc"
+      },
+      "company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "contact": {
+        "name": "Jenny Cakeman",
+        "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+      },
+      "primary_market": {
+        "name": "France",
+        "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "sector": {
+        "name": "Aerospace : Component Manufacturing",
+        "id": "e74171b4-efe9-e511-8ffa-e4115bead28a"
+      },
+      "service_types": [
+        {
+          "name": "Validated contacts",
+          "id": "c7915c75-cf29-42cf-99db-2acb75b96a78"
+        },
+        {
+          "name": "Visit programme",
+          "id": "8b48de3d-0066-4d98-991e-f79594bf55c0"
+        },
+        {
+          "name": "Strategic offer",
+          "id": "622aedd8-8936-4e62-99f2-2b8bb3783166"
+        },
+        {
+          "name": "Subscription",
+          "id": "66b57a5b-ca6e-4d6e-9941-4a6e7f9aa3ae"
+        },
+        {
+          "name": "Retainer",
+          "id": "80beb270-c1ce-40a3-8ad4-20a569a7bca0"
+        }
+      ],
+      "description": "Yeah yeah yeah",
+      "contacts_not_to_approach": "Brian",
+      "contact_email": "",
+      "contact_phone": "",
+      "product_info": "",
+      "further_info": "",
+      "existing_agents": "",
+      "permission_to_approach_contacts": "",
+      "delivery_date": ""
+    },
+    {
+      "id": "9bd0217e-7031-40b5-b179-a6f7862e4cd1",
+      "reference": "FXM474/17",
+      "status": "draft",
+      "created_on": "2017-07-26T14:08:36.380979",
+      "created_by": null,
+      "modified_on": "2017-08-16T14:18:28.328729",
+      "modified_by": {
+        "name": "Test CMU 1",
+        "id": "8036f207-ae3e-e611-8d53-e4115bed50dc"
+      },
+      "company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "contact": {
+        "name": "Jenny Cakeman",
+        "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+      },
+      "primary_market": {
+        "name": "France",
+        "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "sector": {
+        "name": "Aerospace : Component Manufacturing",
+        "id": "e74171b4-efe9-e511-8ffa-e4115bead28a"
+      },
+      "service_types": [
+        {
+          "name": "Validated contacts",
+          "id": "c7915c75-cf29-42cf-99db-2acb75b96a78"
+        },
+        {
+          "name": "Visit programme",
+          "id": "8b48de3d-0066-4d98-991e-f79594bf55c0"
+        },
+        {
+          "name": "Strategic offer",
+          "id": "622aedd8-8936-4e62-99f2-2b8bb3783166"
+        },
+        {
+          "name": "Subscription",
+          "id": "66b57a5b-ca6e-4d6e-9941-4a6e7f9aa3ae"
+        },
+        {
+          "name": "Retainer",
+          "id": "80beb270-c1ce-40a3-8ad4-20a569a7bca0"
+        }
+      ],
+      "description": "Yeah yeah yeah",
+      "contacts_not_to_approach": "Brian",
+      "contact_email": "",
+      "contact_phone": "",
+      "product_info": "",
+      "further_info": "",
+      "existing_agents": "",
+      "permission_to_approach_contacts": "",
+      "delivery_date": ""
+    },
+    {
+      "id": "c976e931-0f92-4a1f-a07e-64ede038e852",
+      "reference": "XNV946/17",
+      "status": "draft",
+      "created_on": "2017-07-26T14:08:36.380979",
+      "created_by": null,
+      "modified_on": "2017-08-16T14:18:28.328729",
+      "modified_by": {
+        "name": "Test CMU 1",
+        "id": "8036f207-ae3e-e611-8d53-e4115bed50dc"
+      },
+      "company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "contact": {
+        "name": "Jenny Cakeman",
+        "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+      },
+      "primary_market": {
+        "name": "France",
+        "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "sector": {
+        "name": "Aerospace : Component Manufacturing",
+        "id": "e74171b4-efe9-e511-8ffa-e4115bead28a"
+      },
+      "service_types": [
+        {
+          "name": "Validated contacts",
+          "id": "c7915c75-cf29-42cf-99db-2acb75b96a78"
+        },
+        {
+          "name": "Visit programme",
+          "id": "8b48de3d-0066-4d98-991e-f79594bf55c0"
+        },
+        {
+          "name": "Strategic offer",
+          "id": "622aedd8-8936-4e62-99f2-2b8bb3783166"
+        },
+        {
+          "name": "Subscription",
+          "id": "66b57a5b-ca6e-4d6e-9941-4a6e7f9aa3ae"
+        },
+        {
+          "name": "Retainer",
+          "id": "80beb270-c1ce-40a3-8ad4-20a569a7bca0"
+        }
+      ],
+      "description": "Yeah yeah yeah",
+      "contacts_not_to_approach": "Brian",
+      "contact_email": "",
+      "contact_phone": "",
+      "product_info": "",
+      "further_info": "",
+      "existing_agents": "",
+      "permission_to_approach_contacts": "",
+      "delivery_date": ""
+    }
+  ]
+}


### PR DESCRIPTION
This adds basic filtering to the OMIS orders collection view.

It enhances some of the middleware and controllers to support
filtering down the list of orders.

## Before

![localhost_3001_omis_sortby created_on 3adesc 1](https://user-images.githubusercontent.com/3327997/31733222-e08249c4-b432-11e7-8550-85578263d3a0.png)

## After

![localhost_3001_omis_sortby created_on 3adesc](https://user-images.githubusercontent.com/3327997/31733194-d05f6dce-b432-11e7-835b-392153209a88.png)