### PR TITLE
Add support for links to key value table

### DIFF
--- a/assets/stylesheets/_deprecated/components/_table.scss
+++ b/assets/stylesheets/_deprecated/components/_table.scss
@@ -68,3 +68,11 @@ table.table--key-value.table--small {
     }
   }
 }
+
+.table__actions {
+  float: right;
+}
+
+.table__action {
+  padding-left: $default-spacing-unit / 2;
+}

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -96,6 +96,41 @@ function renderProgress (req, res) {
     })
 }
 
+function renderKeyValueTables (req, res) {
+  const tableData = {
+    'Company': 'Acme corp',
+    'Something': {
+      name: 'Else',
+      url: '/components/',
+    },
+    'Date': {
+      type: 'date',
+      name: '20170107',
+    },
+    'Region': {
+      id: '1234',
+      name: 'South',
+    },
+    'Flavours': ['Chocolate', 'Strawberry', 'Melon'],
+    'Related Company': {
+      name: 'Freds Bananas',
+      actions: [{
+        url: '/components/',
+        label: 'Add company',
+      }, {
+        url: '/components/',
+        label: 'Remove company',
+      }],
+    },
+  }
+
+  return res
+    .breadcrumb('Key Value Tables')
+    .render('components/views/keyvaluetables', {
+      tableData,
+    })
+}
+
 module.exports = {
   renderEntityList,
   renderIndex,
@@ -105,4 +140,5 @@ module.exports = {
   renderPagination,
   renderProgress,
   renderCollection,
+  renderKeyValueTables,
 }

--- a/src/apps/components/router.js
+++ b/src/apps/components/router.js
@@ -9,6 +9,7 @@ const {
   renderPagination,
   renderProgress,
   renderCollection,
+  renderKeyValueTables,
 } = require('./controllers')
 
 const { renderFormElements } = require('./form/controllers')
@@ -26,6 +27,7 @@ router
   .get('/pagination', renderPagination)
   .get('/collection', getInvestmentProjectsCollection, renderCollection)
   .get('/progress', renderProgress)
+  .get('/keyvaluetables', renderKeyValueTables)
   .all('/form', renderFormElements)
 
 module.exports = router

--- a/src/apps/components/views/index.njk
+++ b/src/apps/components/views/index.njk
@@ -27,5 +27,8 @@
     <li>
       <a href="components/collection">Collection</a>
     </li>
+    <li>
+      <a href="components/keyvaluetables">Key value tables</a>
+    </li>
   </ul>
 {% endblock %}

--- a/src/apps/components/views/keyvaluetables.njk
+++ b/src/apps/components/views/keyvaluetables.njk
@@ -1,0 +1,9 @@
+{% extends "./_layout.njk" %}
+
+{% block body_main_content %}
+  <h2 class="heading-medium">Key value table</h2>
+  {% component 'key-value-table', items=tableData %}
+
+  <h2 class="heading-medium">Key value striped</h2>
+  {% component 'key-value-table', items=tableData, variant='striped' %}
+{% endblock %}

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -33,6 +33,15 @@
               {% else %}
                 {{ data.name }}
               {% endif %}
+
+              {% if data.actions %}
+                <span class="table__actions">
+                  {% for item in data.actions %}
+                    <a class="table__action" href="{{ item.url }}">{{ item.label }}</a>
+                  {% endfor %}
+                </span>
+              {% endif %}
+
             {% else %}
               {{ data }}
             {% endif %}


### PR DESCRIPTION
Add the ability to action links to appear next to a value in a key-value table.

![table](https://user-images.githubusercontent.com/56056/32101887-ecc4bea2-bb11-11e7-8687-d69492e294d1.PNG)

<a href="https://datahub-beta2-pr-836.herokuapp.com/components/keyvaluetables">:eyes: Demo</a>