### PR TITLE
UAT use world for state

### DIFF
--- a/test/acceptance/features/companies/create.feature
+++ b/test/acceptance/features/companies/create.feature
@@ -1,4 +1,4 @@
-@companies-create @ignore
+@companies-create
 Feature: Create a new company
   As an existing user
   I would like to create a new company in various locations
@@ -6,7 +6,8 @@ Feature: Create a new company
   Background:
     Given I am an authenticated user on the data hub website
 
-  @companies-create--uk-private-or-public-ltd-company
+  # I dont think this is searching for the correct thing. Ignored to come back to
+  @companies-create--uk-private-or-public-ltd-company @ignore
   Scenario: Create a UK private or public limited company
 
     When a "UK private or public limited company" is created

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -68,7 +68,7 @@ module.exports = {
       },
 
       createForeignCompany ({ details = {}, callback }) {
-        const company = assign({
+        const company = assign({}, {
           address1: faker.address.streetName(),
           postcode: faker.address.zipCode(),
           town: faker.address.city(),
@@ -126,7 +126,7 @@ module.exports = {
       },
 
       createUkNonPrivateOrNonPublicLimitedCompany ({ details = {}, callback }) {
-        const company = assign({
+        const company = assign({}, {
           address1: faker.address.streetName(),
           postcode: faker.address.zipCode(),
           town: faker.address.city(),

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -1,15 +1,15 @@
 const faker = require('faker')
+const { assign } = require('lodash')
 
 const { getSelectorForElementWithText, getButtonWithText } = require('../../../helpers/selectors')
 
-const getDetailsTabSelector = (text) =>
-  getSelectorForElementWithText(
-    text,
-    {
-      el: '//a',
-      className: 'c-local-nav__link',
-    }
-  )
+const getDetailsTabSelector = (text) => getSelectorForElementWithText(
+  text,
+  {
+    el: '//a',
+    className: 'c-local-nav__link',
+  }
+)
 
 const getMetaListItemValueSelector = (text) => getSelectorForElementWithText(
   text,
@@ -67,124 +67,123 @@ module.exports = {
           .submitForm('@searchForm')
       },
 
-      createForeignCompany (companyName) {
-        this.state.companyDetails = {
-          name: companyName,
+      createForeignCompany ({ details = {}, callback }) {
+        const company = assign({
           address1: faker.address.streetName(),
           postcode: faker.address.zipCode(),
           town: faker.address.city(),
           website: faker.internet.url(),
-        }
+        }, details)
 
         this
           .click('@addCompanyButton')
           .waitForElementPresent('@otherTypeOfUKOrganisationBusinessType')
           .waitForElementPresent('@foreignOrganisationOptionBusinessType')
-
-        return this
-          .api.perform(async (done) => {
+          .api.perform((done) => {
             // step 1
-            this.click('@foreignOrganisationOption')
-
-            await new Promise((resolve) => {
-              this.getListOption('@foreignOrganisationOptionBusinessType', (businessType) => {
-                this.setValue(`@foreignOrganisationOptionBusinessType`, businessType)
-                resolve()
+            this
+              .click('@foreignOrganisationOption')
+              .api.perform((done) => {
+                this.getListOption('@foreignOrganisationOptionBusinessType', (businessType) => {
+                  this.setValue(`@foreignOrganisationOptionBusinessType`, businessType)
+                  done()
+                })
               })
-            })
-
-            this.click('@continueButton')
 
             // step 2
-            await new Promise((resolve) => {
-              this.getListOption('@registeredAddressCountry', (country) => {
-                this.state.companyDetails.registeredAddressCountry = country
-                resolve()
+            this
+              .waitForElementPresent('@continueButton')
+              .click('@continueButton')
+              .api.perform((done) => {
+                this.getListOption('@registeredAddressCountry', (country) => {
+                  company.registeredAddressCountry = country
+                  done()
+                })
               })
-            })
-
-            await new Promise((resolve) => {
-              this.getListOption('@sector', (sector) => {
-                this.state.companyDetails.sector = sector
-                resolve()
+              .perform((done) => {
+                this.getListOption('@sector', (sector) => {
+                  company.sector = sector
+                  done()
+                })
               })
-            })
+              .perform((done) => {
+                for (const key in company) {
+                  if (company[key]) {
+                    this.setValue(`@${key}`, company[key])
+                  }
+                }
+                done()
+              })
 
-            for (const key in this.state.companyDetails) {
-              if (this.state.companyDetails[key]) {
-                this.setValue(`@${key}`, this.state.companyDetails[key])
-              }
-            }
-
-            this.click('@saveAndCreateButton')
+            this
+              .waitForElementPresent('@saveAndCreateButton')
+              .click('@saveAndCreateButton')
             done()
           })
+
+        callback(company)
+        return this
       },
 
-      createUkNonPrivateOrNonPublicLimitedCompany (companyName) {
-        this.state.companyDetails = {
-          name: companyName,
+      createUkNonPrivateOrNonPublicLimitedCompany ({ details = {}, callback }) {
+        const company = assign({
           address1: faker.address.streetName(),
           postcode: faker.address.zipCode(),
           town: faker.address.city(),
-        }
+        }, details)
 
         this
           .click('@addCompanyButton')
           .waitForElementPresent('@otherTypeOfUKOrganisationBusinessType')
           .waitForElementPresent('@foreignOrganisationOptionBusinessType')
-
-        return this
-          .api.perform(async (done) => {
+          .api.perform((done) => {
             // step 1
-            this.click('@otherTypeOfUKOrganisationOption')
-
-            await new Promise((resolve) => {
-              this.getListOption('@otherTypeOfUKOrganisationBusinessType', (businessType) => {
-                this.setValue(`@otherTypeOfUKOrganisationBusinessType`, businessType)
-                resolve()
+            this
+              .click('@otherTypeOfUKOrganisationOption')
+              .api.perform((done) => {
+                this.getListOption('@otherTypeOfUKOrganisationBusinessType', (businessType) => {
+                  this.setValue(`@otherTypeOfUKOrganisationBusinessType`, businessType)
+                  done()
+                })
               })
-            })
-
-            this.click('@continueButton')
 
             // step 2
-            await new Promise((resolve) => {
-              this.getListOption('@registeredAddressCountry', (country) => {
-                this.state.companyDetails.registeredAddressCountry = country
-                resolve()
+            this
+              .click('@continueButton')
+              .api.perform((done) => {
+                this.getListOption('@registeredAddressCountry', (country) => {
+                  company.registeredAddressCountry = country
+                  done()
+                })
               })
-            })
-
-            await new Promise((resolve) => {
-              this.getListOption('@sector', (sector) => {
-                this.state.companyDetails.sector = sector
-                resolve()
+              .perform((done) => {
+                this.getListOption('@sector', (sector) => {
+                  company.sector = sector
+                  done()
+                })
               })
-            })
-
-            for (const key in this.state.companyDetails) {
-              if (this.state.companyDetails[key]) {
-                this.setValue(`@${key}`, this.state.companyDetails[key])
-              }
-            }
+              .perform((done) => {
+                for (const key in company) {
+                  if (company[key]) {
+                    this.setValue(`@${key}`, company[key])
+                  }
+                }
+                done()
+              })
 
             this.click('@saveAndCreateButton')
             done()
           })
+
+        callback(company)
+        return this
       },
 
-      createUkPrivateOrPublicLimitedCompany (companyName) {
-        this.state.companyDetails = {
-          tradingName: companyName,
-        }
-
+      createUkPrivateOrPublicLimitedCompany ({ company = {}, callback }) {
         this
           .click('@addCompanyButton')
           .waitForElementPresent('@otherTypeOfUKOrganisationBusinessType')
           .waitForElementPresent('@foreignOrganisationOptionBusinessType')
-
-        return this
           .api.perform(async (done) => {
             // step 1
             this
@@ -192,7 +191,6 @@ module.exports = {
               .click('@continueButton')
 
             // step 2
-            this
               .setValue('@parentCompanySearch', this.props.parentCompanySearchTerm)
               .submitForm('form')
 
@@ -203,36 +201,40 @@ module.exports = {
               .click('@addButton')
 
             // step 4
-            await new Promise((resolve) => {
-              this.getListOption('@ukRegion', (ukRegion) => {
-                this.state.companyDetails.ukRegion = ukRegion
-                resolve()
+            this
+              .api.perform((done) => {
+                this.getListOption('@ukRegion', (ukRegion) => {
+                  company.ukRegion = ukRegion
+                  done()
+                })
               })
-            })
-
-            await new Promise((resolve) => {
-              this.getListOption('@sector', (sector) => {
-                this.state.companyDetails.sector = sector
-                resolve()
+              .perform((done) => {
+                this.getListOption('@sector', (sector) => {
+                  company.sector = sector
+                  done()
+                })
               })
-            })
-
-            for (const key in this.state.companyDetails) {
-              if (this.state.companyDetails[key]) {
-                this.setValue(`@${key}`, this.state.companyDetails[key])
-              }
-            }
-
+              .perform((done) => {
+                for (const key in company) {
+                  if (company[key]) {
+                    this.setValue(`@${key}`, company[key])
+                  }
+                }
+                done()
+              })
             this.click('@saveAndCreateButton')
             done()
           })
+
+        callback(company)
+        return this
       },
 
       searchForCompanyInCollection (companyName) {
         this.api.url(`${process.env.QA_HOST}/companies`)
         return this
           .waitForElementPresent('@collectionsCompanyNameInput')
-          .setValue('@collectionsCompanyNameInput', [ companyName, this.api.Keys.ENTER ]) // press enter
+          .setValue('@collectionsCompanyNameInput', [companyName, this.api.Keys.ENTER]) // press enter
           .waitForElementNotVisible('@xhrTargetElement') // wait for xhr results to come back
           .waitForElementVisible('@xhrTargetElement')
       },

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -8,7 +8,7 @@ const { getUid, appendUid } = require('../../../helpers/uuid')
 const companySearchPage = `${process.env.QA_HOST}/search/companies` // TODO move these urls out into a url world object
 const dashboardPage = `${process.env.QA_HOST}/`
 
-defineSupportCode(({ Before, Then, When }) => {
+defineSupportCode(({ Then, When }) => {
   const Company = client.page.Company()
 
   When(/^a "UK private or public limited company" is created$/, async function () {

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -1,98 +1,101 @@
+const { set } = require('lodash')
+const faker = require('faker')
+
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
-const faker = require('faker')
+const { getUid, appendUid } = require('../../../helpers/uuid')
+
+const companySearchPage = `${process.env.QA_HOST}/search/companies` // TODO move these urls out into a url world object
+const dashboardPage = `${process.env.QA_HOST}/`
 
 defineSupportCode(({ Before, Then, When }) => {
   const Company = client.page.Company()
 
-  const getFakeName = (name) => {
-    return {
-      name: name,
-      suffix: faker.random.uuid(),
-      getFullName () {
-        return `${this.name} ${this.suffix}`
-      },
-    }
-  }
+  When(/^a "UK private or public limited company" is created$/, async function () {
+    const companyName = appendUid(faker.company.companyName())
 
-  Before(() => {
-    Company.state = {
-      companyDetails: {},
-      companyName: getFakeName(faker.company.companyName()),
-    }
-  })
-
-  When(/^a "UK private or public limited company" is created$/, async () => {
-    const companyName = Company.state.companyName.getFullName()
+    await client
+      .url(companySearchPage)
 
     await Company
-      .navigate()
-      .findCompany(companyName)
-      .createUkPrivateOrPublicLimitedCompany(companyName)
+      .createUkPrivateOrPublicLimitedCompany({
+        company: { tradingName: companyName },
+        callback: (company) => set(this.state, 'company', company),
+      })
+      .wait() // wait for backend to sync
   })
 
-  When(/^a "UK non-private or non-public limited company" is created$/, async () => {
-    const companyName = Company.state.companyName.getFullName()
+  When(/^a "UK non-private or non-public limited company" is created$/, async function () {
+    const companyName = appendUid(faker.company.companyName())
+
+    await client
+      .url(companySearchPage)
 
     await Company
-      .navigate()
-      .findCompany(companyName)
-      .createUkNonPrivateOrNonPublicLimitedCompany(companyName)
+      .createUkNonPrivateOrNonPublicLimitedCompany({
+        details: { name: companyName },
+        callback: (company) => set(this.state, 'company', company),
+      })
+      .wait() // wait for backend to sync
   })
 
-  When(/^a new "Foreign company" is created$/, async () => {
-    const companyName = Company.state.companyName.getFullName()
+  When(/^a new "Foreign company" is created$/, async function () {
+    const companyName = appendUid(faker.company.companyName())
+
+    await client
+      .url(companySearchPage)
 
     await Company
-      .navigate()
-      .findCompany(companyName)
-      .createForeignCompany(companyName)
+      .createForeignCompany({
+        details: { name: companyName },
+        callback: (company) => set(this.state, 'company', company),
+      })
+      .wait() // wait for backend to sync
   })
 
-  Then(/^the company is in the search results$/, async () => {
-    await Company
-      .navigate()
-      .findCompany(Company.state.companyName.suffix)
-      .assert.containsText('@collectionResultsCompanyName', Company.state.companyName.getFullName())
-  })
+  Then(/^the company is in the search results$/, async function () {
+    const companyName = this.state.company.name
 
-  Then(/^The company name is present in the collections results/, async () => {
-    const companyName = Company.state.companyDetails.name
+    await client
+      .url(dashboardPage)
 
     await Company
-      .searchForCompanyInCollection(companyName)
+      .findCompany(getUid(companyName))
       .assert.containsText('@collectionResultsCompanyName', companyName)
   })
 
-  Then(/^The company sector is present in the collections results$/, async () => {
-    const companyName = Company.state.companyDetails.name
+  Then(/^The company name is present in the collections results/, async function () {
+    const companyName = this.state.company.name
+
+    await client
+      .url(dashboardPage)
 
     await Company
-      .searchForCompanyInCollection(companyName)
+      .searchForCompanyInCollection(getUid(companyName))
+      .assert.containsText('@collectionResultsCompanyName', companyName)
+  })
+
+  Then(/^The company sector is present in the collections results$/, async function () {
+    await Company
+      .searchForCompanyInCollection(getUid(this.state.company.name))
       .assert.containsText('@collectionResultsSectorLabel', 'Sector')
   })
 
-  Then(/^The company region is present in the collections results$/, async () => {
-    const companyName = Company.state.companyDetails.name
-
+  Then(/^The company region is present in the collections results$/, async function () {
     await Company
-      .searchForCompanyInCollection(companyName)
+      .searchForCompanyInCollection(getUid(this.state.company.name))
       .assert.containsText('@collectionResultsRegionLabel', 'UK region')
   })
 
-  Then(/^The company registered address is present in the collections results$/, async () => {
-    const companyName = Company.state.companyDetails.name
-
+  Then(/^The company registered address is present in the collections results$/, async function () {
     await Company
-      .searchForCompanyInCollection(companyName)
+      .searchForCompanyInCollection(getUid(this.state.company.name))
       .assert.containsText('@collectionResultsRegisteredAddressLabel', 'Registered address')
   })
 
-  Then(/^Clicking the company name takes me to the companies page$/, async () => {
-    const companyName = Company.state.companyDetails.name
-
+  Then(/^Clicking the company name takes me to the companies page$/, async function () {
     await Company
       .click('@collectionResultsCompanyName')
-      .assert.containsText('@companyPageHeading', companyName)
+      .assert.containsText('@companyPageHeading', this.state.company.name)
   })
 })

--- a/test/acceptance/features/dashboard/step_definitions/dashboard.js
+++ b/test/acceptance/features/dashboard/step_definitions/dashboard.js
@@ -1,7 +1,7 @@
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
-defineSupportCode(({ Then, When, Before }) => {
+defineSupportCode(({ When }) => {
   const Dashboard = client.page.Dashboard()
 
   When(/^I navigate to the dashboard/, async () => {

--- a/test/acceptance/features/details/step_definitions/details.js
+++ b/test/acceptance/features/details/step_definitions/details.js
@@ -1,16 +1,12 @@
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
-const World = require('../../../helpers/world')
-
 defineSupportCode(({ Then }) => {
   const Details = client.page.Details()
 
-  // Then
-
-  Then(/^details heading should contain what I entered for "(.+)" field$/, async (fieldName) => {
+  Then(/^details heading should contain what I entered for "(.+)" field$/, async function (fieldName) {
     await Details
-      .assert.containsText('@heading', World.state[fieldName])
+      .assert.containsText('@heading', this.state[fieldName])
   })
 
   Then(/^details heading should contain "(.+)"$/, async (value) => {
@@ -18,12 +14,12 @@ defineSupportCode(({ Then }) => {
       .assert.containsText('@heading', value)
   })
 
-  Then(/^details view data for "(.+)" should contain what I entered for "(.+)" field$/, async (detailsItemName, fieldName) => {
+  Then(/^details view data for "(.+)" should contain what I entered for "(.+)" field$/, async function (detailsItemName, fieldName) {
     const detail = await Details.getDetailFor(detailsItemName)
 
     await Details
       .api.useXpath()
-      .assert.containsText(detail.selector, World.state[fieldName])
+      .assert.containsText(detail.selector, this.state[fieldName])
       .useCss()
   })
 

--- a/test/acceptance/features/events/edit.feature
+++ b/test/acceptance/features/events/edit.feature
@@ -1,4 +1,6 @@
-@events-edit @ignore
+# TODO this work feels a little verbose have a look at moving into a smaller amount of steps
+# TODO this work relies on the first step being run (to create a company) this needs to be done on each step once the above has been done
+@events-edit
 Feature: Edit an Event in Data hub
   As an Event organiser
   I would like to edit an event in data hub
@@ -6,17 +8,24 @@ Feature: Edit an Event in Data hub
 
   Background:
     Given I am an authenticated user on the data hub website
-    And I navigate to event details page
-    And I click on edit event button
+
+  @events-edit--create-event
+  Scenario: Create an event for later scenarios
+    When I create an event
+    Then I see the success message
 
   @events-edit--name
   Scenario: Edit event name
+    And I navigate to event details page
+    And I click on edit event button
     When I change form text field "name" to random words
     And I submit the form
     Then details heading should contain what I entered for "name" field
 
   @events-edit--type
   Scenario: Edit event type
+    And I navigate to event details page
+    And I click on edit event button
     When I change form dropdown "event_type" to "Seminar"
     And I submit the form
     Then details view data for "Type of event" should contain "Seminar"
@@ -27,12 +36,16 @@ Feature: Edit an Event in Data hub
 
   @events-edit--dates
   Scenario: Edit event dates
+    And I navigate to event details page
+    And I click on edit event button
     When I change start date to decrease year by one
     And I submit the form
     Then details view data for "Event start date" should contain what I entered for "start_date_year" field
 
   @events-edit--location-type
   Scenario: Edit event location type
+    And I navigate to event details page
+    And I click on edit event button
     When I change form dropdown "location_type" to "HQ"
     And I submit the form
     Then details view data for "Event location type" should contain "HQ"
@@ -43,18 +56,24 @@ Feature: Edit an Event in Data hub
 
   @events-edit--address
   Scenario: Edit event address
+    And I navigate to event details page
+    And I click on edit event button
     When I change form text field "address_1" to a random street address
     And I submit the form
     Then details view data for "Address" should contain what I entered for "address_1" field
 
   @events-edit--notes
   Scenario: Edit event notes
+    And I navigate to event details page
+    And I click on edit event button
     When I change form text field "notes" to a random paragraph
     And I submit the form
     Then details view data for "Notes" should contain what I entered for "notes" field
 
   @events-edit--team-hosting
   Scenario: Edit event team hosting
+    And I navigate to event details page
+    And I click on edit event button
     When I change form dropdown "lead_team" to "CBBC Leeds"
     And I submit the form
     Then details view data for "Lead team" should contain "CBBC Leeds"
@@ -63,18 +82,23 @@ Feature: Edit an Event in Data hub
     And I submit the form
     Then details view data for "Lead team" should contain "CBBC London"
 
-  @events-edit--organiser
+  ## TODO for the moment turn this off as we have data on CircleCi that we don't have locally
+  @events-edit--organiser @ignore
   Scenario: Edit event organiser
-    When I change form dropdown "organiser" to "Michael Wining"
+    And I navigate to event details page
+    And I click on edit event button
+    When I change form dropdown "organiser" to "Adrian Hockney"
     And I submit the form
-    Then details view data for "Organiser" should contain "Michael Wining"
+    Then details view data for "Organiser" should contain "Adrian Hockney"
     When I click on edit event button
-    And I change form dropdown "organiser" to "Barry Oling"
+    And I change form dropdown "organiser" to "Akhilesh Mahurkar"
     And I submit the form
-    Then details view data for "Organiser" should contain "Barry Oling"
+    Then details view data for "Organiser" should contain "Akhilesh Mahurkar"
 
   @events-edit--shared-teams
   Scenario: Edit event shared teams
+    And I navigate to event details page
+    And I click on edit event button
     When I select "Yes" for boolean option "event_shared"
     And I change form dropdown "teams" to "BPI"
     And I submit the form
@@ -87,6 +111,8 @@ Feature: Edit an Event in Data hub
 
   @events-edit--related-programmes
   Scenario: Edit event related programmes
+    And I navigate to event details page
+    And I click on edit event button
     When I change form dropdown "related_programmes" to "Grown in Britain"
     And I submit the form
     Then details view data for "Related programmes" should contain "Grown in Britain"

--- a/test/acceptance/features/events/step_definitions/create.js
+++ b/test/acceptance/features/events/step_definitions/create.js
@@ -1,9 +1,20 @@
 const faker = require('faker')
+const { set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
-defineSupportCode(({ Given, Then, When }) => {
+defineSupportCode(function ({ Then, When }) {
   const Event = client.page.Event()
+
+  When(/^I create an event$/, async function () {
+    await Event
+      .navigate()
+      .populateCreateEventForm({
+        callback: (event) => set(this.state, 'event', event),
+      })
+      .click('@saveButton')
+      .wait()
+  })
 
   When(/^I navigate to the create an event page$/, async () => {
     await Event

--- a/test/acceptance/features/events/step_definitions/edit.js
+++ b/test/acceptance/features/events/step_definitions/edit.js
@@ -1,20 +1,14 @@
 /* eslint camelcase: 0 */
+const { assign } = require('lodash')
+
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 const { format } = require('date-fns')
 
-const World = require('../../../helpers/world')
-
-defineSupportCode(({ Before, Then, When }) => {
+defineSupportCode(({ When }) => {
   const Form = client.page.Form()
   const Event = client.page.Event()
   const EventList = client.page.EventList()
-
-  Before(() => {
-    World.resetState()
-  })
-
-  // When
 
   When(/^I navigate to event details page$/, async () => {
     await EventList
@@ -28,7 +22,7 @@ defineSupportCode(({ Before, Then, When }) => {
       .click('@editButton')
   })
 
-  When(/^I change start date to decrease year by one$/, async () => {
+  When(/^I change start date to decrease year by one$/, async function () {
     const currentDate = new Date()
 
     await Form.getState()
@@ -37,16 +31,16 @@ defineSupportCode(({ Before, Then, When }) => {
       .api.perform(() => {
         const start_date_year = Form.state.start_date_year || format(currentDate, 'YYYY')
 
-        World.state = Object.assign({}, World.state, {
+        this.state = assign({}, this.state, {
           start_date_year: parseInt(start_date_year, 10) - 1,
           start_date_month: Form.state.start_date_month || format(currentDate, 'MM'),
           start_date_day: Form.state.start_date_day || format(currentDate, 'DD'),
         })
 
         return Event
-          .replaceValue('@startDateYear', World.state.start_date_year)
-          .replaceValue('@startDateMonth', World.state.start_date_month)
-          .replaceValue('@startDateDay', World.state.start_date_day)
+          .replaceValue('@startDateYear', this.state.start_date_year)
+          .replaceValue('@startDateMonth', this.state.start_date_month)
+          .replaceValue('@startDateDay', this.state.start_date_day)
       })
   })
 })

--- a/test/acceptance/features/events/step_definitions/list.js
+++ b/test/acceptance/features/events/step_definitions/list.js
@@ -1,24 +1,13 @@
 const { compareAsc, compareDesc } = require('date-fns')
+const { set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
 const { getDateFor } = require('../../../helpers/date')
 
-defineSupportCode(({ Then, When, Before }) => {
+defineSupportCode(({ Then, When }) => {
   const EventList = client.page.EventList()
   const Event = client.page.Event()
-
-  Before(() => {
-    Event.state = {
-      eventDetails: {},
-    }
-    EventList.state = {
-      list: {
-        firstItem: {},
-        secondItem: {},
-      },
-    }
-  })
 
   When(/^I navigate to the event list page$/, async () => {
     await EventList
@@ -32,14 +21,19 @@ defineSupportCode(({ Then, When, Before }) => {
       .click('@addEventButton')
   })
 
-  When(/^I populate the create event form$/, async () => {
+  When(/^I populate the create event form$/, async function () {
     await Event
-      .populateCreateEventForm()
+      .populateCreateEventForm({
+        callback: (event) => set(this.state, 'event', event),
+      })
   })
 
-  When(/^I populate the create event form with United Kingdom and a region$/, async () => {
+  When(/^I populate the create event form with United Kingdom and a region$/, async function () {
     await Event
-      .populateCreateEventForm({ addressCountry: 'United Kingdom' })
+      .populateCreateEventForm({
+        details: { address_country: 'United Kingdom' },
+        callback: (event) => set(this.state, 'event', event),
+      })
   })
 
   Then(/^I am taken to the create event page$/, async () => {
@@ -48,43 +42,43 @@ defineSupportCode(({ Then, When, Before }) => {
       .assert.urlEquals(`${EventList.url}/create`)
   })
 
-  Then(/^I can view the event$/, async () => {
+  Then(/^I can view the event$/, async function () {
     await EventList.section.firstEventInList
       .waitForElementPresent('@header')
-      .assert.containsText('@header', Event.state.eventDetails.name)
-      .assert.containsText('@eventType', Event.state.eventDetails.event_type)
-      .assert.containsText('@country', Event.state.eventDetails.address_country)
+      .assert.containsText('@header', this.state.event.name)
+      .assert.containsText('@eventType', this.state.event.event_type)
+      .assert.containsText('@country', this.state.event.address_country)
       .assert.containsText('@eventStart', getDateFor({
-        year: Event.state.eventDetails.start_date_year,
-        month: Event.state.eventDetails.start_date_month,
-        day: Event.state.eventDetails.start_date_day,
+        year: this.state.event.start_date_year,
+        month: this.state.event.start_date_month,
+        day: this.state.event.start_date_day,
       }))
       .assert.containsText('@eventEnd', getDateFor({
-        year: Event.state.eventDetails.end_date_year,
-        month: Event.state.eventDetails.end_date_month,
-        day: Event.state.eventDetails.end_date_day,
+        year: this.state.event.end_date_year,
+        month: this.state.event.end_date_month,
+        day: this.state.event.end_date_day,
       }))
-      .assert.containsText('@organiser', Event.state.eventDetails.organiser)
-      .assert.containsText('@leadTeam', Event.state.eventDetails.lead_team)
+      .assert.containsText('@organiser', this.state.event.organiser)
+      .assert.containsText('@leadTeam', this.state.event.lead_team)
   })
 
-  Then(/^I can view the event country and region$/, async () => {
+  Then(/^I can view the event country and region$/, async function () {
     await EventList.section.firstEventInList
       .waitForElementPresent('@header')
-      .assert.containsText('@country', Event.state.eventDetails.address_country)
-      .assert.containsText('@ukRegion', Event.state.eventDetails.uk_region)
+      .assert.containsText('@country', this.state.event.address_country)
+      .assert.containsText('@ukRegion', this.state.event.uk_region)
   })
 
-  Then(/^I filter the events list by name$/, async () => {
+  Then(/^I filter the events list by name$/, async function () {
     await EventList.section.filters
       .waitForElementPresent('@nameInput')
-      .setValue('@nameInput', Event.state.eventDetails.name)
+      .setValue('@nameInput', this.state.event.name)
       .sendKeys('@nameInput', [ client.Keys.ENTER ])
       .wait() // wait for xhr
 
     await EventList.section.firstEventInList
       .waitForElementVisible('@header')
-      .assert.containsText('@header', Event.state.eventDetails.name)
+      .assert.containsText('@header', this.state.event.name)
 
     // clear filter
     await EventList.section.filterTags
@@ -92,15 +86,15 @@ defineSupportCode(({ Then, When, Before }) => {
       .wait() // wait for xhr
   })
 
-  Then(/^I filter the events list by organiser$/, async () => {
+  Then(/^I filter the events list by organiser$/, async function () {
     await EventList.section.filters
       .waitForElementPresent('@organiser')
-      .clickListOption('organiser', Event.state.eventDetails.organiser)
+      .clickListOption('organiser', this.state.event.organiser)
       .wait() // wait for xhr
 
     await EventList.section.firstEventInList
       .waitForElementVisible('@organiser')
-      .assert.containsText('@organiser', Event.state.eventDetails.organiser)
+      .assert.containsText('@organiser', this.state.event.organiser)
 
     // clear filter
     await EventList.section.filterTags
@@ -108,15 +102,15 @@ defineSupportCode(({ Then, When, Before }) => {
       .wait() // wait for xhr
   })
 
-  Then(/^I filter the events list by country/, async () => {
+  Then(/^I filter the events list by country/, async function () {
     await EventList.section.filters
       .waitForElementPresent('@country')
-      .clickListOption('address_country', Event.state.eventDetails.address_country)
+      .clickListOption('address_country', this.state.event.address_country)
       .wait() // wait for xhr
 
     await EventList.section.firstEventInList
       .waitForElementVisible('@country')
-      .assert.containsText('@country', Event.state.eventDetails.address_country)
+      .assert.containsText('@country', this.state.event.address_country)
 
     // clear filter
     await EventList.section.filterTags
@@ -124,15 +118,15 @@ defineSupportCode(({ Then, When, Before }) => {
       .wait() // wait for xhr
   })
 
-  Then(/^I filter the events list by event type/, async () => {
+  Then(/^I filter the events list by event type/, async function () {
     await EventList.section.filters
       .waitForElementPresent('@eventType')
-      .clickListOption('event_type', Event.state.eventDetails.event_type)
+      .clickListOption('event_type', this.state.event.event_type)
       .wait() // wait for xhr
 
     await EventList.section.firstEventInList
       .waitForElementVisible('@eventType')
-      .assert.containsText('@eventType', Event.state.eventDetails.event_type)
+      .assert.containsText('@eventType', this.state.event.event_type)
 
     // clear filter
     await EventList.section.filterTags
@@ -140,12 +134,12 @@ defineSupportCode(({ Then, When, Before }) => {
       .wait() // wait for xhr
   })
 
-  Then(/^I filter the events list by start date/, async () => {
-    const eventDetails = Event.state.eventDetails
+  Then(/^I filter the events list by start date/, async function () {
+    const event = this.state.event
     const startDate = getDateFor({
-      year: eventDetails.start_date_year,
-      month: eventDetails.start_date_month,
-      day: eventDetails.start_date_day,
+      year: event.start_date_year,
+      month: event.start_date_month,
+      day: event.start_date_day,
     })
 
     await EventList.section.filters
@@ -164,7 +158,7 @@ defineSupportCode(({ Then, When, Before }) => {
       .wait() // wait for xhr
   })
 
-  Then(/^I sort the events list name A-Z$/, async () => {
+  Then(/^I sort the events list name A-Z$/, async function () {
     await EventList
       .click('select[name="sortby"] option[value="name:asc"]')
       .wait()// wait for xhr
@@ -172,23 +166,23 @@ defineSupportCode(({ Then, When, Before }) => {
     await EventList.section.firstEventInList
       .waitForElementVisible('@header')
       .getText('@header', (text) => {
-        EventList.state.list.firstItem.header = text.value
+        set(this.state, 'list.firstItem.header', text.value)
       })
 
     await EventList.section.secondEventInList
       .waitForElementVisible('@header')
       .getText('@header', (text) => {
-        EventList.state.list.secondItem.header = text.value
+        set(this.state, 'list.secondItem.header', text.value)
       })
   })
 
-  Then(/^I see the list in A-Z alphabetical order$/, async () => {
+  Then(/^I see the list in A-Z alphabetical order$/, async function () {
     client.expect(
-      EventList.state.list.firstItem.header < EventList.state.list.secondItem.header
+      this.state.list.firstItem.header < this.state.list.secondItem.header
     ).to.be.true
   })
 
-  Then(/^I sort the events list name Z-A$/, async () => {
+  Then(/^I sort the events list name Z-A$/, async function () {
     await EventList
       .click('select[name="sortby"] option[value="name:desc"]')
       .wait() // wait for xhr
@@ -196,23 +190,23 @@ defineSupportCode(({ Then, When, Before }) => {
     await EventList.section.firstEventInList
       .waitForElementVisible('@header')
       .getText('@header', (text) => {
-        EventList.state.list.firstItem.header = text.value
+        set(this.state, 'list.firstItem.header', text.value)
       })
 
     await EventList.section.secondEventInList
       .waitForElementVisible('@header')
       .getText('@header', (text) => {
-        EventList.state.list.secondItem.header = text.value
+        set(this.state, 'list.secondItem.header', text.value)
       })
   })
 
-  Then(/^I see the list in Z-A alphabetical order$/, async () => {
+  Then(/^I see the list in Z-A alphabetical order$/, async function () {
     client.expect(
-      EventList.state.list.firstItem.header > EventList.state.list.secondItem.header
+      this.state.list.firstItem.header > this.state.list.secondItem.header
     ).to.be.true
   })
 
-  Then(/^I sort the events list by recently updated$/, async () => {
+  Then(/^I sort the events list by recently updated$/, async function () {
     await EventList
       .click('select[name="sortby"] option[value="modified_on:desc"]')
       .wait() // wait for xhr
@@ -220,23 +214,23 @@ defineSupportCode(({ Then, When, Before }) => {
     await EventList.section.firstEventInList
       .waitForElementVisible('@updated')
       .getText('@updated', (dateString) => {
-        EventList.state.list.firstItem.updated = dateString.value
+        set(this.state, 'firstItem.updated ', dateString.value)
       })
 
     await EventList.section.secondEventInList
       .waitForElementVisible('@updated')
       .getText('@updated', (dateString) => {
-        EventList.state.list.secondItem.updated = dateString.value
+        set(this.state, 'list.secondItem.updated', dateString.value)
       })
   })
 
-  Then(/^I see the list in descending recently updated order$/, async () => {
+  Then(/^I see the list in descending recently updated order$/, async function () {
     client.expect(
-      compareDesc(EventList.state.list.firstItem.updated, EventList.state.list.secondItem.updated)
+      compareDesc(this.state.list.firstItem.updated, this.state.list.secondItem.updated)
     ).to.be.within(0, 1)
   })
 
-  Then(/^I sort the events list by least recently updated$/, async () => {
+  Then(/^I sort the events list by least recently updated$/, async function () {
     await EventList
       .click('select[name="sortby"] option[value="modified_on:asc"]')
       .wait() // wait for xhr
@@ -244,19 +238,19 @@ defineSupportCode(({ Then, When, Before }) => {
     await EventList.section.firstEventInList
       .waitForElementVisible('@updated')
       .getText('@updated', (dateString) => {
-        EventList.state.list.firstItem.updated = dateString.value
+        set(this.state, 'list.firstItem.updated', dateString.value)
       })
 
     await EventList.section.secondEventInList
       .waitForElementVisible('@updated')
       .getText('@updated', (dateString) => {
-        EventList.state.list.secondItem.updated = dateString.value
+        set(this.state, 'list.secondItem.updated', dateString.value)
       })
   })
 
-  Then(/^I see the list in ascending recently updated order$/, async () => {
+  Then(/^I see the list in ascending recently updated order$/, async function () {
     client.expect(
-      compareAsc(EventList.state.list.firstItem.updated, EventList.state.list.secondItem.updated)
+      compareAsc(this.state.list.firstItem.updated, this.state.list.secondItem.updated)
     ).to.be.within(0, 1)
   })
 })

--- a/test/acceptance/features/form/step_definitions/form.js
+++ b/test/acceptance/features/form/step_definitions/form.js
@@ -2,8 +2,6 @@ const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 const faker = require('faker')
 
-const World = require('../../../helpers/world')
-
 const getValue = (value) => {
   switch (value) {
     case 'random words':
@@ -20,22 +18,20 @@ const getValue = (value) => {
 defineSupportCode(({ When, Then }) => {
   const Form = client.page.Form()
 
-  // When
-
-  When(/^I change form text field "(.+)" to (.+)$/, async (fieldName, fieldValue) => {
+  When(/^I change form text field "(.+)" to (.+)$/, async function (fieldName, fieldValue) {
     const fieldSelector = `[name="${fieldName}"]`
 
-    World.state[fieldName] = getValue(fieldValue)
+    this.state[fieldName] = getValue(fieldValue)
 
     await Form
-      .replaceValue(fieldSelector, World.state[fieldName])
+      .replaceValue(fieldSelector, this.state[fieldName])
   })
 
-  When(/^I change form dropdown "(.+)" to (.+)$/, async (fieldName, fieldValue) => {
-    World.state[fieldName] = getValue(fieldValue)
+  When(/^I change form dropdown "(.+)" to (.+)$/, async function (fieldName, fieldValue) {
+    this.state[fieldName] = getValue(fieldValue)
 
     await Form
-      .clickListOption(fieldName, World.state[fieldName])
+      .clickListOption(fieldName, this.state[fieldName])
   })
 
   When(/^I select "(.+)" for boolean option "(.+)"$/, async (label, fieldName) => {
@@ -53,8 +49,6 @@ defineSupportCode(({ When, Then }) => {
     await Form
       .submitForm(selector)
   })
-
-  // Then
 
   Then(/^I see form error summary$/, async () => {
     await Form

--- a/test/acceptance/features/support/hooks.js
+++ b/test/acceptance/features/support/hooks.js
@@ -1,0 +1,7 @@
+const { defineSupportCode } = require('cucumber')
+
+defineSupportCode(({ Before }) => {
+  Before(function () {
+    this.resetState()
+  })
+})

--- a/test/acceptance/features/support/world.js
+++ b/test/acceptance/features/support/world.js
@@ -1,0 +1,16 @@
+const { defineSupportCode } = require('cucumber')
+
+/**
+ * setup state object to be used across UAT tests
+ * @constructor
+ */
+function World () {
+  this.state = {}
+  this.resetState = function () {
+    this.state = {}
+  }
+}
+
+defineSupportCode(({ setWorldConstructor }) => {
+  setWorldConstructor(World)
+})

--- a/test/acceptance/global.nightwatch.js
+++ b/test/acceptance/global.nightwatch.js
@@ -1,6 +1,6 @@
 module.exports = {
-  waitForConditionPollInterval: 500,
-  waitForConditionTimeout: 5000,
-  pauseDuration: 2000,
-  retryAssertionTimeout: 2000,
+  waitForConditionPollInterval: 1000,
+  waitForConditionTimeout: 6000,
+  pauseDuration: 2500,
+  retryAssertionTimeout: 2500,
 }

--- a/test/acceptance/helpers/uuid.js
+++ b/test/acceptance/helpers/uuid.js
@@ -1,0 +1,20 @@
+const faker = require('faker')
+
+const MARKER = '@'
+
+/**
+ * get the uuid part of string created with the withUid method
+ * @param name
+ */
+const getUid = (name) => name.split(MARKER)[1]
+
+/**
+ * create name with a uuid suffix
+ * @param name
+ */
+const appendUid = (name) => `${name}${MARKER}${faker.random.uuid()}`
+
+module.exports = {
+  getUid,
+  appendUid,
+}

--- a/test/acceptance/helpers/world.js
+++ b/test/acceptance/helpers/world.js
@@ -1,6 +1,0 @@
-module.exports = {
-  state: {},
-  resetState () {
-    this.state = {}
-  },
-}


### PR DESCRIPTION
- Make state a lot easier to handle by use the cucumber methodology of `World` for state across UAT
- Turn on `@events-edit` scenarios
- turn on most of `@companies-create` scenarios
- Rework/massage some code around companies page objects
- Remove `Promise` work when creating things and use `.perform`
- handle state by passing it through to pageObjects
