### PR TITLE
turn up the logging on the node app on CIrcleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ jobs:
           QA_USER_PASSWORD: secretSquiR3L
           REDIS_HOST: localhost
           TZ: "/usr/share/zoneinfo/Europe/London"
+          LOG_LEVEL: debug
       - &docker_redis
         image: redis:3.2.10
       - &docker_elasticsearch

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "test:acceptance": "nightwatch --config test/acceptance/nightwatch.conf.js --env default --skiptags ignore",
     "coverage": "nyc --reporter=html --reporter=text --reporter=lcov npm run test:unit",
     "circle:unit": "nyc --reporter=lcov npm run test:unit -- --reporter mocha-circleci-reporter && codeclimate-test-reporter < coverage/lcov.info",
-    "circle:acceptance": "nightwatch --config test/acceptance/nightwatch.conf.js --env circleci --skiptags ignore",
+    "circle:acceptance": "nightwatch --config test/acceptance/nightwatch.conf.js --verbose --env circleci --skiptags ignore",
     "heroku-postbuild": "npm rebuild && npm run build"
   },
   "pre-commit": [


### PR DESCRIPTION
We have an intermittent issue that we need to debug. 
This turns up:
- logging on the node app
- logging on nightwatch 