### PR TITLE
Move whitespace removal to source of inflated responses

### DIFF
--- a/config/nunjucks/index.js
+++ b/config/nunjucks/index.js
@@ -13,6 +13,7 @@ const templateGlobals = require('./globals')
 const COMPONENTS_PATH = '_components/' // relative to templates path
 const COMPONENT_EXT = 'njk'
 const WHITESPACE_AT_START = /^\s+/
+const WHITESPACE_AT_NEWLINE = /\n\s+/g
 const WHITESPACE_BETWEEN_TAGS = />\s+</g
 const WHITESPACE_AT_END = /\s+$/
 
@@ -65,6 +66,7 @@ function SafeSpacelessExtension () {
       .replace(WHITESPACE_AT_START, '')
       .replace(WHITESPACE_BETWEEN_TAGS, '><')
       .replace(WHITESPACE_AT_END, '')
+      .replace(WHITESPACE_AT_NEWLINE, '')
     return new nunjucks.runtime.SafeString(result)
   }
 }

--- a/src/templates/_layouts/xhr.njk
+++ b/src/templates/_layouts/xhr.njk
@@ -1,5 +1,3 @@
-{% safespaceless %}
-  <div class="main-content__inner l-container" id="xhr-outlet">
-    {% block body_main_content %}{% endblock %}
-  </div>
-{% endsafespaceless %}
+<div class="main-content__inner l-container" id="xhr-outlet">
+  {% block body_main_content %}{% endblock %}
+</div>

--- a/src/templates/_macros/form/select-box.njk
+++ b/src/templates/_macros/form/select-box.njk
@@ -29,9 +29,11 @@
     {% for option in options %}
       {% set label = option.name or option.label %}
       {% set value = option.id or option.value %}
-      <option value="{{ value }}" {% if value and fieldValue === value %}selected{% endif %}>
-        {{ label }}
-      </option>
+      {% safespaceless %}
+        <option value="{{ value }}" {% if value and fieldValue === value %}selected{% endif %}>
+          {{ label }}
+        </option>
+      {% endsafespaceless %}
     {% endfor %}
   </select>
 {% endmacro %}


### PR DESCRIPTION
Removing whitepsace from entire XHR responses had unwanted side effects.

By narrowing down where we remove whitespace we solve for the largest offenders but reduce the scope for unwanted side-effects.