### PR TITLE
Add UK region to display of advisers in the UK

### DIFF
--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -6,10 +6,10 @@ const logger = require('../../../../../config/logger')
 async function renderWorkOrder (req, res) {
   const order = res.locals.order
   let values
+  const assignees = res.locals.assignees
 
   try {
     const subscribers = await Order.getSubscribers(req.session.token, order.id)
-    const assignees = await Order.getAssignees(req.session.token, order.id)
 
     values = merge({}, order, {
       subscribers,

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -1,25 +1,16 @@
 const { get, merge, sumBy } = require('lodash')
 
-const { Order } = require('../../models')
-const logger = require('../../../../../config/logger')
-
-async function renderWorkOrder (req, res) {
+function renderWorkOrder (req, res) {
   const order = res.locals.order
-  let values
   const assignees = res.locals.assignees
+  const subscribers = res.locals.subscribers
 
-  try {
-    const subscribers = await Order.getSubscribers(req.session.token, order.id)
-
-    values = merge({}, order, {
-      subscribers,
-      assignees,
-      contact: res.locals.contact,
-      estimatedTimeSum: sumBy(assignees, 'estimated_time'),
-    })
-  } catch (e) {
-    logger.error(e)
-  }
+  const values = merge({}, order, {
+    assignees,
+    subscribers,
+    contact: res.locals.contact,
+    estimatedTimeSum: sumBy(assignees, 'estimated_time'),
+  })
 
   res.render('omis/apps/view/views/work-order', {
     values,

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -1,9 +1,11 @@
 const { get, merge, sumBy } = require('lodash')
 
+const { transformSubscriberToView } = require('../../transformers')
+
 function renderWorkOrder (req, res) {
   const order = res.locals.order
   const assignees = res.locals.assignees
-  const subscribers = res.locals.subscribers
+  const subscribers = res.locals.subscribers.map(transformSubscriberToView(get(res.locals, 'user.id')))
 
   const values = merge({}, order, {
     assignees,

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -2,7 +2,6 @@ const { get, merge, sumBy } = require('lodash')
 
 const { Order } = require('../../models')
 const logger = require('../../../../../config/logger')
-const { getContact } = require('../../../contacts/repos')
 
 async function renderWorkOrder (req, res) {
   const order = res.locals.order
@@ -11,12 +10,11 @@ async function renderWorkOrder (req, res) {
   try {
     const subscribers = await Order.getSubscribers(req.session.token, order.id)
     const assignees = await Order.getAssignees(req.session.token, order.id)
-    const contact = await getContact(req.session.token, order.contact.id)
 
     values = merge({}, order, {
-      contact,
       subscribers,
       assignees,
+      contact: res.locals.contact,
       estimatedTimeSum: sumBy(assignees, 'estimated_time'),
     })
   } catch (e) {

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -54,6 +54,18 @@ async function setAssignees (req, res, next) {
   next()
 }
 
+async function setSubscribers (req, res, next) {
+  try {
+    const orderId = get(res.locals, 'order.id')
+    const subscribers = await Order.getSubscribers(req.session.token, orderId)
+
+    res.locals.subscribers = subscribers
+  } catch (error) {
+    logger.error(error)
+  }
+  next()
+}
+
 async function setQuoteSummary (req, res, next) {
   const order = get(res.locals, 'order')
 
@@ -235,6 +247,7 @@ module.exports = {
   setCompany,
   setContact,
   setAssignees,
+  setSubscribers,
   setQuoteSummary,
   setQuotePreview,
   setQuote,

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -5,6 +5,7 @@ const i18nFuture = require('i18n-future')
 const logger = require('../../../../../config/logger')
 const { Order } = require('../../models')
 const { getCompany } = require('../../middleware')
+const { getContact } = require('../../../contacts/repos')
 const { transformPaymentToView } = require('../../transformers')
 const editSteps = require('../edit/steps')
 
@@ -27,6 +28,18 @@ function setCompany (req, res, next) {
   }
 
   getCompany(req, res, next, res.locals.order.company.id)
+}
+
+async function setContact (req, res, next) {
+  try {
+    const contactId = get(res.locals, 'order.contact.id')
+    const contact = await getContact(req.session.token, contactId)
+
+    res.locals.order.contact = contact
+  } catch (error) {
+    logger.error(error)
+  }
+  next()
 }
 
 async function setQuoteSummary (req, res, next) {
@@ -208,6 +221,7 @@ function setQuoteForm (req, res, next) {
 module.exports = {
   setTranslation,
   setCompany,
+  setContact,
   setQuoteSummary,
   setQuotePreview,
   setQuote,

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -42,6 +42,18 @@ async function setContact (req, res, next) {
   next()
 }
 
+async function setAssignees (req, res, next) {
+  try {
+    const orderId = get(res.locals, 'order.id')
+    const assignees = await Order.getAssignees(req.session.token, orderId)
+
+    res.locals.assignees = assignees
+  } catch (error) {
+    logger.error(error)
+  }
+  next()
+}
+
 async function setQuoteSummary (req, res, next) {
   const order = get(res.locals, 'order')
 
@@ -222,6 +234,7 @@ module.exports = {
   setTranslation,
   setCompany,
   setContact,
+  setAssignees,
   setQuoteSummary,
   setQuotePreview,
   setQuote,

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -13,6 +13,7 @@ const {
 const {
   setTranslation,
   setCompany,
+  setContact,
   setQuoteSummary,
   setQuotePreview,
   setQuote,
@@ -38,7 +39,7 @@ router.use(setQuoteSummary)
 router.use(setArchivedDocumentsBaseUrl)
 
 router.get('/', redirectToFirstNavItem)
-router.get('/work-order', renderWorkOrder)
+router.get('/work-order', setContact, renderWorkOrder)
 router.get('/payment-receipt', setInvoice, setPayments, renderPaymentReceipt)
 router
   .route('/quote')

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -15,6 +15,7 @@ const {
   setCompany,
   setContact,
   setAssignees,
+  setSubscribers,
   setQuoteSummary,
   setQuotePreview,
   setQuote,
@@ -40,7 +41,7 @@ router.use(setQuoteSummary)
 router.use(setArchivedDocumentsBaseUrl)
 
 router.get('/', redirectToFirstNavItem)
-router.get('/work-order', setContact, setAssignees, renderWorkOrder)
+router.get('/work-order', setContact, setAssignees, setSubscribers, renderWorkOrder)
 router.get('/payment-receipt', setInvoice, setPayments, renderPaymentReceipt)
 router
   .route('/quote')

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -14,6 +14,7 @@ const {
   setTranslation,
   setCompany,
   setContact,
+  setAssignees,
   setQuoteSummary,
   setQuotePreview,
   setQuote,
@@ -39,7 +40,7 @@ router.use(setQuoteSummary)
 router.use(setArchivedDocumentsBaseUrl)
 
 router.get('/', redirectToFirstNavItem)
-router.get('/work-order', setContact, renderWorkOrder)
+router.get('/work-order', setContact, setAssignees, renderWorkOrder)
 router.get('/payment-receipt', setInvoice, setPayments, renderPaymentReceipt)
 router
   .route('/quote')

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -130,7 +130,7 @@
       url: 'edit/subscribers' if order.isEditable,
       label: 'Add or remove'
     }],
-    items: values.subscribers | map('name') if values.subscribers.length,
+    items: values.subscribers,
     fallbackText: 'No advisers added'
   }) }}
 

--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -107,8 +107,29 @@ function transformPaymentToView ({
   }
 }
 
+function transformSubscriberToView (currentUserId) {
+  return function ({
+    name,
+    id,
+    dit_team,
+  } = {}) {
+    if (!id) { return }
+
+    const ukTeam = get(dit_team, 'uk_region.name')
+    const teamLabel = ukTeam ? `, ${ukTeam}` : ''
+    const youLabel = id === currentUserId ? ' (you)' : ''
+
+    return [
+      name,
+      teamLabel,
+      youLabel,
+    ].join('')
+  }
+}
+
 module.exports = {
   transformOrderToListItem,
   transformOrderToTableItem,
   transformPaymentToView,
+  transformSubscriberToView,
 }

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -5,34 +5,23 @@ const contactData = require('~/test/unit/data/simple-contact')
 const orderMock = {
   id: '1230asd-123dasda',
   status: 'draft',
-  contact: {
-    id: '123dasda-1230asd',
-  },
+  contact: contactData,
   foo: 'bar',
 }
 const tokenMock = 'session-12345'
+const transformerStub = (item) => {
+  return item
+}
 
 describe('OMIS View controllers', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
 
-    this.getSubscribersStub = this.sandbox.stub().resolves(subscriberData)
-    this.getAssigneesStub = this.sandbox.stub().resolves(assigneeData)
-    this.getContactStub = this.sandbox.stub().resolves(contactData)
-    this.loggerSpy = this.sandbox.spy()
+    this.transformSubscriberToViewStub = this.sandbox.stub().returns(transformerStub)
 
     this.controllers = proxyquire('~/src/apps/omis/apps/view/controllers', {
-      '../../../../../config/logger': {
-        error: this.loggerSpy,
-      },
-      '../../models': {
-        Order: {
-          getSubscribers: this.getSubscribersStub,
-          getAssignees: this.getAssigneesStub,
-        },
-      },
-      '../../../contacts/repos': {
-        getContact: this.getContactStub,
+      '../../transformers': {
+        transformSubscriberToView: this.transformSubscriberToViewStub,
       },
     })
   })
@@ -51,6 +40,8 @@ describe('OMIS View controllers', () => {
         render: this.renderSpy,
         locals: {
           order: orderMock,
+          subscribers: subscriberData,
+          assignees: assigneeData,
         },
       }
       this.reqMock = {
@@ -58,97 +49,35 @@ describe('OMIS View controllers', () => {
           token: tokenMock,
         },
       }
+
+      this.controllers.renderWorkOrder(this.reqMock, this.resMock)
     })
 
-    it('should not set a breadcrumb option', async () => {
-      await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
-
+    it('should not set a breadcrumb option', () => {
       expect(this.breadcrumbSpy).not.to.have.been.called
     })
 
-    it('should render a template', async () => {
-      await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
-
+    it('should render a template', () => {
       expect(this.renderSpy).to.have.been.called
     })
 
-    context('when api calls resolve', () => {
-      beforeEach(async () => {
-        await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
-      })
-
-      it('should get subscribers with correct args', () => {
-        expect(this.getSubscribersStub).to.have.been.calledWith(tokenMock, orderMock.id)
-      })
-
-      it('should get assignees with correct args', () => {
-        expect(this.getAssigneesStub).to.have.been.calledWith(tokenMock, orderMock.id)
-      })
-
-      it('should get contact with correct args', () => {
-        expect(this.getContactStub).to.have.been.calledWith(tokenMock, orderMock.contact.id)
-      })
-
-      it('should call correct template', () => {
-        expect(this.renderSpy.args[0][0]).to.equal('omis/apps/view/views/work-order')
-      })
-
-      it('should send correct properties to view', () => {
-        const values = this.renderSpy.args[0][1].values
-
-        expect(values).to.have.property('id')
-        expect(values).to.have.property('contact')
-        expect(values).to.have.property('foo')
-        expect(values).to.have.property('subscribers')
-        expect(values).to.have.property('assignees')
-        expect(values).to.have.property('estimatedTimeSum')
-      })
-
-      it('should send correct subscribers', () => {
-        const values = this.renderSpy.args[0][1].values
-
-        expect(values.subscribers).to.be.an('array').to.have.length(2)
-      })
-
-      it('should send correct assignees', () => {
-        const values = this.renderSpy.args[0][1].values
-
-        expect(values.assignees).to.be.an('array').to.have.length(2)
-      })
-
-      it('should merge short contact with full contact', () => {
-        const values = this.renderSpy.args[0][1].values
-
-        expect(values.contact).to.be.an('object').to.deep.equal(contactData)
-      })
-
-      it('should estimate sum correctly', () => {
-        const values = this.renderSpy.args[0][1].values
-
-        expect(values.estimatedTimeSum).to.be.a('number').to.equal(450)
-      })
+    it('should send values property to view', () => {
+      expect(this.renderSpy.firstCall.args[1]).to.have.property('values')
     })
 
-    context('when api calls reject', () => {
-      beforeEach(async () => {
-        this.error = {
-          statusCode: 500,
-        }
-        this.getSubscribersStub.rejects(this.error)
+    it('should contain correct values', () => {
+      const values = this.renderSpy.firstCall.args[1].values
 
-        await this.controllers.renderWorkOrder(this.reqMock, this.resMock)
-      })
+      expect(values).to.have.property('assignees')
+      expect(values).to.have.property('subscribers')
+      expect(values).to.have.property('contact')
+      expect(values).to.have.property('estimatedTimeSum')
+    })
 
-      it('values should not be defined', () => {
-        expect(this.renderSpy).to.have.been.calledWith('omis/apps/view/views/work-order', {
-          values: undefined,
-        })
-      })
+    it('should set the correct time sum', () => {
+      const values = this.renderSpy.firstCall.args[1].values
 
-      it('should log the error', () => {
-        expect(this.loggerSpy).to.have.been.calledWith(this.error)
-        expect(this.loggerSpy).to.have.been.calledOnce
-      })
+      expect(values.estimatedTimeSum).to.be.a('number').to.equal(450)
     })
   })
 
@@ -161,17 +90,15 @@ describe('OMIS View controllers', () => {
         breadcrumb: this.breadcrumbSpy,
         render: this.renderSpy,
       }
+
+      this.controllers.renderQuote({}, this.resMock)
     })
 
     it('should set a breadcrumb option', () => {
-      this.controllers.renderQuote({}, this.resMock)
-
       expect(this.breadcrumbSpy).to.have.been.called
     })
 
     it('should render a template', () => {
-      this.controllers.renderQuote({}, this.resMock)
-
       expect(this.renderSpy).to.have.been.called
     })
   })

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -1,3 +1,4 @@
+const contactMock = require('~/test/unit/data/contacts/contacts')[0]
 const invoiceMock = require('~/test/unit/data/omis/invoice')
 const paymentsMock = require('~/test/unit/data/omis/payments')
 
@@ -7,6 +8,7 @@ describe('OMIS View middleware', () => {
 
     this.getCompanySpy = this.sandbox.spy()
     this.loggerErrorSpy = this.sandbox.spy()
+    this.getContactStub = this.sandbox.stub()
     this.previewQuoteStub = this.sandbox.stub()
     this.getQuoteStub = this.sandbox.stub()
     this.getInvoiceStub = this.sandbox.stub()
@@ -40,6 +42,9 @@ describe('OMIS View middleware', () => {
       },
       '../../../../../config/logger': {
         error: this.loggerErrorSpy,
+      },
+      '../../../contacts/repos': {
+        getContact: this.getContactStub,
       },
       '../../models': {
         Order: {
@@ -122,6 +127,48 @@ describe('OMIS View middleware', () => {
 
       it('should not call next itself', () => {
         expect(this.nextSpy).not.to.have.been.called
+      })
+    })
+  })
+
+  describe('setContact()', () => {
+    context('when invoice call resolves', () => {
+      beforeEach(async () => {
+        this.getContactStub.resolves(contactMock)
+
+        await this.middleware.setContact(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set contact property on locals', () => {
+        expect(this.resMock.locals.order).to.have.property('contact')
+      })
+
+      it('should set correct contact object', () => {
+        expect(this.resMock.locals.order.contact).to.deep.equal(contactMock)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
+    context('when call generates an error', () => {
+      beforeEach(async () => {
+        this.error = {
+          statusCode: 500,
+        }
+        this.getContactStub.rejects(this.error)
+
+        await this.middleware.setContact(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should log error', () => {
+        expect(this.loggerErrorSpy).to.have.been.calledOnce
+        expect(this.loggerErrorSpy).to.have.been.calledWith(this.error)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
       })
     })
   })

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -2,6 +2,7 @@ const contactMock = require('~/test/unit/data/contacts/contacts')[0]
 const invoiceMock = require('~/test/unit/data/omis/invoice')
 const paymentsMock = require('~/test/unit/data/omis/payments')
 const assigneesMock = require('~/test/unit/data/omis/assignees')
+const subscribersMock = require('~/test/unit/data/omis/subscribers')
 
 describe('OMIS View middleware', () => {
   beforeEach(() => {
@@ -11,6 +12,7 @@ describe('OMIS View middleware', () => {
     this.loggerErrorSpy = this.sandbox.spy()
     this.getContactStub = this.sandbox.stub()
     this.getAssigneesStub = this.sandbox.stub()
+    this.getSubscribersStub = this.sandbox.stub()
     this.previewQuoteStub = this.sandbox.stub()
     this.getQuoteStub = this.sandbox.stub()
     this.getInvoiceStub = this.sandbox.stub()
@@ -51,6 +53,7 @@ describe('OMIS View middleware', () => {
       '../../models': {
         Order: {
           getAssignees: this.getAssigneesStub,
+          getSubscribers: this.getSubscribersStub,
           previewQuote: this.previewQuoteStub,
           getQuote: this.getQuoteStub,
           getInvoice: this.getInvoiceStub,
@@ -209,6 +212,52 @@ describe('OMIS View middleware', () => {
         this.getAssigneesStub.rejects(this.error)
 
         await this.middleware.setAssignees(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should log error', () => {
+        expect(this.loggerErrorSpy).to.have.been.calledOnce
+        expect(this.loggerErrorSpy).to.have.been.calledWith(this.error)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+  })
+
+  describe('setSubscribers()', () => {
+    context('when invoice call resolves', () => {
+      beforeEach(async () => {
+        this.getSubscribersStub.resolves(subscribersMock)
+
+        await this.middleware.setSubscribers(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set subscribers property on locals', () => {
+        expect(this.resMock.locals).to.have.property('subscribers')
+      })
+
+      it('should set correct number of subscribers', () => {
+        expect(this.resMock.locals.subscribers).to.have.length(2)
+      })
+
+      it('should set correct objects on subscribers', () => {
+        expect(this.resMock.locals.subscribers).to.deep.equal(subscribersMock)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
+    context('when call generates an error', () => {
+      beforeEach(async () => {
+        this.error = {
+          statusCode: 500,
+        }
+        this.getSubscribersStub.rejects(this.error)
+
+        await this.middleware.setSubscribers(this.reqMock, this.resMock, this.nextSpy)
       })
 
       it('should log error', () => {

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -1,3 +1,5 @@
+const { merge } = require('lodash')
+
 describe('OMIS list transformers', function () {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
@@ -121,6 +123,59 @@ describe('OMIS list transformers', function () {
         const amount = actual.amount
 
         expect(amount).to.equal(53.43)
+      })
+    })
+  })
+
+  describe('#transformSubscriberToView', () => {
+    const subscriber = require('~/test/unit/data/omis/subscribers.json')[0]
+    const subscriberWithTeam = merge({}, subscriber, {
+      dit_team: {
+        uk_region: {
+          name: 'London',
+        },
+      },
+    })
+
+    context('when given an unqualified result', () => {
+      it('should return undefined', () => {
+        expect(this.transformers.transformSubscriberToView()()).to.be.undefined
+        expect(this.transformers.transformSubscriberToView()({ a: 'b' })).to.be.undefined
+        expect(this.transformers.transformSubscriberToView()({ name: 'abcd' })).to.be.undefined
+      })
+    })
+
+    context('when given a qualified result', () => {
+      context('when the subscriber is not the current user', () => {
+        it('should return just the name', () => {
+          const actual = this.transformers.transformSubscriberToView()(subscriber)
+
+          expect(actual).to.equal('Puck Head')
+        })
+
+        context('when the subscriber has a UK region', () => {
+          it('should return the name and Uk region', () => {
+            const actual = this.transformers.transformSubscriberToView()(subscriberWithTeam)
+
+            expect(actual).to.equal('Puck Head, London')
+          })
+        })
+      })
+
+      context('when the subscriber is the current user', () => {
+        it('should return the name with suffix', () => {
+          const actual = this.transformers.transformSubscriberToView(subscriber.id)(subscriber)
+
+          expect(actual).to.equal('Puck Head (you)')
+        })
+
+        context('when the subscriber has a UK region', () => {
+          it('should return the name and Uk region', () => {
+            const actual = this.transformers.transformSubscriberToView(subscriber.id)(subscriberWithTeam)
+
+            expect(actual).to.equal('Puck Head, London (you)')
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
This changes the format of the adviser display to include the UK
region to the list of advisers on the work order.

It also adds functionality to display if _you_ are one of the
advisers in the list that is currently present in the advisers in
the market.

## Before

![image](https://user-images.githubusercontent.com/3327997/32836315-3c1440ec-ca01-11e7-926d-4ec04a491a29.png)

## After

![image](https://user-images.githubusercontent.com/3327997/32836295-2a673502-ca01-11e7-823b-acca0a172e3a.png)
