### PR TITLE
Quote vs internal

### DIFF
--- a/src/apps/omis/apps/edit/controllers/index.js
+++ b/src/apps/omis/apps/edit/controllers/index.js
@@ -2,7 +2,7 @@ const EditAssigneesController = require('./assignees')
 const EditAssigneeTimeController = require('./assignee-time')
 const EditClientDetailsController = require('./client-details')
 const EditSubscribersController = require('./subscribers')
-const EditWorkDescriptionController = require('./work-description')
+const EditQuoteDetailsController = require('./quote-details')
 const editHandler = require('./edit-handler')
 const editLeadAssignee = require('./edit-lead-assignee')
 const editRedirect = require('./edit-redirect')
@@ -12,7 +12,7 @@ module.exports = {
   EditAssigneeTimeController,
   EditClientDetailsController,
   EditSubscribersController,
-  EditWorkDescriptionController,
+  EditQuoteDetailsController,
   editHandler,
   editLeadAssignee,
   editRedirect,

--- a/src/apps/omis/apps/edit/controllers/internal-details.js
+++ b/src/apps/omis/apps/edit/controllers/internal-details.js
@@ -1,0 +1,37 @@
+const { filter, find, flatten } = require('lodash')
+
+const { EditController } = require('../../../controllers')
+const { transformObjectToOption } = require('../../../../transformers')
+const metadataRepo = require('../../../../../lib/metadata')
+
+class EditInternalDetailsController extends EditController {
+  configure (req, res, next) {
+    const filteredServiceTypes = filter(metadataRepo.orderServiceTypesOptions, (service) => {
+      if (!service.disabled_on) { return true }
+
+      const serviceDisabledDate = Date.parse(service.disabled_on)
+      const orderCreatedDate = Date.parse(res.locals.order.created_on)
+
+      if (serviceDisabledDate > orderCreatedDate) {
+        return true
+      }
+
+      if (find(res.locals.order.service_types, { id: service.id })) {
+        return true
+      }
+
+      return false
+    })
+
+    req.form.options.fields.sector.options = metadataRepo.sectorOptions.map(transformObjectToOption)
+    req.form.options.fields.service_types.options = filteredServiceTypes.map(transformObjectToOption)
+    super.configure(req, res, next)
+  }
+
+  process (req, res, next) {
+    req.form.values.service_types = filter(flatten([req.form.values.service_types]))
+    next()
+  }
+}
+
+module.exports = EditInternalDetailsController

--- a/src/apps/omis/apps/edit/controllers/quote-details.js
+++ b/src/apps/omis/apps/edit/controllers/quote-details.js
@@ -1,33 +1,7 @@
-const { filter, find, flatten } = require('lodash')
 const chrono = require('chrono-node')
 const dateFns = require('date-fns')
 
 const { EditController } = require('../../../controllers')
-const { transformObjectToOption } = require('../../../../transformers')
-const metadataRepo = require('../../../../../lib/metadata')
-
-  configure (req, res, next) {
-    const filteredServiceTypes = filter(metadataRepo.orderServiceTypesOptions, (service) => {
-      if (!service.disabled_on) { return true }
-
-      const serviceDisabledDate = Date.parse(service.disabled_on)
-      const orderCreatedDate = Date.parse(res.locals.order.created_on)
-
-      if (serviceDisabledDate > orderCreatedDate) {
-        return true
-      }
-
-      if (find(res.locals.order.service_types, { id: service.id })) {
-        return true
-      }
-
-      return false
-    })
-
-    req.form.options.fields.sector.options = metadataRepo.sectorOptions.map(transformObjectToOption)
-    req.form.options.fields.service_types.options = filteredServiceTypes.map(transformObjectToOption)
-    super.configure(req, res, next)
-  }
 
 class EditQuoteDetailsController extends EditController {
   process (req, res, next) {
@@ -39,8 +13,6 @@ class EditQuoteDetailsController extends EditController {
     } else {
       req.form.values.delivery_date = deliveryDateStr
     }
-
-    req.form.values.service_types = filter(flatten([req.form.values.service_types]))
     next()
   }
 

--- a/src/apps/omis/apps/edit/controllers/quote-details.js
+++ b/src/apps/omis/apps/edit/controllers/quote-details.js
@@ -6,7 +6,6 @@ const { EditController } = require('../../../controllers')
 const { transformObjectToOption } = require('../../../../transformers')
 const metadataRepo = require('../../../../../lib/metadata')
 
-class EditWorkDescriptionController extends EditController {
   configure (req, res, next) {
     const filteredServiceTypes = filter(metadataRepo.orderServiceTypesOptions, (service) => {
       if (!service.disabled_on) { return true }
@@ -30,6 +29,7 @@ class EditWorkDescriptionController extends EditController {
     super.configure(req, res, next)
   }
 
+class EditQuoteDetailsController extends EditController {
   process (req, res, next) {
     const deliveryDateStr = req.body.delivery_date
     const parsedDeliveryDate = chrono.en_GB.parseDate(deliveryDateStr)
@@ -57,4 +57,4 @@ class EditWorkDescriptionController extends EditController {
   }
 }
 
-module.exports = EditWorkDescriptionController
+module.exports = EditQuoteDetailsController

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -6,6 +6,7 @@ const EditAssigneeTimeController = require('./controllers/assignee-time')
 const EditClientDetailsController = require('./controllers/client-details')
 const EditSubscribersController = require('./controllers/subscribers')
 const EditQuoteDetailsController = require('./controllers/quote-details')
+const EditInternalDetailsController = require('./controllers/internal-details')
 const EditBillingAddressController = require('./controllers/billing-address')
 const EditPaymentReconciliationController = require('./controllers/payment-reconciliation')
 const CompleteOrderController = require('./controllers/complete-order')
@@ -46,6 +47,15 @@ const steps = merge({}, createSteps, {
       'delivery_date',
     ],
     controller: EditQuoteDetailsController,
+  },
+  '/internal-details': {
+    heading: 'Edit internal information',
+    fields: [
+      'service_types',
+      'contacts_not_to_approach',
+      'sector',
+    ],
+    controller: EditInternalDetailsController,
   },
   '/payment': {
     heading: 'Edit invoice details',

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -5,7 +5,7 @@ const EditAssigneesController = require('./controllers/assignees')
 const EditAssigneeTimeController = require('./controllers/assignee-time')
 const EditClientDetailsController = require('./controllers/client-details')
 const EditSubscribersController = require('./controllers/subscribers')
-const EditWorkDescriptionController = require('./controllers/work-description')
+const EditQuoteDetailsController = require('./controllers/quote-details')
 const EditBillingAddressController = require('./controllers/billing-address')
 const EditPaymentReconciliationController = require('./controllers/payment-reconciliation')
 const CompleteOrderController = require('./controllers/complete-order')
@@ -36,8 +36,8 @@ const steps = merge({}, createSteps, {
     templatePath: 'omis/apps/edit/views',
     template: 'assignee-time.njk',
   },
-  '/work-description': {
-    heading: 'Edit work description',
+  '/quote-details': {
+    heading: 'Edit quote information',
     fields: [
       'service_types',
       'description',
@@ -45,7 +45,7 @@ const steps = merge({}, createSteps, {
       'sector',
       'delivery_date',
     ],
-    controller: EditWorkDescriptionController,
+    controller: EditQuoteDetailsController,
   },
   '/payment': {
     heading: 'Edit invoice details',

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -40,10 +40,7 @@ const steps = merge({}, createSteps, {
   '/quote-details': {
     heading: 'Edit quote information',
     fields: [
-      'service_types',
       'description',
-      'contacts_not_to_approach',
-      'sector',
       'delivery_date',
     ],
     controller: EditQuoteDetailsController,

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -138,6 +138,18 @@
       value: values.delivery_date | formatDate if values.delivery_date,
       fallbackText: 'Not set'
     }, {
+      label: 'Description of the activity',
+      value: values.description,
+      fallbackText: 'Not added'
+    }]
+  }) }}
+
+  {{ AnswersSummary({
+    heading: 'Internal use only',
+    actions: [{
+      url: 'edit/internal-details' if order.isEditable
+    }],
+    items: [{
       label: 'Service type' | pluralise(values.service_types.length),
       value: values.service_types | map('name') | join(', ') if values.service_types.length,
       fallbackText: 'None selected'
@@ -145,10 +157,6 @@
       label: 'Sector',
       value: values.sector.name,
       fallbackText: 'Not selected'
-    }, {
-      label: 'Description of the activity',
-      value: values.description,
-      fallbackText: 'Not added'
     }, {
       label: 'Contacts not to approach',
       value: values.contacts_not_to_approach,

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -129,9 +129,9 @@
   }) }}
 
   {{ AnswersSummary({
-    heading: 'Work description',
+    heading: 'Information for the quote',
     actions: [{
-      url: 'edit/work-description' if order.isEditable
+      url: 'edit/quote-details' if order.isEditable
     }],
     items: [{
       label: 'Delivery date',


### PR DESCRIPTION
This work includes moving and renaming a section and splitting it in two to help distinguish between information that will populate the quote sent to the customer and information that is used internally to support the delivery of the order.

This is something that has come out frequently during research so helps to clearer explain where the data entered will or will not be used.

## Before

![image](https://user-images.githubusercontent.com/3327997/32334739-25ccbe7c-bfe3-11e7-9ab3-0246909af557.png)

## After

![image](https://user-images.githubusercontent.com/3327997/32334694-0a2490be-bfe3-11e7-95fc-b8d76fbc66f0.png)
