### PR TITLE
Make sector viewable during edit journey

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -73,6 +73,11 @@ const editFields = merge({}, globalFields, {
     hint: 'fields.further_info.hint',
     optional: true,
   },
+  sector: {
+    condition: null,
+    dependent: null,
+    modifier: '',
+  },
   assignees: {
     fieldType: 'MultipleChoiceField',
     legend: 'fields.assignees.legend',

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -116,7 +116,8 @@
       "delivery_date": "Set a delivery date of at least 21 days from now",
       "assignees": "Add at least one adviser in the market",
       "assignee_time": "Allocate hours to at least one adviser in the market",
-      "vat_status": "Choose a VAT category"
+      "vat_status": "Choose a VAT category",
+      "vat_verified": "Verify the EU company's VAT number"
     }
   },
   "validation": {


### PR DESCRIPTION
This mainly fixes the display of sector during the edit journey but also adds a small fix to the validation error messages for creating a quote.