### PR TITLE
Show link to archived files and documents for legacy orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This file expects the following environment variables:
 | ZEN_SERVICE | Zendesk service ID |
 | SENTRY_DSN | Sentry DSN (optional) |
 | WEBPACK_ENV | Optionally select the webpack configuration variation to use, the default will correctly pick a production or development config based on NODE_ENV. Valid values include `prod`, `develop` and `docker` |
+| OMIS_ARCHIVED_DOCUMENTS_BASE_URL | The base URL for the OMIS archived document store. Holds archived quotes and deliverables |
 
 Either set these variables manually or why not look at [autoenv](https://github.com/kennethreitz/autoenv).
 To start the server just:
@@ -339,14 +340,14 @@ You can tell `nightwatch.js` not to run a feature by adding the tag `@ignore`.
 
 
 ## Continuous Integration
-Data hub uses [CircleCI](https://circleci.com/) for continuous integration. 
+Data hub uses [CircleCI](https://circleci.com/) for continuous integration.
 
 ### Base docker image
-The acceptance tests `user_acceptance_tests` job uses the docker image `ukti/docker-data-hub-base` as a base for running a selenium server and data hub frontend 
+The acceptance tests `user_acceptance_tests` job uses the docker image `ukti/docker-data-hub-base` as a base for running a selenium server and data hub frontend
 Details can be found in the [GitHub](https://github.com/uktrade/docker-data-hub-base) and [docker](https://hub.docker.com/r/ukti/docker-data-hub-base/) repositories.
 
 ### Data hub backend docker image
-The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo). 
+The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo).
 The `uktrade/data-hub-leeloo` docker image and tags that is used is automatically built via a Docker hub automated job. Details can be found [https://hub.docker.com/r/ukti/data-hub-leeloo](https://hub.docker.com/r/ukti/data-hub-leeloo).
 
 - `user_acceptance_tests` job uses `ukti/data-hub-leeloo:latest`
@@ -358,7 +359,7 @@ CircleCI has been configured to show you a summary report of what has failed on 
 - `lint_code`
 - `user_acceptance_tests`
 
-When acceptance tests fail you can also have a look at the `Nightwatch.js` html report found in the jobs artifacts folder. 
+When acceptance tests fail you can also have a look at the `Nightwatch.js` html report found in the jobs artifacts folder.
 This can be accessed by logging in to [CircleCI](https://circleci.com/)
 
 ## Deployment

--- a/config/index.js
+++ b/config/index.js
@@ -49,6 +49,7 @@ const config = {
   mediumDateTimeFormat: 'D MMM YYYY, h:mma',
   paginationMaxResults: 10000,
   performanceDashboardsUrl: process.env.PERFORMANCE_DASHBOARDS_URL || 'https://mi.exportwins.service.trade.gov.uk',
+  omisArchivedDocumentsBaseUrl: process.env.OMIS_ARCHIVED_DOCUMENTS_BASE_URL,
 }
 
 module.exports = config

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,7 +1,10 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
-const { setOrderBreadcrumb } = require('../../middleware')
+const {
+  setOrderBreadcrumb,
+  setArchivedDocumentsBaseUrl,
+} = require('../../middleware')
 const { renderWorkOrder, renderQuote } = require('./controllers')
 const {
   setTranslation,
@@ -26,6 +29,7 @@ router.use(setTranslation)
 router.use(setCompany)
 router.use(setOrderBreadcrumb)
 router.use(setQuoteSummary)
+router.use(setArchivedDocumentsBaseUrl)
 
 router.get('/', redirectToFirstNavItem)
 router.get('/work-order', renderWorkOrder)

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -2,13 +2,21 @@
 
 {% block local_header %}
   {% set actions %}
-    <p class="c-local-header__action">
-      {% if order.status == 'draft' %}
-        <a href="quote" class="button">Preview quote</a>
-      {% else %}
-        <a href="quote">View quote</a>
-      {% endif %}
-    </p>
+    {% if order.archived_documents_url_path %}
+      <p class="c-local-header__action">
+        <a href="{{ archivedDocumentsBaseUrl }}{{ order.archived_documents_url_path }}">View files and documents</a>
+        <br>
+        (will open another website)
+      </p>
+    {% else %}
+      <p class="c-local-header__action">
+        {% if order.status == 'draft' %}
+          <a href="quote" class="button">Preview quote</a>
+        {% else %}
+          <a href="quote">View quote</a>
+        {% endif %}
+      </p>
+    {% endif %}
   {% endset %}
 
   {% call LocalHeader({

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,5 +1,6 @@
 const { assign, get } = require('lodash')
 
+const config = require('../../../config')
 const logger = require('../../../config/logger')
 const { getDitCompany } = require('../companies/repos')
 const { setHomeBreadcrumb } = require('../middleware')
@@ -44,8 +45,14 @@ function setOrderBreadcrumb (req, res, next) {
   return setHomeBreadcrumb(reference)(req, res, next)
 }
 
+function setArchivedDocumentsBaseUrl (req, res, next) {
+  res.locals.archivedDocumentsBaseUrl = config.omisArchivedDocumentsBaseUrl
+  next()
+}
+
 module.exports = {
   getCompany,
   getOrder,
   setOrderBreadcrumb,
+  setArchivedDocumentsBaseUrl,
 }

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -1,6 +1,8 @@
 const companyData = require('~/test/unit/data/company.json')
 const orderData = require('~/test/unit/data/omis/simple-order.json')
 
+const omisArchivedDocumentsBaseUrl = 'http://docs-base-url'
+
 describe('OMIS middleware', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
@@ -24,6 +26,9 @@ describe('OMIS middleware', () => {
     this.middleware = proxyquire('~/src/apps/omis/middleware', {
       '../companies/repos': {
         getDitCompany: this.getDitCompanyStub,
+      },
+      '../../../config': {
+        omisArchivedDocumentsBaseUrl: omisArchivedDocumentsBaseUrl,
       },
       '../../../config/logger': {
         error: this.loggerSpy,
@@ -202,6 +207,18 @@ describe('OMIS middleware', () => {
 
       expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledOnce
       expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, this.resMock, this.nextSpy)
+    })
+  })
+
+  describe('setArchivedDocumentsBaseUrl()', () => {
+    it('should call setHomeBreadcrumb with order reference', () => {
+      this.middleware.setArchivedDocumentsBaseUrl({}, this.resMock, this.nextSpy)
+
+      expect(this.resMock.locals).to.have.property('archivedDocumentsBaseUrl')
+      expect(this.resMock.locals.archivedDocumentsBaseUrl).to.equal(omisArchivedDocumentsBaseUrl)
+
+      expect(this.nextSpy).to.have.been.calledOnce
+      expect(this.nextSpy).to.have.been.calledWith()
     })
   })
 })


### PR DESCRIPTION
For legacy orders we need to provide a link to the supporting files
and documents for the order. This shows that link in the actions
header.

## What it looks like

![image](https://user-images.githubusercontent.com/3327997/32057603-a082e850-ba5f-11e7-95bc-4c2e8213d534.png)
