### PR TITLE
Add sector during order creation

### DIFF
--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -78,8 +78,4 @@
   background: $grey-4;
   font-size: inherit;
   font-weight: inherit;
-
-  *:not(button) {
-    font-weight: inherit;
-  }
 }

--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -1,17 +1,21 @@
-const { find, unset } = require('lodash')
+const { assign, find, get, unset } = require('lodash')
 
 const metadataRepo = require('../../../../../lib/metadata')
 const { FormController } = require('../../../controllers')
 const { Order } = require('../../../models')
 
 class ConfirmController extends FormController {
-  async getValues (req, res, next) {
+  getValues (req, res, next) {
     super.getValues(req, res, (err, values) => {
-      values.company = res.locals.company
-      values.contact = find(values.company.contacts, { id: values.contact })
-      values.primary_market = find(metadataRepo.countryOptions, { id: values.primary_market })
+      const company = get(res.locals, 'company')
+      const summaryValues = assign({}, values, {
+        company,
+        contact: find(company.contacts, { id: values.contact }),
+        primary_market: find(metadataRepo.countryOptions, { id: values.primary_market }),
+        sector: find(metadataRepo.sectorOptions, { id: values.sector }),
+      })
 
-      next(err, values)
+      next(err, summaryValues)
     })
   }
 

--- a/src/apps/omis/apps/create/controllers/index.js
+++ b/src/apps/omis/apps/create/controllers/index.js
@@ -1,9 +1,11 @@
 const ClientDetailsController = require('./client-details')
 const MarketController = require('./market')
+const SectorController = require('./sector')
 const ConfirmController = require('./confirm')
 
 module.exports = {
   ClientDetailsController,
   MarketController,
+  SectorController,
   ConfirmController,
 }

--- a/src/apps/omis/apps/create/controllers/sector.js
+++ b/src/apps/omis/apps/create/controllers/sector.js
@@ -1,0 +1,21 @@
+const { get } = require('lodash')
+
+const metadataRepo = require('../../../../../lib/metadata')
+const { FormController } = require('../../../controllers')
+const { transformObjectToOption } = require('../../../../transformers')
+
+class SectorController extends FormController {
+  configure (req, res, next) {
+    req.form.options.fields.sector.options = metadataRepo.sectorOptions.map(transformObjectToOption)
+    super.configure(req, res, next)
+  }
+
+  saveValues (req, res, next) {
+    if (get(req.form, 'values.use_sector_from_company') === 'true') {
+      req.form.values.sector = get(res.locals, 'company.sector.id')
+    }
+    super.saveValues(req, res, next)
+  }
+}
+
+module.exports = SectorController

--- a/src/apps/omis/apps/create/steps.js
+++ b/src/apps/omis/apps/create/steps.js
@@ -1,6 +1,7 @@
 const {
   ClientDetailsController,
   MarketController,
+  SectorController,
   ConfirmController,
 } = require('./controllers')
 
@@ -24,9 +25,18 @@ module.exports = {
   '/market': {
     heading: 'Market (country) of interest',
     editable: true,
-    next: 'confirm',
+    next: 'sector',
     fields: ['primary_market'],
     controller: MarketController,
+  },
+  '/sector': {
+    heading: 'Choose the sector',
+    editable: true,
+    next: 'confirm',
+    fields: ['use_sector_from_company', 'sector'],
+    controller: SectorController,
+    templatePath: 'omis/apps/create/views',
+    template: 'sector',
   },
   '/confirm': {
     heading: 'Check order details',

--- a/src/apps/omis/apps/create/views/sector.njk
+++ b/src/apps/omis/apps/create/views/sector.njk
@@ -1,0 +1,9 @@
+{% extends "_layouts/form-wizard-step.njk" %}
+
+{% block fields %}
+  {% call Message({ type: 'muted' }) %}
+    {{ company.name }}'s primary sector is <strong>{{ company.sector.name }}</strong>
+  {% endcall %}
+
+  {{ super() }}
+{% endblock %}

--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -33,6 +33,14 @@
       items: [values.primary_market.name]
     }) }}
 
