### PR TITLE
Quote (preview) improvements

### DIFF
--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -29,8 +29,11 @@ async function renderWorkOrder (req, res) {
 }
 
 function renderQuote (req, res) {
+  const orderStatus = get(res.locals, 'order.status')
+  const heading = `Quote${orderStatus === 'draft' ? ' preview' : ''}`
+
   res
-    .breadcrumb('Quote preview')
+    .breadcrumb(heading)
     .render('omis/apps/view/views/quote')
 }
 

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -25,15 +25,21 @@
   {% endif %}
 
   {% if quote %}
-    {% if order.status === 'quote_awaiting_acceptance' %}
-      {% set expiryLabel = 'Expire' + ('d' if quote.expired else 's') %}
-    {% else %}
-      {% set expiryLabel = 'Will expire' %}
-    {% endif %}
+    {% set expiryLabel %}
+      {% if order.status === 'quote_awaiting_acceptance' %}
+        Expire{{ 'd' if quote.expired else 's' }} on
+      {% else %}
+        Will expire on
+      {% endif %}
+    {% endset %}
+
+    {% set expiryValue %}
+      {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }})
+    {% endset %}
 
     {{ MetaList({
       items: [
-        { label: expiryLabel, value: quote.expires_on, type: 'fromNow' }
+        { label: expiryLabel, value: expiryValue }
       ],
       itemModifier: 'stacked'
     }) }}

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -37,12 +37,14 @@
       {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }})
     {% endset %}
 
-    {{ MetaList({
-      items: [
-        { label: expiryLabel, value: expiryValue }
-      ],
-      itemModifier: 'stacked'
-    }) }}
+    {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
+      {{ MetaList({
+        items: [
+          { label: expiryLabel, value: expiryValue }
+        ],
+        itemModifier: 'stacked'
+      }) }}
+    {% endif %}
 
     {{ MetaList({
       items: [


### PR DESCRIPTION
This change adds some changes to the quote page:

- display expiry date in long format
- only show expiry date when in draft/awaiting acceptance states
- don't display `preview` in heading when not a preview

## Before

### Accepted quote
![localhost_3000_omis_44397fda-6965-4f41-855b-ec0cc4ed5d0a_quote 1](https://user-images.githubusercontent.com/3327997/32741658-e78eb074-c89e-11e7-9d70-96c7762215e1.png)

### Draft quote
![localhost_3000_omis_c37906f7-9792-4df5-b26e-8cef9684a9e9_quote 1](https://user-images.githubusercontent.com/3327997/32741665-ee3d5966-c89e-11e7-914f-85dc683297c2.png)

## After

### Accepted quote
![localhost_3000_omis_44397fda-6965-4f41-855b-ec0cc4ed5d0a_quote](https://user-images.githubusercontent.com/3327997/32741576-98648e92-c89e-11e7-94cd-25cba4b742af.png)

### Draft quote
![localhost_3000_omis_c37906f7-9792-4df5-b26e-8cef9684a9e9_quote](https://user-images.githubusercontent.com/3327997/32741640-d4b1b62c-c89e-11e7-8131-0848ecc9f056.png)
