### PR TITLE
Show return to order link on accepted and cancelled quotes

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -88,7 +88,7 @@ async function setQuotePreview (req, res, next) {
 
 async function setQuote (req, res, next) {
   try {
-    const quote = await Order.getQuote(req.session.token, res.locals.order.Id)
+    const quote = await Order.getQuote(req.session.token, res.locals.order.id)
 
     res.locals.quote = assign({}, quote, {
       expired: new Date(quote.expires_on) < new Date(),
@@ -169,7 +169,7 @@ function setQuoteForm (req, res, next) {
     form.buttonModifiers = 'button-secondary'
 
     if (quote.accepted_on || quote.cancelled_on) {
-      form.disableFormAction = true
+      form.hidePrimaryFormAction = true
     }
 
     if (new Date(quote.expires_on) > new Date()) {

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -59,15 +59,15 @@
         </div>
       {% endcall %}
     {% endif %}
-  {% endif %}
 
-  {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
-    {% if destructive %}
-      {{ Message({
-        type: 'error',
-        text: 'Editing the order whilst it is out for acceptance will invalidate the
-        current quote and the client will no longer be able to accept it.'
-      }) }}
+    {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
+      {% if destructive %}
+        {{ Message({
+          type: 'error',
+          text: 'Editing the order whilst it is out for acceptance will invalidate the
+          current quote and the client will no longer be able to accept it.'
+        }) }}
+      {% endif %}
     {% endif %}
 
     {{ Form(quoteForm) }}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -719,7 +719,7 @@ describe('OMIS View middleware', () => {
           it('should disable form actions', (done) => {
             const nextSpy = () => {
               try {
-                expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+                expect(this.resMock.locals.quoteForm).to.have.property('hidePrimaryFormAction', true)
 
                 done()
               } catch (error) {
@@ -737,7 +737,7 @@ describe('OMIS View middleware', () => {
           it('should disable form actions', (done) => {
             const nextSpy = () => {
               try {
-                expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+                expect(this.resMock.locals.quoteForm).to.have.property('hidePrimaryFormAction', true)
 
                 done()
               } catch (error) {


### PR DESCRIPTION
There was previously now way to return the order if a quote had been
accepted or cancelled.