### PR TITLE
Added address to investment requirements form

### DIFF
--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -117,6 +117,40 @@ const requirementsFormConfig = {
         { label: 'No', value: 'false' },
       ],
     },
+    {
+      macroName: 'Fieldset',
+      legend: 'Address',
+      condition: {
+        name: 'site_decided',
+        value: 'true',
+      },
+      children: [
+        {
+          macroName: 'TextField',
+          name: 'address_1',
+          label: 'Street',
+          modifier: 'compact',
+        },
+        {
+          macroName: 'TextField',
+          name: 'address_2',
+          label: 'Street 2',
+          isLabelHidden: true,
+          modifier: 'compact',
+        },
+        {
+          macroName: 'TextField',
+          name: 'address_town',
+          label: 'Town',
+        },
+        {
+          macroName: 'TextField',
+          name: 'address_postcode',
+          label: 'Postcode',
+          modifier: 'short',
+        },
+      ],
+    },
   ],
 }
 


### PR DESCRIPTION
Just adds address fields to the investment requirements form, though they are not shown on the details form as not requested at this time.

![address](https://user-images.githubusercontent.com/56056/31831947-19fcb050-b5bd-11e7-885d-cb0376177d77.PNG)
