### PR TITLE
Move non-editable order fields to shared header

### DIFF
--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -58,6 +58,7 @@
 
   @include media(tablet) {
     display: inline-block;
+    vertical-align: top;
 
     & + & {
       margin-left: $default-spacing-unit * 2;

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -17,15 +17,27 @@
     modifier: 'light-banner'
   }) %}
     {% set status = order.status | sentenceCase %}
+    {% set companyText %}
+      <a href="/companies/{{ order.company.id }}">{{ order.company.name }}</a>
+    {% endset %}
     {% set quoteStatusSuffix %}
+      <br>
       (expire{{ 'd' if quote.expired else 's' }} {{ FromNow({ datetime: quote.expires_on }) }})
     {% endset %}
 
     {{ MetaList({
       items: [
-        { 'label': 'Created on', 'value': order.created_on | formatDateTime },
-        { 'label': 'Updated on', 'value': order.updated_on | formatDateTime },
-        { 'label': 'Status', 'value': status + (quoteStatusSuffix if order.status === 'quote_awaiting_acceptance'), 'safe': true }
+      { label: 'Client company', value: companyText | safe },
+      { label: 'Market (country)', value: order.primary_market }
+      ],
+      itemModifier: 'stacked'
+    }) }}
+
+    {{ MetaList({
+      items: [
+        { label: 'Created on', value: order.created_on, type: 'datetime' },
+        { label: 'Updated on', value: order.modified_on, type: 'datetime' },
+        { label: 'Status', value: status + (quoteStatusSuffix if order.status === 'quote_awaiting_acceptance'), safe: true }
       ],
       itemModifier: 'stacked'
     }) }}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -3,11 +3,12 @@
 {% set companyLink %}
   <a href="/companies/{{ values.company.id }}">{{ values.company.name }}</a>
 {% endset %}
-{% set contactText %}
+
+{% set contactName %}
   <a href="/contacts/{{ values.contact.id }}">{{ values.contact.name }}</a>
+{% endset %}
 
-  <br>
-
+{% set contactEmail %}
   {% if values.contact_email %}
     {{ values.contact_email }}
   {% else %}
@@ -17,9 +18,9 @@
       or <a href="mailto:{{ values.contact.email_alternative }}">{{ values.contact.email_alternative }}</a>
     {% endif %}
   {% endif %}
+{% endset %}
 
-  <br>
-
+{% set contactPhone %}
   {% if values.contact_phone %}
     {{ values.contact_phone }}
   {% else %}
@@ -41,27 +42,20 @@
   {% endif %}
 
   {{ AnswersSummary({
-    heading: 'Client details',
+    heading: 'Client contact details',
     actions: [{
       url: 'edit/client-details' if order.isEditable
     }],
     items: [{
-      label: 'Company',
-      value: companyLink
+      label: 'Name',
+      value: contactName
     }, {
-      label: 'Contact',
-      value: contactText
+      label: 'Phone',
+      value: contactPhone
+    }, {
+      label: 'Email',
+      value: contactEmail
     }]
-  }) }}
-
-  {{ AnswersSummary({
-    heading: 'Market (country)',
-    items: [values.primary_market.name]
-  }) }}
-
-  {{ Message({
-    type: 'muted',
-    text: 'The market cannot be changed. If you have chosen the wrong market you’ll have to cancel the order and create a new one.'
   }) }}
 
   {% call AnswersSummary({

--- a/src/templates/_macros/common/answers-summary.njk
+++ b/src/templates/_macros/common/answers-summary.njk
@@ -35,7 +35,7 @@
       {% else %}
         <tbody>
           {% for item in props.items %}
-            {% if item | isString %}
+            {% if not item | isPlainObject %}
               <tr>
                 <td class="c-answers-summary__content" colspan="2">{{ item }}</td>
               </tr>


### PR DESCRIPTION
The client and market cannot be changed after an order has been created
so they can be moved to a more static place and avoid having editable
and non-editable data in the work order.

## Before

![localhost_3001_omis_80078f16-b5a5-4348-8534-a681f3c923f8_work-order](https://user-images.githubusercontent.com/3327997/31909527-550cb6e6-b832-11e7-9f80-aebec218c157.png)

## After

![localhost_3001_omis_80078f16-b5a5-4348-8534-a681f3c923f8_work-order 1](https://user-images.githubusercontent.com/3327997/31909556-68284df8-b832-11e7-8e27-0eb5ee9ded3b.png)
