### PR TITLE
Fixed show investment details errors

### DIFF
--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -36,7 +36,7 @@ function editValuePost (req, res) {
 
 function editRequirementsPost (req, res, next) {
   if (get(res.locals, 'requirementsForm.errors')) {
-    return next()
+    return res.render('investment-projects/views/requirements-edit')
   }
   req.flash('success', 'Investment requirements updated')
   return res.redirect(`/investment-projects/${res.locals.projectId}/details`)

--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -34,7 +34,7 @@ function editValuePost (req, res) {
   return res.redirect(`/investment-projects/${res.locals.projectId}/details`)
 }
 
-function editRequirementsPost (req, res, next) {
+function editRequirementsPost (req, res) {
   if (get(res.locals, 'requirementsForm.errors')) {
     return res.render('investment-projects/views/requirements-edit')
   }

--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -34,9 +34,9 @@ function editValuePost (req, res) {
   return res.redirect(`/investment-projects/${res.locals.projectId}/details`)
 }
 
-function editRequirementsPost (req, res) {
+function editRequirementsPost (req, res, next) {
   if (get(res.locals, 'requirementsForm.errors')) {
-    return res.render('investment-projects/views/requirements-edit')
+    return next()
   }
   req.flash('success', 'Investment requirements updated')
   return res.redirect(`/investment-projects/${res.locals.projectId}/details`)

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -1,4 +1,4 @@
-const { get, isEmpty } = require('lodash')
+const { flatten, get, isEmpty } = require('lodash')
 
 const { transformToApi, transformFromApi } = require('../../services/formatting')
 const { isValidGuid } = require('../../../../lib/controller-utils')
@@ -83,13 +83,8 @@ async function populateForm (req, res, next) {
 function handleFormPost (req, res, next) {
   // force contacts and actitivies to be arrays to make handling them consistent,
   // and avoid issues when errors happen and form is re-built
-  if (!Array.isArray(req.body['client_contacts'])) {
-    req.body['client_contacts'] = [req.body['client_contacts']]
-  }
-
-  if (!Array.isArray(req.body['business_activities'])) {
-    req.body['business_activities'] = [req.body['business_activities']]
-  }
+  req.body.client_contacts = flatten([req.body.client_contacts])
+  req.body.business_activities = flatten([req.body.client_contacts])
 
   const formattedBody = transformToApi(Object.assign({}, req.body))
   const projectId = res.locals.projectId || req.params.investmentId
@@ -99,6 +94,7 @@ function handleFormPost (req, res, next) {
   // Todo - currently only supports add with non-js,
   // add remove action for non-js later, for now the user just sets the value to nothing.
   if (addKey) {
+    req.body[addKey] = flatten([req.body[addKey]])
     req.body[addKey].push('')
 
     res.locals.form = Object.assign({}, res.locals.form, {

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -1,4 +1,4 @@
-const { flatten, get, isEmpty } = require('lodash')
+const { get, isEmpty } = require('lodash')
 
 const { transformToApi, transformFromApi } = require('../../services/formatting')
 const { isValidGuid } = require('../../../../lib/controller-utils')
@@ -81,6 +81,16 @@ async function populateForm (req, res, next) {
 }
 
 function handleFormPost (req, res, next) {
+  // force contacts and actitivies to be arrays to make handling them consistent,
+  // and avoid issues when errors happen and form is re-built
+  if (!Array.isArray(req.body['client_contacts'])) {
+    req.body['client_contacts'] = [req.body['client_contacts']]
+  }
+
+  if (!Array.isArray(req.body['business_activities'])) {
+    req.body['business_activities'] = [req.body['business_activities']]
+  }
+
   const formattedBody = transformToApi(Object.assign({}, req.body))
   const projectId = res.locals.projectId || req.params.investmentId
   const addKey = req.body['add-item']
@@ -89,7 +99,6 @@ function handleFormPost (req, res, next) {
   // Todo - currently only supports add with non-js,
   // add remove action for non-js later, for now the user just sets the value to nothing.
   if (addKey) {
-    req.body[addKey] = flatten([req.body[addKey]])
     req.body[addKey].push('')
 
     res.locals.form = Object.assign({}, res.locals.form, {

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -81,11 +81,6 @@ async function populateForm (req, res, next) {
 }
 
 function handleFormPost (req, res, next) {
-  // force contacts and actitivies to be arrays to make handling them consistent,
-  // and avoid issues when errors happen and form is re-built
-  req.body.client_contacts = flatten([req.body.client_contacts])
-  req.body.business_activities = flatten([req.body.client_contacts])
-
   const formattedBody = transformToApi(Object.assign({}, req.body))
   const projectId = res.locals.projectId || req.params.investmentId
   const addKey = req.body['add-item']
@@ -117,8 +112,13 @@ function handleFormPost (req, res, next) {
     })
     .catch((err) => {
       if (err.statusCode === 400) {
+        const state = Object.assign({}, req.body, {
+          client_contacts: flatten([req.body.client_contacts]),
+          business_activities: flatten([req.body.client_contacts]),
+        })
+
         res.locals.form = Object.assign({}, res.locals.form, {
-          state: req.body,
+          state,
           errors: {
             messages: err.error,
           },


### PR DESCRIPTION
Previously if a user saved investment details form with a single contact or business activity, and that form had an error, then the form redraw would show multiple contacts and activities, all empty. This was caused because the form expects contacts and activities to be an array and if the form submits a single value then that value was passed back to the form to redraw.

The fix, for now, is to force the contact and activities fields to an array when the form is posted.

![fix](https://user-images.githubusercontent.com/56056/31771157-f54e3796-b4d2-11e7-80e6-b66c58c69239.gif)
