### PR TITLE
Remove ltd child old code

### DIFF
--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -49,7 +49,6 @@ function postAddStepOne (req, res, next) {
   let params
   switch (req.body.business_type) {
     case 'ltd':
-    case 'ltdchild':
       params = {
         business_type: req.body.business_type,
         country: 'uk',

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -44,7 +44,6 @@ const chDetailsLabels = {
 }
 const companyTypeOptions = {
   ltd: 'UK private or public limited company',
-  ltdchild: 'Child of a UK private or public limited company',
   ukother: 'Other type of UK organisation',
   foreign: 'Foreign organisation',
 }

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -79,7 +79,6 @@ describe('Company add controller', function () {
           const allOptions = mergeLocals(res, options)
           expect(allOptions.companyTypeOptions).to.deep.equal({
             ltd: 'UK private or public limited company',
-            ltdchild: 'Child of a UK private or public limited company',
             ukother: 'Other type of UK organisation',
             foreign: 'Foreign organisation',
           })
@@ -99,7 +98,6 @@ describe('Company add controller', function () {
           const allOptions = mergeLocals(res, options)
           expect(allOptions.companyTypeOptions).to.deep.equal({
             ltd: 'UK private or public limited company',
-            ltdchild: 'Child of a UK private or public limited company',
             ukother: 'Other type of UK organisation',
             foreign: 'Foreign organisation',
           })
@@ -247,7 +245,6 @@ describe('Company add controller', function () {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.companyTypeOptions).to.deep.equal({
               ltd: 'UK private or public limited company',
-              ltdchild: 'Child of a UK private or public limited company',
               ukother: 'Other type of UK organisation',
               foreign: 'Foreign organisation',
             })


### PR DESCRIPTION
Pretty sure this is no longer in use as it ben its coming in from the `req.body` and its not in the `req.body` [add.js](https://github.com/uktrade/data-hub-frontend/blob/develop/src/apps/companies/controllers/add.js#L47)

Awaiting conformation from @jim68000 and @reupen 