### PR TITLE
Interaction filters

### DIFF
--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -19,7 +19,12 @@ const {
 } = require('./controllers/exports')
 
 const { setDefaultQuery, setLocalNav, redirectToFirstNavItem } = require('../middleware')
-const { getInteractionCollection } = require('../interactions/middleware/collection')
+const {
+  getInteractionCollection,
+  getInteractionsRequestBody,
+  getInteractionSortForm,
+} = require('../interactions/middleware/collection')
+
 const { getRequestBody, getCompanyCollection } = require('./middleware/collection')
 const { populateForm, handleFormPost } = require('./middleware/form')
 const { getCompany, getCompaniesHouseRecord } = require('./middleware/params')
@@ -77,7 +82,13 @@ router.use('/:companyId', setLocalNav(LOCAL_NAV))
 router.get('/:companyId', redirectToFirstNavItem)
 router.get('/:companyId/details', renderDetails)
 router.get('/:companyId/contacts', renderContacts)
-router.get('/:companyId/interactions', setInteractionsReturnUrl, getInteractionCollection, renderInteractions)
+router.get('/:companyId/interactions',
+  setInteractionsReturnUrl,
+  getInteractionsRequestBody,
+  getInteractionCollection,
+  getInteractionSortForm,
+  renderInteractions
+)
 router.get('/:companyId/exports', renderExports)
 router.get('/:companyId/investments', renderInvestments)
 router.get('/:companyId/orders', renderOrders)

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -10,7 +10,11 @@ const { renderInteractions } = require('./controllers/interactions')
 const { getAudit } = require('./controllers/audit')
 
 const { setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails } = require('./middleware/interactions')
-const { getInteractionCollection } = require('../interactions/middleware/collection')
+const {
+  getInteractionCollection,
+  getInteractionsRequestBody,
+  getInteractionSortForm,
+} = require('../interactions/middleware/collection')
 
 const interactionsRouter = require('../interactions/router.sub-app')
 
