### PR TITLE
Add VAT Number field to company edit

### DIFF
--- a/src/apps/companies/controllers/view.js
+++ b/src/apps/companies/controllers/view.js
@@ -16,6 +16,7 @@ const companyDetailsDisplayOrder = [
   'description',
   'employee_range',
   'turnover_range',
+  'vat_number',
 ]
 const companiesHouseDetailsDisplayOrder = [
   'trading_name',

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -32,6 +32,7 @@ const companyDetailsLabels = {
   archived_by_id: 'Archived by',
   company_number: 'Companies House number',
   account_manager_id: 'Account manager',
+  vat_number: 'VAT number',
 }
 const chDetailsLabels = {
   name: 'Registered name',

--- a/src/apps/companies/services/form.js
+++ b/src/apps/companies/services/form.js
@@ -1,13 +1,12 @@
-const { nullEmptyFields, convertYesNoToBoolean } = require('../../../lib/property-helpers')
+const { convertYesNoToBoolean } = require('../../../lib/property-helpers')
 const companyRepository = require('../repos')
 
 async function saveCompanyForm (token, companyForm) {
   return new Promise(async (resolve, reject) => {
     try {
-      let dataToSave = convertYesNoToBoolean(companyForm)
-      dataToSave = nullEmptyFields(dataToSave)
-      const savedContact = await companyRepository.saveCompany(token, dataToSave)
-      resolve(savedContact)
+      const dataToSave = convertYesNoToBoolean(companyForm)
+      const savedCompany = await companyRepository.saveCompany(token, dataToSave)
+      resolve(savedCompany)
     } catch (error) {
       reject(error)
     }

--- a/src/apps/companies/services/formatting.js
+++ b/src/apps/companies/services/formatting.js
@@ -1,4 +1,5 @@
 const { title } = require('case')
+const { omitBy } = require('lodash')
 
 const { companyDetailsLabels, chDetailsLabels, hqLabels } = require('../labels')
 const { getFormattedAddress } = require('../../../lib/address')
@@ -41,10 +42,9 @@ function getDisplayCompany (company) {
     turnover_range: (company.turnover_range && company.turnover_range.name) ? company.turnover_range.name : null,
     account_manager: (company.account_manager && company.account_manager.name) ? company.account_manager.name : null,
     headquarter_type: (company.headquarter_type && company.headquarter_type.name && company.headquarter_type.name.length > 0) ? hqLabels[company.headquarter_type.name] : 'Not a headquarters',
-    trading_name: company.trading_name || null,
+    trading_name: (company.trading_name && company.trading_name.length > 0) ? company.trading_name : null,
+    vat_number: company.vat_number,
   }
-
-  if (company.trading_name && company.trading_name.length > 0) displayCompany.trading_name = company.trading_name
 
   const registeredAddress = getFormattedAddress(company, 'registered')
   displayCompany.registered_address = registeredAddress
@@ -61,7 +61,8 @@ function getDisplayCompany (company) {
 
   if (company.uk_region && company.uk_region.name && company.uk_region.name !== 'Undefined') displayCompany.uk_region = company.uk_region.name
 
-  return displayCompany
+  // Strip out empty or null fields
+  return omitBy(displayCompany, val => !val)
 }
 
 module.exports = {

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -304,5 +304,14 @@
       value: formData.turnover_range,
       error: errors.turnover_range
     }) }}
+
+    {% if not isForeign %}
+      {{ TextField({
+        name: 'vat_number',
+        label: 'VAT number',
+        value: formData.vat_number,
+        error: errors.vat_number
+      }) }}
+    {% endif %}
   {% endcall %}
 {% endblock %}

--- a/test/unit/apps/companies/services/form.test.js
+++ b/test/unit/apps/companies/services/form.test.js
@@ -33,15 +33,6 @@ describe('company form service', function () {
           expect(saveCompanyStub).to.be.calledWith('1234', { thing: true, other: false })
         })
     })
-    it('nulls empty fields', function () {
-      const company = {
-        thing: '',
-      }
-      return companyFormService.saveCompanyForm('1234', company)
-        .then((result) => {
-          expect(saveCompanyStub).to.be.calledWith('1234', { thing: null })
-        })
-    })
     it('handles errors', function () {
       saveCompanyStub = sinon.stub().rejects({ error: 'test' })
       companyFormService = proxyquire('~/src/apps/companies/services/form', {

--- a/test/unit/apps/companies/services/formatting.test.js
+++ b/test/unit/apps/companies/services/formatting.test.js
@@ -34,7 +34,7 @@ describe('Company formatting service', () => {
       expect(actual).to.be.null
     })
     describe('company contains CDMS data', () => {
-      it('should show company data, even empty values', () => {
+      it('should show company data', () => {
         const company = {
           'id': '3a4b36c6-a950-43c5-ba41-82cf6bffaa91',
           'name': 'Fresh Flowers',
@@ -111,6 +111,7 @@ describe('Company formatting service', () => {
             'id': '874cd12a-6095-e211-a939-e4115bead28a',
             'name': 'London',
           },
+          vat_number: '123412341234',
         }
         const expected = {
           business_type: 'Company',
@@ -123,13 +124,21 @@ describe('Company formatting service', () => {
           sector: 'Giftware, Jewellery and Tableware',
           website: '<a href="http://www.test.com">http://www.test.com</a>',
           description: 'description',
-          employee_range: null,
-          turnover_range: null,
           account_manager: 'Yvonne Ahern',
           country: 'United Kingdom',
+          vat_number: '123412341234',
         }
         const actual = companyFormattingService.getDisplayCompany(company)
         expect(actual).to.deep.equal(expected)
+      })
+      it('should not return a vat number if it is empty', () => {
+        const company = {
+          'id': '1234',
+          'vat_number': '',
+        }
+
+        const actual = companyFormattingService.getDisplayCompany(company)
+        expect(actual).to.not.have.property('vat_number')
       })
       it('should convert website to link', () => {
         const company = {


### PR DESCRIPTION
Allow the user to specify a VAT Number associated with a UK company.

Also has minor changes to behaviour due to API requiring new text fields to specify no value as '' instead of null.

![vat](https://user-images.githubusercontent.com/56056/32840622-1ea460be-ca10-11e7-888c-1a9c40c0fd23.gif)
