### PR TITLE
Display estimated time when completing an order

### DIFF
--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -9,7 +9,9 @@
     <table class="c-answers-summary">
       <thead>
         <tr>
-          <th class="c-answers-summary__control" colspan="2">Estimated time (HH:MM)</th>
+          <th></th>
+          <th class="c-answers-summary__content">Estimated time</th>
+          <th class="c-answers-summary__control">Actual time spent (HH:MM)</th>
         </tr>
       </thead>
       <tbody>
@@ -23,7 +25,12 @@
             isLabelHidden: true
           }) %}
           <tr>
-            <th class="c-answers-summary__title">{{ assignee.adviser.name }}</th>
+            <th class="c-answers-summary__title">
+              {{ assignee.adviser.name }}
+            </th>
+            <th class="c-answers-summary__content">
+              {{ assignee.estimated_time | humanizeDuration }}
+            </th>
             <td class="c-answers-summary__control">
               {{ callAsMacro(props.fieldType)(props) }}
             </td>


### PR DESCRIPTION
We ask for the actual time to be added before completing an order
so it provides better context if we also provide the estimated hours
when asking for this information.