### PR TITLE
Ensure estimate time edit action is always present

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -4,6 +4,12 @@ const { EditController } = require('../../../controllers')
 const { Order } = require('../../../models')
 
 class EditAssigneeHoursController extends EditController {
+  configure (req, res, next) {
+    req.form.options.hidePrimaryFormAction = true
+
+    super.configure(req, res, next)
+  }
+
   async successHandler (req, res, next) {
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
     const timeValues = flatten([data.assignee_time])

--- a/src/apps/omis/apps/edit/views/assignee-time.njk
+++ b/src/apps/omis/apps/edit/views/assignee-time.njk
@@ -1,40 +1,54 @@
 {% extends "_layouts/form-wizard-step.njk" %}
 
 {% block fields %}
-  {% set key = 'assignee_time' %}
-  {% set defaultProps = options.fields[key] %}
-  <p>These hours will be used to calculate the cost of the order.</p>
+  {% if not order.assignees.length %}
 
-  <table class="c-answers-summary">
-    <thead>
-      <tr>
-        <th class="c-answers-summary__control" colspan="2">Estimated time (HH:MM)</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for assignee in order.assignees %}
-        {% set props = {} | assign(defaultProps, {
-          name: key,
-          idSuffix: assignee.adviser.id,
-          label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
-          value: values[key][loop.index0] or assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time,
-          error: errors[key].message,
-          isLabelHidden: true
-        }) %}
+    {% call Message({ type: 'info', element: 'div' }) %}
+      <p>Advisers in the market must be added before time can be estimated.</p>
+
+      <p>
+        <a href="edit/assignees">Add advisers</a>
+      </p>
+    {% endcall %}
+
+  {% else %}
+
+    {% set key = 'assignee_time' %}
+    {% set defaultProps = options.fields[key] %}
+    <p>These hours will be used to calculate the cost of the order.</p>
+
+    <table class="c-answers-summary">
+      <thead>
         <tr>
-          <th class="c-answers-summary__title">{{ assignee.adviser.name }}</th>
-          <td class="c-answers-summary__control">
-            {{ callAsMacro(props.fieldType)(props) }}
+          <th class="c-answers-summary__control" colspan="2">Estimated time (HH:MM)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for assignee in order.assignees %}
+          {% set props = {} | assign(defaultProps, {
+            name: key,
+            idSuffix: assignee.adviser.id,
+            label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
+            value: values[key][loop.index0] or assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time,
+            error: errors[key].message,
+            isLabelHidden: true
+          }) %}
+          <tr>
+            <th class="c-answers-summary__title">{{ assignee.adviser.name }}</th>
+            <td class="c-answers-summary__control">
+              {{ callAsMacro(props.fieldType)(props) }}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+      <tfoot>
+        <tr>
+          <td class="c-answers-summary__title c-answers-summary__title--unstyled">
+            <a href="assignees">Edit advisers</a>
           </td>
         </tr>
-      {% endfor %}
-    </tbody>
-    <tfoot>
-      <tr>
-        <td class="c-answers-summary__title c-answers-summary__title--unstyled">
-          <a href="assignees">Edit advisers</a>
-        </td>
-      </tr>
-    </tfoot>
-  </table>
+      </tfoot>
+    </table>
+
+  {% endif %}
 {% endblock %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -45,8 +45,8 @@
       url: 'edit/assignees' if order.isEditable,
       label: 'Add or remove'
     }, {
-      url: 'edit/assignee-time' if values.assignees.length and order.isEditable,
-      label: 'Edit time'
+      url: 'edit/assignee-time' if order.isEditable,
+      label: 'Estimate time'
     }]
   }) %}
     <tbody>
@@ -83,15 +83,20 @@
       {% endfor %}
     </tbody>
 
-    {% if values.estimatedTimeSum and values.assignees.length %}
-      <tfoot>
-        <tr>
-          <td class="c-answers-summary__footer" colspan="3">
-            <span class="c-answers-summary__footer-value">{{ values.estimatedTimeSum | humanizeDuration }}</span> total estimated time
-          </td>
-        </tr>
-      </tfoot>
-    {% endif %}
+    <tfoot>
+      <tr>
+        <td class="c-answers-summary__footer" colspan="3">
+          {% if not values.assignees.length or values.estimatedTimeSum < 1 %}
+            <span class="c-answers-summary__footer-value">No time estimated</span>
+          {% else %}
+            <span class="c-answers-summary__footer-value">
+              {{ values.estimatedTimeSum | humanizeDuration }}
+            </span>
+            total estimated time
+          {% endif %}
+        </td>
+      </tr>
+    </tfoot>
   {% endcall %}
 
   {{ AnswersSummary({

--- a/src/templates/_macros/form/form.njk
+++ b/src/templates/_macros/form/form.njk
@@ -9,6 +9,7 @@
  # @param {object} [props.errors] - Object containing form errors
  # @param {object} [props.hiddenFields] - Custom fields to be added as hidden inputs
  # @param {boolean} [props.hideFormActions] - Hide form actions
+ # @param {boolean} [props.hidePrimaryFormAction] - Hide primary form action
  # @param {boolean} [props.disableFormAction] - Disable form submit button
  # @param {string} [props.class] - Form class name
  # @param {string} [props.role] - Form role attribute value
@@ -57,7 +58,9 @@
 
     {% if not hideFormActions %}
       <div class="c-form-actions {{ props.actionsClass }}">
-        <button class="button {{ buttonModifiers }}" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
+        {% if not props.hidePrimaryFormAction %}
+          <button class="button {{ buttonModifiers }}" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
+        {% endif %}
         {% if props.returnLink %}
           <a href="{{ props.returnLink }}">{{ returnText }}</a>
         {% endif %}

--- a/test/unit/macros/form/form.test.js
+++ b/test/unit/macros/form/form.test.js
@@ -53,7 +53,7 @@ describe('Form component', () => {
       expect(component.querySelector('button.button').textContent).to.equal('Save')
     })
 
-    it('should render form without submit button', () => {
+    it('should render form without form actions', () => {
       const formProps = {
         hideFormActions: true,
       }
@@ -61,6 +61,20 @@ describe('Form component', () => {
         macros.renderToDom('TextField'),
       )
       expect(component.querySelector('.c-form-actions')).to.not.exist
+    })
+
+    it('should render form without submit button', () => {
+      const formProps = {
+        hidePrimaryFormAction: true,
+        returnLink: '/previous-page',
+      }
+      const component = macros.renderWithCallerToDom('Form', formProps)(
+        macros.renderToDom('TextField'),
+      )
+      const returnLink = component.querySelector('[href="/previous-page"]')
+      expect(returnLink).to.exist
+      expect(returnLink.textContent).to.equal('Back')
+      expect(component.querySelector('.c-form-actions .button')).to.not.exist
     })
 
     it('should render form with button modifier as string', () => {


### PR DESCRIPTION
It's better to always show the link and handle no assignees being
set when the user goes to the page rather than hiding/showing the
action.

## What it looks like

### Work order

#### Before

![image](https://user-images.githubusercontent.com/3327997/31783430-1dec8536-b4f6-11e7-8599-5133494e50b3.png)

#### After

![image](https://user-images.githubusercontent.com/3327997/31783399-0760066c-b4f6-11e7-86d1-6325618dd1ef.png)

### Estimate time with no assignees

![localhost_3001_omis_b1e17aef-f22a-49ba-b364-42da12564090_edit_assignee-time](https://user-images.githubusercontent.com/3327997/31783381-f5932892-b4f5-11e7-9e28-9a30299c43c5.png)