### PR TITLE
try out a different split type to see how it affects test splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           name: Split tests for parallelisation and then run acceptance tests
           command: |
             # split .features for parallelisation
-            FEATURES="$(circleci tests glob "test/acceptance/features/**/*.feature" | circleci tests split --split-by=timings --timings-type=filename)"
+            FEATURES="$(circleci tests glob "test/acceptance/features/**/*.feature" | circleci tests split --split-by=filesize)"
 
             # move groups of .features to folder
             mkdir -p ~/data-hub-frontend/test/acceptance/features_${CIRCLE_NODE_INDEX}


### PR DESCRIPTION
When using `--split-by=timings --timings-type=filename` CircleCi generally reports back:
```
Requested historical based timing, but they are not present.  Falling back to name based sorting
```

This work changes the split to be by `filesize` which feels like we may get a fairer distribution between the parallel boxes.
