### PR TITLE
Client details

### DIFF
--- a/src/apps/omis/apps/create/controllers/client-details.js
+++ b/src/apps/omis/apps/create/controllers/client-details.js
@@ -1,16 +1,18 @@
-const { sortBy } = require('lodash')
+const { get, sortBy } = require('lodash')
 
 const { FormController } = require('../../../controllers')
 const { transformContactToOption } = require('../../../../transformers')
 
 class ClientDetailsController extends FormController {
   configure (req, res, next) {
-    const company = res.locals.company
+    const company = get(res.locals, 'company')
     let contacts = []
 
     if (company) {
+      const companyName = company.trading_name || company.name
       contacts = company.contacts.map(transformContactToOption)
       contacts = sortBy(contacts, 'label')
+      req.form.options.heading = req.form.options.heading.replace('the client company', companyName)
     }
 
     req.form.options.fields.contact.options = contacts

--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -1,4 +1,4 @@
-const { find, get, unset } = require('lodash')
+const { find, unset } = require('lodash')
 
 const metadataRepo = require('../../../../../lib/metadata')
 const { FormController } = require('../../../controllers')
@@ -7,11 +7,8 @@ const { Order } = require('../../../models')
 class ConfirmController extends FormController {
   async getValues (req, res, next) {
     super.getValues(req, res, (err, values) => {
-      const company = res.locals.company
-      const contact = find(company.contacts, { id: values.contact })
-
-      values.company = company
-      values.contact = `${get(contact, 'first_name')} ${get(contact, 'last_name')}`
+      values.company = res.locals.company
+      values.contact = find(values.company.contacts, { id: values.contact })
       values.primary_market = find(metadataRepo.countryOptions, { id: values.primary_market })
 
       next(err, values)

--- a/src/apps/omis/apps/create/steps.js
+++ b/src/apps/omis/apps/create/steps.js
@@ -12,7 +12,7 @@ module.exports = {
     next: 'client-details',
   },
   '/client-details': {
-    heading: 'Client details',
+    heading: 'Choose the contact at the client company',
     backLink: null,
     editable: true,
     next: 'market',

--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -1,6 +1,12 @@
 {% extends "_layouts/form-wizard-step.njk" %}
 
 {% block form %}
+  {% set contactValue %}
+    {{ values.contact.first_name }} {{ values.contact.last_name }}
+    {%- if values.contact.job_title -%}
+      , {{ values.contact.job_title }}
+    {%- endif -%}
+  {% endset %}
   {% call MultiStepForm({
     buttonText: 'Continue'
   }) %}
@@ -15,7 +21,7 @@
         value: values.company.name
       }, {
         label: 'Contact',
-        value: values.contact
+        value: contactValue
       }]
     }) }}
 

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { keyBy, snakeCase, isPlainObject, isFunction } = require('lodash')
+const { filter, keyBy, snakeCase, isPlainObject, isFunction } = require('lodash')
 const { isValid, format, parse } = require('date-fns')
 
 const { buildPagination } = require('../lib/pagination')
@@ -18,10 +18,10 @@ function transformStringToOption (string) {
   }
 }
 
-function transformContactToOption ({ id, first_name, last_name }) {
+function transformContactToOption ({ id, first_name, last_name, job_title, email }) {
   return {
     value: id,
-    label: `${first_name} ${last_name}`,
+    label: filter([`${first_name} ${last_name}`, job_title]).join(', '),
   }
 }
 

--- a/test/unit/apps/omis/apps/create/controllers/client-details.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/client-details.test.js
@@ -16,6 +16,7 @@ describe('OMIS create client details controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.nextSpy = this.sandbox.spy()
+    this.breadcrumbStub = this.sandbox.stub().returnsThis()
     this.controller = new Controller({ route: '/' })
   })
 
@@ -28,6 +29,7 @@ describe('OMIS create client details controller', () => {
       this.reqMock = Object.assign({}, globalReq, {
         form: {
           options: {
+            heading: 'Client contact for the client company',
             fields: {
               contact: {},
             },
@@ -35,6 +37,7 @@ describe('OMIS create client details controller', () => {
         },
       })
       this.resMock = Object.assign({}, globalRes, {
+        breadcrumb: this.breadcrumbStub,
         locals: {
           company: undefined,
         },
@@ -44,13 +47,16 @@ describe('OMIS create client details controller', () => {
     })
 
     describe('when a company exists', () => {
-      it('should set the list of contacts', () => {
+      beforeEach(() => {
         this.resMock.locals.company = {
+          name: 'Company',
           contacts: contactsMockData,
         }
 
         this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
 
+      it('should set the list of contacts', () => {
         expect(this.reqMock.form.options.fields.contact.options).to.deep.equal([
           {
             value: '2',
@@ -61,6 +67,14 @@ describe('OMIS create client details controller', () => {
             label: 'Fred Stevens',
           },
         ])
+        expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should update the heading', () => {
+        expect(this.reqMock.form.options.heading).to.equal('Client contact for Company')
+      })
+
+      it('should call the parent method', () => {
         expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, this.resMock, this.nextSpy)
       })
     })

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -77,7 +77,11 @@ describe('OMIS create confirm controller', () => {
                 id: '1234567890',
                 contacts: contactsMockData,
               },
-              contact: 'Fred Stevens',
+              contact: {
+                id: '1',
+                first_name: 'Fred',
+                last_name: 'Stevens',
+              },
               primary_market: metadataCountryMockData[1],
             })
             done()


### PR DESCRIPTION
This change includes some updates to the client details part of creating an order.

It uses a dynamic heading which now includes the name of the company and also displays more detailed contact information on the summary page.

Alongside that it updates the contact transformer to include the job title in the value to help distinguish it from other options.

## Before
![localhost_3000_omis_create_dcdabbc9-1781-e411-8955-e4115bead28a_client-details_edit 1](https://user-images.githubusercontent.com/3327997/32613659-695ac0dc-c563-11e7-899c-919cd780bdd0.png)

## After
![localhost_3000_omis_create_dcdabbc9-1781-e411-8955-e4115bead28a_client-details_edit](https://user-images.githubusercontent.com/3327997/32613620-5625e9ec-c563-11e7-8e80-e430072bb15a.png)
