### PR TITLE
Display full contact details

### DIFF
--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -2,6 +2,7 @@ const { merge, sumBy } = require('lodash')
 
 const { Order } = require('../../models')
 const logger = require('../../../../../config/logger')
+const { getContact } = require('../../../contacts/repos')
 
 async function renderWorkOrder (req, res) {
   const order = res.locals.order
@@ -10,8 +11,10 @@ async function renderWorkOrder (req, res) {
   try {
     const subscribers = await Order.getSubscribers(req.session.token, order.id)
     const assignees = await Order.getAssignees(req.session.token, order.id)
+    const contact = await getContact(req.session.token, order.contact.id)
 
     values = merge({}, order, {
+      contact,
       subscribers,
       assignees,
       estimatedTimeSum: sumBy(assignees, 'estimated_time'),

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -1,16 +1,28 @@
-const { sumBy } = require('lodash')
+const { merge, sumBy } = require('lodash')
 
-function renderWorkOrder (req, res) {
+const { Order } = require('../../models')
+const logger = require('../../../../../config/logger')
+
+async function renderWorkOrder (req, res) {
   const order = res.locals.order
+  let values
 
-  const values = Object.assign({}, order, {
-    estimatedTimeSum: sumBy(order.assignees, 'estimated_time'),
-  })
+  try {
+    const subscribers = await Order.getSubscribers(req.session.token, order.id)
+    const assignees = await Order.getAssignees(req.session.token, order.id)
 
-  res
-    .render('omis/apps/view/views/work-order', {
-      values,
+    values = merge({}, order, {
+      subscribers,
+      assignees,
+      estimatedTimeSum: sumBy(assignees, 'estimated_time'),
     })
+  } catch (e) {
+    logger.error(e)
+  }
+
+  res.render('omis/apps/view/views/work-order', {
+    values,
+  })
 }
 
 function renderQuote (req, res) {

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -3,8 +3,33 @@
 {% set companyLink %}
   <a href="/companies/{{ values.company.id }}">{{ values.company.name }}</a>
 {% endset %}
-{% set contactLink %}
+{% set contactText %}
   <a href="/contacts/{{ values.contact.id }}">{{ values.contact.name }}</a>
+
+  <br>
+
+  {% if values.contact_email %}
+    {{ values.contact_email }}
+  {% else %}
+    <a href="mailto:{{ values.contact.email }}">{{ values.contact.email }}</a>
+
+    {% if values.contact.email_alternative %}
+      or <a href="mailto:{{ values.contact.email_alternative }}">{{ values.contact.email_alternative }}</a>
+    {% endif %}
+  {% endif %}
+
+  <br>
+
+  {% if values.contact_phone %}
+    {{ values.contact_phone }}
+  {% else %}
+    ({{ values.contact.telephone_countrycode }})
+    {{ values.contact.telephone_number }}
+
+    {% if values.contact.telephone_alternative %}
+      or {{ values.contact.telephone_alternative }}
+    {% endif %}
+  {% endif %}
 {% endset %}
 
 {% block body_main_content %}
@@ -25,7 +50,7 @@
       value: companyLink
     }, {
       label: 'Contact',
-      value: contactLink
+      value: contactText
     }]
   }) }}
 

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -17,12 +17,8 @@ async function getCompany (req, res, next, companyId) {
 async function getOrder (req, res, next, orderId) {
   try {
     const order = await Order.getById(req.session.token, orderId)
-    const subscribers = await Order.getSubscribers(req.session.token, orderId)
-    const assignees = await Order.getAssignees(req.session.token, orderId)
 
     res.locals.order = assign({}, order, {
-      subscribers,
-      assignees,
       isEditable: order.status === 'draft',
     })
 

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -1,8 +1,34 @@
-const { renderWorkOrder, renderQuote } = require('~/src/apps/omis/apps/view/controllers')
+const subscriberData = require('~/test/unit/data/omis/subscribers.json')
+const assigneeData = require('~/test/unit/data/omis/assignees.json')
+
+const orderMock = {
+  id: '1230asd-123dasda',
+  contact: {
+    id: '123dasda-1230asd',
+  },
+  foo: 'bar',
+}
+const tokenMock = 'session-12345'
 
 describe('OMIS View controllers', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
+
+    this.getSubscribersStub = this.sandbox.stub().resolves(subscriberData)
+    this.getAssigneesStub = this.sandbox.stub().resolves(assigneeData)
+    this.loggerSpy = this.sandbox.spy()
+
+    this.controllers = proxyquire('~/src/apps/omis/apps/view/controllers', {
+      '../../../../../config/logger': {
+        error: this.loggerSpy,
+      },
+      '../../models': {
+        Order: {
+          getSubscribers: this.getSubscribersStub,
+          getAssignees: this.getAssigneesStub,
+        },
+      },
+    })
   })
 
   afterEach(() => {
@@ -18,41 +44,94 @@ describe('OMIS View controllers', () => {
         breadcrumb: this.breadcrumbSpy,
         render: this.renderSpy,
         locals: {
-          order: {
-            foo: 'bar',
-            assignees: [
-              { id: '1', estimated_time: 30 },
-              { id: '2', estimated_time: 60 },
-            ],
-          },
+          order: orderMock,
+        },
+      }
+      this.reqMock = {
+        session: {
+          token: tokenMock,
         },
       }
     })
 
-    it('should not set a breadcrumb option', () => {
-      renderWorkOrder({}, this.resMock)
+    it('should not set a breadcrumb option', async () => {
+      await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
 
       expect(this.breadcrumbSpy).not.to.have.been.called
     })
 
-    it('should render a template', () => {
-      renderWorkOrder({}, this.resMock)
+    it('should render a template', async () => {
+      await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
 
       expect(this.renderSpy).to.have.been.called
     })
 
-    it('should send expected data to view', () => {
-      renderWorkOrder({}, this.resMock)
+    context('when api calls resolve', () => {
+      beforeEach(async () => {
+        await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
+      })
 
-      expect(this.renderSpy).to.have.been.calledWith('omis/apps/view/views/work-order', {
-        values: {
-          foo: 'bar',
-          assignees: [
-            { id: '1', estimated_time: 30 },
-            { id: '2', estimated_time: 60 },
-          ],
-          estimatedTimeSum: 90,
-        },
+      it('should get subscribers with correct args', () => {
+        expect(this.getSubscribersStub).to.have.been.calledWith(tokenMock, orderMock.id)
+      })
+
+      it('should get assignees with correct args', () => {
+        expect(this.getAssigneesStub).to.have.been.calledWith(tokenMock, orderMock.id)
+      })
+
+      it('should call correct template', () => {
+        expect(this.renderSpy.args[0][0]).to.equal('omis/apps/view/views/work-order')
+      })
+
+      it('should send correct properties to view', () => {
+        const values = this.renderSpy.args[0][1].values
+
+        expect(values).to.have.property('id')
+        expect(values).to.have.property('contact')
+        expect(values).to.have.property('foo')
+        expect(values).to.have.property('subscribers')
+        expect(values).to.have.property('assignees')
+        expect(values).to.have.property('estimatedTimeSum')
+      })
+
+      it('should send correct subscribers', () => {
+        const values = this.renderSpy.args[0][1].values
+
+        expect(values.subscribers).to.be.an('array').to.have.length(2)
+      })
+
+      it('should send correct assignees', () => {
+        const values = this.renderSpy.args[0][1].values
+
+        expect(values.assignees).to.be.an('array').to.have.length(2)
+      })
+
+      it('should estimate sum correctly', () => {
+        const values = this.renderSpy.args[0][1].values
+
+        expect(values.estimatedTimeSum).to.be.a('number').to.equal(450)
+      })
+    })
+
+    context('when api calls reject', () => {
+      beforeEach(async () => {
+        this.error = {
+          statusCode: 500,
+        }
+        this.getSubscribersStub.rejects(this.error)
+
+        await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
+      })
+
+      it('values should not be defined', () => {
+        expect(this.renderSpy).to.have.been.calledWith('omis/apps/view/views/work-order', {
+          values: undefined,
+        })
+      })
+
+      it('should log the error', () => {
+        expect(this.loggerSpy).to.have.been.calledWith(this.error)
+        expect(this.loggerSpy).to.have.been.calledOnce
       })
     })
   })
@@ -69,13 +148,13 @@ describe('OMIS View controllers', () => {
     })
 
     it('should set a breadcrumb option', () => {
-      renderQuote({}, this.resMock)
+      this.controllers.renderQuote({}, this.resMock)
 
       expect(this.breadcrumbSpy).to.have.been.called
     })
 
     it('should render a template', () => {
-      renderQuote({}, this.resMock)
+      this.controllers.renderQuote({}, this.resMock)
 
       expect(this.renderSpy).to.have.been.called
     })

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -1,5 +1,6 @@
 const subscriberData = require('~/test/unit/data/omis/subscribers.json')
 const assigneeData = require('~/test/unit/data/omis/assignees.json')
+const contactData = require('~/test/unit/data/simple-contact')
 
 const orderMock = {
   id: '1230asd-123dasda',
@@ -16,6 +17,7 @@ describe('OMIS View controllers', () => {
 
     this.getSubscribersStub = this.sandbox.stub().resolves(subscriberData)
     this.getAssigneesStub = this.sandbox.stub().resolves(assigneeData)
+    this.getContactStub = this.sandbox.stub().resolves(contactData)
     this.loggerSpy = this.sandbox.spy()
 
     this.controllers = proxyquire('~/src/apps/omis/apps/view/controllers', {
@@ -27,6 +29,9 @@ describe('OMIS View controllers', () => {
           getSubscribers: this.getSubscribersStub,
           getAssignees: this.getAssigneesStub,
         },
+      },
+      '../../../contacts/repos': {
+        getContact: this.getContactStub,
       },
     })
   })
@@ -79,6 +84,10 @@ describe('OMIS View controllers', () => {
         expect(this.getAssigneesStub).to.have.been.calledWith(tokenMock, orderMock.id)
       })
 
+      it('should get contact with correct args', () => {
+        expect(this.getContactStub).to.have.been.calledWith(tokenMock, orderMock.contact.id)
+      })
+
       it('should call correct template', () => {
         expect(this.renderSpy.args[0][0]).to.equal('omis/apps/view/views/work-order')
       })
@@ -104,6 +113,12 @@ describe('OMIS View controllers', () => {
         const values = this.renderSpy.args[0][1].values
 
         expect(values.assignees).to.be.an('array').to.have.length(2)
+      })
+
+      it('should merge short contact with full contact', () => {
+        const values = this.renderSpy.args[0][1].values
+
+        expect(values.contact).to.be.an('object').to.deep.equal(contactData)
       })
 
       it('should estimate sum correctly', () => {

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -1,7 +1,5 @@
 const companyData = require('~/test/unit/data/company.json')
 const orderData = require('~/test/unit/data/omis/simple-order.json')
-const subscriberData = require('~/test/unit/data/omis/subscribers.json')
-const assigneeData = require('~/test/unit/data/omis/assignees.json')
 
 describe('OMIS middleware', () => {
   beforeEach(() => {
@@ -11,8 +9,6 @@ describe('OMIS middleware', () => {
     this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
     this.getDitCompanyStub = this.sandbox.stub()
     this.getByIdStub = this.sandbox.stub()
-    this.getSubscribersStub = this.sandbox.stub()
-    this.getAssigneesStub = this.sandbox.stub()
     this.loggerSpy = this.sandbox.spy()
     this.nextSpy = this.sandbox.spy()
 
@@ -38,8 +34,6 @@ describe('OMIS middleware', () => {
       './models': {
         Order: {
           getById: this.getByIdStub,
-          getSubscribers: this.getSubscribersStub,
-          getAssignees: this.getAssigneesStub,
         },
       },
     })
@@ -109,24 +103,18 @@ describe('OMIS middleware', () => {
     context('when model methods resolve', () => {
       beforeEach(() => {
         this.getByIdStub.resolves(orderData)
-        this.getSubscribersStub.resolves(subscriberData)
-        this.getAssigneesStub.resolves(assigneeData)
       })
 
       it('should call model methods with correct arguments', async () => {
         await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
         expect(this.getByIdStub).to.have.been.calledWith(this.reqMock.session.token, this.orderId)
-        expect(this.getSubscribersStub).to.have.been.calledWith(this.reqMock.session.token, this.orderId)
-        expect(this.getAssigneesStub).to.have.been.calledWith(this.reqMock.session.token, this.orderId)
       })
 
       it('should set a order property on locals', async () => {
         await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
         const order = Object.assign({}, orderData, {
-          subscribers: subscriberData,
-          assignees: assigneeData,
           isEditable: true,
         })
         expect(this.resMock.locals).to.have.property('order')


### PR DESCRIPTION
This handles 2 things:

- Adding the display of `contact_phone` and `contact_email` for legacy orders
- Bringing through contact information for company/contact of order

## Before

![image](https://user-images.githubusercontent.com/3327997/31905002-aea13906-b824-11e7-99b4-8081614505b4.png)

## After

![image](https://user-images.githubusercontent.com/3327997/31904950-812d4e9c-b824-11e7-928f-0e2645b93347.png)
