### PR TITLE
Fix company edit not showing business type

### DIFF
--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -13,13 +13,14 @@ function getBusinessTypeOption (businessTypeUUID) {
   )
 }
 
-function getBusinessTypeLabel (isLimitedCompany, isForeign, businessTypeUUID) {
-  if (isLimitedCompany) {
-    return 'UK limited company'
+function getBusinessTypeLabel (companiesHouseCategory, isForeign, businessTypeUUID) {
+  let prefix = isForeign ? 'Foreign' : 'UK'
+  if (companiesHouseCategory) {
+    return `${prefix} ${companiesHouseCategory}`
   }
   const businessTypeOption = getBusinessTypeOption(businessTypeUUID)
   if (businessTypeOption) {
-    return (isForeign ? 'Foreign ' : 'UK ') + businessTypeOption.label
+    return `${prefix} ${businessTypeOption.label}`
   }
 }
 
@@ -35,16 +36,15 @@ function renderForm (req, res) {
   if (req.query.country === 'non-uk') {
     isForeign = true
   }
-  const isCompaniesHouse = !!res.locals.companiesHouseRecord
 
   if (res.locals.companiesHouseRecord) {
     res.locals = assign({}, res.locals, {
-      isCompaniesHouse,
+      isCompaniesHouse: true,
       chDetails: companyFormattingService.getDisplayCH(res.locals.companiesHouseRecord),
     })
   }
   const businessTypeLabel = getBusinessTypeLabel(
-    isCompaniesHouse, isForeign, res.locals.businessType
+    res.locals.companiesHouseCategory, isForeign, res.locals.businessType
   )
 
   res

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 const { getFormattedAddress } = require('../../../lib/address')
 const { getDitCompany, getCHCompany } = require('../repos')
 
@@ -22,9 +24,8 @@ async function getCompany (req, res, next, id) {
     const company = await getDitCompany(req.session.token, id)
 
     company.address = getHeadingAddress(company)
-
     res.locals.company = company
-
+    res.locals.companiesHouseCategory = get(company, 'companies_house_data.company_category')
     next()
   } catch (error) {
     next(error)
@@ -33,7 +34,9 @@ async function getCompany (req, res, next, id) {
 
 async function getCompaniesHouseRecord (req, res, next, companyNumber) {
   try {
-    res.locals.companiesHouseRecord = await getCHCompany(req.session.token, companyNumber)
+    const companiesHouseRecord = await getCHCompany(req.session.token, companyNumber)
+    res.locals.companiesHouseCategory = companiesHouseRecord.company_category
+    res.locals.companiesHouseRecord = companiesHouseRecord
     next()
   } catch (error) {
     next(error)

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -78,91 +78,91 @@ describe('Company export controller', () => {
 
   describe('getBusinessTypeLabel()', () => {
     it('should handle UK limited company', () => {
-      const label = this.controller.getBusinessTypeLabel(true, false, null)
+      const label = this.controller.getBusinessTypeLabel('limited company', false, null)
       expect(label).to.equal('UK limited company')
     })
 
     it('should handle UK charity', () => {
       const uuid = '9dd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, false, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
       expect(label).to.equal('UK Charity')
     })
 
     it('should handle UK government department', () => {
       const uuid = '9cd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, false, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
       expect(label).to.equal('UK Government Dept')
     })
 
     it('should handle UK Intermediary', () => {
       const uuid = '9bd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, false, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
       expect(label).to.equal('UK Intermediary')
     })
 
     it('should handle UK Limited partnership', () => {
       const uuid = '8b6eaf7e-03e7-e611-bca1-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, false, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
       expect(label).to.equal('UK Limited partnership')
     })
 
     it('should handle UK Partnership', () => {
       const uuid = '9ad14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, false, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
       expect(label).to.equal('UK Partnership')
     })
 
     it('should handle UK Sole trader', () => {
       const uuid = '99d14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, false, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
       expect(label).to.equal('UK Sole Trader')
     })
 
     it('should handle Foreign charity', () => {
       const uuid = '9dd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal('Foreign Charity')
     })
 
     it('should handle Foreign government department', () => {
       const uuid = '9cd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal('Foreign Government Dept')
     })
 
     it('should handle Foreign Intermediary', () => {
       const uuid = '9bd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal('Foreign Intermediary')
     })
 
     it('should handle Foreign Limited partnership', () => {
       const uuid = '8b6eaf7e-03e7-e611-bca1-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal('Foreign Limited partnership')
     })
 
     it('should handle Foreign Partnership', () => {
       const uuid = '9ad14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal('Foreign Partnership')
     })
 
     it('should handle Foreign Sole trader', () => {
       const uuid = '99d14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal('Foreign Sole Trader')
     })
 
     it('should handle Foreign Company', () => {
       const uuid = '98d14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal('Foreign Company')
     })
 
     it('should handle unrecognised uuids', () => {
       const uuid = '98d14e94-milk-eggs-beef-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(false, true, uuid)
+      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
       expect(label).to.equal(undefined)
     })
   })
@@ -205,7 +205,10 @@ describe('Company export controller', () => {
     it('should expose businessTypeLabel', () => {
       const reqMock = this.buildReq({ query: {} })
       const resMock = this.buildRes({
-        locals: { companiesHouseRecord: { country: 'uk' } },
+        locals: {
+          companiesHouseRecord: { country: 'uk' },
+          companiesHouseCategory: 'limited company',
+        },
       })
       this.controller.renderForm(reqMock, resMock, this.nextSpy)
       expect(this.renderSpy.args[0][1].businessTypeLabel).to.equal('UK limited company')

--- a/test/unit/apps/companies/middleware/params.test.js
+++ b/test/unit/apps/companies/middleware/params.test.js
@@ -1,0 +1,60 @@
+const companiesHouseCompany = require('~/test/unit/data/companies/companiesHouseCompany')
+
+describe('Companies form middleware', function () {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.getDitCompanyStub = this.sandbox.stub().resolves({})
+    this.getCHCompanyStub = this.sandbox.stub().resolves(companiesHouseCompany)
+    this.reqMock = { query: {}, session: { token: 2 } }
+    this.resMock = { locals: {} }
+    this.middleware = proxyquire('~/src/apps/companies/middleware/params.js', {
+      '../repos': {
+        getCHCompany: (token, number) => this.getCHCompanyStub(token, number),
+        getDitCompany: (token, id) => this.getDitCompanyStub(token, id),
+      },
+    })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('getCompany', () => {
+    it('should handle non-companies house companies when setting category', () => {
+      this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, 2)
+      expect(this.resMock.locals.companiesHouseCategory).to.equal(undefined)
+    })
+
+    it('should handle companies house companies when setting category', done => {
+      const next = () => {
+        expect(this.resMock.locals.companiesHouseCategory).to.equal('Limited company')
+        done()
+      }
+      this.getDitCompanyStub = this.sandbox.stub().resolves({
+        companies_house_data: {
+          company_category: 'Limited company',
+        },
+      })
+      this.middleware.getCompany(this.reqMock, this.resMock, next, 2)
+    })
+  })
+
+  describe('getCompaniesHouseRecord', () => {
+    it('should handle non-companies house companies when setting category', () => {
+      this.middleware.getCompaniesHouseRecord(this.reqMock, this.resMock, this.nextSpy, 2)
+      expect(this.resMock.locals.companiesHouseCategory).to.equal(undefined)
+    })
+
+    it('should handle companies house companies when setting category', done => {
+      const next = () => {
+        expect(this.resMock.locals.companiesHouseCategory).to.equal('Limited company')
+        done()
+      }
+      this.getCHCompanyStub = this.sandbox.stub().resolves({
+        company_category: 'Limited company',
+      })
+      this.middleware.getCompaniesHouseRecord(this.reqMock, this.resMock, next, 2)
+    })
+  })
+})


### PR DESCRIPTION
# cause of the bug

Misuse of the variable `isCompaniesHouse`. I thought it means "is the company in companies house". It actually means "have we retrieved the `companiesHouseRecord` from companies house? (which is only retrieved when adding a company, not editing a company)"

# the fix

- set `locals.companiesHouseCategory` in `getCompany` and `getCompaniesHouseRecord` middleware which are called on company edit and company add
- in the controller, first, try to use `companiesHouseCategory` and fall back to getting the business type label using the business type uuid.

# demo

## adding non-limited company

![image](https://user-images.githubusercontent.com/5485798/32888430-23ea6d16-cabf-11e7-80dc-cdf23f7edcb3.png)

## adding companies from companies house (note not all companies in companies house are limited)

![image](https://user-images.githubusercontent.com/5485798/32888447-31d46dbe-cabf-11e7-9da0-65fc62c8b03c.png)

![image](https://user-images.githubusercontent.com/5485798/32888890-b9527f14-cac0-11e7-8dbd-9c71049eb23c.png)

## editing a company from companies house

![image](https://user-images.githubusercontent.com/5485798/32888491-5325bdb0-cabf-11e7-9fba-ee78595c95e5.png)