+    {{ AnswersSummary({
+      heading: 'Sector',
+      actions: [{
+        url: 'sector/edit'
+      }],
+      items: [values.sector.name]
+    }) }}
+
     <h2 class="heading-medium">What happens next</h2>
 
     <p>Continuing with the order will notify the post manager for {{ values.primary_market.name }}.</p>

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -47,13 +47,6 @@ const editFields = merge({}, globalFields, {
     type: 'textarea',
     label: 'fields.description.label',
   },
-  sector: {
-    fieldType: 'MultipleChoiceField',
-    label: 'fields.sector.label',
-    optional: true,
-    initialOption: '-- Select sector --',
-    options: [],
-  },
   delivery_date: {
     fieldType: 'TextField',
     label: 'fields.delivery_date.label',

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -112,4 +112,7 @@ const steps = merge({}, createSteps, {
 // Market cannot be edited after creation
 delete steps['/market']
 
+// Sector can be edited as part of a different section at this stage
+delete steps['/sector']
+
 module.exports = steps

--- a/src/apps/omis/fields.js
+++ b/src/apps/omis/fields.js
@@ -13,9 +13,40 @@ module.exports = {
     fieldType: 'MultipleChoiceField',
     label: 'fields.primary_market.label',
     validate: 'required',
-    initialOption: '-- Select market --',
+    initialOption: '-- Select country --',
     options: [],
     supportingContent: 'fields.primary_market.supportingContent',
+  },
+  use_sector_from_company: {
+    fieldType: 'MultipleChoiceField',
+    type: 'radio',
+    modifier: ['inline'],
+    validate: 'required',
+    label: 'fields.use_sector_from_company.label',
+    options: [{
+      value: 'true',
+      label: 'Yes',
+    },
+    {
+      value: 'false',
+      label: 'No',
+    }],
+  },
+  sector: {
+    fieldType: 'MultipleChoiceField',
+    label: 'fields.sector.label',
+    modifier: ['subfield'],
+    validate: 'required',
+    initialOption: '-- Select sector --',
+    options: [],
+    condition: {
+      name: 'use_sector_from_company',
+      value: 'false',
+    },
+    dependent: {
+      field: 'use_sector_from_company',
+      value: 'false',
+    },
   },
   subscribers: {
     fieldType: 'MultipleChoiceField',

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -22,6 +22,9 @@
     "description": {
       "label": "Description of the work or activity"
     },
+    "use_sector_from_company": {
+      "label": "Do you want to use the company's primary sector (shown above) for this order?"
+    },
     "sector": {
       "label": "Sector"
     },

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -10,6 +10,13 @@ const metadataCountryMockData = [{
   id: '2',
   name: 'Country Two',
 }]
+const metadataSectorMockData = [{
+  id: '1',
+  name: 'ICT',
+}, {
+  id: '2',
+  name: 'Engineering',
+}]
 const contactsMockData = [{
   id: '1',
   first_name: 'Fred',
@@ -29,6 +36,7 @@ describe('OMIS create confirm controller', () => {
     this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/confirm', {
       '../../../../../lib/metadata': {
         countryOptions: metadataCountryMockData,
+        sectorOptions: metadataSectorMockData,
       },
       '../../../models': {
         Order: {
@@ -58,6 +66,7 @@ describe('OMIS create confirm controller', () => {
         contact: '1',
         company: 'company-12345',
         primary_market: '2',
+        sector: '2',
       }
     })
 
@@ -71,7 +80,7 @@ describe('OMIS create confirm controller', () => {
       it('should set the correct values', (done) => {
         const nextMock = (e, values) => {
           try {
-            expect(Object.keys(values).length).to.equal(3)
+            expect(Object.keys(values).length).to.equal(4)
             expect(values).to.deep.equal({
               company: {
                 id: '1234567890',
@@ -83,6 +92,10 @@ describe('OMIS create confirm controller', () => {
                 last_name: 'Stevens',
               },
               primary_market: metadataCountryMockData[1],
+              sector: {
+                id: '2',
+                name: 'Engineering',
+              },
             })
             done()
           } catch (err) {

--- a/test/unit/apps/omis/apps/create/controllers/sector.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/sector.test.js
@@ -1,0 +1,121 @@
+const FormController = require('~/src/apps/omis/controllers/form')
+
+const sectorOptionsMock = [{
+  id: '1',
+  name: 'Sector one',
+}, {
+  id: '2',
+  name: 'Sector two',
+}, {
+  id: '3',
+  name: 'Sector three',
+}]
+
+const Controller = proxyquire('~/src/apps/omis/apps/create/controllers/sector', {
+  '../../../../../lib/metadata': {
+    sectorOptions: sectorOptionsMock,
+  },
+})
+
+describe('OMIS create sector controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.controller = new Controller({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('configure()', () => {
+    beforeEach(() => {
+      this.reqMock = Object.assign({}, globalReq, {
+        form: {
+          options: {
+            fields: {
+              sector: {},
+            },
+          },
+        },
+      })
+
+      this.sandbox.spy(FormController.prototype, 'configure')
+    })
+
+    it('should set the list of markets', () => {
+      this.controller.configure(this.reqMock, globalRes, this.nextSpy)
+
+      expect(this.reqMock.form.options.fields.sector.options).to.deep.equal([
+        {
+          value: '1',
+          label: 'Sector one',
+        },
+        {
+          value: '2',
+          label: 'Sector two',
+        },
+        {
+          value: '3',
+          label: 'Sector three',
+        },
+      ])
+      expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, globalRes, this.nextSpy)
+    })
+  })
+
+  describe('saveValues()', () => {
+    beforeEach(() => {
+      this.reqMock = Object.assign({}, globalReq, {
+        form: {
+          values: {},
+        },
+      })
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          company: {
+            sector: {
+              id: 'b3959812-6095-e211-a939-e4115bead28a',
+              name: 'ICT',
+            },
+          },
+        },
+      })
+
+      this.sandbox.stub(FormController.prototype, 'saveValues')
+    })
+
+    context('when using company\'s sector', () => {
+      beforeEach(() => {
+        this.reqMock.form.values.use_sector_from_company = 'true'
+
+        this.controller.saveValues(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set sector to company\'s sector value', () => {
+        expect(this.reqMock.form.values.sector).to.equal('b3959812-6095-e211-a939-e4115bead28a')
+      })
+
+      it('should call parent saveValues method', () => {
+        expect(FormController.prototype.saveValues).to.have.been.calledOnce
+      })
+    })
+
+    context('when setting a custom sector', () => {
+      beforeEach(() => {
+        this.reqMock.form.values.use_sector_from_company = 'false'
+        this.reqMock.form.values.sector = '98d14e94-5d95-e211-a939-e4115bead28a'
+
+        this.controller.saveValues(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set sector to custom sector value', () => {
+        expect(this.reqMock.form.values.sector).to.equal('98d14e94-5d95-e211-a939-e4115bead28a')
+      })
+
+      it('should call parent saveValues method', () => {
+        expect(FormController.prototype.saveValues).to.have.been.calledOnce
+      })
+    })
+  })
+})


### PR DESCRIPTION
This adds the sector field to the creation journey rather than as part of the edit journey.

It can still be changed during the creation but is now required as part of the minimal initial creation journey.

## What it looks like

### Step in creation journey
![localhost_3000_omis_create_dcdabbc9-1781-e411-8955-e4115bead28a_sector_edit](https://user-images.githubusercontent.com/3327997/32745489-d2739e32-c8aa-11e7-82ce-98b95ccfc84e.png)

### Creation summary step
![localhost_3000_omis_create_dcdabbc9-1781-e411-8955-e4115bead28a_confirm 1](https://user-images.githubusercontent.com/3327997/32745556-f77513f0-c8aa-11e7-8eb2-983a32f06422.png)

#### Todo

- [ ] update/add unit tests
