### PR TITLE
add the SSO_ENABLED env to Circle.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
           POSTGRES_URL: tcp://postgres:5432
           QA_USER_EMAIL: circleci@datahub.com
           QA_USER_PASSWORD: secretSquiR3L
+          SSO_ENABLED: 'false'
     parallelism: 6
     working_directory: ~/data-hub-frontend
     steps:


### PR DESCRIPTION
Leeloo now requires the `SSO_ENABLED` env to run