### PR TITLE
Handle no advisers when saving project members

### DIFF
--- a/src/apps/investment-projects/middleware/forms/team-members.js
+++ b/src/apps/investment-projects/middleware/forms/team-members.js
@@ -1,4 +1,4 @@
-const { zipWith, get } = require('lodash')
+const { zipWith, get, isArray, isString } = require('lodash')
 const { getAdvisers } = require('../../../adviser/repos')
 const { updateInvestmentTeamMembers } = require('../../repos')
 const { teamMembersLabels } = require('../../labels')
@@ -7,17 +7,13 @@ const { transformObjectToOption } = require('../../../transformers')
 // Transform the form posted to an array of objects to save
 // and filter out any blanks
 function transformDataToTeamMemberArray (body) {
-  if (Array.isArray(body.adviser)) {
-    return zipWith(body.adviser, body.role, (adviser, role) => ({ adviser, role }))
-      .filter(member => member.adviser.length > 0)
-  } else if (body.adviser.length > 0) {
-    return [{
-      adviser: body.adviser,
-      role: body.role,
-    }]
+  let teamMembers = []
+  if (isArray(body.adviser)) {
+    teamMembers = zipWith(body.adviser, body.role, (adviser, role) => ({ adviser, role }))
+  } else if (isString(body.adviser)) {
+    teamMembers = [{ adviser: body.adviser, role: body.role }]
   }
-
-  return []
+  return teamMembers.filter(member => member.adviser.length)
 }
 
 async function populateForm (req, res, next) {

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -326,5 +326,15 @@ describe('Investment form middleware - team members', () => {
 
       expect(actual).to.deep.equal(expected)
     })
+
+    it('should handle absent adviser and return empty array', () => {
+      const body = {}
+
+      const expected = []
+
+      const actual = this.controller.transformDataToTeamMemberArray(body)
+
+      expect(actual).to.deep.equal(expected)
+    })
   })
 })


### PR DESCRIPTION
## the bug

The update project member middleware did not handle the case when all advisers are removed from the project.

![no-adviser-bug](https://user-images.githubusercontent.com/5485798/33012794-e0560222-cdd9-11e7-8d76-2f9b5433bd5a.gif)

## the fix
![no-adviser-fix](https://user-images.githubusercontent.com/5485798/33012800-e43b7a84-cdd9-11e7-9d36-f46e7002775b.gif)
