### PR TITLE
Remove supporting content key from market field

### DIFF
--- a/src/apps/omis/fields.js
+++ b/src/apps/omis/fields.js
@@ -15,7 +15,6 @@ module.exports = {
     validate: 'required',
     initialOption: '-- Select country --',
     options: [],
-    supportingContent: 'fields.primary_market.supportingContent',
   },
   use_sector_from_company: {
     fieldType: 'MultipleChoiceField',


### PR DESCRIPTION
The content was removed from the i18n definitions but the key was
still being included in the field definition. Needs to be removed from
here so that it doesn't display the value.