### PR TITLE
Improve event acceptance test reliability

### DIFF
--- a/test/acceptance/features/events/edit.feature
+++ b/test/acceptance/features/events/edit.feature
@@ -9,11 +9,6 @@ Feature: Edit an Event in Data hub
   Background:
     Given I am an authenticated user on the data hub website
 
-  @events-edit--create-event
-  Scenario: Create an event for later scenarios
-    When I create an event
-    Then I see the success message
-
   @events-edit--name
   Scenario: Edit event name
     And I navigate to event details page

--- a/test/acceptance/features/events/page-objects/Event.js
+++ b/test/acceptance/features/events/page-objects/Event.js
@@ -60,7 +60,7 @@ module.exports = {
         return this
           .assert.visible('#group-field-related_programmes #group-field-related_programmes:nth-child(' + listNumber + ') select')
       },
-      populateCreateEventForm (details = {}, callback) {
+      populateCreateEventForm (details = {}, selectUkRegion, callback) {
         const today = new Date()
         const futureDate = addWeeks(today, 1)
         const event = assign({}, {
@@ -101,7 +101,7 @@ module.exports = {
               })
             )
               .then(() => {
-                if (event.address_country === 'United Kingdom') {
+                if (event.address_country === 'United Kingdom' && selectUkRegion) {
                   return new Promise((resolve) => {
                     this.getListOption('@ukRegion', (ukRegion) => {
                       event.uk_region = ukRegion

--- a/test/acceptance/features/events/save.feature
+++ b/test/acceptance/features/events/save.feature
@@ -10,15 +10,14 @@ Feature: Save a new Event in Data hub
   @events-save--submit
   Scenario: Verify event is submitted
 
-    When I navigate to the create an event page
-    And I enter all mandatory fields related to the event
-    And I click the save button
+    When I create an event
     Then I see the success message
 
   @events-save--mandatory-fields
   Scenario: Verify event mandatory fields
 
-    When I navigate to the create an event page
+    And I navigate to the event list page
+    When I click the add an event link
     And I click the save button
     Then the event fields have error messages
     And I see form error summary
@@ -26,9 +25,9 @@ Feature: Save a new Event in Data hub
   @events-save--uk-region
   Scenario: Verify event UK region mandatory field
 
-    When I navigate to the create an event page
-    And I enter all mandatory fields related to the event
-    And I choose the United Kingdom country option
+    And I navigate to the event list page
+    When I click the add an event link
+    When I populate the create event form with United Kingdom and without a region
     And I click the save button
     And I verify the event UK region has an error message
     Then I see form error summary

--- a/test/acceptance/features/events/step_definitions/create.js
+++ b/test/acceptance/features/events/step_definitions/create.js
@@ -1,8 +1,6 @@
-const faker = require('faker')
 const { set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
-const { getDate, getMonth, getYear, addDays } = require('date-fns')
 
 defineSupportCode(function ({ Then, When }) {
   const Event = client.page.Event()
@@ -10,7 +8,7 @@ defineSupportCode(function ({ Then, When }) {
   When(/^I create an event$/, async function () {
     await Event
       .navigate()
-      .populateCreateEventForm({}, (event) => set(this.state, 'event', event))
+      .populateCreateEventForm({}, true, (event) => set(this.state, 'event', event))
       .click('@saveButton')
       .wait() // wait for backend to sync
   })
@@ -187,27 +185,6 @@ defineSupportCode(function ({ Then, When }) {
   When(/^I add it to the programmes list$/, async () => {
     await Event
       .click('@addAnotherProgramme')
-  })
-
-  When(/^I enter all mandatory fields related to the event$/, async () => {
-    const startDate = faker.date.future()
-    const endDate = addDays(startDate, Math.floor(Math.random() * 20))
-
-    await Event
-      .waitForElementVisible('@eventName')
-      .setValue('@eventName', faker.company.companyName())
-      .selectListOption('event_type', 2)
-      .setValue('@startDateYear', getYear(startDate))
-      .setValue('@startDateMonth', getMonth(startDate))
-      .setValue('@startDateDay', getDate(startDate))
-      .setValue('@endDateYear', getYear(endDate))
-      .setValue('@endDateMonth', getMonth(endDate))
-      .setValue('@endDateDay', getDate(endDate))
-      .setValue('@addressLine1', faker.address.streetName())
-      .setValue('@addressTown', faker.address.city())
-      .setValue('@addressPostcode', faker.address.zipCode())
-      .setValue('@addressCountry', faker.address.country())
-      .selectListOption('service', 2)
   })
 
   Then(/^I verify there should be ([0-9]) programmes lists$/, async (expected) => {

--- a/test/acceptance/features/events/step_definitions/list.js
+++ b/test/acceptance/features/events/step_definitions/list.js
@@ -23,12 +23,17 @@ defineSupportCode(({ Then, When }) => {
 
   When(/^I populate the create event form$/, async function () {
     await Event
-      .populateCreateEventForm({}, (event) => set(this.state, 'event', event))
+      .populateCreateEventForm({}, true, (event) => set(this.state, 'event', event))
   })
 
   When(/^I populate the create event form with United Kingdom and a region$/, async function () {
     await Event
-      .populateCreateEventForm({ address_country: 'United Kingdom' }, (event) => set(this.state, 'event', event))
+      .populateCreateEventForm({ address_country: 'United Kingdom' }, true, (event) => set(this.state, 'event', event))
+  })
+
+  When(/^I populate the create event form with United Kingdom and without a region$/, async function () {
+    await Event
+      .populateCreateEventForm({ address_country: 'United Kingdom' }, false, (event) => set(this.state, 'event', event))
   })
 
   Then(/^I am taken to the create event page$/, async () => {

--- a/test/acceptance/features/search/step_definitions/search.js
+++ b/test/acceptance/features/search/step_definitions/search.js
@@ -16,7 +16,7 @@ defineSupportCode(function ({ Then, When }) {
     const eventName = appendUid(faker.company.companyName())
 
     await Event
-      .populateCreateEventForm({ name: eventName }, (event) => set(this.state, 'event', event))
+      .populateCreateEventForm({ name: eventName }, true, (event) => set(this.state, 'event', event))
   })
 
   When(/^a company is created to search$/, async function () {


### PR DESCRIPTION
This change will improve reliability around event acceptance tests. A recent change introduced setting of start and end date which appeared to be occasionally incorrectly formatted.

This change will:
- make tests more reliable
- consolidate step definitions as there was some repetition

Special attention needs to be given to the new parameter here -- https://github.com/uktrade/data-hub-frontend/pull/860/files#diff-e8d0d97fc5653713ec9de221cea4fd88R63