### PR TITLE
List service delivery events in alphabetical order

### DIFF
--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -6,7 +6,7 @@ const { fetchInteraction, saveInteraction } = require('../repos')
 const metaDataRepository = require('../../../lib/metadata')
 const { getContactsForCompany } = require('../../contacts/repos')
 const { getAllAdvisers } = require('../../adviser/repos')
-const { getAllEvents } = require('../../events/repos')
+const { search } = require('../../search/services')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -50,7 +50,17 @@ async function getInteractionOptions (req, res, next) {
     res.locals.advisers = await getAllAdvisers(req.session.token)
     res.locals.contacts = await getContactsForCompany(req.session.token, res.locals.company.id)
     res.locals.services = await metaDataRepository.getServices(req.session.token)
-    res.locals.events = await getAllEvents(req.session.token)
+
+    if (req.params.kind === 'service-delivery') {
+      res.locals.events = await search({
+        searchEntity: 'event',
+        requestBody: { sortby: 'name:asc' },
+        token: req.session.token,
+        limit: 100000,
+        isAggregation: false,
+      })
+    }
+
     next()
   } catch (err) {
     next(err)

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -42,8 +42,8 @@ describe('Interaction details middleware', () => {
       '../../contacts/repos': {
         getContactsForCompany: this.getContactsForCompanyStub.returns(contactsData),
       },
-      '../../events/repos': {
-        getAllEvents: this.getAllEventsStub.returns(eventsData),
+      '../../search/services': {
+        search: this.getAllEventsStub.returns(eventsData),
       },
     })
     this.req = {
@@ -176,9 +176,36 @@ describe('Interaction details middleware', () => {
   })
 
   describe('#getInteractionOptions', () => {
-    context('when success', () => {
+    context('when interaction', () => {
       beforeEach(async () => {
         await this.middleware.getInteractionOptions(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set contacts on locals', () => {
+        expect(this.res.locals.contacts).to.deep.equal(contactsData)
+      })
+
+      it('should set advisers on locals', () => {
+        expect(this.res.locals.advisers).to.deep.equal(advisersData)
+      })
+
+      it('should set services data on locals', async () => {
+        expect(this.res.locals.services).to.deep.equal(servicesData)
+      })
+
+      it('should not set events data on locals', async () => {
+        expect(this.res.locals.events).to.be.undefined
+      })
+    })
+
+    context('when service delivery', () => {
+      beforeEach(async () => {
+        const req = merge({}, this.req, {
+          params: {
+            kind: 'service-delivery',
+          },
+        })
+        await this.middleware.getInteractionOptions(req, this.res, this.nextSpy)
       })
 
       it('should set contacts on locals', () => {


### PR DESCRIPTION
All events are listed in a drop down when adding or editing a service delivery. This changes will ensure the list is in alphabetical order.

<img width="756" alt="screen shot 2017-10-23 at 14 20 33" src="https://user-images.githubusercontent.com/1150417/31891142-69236d44-b7fd-11e7-9781-3726235be3d2.png">
