### PR TITLE
Reconciliation flow

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -4,6 +4,7 @@ require('moment-duration-format')
 const dateFns = require('date-fns')
 const Case = require('case')
 const numeral = require('numeral')
+const queryString = require('query-string')
 const {
   assign,
   concat,
@@ -52,8 +53,6 @@ function pluralise (string, count, pluralisedWord) {
 }
 
 const filters = {
-  stringify: JSON.stringify,
-  sentenceCase: Case.sentence,
   lowerCase,
   kebabCase,
   assign,
@@ -73,6 +72,12 @@ const filters = {
   isPlainObject,
   isString,
   pluralise,
+  stringify: JSON.stringify,
+  sentenceCase: Case.sentence,
+
+  encodeQueryString (value) {
+    return encodeURIComponent(queryString.stringify(value))
+  },
 
   assignCopy (...args) {
     return assign({}, ...args)

--- a/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
+++ b/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
@@ -64,7 +64,7 @@ class EditPaymentReconciliationController extends EditController {
   }
 
   async successHandler (req, res, next) {
-    const nextUrl = req.form.options.next || `/omis/reconciliation`
+    const nextUrl = `/omis/${res.locals.order.id}/payment-receipt`
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
 
     // convert pounds to pence

--- a/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
+++ b/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
@@ -1,4 +1,4 @@
-const { assign, pick } = require('lodash')
+const { assign, get, pick } = require('lodash')
 const numeral = require('numeral')
 const chrono = require('chrono-node')
 const dateFns = require('date-fns')
@@ -9,11 +9,18 @@ const { Order } = require('../../../models')
 
 class EditPaymentReconciliationController extends EditController {
   async configure (req, res, next) {
+    const orderStatus = get(res.locals, 'order.status')
+
     req.form.options.disableFormAction = false
     req.form.options = assign({}, req.form.options, {
       buttonText: 'Reconcile payment',
       disableFormAction: false,
     })
+
+    if (orderStatus !== 'quote_accepted') {
+      req.form.options.hidePrimaryFormAction = true
+      req.form.options.returnText = 'Return'
+    }
 
     super.configure(req, res, next)
   }

--- a/src/apps/omis/apps/edit/views/payment-reconciliation.njk
+++ b/src/apps/omis/apps/edit/views/payment-reconciliation.njk
@@ -1,42 +1,61 @@
 {% extends "_layouts/form-wizard-step.njk" %}
 
 {% block fields %}
-  <h2 class="heading-medium">Company details</h2>
-  <div>
-    {{ company.name }}
-    <br>
-    {{ [
-      company.registered_address_1,
-      company.registered_address_2,
-      company.registered_address_county,
-      company.registered_address_town,
-      company.registered_address_postcode
-    ] | removeNilAndEmpty | join(", ") }}
-  </div>
+  {% if order.status in ['paid', 'complete'] %}
+    {% call Message({ type: 'info', element: 'div' }) %}
+      <p>This order has been paid in full.</p>
 
-  <h2 class="heading-medium">Invoice details</h2>
+      <p>
+        <a href="/omis/{{ order.id }}/payment-receipt">View payment receipt</a>
+      </p>
+    {% endcall %}
+  {% endif %}
 
-  <table>
-    <tbody>
-      <tr>
-        <th>Amount (excluding VAT)</th>
-        <td>{{ order.subtotal_cost | formatCurrency }}</td>
-      </tr>
-      <tr>
-        <th>Amount (including VAT)</th>
-        <td>{{ order.total_cost | formatCurrency }}</td>
-      </tr>
-      <tr>
-        <th>Payment due date</th>
-        <td>
-          {{ values.invoice.payment_due_date | formatDate }}
-          ({{ FromNow({ datetime: values.invoice.payment_due_date }) }})
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
+    {% call Message({ type: 'info', element: 'div' }) %}
+      <p>This quote for this order has not been accepted so payment cannot be reconciled.</p>
+    {% endcall %}
+  {% endif %}
 
-  <h2 class="heading-medium">Payment details</h2>
+  {% if order.status === 'quote_accepted' %}
+    <h2 class="heading-medium">Company details</h2>
 
-  {{ super() }}
+    <div>
+      {{ company.name }}
+      <br>
+      {{ [
+        company.registered_address_1,
+        company.registered_address_2,
+        company.registered_address_county,
+        company.registered_address_town,
+        company.registered_address_postcode
+        ] | removeNilAndEmpty | join(", ") }}
+    </div>
+
+    <h2 class="heading-medium">Invoice details</h2>
+
+    <table>
+      <tbody>
+        <tr>
+          <th>Amount (excluding VAT)</th>
+          <td>{{ order.subtotal_cost | formatCurrency }}</td>
+        </tr>
+        <tr>
+          <th>Amount (including VAT)</th>
+          <td>{{ order.total_cost | formatCurrency }}</td>
+        </tr>
+        <tr>
+          <th>Payment due date</th>
+          <td>
+            {{ values.invoice.payment_due_date | formatDate }}
+            ({{ FromNow({ datetime: values.invoice.payment_due_date }) }})
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 class="heading-medium">Payment details</h2>
+
+    {{ super() }}
+  {% endif %}
 {% endblock %}

--- a/src/apps/omis/apps/list/views/list-reconciliation.njk
+++ b/src/apps/omis/apps/list/views/list-reconciliation.njk
@@ -28,7 +28,7 @@
         {% for item in results.items %}
           <tr>
             <td>
-              <a href="/omis/{{ item.id }}/edit/payment-reconciliation?returnUrl=/omis/reconciliation">
+              <a href="/omis/{{ item.id }}/edit/payment-reconciliation?returnUrl=/omis/reconciliation?{{ QUERY | encodeQueryString }}">
                 {{ item.reference }}
               </a>
             </td>

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -1,4 +1,4 @@
-const { merge, sumBy } = require('lodash')
+const { get, merge, sumBy } = require('lodash')
 
 const { Order } = require('../../models')
 const logger = require('../../../../../config/logger')
@@ -35,6 +35,12 @@ function renderQuote (req, res) {
 }
 
 function renderPaymentReceipt (req, res) {
+  const { id, status } = get(res.locals, 'order')
+
+  if (!['paid', 'complete'].includes(status)) {
+    return res.redirect(`/omis/${id}`)
+  }
+
   res
     .breadcrumb('Payment receipt')
     .render('omis/apps/view/views/payment-receipt')

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -4,6 +4,7 @@ const contactData = require('~/test/unit/data/simple-contact')
 
 const orderMock = {
   id: '1230asd-123dasda',
+  status: 'draft',
   contact: {
     id: '123dasda-1230asd',
   },
@@ -179,23 +180,48 @@ describe('OMIS View controllers', () => {
     beforeEach(() => {
       this.breadcrumbSpy = this.sandbox.stub().returnsThis()
       this.renderSpy = this.sandbox.spy()
+      this.redirectSpy = this.sandbox.spy()
 
       this.resMock = {
         breadcrumb: this.breadcrumbSpy,
+        redirect: this.redirectSpy,
         render: this.renderSpy,
+        locals: {
+          order: orderMock,
+        },
       }
     })
 
-    it('should set a breadcrumb option', () => {
-      this.controllers.renderPaymentReceipt({}, this.resMock)
+    context('when an order is not paid', () => {
+      it('should redirect back to the order overview', () => {
+        this.controllers.renderPaymentReceipt({}, this.resMock)
 
-      expect(this.breadcrumbSpy).to.have.been.called
+        expect(this.redirectSpy).to.have.been.calledWith(`/omis/${this.resMock.locals.order.id}`)
+      })
     })
 
-    it('should render a template', () => {
-      this.controllers.renderPaymentReceipt({}, this.resMock)
+    context('when an order is in paid state', () => {
+      beforeEach(() => {
+        this.resMock.locals.order.status = 'paid'
+      })
 
-      expect(this.renderSpy).to.have.been.called
+      it('should set a breadcrumb option', () => {
+        this.controllers.renderPaymentReceipt({}, this.resMock)
+
+        expect(this.breadcrumbSpy).to.have.been.called
+      })
+
+      it('should render a template', () => {
+        this.controllers.renderPaymentReceipt({}, this.resMock)
+
+        expect(this.renderSpy).to.have.been.called
+      })
+
+      it('should not redirect', () => {
+        this.controllers.renderPaymentReceipt({}, this.resMock)
+
+        expect(this.redirectSpy).not.to.have.been.called
+      })
     })
   })
 })


### PR DESCRIPTION
This adapts the current flow now that the payment receipt route is present.

### Summary

- Change reconciliation flow to redirect to receipt on successful submission
- Show appropriate messages when payment reconciliation is not in a valid state
- Only render payment receipt when available

See commit history for detailed changes. 