### PR TITLE
Correct quote generation logic

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -180,21 +180,20 @@ function setQuoteForm (req, res, next) {
   }
 
   if (res.locals.incompleteFields) {
-    form.disableFormAction = true
+    form.hidePrimaryFormAction = true
   }
 
-  if (get(quote, 'created_on')) {
+  if (get(quote, 'created_on') && !get(quote, 'cancelled_on')) {
     form.action = `/omis/${orderId}/quote/cancel`
     form.buttonText = 'Cancel quote'
     form.buttonModifiers = 'button-secondary'
 
-    if (quote.accepted_on || quote.cancelled_on) {
+    if (quote.accepted_on) {
       form.hidePrimaryFormAction = true
     }
 
-    if (new Date(quote.expires_on) > new Date()) {
+    if (!quote.accepted_on && new Date(quote.expires_on) > new Date()) {
       form.buttonModifiers = 'button--destructive'
-
       res.locals.destructive = true
     }
   }

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -69,7 +69,7 @@
         }) }}
       {% endif %}
     {% endif %}
-
-    {{ Form(quoteForm) }}
   {% endif %}
+
+  {{ Form(quoteForm) }}
 {% endblock %}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -723,12 +723,12 @@ describe('OMIS View middleware', () => {
       })
     })
 
-    context('when quote preview errors exist exist', () => {
+    context('when quote preview errors exist', () => {
       beforeEach(() => {
         this.resMock.locals.incompleteFields = ['service_types']
       })
 
-      it('should set disable the form actions', (done) => {
+      it('should hide the primary form action', (done) => {
         const nextSpy = () => {
           try {
             expect(this.resMock.locals).to.have.property('quoteForm')
@@ -736,7 +736,7 @@ describe('OMIS View middleware', () => {
             expect(this.resMock.locals.quoteForm).to.have.property('buttonText')
             expect(this.resMock.locals.quoteForm).to.have.property('returnText')
             expect(this.resMock.locals.quoteForm).to.have.property('returnLink')
-            expect(this.resMock.locals.quoteForm).to.have.property('disableFormAction', true)
+            expect(this.resMock.locals.quoteForm).to.have.property('hidePrimaryFormAction', true)
 
             done()
           } catch (error) {
@@ -819,10 +819,12 @@ describe('OMIS View middleware', () => {
         })
 
         context('when quote has been cancelled', () => {
-          it('should disable form actions', (done) => {
+          it('should contain default form actions', (done) => {
             const nextSpy = () => {
               try {
-                expect(this.resMock.locals.quoteForm).to.have.property('hidePrimaryFormAction', true)
+                expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Send quote')
+                expect(this.resMock.locals.quoteForm).to.have.property('returnText', 'Return to order')
+                expect(this.resMock.locals.quoteForm).to.have.property('returnLink', '/omis/123456789')
 
                 done()
               } catch (error) {


### PR DESCRIPTION
This allows the quote to be re-sent after one has been cancelled.

Also ensure the form is always present even when error exist.