### PR TITLE
When a quote preview exists don't overwrite with quote result

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -138,6 +138,10 @@ async function setQuotePreview (req, res, next) {
 }
 
 async function setQuote (req, res, next) {
+  if (res.locals.quote) {
+    return next()
+  }
+
   try {
     const quote = await Order.getQuote(req.session.token, res.locals.order.id)
 

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -576,11 +576,32 @@ describe('OMIS View middleware', () => {
   })
 
   describe('setQuote()', () => {
-    context('when an order is not in draft', () => {
-      beforeEach(() => {
-        this.resMock.locals.order.status = 'complete'
+    context('when quote already exists on locals', () => {
+      beforeEach(async () => {
+        this.resMock.locals.quote = {
+          id: '12345',
+          content: 'Quote content',
+        }
+        await this.middleware.setQuote(this.reqMock, this.resMock, this.nextSpy)
       })
 
+      it('should not make call to get quote', () => {
+        expect(this.getQuoteStub).not.to.have.been.called
+      })
+
+      it('should not change quote property on locals', () => {
+        expect(this.resMock.locals.quote).to.deep.equal({
+          id: '12345',
+          content: 'Quote content',
+        })
+      })
+
+      it('should call next with no error', () => {
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+    })
+
+    context('when quote does not exist on locals', () => {
       context('when quote resolves', () => {
         beforeEach(async () => {
           this.getQuoteStub.resolves({


### PR DESCRIPTION
As the middleware is chained it would previously overwrite the quote
preview object with the quote response.

This caused an issue when a previous quote had been cancelled and then
a user navigated to generate a new preview. It would use the values
from the cancelled quote rather than the new quote preview.

This change ensures that if a quote exists on the locals object then
it will not try and get the previous quote values.

## Before
![localhost_3001_omis_10465330-290c-4b62-ba36-2c1d2f79bd0c_quote 1](https://user-images.githubusercontent.com/3327997/33088192-d7ec608e-cee4-11e7-8e82-22eacec0ef61.png)

## After
![localhost_3001_omis_10465330-290c-4b62-ba36-2c1d2f79bd0c_quote](https://user-images.githubusercontent.com/3327997/33088176-cabf641a-cee4-11e7-83e3-d0f8ca400fbd.png)
