### PR TITLE
Filter out advisers with no name

### DIFF
--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -1,11 +1,17 @@
+const { assign } = require('lodash')
 const config = require('../../../config')
 const logger = require('../../../config/logger')
 const authorisedRequest = require('../../lib/authorised-request')
 
 // TODO: Make sure this is removed and replaced with a better way to
 // filter/select advisers
+// TODO: advisers with no name are filtered on the front end. Make changes on
+// the back end to make this not necessary.
 function getAdvisers (token) {
   return authorisedRequest(token, `${config.apiRoot}/adviser/?limit=100000&offset=0`)
+    .then(data => assign({}, data, {
+      results: data.results.filter(adviser => Boolean(adviser.first_name || adviser.last_name)),
+    }))
 }
 
 function getAdviser (token, id) {

--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -1,0 +1,32 @@
+const nock = require('nock')
+const adviserData = require('~/test/unit/data/advisers/advisers.json')
+const badAdviserData = require('~/test/unit/data/advisers/advisers-with-bad-data.json')
+const config = require('~/config')
+const repos = require('~/src/apps/adviser/repos')
+
+describe('Adviser repository', () => {
+  describe('getAdvisers', () => {
+    context('when an adviser without a name is encountered', () => {
+      beforeEach(() => {
+        nock(config.apiRoot)
+          .get(`/adviser/?limit=100000&offset=0`)
+          .reply(200, badAdviserData)
+      })
+      it('will be filtered out', async () => {
+        const actual = await repos.getAdvisers(123)
+        expect(actual.results.length).to.equal(4)
+      })
+    })
+    context('when all advisers have names', () => {
+      beforeEach(() => {
+        nock(config.apiRoot)
+          .get(`/adviser/?limit=100000&offset=0`)
+          .reply(200, adviserData)
+      })
+      it('will not filter out any advisers', async () => {
+        const actual = await repos.getAdvisers(123)
+        expect(actual.results.length).to.equal(5)
+      })
+    })
+  })
+})

--- a/test/unit/data/advisers/advisers-with-bad-data.json
+++ b/test/unit/data/advisers/advisers-with-bad-data.json
@@ -1,0 +1,90 @@
+{
+  "count": 6,
+  "results": [
+    {
+      "id": "a0dae366-1134-e411-985c-e4115bead28b",
+      "name": " ",
+      "last_login": null,
+      "first_name": "",
+      "last_name": "",
+      "email": "james.thing@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "4348318c-9698-e211-a939-e4115bead28a",
+        "name": "Team A",
+        "role": "66329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": "874cd12a-6095-e211-a939-e4115bead28a",
+        "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "e13209b8-8d61-e311-8255-e4115bead28a",
+      "name": "Aaron Mr",
+      "last_login": null,
+      "first_name": "Aaron",
+      "last_name": "Mr",
+      "email": "aaron.mr@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "f57d43ce-9698-e211-a939-e4115bead28a",
+        "name": "Team B",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "81756b9a-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "b9d6b3dc-7af4-e411-bcbe-e4115bead28a",
+      "name": "Mr Benjamin",
+      "last_login": null,
+      "first_name": "Mr",
+      "last_name": "Benjamin",
+      "email": "mr.benjamin@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "1a8433c8-9698-e211-a939-e4115bead28a",
+        "name": "Team C",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "5161b8be-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "0119a99e-9798-e211-a939-e4115bead28a",
+      "name": "George Chan",
+      "last_login": null,
+      "first_name": "George",
+      "last_name": "Chan",
+      "email": "george.chan@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "ab4d24c2-9698-e211-a939-e4115bead28a",
+        "name": "Team D",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "1f0be5c4-5d95-e211-a939-e4115bead28a"
+      }
+    },
+    {
+      "id": "0919a99e-9798-e211-a939-e4115bead28a",
+      "name": "Fred Rafters",
+      "last_login": null,
+      "first_name": "Fred",
+      "last_name": "Rafters",
+      "email": "fred.rafters@mockexample.com",
+      "contact_email": "",
+      "telephone_number": "",
+      "dit_team": {
+        "id": "346e1abc-9698-e211-a939-e4115bead28a",
+        "name": "Team E",
+        "role": "62329c18-6095-e211-a939-e4115bead28a",
+        "uk_region": null,
+        "country": "955f66a0-5d95-e211-a939-e4115bead28a"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The database has some bad data (advisers with no name). We can guard against bad data by filtering out those advisers.

## after the fix

![image](https://user-images.githubusercontent.com/5485798/33069732-591b7f88-cead-11e7-89b5-8b1967a2fff4.png)

## before the fix

![image](https://user-images.githubusercontent.com/5485798/33069776-7b49b296-cead-11e7-84f1-64884b7af217.png)

