### PR TITLE
Correctly validate a list as required

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -1,4 +1,4 @@
-const { isArray, merge } = require('lodash')
+const { isArray, flatten, merge } = require('lodash')
 
 const globalFields = require('../../fields')
 
@@ -21,6 +21,14 @@ function isDuration (value) {
   })
 
   return valid
+}
+
+function arrayRequired (value) {
+  const invalidItems = flatten([value]).filter(itemValue => {
+    return itemValue === undefined || itemValue === ''
+  })
+
+  return invalidItems.length === 0
 }
 
 const editFields = merge({}, globalFields, {
@@ -92,7 +100,7 @@ const editFields = merge({}, globalFields, {
     fieldType: 'TextField',
     label: 'fields.assignee_actual_time.label',
     modifier: ['shorter', 'soft'],
-    validate: ['required', isDuration],
+    validate: [arrayRequired, isDuration],
   },
   vat_status: {
     fieldType: 'MultipleChoiceField',

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -118,6 +118,7 @@
   },
   "validation": {
     "required": "cannot not be blank",
+    "arrayRequired": "cannot not be blank",
     "numeric": "can only contain numbers",
     "date": "must be a valid date",
     "after": "must be in the future",


### PR DESCRIPTION
The default required validation doesn't support validating an array
of values and failing if any of them don't contain a value.

This validation is required for use on the order complete page so
a new validator has been added.