@@ -46,7 +50,9 @@ router.get('/:id/unarchive', unarchiveContact)
 router.get('/:contactId/interactions',
   getCommon,
   setInteractionsReturnUrl,
+  getInteractionsRequestBody,
   getInteractionCollection,
+  getInteractionSortForm,
   renderInteractions
 )
 

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -1,7 +1,17 @@
-function renderInteractionList (req, res, next) {
+const { getAllAdvisers } = require('../../adviser/repos')
+const { interactionFiltersFieldConfig } = require('../macros')
+const { buildSelectedFiltersSummary } = require('../../builders')
+
+async function renderInteractionList (req, res, next) {
   try {
+    const { results: advisers } = await getAllAdvisers(req.session.token)
+    const filtersFields = interactionFiltersFieldConfig(advisers)
+    const selectedFilters = buildSelectedFiltersSummary(filtersFields, req.query)
+
     res.render('interactions/views/list', {
       title: 'Interactions',
+      filtersFields,
+      selectedFilters,
     })
   } catch (error) {
     next(error)

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -24,7 +24,16 @@ const serviceDelivery = {
   event: 'Event',
 }
 
+const filters = {
+  kind: 'Kind',
+  communication_channel: 'Communication channel',
+  dit_adviser: 'Adviser',
+  date_after: 'From',
+  date_before: 'To',
+}
+
 module.exports = {
   interaction,
   serviceDelivery,
+  filters,
 }

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -4,6 +4,8 @@ const formLabels = require('./labels')
 const metaData = require('../../lib/metadata')
 const { transformContactToOption, transformObjectToOption } = require('../transformers')
 
+const currentYear = (new Date()).getFullYear()
+
 const interactionSortForm = {
   method: 'get',
   class: 'c-collection__sort-form js-AutoSubmit',
@@ -120,6 +122,47 @@ const interactionFields = {
   },
 }
 
+const interactionFiltersFieldConfig = function (advisers) {
+  return [
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'kind',
+      type: 'checkbox',
+      options: [
+        { value: 'interaction', label: 'Interaction' },
+        { value: 'service_delivery', label: 'Service delivery' },
+      ],
+    },
+    assign(
+      {},
+      interactionFields.communicationChannel,
+      { initialOption: '-- All channels --' }
+    ),
+    assign(
+      {},
+      interactionFields.adviser(advisers),
+      { initialOption: '-- All advisers --' }
+    ),
+    {
+      macroName: 'TextField',
+      name: 'date_after',
+      hint: 'YYYY-MM-DD',
+      placeholder: `e.g. ${currentYear}-07-18`,
+    },
+    {
+      macroName: 'TextField',
+      name: 'date_before',
+      hint: 'YYYY-MM-DD',
+      placeholder: `e.g. ${currentYear}-07-21`,
+    },
+  ].map(filter => {
+    return assign(filter, {
+      label: formLabels.filters[filter.name],
+      modifier: ['smaller', 'light'],
+    })
+  })
+}
+
 const interactionFormConfig = function ({
   returnLink,
   contacts = [],
@@ -210,6 +253,7 @@ const serviceDeliveryFormConfig = function ({
 }
 
 module.exports = {
+  interactionFiltersFieldConfig,
   interactionSortForm,
   selectKindFormConfig,
   interactionFormConfig,

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -5,7 +5,12 @@ const { renderDetailsPage } = require('./controllers/details')
 const { renderInteractionList } = require('./controllers/list')
 
 const { setDefaultQuery } = require('../middleware')
-const { getInteractionCollection } = require('./middleware/collection')
+const {
+  getInteractionCollection,
+  getInteractionsRequestBody,
+  getInteractionSortForm,
+} = require('./middleware/collection')
+
 const { postDetails, getInteractionOptions, getInteractionDetails } = require('./middleware/details')
 
 const DEFAULT_COLLECTION_QUERY = {
@@ -14,7 +19,13 @@ const DEFAULT_COLLECTION_QUERY = {
 
 router.param('interactionId', getInteractionDetails)
 
-router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getInteractionCollection, renderInteractionList)
+router.get('/',
+  setDefaultQuery(DEFAULT_COLLECTION_QUERY),
+  getInteractionsRequestBody,
+  getInteractionCollection,
+  getInteractionSortForm,
+  renderInteractionList
+)
 
 router
   .route('/:interactionId/:kind/edit')

--- a/src/apps/interactions/views/list.njk
+++ b/src/apps/interactions/views/list.njk
@@ -1,10 +1,20 @@
 {% extends "_layouts/two-column.njk" %}
 
+{% block main_grid_left_column %}
+  {{
+    CollectionFilters({
+      query: QUERY,
+      filtersFields: filtersFields
+    })
+  }}
+{% endblock %}
+
 {% block main_grid_right_column %}
   {{
     Collection(interactions | assign({
       countLabel: 'interaction',
       sortForm: sortForm,
+      selectedFilters: selectedFilters,
       query: QUERY
     }))
   }}

--- a/test/unit/apps/interactions/middleware/collection.test.js
+++ b/test/unit/apps/interactions/middleware/collection.test.js
@@ -1,30 +1,7 @@
 const { assign } = require('lodash')
-
-describe('#getInteractionCollection', () => {
+describe('interaction collection middleware', () => {
   beforeEach(async () => {
     this.sandbox = sinon.sandbox.create()
-    this.transformApiResponseToSearchCollectionStub = this.sandbox.stub()
-
-    this.searchStub = this.sandbox.stub().resolves({
-      count: 1,
-      results: [{ id: '1' }],
-    })
-
-    this.transformedInteractionStub = { id: '1234' }
-    this.transformedInteractionWithUrlPrefixStub = assign({}, this.transformedInteractionStub, { urlPrefix: 'return' })
-    this.transformInteractionToListItemStub = this.sandbox.stub().returns(this.transformedInteractionStub)
-    this.transformInteractionListItemToHaveUrlPrefixStub =
-      this.sandbox.stub().returns(() => { return this.transformedInteractionWithUrlPrefixStub })
-
-    this.middleware = proxyquire('~/src/apps/interactions/middleware/collection', {
-      '../../search/services': {
-        search: this.searchStub,
-      },
-      '../transformers': {
-        transformInteractionToListItem: this.transformInteractionToListItemStub,
-        transformInteractionListItemToHaveUrlPrefix: this.transformInteractionListItemToHaveUrlPrefixStub,
-      },
-    })
 
     this.req = {
       body: {},
@@ -46,8 +23,35 @@ describe('#getInteractionCollection', () => {
     this.next = this.sandbox.spy()
   })
 
-  context('when called with default values', () => {
+  afterEach(() => {
+    this.sandbox.reset()
+  })
+
+  describe('#getInteractionCollection', () => {
     beforeEach(async () => {
+      this.transformApiResponseToSearchCollectionStub = this.sandbox.stub()
+
+      this.searchStub = this.sandbox.stub().resolves({
+        count: 1,
+        results: [{ id: '1' }],
+      })
+
+      this.transformedInteractionStub = { id: '1234' }
+      this.transformedInteractionWithUrlPrefixStub = assign({}, this.transformedInteractionStub, { urlPrefix: 'return' })
+      this.transformInteractionToListItemStub = this.sandbox.stub().returns(this.transformedInteractionStub)
+      this.transformInteractionListItemToHaveUrlPrefixStub =
+        this.sandbox.stub().returns(() => { return this.transformedInteractionWithUrlPrefixStub })
+
+      this.middleware = proxyquire('~/src/apps/interactions/middleware/collection', {
+        '../../search/services': {
+          search: this.searchStub,
+        },
+        '../transformers': {
+          transformInteractionToListItem: this.transformInteractionToListItemStub,
+          transformInteractionListItemToHaveUrlPrefix: this.transformInteractionListItemToHaveUrlPrefixStub,
+        },
+      })
+
       await this.middleware.getInteractionCollection(this.req, this.res, this.next)
     })
 
@@ -65,42 +69,101 @@ describe('#getInteractionCollection', () => {
       expect(this.res.locals.interactions.count).to.equal(1)
       expect(this.res.locals.interactions.items[0]).to.deep.equal(this.transformedInteractionWithUrlPrefixStub)
     })
-
-    it('sould create a sort form', () => {
-      expect(this.res.locals).to.have.property('sortForm')
-    })
   })
 
-  context('when called with contact id', () => {
-    beforeEach(async () => {
-      this.req.params.contactId = '1234'
-      await this.middleware.getInteractionCollection(this.req, this.res, this.next)
+  describe('#getInteractionsRequestBody', () => {
+    beforeEach(() => {
+      this.middleware = require('~/src/apps/interactions/middleware/collection')
     })
 
-    it('should call search with a filter for contact id', () => {
-      expect(this.searchStub).to.be.calledWith({
-        searchEntity: 'interaction',
-        requestBody: { contact: '1234' },
-        token: this.req.session.token,
-        page: this.req.query.page,
-        isAggregation: false,
+    context('when called with contact id', () => {
+      beforeEach(() => {
+        this.req.params.contactId = '1234'
+        this.middleware.getInteractionsRequestBody(this.req, this.res, this.next)
+      })
+
+      it('should set the contact in the request body', () => {
+        expect(this.req.body.contact).to.equal('1234')
+      })
+    })
+
+    context('when called with company id', () => {
+      beforeEach(() => {
+        this.req.params.companyId = '1234'
+        this.middleware.getInteractionsRequestBody(this.req, this.res, this.next)
+      })
+
+      it('should set the contact in the request body', () => {
+        expect(this.req.body.company).to.equal('1234')
+      })
+    })
+
+    context('when called with sort order', () => {
+      beforeEach(() => {
+        this.req.query.sortby = 'name'
+        this.middleware.getInteractionsRequestBody(this.req, this.res, this.next)
+      })
+
+      it('should set the sort order in the request body', () => {
+        expect(this.req.body.sortby).to.equal('name')
+      })
+    })
+
+    context('when called with filter criteria', () => {
+      beforeEach(() => {
+        this.req.query = assign({}, this.req.query, {
+          kind: 'interaction',
+          communication_channel: 'phone',
+          dit_adviser: '4321',
+          date_after: '2017-02-01',
+          date_before: '2018-01-01',
+          fruit: 'Orange',
+        })
+
+        this.middleware.getInteractionsRequestBody(this.req, this.res, this.next)
+      })
+
+      it('should put the criteria in the request body', () => {
+        expect(this.req.body.kind).to.equal(this.req.query.kind)
+        expect(this.req.body.communication_channel).to.equal(this.req.query.communication_channel)
+        expect(this.req.body.dit_adviser).to.equal(this.req.query.dit_adviser)
+        expect(this.req.body.date_after).to.equal(this.req.query.date_after)
+        expect(this.req.body.date_before).to.equal(this.req.query.date_before)
+      })
+
+      it('should not include invalid parameters', () => {
+        expect(this.req.body).to.not.have.property('fruit')
       })
     })
   })
 
-  context('when called with sort order', () => {
-    beforeEach(async () => {
-      this.req.query.sortby = 'subject'
-      await this.middleware.getInteractionCollection(this.req, this.res, this.next)
+  describe('#getInteractionSortForm', () => {
+    beforeEach(() => {
+      this.middleware = require('~/src/apps/interactions/middleware/collection')
     })
 
-    it('should set the sort order in the search query', () => {
-      expect(this.searchStub).to.be.calledWith({
-        searchEntity: 'interaction',
-        requestBody: { sortby: 'subject' },
-        token: this.req.session.token,
-        page: this.req.query.page,
-        isAggregation: false,
+    context('when called with no sort order', () => {
+      beforeEach(() => {
+        this.middleware.getInteractionSortForm(this.req, this.res, this.next)
+      })
+
+      it('should generate a sort form', () => {
+        expect(this.res.locals).to.have.property('sortForm')
+      })
+    })
+
+    context('when called with a sort order', () => {
+      beforeEach(() => {
+        this.req.query.sortby = 'name'
+        this.middleware.getInteractionSortForm(this.req, this.res, this.next)
+      })
+
+      it('should generate a sort form', () => {
+        expect(this.res.locals).to.have.property('sortForm')
+      })
+
+      it('should indicate the selected sort order', () => {
+        expect(this.res.locals.sortForm.children[0].value).to.equal('name')
       })
     })
   })


### PR DESCRIPTION
Minor refactor for interaction collections middleware to split out the 3 common jobs it needs to do:
- Parse request body and parameters
- Generate form for sorting
- Get collection data

Added support to the interaction list controller and view to introduce a filter form.

![interactions](https://user-images.githubusercontent.com/56056/32462795-9000e794-c332-11e7-8496-daad56563c0a.PNG)
