### PR TITLE
Mark order as completed

### DIFF
--- a/src/apps/omis/apps/edit/controllers/complete-order.js
+++ b/src/apps/omis/apps/edit/controllers/complete-order.js
@@ -1,0 +1,64 @@
+const { assign, filter, flatten, get, pick } = require('lodash')
+
+const { EditController } = require('../../../controllers')
+const { Order } = require('../../../models')
+
+class CompleteOrderController extends EditController {
+  async configure (req, res, next) {
+    if (get(res.locals, 'order.status') !== 'paid') {
+      return res.redirect(`/omis/${res.locals.order.id}`)
+    }
+
+    const orderId = get(res.locals, 'order.id')
+    const token = get(req.session, 'token')
+    const assignees = await Order.getAssignees(token, orderId)
+
+    if (!assignees.length) {
+      req.form.options.hidePrimaryFormAction = true
+    }
+
+    req.form.options = assign({}, req.form.options, {
+      disableFormAction: false,
+      buttonText: 'Complete order',
+    })
+
+    res.locals.assignees = assignees
+
+    super.configure(req, res, next)
+  }
+
+  async successHandler (req, res, next) {
+    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
+    const timeValues = flatten([data.assignee_actual_time])
+    const assignees = timeValues.map((value, index) => {
+      if (!value) { return }
+
+      const [ hours, minutes ] = value.split(':')
+
+      return {
+        adviser: {
+          id: res.locals.assignees[index].adviser.id,
+        },
+        actual_time: parseInt((hours * 60)) + parseInt(minutes),
+      }
+    })
+
+    try {
+      await Order.saveAssignees(req.session.token, res.locals.order.id, filter(assignees))
+      await Order.complete(req.session.token, res.locals.order.id)
+      const nextUrl = req.form.options.next || `/omis/${res.locals.order.id}`
+
+      req.journeyModel.reset()
+      req.journeyModel.destroy()
+      req.sessionModel.reset()
+      req.sessionModel.destroy()
+
+      req.flash('success', 'Order completed')
+      res.redirect(nextUrl)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = CompleteOrderController

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -75,6 +75,12 @@ const editFields = merge({}, globalFields, {
     modifier: ['shorter', 'soft'],
     validate: [isDuration],
   },
+  assignee_actual_time: {
+    fieldType: 'TextField',
+    label: 'fields.assignee_actual_time.label',
+    modifier: ['shorter', 'soft'],
+    validate: ['required', isDuration],
+  },
   vat_status: {
     fieldType: 'MultipleChoiceField',
     type: 'radio',

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -8,6 +8,7 @@ const EditSubscribersController = require('./controllers/subscribers')
 const EditWorkDescriptionController = require('./controllers/work-description')
 const EditBillingAddressController = require('./controllers/billing-address')
 const EditPaymentReconciliationController = require('./controllers/payment-reconciliation')
+const CompleteOrderController = require('./controllers/complete-order')
 
 const steps = merge({}, createSteps, {
   '/client-details': {
@@ -79,6 +80,15 @@ const steps = merge({}, createSteps, {
     templatePath: 'omis/apps/edit/views',
     template: 'payment-reconciliation.njk',
     controller: EditPaymentReconciliationController,
+  },
+  '/complete-order': {
+    heading: 'Complete order',
+    fields: [
+      'assignee_actual_time',
+    ],
+    templatePath: 'omis/apps/edit/views',
+    template: 'complete-order.njk',
+    controller: CompleteOrderController,
   },
 })
 

--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -1,0 +1,36 @@
+{% extends "_layouts/form-wizard-step.njk" %}
+
+{% block fields %}
+  {% if assignees.length %}
+
+    {% set key = 'assignee_actual_time' %}
+    {% set defaultProps = options.fields[key] %}
+
+    <table class="c-answers-summary">
+      <thead>
+        <tr>
+          <th class="c-answers-summary__control" colspan="2">Estimated time (HH:MM)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for assignee in assignees %}
+          {% set props = {} | assign(defaultProps, {
+            name: key,
+            idSuffix: assignee.adviser.id,
+            label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
+            value: values[key][loop.index0] or assignee.actual_time | formatDuration('hh:mm') if assignee.actual_time,
+            error: errors[key].message,
+            isLabelHidden: true
+          }) %}
+          <tr>
+            <th class="c-answers-summary__title">{{ assignee.adviser.name }}</th>
+            <td class="c-answers-summary__control">
+              {{ callAsMacro(props.fieldType)(props) }}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+  {% endif %}
+{% endblock %}

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -2,6 +2,12 @@
 
 {% block local_header %}
   {% set actions %}
+    {% if order.status in ['paid'] %}
+      <p class="c-local-header__action">
+        <a href="edit/complete-order" class="button">Complete order</a>
+      </p>
+    {% endif %}
+
     {% if order.status in ['paid', 'complete'] %}
       <p class="c-local-header__action">
         <a href="payment-receipt">View payment receipt</a>

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -42,6 +42,9 @@
     "assignee_time": {
       "label": "Estimated time"
     },
+    "assignee_actual_time": {
+      "label": "Actual time"
+    },
     "vat_status": {
       "label": "VAT category",
       "options": {

--- a/src/apps/omis/models.js
+++ b/src/apps/omis/models.js
@@ -94,6 +94,14 @@ const Order = {
       body,
     })
   },
+
+  complete (token, id, body) {
+    return authorisedRequest(token, {
+      url: `${config.apiRoot}/v3/omis/order/${id}/complete`,
+      method: 'POST',
+      body,
+    })
+  },
 }
 
 module.exports = {


### PR DESCRIPTION
This adds the ability to complete an OMIS order. Before that can be done the actual hours spent needs to be recorded so this is combined into one step.

## What it looks like

![localhost_3001_omis_6d3c9849-8dd4-4406-8336-2d8b8970e792_edit_complete-order](https://user-images.githubusercontent.com/3327997/32223895-272e4892-be37-11e7-9871-cda47ad69293.png)
