### PR TITLE
403 support

### DIFF
--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -5,7 +5,7 @@ const { transformSubscriberToView } = require('../../transformers')
 function renderWorkOrder (req, res) {
   const order = res.locals.order
   const assignees = res.locals.assignees
-  const subscribers = res.locals.subscribers.map(transformSubscriberToView(get(res.locals, 'user.id')))
+  const subscribers = get(res.locals, 'subscribers', []).map(transformSubscriberToView(get(res.locals, 'user.id')))
 
   const values = merge({}, order, {
     assignees,

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,7 +1,6 @@
 const { assign, get } = require('lodash')
 
 const config = require('../../../config')
-const logger = require('../../../config/logger')
 const { getDitCompany } = require('../companies/repos')
 const { setHomeBreadcrumb } = require('../middleware')
 const { Order } = require('./models')
@@ -33,10 +32,11 @@ async function getOrder (req, res, next, orderId) {
     currencyFields.forEach((field) => {
       res.locals.order[field] = parseFloat(res.locals.order[field]) / 100
     })
-  } catch (e) {
-    logger.error(e)
+
+    next()
+  } catch (error) {
+    next(error)
   }
-  next()
 }
 
 function setOrderBreadcrumb (req, res, next) {

--- a/src/middleware/errors.js
+++ b/src/middleware/errors.js
@@ -1,23 +1,31 @@
 const config = require('../../config')
 const logger = require('../../config/logger')
 
+function getStatusMessage (error) {
+  if (error.code === 'EBADCSRFTOKEN') {
+    return 'This form has been tampered with'
+  }
+
+  if (error.statusCode === 404) {
+    return 'Page not found'
+  }
+
+  if (error.statusCode === 403) {
+    return 'You don’t have permission to view this page'
+  }
+
+  return 'Page unavailable'
+}
+
 function notFound (req, res, next) {
   const error = new Error('Not Found')
   error.statusCode = 404
-  res.locals.BREADCRUMBS = null
 
   next(error)
 }
 
 function catchAll (error, req, res, next) {
-  const statusCode = error.statusCode = (error.statusCode || 500)
-  let statusMessage = statusCode === 404
-    ? 'Sorry we couldn\'t find that page!'
-    : 'Sorry something has gone wrong!'
-
-  if (error.code === 'EBADCSRFTOKEN') {
-    statusMessage = 'This form has been tampered with'
-  }
+  const statusCode = error.statusCode || 500
 
   if (res.headersSent) {
     return next(error)
@@ -26,11 +34,13 @@ function catchAll (error, req, res, next) {
   logger[statusCode === 404 ? 'info' : 'error'](error)
 
   res.locals.BREADCRUMBS = null
-  res.status(statusCode)
+  res
+    .status(statusCode)
     .render('errors', {
+      error,
       statusCode,
-      statusMessage,
-      devErrorDetail: config.isDev && error,
+      statusMessage: getStatusMessage(error),
+      showStackTrace: config.isDev,
     })
 }
 

--- a/src/templates/errors.njk
+++ b/src/templates/errors.njk
@@ -1,16 +1,33 @@
 {% extends "_layouts/datahub-base.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ heading: statusMessage, modifier: 'light-banner' }) %}
-    <p>{{ statusCode }}</p>
-  {% endcall %}
+  {{ LocalHeader({ heading: statusMessage, modifier: 'light-banner' }) }}
 {% endblock %}
 
 {% block body_main_content %}
-  {% if devErrorDetail %}
+  {% if statusCode == '404' %}
+    <p>If you entered a web address check it was correct.</p>
+
+    <p>If you followed a link here <a href="/support">let us know</a>.</p>
+  {% elseif statusCode == '403' and error.code === 'EBADCSRFTOKEN' %}
+    <p>Try to submit the form again in a few moments.</p>
+
+    <p>If you’re still having trouble <a href="/support">report a problem</a>.</p>
+  {% elseif statusCode == '403' %}
+    <p>If you think you should have access or need to sign up to a DIT system then <a href="/support">request access</a>.</p>
+  {% else %}
+    <p>We are experiencing technical problems and the error has been reported. Try again in a few moments.</p>
+
+    <p>If you’re still having trouble <a href="/support">report a problem</a>.</p>
+  {% endif %}
+
+  <p>You can also <a href="/">browse or search from the homepage</a> to find the information you need.</p>
+
+  {% if showStackTrace %}
+    <h3 class="heading-medium">{{ statusCode }}</h3>
     <dl class="stack-trace">
-      <dt class="stack-trace__heading">{{ devErrorDetail.message }}</dt>
-      <dd class="stack-trace__details">{{ devErrorDetail.stack }}</dd>
+      <dt class="stack-trace__heading">{{ error.message }}</dt>
+      <dd class="stack-trace__details">{{ error.stack }}</dd>
     </dl>
   {% endif %}
 {% endblock %}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -138,11 +138,33 @@ describe('OMIS View middleware', () => {
   })
 
   describe('setContact()', () => {
-    context('when invoice call resolves', () => {
+    context('when no contact ID exists', () => {
       beforeEach(async () => {
+        await this.middleware.setContact(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not make an API request', () => {
+        expect(this.getContactStub).not.to.have.called
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
+    context('when API call resolves', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.contact = {
+          id: 'contact-id',
+        }
         this.getContactStub.resolves(contactMock)
 
         await this.middleware.setContact(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call getContact with correct arguments', () => {
+        expect(this.getContactStub).to.have.been.calledOnce
+        expect(this.getContactStub).to.have.been.calledWith('12345', 'contact-id')
       })
 
       it('should set contact property on locals', () => {
@@ -160,6 +182,9 @@ describe('OMIS View middleware', () => {
 
     context('when call generates an error', () => {
       beforeEach(async () => {
+        this.resMock.locals.order.contact = {
+          id: 'contact-id',
+        }
         this.error = {
           statusCode: 500,
         }
@@ -168,23 +193,38 @@ describe('OMIS View middleware', () => {
         await this.middleware.setContact(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should log error', () => {
-        expect(this.loggerErrorSpy).to.have.been.calledOnce
-        expect(this.loggerErrorSpy).to.have.been.calledWith(this.error)
+      it('should call next with error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+    })
+  })
+
+  describe('setAssignees()', () => {
+    context('when no order ID exists', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order = null
+        await this.middleware.setAssignees(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not make an API request', () => {
+        expect(this.getAssigneesStub).not.to.have.called
       })
 
       it('should call next', () => {
         expect(this.nextSpy).to.have.been.calledWith()
       })
     })
-  })
 
-  describe('setAssignees()', () => {
     context('when invoice call resolves', () => {
       beforeEach(async () => {
         this.getAssigneesStub.resolves(assigneesMock)
 
         await this.middleware.setAssignees(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call getAssigneesStub with correct arguments', () => {
+        expect(this.getAssigneesStub).to.have.been.calledOnce
+        expect(this.getAssigneesStub).to.have.been.calledWith('12345', '123456789')
       })
 
       it('should set assignees property on locals', () => {
@@ -214,23 +254,38 @@ describe('OMIS View middleware', () => {
         await this.middleware.setAssignees(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should log error', () => {
-        expect(this.loggerErrorSpy).to.have.been.calledOnce
-        expect(this.loggerErrorSpy).to.have.been.calledWith(this.error)
+      it('should call next', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+    })
+  })
+
+  describe('setSubscribers()', () => {
+    context('when no order ID exists', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order = null
+        await this.middleware.setSubscribers(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not make an API request', () => {
+        expect(this.getSubscribersStub).not.to.have.called
       })
 
       it('should call next', () => {
         expect(this.nextSpy).to.have.been.calledWith()
       })
     })
-  })
 
-  describe('setSubscribers()', () => {
     context('when invoice call resolves', () => {
       beforeEach(async () => {
         this.getSubscribersStub.resolves(subscribersMock)
 
         await this.middleware.setSubscribers(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call getAssigneesStub with correct arguments', () => {
+        expect(this.getSubscribersStub).to.have.been.calledOnce
+        expect(this.getSubscribersStub).to.have.been.calledWith('12345', '123456789')
       })
 
       it('should set subscribers property on locals', () => {
@@ -260,13 +315,8 @@ describe('OMIS View middleware', () => {
         await this.middleware.setSubscribers(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should log error', () => {
-        expect(this.loggerErrorSpy).to.have.been.calledOnce
-        expect(this.loggerErrorSpy).to.have.been.calledWith(this.error)
-      })
-
       it('should call next', () => {
-        expect(this.nextSpy).to.have.been.calledWith()
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
       })
     })
   })

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -164,29 +164,21 @@ describe('OMIS middleware', () => {
     })
 
     context('when a model method rejects', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         this.error = {
           statusCode: 404,
         }
         this.getByIdStub.rejects(this.error)
+
+        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
       })
 
-      it('should not set an order property on locals', async () => {
-        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
-
+      it('should not set an order property on locals', () => {
         expect(this.resMock.locals).to.not.have.property('order')
       })
 
-      it('should log the error', async () => {
-        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
-
-        expect(this.loggerSpy).to.have.been.calledWith(this.error)
-      })
-
-      it('should call next without an error', async () => {
-        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
-
-        expect(this.nextSpy).to.have.been.calledWith()
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
       })
     })
   })


### PR DESCRIPTION
This change adds better support when the API returns a `403` status code for OMIS orders.

It adds work around the global error handler to support a `403` code and render a more useful message to users.

It also adds the work to error OMIS middleware correctly.

## Error pages

### Before 

#### 404

![image](https://user-images.githubusercontent.com/3327997/33031826-4bfe1446-ce17-11e7-8b73-22d65a2bd13d.png)

#### 500

![image](https://user-images.githubusercontent.com/3327997/33031901-814b0a64-ce17-11e7-99a1-2d44bed6d847.png)

### After

#### 404

![image](https://user-images.githubusercontent.com/3327997/33031980-b93ef4bc-ce17-11e7-93f2-870c148651fc.png)

#### 403

![image](https://user-images.githubusercontent.com/3327997/33032007-d4d708c2-ce17-11e7-8263-134b1ee9ae3c.png)

#### 500

![image](https://user-images.githubusercontent.com/3327997/33031941-9cbce84e-ce17-11e7-93cf-4e0d2688549b.png)
