### PR TITLE
Use the correct method to reset the value of conditional subfields

### DIFF
--- a/assets/javascripts/modules/conditional-subfields.js
+++ b/assets/javascripts/modules/conditional-subfields.js
@@ -139,8 +139,11 @@ const ConditionalSubfields = {
 
       Array.from(children).forEach((field) => {
         if (!field.getAttribute('data-persist-values')) {
-          field.value = ''
-          field.checked = false
+          if (['select', 'radio', 'checkbox'].indexOf(field.type) > -1) {
+            field.checked = false
+          } else {
+            field.value = ''
+          }
         }
 
         const event = this.wrapper.createEvent('HTMLEvents')


### PR DESCRIPTION
When resetting the value for subfields this method was setting
the value to an empty string and setting checked to false.

This caused an issue for radio or checkbox elements as they were having
the value they needed removed. So when the form was submitted with
their value it was empty.