### PR TITLE
Add a listing for orders for a specific company

### DIFF
--- a/src/apps/companies/controllers/orders.js
+++ b/src/apps/companies/controllers/orders.js
@@ -1,0 +1,38 @@
+const { search } = require('../../search/services')
+const { transformApiResponseToCollection } = require('../../transformers')
+const { transformOrderToListItem } = require('../../omis/transformers')
+
+async function renderOrders (req, res, next) {
+  const token = req.session.token
+  const page = req.query.page || 1
+  const { id, name } = res.locals.company
+
+  try {
+    const results = await search({
+      token,
+      page,
+      searchEntity: 'order',
+      requestBody: {
+        company: id,
+      },
+      isAggregation: false,
+    })
+      .then(transformApiResponseToCollection(
+        { query: req.query },
+        transformOrderToListItem,
+      ))
+
+    res
+      .breadcrumb(name, `/companies/${id}`)
+      .breadcrumb('Orders (OMIS)')
+      .render('companies/views/orders', {
+        results,
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderOrders,
+}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -5,6 +5,7 @@ const { renderCompanyList } = require('./controllers/list')
 const { renderForm } = require('./controllers/edit')
 const { renderDetails } = require('./controllers/view')
 const { renderInvestments } = require('./controllers/investments')
+const { renderOrders } = require('./controllers/orders')
 const { renderAuditLog } = require('./controllers/audit')
 const { renderInteractions } = require('./controllers/interactions')
 const { renderCompaniesHouseCompany } = require('./controllers/companies-house')
@@ -32,6 +33,7 @@ const LOCAL_NAV = [
   { path: 'interactions', label: 'Interactions' },
   { path: 'exports', label: 'Export' },
   { path: 'investments', label: 'Investment' },
+  { path: 'orders', label: 'Orders (OMIS)' },
   { path: 'audit', label: 'Audit history' },
 ]
 const DEFAULT_COLLECTION_QUERY = {
@@ -78,6 +80,7 @@ router.get('/:companyId/contacts', renderContacts)
 router.get('/:companyId/interactions', setInteractionsReturnUrl, getInteractionCollection, renderInteractions)
 router.get('/:companyId/exports', renderExports)
 router.get('/:companyId/investments', renderInvestments)
+router.get('/:companyId/orders', renderOrders)
 router.get('/:companyId/audit', renderAuditLog)
 
 router.use('/:companyId', setInteractionsReturnUrl, setInteractionsEntityName, interactionsRouter)

--- a/src/apps/companies/views/orders.njk
+++ b/src/apps/companies/views/orders.njk
@@ -1,0 +1,18 @@
+{% extends "./_layout-view.njk" %}
+
+{% set addButton %}
+  <a class="button button-secondary" href="/omis/create/{{ company.id }}">Add order</a>
+{% endset %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Orders (OMIS)</h2>
+
+  {{
+    Collection(results | assignCopy({
+      sort: sort,
+      countLabel: 'order',
+      query: QUERY,
+      summaryActionsHTML: addButton
+    }))
+  }}
+{% endblock %}

--- a/test/unit/apps/companies/controllers/orders.test.js
+++ b/test/unit/apps/companies/controllers/orders.test.js
@@ -1,0 +1,125 @@
+const ordersMock = require('~/test/unit/data/omis/collection.json')
+const companyMock = require('~/test/unit/data/company.json')
+const tokenMock = '12345abcde'
+
+describe('Company investments controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+
+    this.searchStub = this.sandbox.stub()
+    this.transformOrderToListItemSpy = this.sandbox.spy()
+    this.transformApiResponseToCollectionSpy = this.sandbox.spy()
+    this.breadcrumbStub = this.sandbox.stub().returnsThis()
+    this.renderSpy = this.sandbox.spy()
+    this.nextSpy = this.sandbox.spy()
+
+    this.controller = proxyquire('~/src/apps/companies/controllers/orders', {
+      '../../search/services': {
+        search: this.searchStub,
+      },
+      '../../omis/transformers': {
+        transformOrderToListItem: this.transformOrderToListItemSpy,
+      },
+      '../../transformers': {
+        transformApiResponseToCollection: this.transformApiResponseToCollectionSpy,
+      },
+    })
+
+    this.reqMock = {
+      query: {},
+      session: {
+        token: tokenMock,
+      },
+    }
+    this.resMock = {
+      breadcrumb: this.breadcrumbStub,
+      render: this.renderSpy,
+      locals: {
+        company: companyMock,
+      },
+    }
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  context('when investments returns successfully', () => {
+    beforeEach(() => {
+      this.searchStub.resolves(ordersMock.results)
+    })
+
+    context('with default page number', () => {
+      beforeEach(async () => {
+        await this.controller.renderOrders(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call search with correct arguments', () => {
+        expect(this.searchStub).to.have.been.calledWith({
+          isAggregation: false,
+          page: 1,
+          requestBody: {
+            company: companyMock.id,
+          },
+          searchEntity: 'order',
+          token: tokenMock,
+        })
+      })
+
+      it('should call list item transformer', () => {
+        expect(this.transformApiResponseToCollectionSpy).to.have.been.calledOnce
+      })
+
+      it('should set the correct number of breadcrumbs', () => {
+        expect(this.breadcrumbStub).to.have.been.calledTwice
+      })
+
+      it('should render the correct template', () => {
+        expect(this.renderSpy.args[0][0]).to.equal('companies/views/orders')
+        expect(this.renderSpy).to.have.been.calledOnce
+      })
+
+      it('should send the correct template data', () => {
+        expect(this.renderSpy.args[0][1]).to.deep.equal({
+          results: ordersMock.results,
+        })
+      })
+    })
+
+    context('when a custom page number', () => {
+      beforeEach(async () => {
+        this.reqMock.query.page = 2
+
+        await this.controller.renderOrders(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call with custom page number', () => {
+        expect(this.searchStub).to.have.been.calledWith({
+          isAggregation: false,
+          page: 2,
+          requestBody: {
+            company: companyMock.id,
+          },
+          searchEntity: 'order',
+          token: tokenMock,
+        })
+      })
+    })
+  })
+
+  context('when search rejects', () => {
+    beforeEach(async () => {
+      this.errorMock = {
+        errorCode: 500,
+      }
+      this.searchStub.rejects(this.errorMock)
+
+      await this.controller.renderOrders(this.reqMock, this.resMock, this.nextSpy)
+    })
+
+    it('should call next with error', () => {
+      expect(this.nextSpy).to.have.been.calledWith(this.errorMock)
+      expect(this.nextSpy).to.have.been.calledOnce
+    })
+  })
+})


### PR DESCRIPTION
This change adds the listing of orders filtered by company id
and also adds a place to begin a new order for this company.

## What it looks like

![localhost_3001_companies_dcdabbc9-1781-e411-8955-e4115bead28a_orders](https://user-images.githubusercontent.com/3327997/31906174-541e64be-b828-11e7-9c7b-3e3dff931fd9.png)
