### PR TITLE
Add project status

### DIFF
--- a/src/apps/investment-projects/controllers/status.js
+++ b/src/apps/investment-projects/controllers/status.js
@@ -1,0 +1,41 @@
+const { assign } = require('lodash')
+
+const { buildFormWithStateAndErrors } = require('../../builders')
+const { statusFormConfig } = require('../macros')
+const { updateInvestment } = require('../repos')
+
+function renderStatusPage (req, res, next) {
+  const status = req.body.status || res.locals.investmentData.status
+
+  const statusForm = assign(
+    buildFormWithStateAndErrors(statusFormConfig, { status }, res.locals.errors),
+    { returnLink: `/investment-projects/${res.locals.investmentData.id}/details` },
+  )
+
+  res
+    .breadcrumb('Change project status')
+    .render('investment-projects/views/status', { statusForm })
+}
+
+async function postStatus (req, res, next) {
+  try {
+    await updateInvestment(req.session.token, req.params.investmentId, {
+      status: req.body.status,
+    })
+
+    req.flash('success', 'Investment details updated')
+
+    return res.redirect(`/investment-projects/${res.locals.investmentData.id}/details`)
+  } catch (error) {
+    if (error.statusCode === 400) {
+      res.locals.errors = error.error
+      return next()
+    }
+    next(error)
+  }
+}
+
+module.exports = {
+  renderStatusPage,
+  postStatus,
+}

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -154,8 +154,26 @@ const requirementsFormConfig = {
   ],
 }
 
+const statusFormConfig = {
+  buttonText: 'Save',
+  children: [{
+    macroName: 'MultipleChoiceField',
+    type: 'radio',
+    name: 'status',
+    label: 'Status',
+    isLabelHidden: true,
+    options: [
+      { label: 'Ongoing', value: 'ongoing' },
+      { label: 'Delayed', value: 'delayed' },
+      { label: 'Abandoned', value: 'abandoned' },
+      { label: 'Lost', value: 'lost' },
+    ],
+  }],
+}
+
 module.exports = {
   investmentFiltersFields,
   investmentSortForm,
   requirementsFormConfig,
+  statusFormConfig,
 }

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash')
+const { get, upperFirst } = require('lodash')
 
 const metadata = require('../../../lib/metadata')
 const { isValidGuid } = require('../../../lib/controller-utils')
