### PR TITLE
set the contacts to display active only by default

### DIFF
--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -48,6 +48,7 @@ const LOCAL_NAV = [
 ]
 const DEFAULT_COLLECTION_QUERY = {
   sortby: 'modified_on:desc',
+  archived: false,
 }
 
 router.param('companyId', getCompany)

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -26,6 +26,7 @@ const LOCAL_NAV = [
 
 const DEFAULT_COLLECTION_QUERY = {
   sortby: 'modified_on:desc',
+  archived: false,
 }
 
 router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getRequestBody, getContactsCollection, renderContactList)

--- a/test/acceptance/features/companies/contacts-collection.feature
+++ b/test/acceptance/features/companies/contacts-collection.feature
@@ -40,6 +40,8 @@ Feature: View collection of contacts for a company
     Then I wait and then refresh the page
     Then I confirm I am on the Lambda plc page
     And the results count header for contacts is present
+    When the status filter is cleared
+    Then there are no filters selected
     When I filter the contacts list by sector
     Then the contacts should be filtered by company sector
     When the sector filter is cleared

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -40,6 +40,8 @@ Feature: View collection of contacts
     Then I see the success message
     Then I wait and then refresh the page
     When I navigate to the Contacts collection page
+    When the status filter is cleared
+    Then there are no filters selected
     And I filter the contacts list by company
     Then the contacts should be filtered by company name
     When the company filter is cleared

--- a/test/acceptance/features/contacts/page-objects/ContactList.js
+++ b/test/acceptance/features/contacts/page-objects/ContactList.js
@@ -50,6 +50,7 @@ module.exports = {
         sector: getFilterTagRemoveBtnSelector('Sectors'),
         country: getFilterTagRemoveBtnSelector('Country'),
         ukRegion: getFilterTagRemoveBtnSelector('UK Region'),
+        status: getFilterTagRemoveBtnSelector('Status'),
       },
     },
     firstContactInList: {


### PR DESCRIPTION
Display only active contacts by default for `/contacts` and `/company/<id>/contacts`

![screen shot 2017-11-22 at 09 01 06](https://user-images.githubusercontent.com/2305016/33118424-b8394304-cf63-11e7-8bfd-81e8ba9a94e9.png)
