### PR TITLE
Display one list account manager

### DIFF
--- a/src/apps/companies/controllers/view.js
+++ b/src/apps/companies/controllers/view.js
@@ -49,8 +49,7 @@ function renderDetails (req, res) {
     companyDetailsLabels: companyDetailsLabels,
     accountManagementDisplayLabels: accountManagementDisplayLabels,
     accountManagementDisplay: {
-      // TODO: Should this get real data back?
-      oneListAccountManager: 'None',
+      oneListAccountManager: get(res.locals, 'company.one_list_account_owner.name', 'None'),
       oneListTier: get(res.locals, 'company.classification.name', 'None'),
     },
   })

--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -24,7 +24,6 @@
     <div class="section">
       <h2 class="heading-medium">Account management</h2>
       {{ keyvaluetable(accountManagementDisplay, stripey=true, labels=accountManagementDisplayLabels) }}
-      <p class="footnote">You do not have permission to edit the account management section</strong></p>
     </div>
   {% endif %}
 

--- a/test/unit/apps/companies/controllers/view.test.js
+++ b/test/unit/apps/companies/controllers/view.test.js
@@ -1,0 +1,83 @@
+const { assign } = require('lodash')
+
+const companyData = require('~/test/unit/data/companies/company.json')
+const viewController = require('~/src/apps/companies/controllers/view')
+
+describe('Companies view controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+
+    this.req = {
+      session: {
+        token: '1234',
+      },
+      params: {
+        companyId: '999',
+      },
+    }
+
+    this.res = {
+      locals: {},
+      breadcrumb: this.sandbox.stub().returnsThis(),
+      render: this.sandbox.stub(),
+    }
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('renderDetails', () => {
+    context('when there is one list data associated with a company', () => {
+      beforeEach(() => {
+        const company = assign({}, companyData, {
+          one_list_account_owner: {
+            id: '888',
+            name: 'Fred Bloggs',
+          },
+          classification: {
+            id: '777',
+            name: 'Top',
+          },
+        })
+
+        this.res.locals = assign({}, this.res.locals, { company })
+        viewController.renderDetails(this.req, this.res)
+      })
+
+      it('should pass account management display data to the view', () => {
+        expect(this.res.locals).to.have.deep.property('accountManagementDisplay', {
+          oneListAccountManager: 'Fred Bloggs',
+          oneListTier: 'Top',
+        })
+      })
+
+      it('should pass account management labels to the view', () => {
+        expect(this.res.locals).to.have.property('accountManagementDisplayLabels')
+      })
+    })
+
+    context('when there is no one list data associated with a company', () => {
+      beforeEach(() => {
+        const company = assign({}, companyData, {
+          one_list_account_owner: null,
+          classification: null,
+        })
+
+        this.res.locals = assign({}, this.res.locals, { company })
+        viewController.renderDetails(this.req, this.res)
+      })
+
+      it('should indicate there is non one list account information', () => {
+        expect(this.res.locals).to.have.deep.property('accountManagementDisplay', {
+          oneListAccountManager: 'None',
+          oneListTier: 'None',
+        })
+      })
+
+      it('should pass account management labels to the view', () => {
+        expect(this.res.locals).to.have.property('accountManagementDisplayLabels')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Previously the one list account manager wasn't supported, so was hardcoded to 'none'. This small change picks up the one list account manager from the API response if it is provided.