### PR TITLE
Fix companies filtering on Firefox

### DIFF
--- a/src/apps/companies/views/interactions.njk
+++ b/src/apps/companies/views/interactions.njk
@@ -16,7 +16,7 @@
       Collection(interactions | assignCopy({
         countLabel: 'interaction',
         summaryActionsHTML: addButton,
-        sortForm: sortForm,
+        sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
         query: QUERY
       }))
     }}

--- a/src/apps/companies/views/list.njk
+++ b/src/apps/companies/views/list.njk
@@ -4,7 +4,8 @@
   {{
     CollectionFilters({
       query: QUERY,
-      filtersFields: filtersFields
+      filtersFields: filtersFields,
+      action: CURRENT_PATH
     })
   }}
 {% endblock %}
@@ -17,7 +18,7 @@
   {{
     Collection(results | assign({
       countLabel: 'company',
-      sortForm: sortForm,
+      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
       selectedFilters: selectedFilters,
       highlightTerm: selectedFilters.company_name.valueLabel,
       query: QUERY,

--- a/src/apps/components/views/collection.njk
+++ b/src/apps/components/views/collection.njk
@@ -57,7 +57,8 @@
             value: form.data.filters.estimated_land_date_before,
             modifier: ['small', 'light']
           }
-        ]
+        ],
+        action: CURRENT_PATH
       })
     }}
   {% endcall %}

--- a/src/apps/contacts/views/interactions.njk
+++ b/src/apps/contacts/views/interactions.njk
@@ -13,7 +13,7 @@
     Collection(interactions | assignCopy({
       countLabel: 'interaction',
       summaryActionsHTML: addButton,
-      sortForm: sortForm,
+      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
       query: QUERY
     }))
   }}

--- a/src/apps/contacts/views/list.njk
+++ b/src/apps/contacts/views/list.njk
@@ -4,7 +4,8 @@
   {{
     CollectionFilters({
       query: QUERY,
-      filtersFields: filtersFields
+      filtersFields: filtersFields,
+      action: CURRENT_PATH
     })
   }}
 {% endblock %}
