### PR TITLE
Update investment requirements to add another

### DIFF
--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -45,16 +45,16 @@ const labels = {
   },
   requirementsLabels: {
     view: {
-      strategic_drivers: 'Main strategic driver',
+      strategic_drivers: 'Strategic drivers',
       client_requirements: 'Client requirements',
       competitor_countries: 'Competitor countries',
       uk_region_locations: 'Possible UK locations',
       uk_company: 'UK recipient company',
     },
     edit: {
-      strategic_drivers: 'Main strategic driver behind this investment',
+      strategic_drivers: 'Strategic drivers behind this investment',
       client_considering_other_countries: 'Is the client considering other countries?',
-      uk_region_locations: 'Possible UK location for this investment',
+      uk_region_locations: 'Possible UK locations for this investment',
       site_decided: 'Has the UK location (site address) for this investment been decided yet?',
     },
   },

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -89,10 +89,20 @@ const investmentSortForm = {
 const requirementsFormConfig = {
   buttonText: 'Save',
   children: [
-    Object.assign({}, globalFields.strategicDrivers, {
-      initialOption: 'Choose a strategic driver',
+    {
+      macroName: 'AddAnother',
+      buttonName: 'add_item',
+      name: 'strategic_drivers',
       label: requirementsLabels.edit.strategic_drivers,
-    }),
+      optional: true,
+      children: [
+        Object.assign({}, globalFields.strategicDrivers, {
+          initialOption: 'Choose a strategic driver',
+          label: requirementsLabels.edit.strategic_drivers,
+          isLabelHidden: true,
+        }),
+      ],
+    },
     {
       macroName: 'TextField',
       type: 'textarea',
@@ -112,21 +122,38 @@ const requirementsFormConfig = {
         { label: 'No', value: 'false' },
       ],
     },
-    Object.assign({}, globalFields.countries, {
-      name: 'competitor_countries',
-      initialOption: 'Select country',
+    {
+      macroName: 'AddAnother',
+      buttonName: 'add_item',
       label: requirementsLabels.edit.competitor_countries,
       modifier: 'subfield',
       condition: {
         name: 'client_considering_other_countries',
         value: 'true',
       },
-    }),
-    Object.assign({}, globalFields.ukRegions, {
-      name: 'uk_region_locations',
+      children: [
+        Object.assign({}, globalFields.countries, {
+          name: 'competitor_countries',
+          initialOption: 'Select country',
+          label: requirementsLabels.edit.competitor_countries,
+          isLabelHidden: true,
+        }),
+      ],
+    },
+    {
+      macroName: 'AddAnother',
+      buttonName: 'add_item',
       label: requirementsLabels.edit.uk_region_locations,
-      initialOption: 'Select UK region',
-    }),
+      optional: true,
+      children: [
+        Object.assign({}, globalFields.ukRegions, {
+          name: 'uk_region_locations',
+          label: requirementsLabels.edit.uk_region_locations,
+          initialOption: 'Select UK region',
+          isLabelHidden: true,
+        }),
+      ],
+    },
     {
       macroName: 'MultipleChoiceField',
       type: 'radio',


### PR DESCRIPTION
Adds 'add another' support to the investment requirements form forstrategic drivers, competitor countries and possible uk regions.

![screencapture-localhost-3000-investment-projects-d886a660-5268-4149-823b-5805029e0639-edit-requirements-1509030249644](https://user-images.githubusercontent.com/56056/32060735-97242636-ba67-11e7-9846-dfa69507a4e6.png)

![screencapture-localhost-3000-investment-projects-d886a660-5268-4149-823b-5805029e0639-details-1509030274533](https://user-images.githubusercontent.com/56056/32060734-97089556-ba67-11e7-9b0e-d6b5e4b5c89f.png)
