### PR TITLE
Add documents link to company details local nav

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
           - LOG_LEVEL: debug
           - &oauth2_dev_token
             OAUTH2_DEV_TOKEN: topSecretSquirrel
+            ARCHIVED_DOCUMENTS_BASE_URL: http://example-documents-url.io
       - &docker_redis
         image: redis:3.2.10
       - &docker_elasticsearch

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This file expects the following environment variables:
 | Name | Description |
 |:-----|:------------|
 | API_ROOT | The url for a back end server instance for the service |
+| ARCHIVED_DOCUMENTS_BASE_URL | The url for the archived documents store |
 | ASSETS_HOST | Optional host for assets CDN, defaults to app’s host |
 | CI | Set to true for UAT testing, otherwise ignore |
 | FEATURES_FOLDER | Lo  cation of the Cucumber feature files |

--- a/config/index.js
+++ b/config/index.js
@@ -49,7 +49,7 @@ const config = {
   mediumDateTimeFormat: 'D MMM YYYY, h:mma',
   paginationMaxResults: 10000,
   performanceDashboardsUrl: process.env.PERFORMANCE_DASHBOARDS_URL || 'https://mi.exportwins.service.trade.gov.uk',
-  omisArchivedDocumentsBaseUrl: process.env.OMIS_ARCHIVED_DOCUMENTS_BASE_URL,
+  archivedDocumentsBaseUrl: process.env.ARCHIVED_DOCUMENTS_BASE_URL,
   oauth: {
     url: process.env.OAUTH2_AUTH_URL,
     clientId: process.env.OAUTH2_CLIENT_ID,

--- a/sample.env
+++ b/sample.env
@@ -28,3 +28,5 @@ OAUTH2_REDIRECT_URL=http://localhost:3000/oauth/callback
 
 # Not used for local development
 SENTRY_DSN=
+
+ARCHIVED_DOCUMENTS_BASE_URL=

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -1,5 +1,7 @@
 const router = require('express').Router()
+const { get } = require('lodash')
 
+const { archivedDocumentsBaseUrl } = require('../../../config')
 const {
   renderAddStepOne,
   postAddStepOne,
@@ -84,7 +86,20 @@ router
 router.post('/:companyId/archive', archiveCompany)
 router.get('/:companyId/unarchive', unarchiveCompany)
 
-router.use('/:companyId', setLocalNav(LOCAL_NAV))
+router.use('/:companyId', (req, res, next) => {
+  const archivedDocumentsUrlPath = get(res.locals, 'company.archived_documents_url_path')
+  const localNav = LOCAL_NAV.slice()
+
+  if (archivedDocumentsUrlPath) {
+    localNav.push({
+      label: 'Documents',
+      url: archivedDocumentsBaseUrl + archivedDocumentsUrlPath,
+      isExternal: true,
+    })
+  }
+
+  setLocalNav(localNav)(req, res, next)
+})
 
 router.get('/:companyId', redirectToFirstNavItem)
 router.get('/:companyId/details', renderDetails)

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -16,7 +16,7 @@ function setHomeBreadcrumb (name) {
 function setLocalNav (items = []) {
   return function buildLocalNav (req, res, next) {
     res.locals.localNavItems = items.map(item => {
-      const url = `${req.baseUrl}/${item.path}`
+      const url = item.isExternal ? item.url : `${req.baseUrl}/${item.path}`
       return Object.assign(item, {
         url,
         isActive: res.locals.CURRENT_PATH === url,

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -46,7 +46,7 @@ function setOrderBreadcrumb (req, res, next) {
 }
 
 function setArchivedDocumentsBaseUrl (req, res, next) {
-  res.locals.archivedDocumentsBaseUrl = config.omisArchivedDocumentsBaseUrl
+  res.locals.archivedDocumentsBaseUrl = config.archivedDocumentsBaseUrl
   next()
 }
 

--- a/test/acceptance/features/companies/details.feature
+++ b/test/acceptance/features/companies/details.feature
@@ -5,13 +5,32 @@ Feature: Company details
   Scenario: Company has CDMS reference
 
     When browsing to company fixture Venus Ltd
-    Then the company details CDMS reference is displayed
+    Then there should be a local nav
+      | text                        |
+      | Details                     |
+      | Contacts                    |
+      | Interactions                |
+      | Export                      |
+      | Investment                  |
+      | Orders (OMIS)               |
+      | Audit history               |
+      | Documents                   |
+    And the company details CDMS reference is displayed
 
   @companies-details--no-cdms-reference
   Scenario: Company does not have CDMS reference
 
     When browsing to company fixture Lambda plc
-    Then the company details CDMS reference is not displayed
+    Then there should be a local nav
+      | text                        |
+      | Details                     |
+      | Contacts                    |
+      | Interactions                |
+      | Export                      |
+      | Investment                  |
+      | Orders (OMIS)               |
+      | Audit history               |
+    And the company details CDMS reference is not displayed
 
 
 

--- a/test/acceptance/features/details/page-objects/Details.js
+++ b/test/acceptance/features/details/page-objects/Details.js
@@ -9,6 +9,15 @@ module.exports = {
       getDetailFor (label) {
         return getSelectorForElementWithText(label, { el: '//th', child: '/following-sibling::td' })
       },
+      getDetailsTabSelector (text) {
+        return getSelectorForElementWithText(
+          text,
+          {
+            el: '//a',
+            className: 'c-local-nav__link',
+          },
+        )
+      },
     },
   ],
 }

--- a/test/acceptance/features/details/step_definitions/details.js
+++ b/test/acceptance/features/details/step_definitions/details.js
@@ -31,4 +31,20 @@ defineSupportCode(({ Then }) => {
       .assert.containsText(detail.selector, value)
       .useCss()
   })
+
+  Then(/^there should be a local nav$/, async (dataTable) => {
+    const expectedLocalNav = dataTable.hashes()
+
+    await Details.api.elements('css selector', '.c-local-nav__link', (result) => {
+      client.expect(result.value.length).to.equal(expectedLocalNav.length)
+    })
+
+    for (const row of expectedLocalNav) {
+      const detailsTabSelector = Details.getDetailsTabSelector(row.text)
+      await Details
+        .api.useXpath()
+        .assert.visible(detailsTabSelector.selector)
+        .useCss()
+    }
+  })
 })

--- a/test/unit/apps/middleware.test.js
+++ b/test/unit/apps/middleware.test.js
@@ -28,7 +28,6 @@ describe('Apps middleware', () => {
 
       this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
-      expect(resMock.locals).to.haveOwnProperty('localNavItems')
       expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
       expect(resMock.locals.localNavItems[0].isActive).to.be.false
       expect(this.nextSpy.calledOnce).to.be.true
@@ -45,10 +44,29 @@ describe('Apps middleware', () => {
       }
       this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
-      expect(resMock.locals).to.haveOwnProperty('localNavItems')
       expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
       expect(resMock.locals.localNavItems[0].isActive).to.be.true
       expect(this.nextSpy.calledOnce).to.be.true
+    })
+
+    context('when a nav item has the external property set', () => {
+      it('should set url on the nav item link to url value', () => {
+        const url = 'http://url/path'
+        const mockNavItem = {
+          url,
+          isExternal: true,
+        }
+        const reqMock = {}
+        const resMock = {
+          locals: {},
+        }
+
+        this.middleware.setLocalNav([ mockNavItem ])(reqMock, resMock, this.nextSpy)
+
+        expect(resMock.locals.localNavItems[0].url).to.equal(url)
+        expect(resMock.locals.localNavItems[0].isActive).to.be.false
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
     })
   })
 

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -1,7 +1,7 @@
 const companyData = require('~/test/unit/data/company.json')
 const orderData = require('~/test/unit/data/omis/simple-order.json')
 
-const omisArchivedDocumentsBaseUrl = 'http://docs-base-url'
+const archivedDocumentsBaseUrl = 'http://docs-base-url'
 
 describe('OMIS middleware', () => {
   beforeEach(() => {
@@ -28,7 +28,7 @@ describe('OMIS middleware', () => {
         getDitCompany: this.getDitCompanyStub,
       },
       '../../../config': {
-        omisArchivedDocumentsBaseUrl: omisArchivedDocumentsBaseUrl,
+        archivedDocumentsBaseUrl,
       },
       '../../../config/logger': {
         error: this.loggerSpy,
@@ -207,7 +207,7 @@ describe('OMIS middleware', () => {
       this.middleware.setArchivedDocumentsBaseUrl({}, this.resMock, this.nextSpy)
 
       expect(this.resMock.locals).to.have.property('archivedDocumentsBaseUrl')
-      expect(this.resMock.locals.archivedDocumentsBaseUrl).to.equal(omisArchivedDocumentsBaseUrl)
+      expect(this.resMock.locals.archivedDocumentsBaseUrl).to.equal(archivedDocumentsBaseUrl)
 
       expect(this.nextSpy).to.have.been.calledOnce
       expect(this.nextSpy).to.have.been.calledWith()


### PR DESCRIPTION
This change will:
- add the `Documents` link to the company details local nav
- acceptance tests

<img width="959" alt="screen shot 2017-11-21 at 13 26 11" src="https://user-images.githubusercontent.com/1150417/33074901-b59ea2a0-cebf-11e7-87a9-3e1d66bff270.png">
