### PR TITLE
Refactor: form group and stop using it in wrong situation

### DIFF
--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -4,18 +4,19 @@
   <button class="button button-secondary postcode-lookup-button" type="button">Find UK address</button>
 {% endset %}
 
+{% set businessType %}
+  {{ 'Foreign' if isForeign else 'UK' }}
+  {{ 'limited company' if isCompaniesHouse else businessType or '(type of organisation not known)' }}
+{% endset %}
+
 {% block main_grid_right_column %}
   <div class="section">
-    {% call FormGroup({
-      label: 'Business type'
-    }) %}
-      <div>
-        {{ 'Foreign' if isForeign else 'UK' }}
-        {{ 'limited company' if isCompaniesHouse else businessType or '(type of organisation not known)' }}
-
-        <a href="/companies/add-step-1">Change</a>
-      </div>
-    {% endcall %}
+    <h2 class="heading-medium">Business type</h2>
+    {{ MetaList({
+        items: [
+          { label: businessType, value: '<a href="/companies/add-step-1">Change</a>', safe: true }
+        ]
+      }) }}
   </div>
 
   {% if chDetails %}
@@ -134,12 +135,11 @@
         }) }}
 
         {% if not isForeign %}
-          {% call FormGroup({
-            label: 'Country'
-          }) %}
+          <div class="section">
+            <h2 class="heading-medium">Country</h2>
             <p>United Kingdom</p>
             <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}">
-          {% endcall %}
+          </div>
         {% else %}
           {{ MultipleChoiceField({
             name: 'registered_address_country',
@@ -222,12 +222,11 @@
         }) }}
 
         {% if not isForeign %}
-          {% call FormGroup({
-            label: 'Country'
-          }) %}
+          <div class="section">
+            <h2 class="heading-medium">Country</h2>
             <p>United Kingdom</p>
             <input type="hidden" name="trading_address_country" value="">
-          {% endcall %}
+          </div>
         {% else %}
           {{ MultipleChoiceField({
             name: 'trading_address_country',

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -1,7 +1,7 @@
 {# // TODO remove these as they are refactored #}
 {% from "_macros/_deprecated/trade-elements/keyvaluetable.njk" import keyvaluetable %}
 
-{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
+{% from "_macros/form.njk" import Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Message, MessageList, Breadcrumbs, Pagination, GlobalNav, LocalNav, Progress, FromNow, AnswersSummary %}

--- a/src/templates/_macros/form/form-group.njk
+++ b/src/templates/_macros/form/form-group.njk
@@ -31,7 +31,7 @@
   {% set fieldsetModifier = props.modifier | concat('') | reverse | join(' c-form-fieldset--') if props.modifier %}
   {% set children = caller() if caller else renderAsMacro(props.children) %}
 
-  {% if props.label -%}
+  {% if props.label and props.name -%}
     <{{ groupElement }}
       id="group-{{ props.fieldId }}"
       class="

--- a/test/unit/macros/form/text-field.test.js
+++ b/test/unit/macros/form/text-field.test.js
@@ -14,6 +14,13 @@ describe('TextField component', () => {
       })
       expect(component).to.be.null
     })
+
+    it('should not render if name is not provided', () => {
+      const component = macros.renderToDom('TextField', {
+        label: 'First name',
+      })
+      expect(component).to.be.null
+    })
   })
 
   describe('valid props', () => {


### PR DESCRIPTION
I have been meaning to get back to this since I changed it in [#818](https://github.com/uktrade/data-hub-frontend/pull/818)

Essentially I was using the `FormGroup` macro for its styling.

This work:
-  uses `MetaList` and vanilla markup. There is potential for a new macro if we see a pattern of `Heading` -> `Text` -> `hidden input`.
- reinstates a `text-field.test.js`
- reinstates the fact you can only use `FormGroup` when it has a containing `input` element
- removes `FormGroup` from the import in `datahub-base.njk` essentially saying this should only be used by proxying through a higher level macro.

### Business type on add/edit company flow
![screen shot 2017-11-04 at 12 31 05](https://user-images.githubusercontent.com/2305016/32405495-77b441e8-c15e-11e7-8659-96af58d96f8c.png)

### United Kingdom value on add/edit company flow
![screen shot 2017-11-04 at 12 31 11](https://user-images.githubusercontent.com/2305016/32405496-78eef486-c15e-11e7-9a42-992abe728eae.png)


