### PR TITLE
Fix website link in investment project management page

### DIFF
--- a/src/apps/investment-projects/services/formatting.js
+++ b/src/apps/investment-projects/services/formatting.js
@@ -308,6 +308,7 @@ function transformBriefInvestmentSummary (data) {
   const investorCompany = data.investor_company
   const competitorCountries = data.competitor_countries || []
   const regionLocations = data.uk_region_locations || []
+  const date = moment(data.estimated_land_date)
 
   return {
     sector: get(data, 'sector.name', null),
@@ -315,11 +316,14 @@ function transformBriefInvestmentSummary (data) {
       name: investorCompany.name,
       url: `/companies/${investorCompany.id}`,
     },
-    website: (investorCompany.website) ? `<a href="${investorCompany.website}">${investorCompany.website}</a>` : '',
+    website: investorCompany.website ? {
+      name: investorCompany.website,
+      url: investorCompany.website,
+    } : null,
     account_tier: (investorCompany.classification && investorCompany.classification !== null && investorCompany.classification.name) ? investorCompany.classification.name : 'None',
     uk_region_locations: regionLocations.map(region => region.name).join(', '),
     competitor_countries: competitorCountries.map(country => country.name).join(', '),
-    estimated_land_date: data.estimated_land_date ? moment(data.estimated_land_date).format('MMMM YYYY') : null,
+    estimated_land_date: date.isValid() ? date.format('MMMM YYYY') : null,
     total_investment: formatCurrency(data.total_investment),
   }
 }

--- a/test/unit/apps/investment-projects/formatting.test.js
+++ b/test/unit/apps/investment-projects/formatting.test.js
@@ -1,3 +1,5 @@
+const { assign } = require('lodash')
+
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
 const formattingService = require('~/src/apps/investment-projects/services/formatting')
 
@@ -281,6 +283,309 @@ describe('Investment project formatting service', () => {
 
       it('should indicate there is no non-fdi r&d project', () => {
         expect(this.transformedInvestmentValues.associated_non_fdi_r_and_d_project).to.equal('Not linked to a non-FDI R&D project')
+      })
+    })
+  })
+
+  describe('#transformBriefInvestmentSummary', () => {
+    context('when a project contains data', () => {
+      beforeEach(() => {
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(investmentData)
+      })
+
+      it('sound contain the properties required of an investment summary', () => {
+        expect(Object.keys(this.investmentSummary)).to.deep.equal([
+          'sector',
+          'investor_company',
+          'website',
+          'account_tier',
+          'uk_region_locations',
+          'competitor_countries',
+          'estimated_land_date',
+          'total_investment',
+        ])
+      })
+
+      it('should provide the investor company as a link', () => {
+        beforeEach(() => {
+          const data = assign({}, investmentData, {
+            investor_company: {
+              id: '1234',
+              name: 'test',
+            },
+          })
+
+          this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+        })
+
+        it('should include the sector name', () => {
+          expect(this.investmentSummary).to.have.deep.property('investment_company', {
+            id: '1234',
+            name: 'test',
+            url: '/companies/1234',
+          })
+        })
+      })
+    })
+
+    context('when a sector is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          sector: {
+            id: '1234',
+            name: 'test',
+          },
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the sector name', () => {
+        expect(this.investmentSummary).to.have.property('sector', 'test')
+      })
+    })
+
+    context('when a sector isn\'t provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          sector: null,
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include a null sector', () => {
+        expect(this.investmentSummary).to.have.property('sector', null)
+      })
+    })
+
+    context('when an investor company has a website', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_company: {
+            id: '1234',
+            name: 'test',
+            website: 'http://www.test.com',
+          },
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.deep.property('website', {
+          name: 'http://www.test.com',
+          url: 'http://www.test.com',
+        })
+      })
+    })
+
+    context('when an investor company does not have a website', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_company: {
+            id: '1234',
+            name: 'test',
+            website: null,
+          },
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('website', null)
+      })
+    })
+
+    context('when investor company has no classification', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_company: {
+            classification: null,
+          },
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('account_tier', 'None')
+      })
+    })
+
+    context('when investor company has a malformed classification', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_company: {
+            classification: {
+              'colour': 'red',
+            },
+          },
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('account_tier', 'None')
+      })
+    })
+
+    context('when investor company has a valid classification', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_company: {
+            classification: {
+              id: '1321',
+              name: 'Test',
+            },
+          },
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('account_tier', 'Test')
+      })
+    })
+
+    context('when uk regions are provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          uk_region_locations: [{
+            id: '4321',
+            name: 'Region 1',
+          }, {
+            id: '1234',
+            name: 'Region 2',
+          }],
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('uk_region_locations', 'Region 1, Region 2')
+      })
+    })
+
+    context('when uk regions are not provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          uk_region_locations: null,
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('uk_region_locations', '')
+      })
+    })
+
+    context('when competitor countries are provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          competitor_countries: [{
+            id: '4321',
+            name: 'Country 1',
+          }, {
+            id: '1234',
+            name: 'Country 2',
+          }],
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('competitor_countries', 'Country 1, Country 2')
+      })
+    })
+
+    context('when competitor countries are not provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          competitor_countries: null,
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('competitor_countries', '')
+      })
+    })
+
+    context('when a land date is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          estimated_land_date: '2017-01-07',
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('estimated_land_date', 'January 2017')
+      })
+    })
+
+    context('when a land date is not provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          estimated_land_date: null,
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('estimated_land_date', null)
+      })
+    })
+
+    context('when a malformed land date is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          estimated_land_date: 'dog',
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('estimated_land_date', null)
+      })
+    })
+
+    context('when a total investment is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          total_investment: '100.24',
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('total_investment', '£100.24')
+      })
+    })
+
+    context('when a cotal investment is not provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          total_investment: null,
+        })
+
+        this.investmentSummary = formattingService.transformBriefInvestmentSummary(data)
+      })
+
+      it('should include the website and a link', () => {
+        expect(this.investmentSummary).to.have.property('total_investment', null)
       })
     })
   })


### PR DESCRIPTION
Previously the project management page incorrectly rendered links to an investor company website. 

Added some tests and more robust date handling while fixing the bug.

<img width="841" alt="dhcrm-investment-project-assign-pm-website" src="https://user-images.githubusercontent.com/56056/32783387-78840968-c943-11e7-86bd-1c5265fdd0ef.png">


![link](https://user-images.githubusercontent.com/56056/32783390-7b77c024-c943-11e7-8f5e-e6e3eb19dfad.PNG)
