### PR TITLE
Turn off workers in nightwatch

### DIFF
--- a/test/acceptance/nightwatch.conf.js
+++ b/test/acceptance/nightwatch.conf.js
@@ -18,10 +18,6 @@ module.exports = {
   page_objects_path: glob.sync(join(__dirname, 'features/**/page-objects')),
   globals_path: 'test/acceptance/global.nightwatch.js',
   selenium: {
-    test_workers: {
-      enabled: true,
-      workers: 'auto',
-    },
     start_process: true,
     server_path: seleniumServer.path,
     host: process.env.QA_SELENIUM_HOST,


### PR DESCRIPTION
I have a sneaky feeling this may be causing us some race condition issues that we are seeing with data being manipulated across different tests.

Tests expect 2 results but there are actually 3 - as seen here:
https://10463-83823675-gh.circle-artifacts.com/1/root/data-hub-frontend/cucumber/report.html