### PR TITLE
Payment receipt

### DIFF
--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -103,5 +103,6 @@
 
   .c-meta-list__item + .c-meta-list__item {
     margin-left: 0;
+    margin-top: $default-spacing-unit / 2;
   }
 }

--- a/assets/stylesheets/elements/_table.scss
+++ b/assets/stylesheets/elements/_table.scss
@@ -35,3 +35,8 @@ table {
     text-align: right;
   }
 }
+
+
+.table__cell--plain {
+  border-bottom: 0;
+}

--- a/assets/stylesheets/objects/_list.scss
+++ b/assets/stylesheets/objects/_list.scss
@@ -26,3 +26,13 @@
   list-style: disc outside;
   padding-left: 1em;
 }
+
+.list-spaced {
+  * + & {
+    margin-top: $default-spacing-unit * 2;
+  }
+
+  li + li {
+    margin-top: $default-spacing-unit / 2;
+  }
+}

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -34,7 +34,14 @@ function renderQuote (req, res) {
     .render('omis/apps/view/views/quote')
 }
 
+function renderPaymentReceipt (req, res) {
+  res
+    .breadcrumb('Payment receipt')
+    .render('omis/apps/view/views/payment-receipt')
+}
+
 module.exports = {
   renderWorkOrder,
   renderQuote,
+  renderPaymentReceipt,
 }

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -112,6 +112,16 @@ async function setInvoice (req, res, next) {
   next()
 }
 
