### PR TITLE
Handle absent user when rendering investment project audit log

### DIFF
--- a/src/apps/investment-projects/controllers/audit.js
+++ b/src/apps/investment-projects/controllers/audit.js
@@ -5,7 +5,7 @@ const { getInvestmentProjectAuditLog } = require('../repos')
 
 function formatAuditLog (logEntry) {
   return {
-    name: logEntry.user.name,
+    name: get(logEntry, 'user.name'),
     timestamp: formatLongDate(logEntry.timestamp),
     changes: (logEntry.changes && Object.keys(logEntry.changes).length) || 0,
   }

--- a/src/apps/investment-projects/views/audit.njk
+++ b/src/apps/investment-projects/views/audit.njk
@@ -6,7 +6,7 @@
   <ul class="list-lined">
     {% for logEntry in auditLog %}
       <li>
-        User {{ logEntry.name }} changed {{ logEntry.changes }} {{ 'item' | pluralise(logEntry.changes) }} on {{ logEntry.timestamp }}
+        User {{ logEntry.name | default('Unknown adviser') }} changed {{ logEntry.changes }} {{ 'item' | pluralise(logEntry.changes) }} on {{ logEntry.timestamp }}
       </li>
     {% endfor %}
   </ul>

--- a/test/unit/apps/investment-projects/controllers/audit.test.js
+++ b/test/unit/apps/investment-projects/controllers/audit.test.js
@@ -215,4 +215,51 @@ describe('Investment audit controller', () => {
       },
     }, this.next)
   })
+
+  describe('formatAuditLog', () => {
+    beforeEach(() => {
+      this.timestamp = '2017-08-09T13:25:29.568665Z'
+      this.formattedDate = '9 August 2017'
+      this.changes = {
+        'thing': 'a thing',
+        'other thing': 'another thing',
+      }
+    })
+
+    it('should return the user name', () => {
+      const actual = this.controller.formatAuditLog({
+        user: { name: 'James Example' },
+        timestamp: this.timestamp,
+        changes: this.changes,
+      })
+      expect(actual).to.deep.equal({
+        name: 'James Example',
+        timestamp: this.formattedDate,
+        changes: 2,
+      })
+    })
+    it('should handle absent users', () => {
+      const actual = this.controller.formatAuditLog({
+        timestamp: this.timestamp,
+        changes: this.changes,
+      })
+      expect(actual).to.deep.equal({
+        name: undefined,
+        timestamp: this.formattedDate,
+        changes: 2,
+      })
+    })
+    it('should handle empty users', () => {
+      const actual = this.controller.formatAuditLog({
+        user: {},
+        timestamp: this.timestamp,
+        changes: this.changes,
+      })
+      expect(actual).to.deep.equal({
+        name: undefined,
+        timestamp: this.formattedDate,
+        changes: 2,
+      })
+    })
+  })
 })


### PR DESCRIPTION
## user known
![image](https://user-images.githubusercontent.com/5485798/32852083-d2ebf190-ca2e-11e7-8de2-7d60e0b8d626.png)

## user unknown
![image](https://user-images.githubusercontent.com/5485798/32852096-dbb7211e-ca2e-11e7-8b94-26d1b3f55aa1.png)
