### PR TITLE
Lead adviser (assignee) validation

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -118,6 +118,7 @@ async function setQuotePreview (req, res, next) {
       }
     })
 
+    res.locals.missingLeadAssignee = error.error.hasOwnProperty('assignee_lead')
     res.locals.incompleteFields = pickBy(quoteErrors)
   }
 

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -29,87 +29,88 @@
         {% endfor %}
       </ul>
     {% endcall %}
-  {% endif %}
+  {% else %}
 
-  {% if quote %}
-    {% set expiryLabel %}
-      {% if order.status === 'quote_awaiting_acceptance' %}
-        Expire{{ 'd' if quote.expired else 's' }} on
-      {% else %}
-        Will expire on
+    {% if quote %}
+      {% set expiryLabel %}
+        {% if order.status === 'quote_awaiting_acceptance' %}
+          Expire{{ 'd' if quote.expired else 's' }} on
+        {% else %}
+          Will expire on
+        {% endif %}
+      {% endset %}
+
+      {% set expiryValue %}
+        {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }})
+      {% endset %}
+
+      {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
+        {{ MetaList({
+          items: [
+            { label: expiryLabel, value: expiryValue }
+          ],
+          itemModifier: 'stacked'
+        }) }}
       {% endif %}
-    {% endset %}
 
-    {% set expiryValue %}
-      {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }})
-    {% endset %}
-
-    {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
       {{ MetaList({
         items: [
-          { label: expiryLabel, value: expiryValue }
+          { label: 'Sent on', value: quote.created_on, type: 'datetime' },
+          { label: 'Sent by', value: quote.created_by if quote.created_on }
         ],
         itemModifier: 'stacked'
       }) }}
-    {% endif %}
 
-    {{ MetaList({
-      items: [
-        { label: 'Sent on', value: quote.created_on, type: 'datetime' },
-        { label: 'Sent by', value: quote.created_by if quote.created_on }
-      ],
-      itemModifier: 'stacked'
-    }) }}
+      {{ MetaList({
+        items: [
+          { label: 'Cancelled on', value: quote.cancelled_on, type: 'datetime' },
+          { label: 'Cancelled by', value: quote.cancelled_by },
+          { label: 'Accepted on', value: quote.accepted_on, type: 'datetime' },
+          { label: 'Accepted by', value: quote.accepted_by }
+        ],
+        itemModifier: 'stacked'
+      }) }}
 
-    {{ MetaList({
-      items: [
-        { label: 'Cancelled on', value: quote.cancelled_on, type: 'datetime' },
-        { label: 'Cancelled by', value: quote.cancelled_by },
-        { label: 'Accepted on', value: quote.accepted_on, type: 'datetime' },
-        { label: 'Accepted by', value: quote.accepted_by }
-      ],
-      itemModifier: 'stacked'
-    }) }}
+      {% if quote.content %}
+        {% call Example(tabTitle = '') %}
+          <div class="l-markdown">
+  {# Ugly indentation is so that markdown spacing is handled correctly #}
+  {% markdown %}{{ quote.content | safe }}{% endmarkdown %}
 
-    {% if quote.content %}
-      {% call Example(tabTitle = '') %}
-        <div class="l-markdown">
-{# Ugly indentation is so that markdown spacing is handled correctly #}
-{% markdown %}{{ quote.content | safe }}{% endmarkdown %}
-
-          {% call HiddenContent({ summary: 'View full terms and conditions' }) %}
-{# Ugly indentation is so that markdown spacing is handled correctly #}
-{% markdown %}{{ quote.terms_and_conditions | safe }}{% endmarkdown %}
-          {% endcall %}
-        </div>
-      {% endcall %}
-    {% endif %}
-
-    {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
-      {% if destructive %}
-        {{ Message({
-          type: 'error',
-          text: 'Editing the order whilst it is out for acceptance will invalidate the
-          current quote and the client will no longer be able to accept it.'
-        }) }}
+            {% call HiddenContent({ summary: 'View full terms and conditions' }) %}
+  {# Ugly indentation is so that markdown spacing is handled correctly #}
+  {% markdown %}{{ quote.terms_and_conditions | safe }}{% endmarkdown %}
+            {% endcall %}
+          </div>
+        {% endcall %}
       {% endif %}
+
+      {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}
+        {% if destructive %}
+          {{ Message({
+            type: 'error',
+            text: 'Editing the order whilst it is out for acceptance will invalidate the
+            current quote and the client will no longer be able to accept it.'
+          }) }}
+        {% endif %}
+      {% endif %}
+
     {% endif %}
 
+    {% if order.status === 'draft' and quote %}
+      {{ Message({
+        type: 'info',
+        text: 'Quotes should be reviewed by a manager before being sent.'
+      }) }}
+
+      <h2 class="heading-medium">What happens next</h2>
+
+      <ul class="list-disc">
+        <li>An email with a link to this quote will be sent to the client for acceptance</li>
+      </ul>
+    {% endif %}
+
+    {{ Form(quoteForm) }}
+
   {% endif %}
-
-  {% if order.status === 'draft' and quote %}
-    {{ Message({
-      type: 'info',
-      text: 'Quotes should be reviewed by a manager before being sent.'
-    }) }}
-
-    <h2 class="heading-medium">What happens next</h2>
-
-    <ul class="list-disc">
-      <li>An email with a link to this quote will be sent to the client for acceptance</li>
-    </ul>
-  {% endif %}
-
-  {{ Form(quoteForm) }}
-
 {% endblock %}

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -11,6 +11,13 @@
       <p>To preview a quote you must complete the following:</p>
 
       <ul class="list-disc">
+        {% if missingLeadAssignee %}
+          <li>
+            <a href="/omis/{{ order.id }}#assignees">
+              {{ translate('errors.quote.assignee_lead') }}
+            </a>
+          </li>
+        {% endif %}
         {% for stepUrl, stepData in incompleteFields %}
           {% for field in stepData.errors %}
             <li>

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -67,6 +67,7 @@
   }) }}
 
   {% call AnswersSummary({
+    id: 'assignees',
     heading: 'Advisers in the market',
     actions: [{
       url: 'edit/assignees' if order.isEditable,

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -116,6 +116,7 @@
       "delivery_date": "Set a delivery date of at least 21 days from now",
       "assignees": "Add at least one adviser in the market",
       "assignee_time": "Allocate hours to at least one adviser in the market",
+      "assignee_lead": "Set a lead adviser",
       "vat_status": "Choose a VAT category",
       "vat_number": "Enter the EU company's VAT number",
       "vat_verified": "Verify the EU company's VAT number"

--- a/src/templates/_macros/common/answers-summary.njk
+++ b/src/templates/_macros/common/answers-summary.njk
@@ -7,6 +7,7 @@
  # @param {string} props.items.label - item label
  # @param {string} [props.items.fallbackText] - fallback text if value is empty
  # @param {string} [props.fallbackText] - component level fallback when items is a list of strings
+ # @param {string} [props.id] - ID to use for table
  # @param {string} [props.heading] - heading to use as caption for the table
  # @param {object[]} [props.actions] - array of actions to display
  # @param {string} [props.actions.url] - URL for the action
@@ -16,7 +17,10 @@
  #}
 {% macro AnswersSummary(props) %}
   {% if props.items or props.fallbackText or caller %}
-    <table class="c-answers-summary">
+    <table
+      class="c-answers-summary"
+      {% if props.id %}id="{{ props.id }}"{% endif %}
+    >
       {% if props.heading or props.actions.length %}
         <caption class="c-answers-summary__heading">
           {{ props.heading }}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -459,6 +459,48 @@ describe('OMIS View middleware', () => {
           })
         })
 
+        it('should set a missingLeadAssignee property', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.resMock.locals).to.have.property('missingLeadAssignee')
+        })
+
+        it('should set a missingLeadAssignee to false', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.resMock.locals.missingLeadAssignee).to.equal(false)
+        })
+
+        it('should return next without error', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.nextSpy).to.have.been.calledWith()
+        })
+      })
+
+      context('when quote preview errors contains assignee_lead error', () => {
+        beforeEach(() => {
+          const error = {
+            statusCode: 400,
+            error: {
+              'assignee_lead': ['Required'],
+            },
+          }
+          this.previewQuoteStub.rejects(error)
+        })
+
+        it('should set a missingLeadAssignee property', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.resMock.locals).to.have.property('missingLeadAssignee')
+        })
+
+        it('should set a missingLeadAssignee to true', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.resMock.locals.missingLeadAssignee).to.equal(true)
+        })
+
         it('should return next without error', async () => {
           await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
 

--- a/test/unit/macros/common/answers-summary.test.js
+++ b/test/unit/macros/common/answers-summary.test.js
@@ -129,6 +129,22 @@ describe('Answers Summary macro', () => {
       })
     })
 
+    context('with an ID', () => {
+      beforeEach(() => {
+        this.component = commonMacros.renderToDom('AnswersSummary', {
+          items,
+          id: 'component-id',
+        })
+      })
+      it('should add an id attribute to table element', () => {
+        expect(this.component.hasAttribute('id')).to.equal(true)
+      })
+
+      it('should set the correct value to the id attribute', () => {
+        expect(this.component.getAttribute('id')).to.equal('component-id')
+      })
+    })
+
     context('with actions', () => {
       beforeEach(() => {
         this.component = commonMacros.renderToDom('AnswersSummary', {


### PR DESCRIPTION
As setting the lead assignee isn't part of the standard edit steps
it needs to be handled slightly differently. This adds support for a
new custom variable for the view which determines whether the
error message is displayed.

## What it looks like 

![localhost_3001_omis_b85a4802-17f0-4fec-82ee-5f49225dfe83_quote](https://user-images.githubusercontent.com/3327997/32893565-eb23230c-cad1-11e7-858f-6f32eeceee74.png)
