### PR TITLE
Payment reconciliation updates

### DIFF
--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -78,4 +78,10 @@
   background: $grey-4;
   font-size: inherit;
   font-weight: inherit;
+
+  * {
+    &:not(button) {
+      font-weight: inherit;
+    }
+  }
 }

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -205,12 +205,6 @@ const editFields = merge({}, globalFields, {
     validate: ['required', 'date', 'before'],
     modifier: 'medium',
   },
-  transaction_reference: {
-    fieldType: 'TextField',
-    label: 'fields.transaction_reference.label',
-    optional: true,
-    modifier: 'medium',
-  },
   cancellation_reason: {
     fieldType: 'MultipleChoiceField',
     label: 'fields.cancellation_reason.label',

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -85,7 +85,6 @@ const steps = merge({}, createSteps, {
     fields: [
       'amount',
       'received_on',
-      'transaction_reference',
     ],
     templatePath: 'omis/apps/edit/views',
     template: 'payment-reconciliation.njk',

--- a/src/apps/omis/apps/edit/views/payment-reconciliation.njk
+++ b/src/apps/omis/apps/edit/views/payment-reconciliation.njk
@@ -61,5 +61,12 @@
     <h2 class="heading-medium">Payment details</h2>
 
     {{ super() }}
+
+    {% call HiddenContent({ summary: 'Something is wrong with the payment' }) %}
+      {% call Message({ type: 'muted' }) %}
+        <a href="/omis/{{ order.id }}">View the order</a> to contact an adviser
+          in the UK or contact <a href="mailto:omis.orders@digital.trade.gov.uk">omis.orders@digital.trade.gov.uk</a>.
+      {% endcall %}
+    {% endcall %}
   {% endif %}
 {% endblock %}

--- a/src/apps/omis/apps/edit/views/payment-reconciliation.njk
+++ b/src/apps/omis/apps/edit/views/payment-reconciliation.njk
@@ -37,6 +37,10 @@
     <table>
       <tbody>
         <tr>
+          <th>Order reference</th>
+          <td>{{ order.reference }}</td>
+        </tr>
+        <tr>
           <th>Amount (excluding VAT)</th>
           <td>{{ order.subtotal_cost | formatCurrency }}</td>
         </tr>

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -101,9 +101,6 @@
       "label": "Payment received date",
       "hint": "For example 28/10/2017"
     },
-    "transaction_reference": {
-      "label": "Transaction reference"
-    },
     "cancellation_reason": {
       "label": "Reason for cancelling"
     }


### PR DESCRIPTION
This change updates the payment reconciliation journey with some feedback from user research.

- Remove transaction reference data input
- Display order reference on reconciliation view
- Add contact information for when an order has something wrong

## Before
![localhost_3001_omis_ec423e60-aaea-407e-90ce-a22402a82664_edit_payment-reconciliation_returnurl _omis_reconciliation_sortby 3dpayment_due_date 253aasc 26status 3dquote_accepted 2](https://user-images.githubusercontent.com/3327997/33022219-57b632a2-cdfc-11e7-93d3-86c891c27fa4.png)

## After
![localhost_3001_omis_ec423e60-aaea-407e-90ce-a22402a82664_edit_payment-reconciliation_returnurl _omis_reconciliation_sortby 3dpayment_due_date 253aasc 26status 3dquote_accepted](https://user-images.githubusercontent.com/3327997/33022184-2f0dd6de-cdfc-11e7-844c-51b8b3433bd4.png)
