### PR TITLE
Fix sort form options for OMIS collection route

### DIFF
--- a/src/apps/omis/apps/list/macros.js
+++ b/src/apps/omis/apps/list/macros.js
@@ -99,11 +99,20 @@ const collectionSortForm = {
   ],
 }
 
-const reconciliationSortForm = assign({}, collectionSortForm)
-reconciliationSortForm.children[0].options = [
-  { value: 'payment_due_date:asc', label: 'Earliest payment due date' },
-  { value: 'payment_due_date:desc', label: 'Lastest payment due date' },
-]
+const reconciliationSortForm = assign({}, collectionSortForm, {
+  children: [
+    {
+      macroName: 'MultipleChoiceField',
+      label: 'Sort by',
+      name: 'sortby',
+      modifier: ['small', 'inline', 'light'],
+      options: [
+        { value: 'payment_due_date:asc', label: 'Earliest payment due date' },
+        { value: 'payment_due_date:desc', label: 'Lastest payment due date' },
+      ],
+    },
+  ],
+})
 
 module.exports = {
   collectionSortForm,


### PR DESCRIPTION
The previous code was mutating the property on the OMIS collection
sort form causing both views to have the same options for sort.

This changes it so that the sort form displays different values
based on the view.