### PR TITLE
Duplicate children in MultipleChoiceField macro

### DIFF
--- a/src/apps/investment-projects/views/_details-form.njk
+++ b/src/apps/investment-projects/views/_details-form.njk
@@ -181,7 +181,7 @@
         label: 'No'
       }
     ],
-    children:  [
+    children: [
       {
         macroName: 'MultipleChoiceField',
         name: 'client_relationship_manager',
@@ -215,22 +215,23 @@
         value: 'false',
         label: 'No'
       }
+    ],
+    children: [
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'referral_source_adviser',
+        label: 'Referral source adviser',
+        error: form.errors.messages.referral_source_adviser,
+        value: form.state.referral_source_adviser,
+        options: form.options.advisers,
+        initialOption: '-- Select referral source adviser --',
+        modifier: 'subfield',
+        condition: {
+          name: 'is_referral_source',
+          value: 'false'
+        }
+      }
     ]
-  }) }}
-
-  {{ MultipleChoiceField({
-    macroName: 'MultipleChoiceField',
-    name: 'referral_source_adviser',
-    label: 'Referral source adviser',
-    error: form.errors.messages.referral_source_adviser,
-    value: form.state.referral_source_adviser,
-    options: form.options.advisers,
-    initialOption: '-- Select referral source adviser --',
-    modifier: 'subfield',
-    condition: {
-      name: 'is_referral_source',
-      value: 'false'
-    }
   }) }}
 
   {{  MultipleChoiceField({
@@ -239,48 +240,50 @@
     initialOption: '-- Choose referral source activity --',
     options: form.options.referralSourceActivities,
     error: form.errors.messages.referral_source_activity,
-    value: form.state.referral_source_activity
-  }) }}
-
-  {{ MultipleChoiceField({
-    name: 'referral_source_activity_marketing',
-    label: 'Marketing',
-    error: form.errors.messages.referral_source_activity_marketing,
-    value: form.state.referral_source_activity_marketing,
-    options: form.options.referralSourceMarketing,
-    initialOption: '-- Choose a marketing type --',
-    condition: {
-      name: 'referral_source_activity',
-      value: form.options.referralSourceActivities[3].value
-    },
-    modifier: 'subfield'
-  }) }}
-
-  {{ MultipleChoiceField({
-    name: 'referral_source_activity_website',
-    label: 'Website',
-    error: form.errors.messages.referral_source_activity_website,
-    value: form.state.referral_source_activity_website,
-    options: form.options.referralSourceWebsite,
-    initialOption: '-- Choose a website --',
-    condition: {
-      name: 'referral_source_activity',
-      value: form.options.referralSourceActivities[9].value
-    },
-    modifier: 'subfield'
-  }) }}
-
-  {{ TextField({
-    name: 'referral_source_activity_event',
-    label: 'Event',
-    placeholder: 'e.g conversation at conference',
-    error: form.errors.messages.referral_source_activity_event,
-    value: form.state.referral_source_activity_event,
-    condition: {
-      name: 'referral_source_activity',
-      value: form.options.referralSourceActivities[2].value
-    },
-    modifier: 'subfield'
+    value: form.state.referral_source_activity,
+    children: [
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'referral_source_activity_marketing',
+        label: 'Marketing',
+        error: form.errors.messages.referral_source_activity_marketing,
+        value: form.state.referral_source_activity_marketing,
+        options: form.options.referralSourceMarketing,
+        initialOption: '-- Choose a marketing type --',
+        modifier: 'subfield',
+        condition: {
+          name: 'referral_source_activity',
+          value: form.options.referralSourceActivities[3].value
+        }
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'referral_source_activity_website',
+        label: 'Website',
+        error: form.errors.messages.referral_source_activity_website,
+        value: form.state.referral_source_activity_website,
+        options: form.options.referralSourceWebsite,
+        initialOption: '-- Choose a website --',
+        modifier: 'subfield',
+        condition: {
+          name: 'referral_source_activity',
+          value: form.options.referralSourceActivities[9].value
+        }
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'referral_source_activity_event',
+        label: 'Event',
+        placeholder: 'e.g conversation at conference',
+        error: form.errors.messages.referral_source_activity_event,
+        value: form.state.referral_source_activity_event,
+        modifier: 'subfield',
+        condition: {
+          name: 'referral_source_activity',
+          value: form.options.referralSourceActivities[2].value
+        }
+      }
+    ]
   }) }}
 
   {{ DateFieldset({

--- a/src/templates/_macros/form/multiple-choice-field.njk
+++ b/src/templates/_macros/form/multiple-choice-field.njk
@@ -1,5 +1,7 @@
 {% from "./form-group.njk" import FormGroup %}
 {% from "./select-box.njk" import SelectBox %}
+{% from "./text-area.njk" import TextArea with context %}
+{% from "./text-field.njk" import TextField %}
 
 {##
  # Render form group with a multi choice field (dropdown, radio, checkboxes)
@@ -53,7 +55,6 @@
   {% if props.type in ['checkbox', 'radio'] %}
     {% set modifier = props.modifier | concat('') | reverse | join(' c-multiple-choice--') if props.modifier %}
     {% set options = props.options() if props.options | isFunction else props.options %}
-    {% set fieldChildren = props.children | map(callAsMacro) if props.children | isArray else props.children %}
 
     {% if props.type == 'radio' and props.initialOption %}
       <div class="c-multiple-choice {{ modifier }}">
@@ -102,7 +103,5 @@
         {{ children }}
       </div>
     {% endfor %}
-
-    {{ fieldChildren }}
   {% endif %}
 {% endmacro %}

--- a/test/unit/macros/form/multiple-choice-field.test.js
+++ b/test/unit/macros/form/multiple-choice-field.test.js
@@ -114,5 +114,47 @@ describe('MultipleChoice component', () => {
         })
       })
     })
+
+    context('children are set', () => {
+      beforeEach(() => {
+        this.valueProps = Object.assign({}, minimumProps, {
+          children: [
+            {
+              macroName: 'TextField',
+              name: 'first-child',
+              label: 'First child',
+            },
+            {
+              macroName: 'TextField',
+              name: 'second-child',
+              label: 'Second child',
+            },
+          ],
+        })
+      })
+
+      it('should display first child within form group inner', () => {
+        const component = macros.renderToDom('MultipleChoiceField', Object.assign({}, this.valueProps)).parentElement
+        const children = component.querySelectorAll('.c-form-group__inner .c-form-group')
+        const firstChild = children[0]
+
+        expect(firstChild.querySelector('input').name).to.equal('first-child')
+      })
+
+      it('should display second child within form group inner', () => {
+        const component = macros.renderToDom('MultipleChoiceField', Object.assign({}, this.valueProps)).parentElement
+        const children = component.querySelectorAll('.c-form-group__inner .c-form-group')
+        const secondChild = children[1]
+
+        expect(secondChild.querySelector('input').name).to.equal('second-child')
+      })
+
+      it('should display the correct number of children', () => {
+        const component = macros.renderToDom('MultipleChoiceField', Object.assign({}, this.valueProps)).parentElement
+        const children = component.querySelectorAll('.c-form-group__inner .c-form-group')
+
+        expect(children).to.have.length(2)
+      })
+    })
   })
 })


### PR DESCRIPTION
These was an error where using the `children` property would cause a duplicate in form fields to be displayed. This was because children was being called in both the root `MultipleChoiceField` macro and the internal `MultipleChoice` macro if it was a radio/checkbox variant.

The `SelectBox` macro wasn't calling it so removing from the parent meant dropdowns couldn't use the children property.

This is in reference to the initial fix in #848. 

## Before

![image](https://user-images.githubusercontent.com/161962/32218658-9063e6c8-be23-11e7-9ce6-1581ea6357e2.png)

## After

![image](https://user-images.githubusercontent.com/161962/32218783-f865437a-be23-11e7-9d66-efd66d4f05a2.png)