### PR TITLE
Re-enable create ltd company test

### DIFF
--- a/test/acceptance/features/companies/create.feature
+++ b/test/acceptance/features/companies/create.feature
@@ -6,7 +6,7 @@ Feature: Create a new company
   # Disables test due to issue with lack of support for ch search in backend
   # re-enable to prove back end once complete and split into 2 tests
   # One for selecting CH entry and another for selecting existing datahub entry
-  @companies-create--uk-private-or-public-ltd-company @ignore
+  @companies-create--uk-private-or-public-ltd-company
   Scenario: Create a UK private or public limited company
 
     When a "UK private or public limited company" is created

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -220,8 +220,6 @@ module.exports = {
             // step 3
             this.section.firstCompanySearchResult
               .click('@header')
-            this
-              .click('@addButton')
 
             // step 4
             this

--- a/test/acceptance/features/support/fixtures.js
+++ b/test/acceptance/features/support/fixtures.js
@@ -5,7 +5,7 @@
 module.exports = {
   company: {
     companiesHouse: {
-      name: 'Mercury Ltd',
+      name: 'Exobite Skeletons Ltd',
     },
     foreign: {
       name: 'Lambda plc',


### PR DESCRIPTION
Re-enabled the 'Create ltd company' test. This required a new fixture in leeloo, as Mercury was linked to an existing company record.

This change uses the newly added fixture and removes the action of clicking on the add button on a company result as this is no longer part of the process.