### PR TITLE
add the SSO bypass token

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,8 +5,6 @@
     "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-nodejs.git",
     "NODE_MODULES_CACHE": "false",
     "NPM_CONFIG_PRODUCTION": "false",
-    "API_CLIENT_ID": { "required": true },
-    "API_CLIENT_SECRET": { "required": true },
     "API_ROOT": { "required": true },
     "POSTCODE_KEY": { "required": true },
     "OAUTH2_DEV_TOKEN": { "required": true },

--- a/app.json
+++ b/app.json
@@ -9,6 +9,7 @@
     "API_CLIENT_SECRET": { "required": true },
     "API_ROOT": { "required": true },
     "POSTCODE_KEY": { "required": true },
+    "OAUTH2_DEV_TOKEN": { "required": true },
     "ZEN_TOKEN": { "required": true },
     "ZEN_DOMAIN": { "required": true },
     "ZEN_EMAIL": { "required": true },

--- a/config/index.js
+++ b/config/index.js
@@ -4,10 +4,6 @@ const isDev = process.env.NODE_ENV !== 'production'
 const isProd = process.env.NODE_ENV === 'production'
 const root = path.normalize(`${__dirname}/..`)
 
-if (isProd && process.env['OAUTH2_DEV_TOKEN']) {
-  throw new Error('Environment variable "OAUTH2_DEV_TOKEN" not allowed in Production')
-}
-
 const config = {
   root,
   buildDir: path.join(root, '.build'),

--- a/src/middleware/sso-bypass.js
+++ b/src/middleware/sso-bypass.js
@@ -11,7 +11,7 @@ const ssoBypass = () => {
   return function (req, res, next) {
     const token = get(config, 'oauth.token')
 
-    if (config.isDev && token) {
+    if (token) {
       req.session.token = token
     }
     next()

--- a/test/unit/middleware/ssoBypass.test.js
+++ b/test/unit/middleware/ssoBypass.test.js
@@ -17,52 +17,23 @@ describe('SSO bypass middleware', () => {
     this.sandbox.restore()
   })
 
-  describe('when in production mode', () => {
-    context('without oauth token', () => {
-      it('should call the next middleware without setting the session token', () => {
-        set(this.mockConfig, 'isDev', false)
-        this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
+  describe('without oauth bypass token', () => {
+    it('should call the next middleware without setting the session token', () => {
+      this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
 
-        expect(this.nextSpy.calledOnce).to.be.true
-        expect(this.reqMock.session).to.be.an('object').and.empty
-      })
-    })
-
-    context('with oauth token', () => {
-      it('should call the next middleware without setting the session token', () => {
-        set(this.mockConfig, 'isDev', false)
-        set(this.mockConfig, 'oauth.token', 'mockToken')
-        this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
-
-        expect(this.nextSpy.calledOnce).to.be.true
-        expect(this.reqMock.session).to.be.an('object').and.empty
-      })
+      expect(this.nextSpy.calledOnce).to.be.true
+      expect(this.reqMock.session).to.be.an('object').and.empty
     })
   })
 
-  describe('when in development mode', () => {
-    context('without oauth token', () => {
-      it('should call the next middleware without setting the session token', () => {
-        set(this.mockConfig, 'isDev', true)
-        this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
+  describe('with oauth bypass token', () => {
+    it('should set the session token', () => {
+      const mockToken = 'mockToken'
+      set(this.mockConfig, 'oauth.token', 'mockToken')
+      this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
 
-        expect(this.nextSpy.calledOnce).to.be.true
-        expect(this.reqMock.session).to.be.an('object').and.empty
-      })
-    })
-
-    context('with oauth token', () => {
-      it('should call the next middleware without setting the session token', () => {
-        const mockToken = 'mockToken'
-
-        set(this.mockConfig, 'isDev', true)
-        set(this.mockConfig, 'oauth.token', mockToken)
-        this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
-
-        expect(this.nextSpy.calledOnce).to.be.true
-        expect(this.reqMock.session.token).to.equal(mockToken)
-        expect(this.reqMock.session).to.be.an('object').and.not.empty
-      })
+      expect(this.nextSpy.calledOnce).to.be.true
+      expect(this.reqMock.session.token).to.equal(mockToken)
     })
   })
 })


### PR DESCRIPTION
This work:
- adds the bypass token to the heroku `app.json` file
- removes environment variables that are no longer required by the application
- removes the check around `OAUTH2_DEV_TOKEN` not being in production environment
- will apply `OAUTH2_DEV_TOKEN` to `session.token` if it is available