### PR TITLE
Show validation errors if role is missing from advisor

### DIFF
--- a/src/apps/investment-projects/middleware/forms/team-members.js
+++ b/src/apps/investment-projects/middleware/forms/team-members.js
@@ -1,4 +1,4 @@
-const zipWith = require('lodash/zipWith')
+const { zipWith, get } = require('lodash')
 const { getAdvisers } = require('../../../adviser/repos')
 const { updateInvestmentTeamMembers } = require('../../repos')
 const { teamMembersLabels } = require('../../labels')
@@ -63,10 +63,21 @@ async function handleFormPost (req, res, next) {
     next()
   } catch (err) {
     if (err.statusCode === 400) {
+      const teamMembers = transformDataToTeamMemberArray(req.body)
+      const roleError = get(err, 'error.role')
+      let messages = {}
+      if (roleError) {
+        teamMembers.forEach((item, i) => {
+          if (item.role === '') {
+            messages['role-' + i] = roleError
+          }
+        })
+      }
       res.locals.form = Object.assign({}, res.locals.form, {
-        errors: err.error,
-        state: req.body,
+        errors: { messages },
+        state: { teamMembers },
       })
+
       next()
     } else {
       next(err)

--- a/src/apps/investment-projects/views/team/edit-team-members.njk
+++ b/src/apps/investment-projects/views/team/edit-team-members.njk
@@ -4,9 +4,6 @@
   <h2 class="heading-medium">Assign project specialist and team members</h2>
 
   {% call Form(form) %}
-    {% if form.errors.team_members %}
-      <div class="error">{{ form.errors.team_members }}</div>
-    {% endif %}
     <div class="js-AddItems"
       data-item-selector=".c-form-fieldset"
       data-item-name="team member"
@@ -28,7 +25,8 @@
               name: 'role',
               label: form.labels.role,
               value: teamMember.role,
-              idSuffix: loop.index
+              idSuffix: loop.index0,
+              error: form.errors.messages['role-' + loop.index0]
             }) }}
           {% endcall %}
         {% endfor %}

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -10,7 +10,9 @@ describe('Investment form middleware - team members', () => {
     this.nextSpy = this.sandbox.spy()
     this.resMock = {
       locals: {
-        form: {},
+        form: {
+          state: {},
+        },
         investmentData,
       },
     }
@@ -205,9 +207,10 @@ describe('Investment form middleware - team members', () => {
         this.error = {
           statusCode: 400,
           error: {
-            project_assurance_adviser: 'Cannot be null',
+            role: ['This field is required'],
           },
         }
+        const resMock = Object.assign({}, this.resMock)
 
         this.updateInvestmentTeamMembersStub.rejects(this.error)
 
@@ -218,11 +221,20 @@ describe('Investment form middleware - team members', () => {
           params: {
             investmentId: investmentData.id,
           },
-          body: this.body,
-        }, this.resMock, (error) => {
+          body: {
+            adviser: ['1234', '4321', '4323'],
+            role: ['manager', 'supervisor', ''],
+          },
+        }, resMock, (error) => {
           expect(error).to.equal(undefined)
-          expect(this.resMock.locals.form.state).to.deep.equal(this.body)
-          expect(this.resMock.locals.form.errors).to.deep.equal(this.error.error)
+          expect(resMock.locals.form.state.teamMembers).to.deep.equal([
+            { adviser: '1234', role: 'manager' },
+            { adviser: '4321', role: 'supervisor' },
+            { adviser: '4323', role: '' },
+          ])
+          expect(this.resMock.locals.form.errors.messages).to.deep.equal({
+            'role-2': ['This field is required'],
+          })
           done()
         })
       })


### PR DESCRIPTION
# after this fix

![image](https://user-images.githubusercontent.com/5485798/32739486-eb77139a-c897-11e7-9aca-8a8d61ab6d17.png)


# before this fix

![image](https://user-images.githubusercontent.com/5485798/32739546-185ddba0-c898-11e7-9c38-2a43bc04814a.png)

## the cause

The form's state was being overridden with the request body, which was in a structure the template was not expecting.

## the fix

format the request body to be in a structure that the template expects.
