### PR TITLE
Feature/fix circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,8 @@ jobs:
       - store_artifacts:
           path: coverage
   user_acceptance_tests: &user_acceptance_tests
+    environment:
+      BASH_ENV: "/usr/local/nvm/nvm.sh"
     docker:
       - &docker_dat_hub_base
         image: ukti/docker-data-hub-base

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "nightwatch": "^0.9.16",
     "nightwatch-cucumber": "^8.0.5",
     "pre-commit": "^1.2.2",
-    "selenium-server": "^3.5.3",
+    "selenium-server": "^3.6.0",
     "shortid": "^2.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "devDependencies": {
     "chai-as-promised": "^7.1.1",
-    "chromedriver": "^2.32.2",
+    "chromedriver": "^2.33.1",
     "codeclimate-test-reporter": "^0.5.0",
     "cucumber": "^3.0.1",
     "cucumber-html-reporter": "^3.0.1",

--- a/test/acceptance/nightwatch.conf.js
+++ b/test/acceptance/nightwatch.conf.js
@@ -44,11 +44,13 @@ module.exports = {
       desiredCapabilities: {
         browserName: 'chrome',
         acceptInsecureCerts: true,
+        acceptSslCerts: true,
         javascriptEnabled: true,
         chromeOptions: {
           args: [
             'headless',
             'disable-gpu',
+            '--no-sandbox',
           ],
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7757,9 +7757,9 @@ seek-bzip@^1.0.3:
   dependencies:
     commander "~2.8.1"
 
-selenium-server@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/selenium-server/-/selenium-server-3.5.3.tgz#278c0af61ac2961476a59c6ff951216d67f2095c"
+selenium-server@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/selenium-server/-/selenium-server-3.6.0.tgz#9ce63e8351802876e36cd7ed231e534b09e1842f"
 
 semver-diff@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,9 +1419,9 @@ chokidar@1.7.0, chokidar@^1.4.3, chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7
   optionalDependencies:
     fsevents "^1.0.0"
 
-chromedriver@^2.32.2:
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-2.32.2.tgz#421bf30df37164e465e71461a7492e49b42380c5"
+chromedriver@^2.33.1:
+  version "2.33.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-2.33.1.tgz#e5434f1a1636aa7d826099cd5616276e55ac4ec1"
   dependencies:
     extract-zip "^1.6.5"
     kew "^0.7.0"


### PR DESCRIPTION
- bump `selenium-server` and `chromeDriver` dependencies
- add `--no-sandbox` arg
- source `nvm.sh` before each `run` command via `BASH_ENV`

Associated `docker-data-hub-base` PR [#3](https://github.com/uktrade/docker-data-hub-base/pull/3)