@@ -13,7 +14,7 @@
   {{
     Collection(results | assign({
       countLabel: 'contact',
-      sortForm: sortForm,
+      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
       selectedFilters: selectedFilters,
       highlightTerm: selectedFilters.company_name.valueLabel,
       query: QUERY

--- a/src/apps/events/views/list.njk
+++ b/src/apps/events/views/list.njk
@@ -4,7 +4,8 @@
   {{
     CollectionFilters({
       query: QUERY,
-      filtersFields: filtersFields
+      filtersFields: filtersFields,
+      action: CURRENT_PATH
     })
   }}
 {% endblock %}
@@ -17,7 +18,7 @@
   {{
     Collection(results | assign({
       countLabel: 'event',
-      sortForm: sortForm,
+      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
       selectedFilters: selectedFilters,
       highlightTerm: selectedFilters.company_name.valueLabel,
       query: QUERY,

--- a/src/apps/interactions/views/list.njk
+++ b/src/apps/interactions/views/list.njk
@@ -4,7 +4,8 @@
   {{
     CollectionFilters({
       query: QUERY,
-      filtersFields: filtersFields
+      filtersFields: filtersFields,
+      action: CURRENT_PATH
     })
   }}
 {% endblock %}
@@ -13,7 +14,7 @@
   {{
     Collection(interactions | assign({
       countLabel: 'interaction',
-      sortForm: sortForm,
+      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
       selectedFilters: selectedFilters,
       query: QUERY
     }))

--- a/src/apps/investment-projects/views/list.njk
+++ b/src/apps/investment-projects/views/list.njk
@@ -6,7 +6,8 @@
   {{
     CollectionFilters({
       query: QUERY,
-      filtersFields: filtersFields
+      filtersFields: filtersFields,
+      action: CURRENT_PATH
     })
   }}
 {% endblock %}
@@ -14,7 +15,7 @@
 {% block main_grid_right_column %}
   {{
     Collection(results | assign({
-      sortForm: sortForm,
+      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
       selectedFilters: selectedFilters,
       countLabel: 'project',
       query: QUERY

--- a/src/apps/omis/apps/list/views/list-collection.njk
+++ b/src/apps/omis/apps/list/views/list-collection.njk
@@ -4,7 +4,8 @@
   {{
     CollectionFilters({
       query: QUERY,
-      filtersFields: filtersFields
+      filtersFields: filtersFields,
+      action: CURRENT_PATH
     })
   }}
 {% endblock %}
@@ -13,7 +14,7 @@
   {{
     Collection(results | assign({
       countLabel: 'order',
-      sortForm: sortForm,
+      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
       selectedFilters: selectedFilters,
       query: QUERY
     }))

--- a/src/apps/omis/apps/list/views/list-reconciliation.njk
+++ b/src/apps/omis/apps/list/views/list-reconciliation.njk
@@ -1,16 +1,19 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block main_grid_left_column %}
-  {{ CollectionFilters({
-    query: QUERY,
-    filtersFields: filtersFields
-  }) }}
+  {{
+    CollectionFilters({
+      query: QUERY,
+      filtersFields: filtersFields,
+      action: CURRENT_PATH
+    })
+  }}
 {% endblock %}
 
 {% block main_grid_right_column %}
   {% call Collection(results | assign({
     countLabel: 'order',
-    sortForm: sortForm,
+    sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
     selectedFilters: selectedFilters,
     query: QUERY
   })) %}

--- a/src/templates/_macros/collection/collection-filters.njk
+++ b/src/templates/_macros/collection/collection-filters.njk
@@ -14,6 +14,7 @@
     {% call Form({
       method: 'get',
       class: 'c-collection-filters js-AutoSubmit',
+      action: props.action,
       buttonText: 'Refresh results',
       actionsClass: 'u-js-hidden',
       hiddenFields: props.query | pick(['sortby']) | assign({ custom: true })

--- a/src/templates/_macros/form/form.njk
+++ b/src/templates/_macros/form/form.njk
@@ -32,7 +32,7 @@
 
   <form
     method="{{ method }}"
-    {% if props.action %}action="{{ props.action }}"{% endif -%}
+    action="{{ props.action }}"
     {% if props.class %}class="{{ props.class }}"{% endif %}
     {% if props.role %}role="{{ props.role }}"{% endif %}
   >


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/DH-974)

todo:
 - [x] make forms explicitly recieve action prop

## The cause

The urls generated upon filtering are different:

browser| url
------------ | -------------
Chrome | http://localhost:3000/companies?custom=true&name=cool&sector=af22c9d2-5f95-e211-a939-e4115bead28a&sortby=modified_on%3Aasc
Firefox | http://localhost:3000/companies?custom=true&name=cool&sector=af22c9d2-5f95-e211-a939-e4115bead28a&sortby=modified_on%3Aasc?custom=true&name=cool&sector=af22c9d2-5f95-e211-a939-e4115bead28a&sortby=modified_on%3Aasc

The cause of this different behaviour is the HTML `<form>` elements were being rendered without the `action` attribute. Firefox and Chrome do different things in this situation:

browser| behaviour
------------ | -------------
Chrome | treat the form element's action attribute as an empty string
Firefox | treat the form element's action attribute as the current url (including the qureystring)

This affect's how the [`auto-submit`](https://github.com/uktrade/data-hub-frontend/blob/develop/assets/javascripts/modules/auto-submit.js#L37) will generate the url to submit the form:

browser| behaviour
------------ | -------------
Chrome | concatenate the empty string with the query, resulting in a valid url
Firefox | concatenate the current url (including the querystring) with the query, resulting in an invalid url with duplicate query fields, which the server does not comprehend.

## The fix

Setting the form element's action attribute to the current url (without the querystring).