### PR TITLE
Provide a default subject for interaction lists

### DIFF
--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -54,7 +54,7 @@ function transformInteractionToListItem ({
   return {
     id,
     type: 'interaction',
-    name: subject,
+    name: subject || 'No subject',
     meta: [
       {
         label: 'Type',

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -147,6 +147,26 @@ describe('Interaction transformers', () => {
       })
     })
 
+    context('when the source is an interaction with an empty subject', () => {
+      beforeEach(() => {
+        this.transformed = transformInteractionToListItem(assign({}, mockInteraction, { subject: '' }))
+      })
+
+      it('should transform data from interaction response to list item', () => {
+        expect(this.transformed).have.property('name', 'No subject')
+      })
+    })
+
+    context('when the source is an interaction with a null subject', () => {
+      beforeEach(() => {
+        this.transformed = transformInteractionToListItem(assign({}, mockInteraction, { subject: null }))
+      })
+
+      it('should transform data from interaction response to list item', () => {
+        expect(this.transformed).have.property('name', 'No subject')
+      })
+    })
+
     context('when the source is a service delivery', () => {
       beforeEach(() => {
         const serviceDelivery = assign({}, mockInteraction, { kind: 'service_delivery' })


### PR DESCRIPTION
When sorting interactions by subject some interactions appear to not have a subject so the list looks broken. This change introduces a message to make the list not look broken and inform the user there is no subject.