### PR TITLE
Only display what happens next text during draft

### DIFF
--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -76,14 +76,18 @@
       {% endif %}
     {% endif %}
 
+  {% endif %}
+
+  {% if order.status === 'draft' and quote %}
     <p>The quote should be reviewed by your manager before being sent.</p>
+
+    <h2 class="heading-medium">What happens next</h2>
+
+    <ul class="list-disc">
+      <li>An email with a link to this quote will be sent to the client for acceptance</li>
+    </ul>
   {% endif %}
 
   {{ Form(quoteForm) }}
 
-  <h2 class="heading-medium">What happens next</h2>
-
-  <ul class="list-disc">
-    <li>An email with a link to this quote will be sent to the client for acceptance</li>
-  </ul>
 {% endblock %}


### PR DESCRIPTION
What happens next text was always being displayed but only needs to be present when in draft status.