+async function setPayments (req, res, next) {
+  try {
+    res.locals.payments = await Order.getPayments(req.session.token, res.locals.order.id)
+  } catch (error) {
+    logger.error(error)
+  }
+
+  next()
+}
+
 async function generateQuote (req, res, next) {
   const orderId = get(res.locals, 'order.id')
 
@@ -200,6 +210,7 @@ module.exports = {
   setQuotePreview,
   setQuote,
   setInvoice,
+  setPayments,
   generateQuote,
   cancelQuote,
   setQuoteForm,

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -102,6 +102,16 @@ async function setQuote (req, res, next) {
   next()
 }
 
+async function setInvoice (req, res, next) {
+  try {
+    res.locals.invoice = await Order.getInvoice(req.session.token, res.locals.order.id)
+  } catch (error) {
+    logger.error(error)
+  }
+
+  next()
+}
+
 async function generateQuote (req, res, next) {
   const orderId = get(res.locals, 'order.id')
 
@@ -189,6 +199,7 @@ module.exports = {
   setQuoteSummary,
   setQuotePreview,
   setQuote,
+  setInvoice,
   generateQuote,
   cancelQuote,
   setQuoteForm,

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -5,7 +5,11 @@ const {
   setOrderBreadcrumb,
   setArchivedDocumentsBaseUrl,
 } = require('../../middleware')
-const { renderWorkOrder, renderQuote } = require('./controllers')
+const {
+  renderWorkOrder,
+  renderQuote,
+  renderPaymentReceipt,
+} = require('./controllers')
 const {
   setTranslation,
   setCompany,
@@ -13,6 +17,8 @@ const {
   setQuotePreview,
   setQuote,
   setQuoteForm,
+  setInvoice,
+  setPayments,
   generateQuote,
   cancelQuote,
 } = require('./middleware')
@@ -33,6 +39,7 @@ router.use(setArchivedDocumentsBaseUrl)
 
 router.get('/', redirectToFirstNavItem)
 router.get('/work-order', renderWorkOrder)
+router.get('/payment-receipt', setInvoice, setPayments, renderPaymentReceipt)
 router
   .route('/quote')
   .get(setQuotePreview, setQuote, setQuoteForm, renderQuote)

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -2,6 +2,12 @@
 
 {% block local_header %}
   {% set actions %}
+    {% if order.status in ['paid', 'complete'] %}
+      <p class="c-local-header__action">
+        <a href="payment-receipt">View payment receipt</a>
+      </p>
+    {% endif %}
+
     {% if order.archived_documents_url_path %}
       <p class="c-local-header__action">
         <a href="{{ archivedDocumentsBaseUrl }}{{ order.archived_documents_url_path }}">View files and documents</a>

--- a/src/apps/omis/apps/view/views/payment-receipt.njk
+++ b/src/apps/omis/apps/view/views/payment-receipt.njk
@@ -1,0 +1,123 @@
+{% extends '_layouts/datahub-base.njk' %}
+
+{% block body_main_content %}
+  {% set billingAddress = [
+    invoice.billing_contact_name,
+    invoice.billing_address_1,
+    invoice.billing_address_2,
+    invoice.billing_address_town,
+    invoice.billing_address_county,
+    invoice.billing_address_postcode,
+    invoice.billing_address_country.name
+  ] | removeNilAndEmpty | join('<br>') %}
+
+  {% set invoiceAddress = [
+    invoice.invoice_company_name,
+    invoice.invoice_address_1,
+    invoice.invoice_address_2,
+    invoice.invoice_address_town,
+    invoice.invoice_address_county,
+    invoice.invoice_address_postcode,
+    invoice.invoice_address_country.name
+  ] | removeNilAndEmpty | join('<br>') %}
+
+  <div class="u-clearfix">
+    <div class="u-float-left">
+      {{ MetaList({
+        items: [
+          { label: 'For the attention of', value: billingAddress, safe: true },
+          { label: 'Purchase order (PO) number', value: invoice.po_number },
+          { label: 'Receipt date', value: invoice.created_on, type: 'datetime' }
+        ],
+        modifier: 'stacked',
+        itemModifier: 'stacked'
+      }) }}
+    </div>
+
+    <div class="u-float-right">
+      {{ MetaList({
+        items: [
+          { label: 'From (charging point)', value: invoiceAddress, safe: true },
+          { label: 'VAT number', value: invoice.invoice_vat_number }
+        ],
+        modifier: 'stacked',
+        itemModifier: 'stacked'
+      }) }}
+    </div>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Order number</th>
+        <th>Service description</th>
+        <th>Market (country)</th>
+        <th></th>
+        <th align="right">Net amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          {{ order.reference }}
+        </td>
+        <td>
+          OMIS
+        </td>
+        <td>
+          {{ order.primary_market.name }}
+        </td>
+        <td></td>
+        <td align="right">
+          {{ order.subtotal_cost | formatCurrency }}
+        </td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="3" class="table__cell--plain"></td>
+        <th>
+          VAT {{ 'at 20%' if order.vat_cost > 0 }}
+        </th>
+        <td align="right">
+          {{ order.vat_cost | formatCurrency }}
+        </td>
+      </tr>
+      <tr>
+        <td colspan="3" class="table__cell--plain"></td>
+        <th>
+          Total amount
+        </th>
+        <td align="right">
+          <strong>{{ order.total_cost | formatCurrency }}</strong>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+
+  <h2 class="heading-medium">Payment details ({{ payments.length }} {{ ' payment' | pluralise(payments.length) }})</h2>
+
+  {% for payment in payments %}
+    <h3 class="heading-small">Payment {{ loop.index }}</h3>
+
+    {{ MetaList({
+      items: [
+        { label: 'Method', value: payment.method | upper },
+        { label: 'Amount received', value: payment.amount | formatCurrency },
+        { label: 'Received on', value: payment.received_on, type: 'date' },
+        { label: 'Transaction reference', value: payment.transaction_reference }
+      ],
+      modifier: 'stacked',
+      itemModifier: 'stacked'
+    }) }}
+  {% endfor %}
+
+  <ul class="list-spaced u-print-hide">
+    <li>
+      <a href="/omis/reconciliation">Reconcile another order</a>
+    </li>
+    <li>
+      <a href="/omis/{{ order.id }}">Return to order</a>
+    </li>
+  </ul>
+{% endblock %}

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -174,4 +174,28 @@ describe('OMIS View controllers', () => {
       expect(this.renderSpy).to.have.been.called
     })
   })
+
+  describe('renderPaymentReceipt()', () => {
+    beforeEach(() => {
+      this.breadcrumbSpy = this.sandbox.stub().returnsThis()
+      this.renderSpy = this.sandbox.spy()
+
+      this.resMock = {
+        breadcrumb: this.breadcrumbSpy,
+        render: this.renderSpy,
+      }
+    })
+
+    it('should set a breadcrumb option', () => {
+      this.controllers.renderPaymentReceipt({}, this.resMock)
+
+      expect(this.breadcrumbSpy).to.have.been.called
+    })
+
+    it('should render a template', () => {
+      this.controllers.renderPaymentReceipt({}, this.resMock)
+
+      expect(this.renderSpy).to.have.been.called
+    })
+  })
 })

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -1,4 +1,5 @@
 const invoiceMock = require('~/test/unit/data/omis/invoice')
+const paymentsMock = require('~/test/unit/data/omis/payments')
 
 describe('OMIS View middleware', () => {
   beforeEach(() => {
@@ -9,6 +10,7 @@ describe('OMIS View middleware', () => {
     this.previewQuoteStub = this.sandbox.stub()
     this.getQuoteStub = this.sandbox.stub()
     this.getInvoiceStub = this.sandbox.stub()
+    this.getPaymentsStub = this.sandbox.stub()
     this.createQuoteStub = this.sandbox.stub()
     this.cancelQuoteStub = this.sandbox.stub()
     this.flashSpy = this.sandbox.spy()
@@ -40,6 +42,7 @@ describe('OMIS View middleware', () => {
           previewQuote: this.previewQuoteStub,
           getQuote: this.getQuoteStub,
           getInvoice: this.getInvoiceStub,
+          getPayments: this.getPaymentsStub,
           createQuote: this.createQuoteStub,
           cancelQuote: this.cancelQuoteStub,
         },
@@ -428,6 +431,45 @@ describe('OMIS View middleware', () => {
         this.getInvoiceStub.rejects(this.error)
 
         await this.middleware.setInvoice(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should log error', () => {
+        expect(this.loggerErrorSpy).to.have.been.calledOnce
+        expect(this.loggerErrorSpy).to.have.been.calledWith(this.error)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+  })
+
+  describe('setPayments()', () => {
+    context('when invoice call resolves', () => {
+      beforeEach(async () => {
+        this.getPaymentsStub.resolves(paymentsMock)
+
+        await this.middleware.setPayments(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set response as quote property on locals', () => {
+        expect(this.resMock.locals).to.have.property('payments')
+        expect(this.resMock.locals.payments).to.deep.equal(paymentsMock)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
+    context('when call generates an error', () => {
+      beforeEach(async () => {
+        this.error = {
+          statusCode: 500,
+        }
+        this.getPaymentsStub.rejects(this.error)
+
+        await this.middleware.setPayments(this.reqMock, this.resMock, this.nextSpy)
       })
 
       it('should log error', () => {

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -1,3 +1,5 @@
+const invoiceMock = require('~/test/unit/data/omis/invoice')
+
 describe('OMIS View middleware', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
@@ -6,6 +8,7 @@ describe('OMIS View middleware', () => {
     this.loggerErrorSpy = this.sandbox.spy()
     this.previewQuoteStub = this.sandbox.stub()
     this.getQuoteStub = this.sandbox.stub()
+    this.getInvoiceStub = this.sandbox.stub()
     this.createQuoteStub = this.sandbox.stub()
     this.cancelQuoteStub = this.sandbox.stub()
     this.flashSpy = this.sandbox.spy()
@@ -36,6 +39,7 @@ describe('OMIS View middleware', () => {
         Order: {
           previewQuote: this.previewQuoteStub,
           getQuote: this.getQuoteStub,
+          getInvoice: this.getInvoiceStub,
           createQuote: this.createQuoteStub,
           cancelQuote: this.cancelQuoteStub,
         },
@@ -394,6 +398,45 @@ describe('OMIS View middleware', () => {
         it('should call next', () => {
           expect(this.nextSpy).to.have.been.calledWith()
         })
+      })
+    })
+  })
+
+  describe('setInvoice()', () => {
+    context('when invoice call resolves', () => {
+      beforeEach(async () => {
+        this.getInvoiceStub.resolves(invoiceMock)
+
+        await this.middleware.setInvoice(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set response as quote property on locals', () => {
+        expect(this.resMock.locals).to.have.property('invoice')
+        expect(this.resMock.locals.invoice).to.deep.equal(invoiceMock)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
+    context('when call generates an error', () => {
+      beforeEach(async () => {
+        this.error = {
+          statusCode: 500,
+        }
+        this.getInvoiceStub.rejects(this.error)
+
+        await this.middleware.setInvoice(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should log error', () => {
+        expect(this.loggerErrorSpy).to.have.been.calledOnce
+        expect(this.loggerErrorSpy).to.have.been.calledWith(this.error)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
       })
     })
   })

--- a/test/unit/data/omis/invoice.json
+++ b/test/unit/data/omis/invoice.json
@@ -1,0 +1,26 @@
+{
+  "created_on": "2017-09-27T08:59:20.381047",
+  "invoice_number": "201709270001",
+  "invoice_company_name": "Department for International Trade",
+  "invoice_address_1": "3 Whitehall Place",
+  "invoice_address_2": "",
+  "invoice_address_town": "London",
+  "invoice_address_county": "",
+  "invoice_address_postcode": "SW1A 2AW",
+  "invoice_address_country": {
+    "name": "United Kingdom",
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "invoice_vat_number": "888 850455",
+  "billing_contact_name": "Jeff Fisher",
+  "billing_address_1": "Apt 0.",
+  "billing_address_2": "0 Foo st.",
+  "billing_address_county": "Eos et quibusdam dignissimos molestias saepe sit exercitationem pariatur. Velit fugit delectus tempore cumque ipsa. Temporibus quaerat deserunt illo perferendis beatae incidunt.",
+  "billing_address_postcode": "SW1A1AA",
+  "billing_address_town": "London",
+  "billing_address_country": {
+    "name": "United Kingdom",
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "po_number": "At ipsam dolorum inventore."
+}

--- a/test/unit/data/omis/payments.json
+++ b/test/unit/data/omis/payments.json
@@ -1,0 +1,20 @@
+[
+  {
+    "created_on": "2017-10-17T10:07:41.838058",
+    "reference": "201710170001",
+    "transaction_reference": "some ref 1",
+    "additional_reference": "",
+    "amount": 5343,
+    "method": "bacs",
+    "received_on": "2017-04-20T13:00:00"
+  },
+  {
+    "created_on": "2017-10-17T10:07:41.931472",
+    "reference": "201710170002",
+    "transaction_reference": "some ref 2",
+    "additional_reference": "",
+    "amount": 100,
+    "method": "bacs",
+    "received_on": "2017-04-21T13:00:00"
+  }
+]


### PR DESCRIPTION
This change adds a new route to view the payment receipt after an order has been paid.

There will be some follow-up changes around the flow but didn't want to bloat this PR too much to keep it easier to review.

## What it looks like

![localhost_3001_omis_419af569-db12-4d41-8f00-a8c764faf578_payment-receipt](https://user-images.githubusercontent.com/3327997/32010575-253cd652-b9aa-11e7-9fdc-8f753f5cadc6.png)
