### PR TITLE
Remove inserting user data into page

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -72,7 +72,6 @@ const filters = {
   isPlainObject,
   isString,
   pluralise,
-  stringify: JSON.stringify,
   sentenceCase: Case.sentence,
 
   encodeQueryString (value) {

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -17,13 +17,6 @@
   {{ super() }}
 
   {% include "_includes/google-tag-manager-snippet.njk" %}
-
-  {% if user %}
-    <script>
-      if (!window.DIT) window.DIT = {};
-      window.DIT.user = {{ user | stringify | safe }};
-    </script>
-  {% endif %}
 {% endblock %}
 
 {% block header_menu %}


### PR DESCRIPTION
Removed a potentially dangerous part of the template that created a javscript copy of the users' information in the webpage. Have searched through all the client side javascript and can find no reason to have this. Removing