### PR TITLE
Display marketing preferences in contact details view

### DIFF
--- a/src/apps/contacts/labels.js
+++ b/src/apps/contacts/labels.js
@@ -4,6 +4,7 @@ const contactDetailsLabels = {
   telephone_number: 'Phone number',
   telephone_countrycode: 'Telephone country code',
   email: 'Email',
+  email_marketing: 'Email marketing',
   address: 'Address',
   telephone_alternative: 'Alternative telephone',
   email_alternative: 'Alternative email',

--- a/src/apps/contacts/services/formatting.js
+++ b/src/apps/contacts/services/formatting.js
@@ -23,6 +23,7 @@ function getDisplayContact (contact, company) {
     job_title: contact.job_title,
     telephone_number: formatPhone(contact.telephone_countrycode, contact.telephone_number),
     email: contact.email,
+    email_marketing: contact.accepts_dit_email_marketing ? 'Yes' : 'No',
     address: getContactAddress(contact, company),
     telephone_alternative: contact.telephone_alternative,
     email_alternative: contact.email_alternative,

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -172,6 +172,7 @@ module.exports = {
                     this.setValue(`@${key}`, company[key])
                   }
                 }
+                company.country = 'United Kingdom'
                 done()
               })
 

--- a/test/acceptance/features/contacts/page-objects/Contact.js
+++ b/test/acceptance/features/contacts/page-objects/Contact.js
@@ -39,6 +39,14 @@ const getCheckBoxLabel = (text) => getSelectorForElementWithText(
   }
 )
 
+const getTableRowValue = (text) => getSelectorForElementWithText(
+  text,
+  {
+    el: '//th',
+    child: '/following-sibling::td',
+  }
+)
+
 module.exports = {
   url: process.env.QA_HOST,
   props: {},
@@ -121,6 +129,12 @@ module.exports = {
             done()
           })
           .perform((done) => {
+            contact.acceptsEmailMarketingFromDit = 'Yes'
+            this.click('@acceptsEmailMarketingFromDit')
+
+            done()
+          })
+          .perform((done) => {
             this
               .click('@sameAddressYes')
 
@@ -199,6 +213,19 @@ module.exports = {
         company: getMetaListItemValueSelector('Company'),
         sector: getMetaListItemValueSelector('Sector'),
         updated: getMetaListItemValueSelector('Updated'),
+      },
+    },
+    contactDetails: {
+      selector: '.table--key-value',
+      elements: {
+        jobTitle: getTableRowValue('Job title'),
+        phoneNumber: getTableRowValue('Phone number'),
+        email: getTableRowValue('Email'),
+        emailMarketing: getTableRowValue('Email marketing'),
+        address: getTableRowValue('Address'),
+        alternativeTelephone: getTableRowValue('Alternative telephone'),
+        alternativeEmail: getTableRowValue('Alternative email'),
+        notes: getTableRowValue('Notes'),
       },
     },
   },

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -16,6 +16,8 @@ Feature: Create New Contact
     Then I see the success message
     When navigating to the company contacts
     Then the contact is displayed on the company contact tab
+    When the contact is clicked
+    Then the contact details are displayed
 
   @contacts-save--primary-new-company-address @ignore
   Scenario: Add a new primary contact with new company address
@@ -36,6 +38,8 @@ Feature: Create New Contact
     Then I see the success message
     When navigating to the company contacts
     Then the contact is displayed on the company contact tab
+    When the contact is clicked
+    Then the contact details are displayed
 
   @contacts-save--primary-dashboard
   Scenario: New primary contact is visible on the dashboard

--- a/test/acceptance/features/contacts/step_definitions/create.js
+++ b/test/acceptance/features/contacts/step_definitions/create.js
@@ -97,6 +97,12 @@ defineSupportCode(({ Given, Then, When }) => {
       .click('@saveButton')
   })
 
