### PR TITLE
Add marketing preferences to contact editing

### DIFF
--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -82,6 +82,20 @@
     }) }}
 
     {{ MultipleChoiceField({
+      type: 'checkbox',
+      name: 'marketing_preferences',
+      label: 'Marketing preferences',
+      isLabelHidden: true,
+      value: formData.marketing_preferences,
+      options: [
+        {
+          label: 'Accepts email marketing from DIT',
+          value: 'accepts_dit_email_marketing'
+        }
+      ]
+    }) }}
+
+    {{ MultipleChoiceField({
       name: 'address_same_as_company',
       type: 'radio',
       label: 'Is the contact’s address the same as the company address?',

--- a/test/acceptance/features/audit/contact.feature
+++ b/test/acceptance/features/audit/contact.feature
@@ -7,45 +7,35 @@ Feature: View Audit history of a contact
   Background:
     Given I am an authenticated user on the data hub website
 
-  @audit-contact--name
+  @audit-contact--fields
   Scenario: View name of the person who made contact record changes
 
-    When I add a new Primary Contact
+    And a company is created for audit
+    When navigating to the company contacts
+    And a primary contact is added for audit
     Then I see the success message
-    And I Amend 1 records of an existing contact record
+    When navigating to the company contacts for audit
+    And the contact has 1 fields edited for audit
+    Then I see the success message
     When I search for this Contact record
     And I navigate to Audit History tab
     Then I see the name of the person who made the recent contact record changes
-
-  @audit-contact--timestamp
-  Scenario: View time stamp when the contact record changes
-
-    When I add a new Primary Contact
-    Then I see the success message
-    And I Amend 1 records of an existing contact record
-    When I search for this Contact record
-    And I navigate to Audit History tab
-    Then I see the date time stamp when the recent contact record changed
+    And I see the date time stamp when the recent contact record changed
+    And I see the field names that were recently changed
 
   @audit-contact--count
   Scenario: View the number of changes occurred on a contact record
 
-    When I add a new Primary Contact
+    And a company is created for audit
+    When navigating to the company contacts
+    And a primary contact is added for audit
     Then I see the success message
-    And I Amend 2 records of an existing contact record
+    When navigating to the company contacts for audit
+    And the contact has 2 fields edited for audit
+    Then I see the success message
     When I search for this Contact record
     And I navigate to Audit History tab
     Then I see the total number of changes occurred recently on this contact record
-
-  @audit-contact--field-names
-  Scenario: View changed field names of a contact record
-
-    When I add a new Primary Contact
-    Then I see the success message
-    And I Amend 1 records of an existing contact record
-    When I search for this Contact record
-    And I navigate to Audit History tab
-    Then I see the field names that were recently changed
 
   @audit-contact--archived @ignore
   Scenario: View audit log for Archived contact

--- a/test/acceptance/features/audit/page-objects/AuditContact.js
+++ b/test/acceptance/features/audit/page-objects/AuditContact.js
@@ -1,7 +1,13 @@
+const faker = require('faker')
+const { merge } = require('lodash')
+
+const { getButtonWithText } = require('../../../helpers/selectors')
+
 module.exports = {
   url: process.env.QA_HOST,
   elements: {
-    editContactDetailsButton: 'a[href*="/edit"]',
+    editContactDetailsButton: getButtonWithText('Edit contact details'),
+    saveButton: getButtonWithText('Save'),
     auditHistoryTab: 'a[href*="/audit"]',
     telephone: '#field-telephone_number',
     telephoneCountryCode: '#field-telephone_countrycode',
@@ -12,7 +18,12 @@ module.exports = {
 
   commands: [
     {
-      editContactDetails (telephone, countryCode, number) {
+      editContactDetails (details = {}, number, callback) {
+        const contact = merge({}, {
+          countryCode: faker.random.number(),
+          telephone: faker.phone.phoneNumber(),
+        }, details)
+
         this
           .waitForElementVisible('@editContactDetailsButton')
           .click('@editContactDetailsButton')
@@ -21,13 +32,18 @@ module.exports = {
           this
             .waitForElementVisible('@telephoneCountryCode')
             .clearValue('@telephoneCountryCode')
-            .setValue('@telephoneCountryCode', countryCode)
+            .setValue('@telephoneCountryCode', contact.countryCode)
         }
 
         this
           .waitForElementVisible('@telephone')
           .clearValue('@telephone')
-          .setValue('@telephone', telephone)
+          .setValue('@telephone', contact.telephone)
+
+        this
+          .click('@saveButton')
+
+        callback(contact)
 
         return this
       },

--- a/test/acceptance/features/audit/step_definitions/company.js
+++ b/test/acceptance/features/audit/step_definitions/company.js
@@ -2,6 +2,7 @@ const faker = require('faker')
 const format = require('date-fns/format')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
+const { set } = require('lodash')
 
 defineSupportCode(({ Given, Then, When }) => {
   const Message = client.page.Message()
@@ -10,59 +11,47 @@ defineSupportCode(({ Given, Then, When }) => {
   const AuditContact = client.page.AuditContact()
   const AuditCompany = client.page.AuditCompany()
   const AuditList = client.page.AuditList()
-  const foreignCompanyName = 'Venus'
-  let companyName
-  let description
-  let website
-  let userName
-
-  Given(/^I Amend (.*) records of an existing company record$/, async (number) => {
-    description = faker.name.jobDescriptor()
-    website = faker.internet.url()
+  Given(/^I Amend (.*) records of an existing company record$/, async function (number) {
     await Company
       .navigate()
-      .findCompany(foreignCompanyName)
+      .findCompany('Venus')
     await AuditList.section.lastContactInList
-      .getText('@header', (result) => {
-        companyName = result.value
-      })
+      .getText('@header', (result) => set(this.state, 'companyName', result.value))
       .click('@header')
     await AuditCompany
-      .editCompanyRecords(description, website, number)
+      .editCompanyRecords(faker.name.jobDescriptor(), faker.internet.url(), number)
       .submitForm('form')
     await Message
       .verifyMessage('success')
   })
 
-  When(/^I search for this company record$/, async () => {
+  When(/^I search for this company record$/, async function () {
     await Company
       .navigate()
-      .findCompany(companyName)
+      .findCompany(this.state.companyName)
     await Contact
       .click('@firstCompanyFromList')
     await AuditContact
-      .getText('@userName', (result) => {
-        userName = result.value
-      })
+      .getText('@userName', (result) => set(this.state, 'username', result.value))
   })
 
-  Then(/^I see the name of the person who made the recent company record changes$/, async () => {
+  Then(/^I see the name of the person who made the recent company record changes$/, async function () {
     await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', userName)
+      .assert.containsText('@adviser', this.state.username)
   })
 
-  Then(/^I see the date time stamp when the recent company record changed$/, async () => {
+  Then(/^I see the date time stamp when the recent company record changed$/, async function () {
     const today = format(new Date(), 'D MMM YYYY')
     await AuditList.section.firstAuditInList
       .assert.containsText('@header', today)
   })
 
-  Then(/^I see the total number of changes occurred recently on this company record$/, async () => {
+  Then(/^I see the total number of changes occurred recently on this company record$/, async function () {
     await AuditList.section.firstAuditInList
       .assert.containsText('@changeCount', '2 changes')
   })
 
-  Then(/^I see the field names that were recently changed on this company record$/, async () => {
+  Then(/^I see the field names that were recently changed on this company record$/, async function () {
     await AuditList.section.firstAuditInList
       .assert.containsText('@fields', 'Business description')
   })

--- a/test/acceptance/features/audit/step_definitions/contact.js
+++ b/test/acceptance/features/audit/step_definitions/contact.js
@@ -2,8 +2,15 @@ const faker = require('faker')
 const format = require('date-fns/format')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
+const { merge, set } = require('lodash')
+
+const { getUid, appendUid } = require('../../../helpers/uuid')
+
+const companySearchPage = `${process.env.QA_HOST}/search/companies` // TODO move these urls out into a url world object
+const dashboardPage = `${process.env.QA_HOST}/`
 
 defineSupportCode(({ Given, Then, When }) => {
+  const Search = client.page.Search()
   const Message = client.page.Message()
   const Company = client.page.Company()
   const Contact = client.page.Contact()
@@ -11,82 +18,29 @@ defineSupportCode(({ Given, Then, When }) => {
   const AuditContact = client.page.AuditContact()
   const AuditList = client.page.AuditList()
   const InvestmentStage = client.page.InvestmentStage()
-  const foreignCompanyName = 'Lambda Plc'
-  let contactName
-  let telephone
-  let countryCode
-  let userName
 
-  Then(/^I Amend (.*) records of an existing contact record$/, async (number) => {
-    telephone = faker.phone.phoneNumber()
-    countryCode = faker.random.number()
+  Given(/^a company is created for audit/, async function () {
+    const companyName = appendUid(faker.company.companyName())
+
+    await client
+      .url(companySearchPage)
+
+    await Company
+      .createUkNonPrivateOrNonPublicLimitedCompany(
+        { name: companyName },
+        (company) => set(this.state, 'company', company),
+      )
+      .wait() // wait for backend to sync
+  })
+
+  Given(/^I archive an existing contact record$/, async function () {
     await Company
       .navigate()
-      .findCompany(foreignCompanyName)
-    await ContactList
-      .click('@contactsTab')
-    await Contact
-      .getText('@firstCompanyFromList', (result) => {
-        contactName = result.value
-      })
-      .click('@firstCompanyFromList')
-    await AuditContact
-      .editContactDetails(telephone, countryCode, number)
-      .submitForm('form')
-    await Message
-      .verifyMessage('success')
-  })
-
-  When(/^I search for this Contact record$/, async () => {
-    await Company
-      .navigate()
-      .findCompany(contactName)
-    await ContactList
-      .click('@contactsTab')
-    await Contact
-      .click('@firstCompanyFromList')
-    await AuditContact
-      .getText('@userName', (result) => {
-        userName = result.value
-      })
-  })
-
-  When(/^I navigate to Audit History tab$/, async () => {
-    await AuditContact
-      .click('@auditHistoryTab')
-  })
-
-  Then(/^I see the name of the person who made the recent contact record changes$/, async () => {
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', userName)
-  })
-
-  Then(/^I see the date time stamp when the recent contact record changed$/, async () => {
-    const today = format(new Date(), 'D MMM YYYY')
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@header', today)
-  })
-
-  Then(/^I see the total number of changes occurred recently on this contact record$/, async () => {
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@changeCount', '2 changes')
-  })
-
-  Then(/^I see the field names that were recently changed$/, async () => {
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@fields', 'Phone number')
-  })
-
-  Given(/^I archive an existing contact record$/, async () => {
-    await Company
-      .navigate()
-      .findCompany(foreignCompanyName)
+      .findCompany(this.fixtures.foreignCompany.name)
     await ContactList
       .click('@contactsTab')
     await AuditList.section.lastContactInList
-      .getText('@header', (result) => {
-        contactName = result.value
-      })
+      .getText('@header', (result) => set(this.state, 'contactName', result.value))
       .click('@header')
     await InvestmentStage
       .click('@archiveButton')
@@ -97,7 +51,59 @@ defineSupportCode(({ Given, Then, When }) => {
       .verifyMessage('success')
   })
 
-  When(/^I archive this contact record$/, async () => {
+  When(/^a primary contact is added for audit$/, async function () {
+    await Contact
+      .createNewContact({}, true, (contact) => set(this.state, 'contact', contact))
+  })
+
+  When(/^navigating to the company contacts for audit$/, async function () {
+    await client
+      .url(dashboardPage)
+
+    await Search
+      .search(getUid(this.state.company.name))
+
+    await Company
+      .section.firstCompanySearchResult
+      .click('@header')
+
+    await Company.section.detailsTabs
+      .waitForElementVisible('@contacts')
+      .click('@contacts')
+
+    await Company
+      .waitForElementVisible('@addContactButton')
+  })
+
+  When(/^the contact has ([0-9]) fields edited for audit$/, async function (count) {
+    await Contact
+      .getText('@firstCompanyFromList', (result) => set(this.state, 'contactName', result.value))
+      .click('@firstCompanyFromList')
+
+    await AuditContact
+      .editContactDetails({}, count, (contact) => {
+        set(this.state, 'contact', merge({}, this.state.contact, contact))
+      })
+  })
+
+  When(/^I search for this Contact record$/, async function () {
+    await Company
+      .navigate()
+      .findCompany(this.state.contactName)
+    await ContactList
+      .click('@contactsTab')
+    await Contact
+      .click('@firstCompanyFromList')
+    await AuditContact
+      .getText('@userName', (result) => set(this.state, 'username', result.value))
+  })
+
+  When(/^I navigate to Audit History tab$/, async function () {
+    await AuditContact
+      .click('@auditHistoryTab')
+  })
+
+  When(/^I archive this contact record$/, async function () {
     await InvestmentStage
       .click('@archiveButton')
     await AuditContact
@@ -107,20 +113,41 @@ defineSupportCode(({ Given, Then, When }) => {
       .verifyMessage('success')
   })
 
-  When(/^I unarchive this contact record$/, async () => {
+  When(/^I unarchive this contact record$/, async function () {
     await AuditContact
       .click('@unarchiveAnContactButton')
     await Message
       .verifyMessage('success')
   })
 
-  Then(/^I see the details who archived the contact$/, async () => {
+  Then(/^I see the name of the person who made the recent contact record changes$/, async function () {
     await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', userName)
+      .assert.containsText('@adviser', this.state.username)
   })
 
-  Then(/^I see the details who unarchived the contact$/, async () => {
+  Then(/^I see the date time stamp when the recent contact record changed$/, async function () {
+    const today = format(new Date(), 'D MMM YYYY')
     await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', userName)
+      .assert.containsText('@header', today)
+  })
+
+  Then(/^I see the total number of changes occurred recently on this contact record$/, async function () {
+    await AuditList.section.firstAuditInList
+      .assert.containsText('@changeCount', '2 changes')
+  })
+
+  Then(/^I see the field names that were recently changed$/, async function () {
+    await AuditList.section.firstAuditInList
+      .assert.containsText('@fields', 'Phone number')
+  })
+
+  Then(/^I see the details who archived the contact$/, async function () {
+    await AuditList.section.firstAuditInList
+      .assert.containsText('@adviser', this.state.username)
+  })
+
+  Then(/^I see the details who unarchived the contact$/, async function () {
+    await AuditList.section.firstAuditInList
+      .assert.containsText('@adviser', this.state.username)
   })
 })

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -26,6 +26,7 @@ module.exports = {
     searchField: '#field-term',
     searchForm: '.c-entity-search__button',
     addCompanyButton: getButtonWithText('Add company'),
+    addContactButton: getButtonWithText('Add contact'),
     addInteractionButton: getButtonWithText('Add interaction'),
     continueButton: getButtonWithText('Continue'),
     addButton: getButtonWithText('Add'),
@@ -268,6 +269,15 @@ module.exports = {
         natureOfBusiness: getMetaListItemValueSelector('Nature of business (SIC)'),
         type: getMetaListItemValueSelector('type'),
         incorporatedOn: getMetaListItemValueSelector('Incorporated on'),
+      },
+    },
+    firstContactsTabContact: {
+      selector: '.c-entity-list li:first-child',
+      elements: {
+        header: {
+          selector: 'a',
+        },
+        updated: getMetaListItemValueSelector('Updated'),
       },
     },
   },

--- a/test/acceptance/features/contacts/create.feature
+++ b/test/acceptance/features/contacts/create.feature
@@ -1,45 +1,17 @@
-@contacts-create @ignore
+@contacts-create
 Feature: Create New Contact
-  As an existing user
-  I would like to create a new contact for a company
+  As a data hub user
+  I would like to add an contact to data hub
+  So that I can collect contact data
 
   Background:
     Given I am an authenticated user on the data hub website
 
-  @contacts-create--option
-  Scenario: Verify Add new Contact option
+  @contacts-create--companies-interaction
+  Scenario: Interaction fields from companies
 
-    When I navigate to Contacts page of any company
-    Then I verify an option to add a new contact
-    And I logout of Data Hub website
+    And a company is created for contacts
+    When navigating to the create company contact page
+    And the add new contact button is clicked
+    Then there are contact fields
 
-  @contacts-create--primary
-  Scenario: Add a new Primary Contact
-
-    When I add a new Primary Contact
-    Then I see the Added new contact confirmation message
-    And I verify my newly added contact in company profile
-    And I logout of Data Hub website
-
-  @contacts-create--primary-new-company-address
-  Scenario: Add a new Primary Contact with new Company address
-
-    When I add a new Primary Contact with a new company address
-    Then I see the Added new contact confirmation message
-    And I verify my newly added contact in company profile
-    And I logout of Data Hub website
-
-  @contacts-create--non-primary
-  Scenario: Add a new non-Primary Contact
-
-    When I add a new non Primary Contact
-    Then I see the Added new contact confirmation message
-    And I verify my newly added contact in company profile
-    And I logout of Data Hub website
-
-  @contacts-create--verify
-  Scenario: Verify newly added contact under search landing page
-    When I add a new Primary Contact
-    Then I see the Added new contact confirmation message
-    And I verify my newly added contact under search landing page
-    And I logout of Data Hub website

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -1,0 +1,58 @@
+@contacts-save
+Feature: Create New Contact
+  As a data hub user
+  I would like to add a contact to data hub
+  So that I can collect contact data
+
+  Background:
+    Given I am an authenticated user on the data hub website
+
+  @contacts-save--primary
+  Scenario: Add a new primary contact
+
+    And a company is created for contacts
+    When navigating to the company contacts
+    And a primary contact is added
+    Then I see the success message
+    When navigating to the company contacts
+    Then the contact is displayed on the company contact tab
+
+  @contacts-save--primary-new-company-address @ignore
+  Scenario: Add a new primary contact with new company address
+
+    And a company is created for contacts
+    When navigating to the company contacts
+    And a primary contact with new company address is added
+    Then I see the success message
+    When navigating to the company contacts
+    Then the contact is displayed on the company contact tab
+
+  @contacts-save--non-primary
+  Scenario: Add a new non-primary contact
+
+    And a company is created for contacts
+    When navigating to the company contacts
+    And a non-primary contact is added
+    Then I see the success message
+    When navigating to the company contacts
+    Then the contact is displayed on the company contact tab
+
+  @contacts-save--primary-dashboard
+  Scenario: New primary contact is visible on the dashboard
+
+    And a company is created for contacts
+    When navigating to the company contacts
+    And a primary contact is added
+    Then I see the success message
+    When I navigate to the dashboard
+    Then the contact is displayed on the dashboard
+
+  @contacts-save--mandatory-fields
+  Scenario: Contact fields are mandatory
+
+    And a company is created for contacts
+    When navigating to the company contacts
+    And the add new contact button is clicked
+    And the save button is clicked
+    Then the contact fields have error messages
+    And I see form error summary

--- a/test/acceptance/features/contacts/step_definitions/create.js
+++ b/test/acceptance/features/contacts/step_definitions/create.js
@@ -1,79 +1,145 @@
 const faker = require('faker')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
+const { set } = require('lodash')
+
+const { getUid, appendUid } = require('../../../helpers/uuid')
+
+const companySearchPage = `${process.env.QA_HOST}/search/companies` // TODO move these urls out into a url world object
+const dashboardPage = `${process.env.QA_HOST}/`
 
 defineSupportCode(({ Given, Then, When }) => {
   const Company = client.page.Company()
   const Contact = client.page.Contact()
-  const foreignCompanyName = 'Lambda plc'
-  let firstName
-  let lastName
+  const Search = client.page.Search()
+  const Dashboard = client.page.Dashboard()
 
-  When(/^I navigate to Contacts page of any company$/, async () => {
+  Given(/^a company is created for contacts/, async function () {
+    const companyName = appendUid(faker.company.companyName())
+
+    await client
+      .url(companySearchPage)
+
     await Company
-      .navigate()
-      .findCompany(foreignCompanyName)
-    await Contact
-      .navigateToContactsPage()
+      .createUkNonPrivateOrNonPublicLimitedCompany(
+        { name: companyName },
+        (company) => set(this.state, 'company', company),
+      )
+      .wait() // wait for backend to sync
   })
 
-  Then(/^I verify an option to add a new contact$/, async () => {
+  When(/^a primary contact is added$/, async function () {
     await Contact
-      .assert.visible('@addContactButton')
-  })
-
-  When(/^I add a new Primary Contact$/, async function () {
-    firstName = faker.name.firstName()
-    lastName = faker.name.lastName()
-    await Company
-      .navigate()
-      .findCompany(foreignCompanyName)
-    await Contact
-      .navigateToContactsPage()
-      .createNewPrimaryContact({ firstName, lastName }, (contact) => {
+      .createNewContact({}, true, (contact) => {
         this.state.contact = contact
       })
   })
 
-  When(/^I add a new non Primary Contact$/, async () => {
-    firstName = faker.name.firstName()
-    lastName = faker.name.lastName()
-    await Company
-      .navigate()
-      .findCompany(foreignCompanyName)
+  When(/^a primary contact with new company address is added$/, async function () {
     await Contact
-      .navigateToContactsPage()
-      .createNewNonPrimaryContact(firstName, lastName)
-  })
-
-  When(/^I add a new Primary Contact with a new company address$/, async () => {
-    firstName = faker.name.firstName()
-    lastName = faker.name.lastName()
-    await Company
-      .navigate()
-      .findCompany(foreignCompanyName)
-    await Contact
-      .navigateToContactsPage()
-      .createNewPrimaryContactWithNewCompanyAddress(firstName, lastName)
-  })
-
-  Then(/^I verify my newly added contact under search landing page$/, async () => {
-    await Company
-      .navigate()
-    await Contact
-      .getText('@contactUnderSearchPage', (result) => {
-        Contact.assert.equal(result.value, `${firstName} ${lastName} from ${foreignCompanyName}`)
+      .createNewPrimaryContactWithNewCompanyAddress({}, (contact) => {
+        this.state.contact = contact
       })
   })
 
-  Then(/^I verify my newly added contact in company profile$/, async () => {
-    await Company
-      .navigate()
-      .findCompany(foreignCompanyName)
+  When(/^a non-primary contact is added$/, async function () {
     await Contact
-      .navigateToContactsPage()
-      .getText('@contactFullname', (result) => {
-        Contact.assert.equal(result.value, `${firstName} ${lastName}`)
+      .createNewContact({}, false, (contact) => {
+        this.state.contact = contact
       })
+  })
+
+  When(/^navigating to the company contacts$/, async function () {
+    await client
+      .url(dashboardPage)
+
+    await Search
+      .search(getUid(this.state.company.name))
+
+    await Company
+      .section.firstCompanySearchResult
+      .click('@header')
+
+    await Company.section.detailsTabs
+      .waitForElementVisible('@contacts')
+      .click('@contacts')
+
+    await Company
+      .waitForElementVisible('@addContactButton')
+  })
+
+  When(/^navigating to the create company contact page/, async function () {
+    await client
+      .url(dashboardPage)
+
+    await Search
+      .search(getUid(this.state.company.name))
+
+    await Company
+      .section.firstCompanySearchResult
+      .click('@header')
+
+    await Company.section.detailsTabs
+      .waitForElementVisible('@contacts')
+      .click('@contacts')
+
+    await Company
+      .waitForElementVisible('@addContactButton')
+  })
+
+  When(/^the add new contact button is clicked/, async function () {
+    await Contact
+      .click('@addContactButton')
+  })
+
+  When(/^the save button is clicked/, async function () {
+    await Contact
+      .click('@saveButton')
+  })
+
+  Then(/^there are contact fields$/, async function () {
+    await Contact
+      .waitForElementVisible('@firstName')
+      .assert.visible('@firstName')
+      .assert.visible('@lastName')
+      .assert.visible('@jobTitle')
+      .assert.visible('@primaryContactYes')
+      .assert.visible('@primaryContactNo')
+      .assert.visible('@telephoneCountryCode')
+      .assert.visible('@telephoneNumber')
+      .assert.visible('@emailAddress')
+      .assert.visible('@acceptsEmailMarketingFromDit')
+      .assert.visible('@sameAddressYes')
+      .assert.visible('@sameAddressNo')
+      .assert.visible('@alternativePhoneNumber')
+      .assert.visible('@alternativeEmail')
+      .assert.visible('@notes')
+  })
+
+  Then(/^the contact fields have error messages$/, async function () {
+    await Contact
+      .assert.visible('@firstNameError')
+      .assert.visible('@lastNameError')
+      .assert.visible('@primaryContactError')
+      .assert.visible('@telephoneCountryCodeError')
+      .assert.visible('@telephoneNumber')
+      .assert.visible('@emailAddressError')
+  })
+
+  Then(/^the contact is displayed on the company contact tab$/, async function () {
+    const contactName = `${this.state.contact.firstName} ${this.state.contact.lastName}`
+
+    await Company
+      .section.firstContactsTabContact
+      .assert.visible('@header')
+      .assert.containsText('@header', contactName)
+  })
+
+  Then(/^the contact is displayed on the dashboard$/, async function () {
+    const contactName = `${this.state.contact.firstName} ${this.state.contact.lastName}`
+    const dashboardContactEntry = `${contactName} from ${this.state.company.name}`
+
+    await Dashboard
+      .assert.containsText('@firstMyLatestContact', dashboardContactEntry)
   })
 })

--- a/test/acceptance/features/contacts/step_definitions/list.js
+++ b/test/acceptance/features/contacts/step_definitions/list.js
@@ -30,7 +30,7 @@ defineSupportCode(({ Given, Then, When }) => {
       .findCompany(foreignCompanyName)
     await Contact
       .navigateToContactsPage()
-      .createNewPrimaryContact({ firstName, lastName }, (contact) => {
+      .createNewContact({ firstName, lastName }, true, (contact) => {
         this.state.contact = contact
       })
   })

--- a/test/acceptance/features/dashboard/page-objects/Dashboard.js
+++ b/test/acceptance/features/dashboard/page-objects/Dashboard.js
@@ -9,11 +9,21 @@ const getGlobalNavSelector = (text) =>
     }
   )
 
+const getDashboardSectionItem = (text, itemNumber) =>
+  getSelectorForElementWithText(
+    text,
+    {
+      el: '//h2',
+      child: `/following-sibling::ol/li[${itemNumber}]`,
+    }
+  )
+
 module.exports = {
   url: process.env.QA_HOST,
   props: {},
   elements: {
     term: '#field-term',
+    firstMyLatestContact: getDashboardSectionItem('My latest contacts', 1),
   },
   sections: {
     globalNav: {

--- a/test/acceptance/features/interactions/step_definitions/create.js
+++ b/test/acceptance/features/interactions/step_definitions/create.js
@@ -44,7 +44,7 @@ defineSupportCode(({ Given, When, Then }) => {
       .click('@contacts')
 
     await Contact
-      .createNewPrimaryContact({}, (contact) => set(this.state, 'contact', contact))
+      .createNewContact({}, true, (contact) => set(this.state, 'contact', contact))
       .wait() // wait for backend to sync
   })
 

--- a/test/unit/apps/contacts/services/form.test.js
+++ b/test/unit/apps/contacts/services/form.test.js
@@ -1,4 +1,5 @@
 /* eslint prefer-promise-reject-errors: 0 */
+const { assign } = require('lodash')
 
 describe('contact form service', function () {
   let contactFormService
@@ -31,51 +32,49 @@ describe('contact form service', function () {
   })
 
   describe('convert API contact into form format', function () {
-    let contact
-
-    beforeEach(function () {
-      contact = {
-        id: '50680966-f5e1-e311-8a2b-e4115bead28a',
-        name: 'Zac Baman',
-        address_1: '99 N Shore Road',
-        address_2: 'Suite 20',
-        address_town: 'Town view',
-        address_country: {
-          id: '81756b9a-5d95-e211-a939-e4115bead28a',
-          name: 'United States',
-        },
-        address_county: 'CA',
-        address_postcode: '94043',
-        created_on: '2014-05-22T21:09:45',
-        modified_on: '2016-04-28T17:06:44',
-        archived: false,
-        archived_on: null,
-        archived_reason: '',
-        first_name: 'Zac',
-        last_name: 'Baman',
-        job_title: 'Co-founder and CEO',
-        primary: true,
-        telephone_countrycode: '+1',
-        telephone_number: '652423467167',
-        email: 'zboasdaan@opasdasdov.com',
-        address_same_as_company: false,
-        telephone_alternative: '999',
-        email_alternative: 'fred@me.com',
-        notes: 'Some notes',
-        archived_by: null,
-        title: {
-          id: '0167b456-0ddd-49bd-8184-e3227a0b6396',
-          name: 'Undefined',
-        },
-        company: {
-          id: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
-          name: 'OpenStuff',
-        },
-        adviser: null,
-      }
-    })
+    const contactData = {
+      id: '50680966-f5e1-e311-8a2b-e4115bead28a',
+      name: 'Zac Baman',
+      address_1: '99 N Shore Road',
+      address_2: 'Suite 20',
+      address_town: 'Town view',
+      address_country: {
+        id: '81756b9a-5d95-e211-a939-e4115bead28a',
+        name: 'United States',
+      },
+      address_county: 'CA',
+      address_postcode: '94043',
+      created_on: '2014-05-22T21:09:45',
+      modified_on: '2016-04-28T17:06:44',
+      archived: false,
+      archived_on: null,
+      archived_reason: '',
+      first_name: 'Zac',
+      last_name: 'Baman',
+      job_title: 'Co-founder and CEO',
+      primary: true,
+      telephone_countrycode: '+1',
+      telephone_number: '652423467167',
+      email: 'zboasdaan@opasdasdov.com',
+      address_same_as_company: false,
+      telephone_alternative: '999',
+      email_alternative: 'fred@me.com',
+      notes: 'Some notes',
+      archived_by: null,
+      title: {
+        id: '0167b456-0ddd-49bd-8184-e3227a0b6396',
+        name: 'Undefined',
+      },
+      company: {
+        id: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
+        name: 'OpenStuff',
+      },
+      adviser: null,
+    }
 
     it('should convert a fully populated expanded contact into a flat form format', function () {
+      const contact = assign({}, contactData)
+
       const expected = {
         id: '50680966-f5e1-e311-8a2b-e4115bead28a',
         company: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
@@ -87,6 +86,7 @@ describe('contact form service', function () {
         telephone_number: '652423467167',
         telephone_countrycode: '+1',
         email: 'zboasdaan@opasdasdov.com',
+        marketing_preferences: null,
         address_same_as_company: 'no',
         address_1: '99 N Shore Road',
         address_2: 'Suite 20',
@@ -103,16 +103,19 @@ describe('contact form service', function () {
 
       expect(actual).to.deep.equal(expected)
     })
+
     it('should handle blank and null fields', function () {
-      contact.last_name = null
-      contact.job_title = null
-      contact.address_same_as_company = true
-      contact.address_1 = ''
-      contact.address_2 = ''
-      contact.address_town = ''
-      contact.address_county = ''
-      contact.address_country = null
-      contact.address_postcode = ''
+      const contact = assign({}, contactData, {
+        last_name: null,
+        job_title: null,
+        address_same_as_company: true,
+        address_1: '',
+        address_2: '',
+        address_town: '',
+        address_county: '',
+        address_country: null,
+        address_postcode: '',
+      })
 
       const expected = {
         id: '50680966-f5e1-e311-8a2b-e4115bead28a',
@@ -125,6 +128,7 @@ describe('contact form service', function () {
         telephone_number: '652423467167',
         telephone_countrycode: '+1',
         email: 'zboasdaan@opasdasdov.com',
+        marketing_preferences: null,
         address_same_as_company: 'yes',
         address_1: null,
         address_2: null,
@@ -141,37 +145,46 @@ describe('contact form service', function () {
 
       expect(actual).to.deep.equal(expected)
     })
+
     it('should handle a null contact', function () {
       expect(contactFormService.getContactAsFormData(null)).to.be.null
     })
+
+    context('when the contact accepts DIT email marketing', () => {
+      it('should set the marketing preferences to accepts_dit_email_marketing', () => {
+        const contact = assign({}, contactData, {
+          accepts_dit_email_marketing: true,
+        })
+
+        const actual = contactFormService.getContactAsFormData(contact)
+
+        expect(actual.marketing_preferences).to.deep.equal('accepts_dit_email_marketing')
+      })
+    })
   })
   describe('save contact form', function () {
-    let formData
-
-    beforeEach(function () {
-      formData = {
-        id: '50680966-f5e1-e311-8a2b-e4115bead28a',
-        company: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
-        title: '0167b456-0ddd-49bd-8184-e3227a0b6396',
-        first_name: 'Zac',
-        last_name: 'Baman',
-        job_title: 'Co-founder and CEO',
-        primary: 'yes',
-        telephone_number: '652423467167',
-        telephone_countrycode: '+1',
-        email: 'zboasdaan@opasdasdov.com',
-        address_same_as_company: 'no',
-        address_1: '99 N Shore Road',
-        address_2: 'Suite 20',
-        address_town: 'Town view',
-        address_county: 'CA',
-        address_postcode: '94043',
-        address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
-        telephone_alternative: '999',
-        email_alternative: 'fred@me.com',
-        notes: 'Some notes',
-      }
-    })
+    const formData = {
+      id: '50680966-f5e1-e311-8a2b-e4115bead28a',
+      company: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
+      title: '0167b456-0ddd-49bd-8184-e3227a0b6396',
+      first_name: 'Zac',
+      last_name: 'Baman',
+      job_title: 'Co-founder and CEO',
+      primary: 'yes',
+      telephone_number: '652423467167',
+      telephone_countrycode: '+1',
+      email: 'zboasdaan@opasdasdov.com',
+      address_same_as_company: 'no',
+      address_1: '99 N Shore Road',
+      address_2: 'Suite 20',
+      address_town: 'Town view',
+      address_county: 'CA',
+      address_postcode: '94043',
+      address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
+      telephone_alternative: '999',
+      email_alternative: 'fred@me.com',
+      notes: 'Some notes',
+    }
 
     it('should accept a fully populated contact and convert it to an api format', function () {
       const expected = {
@@ -189,6 +202,7 @@ describe('contact form service', function () {
         telephone_number: '652423467167',
         telephone_countrycode: '+1',
         email: 'zboasdaan@opasdasdov.com',
+        accepts_dit_email_marketing: false,
         address_same_as_company: false,
         address_1: '99 N Shore Road',
         address_2: 'Suite 20',
@@ -208,6 +222,7 @@ describe('contact form service', function () {
           expect(postedData).to.deep.equal(expected)
         })
     })
+
     it('should return a copy of the saved contact', function () {
       delete formData.id
 
@@ -216,6 +231,7 @@ describe('contact form service', function () {
           expect(savedContact.id).to.not.be.null
         })
     })
+
     it('should throw errors received from the repository if the save fails', function () {
       throwError = true
 
@@ -223,6 +239,18 @@ describe('contact form service', function () {
         .catch((error) => {
           expect(error.error).to.equal('test error')
         })
+    })
+
+    context('when the contact accepts DIT email marketing', () => {
+      it('it should send accepts DIT email marketing as true', async () => {
+        this.formData = assign({}, formData, {
+          marketing_preferences: 'accepts_dit_email_marketing',
+        })
+
+        await contactFormService.saveContactForm('1234', this.formData)
+
+        expect(postedData.accepts_dit_email_marketing).to.deep.equal(true)
+      })
     })
   })
 })


### PR DESCRIPTION
The primary reason for this change is to add the `Accepts email marketing from DIT` checkbox to the contact editing form.

This change covers:
- adding the checkbox which is then persisted
- acceptance tests around contact editing fields
- reinstating acceptance tests around contact editing
- updating contact audit tests to reuse updated functionality

![screen shot 2017-10-27 at 17 01 46](https://user-images.githubusercontent.com/1150417/32113584-a0ff583e-bb38-11e7-9e05-d741496077c3.png)
