### PR TITLE
Fix bug with contact edit address

### DIFF
--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -123,7 +123,7 @@
           <label class="c-form-group__label" for="postcodeLookup">
             <span class="c-form-group__label-text">Postcode look up</span>
           </label>
-          <input id="field-postcode-lookup" class="c-form-control postcode-lookup-value postcode-lookup-field" autoComplete="off">
+          <input id="field-postcode-lookup" class="c-form-control c-form-control--PostcodeLookup" autoComplete="off">
           <button class="button button-secondary postcode-lookup-button" type="button">Find UK address</button>
         </div>
 
@@ -131,7 +131,7 @@
           <label class="c-form-group__label" for="field-postcode-address-suggestions">
             <span class="c-form-group__label-text">Select an address from the drop down</span>
           </label>
-          <select class="c-form-control" id="field-postcode-address-suggestions">
+          <select class="c-form-control c-form-control--PostcodeLookupResult" id="field-postcode-address-suggestions">
             <option>Please enter a postcode to lookup your address</option>
           </select>
         </div>


### PR DESCRIPTION
![address](https://user-images.githubusercontent.com/56056/32506935-d798de4e-c3dd-11e7-87a0-086a4df74313.PNG)

Fixes a bug introduced by changes to the address lookup control. Updates the contact form to assign the new class names to the form address control elements.