### PR TITLE
Fix warning for date parsing during tests

### DIFF
--- a/src/apps/investment-projects/services/formatting.js
+++ b/src/apps/investment-projects/services/formatting.js
@@ -308,7 +308,7 @@ function transformBriefInvestmentSummary (data) {
   const investorCompany = data.investor_company
   const competitorCountries = data.competitor_countries || []
   const regionLocations = data.uk_region_locations || []
-  const date = moment(data.estimated_land_date)
+  const date = moment(data.estimated_land_date, 'YYYY-MM-DD')
 
   return {
     sector: get(data, 'sector.name', null),


### PR DESCRIPTION
Moment issues a warning because it falls back to date parser if it can't understand a date. Moment should be called with a format defined and in this case the land date is always in the format YYYY-MM-DD.