### PR TITLE
Update assignee time to only support hours

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -162,10 +162,9 @@ const filters = {
 
   humanizeDuration: (value, measurement = 'minutes') => {
     const duration = moment.duration(value, measurement)
-    const hrsSuffix = pluralise('hour', duration.hours())
-    const minsSuffix = pluralise('minute', duration.minutes())
+    const hoursSuffix = pluralise('hour', duration.hours())
 
-    return duration.format(`h [${hrsSuffix}], m [${minsSuffix}]`)
+    return duration.format(`h [${hoursSuffix}]`)
   },
 
   formatDuration: (value, format = 'hh:mm', measurement = 'minutes') => {

--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -22,15 +22,11 @@ class EditAssigneeTimeController extends EditController {
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
     const timeValues = flatten([data.assignee_time])
     const assignees = timeValues.map((value, index) => {
-      if (!value) { return }
-
-      const [ hours, minutes ] = value.split(':')
-
       return {
         adviser: {
           id: res.locals.assignees[index].adviser.id,
         },
-        estimated_time: parseInt((hours * 60)) + parseInt(minutes),
+        estimated_time: parseInt(value || 0) * 60,
       }
     })
 

--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -3,7 +3,7 @@ const { filter, flatten, get, pick } = require('lodash')
 const { EditController } = require('../../../controllers')
 const { Order } = require('../../../models')
 
-class EditAssigneeHoursController extends EditController {
+class EditAssigneeTimeController extends EditController {
   async configure (req, res, next) {
     const orderId = get(res.locals, 'order.id')
     const token = get(req.session, 'token')
@@ -51,4 +51,4 @@ class EditAssigneeHoursController extends EditController {
   }
 }
 
-module.exports = EditAssigneeHoursController
+module.exports = EditAssigneeTimeController

--- a/src/apps/omis/apps/edit/controllers/complete-order.js
+++ b/src/apps/omis/apps/edit/controllers/complete-order.js
@@ -33,13 +33,11 @@ class CompleteOrderController extends EditController {
     const assignees = timeValues.map((value, index) => {
       if (!value) { return }
 
-      const [ hours, minutes ] = value.split(':')
-
       return {
         adviser: {
           id: res.locals.assignees[index].adviser.id,
         },
-        actual_time: parseInt((hours * 60)) + parseInt(minutes),
+        actual_time: parseInt(value) * 60,
       }
     })
 

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -3,7 +3,7 @@ const { isArray, merge } = require('lodash')
 const globalFields = require('../../fields')
 
 function isDuration (value) {
-  const regex = /^\d+:\d{2}$/
+  const regex = /^\d*$/
 
   if (!isArray(value)) {
     if (!value) { return true }

--- a/src/apps/omis/apps/edit/views/assignee-time.njk
+++ b/src/apps/omis/apps/edit/views/assignee-time.njk
@@ -7,7 +7,7 @@
       <p>Advisers in the market must be added before hours can be estimated.</p>
 
       <p>
-        <a href="assignees">Add advisers</a>
+        <a href="assignees?returnUrl=/omis/{{ order.id }}/edit/assignee-time">Add advisers</a>
       </p>
     {% endcall %}
 
@@ -46,7 +46,7 @@
       <tfoot>
         <tr>
           <td class="c-answers-summary__title c-answers-summary__title--unstyled">
-            <a href="assignees">Edit advisers</a>
+            <a href="assignees?returnUrl=/omis/{{ order.id }}/edit/assignee-time">Edit advisers</a>
           </td>
         </tr>
       </tfoot>

--- a/src/apps/omis/apps/edit/views/assignee-time.njk
+++ b/src/apps/omis/apps/edit/views/assignee-time.njk
@@ -31,7 +31,7 @@
             name: key,
             idSuffix: assignee.adviser.id,
             label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
-            value: values[key][loop.index0] or (assignee.estimated_time | formatDuration('hh:mm') if assignee.estimated_time),
+            value: values[key][loop.index0] or (assignee.estimated_time / 60 if assignee.estimated_time),
             error: errors[key].message,
             isLabelHidden: true
           }) %}

--- a/src/apps/omis/apps/edit/views/assignee-time.njk
+++ b/src/apps/omis/apps/edit/views/assignee-time.njk
@@ -4,7 +4,7 @@
   {% if not assignees.length %}
 
     {% call Message({ type: 'info', element: 'div' }) %}
-      <p>Advisers in the market must be added before time can be estimated.</p>
+      <p>Advisers in the market must be added before hours can be estimated.</p>
 
       <p>
         <a href="assignees">Add advisers</a>
@@ -15,14 +15,14 @@
 
     {% set key = 'assignee_time' %}
     {% set defaultProps = options.fields[key] %}
-    <p>These hours will be used to calculate the cost of the order.</p>
+    <p>Estimated hours will be used to calculate the cost of the order.</p>
 
     <p>All work will be charged at £55 per hour.</p>
 
     <table class="c-answers-summary">
       <thead>
         <tr>
-          <th class="c-answers-summary__control" colspan="2">Estimated time (HH:MM)</th>
+          <th class="c-answers-summary__control" colspan="2">Estimated hours</th>
         </tr>
       </thead>
       <tbody>

--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -20,7 +20,7 @@
             name: key,
             idSuffix: assignee.adviser.id,
             label: translate(defaultProps.label) + ' for ' + assignee.adviser.name,
-            value: values[key][loop.index0] or (assignee.actual_time | formatDuration('hh:mm') if assignee.actual_time),
+            value: values[key][loop.index0] or (assignee.actual_time / 60 if assignee.actual_time),
             error: errors[key].message,
             isLabelHidden: true
           }) %}

--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -10,8 +10,8 @@
       <thead>
         <tr>
           <th></th>
-          <th class="c-answers-summary__content">Estimated time</th>
-          <th class="c-answers-summary__control">Actual time spent (HH:MM)</th>
+          <th class="c-answers-summary__content">Original estimate</th>
+          <th class="c-answers-summary__control">Hours spent</th>
         </tr>
       </thead>
       <tbody>

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -113,9 +113,7 @@
     <tfoot>
       <tr>
         <td class="c-answers-summary__footer" colspan="3">
-          {% if not values.assignees.length or values.estimatedTimeSum < 1 %}
-            <span class="c-answers-summary__footer-value">No time estimated</span>
-          {% else %}
+          {% if values.estimatedTimeSum %}
             <span class="c-answers-summary__footer-value">
               {{ values.estimatedTimeSum | humanizeDuration }}
             </span>

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -73,7 +73,7 @@
       label: 'Add or remove'
     }, {
       url: 'edit/assignee-time' if order.isEditable,
-      label: 'Estimate time'
+      label: 'Estimate hours'
     }]
   }) %}
     <tbody>
