### PR TITLE
Remove reconcile another order link from payment receipt

### DIFF
--- a/src/apps/omis/apps/view/views/payment-receipt.njk
+++ b/src/apps/omis/apps/view/views/payment-receipt.njk
@@ -114,9 +114,6 @@
 
   <ul class="list-spaced u-print-hide">
     <li>
-      <a href="/omis/reconciliation">Reconcile another order</a>
-    </li>
-    <li>
       <a href="/omis/{{ order.id }}">Return to order</a>
     </li>
   </ul>


### PR DESCRIPTION
As we don't have any roles yet we don't want to expose this link
to all users as it is only meant for a small sub-set.