+  When(/^the contact is clicked/, async function () {
+    await Company
+      .section.firstContactsTabContact
+      .click('@header')
+  })
+
   Then(/^there are contact fields$/, async function () {
     await Contact
       .waitForElementVisible('@firstName')
@@ -141,5 +147,33 @@ defineSupportCode(({ Given, Then, When }) => {
 
     await Dashboard
       .assert.containsText('@firstMyLatestContact', dashboardContactEntry)
+  })
+
+  Then(/^the contact details are displayed$/, async function () {
+    const { address1, town, country } = this.state.company
+    const {
+      jobTitle,
+      telephoneCountryCode,
+      telephoneNumber,
+      emailAddress,
+      alternativePhoneNumber,
+      alternativeEmail,
+      notes,
+      acceptsEmailMarketingFromDit,
+    } = this.state.contact
+
+    const expectedAddress = `${address1}, ${town}, ${country}`
+    const expectedTelephoneNumber = `${telephoneCountryCode} ${telephoneNumber}`
+
+    await Contact
+      .section.contactDetails
+      .assert.containsText('@jobTitle', jobTitle)
+      .assert.containsText('@phoneNumber', expectedTelephoneNumber)
+      .assert.containsText('@email', emailAddress)
+      .assert.containsText('@emailMarketing', acceptsEmailMarketingFromDit)
+      .assert.containsText('@address', expectedAddress)
+      .assert.containsText('@alternativeTelephone', alternativePhoneNumber)
+      .assert.containsText('@alternativeEmail', alternativeEmail)
+      .assert.containsText('@notes', notes)
   })
 })

--- a/test/unit/apps/contacts/services/formatting.test.js
+++ b/test/unit/apps/contacts/services/formatting.test.js
@@ -1,11 +1,10 @@
+const { assign } = require('lodash')
+
 const contactFormattingService = require('~/src/apps/contacts/services/formatting')
 
 describe('Contact formatting service', function () {
-  let contact
-  let company
-
   beforeEach(function () {
-    contact = {
+    this.contact = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       created_on: '2017-02-14T14:49:17',
       modified_on: '2017-02-14T14:49:17',
@@ -19,6 +18,7 @@ describe('Contact formatting service', function () {
       telephone_countrycode: '+44',
       telephone_number: '07814 333 777',
       email: 'fred@test.com',
+      accepts_dit_email_marketing: false,
       address_same_as_company: false,
       address_1: '10 The Street',
       address_2: 'Warble',
@@ -37,25 +37,50 @@ describe('Contact formatting service', function () {
       address_country: null,
     }
 
-    company = {
+    this.company = {
       id: '9876',
-      'name': 'My Coorp',
+      name: 'My Corp',
     }
   })
-  describe('contact details', function () {
-    it('Should convert a typical contact into its display format', function () {
-      const expected = {
-        job_title: 'Director',
-        telephone_number: '+44 7814 333 777',
-        email: 'fred@test.com',
-        address: '10 the Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
-        telephone_alternative: '07814 000 333',
-        email_alternative: 'fred@gmail.com',
-        notes: 'some notes',
-      }
 
-      const actual = contactFormattingService.getDisplayContact(contact, company)
-      expect(actual).to.deep.equal(expected)
+  describe('#getDisplayContact', function () {
+    context('when the contact does not want to receiving marketing by email', () => {
+      it('should convert the contact to the display format', function () {
+        const expected = {
+          job_title: 'Director',
+          telephone_number: '+44 7814 333 777',
+          email: 'fred@test.com',
+          email_marketing: 'No',
+          address: '10 the Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
+          telephone_alternative: '07814 000 333',
+          email_alternative: 'fred@gmail.com',
+          notes: 'some notes',
+        }
+
+        const actual = contactFormattingService.getDisplayContact(this.contact, this.company)
+        expect(actual).to.deep.equal(expected)
+      })
+    })
+    context('when the contact does want to receiving marketing by email', () => {
+      it('should convert the contact to the display format', function () {
+        const contact = assign({}, this.contact, {
+          accepts_dit_email_marketing: true,
+        })
+
+        const expected = {
+          job_title: 'Director',
+          telephone_number: '+44 7814 333 777',
+          email: 'fred@test.com',
+          email_marketing: 'Yes',
+          address: '10 the Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
+          telephone_alternative: '07814 000 333',
+          email_alternative: 'fred@gmail.com',
+          notes: 'some notes',
+        }
+
+        const actual = contactFormattingService.getDisplayContact(contact, this.company)
+        expect(actual).to.deep.equal(expected)
+      })
     })
   })
 })


### PR DESCRIPTION
This change adds the marketing preferences to the contact details view.

Covered:
- update to details view
- acceptance tests

![screen shot 2017-10-31 at 20 35 47](https://user-images.githubusercontent.com/1150417/32247737-33a3371a-be7b-11e7-8a59-39d79315058d.png)
