### PR TITLE
Add i18n for VAT number quote validation item

### DIFF
--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -117,6 +117,7 @@
       "assignees": "Add at least one adviser in the market",
       "assignee_time": "Allocate hours to at least one adviser in the market",
       "vat_status": "Choose a VAT category",
+      "vat_number": "Enter the EU company's VAT number",
       "vat_verified": "Verify the EU company's VAT number"
     }
   },


### PR DESCRIPTION
The key for this field was missing from the i18n items. Was previously
just returning the key rather than a useful error message.