@@ -51,6 +51,12 @@ async function getInvestmentDetails (req, res, next) {
     res.locals.investmentStatus = {
       id: investmentData.id,
       meta: [
+        {
+          label: 'Status',
+          value: upperFirst(investmentData.status),
+          url: `/investment-projects/${investmentData.id}/status`,
+          urlLabel: 'change',
+        },
         {
           label: 'Project code',
           value: investmentData.project_code,

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -34,6 +34,11 @@ const { renderInteractionList } = require('./controllers/interactions')
 const { getInvestmentProjectsCollection, getRequestBody } = require('./middleware/collection')
 const { setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails } = require('./middleware/interactions')
 
+const {
+  renderStatusPage,
+  postStatus,
+} = require('./controllers/status')
+
 const interactionsRouter = require('../interactions/router.sub-app')
 
 const LOCAL_NAV = [
@@ -166,5 +171,10 @@ router.get('/:investmentId/evaluation', evaluation.renderEvaluationPage)
 router.post('/:investmentId/change-project-stage', projectStageFormMiddleware.handleFormPost)
 
 router.use('/:investmentId', setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails, interactionsRouter)
+
+router
+  .route('/:investmentId/status')
+  .post(postStatus, renderStatusPage)
+  .get(renderStatusPage)
 
 module.exports = router

--- a/src/apps/investment-projects/views/status.njk
+++ b/src/apps/investment-projects/views/status.njk
@@ -1,0 +1,5 @@
+{% extends "_layouts/datahub-base.njk" %}
+
+{% block body_main_content %}
+  {{ Form(statusForm) }}
+{% endblock %}

--- a/src/templates/_macros/entity/meta-item.njk
+++ b/src/templates/_macros/entity/meta-item.njk
@@ -9,6 +9,7 @@
  # @param {string} props.data.name - API data label
  # @param {string} [props.type] - value type (e.g. 'date' to format dates)
  # @param {string} [props.url] - link URL
+ # @param {string} [props.urlLabel] - If the link should be shown next to the data, what text should the url show
  # @param {string} [props.isSelected] - whether the anchor should be have 'is-selected' state
  # @param {string} [props.isInert] - whether the value should be inert even if it has URL
  # @param {string} [props.isLabelHidden=false] - whether the label should be visually hidden
@@ -44,7 +45,7 @@
           {{ props.label }}
         </span>
       {% endif %}
-      {% if props.url and not props.isInert %}
+      {% if props.url and not props.isInert and not props.urlLabel %}
         <a
           class="js-xhr {{ itemValueClass }} {{ 'is-selected' if props.isSelected }}"
           href="{{ props.url }}"
@@ -52,7 +53,12 @@
           {{- safeValue -}}
         </a>
       {% else %}
-        <span class="{{ itemValueClass }}">{{ safeValue }}</span>
+        <span class="{{ itemValueClass }}">
+          {{ safeValue }}
+          {% if props.url and props.urlLabel %}
+            - <a href="{{ props.url }}">{{ props.urlLabel }}</a>
+          {% endif %}
+        </span>
       {% endif %}
     </div>
   {% endif %}

--- a/test/unit/apps/investment-projects/controllers/status.test.js
+++ b/test/unit/apps/investment-projects/controllers/status.test.js
@@ -1,0 +1,190 @@
+const { merge, find } = require('lodash')
+
+describe('investment status controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.updateInvestmentStub = this.sandbox.stub().resolves()
+
+    this.controller = proxyquire('~/src/apps/investment-projects/controllers/status', {
+      '../repos': {
+        updateInvestment: this.updateInvestmentStub,
+      },
+    })
+
+    this.req = {
+      session: {
+        token: 'abcd',
+      },
+      body: {},
+      params: {
+        investmentId: '111',
+      },
+      flash: this.sandbox.spy(),
+    }
+
+    this.res = {
+      breadcrumb: this.sandbox.stub().returnsThis(),
+      title: this.sandbox.stub().returnsThis(),
+      render: this.sandbox.spy(),
+      redirect: this.sandbox.spy(),
+      locals: {
+        investmentData: {
+          id: '111',
+          status: 'open',
+        },
+      },
+    }
+
+    this.next = this.sandbox.spy()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#renderStatusPage', () => {
+    context('when rendering a form for first time', () => {
+      beforeEach(async () => {
+        this.status = 'open'
+        this.res.locals.investmentData.status = this.status
+        await this.controller.renderStatusPage(this.req, this.res, this.next)
+      })
+
+      it('should render the status page', () => {
+        expect(this.res.render).to.be.calledWith('investment-projects/views/status')
+      })
+
+      it('should render the status page with a return link', async () => {
+        const actual = this.res.render.getCall(0).args[1].statusForm.returnLink
+
+        expect(actual).to.equal('/investment-projects/111/details')
+      })
+
+      it('should render the status page with a status form', () => {
+        const actual = this.res.render.getCall(0).args[1].statusForm.children
+        expect(actual).to.be.an('array')
+      })
+
+      it('should rnder the status page form with the existing status', () => {
+        const statusForm = this.res.render.getCall(0).args[1].statusForm
+        const actualStatus = find(statusForm.children, { name: 'status' }).value
+
+        expect(actualStatus).to.equal(this.status)
+      })
+    })
+
+    context('when re-rendering a form with errors', () => {
+      beforeEach(async () => {
+        this.status = 'bad'
+
+        this.messages = {
+          status: 'error 1',
+        }
+
+        this.res = merge({}, this.res, {
+          locals: {
+            errors: this.messages,
+          },
+        })
+
+        this.req = merge({}, this.req, {
+          body: {
+            status: this.status,
+          },
+        })
+
+        await this.controller.renderStatusPage(this.req, this.res, this.next)
+      })
+
+      it('should render the status page', () => {
+        expect(this.res.render).to.be.calledWith('investment-projects/views/status')
+      })
+
+      it('should render the status page with a return link', async () => {
+        const actual = this.res.render.getCall(0).args[1].statusForm.returnLink
+
+        expect(actual).to.equal('/investment-projects/111/details')
+      })
+
+      it('should render the status page with a status form', () => {
+        const actual = this.res.render.getCall(0).args[1].statusForm.children
+        expect(actual).to.be.an('array')
+      })
+
+      it('should render the status page form with posted status', () => {
+        const statusForm = this.res.render.getCall(0).args[1].statusForm
+        const actualStatus = find(statusForm.children, { name: 'status' }).value
+
+        expect(actualStatus).to.equal(this.status)
+      })
+
+      it('should indicate there is an error for status', () => {
+        const statusForm = this.res.render.getCall(0).args[1].statusForm
+        const actualStatusError = find(statusForm.children, { name: 'status' }).error
+
+        expect(actualStatusError).to.equal(this.messages.status)
+      })
+    })
+  })
+
+  describe('#postStatus', () => {
+    beforeEach(() => {
+      this.req.body = {
+        status: 'test',
+      }
+    })
+
+    context('when a post is good', () => {
+      beforeEach(async () => {
+        await this.controller.postStatus(this.req, this.res, this.next)
+      })
+
+      it('should save the data to the API', () => {
+        expect(this.updateInvestmentStub).to.be.calledWith(this.req.session.token, this.req.params.investmentId, { status: 'test' })
+      })
+
+      it('should send a flash message with an update', () => {
+        expect(this.req.flash).to.be.calledWith('success', 'Investment details updated')
+      })
+
+      it('should redirect the user back to the details screen', () => {
+        expect(this.res.redirect).to.be.calledWith('/investment-projects/111/details')
+      })
+    })
+
+    context('when a post causes form errors', () => {
+      beforeEach(async () => {
+        this.error = this.sandbox.stub()
+
+        this.updateInvestmentStub.rejects({
+          statusCode: 400,
+          error: this.error,
+        })
+
+        await this.controller.postStatus(this.req, this.res, this.next)
+      })
+
+      it('should set the local errors value', () => {
+        expect(this.res.locals.errors).to.deep.equal(this.error)
+      })
+
+      it('should call the next link the chain', () => {
+        expect(this.next).to.be.calledWith()
+      })
+    })
+
+    context('when a post causes an unknown error', () => {
+      beforeEach(async () => {
+        this.error = this.sandbox.stub()
+
+        this.updateInvestmentStub.rejects(this.error)
+
+        await this.controller.postStatus(this.req, this.res, this.next)
+      })
+
+      it('should call the next link the chain with the error', () => {
+        expect(this.next).to.be.calledWith(this.error)
+      })
+    })
+  })
+})

--- a/test/unit/macros/entity/meta-list.test.js
+++ b/test/unit/macros/entity/meta-list.test.js
@@ -60,7 +60,7 @@ describe('MetaList macro', () => {
           }],
       })
 
-      expect(component.querySelector('.c-meta-list__item-value').textContent).to.equal('26 July 2017')
+      expect(component.querySelector('.c-meta-list__item-value').textContent).to.contain('26 July 2017')
     })
 
     it('should not render item formatted as date if it has no value', () => {
@@ -78,7 +78,7 @@ describe('MetaList macro', () => {
           }],
       })
 
-      expect(component.querySelector('.c-meta-list__item-value').textContent).to.equal('26 July 2017')
+      expect(component.querySelector('.c-meta-list__item-value').textContent).to.contain('26 July 2017')
       expect(component.querySelectorAll('.c-meta-list__item')).to.have.length(1)
       expect(component.textContent).not.to.contain('Expiry date')
     })


### PR DESCRIPTION
Add a status indicator for an investment project to the investment project layout, and allow the user to change the status.

As part of the change introduced a new tabular style for metadata and support in meta-list items to have a link separate from the value.

![metalistitems](https://user-images.githubusercontent.com/56056/31945105-189249d0-b8c6-11e7-85bc-f0d0119e55d9.PNG)

![status](https://user-images.githubusercontent.com/56056/31944864-67026cea-b8c5-11e7-8973-f3caa567a6e7.gif)
