### PR TITLE
Display quote terms and conditions

### DIFF
--- a/assets/stylesheets/trumps/_layout.scss
+++ b/assets/stylesheets/trumps/_layout.scss
@@ -56,4 +56,21 @@
   * + * {
     margin-top: $default-spacing-unit;
   }
+
+  ul, ol {
+    padding-left: 1em;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ol {
+    list-style-type: decimal;
+    padding-left: 1.5em;
+
+    li {
+      padding-left: 0;
+    }
+  }
 }

--- a/config/nunjucks/index.js
+++ b/config/nunjucks/index.js
@@ -3,6 +3,8 @@ const njkMarkdown = require('nunjucks-markdown')
 const md = require('markdown-it')({
   html: true,
   typographer: true,
+  breaks: true,
+  linkify: true,
 })
 
 const logger = require('../logger')

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -60,7 +60,7 @@
       {% call Example(tabTitle = '') %}
         <div class="l-markdown">
           {% markdown %}
-            {{ quote.content }}
+            {{ quote.content | safe }}
           {% endmarkdown %}
         </div>
       {% endcall %}

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -59,9 +59,13 @@
     {% if quote.content %}
       {% call Example(tabTitle = '') %}
         <div class="l-markdown">
-          {% markdown %}
-            {{ quote.content | safe }}
-          {% endmarkdown %}
+{# Ugly indentation is so that markdown spacing is handled correctly #}
+{% markdown %}{{ quote.content | safe }}{% endmarkdown %}
+
+          {% call HiddenContent({ summary: 'View full terms and conditions' }) %}
+{# Ugly indentation is so that markdown spacing is handled correctly #}
+{% markdown %}{{ quote.terms_and_conditions | safe }}{% endmarkdown %}
+          {% endcall %}
         </div>
       {% endcall %}
     {% endif %}
@@ -79,7 +83,10 @@
   {% endif %}
 
   {% if order.status === 'draft' and quote %}
-    <p>The quote should be reviewed by your manager before being sent.</p>
+    {{ Message({
+      type: 'info',
+      text: 'Quotes should be reviewed by a manager before being sent.'
+    }) }}
 
     <h2 class="heading-medium">What happens next</h2>
 


### PR DESCRIPTION
This adds work around showing the full quote terms and conditions for OMIS orders.

## What it looks like

![localhost_3000_omis_712d3118-fe8d-41bd-ae49-1a10eaf5c64e_quote](https://user-images.githubusercontent.com/3327997/32564633-cd47299e-c4ac-11e7-89eb-a2c2e0f9bb8c.png)

![localhost_3000_omis_712d3118-fe8d-41bd-ae49-1a10eaf5c64e_quote 1](https://user-images.githubusercontent.com/3327997/32564638-d0b384ce-c4ac-11e7-819b-2fcccee9f560.png)
