### PR TITLE
Fix invest errors

### DIFF
--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -95,7 +95,7 @@ function handleFormPost (req, res, next) {
     req.body[addKey] = flatten([req.body[addKey]])
     req.body[addKey].push('')
 
-    res.locals.form = Object.assign({}, res.locals.form, {
+    res.locals.form = assign({}, res.locals.form, {
       state: req.body,
     })
 
@@ -115,12 +115,12 @@ function handleFormPost (req, res, next) {
     })
     .catch((err) => {
       if (err.statusCode === 400) {
-        const state = Object.assign({}, req.body, {
+        const state = assign({}, req.body, {
           client_contacts: flatten([req.body.client_contacts]),
-          business_activities: flatten([req.body.client_contacts]),
+          business_activities: flatten([req.body.business_activities]),
         })
 
-        res.locals.form = Object.assign({}, res.locals.form, {
+        res.locals.form = assign({}, res.locals.form, {
           state,
           errors: {
             messages: err.error,

--- a/src/apps/investment-projects/views/_details-form.njk
+++ b/src/apps/investment-projects/views/_details-form.njk
@@ -90,12 +90,7 @@
     value: form.state['sector']
   }) }}
 
-  <fieldset class="c-form-fieldset {{ 'has-error' if form.errors.messages['business_activities'] }}">
-
-    <legend class="c-form-fieldset__legend">
-      <span class="c-form-fieldset__legend-text">Business activities</span>
-    </legend>
-
+  {% call Fieldset({ legend: 'Business activities' }) %}
     {% if form.errors.messages['business_activities'] %}
       <span class="c-form-group__error-message">{{ form.errors.messages['business_activities'] }}</span>
     {% endif %}
@@ -128,16 +123,9 @@
       error: form.errors.messages['other_business_activity'],
       value: form.state['other_business_activity']
     }) }}
-  </fieldset>
+  {% endcall %}
 
-  <fieldset
-    class="c-form-fieldset {{ 'has-error' if form.errors.messages['client_contacts'] }}"
-    data-item-selector=".c-form-group"
-    data-add-button-selector=".js-AddItems__add">
-
-    <legend class="c-form-fieldset__legend">
-      <span class="c-form-fieldset__legend-text">Client contact</span>
-    </legend>
+  {% call Fieldset({ legend: 'Client contact' }) %}
 
     {% if form.errors.messages['client_contacts'] %}
       <span class="c-form-group__error-message">{{ form.errors.messages['client_contacts'] }}</span>
@@ -164,7 +152,7 @@
         <button class="button button-secondary js-AddItems__add" type="submit" name="add-item" value="client_contacts" data-persist-values="true">Add another contact</button>
       </p>
     </div>
-  </fieldset>
+  {% endcall %}
 
 {% if not investmentData.id %}
   {{ MultipleChoiceField({

--- a/src/apps/investment-projects/views/_details-form.njk
+++ b/src/apps/investment-projects/views/_details-form.njk
@@ -90,11 +90,15 @@
     value: form.state['sector']
   }) }}
 
-  <fieldset class="c-form-fieldset">
+  <fieldset class="c-form-fieldset {{ 'has-error' if form.errors.messages['business_activities'] }}">
 
     <legend class="c-form-fieldset__legend">
       <span class="c-form-fieldset__legend-text">Business activities</span>
     </legend>
+
+    {% if form.errors.messages['business_activities'] %}
+      <span class="c-form-group__error-message">{{ form.errors.messages['business_activities'] }}</span>
+    {% endif %}
 
     <div class="js-AddItems"
       data-item-selector=".c-form-group"
@@ -127,7 +131,7 @@
   </fieldset>
 
   <fieldset
-    class="c-form-fieldset js-AddItems"
+    class="c-form-fieldset {{ 'has-error' if form.errors.messages['client_contacts'] }}"
     data-item-selector=".c-form-group"
     data-add-button-selector=".js-AddItems__add">
 
@@ -135,21 +139,31 @@
       <span class="c-form-fieldset__legend-text">Client contact</span>
     </legend>
 
-    {% for client_contact in form.state['client_contacts'] %}
-      {{ MultipleChoiceField({
-        name: 'client_contacts',
-        label: 'Client contact',
-        isLabelHidden: true,
-        initialOption: '-- Pick a contact --',
-        options: form.options.contacts,
-        value: client_contact
-      }) }}
-    {% endfor %}
+    {% if form.errors.messages['client_contacts'] %}
+      <span class="c-form-group__error-message">{{ form.errors.messages['client_contacts'] }}</span>
+    {% endif %}
+
+    <div class="js-AddItems"
+      data-item-selector=".c-form-group"
+      data-add-button-selector=".js-AddItems__add">
+
+      {% for client_contact in form.state['client_contacts'] %}
+        {{ MultipleChoiceField({
+          name: 'client_contacts',
+          label: 'Client contact',
+          isLabelHidden: true,
+          initialOption: '-- Pick a contact --',
+          options: form.options.contacts,
+          error: form.errors.messages['client_contacts'],
+          value: client_contact
+        }) }}
+      {% endfor %}
 
 
-    <p class="c-form-fieldset__add-another">
-      <button class="button button-secondary js-AddItems__add" type="submit" name="add-item" value="client_contacts" data-persist-values="true">Add another contact</button>
-    </p>
+      <p class="c-form-fieldset__add-another">
+        <button class="button button-secondary js-AddItems__add" type="submit" name="add-item" value="client_contacts" data-persist-values="true">Add another contact</button>
+      </p>
+    </div>
   </fieldset>
 
 {% if not investmentData.id %}

--- a/test/unit/apps/investment-projects/middleware/forms/details.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/details.test.js
@@ -1,0 +1,152 @@
+describe('investment details middleware', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.next = this.sandbox.stub()
+
+    this.updateInvestmentStub = this.sandbox.stub().resolves({ id: '999' })
+    this.createInvestmentStub = this.sandbox.stub().resolves({ id: '888' })
+
+    this.req = {
+      session: {
+        token: '1234',
+      },
+      body: {},
+      params: {},
+    }
+
+    this.res = {
+      locals: {
+        form: {},
+      },
+    }
+
+    this.detailsMiddleware = proxyquire('~/src/apps/investment-projects/middleware/forms/details', {
+      '../../repos': {
+        updateInvestment: this.updateInvestmentStub,
+        createInvestmentProject: this.createInvestmentStub,
+      },
+    })
+  })
+
+  describe('#handleFormPost', () => {
+    context('when saving a new investment project', () => {
+      beforeEach(async () => {
+        await this.detailsMiddleware.handleFormPost(this.req, this.res, this.next)
+      })
+
+      it('should create a new investment', () => {
+        expect(this.createInvestmentStub).to.be.calledOnce
+      })
+    })
+
+    context('when editing an existing investment project', () => {
+      beforeEach(async () => {
+        this.req.params.investmentId = '777'
+        await this.detailsMiddleware.handleFormPost(this.req, this.res, this.next)
+      })
+
+      it('should create a new investment', () => {
+        expect(this.updateInvestmentStub).to.be.calledOnce
+      })
+    })
+
+    context('when saving the form raises no errors', () => {
+      beforeEach(async () => {
+        await this.detailsMiddleware.handleFormPost(this.req, this.res, this.next)
+      })
+
+      it('should call next', () => {
+        expect(this.next).to.be.called
+      })
+    })
+
+    context('when saving form raises an error', () => {
+      beforeEach(async () => {
+        this.err = {
+          statusCode: 400,
+          error: {},
+        }
+
+        this.createInvestmentStub.rejects(this.err)
+      })
+
+      context('and a single contact and business activity are provided', () => {
+        beforeEach(async () => {
+          this.req.body = {
+            client_contacts: '1234',
+            business_activities: '4321',
+          }
+
+          await this.detailsMiddleware.handleFormPost(this.req, this.res, this.next)
+        })
+
+        it('should return contacts to the form as an array', () => {
+          expect(this.res.locals.form.state.client_contacts).to.deep.equal(['1234'])
+        })
+
+        it('should return activities to the form as an array', () => {
+          expect(this.res.locals.form.state.business_activities).to.deep.equal(['4321'])
+        })
+      })
+
+      context('and multiple contacts and business activities are provided', () => {
+        beforeEach(async () => {
+          this.req.body = {
+            client_contacts: ['1234', '5678'],
+            business_activities: ['4321', '8765'],
+          }
+
+          await this.detailsMiddleware.handleFormPost(this.req, this.res, this.next)
+        })
+
+        it('should return contacts to the form as an array', () => {
+          expect(this.res.locals.form.state.client_contacts).to.deep.equal(['1234', '5678'])
+        })
+
+        it('should return activities to the form as an array', () => {
+          expect(this.res.locals.form.state.business_activities).to.deep.equal(['4321', '8765'])
+        })
+      })
+    })
+
+    context('the user select add another contact', () => {
+      beforeEach(async () => {
+        this.req.body = {
+          client_contacts: ['1234', '5678'],
+          business_activities: ['4321', '8765'],
+          'add-item': 'client_contacts',
+        }
+
+        await this.detailsMiddleware.handleFormPost(this.req, this.res, this.next)
+      })
+
+      it('should not save the data', () => {
+        expect(this.updateInvestmentStub).to.not.be.called
+      })
+
+      it('should return a form state with an additional empty contact', () => {
+        expect(this.res.locals.form.state.client_contacts).to.deep.equal(['1234', '5678', ''])
+      })
+    })
+
+    context('the user select add another business activity', () => {
+      beforeEach(async () => {
+        this.req.body = {
+          client_contacts: ['1234', '5678'],
+          business_activities: ['4321', '8765'],
+          'add-item': 'business_activities',
+        }
+
+        await this.detailsMiddleware.handleFormPost(this.req, this.res, this.next)
+      })
+
+      it('should not save the data', () => {
+        expect(this.updateInvestmentStub).to.not.be.called
+      })
+
+      it('should return a form state with an additional empty contact', () => {
+        expect(this.res.locals.form.state.business_activities).to.deep.equal(['4321', '8765', ''])
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixed 2 errors:

1: Fixed repopulating the contact and business activity fields when saving an investment summary with errors. Added unit tests to confirm.
2: Fixed error not showing error messages for business activities and contacts when saving

![errors](https://user-images.githubusercontent.com/56056/31887763-7a657428-b7f1-11e7-96b6-0d5c2581a990.PNG)
