### PR TITLE
Use subtotal cost in OMIS order views rather than net cost

### DIFF
--- a/src/apps/omis/apps/list/views/list-reconciliation.njk
+++ b/src/apps/omis/apps/list/views/list-reconciliation.njk
@@ -34,7 +34,7 @@
             </td>
             <td>{{ item.payment_due_date | formatDate('DD/MM/YYYY') }}</td>
             <td>{{ item.company }}</td>
-            <td align="right">{{ item.net_cost | formatCurrency }}</td>
+            <td align="right">{{ item.subtotal_cost | formatCurrency }}</td>
             <td align="right">{{ item.total_cost | formatCurrency }}</td>
           </tr>
         {% endfor %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -196,9 +196,13 @@
     {{ values.total_cost | formatCurrency }}
 
     {% if values.vat_cost > 0 %}
-      ({{ values.net_cost | formatCurrency }} excluding VAT)
+      ({{ values.subtotal_cost | formatCurrency }} excluding VAT)
     {% else %}
       (No VAT applies)
+    {% endif %}
+
+    {% if values.discount_value %}
+    (includes a net discount of {{ values.discount_value | formatCurrency }})
     {% endif %}
   {% endset %}
 

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash')
+const { assign, get } = require('lodash')
 
 const logger = require('../../../config/logger')
 const { getDitCompany } = require('../companies/repos')
@@ -20,13 +20,21 @@ async function getOrder (req, res, next, orderId) {
     const subscribers = await Order.getSubscribers(req.session.token, orderId)
     const assignees = await Order.getAssignees(req.session.token, orderId)
 
-    res.locals.order = Object.assign({}, order, {
+    res.locals.order = assign({}, order, {
       subscribers,
       assignees,
       isEditable: order.status === 'draft',
-      net_cost: parseInt(order.net_cost) / 100,
-      vat_cost: parseInt(order.vat_cost) / 100,
-      total_cost: parseInt(order.total_cost) / 100,
+    })
+
+    const currencyFields = [
+      'net_cost',
+      'discount_value',
+      'subtotal_cost',
+      'vat_cost',
+      'total_cost',
+    ]
+    currencyFields.forEach((field) => {
+      res.locals.order[field] = parseFloat(res.locals.order[field]) / 100
     })
   } catch (e) {
     logger.error(e)

--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -69,7 +69,7 @@ function transformOrderToTableItem ({
   status,
   payment_due_date,
   company,
-  net_cost,
+  subtotal_cost,
   total_cost,
 } = {}) {
   if (!id || !reference) { return }
@@ -80,7 +80,7 @@ function transformOrderToTableItem ({
     status,
     payment_due_date,
     company: get(company, 'name'),
-    net_cost: parseInt(net_cost) / 100,
+    subtotal_cost: parseInt(subtotal_cost) / 100,
     total_cost: parseInt(total_cost) / 100,
   }
 }

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -85,7 +85,7 @@ describe('OMIS list transformers', function () {
         expect(actual).to.have.property('id').a('string')
         expect(actual).to.have.property('reference').a('string')
         expect(actual).to.have.property('status').a('string')
-        expect(actual).to.have.property('net_cost').a('number')
+        expect(actual).to.have.property('subtotal_cost').a('number')
         expect(actual).to.have.property('total_cost').a('number')
         expect(actual).to.have.property('company').a('string')
       })


### PR DESCRIPTION
Net cost does not include any discounts from legacy orders so doesn't
reflect the correct ex VAT price as is being suggested.