### PR TITLE
we don't need to send in the Enter key as a paramter here

### DIFF
--- a/test/acceptance/features/interactions/step_definitions/create.js
+++ b/test/acceptance/features/interactions/step_definitions/create.js
@@ -33,7 +33,7 @@ defineSupportCode(({ Given, When, Then }) => {
       .url(dashboardPage)
 
     await Search
-      .search(getUid(this.state.company.name), client.Keys.ENTER)
+      .search(getUid(this.state.company.name))
 
     await Company
       .section.firstCompanySearchResult
@@ -62,7 +62,7 @@ defineSupportCode(({ Given, When, Then }) => {
       .url(dashboardPage)
 
     await Search
-      .search(getUid(this.state.company.name), client.Keys.ENTER)
+      .search(getUid(this.state.company.name))
 
     await Company
       .section.firstCompanySearchResult
@@ -82,7 +82,7 @@ defineSupportCode(({ Given, When, Then }) => {
       .url(dashboardPage)
 
     await Search
-      .search(getUid(this.state.contact.lastName), client.Keys.ENTER)
+      .search(getUid(this.state.contact.lastName))
       .section.tabs.click('@contacts')
 
     await Contact

--- a/test/acceptance/features/search/page-objects/Search.js
+++ b/test/acceptance/features/search/page-objects/Search.js
@@ -28,11 +28,11 @@ module.exports = {
   },
   commands: [
     {
-      search (term, enter) {
+      search (term) {
         return this
           .waitForElementPresent('@term')
           .setValue('@term', term)
-          .sendKeys('@term', [ enter ])
+          .sendKeys('@term', [ this.api.Keys.ENTER ])
           .waitForElementVisible('@addCompanyButton') // wait for xhr
       },
     },

--- a/test/acceptance/features/search/step_definitions/search.js
+++ b/test/acceptance/features/search/step_definitions/search.js
@@ -31,12 +31,12 @@ defineSupportCode(function ({ Then, When }) {
 
   When(/^I search for the event$/, async function () {
     await Search
-      .search(getUid(this.state.event.name), client.Keys.ENTER)
+      .search(getUid(this.state.event.name))
   })
 
   When(/^I search for the company/, async function () {
     await Search
-      .search(getUid(this.state.company.name), client.Keys.ENTER)
+      .search(getUid(this.state.company.name))
   })
 
   When(/^I click the Events tab/, async () => {


### PR DESCRIPTION
I don't see a need to pass through `client.Keys.ENTER` as an argument here