### PR TITLE
business_type errors out on Add company form halting the ability to add a company

### DIFF
--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -2,7 +2,7 @@ const { assign } = require('lodash')
 const queryString = require('query-string')
 
 const logger = require('../../../../config/logger')
-const { ukOtherCompanyOptions, foreignOtherCompanyOptions } = require('../options')
+const { buildUkOtherCompanyOptions, buildForeignOtherCompanyOptions } = require('../options')
 const { getCHCompany } = require('../repos')
 const { isBlank } = require('../../../lib/controller-utils')
 const { searchLimitedCompanies } = require('../../search/services')
@@ -10,7 +10,10 @@ const { transformApiResponseToSearchCollection } = require('../../search/transfo
 const { transformCompaniesHouseCompanyToListItem } = require('../../companies/transformers')
 const { companyDetailsLabels, companyTypeOptions } = require('../labels')
 
-function getAddStepOne (req, res, next) {
+function getAddStepOne (req, res) {
+  const ukOtherCompanyOptions = buildUkOtherCompanyOptions()
+  const foreignOtherCompanyOptions = buildForeignOtherCompanyOptions()
+
   res.render('companies/views/add-step-1.njk', {
     ukOtherCompanyOptions,
     foreignOtherCompanyOptions,

--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -30,7 +30,7 @@ function populateForm (req, res, next) {
 
   if (get(req.query, 'business_type')) {
     const businessType = find(metadataRepository.businessTypeOptions, (type) => {
-      return type.name.toLowerCase() === req.query.business_type.toLowerCase()
+      return type.id === req.query.business_type
     })
 
     res.locals.form.state.business_type = get(businessType, 'id')
@@ -60,7 +60,7 @@ function populateForm (req, res, next) {
     employeeOptions: metadataRepository.employeeOptions.map(transformObjectToOption),
     turnoverOptions: metadataRepository.turnoverOptions.map(transformObjectToOption),
     countryOptions: metadataRepository.countryOptions.map(transformObjectToOption),
-    businessType: req.query.business_type || get(res.locals, 'company.business_type.name'),
+    businessType: req.query.business_type || get(res.locals, 'company.business_type.id'),
     showTradingAddress: get(res.locals, 'form.state.trading_address_1'),
   })
 

--- a/src/apps/companies/options.js
+++ b/src/apps/companies/options.js
@@ -1,20 +1,46 @@
-const ukOtherCompanyOptions = [
+const { filter, map } = require('lodash')
+const { sentence } = require('case')
+
+const metadataRepository = require('../../lib/metadata')
+const ukOtherBusinessTypeNames = [
   'Charity',
-  'Government department',
+  'Government Dept',
   'Intermediary',
   'Limited partnership',
   'Partnership',
-  'Sole trader',
-].map(item => {
-  return {
-    value: item,
-    label: item,
-  }
-})
+  'Sole Trader',
+]
+const foreignOtherBusinessTypeNames = [
+  'Company',
+  ...ukOtherBusinessTypeNames,
+]
 
-const foreignOtherCompanyOptions = [{ value: 'Company', label: 'Company' }, ...ukOtherCompanyOptions]
+/**
+ * extract businessOptions from metadata by name and build an options list with
+ * @param requestedProperties
+ * @param metaDataOptions
+ * @returns {{label: String, id: String}[]}
+ */
+const buildBusinessTypeOptions = (requestedProperties, metaDataOptions) => {
+  return map(filter(metaDataOptions, (option) => {
+    return requestedProperties.indexOf(option.name) >= 0
+  }), (option) => {
+    return {
+      value: option.id,
+      label: sentence(option.name.replace('Dept', 'department'), []),
+    }
+  })
+}
+
+const buildUkOtherCompanyOptions = () => {
+  return buildBusinessTypeOptions(ukOtherBusinessTypeNames, metadataRepository.businessTypeOptions)
+}
+
+const buildForeignOtherCompanyOptions = () => {
+  return buildBusinessTypeOptions(foreignOtherBusinessTypeNames, metadataRepository.businessTypeOptions)
+}
 
 module.exports = {
-  ukOtherCompanyOptions,
-  foreignOtherCompanyOptions,
+  buildUkOtherCompanyOptions,
+  buildForeignOtherCompanyOptions,
 }

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -6,6 +6,20 @@ const next = function (error) {
   throw Error(error)
 }
 
+const mockMetadataRepository = {
+  businessTypeOptions: [
+    { name: 'Not Expected', id: '33243434-343656' },
+    { name: 'Charity', id: '1234-5678' },
+    { name: 'Government Dept', id: '3434-343' },
+    { name: 'Intermediary', id: '5656-5656' },
+    { name: 'Limited partnership', id: '7878-7878' },
+    { name: 'Partnership', id: '8989-898-9' },
+    { name: 'Sole Trader', id: '3434-5656' },
+    { name: 'Company', id: '1212-3454567' },
+    { name: 'Random', id: '34343434-343656' },
+  ],
+}
+
 describe('Company add controller', function () {
   let searchLimitedCompaniesStub
   let getDisplayCHStub
@@ -27,6 +41,9 @@ describe('Company add controller', function () {
       '../services/formatting': {
         getDisplayCH: getDisplayCHStub,
       },
+      '../options': proxyquire('~/src/apps/companies/options.js', {
+        '../../lib/metadata': mockMetadataRepository,
+      }),
     })
   })
 
@@ -34,14 +51,14 @@ describe('Company add controller', function () {
     it('should return options for company types', function (done) {
       const req = { session: {} }
       const expected = [
-        { label: 'Charity', value: 'Charity' },
-        { label: 'Government department', value: 'Government department' },
-        { label: 'Intermediary', value: 'Intermediary' },
-        { label: 'Limited partnership', value: 'Limited partnership' },
-        { label: 'Partnership', value: 'Partnership' },
-        { label: 'Sole trader', value: 'Sole trader' },
+        { label: 'Charity', value: '1234-5678' },
+        { label: 'Government department', value: '3434-343' },
+        { label: 'Intermediary', value: '5656-5656' },
+        { label: 'Limited partnership', value: '7878-7878' },
+        { label: 'Partnership', value: '8989-898-9' },
+        { label: 'Sole trader', value: '3434-5656' },
       ]
-      const expectedForeign = [{ value: 'Company', label: 'Company' }, ...expected]
+      const expectedForeign = [ ...expected, { label: 'Company', value: '1212-3454567' } ]
       const res = {
         locals: {},
         render: function (template, options) {

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -54,7 +54,7 @@ describe('Companies form middleware', function () {
       beforeEach(() => {
         this.reqMock = {
           query: {
-            business_type: 'Charity',
+            business_type: 'example-bussiness-type-id-12345',
           },
         }
 
@@ -62,7 +62,7 @@ describe('Companies form middleware', function () {
           '../../../lib/metadata': Object.assign({}, metadataMock, {
             businessTypeOptions: [{
               name: 'Charity',
-              id: '7890qwerty',
+              id: 'example-bussiness-type-id-12345',
             }],
           }),
         })
@@ -71,7 +71,7 @@ describe('Companies form middleware', function () {
       it('should add it to form state', () => {
         this.middlware.populateForm(this.reqMock, this.resMock, this.nextSpy)
 
-        expect(this.resMock.locals.form.state).to.have.property('business_type', '7890qwerty')
+        expect(this.resMock.locals.form.state).to.have.property('business_type', 'example-bussiness-type-id-12345')
       })
     })
   })


### PR DESCRIPTION
## Problem
When creating a new company **Other type of UK organisation** or **Foreign organisation** and choosing **Government department** as **Type of organisation** you receive a form error on the **Add company** page and would be unable to proceed.

### Steps to reproduce
- Go to company list page
- Press add company button
- Choose Other type of UK organisation
- Select Government department as Type of organisation
- Click Continue
- Enter all relevant information in Add company form
- Click Save and Create
- Note form error

## Info
This work:
- Brings in **all** of the correct `businessTypes` from the metaData repo
- Uses the `business_type.id` rather than `business_type.name`