@@ -100,7 +100,7 @@
             {% endif %}
           </td>
           <td class="c-answers-summary__content c-answers-summary__content--number">
-            {{ assignee.estimated_time | humanizeDuration if assignee.estimated_time else 'No time estimated' }}
+            {{ assignee.estimated_time | humanizeDuration if assignee.estimated_time else 'No hours estimated' }}
           </td>
         </tr>
       {% else %}
@@ -119,7 +119,7 @@
             <span class="c-answers-summary__footer-value">
               {{ values.estimatedTimeSum | humanizeDuration }}
             </span>
-            total estimated time
+            estimated in total
           {% endif %}
         </td>
       </tr>

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -105,7 +105,7 @@
         </tr>
       {% else %}
         <tr>
-          <td class="c-answers-summary__content c-answers-summary__content--muted" colspan="3">None added</td>
+          <td class="c-answers-summary__content c-answers-summary__content--muted" colspan="3">No advisers added</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -133,7 +133,7 @@
       label: 'Add or remove'
     }],
     items: values.subscribers | map('name') if values.subscribers.length,
-    fallbackText: 'None added'
+    fallbackText: 'No advisers added'
   }) }}
 
   {{ AnswersSummary({

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -99,7 +99,7 @@
               {% endcall %}
             {% endif %}
           </td>
-          <td class="c-answers-summary__content c-answers-summary__content--number">
+          <td class="c-answers-summary__content c-answers-summary__content--number {{ 'c-answers-summary__content--muted' if not assignee.estimated_time }}">
             {{ assignee.estimated_time | humanizeDuration if assignee.estimated_time else 'No hours estimated' }}
           </td>
         </tr>

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -122,7 +122,7 @@
     "date": "must be a valid date",
     "after": "must be in the future",
     "before": "must be in the past",
-    "isDuration": "must be a valid duration format, for example 01:30",
+    "isDuration": "must be a whole number, for example 1",
     "isGreaterThanAmount": "must be equal to or larger than the invoice amount",
     "default": "is required"
   }

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -46,10 +46,10 @@
       "label": "Adviser"
     },
     "assignee_time": {
-      "label": "Estimated time"
+      "label": "Estimated hours"
     },
     "assignee_actual_time": {
-      "label": "Actual time"
+      "label": "Hours spent"
     },
     "vat_status": {
       "label": "VAT category",
@@ -112,7 +112,7 @@
       "description": "Add a description of the work or activity",
       "delivery_date": "Set a delivery date of at least 21 days from now",
       "assignees": "Add at least one adviser in the market",
-      "assignee_time": "Allocate time to at least one adviser in the market",
+      "assignee_time": "Allocate hours to at least one adviser in the market",
       "vat_status": "Choose a VAT category"
     }
   },


### PR DESCRIPTION
Time previously support both hours and minutes. After agreeing with the steering group the OMIS service will now only support time to be recorded in hours. This simplifies some of the processing being done on the frontend. 

This change removes this and tidies up the language used to refer to entering estimated and actual time.

## Before

### Order overview
![localhost_3000_omis_f804c606-fcf7-4eb7-bdd4-14fe7ecb7406_work-order 1](https://user-images.githubusercontent.com/3327997/32725230-333b064a-c86c-11e7-80fb-aa05174c9cea.png)

### Editing estimated time
![localhost_3000_omis_f804c606-fcf7-4eb7-bdd4-14fe7ecb7406_edit_assignee-time 1](https://user-images.githubusercontent.com/3327997/32725248-3adda768-c86c-11e7-9800-026c1c1fef1c.png)

### Completing an order
![localhost_3000_omis_6d3c9849-8dd4-4406-8336-2d8b8970e792_edit_complete-order 1](https://user-images.githubusercontent.com/3327997/32725254-4607167e-c86c-11e7-979a-0f5258adbbe5.png)

## After

### Order overview
![localhost_3000_omis_f804c606-fcf7-4eb7-bdd4-14fe7ecb7406_work-order](https://user-images.githubusercontent.com/3327997/32725180-046b42c6-c86c-11e7-87f3-b2f052946ab8.png)

### Editing estimated time
![localhost_3000_omis_f804c606-fcf7-4eb7-bdd4-14fe7ecb7406_edit_assignee-time](https://user-images.githubusercontent.com/3327997/32725153-f0645722-c86b-11e7-859b-0b9e208607dc.png)

### Completing an order
![localhost_3000_omis_6d3c9849-8dd4-4406-8336-2d8b8970e792_edit_complete-order](https://user-images.githubusercontent.com/3327997/32725206-1b0f46d0-c86c-11e7-84d6-951de1b51737.png)
