### PR TITLE
Remove forced capitalisation of first letter in key value tables

### DIFF
--- a/assets/stylesheets/_deprecated/components/_table.scss
+++ b/assets/stylesheets/_deprecated/components/_table.scss
@@ -14,10 +14,6 @@
       }
     }
 
-    td::first-letter {
-      text-transform: capitalize;
-    }
-
     tr:first-child {
       td,
       th {


### PR DESCRIPTION
There is no real need to force the first character in tables to be uppercase, and in some cases this makes the value look incorrect, e.g  url's that are http://www.test.com would look like Http://www.test.com


![32783390-7b77c024-c943-11e7-8f5e-e6e3eb19dfad](https://user-images.githubusercontent.com/56056/32791959-1d395e34-c95a-11e7-9769-eef9ef4e5040.png)

![link](https://user-images.githubusercontent.com/56056/32791976-240c0b4e-c95a-11e7-8ece-c7fc8ab771fa.PNG)
