### PR TITLE
bump the wait time up to 5 seconds

### DIFF
--- a/test/acceptance/global.nightwatch.js
+++ b/test/acceptance/global.nightwatch.js
@@ -1,6 +1,6 @@
 module.exports = {
   waitForConditionPollInterval: 1000,
   waitForConditionTimeout: 6000,
-  pauseDuration: 2500,
+  pauseDuration: 5000,
   retryAssertionTimeout: 2500,
 }


### PR DESCRIPTION
We are seeing a number of failures that look like either http issues or ES sync issues.

- searching and something returning via xhr
- creating something and then searching for it (ES asynchronously syncs these lists)

This just bumps the timing used in `.wait()` up to 5 seconds.