### PR TITLE
Fix next step for OMIS order creation

### DIFF
--- a/src/apps/omis/apps/create/steps.js
+++ b/src/apps/omis/apps/create/steps.js
@@ -24,7 +24,7 @@ module.exports = {
   '/market': {
     heading: 'Market (country) of interest',
     editable: true,
-    next: 'subscribers',
+    next: 'confirm',
     fields: ['primary_market'],
     controller: MarketController,
   },


### PR DESCRIPTION
When removing the subscribers step the next step for market was
missed. This fixes that which caused an error after saving the primary
market.