### PR TITLE
Fix stack error

### DIFF
--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -7,7 +7,7 @@
 {% from "./form/form-group.njk" import FormGroup with context %}
 {% from "./form/hidden-field.njk" import HiddenField %}
 {% from "./form/input.njk" import Input %}
-{% from "./form/multiple-choice-field.njk" import MultipleChoiceField %}
+{% from "./form/multiple-choice-field.njk" import MultipleChoiceField,MultipleChoice %}
 {% from "./form/multi-step-form.njk" import MultiStepForm with context %}
 {% from "./form/select-box.njk" import SelectBox with context %}
 {% from "./form/text-area.njk" import TextArea with context %}
@@ -24,6 +24,7 @@
 {% set Input = Input %}
 {% set MultiStepForm = MultiStepForm %}
 {% set MultipleChoiceField = MultipleChoiceField %}
+{% set MultipleChoice = MultipleChoice %}
 {% set SelectBox = SelectBox %}
 {% set TextArea = TextArea %}
 {% set TextField = TextField %}

--- a/src/templates/_macros/form/multiple-choice-field.njk
+++ b/src/templates/_macros/form/multiple-choice-field.njk
@@ -1,7 +1,5 @@
 {% from "./form-group.njk" import FormGroup %}
 {% from "./select-box.njk" import SelectBox %}
-{% from "./text-area.njk" import TextArea with context %}
-{% from "./text-field.njk" import TextField %}
 
 {##
  # Render form group with a multi choice field (dropdown, radio, checkboxes)

--- a/test/unit/macros/form/multiple-choice-field.test.js
+++ b/test/unit/macros/form/multiple-choice-field.test.js
@@ -120,14 +120,30 @@ describe('MultipleChoice component', () => {
         this.valueProps = Object.assign({}, minimumProps, {
           children: [
             {
-              macroName: 'TextField',
+              macroName: 'SelectBox',
               name: 'first-child',
               label: 'First child',
+              class: 'child',
+              options: [{
+                id: '1234',
+                name: 'Fred Flintstone',
+              }, {
+                id: '4321',
+                name: 'Barney Rubble',
+              }],
             },
             {
-              macroName: 'TextField',
+              macroName: 'SelectBox',
               name: 'second-child',
               label: 'Second child',
+              class: 'child',
+              options: [{
+                id: '1234',
+                name: 'Fred Flintstone',
+              }, {
+                id: '4321',
+                name: 'Barney Rubble',
+              }],
             },
           ],
         })
@@ -135,23 +151,17 @@ describe('MultipleChoice component', () => {
 
       it('should display first child within form group inner', () => {
         const component = macros.renderToDom('MultipleChoiceField', Object.assign({}, this.valueProps)).parentElement
-        const children = component.querySelectorAll('.c-form-group__inner .c-form-group')
-        const firstChild = children[0]
-
-        expect(firstChild.querySelector('input').name).to.equal('first-child')
+        expect(component.querySelector('.c-form-group__inner [name="first-child"]')).to.not.eq(null)
       })
 
       it('should display second child within form group inner', () => {
         const component = macros.renderToDom('MultipleChoiceField', Object.assign({}, this.valueProps)).parentElement
-        const children = component.querySelectorAll('.c-form-group__inner .c-form-group')
-        const secondChild = children[1]
-
-        expect(secondChild.querySelector('input').name).to.equal('second-child')
+        expect(component.querySelector('.c-form-group__inner [name="second-child"]')).to.not.eq(null)
       })
 
       it('should display the correct number of children', () => {
         const component = macros.renderToDom('MultipleChoiceField', Object.assign({}, this.valueProps)).parentElement
-        const children = component.querySelectorAll('.c-form-group__inner .c-form-group')
+        const children = component.querySelectorAll('.c-form-group__inner .child')
 
         expect(children).to.have.length(2)
       })

--- a/test/unit/macros/form/multiple-choice-field.test.js
+++ b/test/unit/macros/form/multiple-choice-field.test.js
@@ -1,5 +1,5 @@
 const { getMacros } = require('~/test/unit/macro-helper')
-const macros = getMacros('form/multiple-choice-field')
+const macros = getMacros('form')
 
 describe('MultipleChoice component', () => {
   const minimumProps = {


### PR DESCRIPTION
Fixed stack overflow error being displayed for first few renders of company, contact or investment details page. 

![error](https://user-images.githubusercontent.com/56056/32404351-e35e528a-c145-11e7-8e90-09db8d51219c.PNG)

After refreshing the page a few times the error would go away. One possible theory is the error was raised during the template compilation and after a few renders, the code is cached.

The failing pages all use the archive template which in turn relies on the multiple choice template which had 2 new imports added in a recent pr #853. The imports are only required for tests and the existing imports worked with no issue.

Removed the imports that triggered the stack overflow and updated tests to use components already being imported. Also updated the import statement for the test to import from 'form', to be consistent with all the other macro tests. Retested the pages that use this control, including the pages mentioned in #853.

Whilst investigating the issue I was able to confirm that this only happens when node js runs in development mode and does not occur when running in production mode.

Further investigation needs to be carried out to confirm the cause using the node JS v8 `profile` tools.
