### PR TITLE
Allow users to go to support when not loggedIn

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,5 +1,5 @@
 module.exports = function auth (req, res, next) {
-  const passThrough = /^\/(healthcheck|oauth|oauth\/callback)\b/.test(req.url) || req.session.token
+  const passThrough = /^\/(support|healthcheck|oauth|oauth\/callback)\b/.test(req.url) || req.session.token
 
   if (passThrough) {
     return next()


### PR DESCRIPTION
add support to the oauth bypass so users can access the support page when not logged in