### PR TITLE
Add support to edit additional internal details

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -59,6 +59,19 @@ const editFields = merge({}, globalFields, {
     label: 'fields.contacts_not_to_approach.label',
     optional: true,
   },
+  existing_agents: {
+    fieldType: 'TextField',
+    type: 'textarea',
+    label: 'fields.existing_agents.label',
+    optional: true,
+  },
+  further_info: {
+    fieldType: 'TextField',
+    type: 'textarea',
+    label: 'fields.further_info.label',
+    hint: 'fields.further_info.hint',
+    optional: true,
+  },
   assignees: {
     fieldType: 'MultipleChoiceField',
     legend: 'fields.assignees.legend',

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -49,8 +49,10 @@ const steps = merge({}, createSteps, {
     heading: 'Edit internal information',
     fields: [
       'service_types',
-      'contacts_not_to_approach',
       'sector',
+      'further_info',
+      'existing_agents',
+      'contacts_not_to_approach',
     ],
     controller: EditInternalDetailsController,
   },

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -158,21 +158,21 @@
       value: values.sector.name,
       fallbackText: 'Not selected'
     }, {
-      label: 'Contacts not to approach',
-      value: values.contacts_not_to_approach,
-      fallbackText: 'None added'
+      label: 'Further information',
+      value: values.further_info
     }, {
       label: 'Existing representatives',
       value: values.existing_agents
+    }, {
+      label: 'Contacts not to approach',
+      value: values.contacts_not_to_approach,
+      fallbackText: 'None added'
     }, {
       label: 'Permission to approach contacts',
       value: values.permission_to_approach_contacts
     }, {
       label: 'Production information',
       value: values.product_info
-    }, {
-      label: 'Further information',
-      value: values.further_info
     }]
   }) }}
 

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -31,7 +31,14 @@
       "hint": "For example 28/10/2017"
     },
     "contacts_not_to_approach": {
-      "label": "Contacts not to approach"
+      "label": "Specific people or organisations the company does not want DIT to talk to"
+    },
+    "existing_agents": {
+      "label": "Contacts the company already has in the market"
+    },
+    "further_info": {
+      "label": "Additional notes and useful information",
+      "hint": "For example other client comments or requirements"
     },
     "assignees": {
       "legend": "Advisers",


### PR DESCRIPTION
This adds support for existing agents the company works with and
any additional notes to help deliver the order.

## What it looks like

![localhost_3001_omis_80078f16-b5a5-4348-8534-a681f3c923f8_edit_internal-details](https://user-images.githubusercontent.com/3327997/32336451-4a68b444-bfe7-11e7-8eb3-2727002cbcb4.png)
