### PR TITLE
Fix postcode lookup error handling

### DIFF
--- a/src/apps/api/controllers.js
+++ b/src/apps/api/controllers.js
@@ -15,15 +15,16 @@ async function postcodeLookupHandler (req, res) {
   try {
     const postcode = req.params.postcode
     const addresses = await lookupAddress(postcode)
+    const unitedKingdomCountryId = metadata.countryOptions.find(
+      country => country.name.toLowerCase() === 'united kingdom'
+    ).id
     const augmentedAddresses = addresses.map(address => {
-      return Object.assign({}, address, {
-        country: metadata.countryOptions.find(country => country.name.toLowerCase() === 'united kingdom').id,
-      })
+      return Object.assign({}, address, { country: unitedKingdomCountryId })
     })
 
     res.json(augmentedAddresses)
   } catch (error) {
-    res.json({ error })
+    res.status(error.statusCode).json({ message: error.message })
   }
 }
 

--- a/test/unit/apps/api/controllers.test.js
+++ b/test/unit/apps/api/controllers.test.js
@@ -1,0 +1,55 @@
+describe('api controllers', () => {
+  beforeEach(() => {
+    this.req = { params: { postcode: 'dn21 6fg' } }
+    this.sandbox = sinon.sandbox.create()
+    this.resMock = {
+      send: this.sandbox.spy(),
+      json: this.sandbox.spy(),
+      status: this.sandbox.stub().returnsThis(),
+    }
+    this.lookupAddressStub = this.sandbox.stub().resolves([
+      { country: 'united kingdom' },
+    ])
+    this.controller = proxyquire('~/src/apps/api/controllers', {
+      './services': {
+        lookupAddress: postcode => this.lookupAddressStub(postcode),
+      },
+      '../../lib/metadata': {
+        countryOptions: [{
+          id: '1234',
+          name: 'United Kingdom',
+        }],
+      },
+    })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('postcodeLookupHandler', () => {
+    context('when the external api service returns successful response', () => {
+      beforeEach(async () => {
+        await this.controller.postcodeLookupHandler(this.req, this.resMock)
+      })
+      it('should return postcode response', () => {
+        expect(this.resMock.json).to.be.calledWith([{ country: '1234' }])
+      })
+    })
+
+    context('when the external api service returns an error', () => {
+      beforeEach(async () => {
+        this.statusCode = 400
+        this.message = 'error'
+        this.lookupAddressStub = this.sandbox.stub().throws({
+          statusCode: this.statusCode, message: this.message,
+        })
+        await this.controller.postcodeLookupHandler(this.req, this.resMock)
+      })
+      it('should return correct status code and message on error', () => {
+        expect(this.resMock.status).to.be.calledWith(this.statusCode)
+        expect(this.resMock.json).to.be.calledWith({ message: this.message })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## the bug

unrecognised postcodes result in `undefined` being displayed on the address selector

![image](https://user-images.githubusercontent.com/5485798/32948147-35898c5a-cb96-11e7-9fdc-45fa90be604b.png)

this is caused by non-200 responses from the external postcode service being returned to the browser as a 200 response.

## the fix

Return the external postcode service's actual response, so the browser will get a 400, which will mean the "render the dropdown" js code is not called