### PR TITLE
Handle *_id fields when converting field names to labels in audit log

### DIFF
--- a/src/apps/audit/transformers.js
+++ b/src/apps/audit/transformers.js
@@ -5,7 +5,7 @@ const { mediumDateTimeFormat } = require('../../../config')
 
 function transformChanges (changes, labels) {
   return Object.keys(changes)
-    .map(key => labels[key] || key)
+    .map(key => labels[key] || labels[key.replace(/_id$/, '')] || key)
     .join(', ')
 }
 
@@ -46,4 +46,5 @@ function transformAuditLogToListItem (labels = {}) {
 
 module.exports = {
   transformAuditLogToListItem,
+  transformChanges,
 }

--- a/src/apps/audit/transformers.js
+++ b/src/apps/audit/transformers.js
@@ -3,6 +3,18 @@ const { get } = require('lodash')
 const dateFns = require('date-fns')
 const { mediumDateTimeFormat } = require('../../../config')
 
+/**
+ * Transforms an audit log of changes into a common seperated list
+ * summerizing the fields that were modified in the change.
+ *
+ * Note that the field name that changed is stripped of '_id', if it ends in it.
+ * by convention the back end API includes the _id part of a fieldname in the
+ * original table even though all of references to the field do not include it
+ *
+ *
+ * @param {Array[Object]} changes
+ * @param {Object} labels
+ */
 function transformChanges (changes, labels) {
   return Object.keys(changes)
     .map(key => labels[key] || labels[key.replace(/_id$/, '')] || key)

--- a/test/unit/apps/audit/transformers.test.js
+++ b/test/unit/apps/audit/transformers.test.js
@@ -1,4 +1,5 @@
 const { contactAuditLabels } = require('~/src/apps/contacts/labels')
+const { companyDetailsLabels } = require('~/src/apps/companies/labels')
 const auditLog = require('~/test/unit/data/audit/contact-audit.json')
 
 describe('Audit transformers', () => {
@@ -92,6 +93,39 @@ describe('Audit transformers', () => {
         label: 'Change count',
         type: 'badge',
         value: 'No changes saved',
+      })
+    })
+  })
+
+  describe('transformChanges', () => {
+    context('when encountering a recognised field', () => {
+      it('strips the human-friendly label is returned', () => {
+        const actual = this.transformers.transformChanges(
+          { account_manager: {} },
+          companyDetailsLabels,
+        )
+        const expected = companyDetailsLabels.account_manager
+        expect(actual).to.equal(expected)
+      })
+    })
+    context('when encountering a field with an _id suffix', () => {
+      it('strips the _id suffix and retrieves the human-friendly label', () => {
+        const actual = this.transformers.transformChanges(
+          { account_manager_id: {} },
+          companyDetailsLabels,
+        )
+        const expected = companyDetailsLabels.account_manager
+        expect(actual).to.equal(expected)
+      })
+    })
+
+    context('when encountering an unrecognised field', () => {
+      it('uses the key', () => {
+        const actual = this.transformers.transformChanges(
+          { unknown_field: {} },
+          companyDetailsLabels,
+        )
+        expect(actual).to.equal('unknown_field')
       })
     })
   })


### PR DESCRIPTION
The `labels.js` files are not expecting a few fields that end with `_id`, meaning users are shown the field name instead of the label in audit pages. Note `labels.js` expects `"account_manager"` but not `"account_manager_id"`

This change handles that by removing `_id` from the field name during the label lookup, but it might be better to update `labels.js` so `account_manager` becomes `account_manager_id` - but I'm not sure because:
 - there may be backwards compatibility issues as field names changed over time
 - I don't know enough about the backend to know which fields should end in an `_id`.

thoughts @ztolley @teneightfive @feedmypixel ?

## after the change
![image](https://user-images.githubusercontent.com/5485798/33032875-7543f30e-ce1a-11e7-9b2f-3b58fc9c2f00.png)

## before the chage
![image](https://user-images.githubusercontent.com/5485798/33032431-21f43b4c-ce19-11e7-8ad6-2574e4c79512.png)
