### PR TITLE
Fix/company issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/uktrade/data-hub-frontend"
   },
   "dependencies": {
-    "asyncro": "^2.0.1",
     "autoprefixer": "^7.1.1",
     "axios": "^0.16.2",
     "babel-core": "^6.23.1",

--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -1,4 +1,3 @@
-const { map } = require('asyncro')
 const { assign } = require('lodash')
 const queryString = require('query-string')
 
@@ -92,11 +91,10 @@ async function getAddStepTwo (req, res, next) {
       token,
       searchTerm,
     })
-      .then(response => response.results.filter(x => x.company_number))
-      .then(async (results) => {
+      .then(async (response) => {
         // TODO: Remove the need to make another call to the API to get the companies house details.
         // The search API should return companies house companies and their relevant information
-        return map(results, async (result) => {
+        return Promise.all(response.results.map(async (result) => {
           try {
             result.companies_house_data = await getCHCompany(token, result.company_number)
             result.url = `/companies/add/${result.company_number}`
@@ -104,7 +102,7 @@ async function getAddStepTwo (req, res, next) {
             logger.error(error)
           }
           return result
-        })
+        }))
       })
       .then((results) => {
         return {

--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -61,7 +61,7 @@ function populateForm (req, res, next) {
     turnoverOptions: metadataRepository.turnoverOptions.map(transformObjectToOption),
     countryOptions: metadataRepository.countryOptions.map(transformObjectToOption),
     businessType: req.query.business_type || get(res.locals, 'company.business_type.name'),
-    showTradingAddress: get(res.locals, 'form.state.trading_address_country'),
+    showTradingAddress: get(res.locals, 'form.state.trading_address_1'),
   })
 
   next()

--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -9,6 +9,7 @@ const { transformObjectToOption } = require('../../transformers')
 const chDetailsDisplayOrder = ['name', 'company_number', 'registered_address', 'business_type', 'company_status', 'incorporation_date', 'sic_code']
 
 function populateForm (req, res, next) {
+  const countryQueryParam = get(req.query, 'country')
   const headquarterOptions = metadataRepository.headquarterOptions
     .map(transformObjectToOption)
     .map(option => {
@@ -33,6 +34,15 @@ function populateForm (req, res, next) {
     })
 
     res.locals.form.state.business_type = get(businessType, 'id')
+  }
+
+  if (countryQueryParam && countryQueryParam === 'uk') {
+    const ukCountryOption = find(metadataRepository.countryOptions.map(transformObjectToOption), (option) => {
+      return option.label === 'United Kingdom'
+    })
+
+    res.locals.form.state.registered_address_country = ukCountryOption.value
+    res.locals.form.state.trading_address_country = ukCountryOption.value
   }
 
   res.locals.formData = assign({}, res.locals.form.state, req.body)

--- a/src/apps/companies/transformers.js
+++ b/src/apps/companies/transformers.js
@@ -130,6 +130,7 @@ function transformCompanyResponseToForm (body) {
     return get(body, `${key}.id`)
   })
 
+  // TODO we need to create an "other" business_type on DH to place any Companies House company_category that do not match DH business_type
   if (body.company_category) {
     const businessType = find(metadataRepository.businessTypeOptions, (type) => {
       return type.name.toLowerCase() === body.company_category.toLowerCase()

--- a/src/apps/companies/transformers.js
+++ b/src/apps/companies/transformers.js
@@ -9,6 +9,7 @@ function transformCompanyToListItem ({
   sector,
   uk_based,
   uk_region,
+  trading_name,
   trading_address_country,
   trading_address_county,
   trading_address_town,
@@ -66,13 +67,14 @@ function transformCompanyToListItem ({
   }
 
   const url = companies_house_data ? `/companies/view/ch/${companies_house_data.company_number}` : `/companies/${id}`
+  const displayName = trading_name || name
 
   return {
-    type: 'company',
     id,
-    name,
     url,
     meta,
+    type: 'company',
+    name: displayName,
   }
 }
 

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -6,11 +6,11 @@
 
 {% block main_grid_right_column %}
   <div class="section">
-    <div class="for-control key-value key-value--vertical">
-      <div id="business-type" class="key-value__key form-label-bold">
-        Business type
-      </div>
-      <div class="key-value__value" aria-labelledby="business-type">
+    <div class="c-form-group">
+      <h3 class="c-form-group__label">
+        <span class="c-form-group__label-text">Business type</span>
+      </h3>
+      <div>
         {{ 'Foreign' if isForeign else 'UK' }}
         {{ 'limited company' if isCompaniesHouse else businessType or '(type of organisation not known)' }}
 

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -6,17 +6,16 @@
 
 {% block main_grid_right_column %}
   <div class="section">
-    <div class="c-form-group">
-      <h3 class="c-form-group__label">
-        <span class="c-form-group__label-text">Business type</span>
-      </h3>
+    {% call FormGroup({
+      label: 'Business type'
+    }) %}
       <div>
         {{ 'Foreign' if isForeign else 'UK' }}
         {{ 'limited company' if isCompaniesHouse else businessType or '(type of organisation not known)' }}
 
         <a href="/companies/add-step-1">Change</a>
       </div>
-    </div>
+    {% endcall %}
   </div>
 
   {% if chDetails %}
@@ -134,14 +133,23 @@
           modifier: 'short'
         }) }}
 
-        {{ MultipleChoiceField({
-          name: 'registered_address_country',
-          label: 'Country',
-          initialOption: '-- Select country --',
-          options: countryOptions,
-          value: formData.registered_address_country,
-          error: errors.registered_address_country
-        }) }}
+        {% if not isForeign %}
+          {% call FormGroup({
+            label: 'Country'
+          }) %}
+            <p>United Kingdom</p>
+            <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}">
+          {% endcall %}
+        {% else %}
+          {{ MultipleChoiceField({
+            name: 'registered_address_country',
+            label: 'Country',
+            initialOption: '-- Select country --',
+            options: countryOptions,
+            value: formData.registered_address_country,
+            error: errors.registered_address_country
+          }) }}
+        {% endif %}
       </fieldset>
     {% endif %}
 
@@ -218,14 +226,24 @@
           modifier: 'short'
         }) }}
 
-        {{ MultipleChoiceField({
-          name: 'trading_address_country',
-          label: 'Country',
-          initialOption: '-- Select country --',
-          options: countryOptions,
-          value: formData.trading_address_country,
-          error: errors.trading_address_country
-        }) }}
+        {% if not isForeign %}
+          {% call FormGroup({
+            label: 'Country'
+          }) %}
+            <p>United Kingdom</p>
+            <input type="hidden" name="trading_address_country" value="">
+          {% endcall %}
+        {% else %}
+          {{ MultipleChoiceField({
+            name: 'trading_address_country',
+            label: 'Country',
+            disabled: true if not isForeign else false,
+            initialOption: '-- Select country --',
+            options: countryOptions,
+            value: formData.trading_address_country,
+            error: errors.trading_address_country
+          }) }}
+        {% endif %}
       </div>
     </fieldset>
 

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -97,15 +97,14 @@
 
         {{ TextField({
           name: 'registered_address_1',
-          label: 'Business',
-          optional: true,
+          label: 'Address line one',
           value: formData.registered_address_1,
           error: errors.registered_address_1
         }) }}
 
         {{ TextField({
           name: 'registered_address_2',
-          label: 'Street',
+          label: 'Address line two',
           optional: true,
           value: formData.registered_address_2,
           error: errors.registered_address_2
@@ -114,7 +113,6 @@
         {{ TextField({
           name: 'registered_address_town',
           label: 'Town or city',
-          optional: true,
           value: formData.registered_address_town,
           error: errors.registered_address_town
         }) }}
@@ -183,15 +181,14 @@
 
         {{ TextField({
           name: 'trading_address_1',
-          label: 'Business',
-          optional: true,
+          label: 'Address line one',
           value: formData.trading_address_1,
           error: errors.trading_address_1
         }) }}
 
         {{ TextField({
           name: 'trading_address_2',
-          label: 'Street',
+          label: 'Address line two',
           optional: true,
           value: formData.trading_address_2,
           error: errors.trading_address_2
@@ -200,7 +197,6 @@
         {{ TextField({
           name: 'trading_address_town',
           label: 'Town or city',
-          optional: true,
           value: formData.trading_address_town,
           error: errors.trading_address_town
         }) }}

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -78,19 +78,21 @@
         </legend>
 
         {% if not isForeign %}
-          {{ TextField({
-            name: 'registered_address_pcode_lookup',
-            label: 'Postcode',
-            modifier: ['short', 'PostcodeLookup'],
-            innerHTML: lookupButton
-          }) }}
+          <span class="u-no-js-hidden">
+            {{ TextField({
+              name: 'registered_address_pcode_lookup',
+              label: 'Postcode',
+              modifier: ['short', 'PostcodeLookup'],
+              innerHTML: lookupButton
+            }) }}
 
-          {{ MultipleChoiceField({
-            name: 'registered_address_pcode_result',
-            label: 'Select an address',
-            initialOption: 'Enter a postcode to lookup your address',
-            modifier: 'PostcodeLookupResult'
-          }) }}
+            {{ MultipleChoiceField({
+              name: 'registered_address_pcode_result',
+              label: 'Select an address',
+              initialOption: 'Enter a postcode to lookup your address',
+              modifier: 'PostcodeLookupResult'
+            }) }}
+          </span>
         {% endif %}
 
         {{ TextField({
@@ -162,19 +164,21 @@
         {% endif %}
 
         {% if not isForeign %}
-          {{ TextField({
-            name: 'trading_address_pcode_lookup',
-            label: 'Postcode',
-            modifier: ['short', 'PostcodeLookup'],
-            innerHTML: lookupButton
-          }) }}
+          <span class="u-no-js-hidden">
+            {{ TextField({
+              name: 'trading_address_pcode_lookup',
+              label: 'Postcode',
+              modifier: ['short', 'PostcodeLookup'],
+              innerHTML: lookupButton
+            }) }}
 
-          {{ MultipleChoiceField({
-            name: 'trading_address_pcode_result',
-            label: 'Select an address',
-            initialOption: 'Enter a postcode to lookup your address',
-            modifier: 'PostcodeLookupResult'
-          }) }}
+            {{ MultipleChoiceField({
+              name: 'trading_address_pcode_result',
+              label: 'Select an address',
+              initialOption: 'Enter a postcode to lookup your address',
+              modifier: 'PostcodeLookupResult'
+            }) }}
+          </span>
         {% endif %}
 
         {{ TextField({

--- a/src/templates/_macros/form/form-group.njk
+++ b/src/templates/_macros/form/form-group.njk
@@ -31,7 +31,7 @@
   {% set fieldsetModifier = props.modifier | concat('') | reverse | join(' c-form-fieldset--') if props.modifier %}
   {% set children = caller() if caller else renderAsMacro(props.children) %}
 
-  {% if props.label and props.name -%}
+  {% if props.label -%}
     <{{ groupElement }}
       id="group-{{ props.fieldId }}"
       class="

--- a/test/acceptance/features/support/fixtures.js
+++ b/test/acceptance/features/support/fixtures.js
@@ -1,0 +1,9 @@
+/**
+ * Easily reference fixtures provided to the UAT tests
+ * @type {}
+ */
+module.exports = {
+  companiesHouseCompany: {
+    name: 'Mercury Ltd',
+  },
+}

--- a/test/acceptance/features/support/world.js
+++ b/test/acceptance/features/support/world.js
@@ -1,3 +1,4 @@
+const fixtures = require('./fixtures')
 const { defineSupportCode } = require('cucumber')
 
 /**
@@ -5,6 +6,7 @@ const { defineSupportCode } = require('cucumber')
  * @constructor
  */
 function World () {
+  this.fixtures = fixtures
   this.state = {}
   this.resetState = function () {
     this.state = {}

--- a/test/unit/macros/form/text-field.test.js
+++ b/test/unit/macros/form/text-field.test.js
@@ -14,13 +14,6 @@ describe('TextField component', () => {
       })
       expect(component).to.be.null
     })
-
-    it('should not render if name is not provided', () => {
-      const component = macros.renderToDom('TextField', {
-        label: 'First name',
-      })
-      expect(component).to.be.null
-    })
   })
 
   describe('valid props', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,10 +353,6 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-asyncro@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/asyncro/-/asyncro-2.0.1.tgz#441783c134d0e13588af894bd4f8d1c834630d5d"
-
 atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"


### PR DESCRIPTION
A number of issues around companies have been fixed in this PR

- Hardcode "United Kingdom" for nonForeign companies
- Turn on and update `@companies-create` UAT tests
- Fix naming used on address fields
- Make `(optional)` from mandatory inputs
- Only show PostCode Lookup when JavaScript is available
- Replace `name` with `trading_name` in company results when it exists
- Added a few `// TODO` around work that can be addressed separately

And lots of other little tweaks around company creation.