### PR TITLE
Re-instate FormGroup to global imports

### DIFF
--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -1,7 +1,7 @@
 {# // TODO remove these as they are refactored #}
 {% from "_macros/_deprecated/trade-elements/keyvaluetable.njk" import keyvaluetable %}
 
-{% from "_macros/form.njk" import Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
+{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Message, MessageList, Breadcrumbs, Pagination, GlobalNav, LocalNav, Progress, FromNow, AnswersSummary %}


### PR DESCRIPTION
The FormGroup macro was being used for the form wizard repeatable
fields so needs to be globally accessible at this point.

@feedmypixel this undoes some changes that were done as part of #880 as they broke some logic within the OMIS app.

We may need to find a way to replace the use of form group there if we want to remove it globally still.