### PR TITLE
Payment amount

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -5,6 +5,7 @@ const i18nFuture = require('i18n-future')
 const logger = require('../../../../../config/logger')
 const { Order } = require('../../models')
 const { getCompany } = require('../../middleware')
+const { transformPaymentToView } = require('../../transformers')
 const editSteps = require('../edit/steps')
 
 const i18n = i18nFuture({
@@ -114,7 +115,9 @@ async function setInvoice (req, res, next) {
 
 async function setPayments (req, res, next) {
   try {
-    res.locals.payments = await Order.getPayments(req.session.token, res.locals.order.id)
+    const payments = await Order.getPayments(req.session.token, res.locals.order.id)
+
+    res.locals.payments = payments.map(transformPaymentToView)
   } catch (error) {
     logger.error(error)
   }

--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -85,7 +85,30 @@ function transformOrderToTableItem ({
   }
 }
 
+function transformPaymentToView ({
+  reference,
+  created_on,
+  transaction_reference,
+  additional_reference,
+  amount,
+  method,
+  received_on,
+} = {}) {
+  if (!reference) { return }
+
+  return {
+    reference,
+    created_on,
+    transaction_reference,
+    additional_reference,
+    method,
+    received_on,
+    amount: parseFloat(amount) / 100,
+  }
+}
+
 module.exports = {
   transformOrderToListItem,
   transformOrderToTableItem,
+  transformPaymentToView,
 }

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -13,6 +13,7 @@ describe('OMIS View middleware', () => {
     this.getPaymentsStub = this.sandbox.stub()
     this.createQuoteStub = this.sandbox.stub()
     this.cancelQuoteStub = this.sandbox.stub()
+    this.transformPaymentToViewStub = this.sandbox.stub().returnsArg(0)
     this.flashSpy = this.sandbox.spy()
     this.nextSpy = this.sandbox.spy()
 
@@ -33,6 +34,9 @@ describe('OMIS View middleware', () => {
     this.middleware = proxyquire('~/src/apps/omis/apps/view/middleware', {
       '../../middleware': {
         getCompany: this.getCompanySpy,
+      },
+      '../../transformers': {
+        transformPaymentToView: this.transformPaymentToViewStub,
       },
       '../../../../../config/logger': {
         error: this.loggerErrorSpy,
@@ -452,8 +456,15 @@ describe('OMIS View middleware', () => {
         await this.middleware.setPayments(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should set response as quote property on locals', () => {
+      it('should set payments property on locals', () => {
         expect(this.resMock.locals).to.have.property('payments')
+      })
+
+      it('should set correct number of payments', () => {
+        expect(this.resMock.locals.payments).to.have.length(2)
+      })
+
+      it('should set correct objects on payments', () => {
         expect(this.resMock.locals.payments).to.deep.equal(paymentsMock)
       })
 

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -91,4 +91,37 @@ describe('OMIS list transformers', function () {
       })
     })
   })
+
+  describe('#transformPaymentToView', () => {
+    const payment = require('~/test/unit/data/omis/payments.json')[0]
+
+    context('when given an unqualified result', () => {
+      it('should return undefined', () => {
+        expect(this.transformers.transformPaymentToView()).to.be.undefined
+        expect(this.transformers.transformPaymentToView({ a: 'b' })).to.be.undefined
+        expect(this.transformers.transformPaymentToView({ id: 'abcd' })).to.be.undefined
+      })
+    })
+
+    context('when given a qualified result', () => {
+      it('should return the correct properties', () => {
+        const actual = this.transformers.transformPaymentToView(payment)
+
+        expect(actual).to.have.property('reference').a('string')
+        expect(actual).to.have.property('transaction_reference').a('string')
+        expect(actual).to.have.property('additional_reference').a('string')
+        expect(actual).to.have.property('method').a('string')
+        expect(actual).to.have.property('received_on').a('string')
+        expect(actual).to.have.property('created_on').a('string')
+        expect(actual).to.have.property('amount').a('number')
+      })
+
+      it('should convert amount to pounds', () => {
+        const actual = this.transformers.transformPaymentToView(payment)
+        const amount = actual.amount
+
+        expect(amount).to.equal(53.43)
+      })
+    })
+  })
 })


### PR DESCRIPTION
This fixes the display of payment amount in the receipt view.

API returns pence and needs to be converted to pounds for the view.