### PR TITLE
Ensure time with errors displays the entered value

### DIFF
--- a/src/apps/omis/apps/edit/views/assignee-time.njk
+++ b/src/apps/omis/apps/edit/views/assignee-time.njk
@@ -29,7 +29,7 @@
             name: key,
             idSuffix: assignee.adviser.id,
             label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
-            value: values[key][loop.index0] or assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time,
+            value: values[key][loop.index0] or (assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time),
             error: errors[key].message,
             isLabelHidden: true
           }) %}

--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -18,7 +18,7 @@
             name: key,
             idSuffix: assignee.adviser.id,
             label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
-            value: values[key][loop.index0] or assignee.actual_time | formatDuration('hh:mm') if assignee.actual_time,
+            value: values[key][loop.index0] or (assignee.actual_time | formatDuration('hh:mm') if assignee.actual_time),
             error: errors[key].message,
             isLabelHidden: true
           }) %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -92,7 +92,7 @@
             {% endif %}
           </td>
           <td class="c-answers-summary__content c-answers-summary__content--number">
-            {{ assignee.estimated_time  | humanizeDuration if assignee.estimated_time else 'No time estimated' }}
+            {{ assignee.estimated_time | humanizeDuration if assignee.estimated_time else 'No time estimated' }}
           </td>
         </tr>
       {% else %}


### PR DESCRIPTION
The logic to display the entered text when a user gets a validation
error when entering time needed parenthesis wrapper around one of the
conditions to ensure the correct value was displayed.