### PR TITLE
Acceptance tests - add postcode lookup work

### DIFF
--- a/test/acceptance/features/address/page-objects/Address.js
+++ b/test/acceptance/features/address/page-objects/Address.js
@@ -1,0 +1,68 @@
+const { forEach, set, pick, get, assign } = require('lodash')
+
+const { getButtonWithText } = require('../../../helpers/selectors')
+
+module.exports = {
+  elements: {
+    postCodeLookupButton: getButtonWithText('Find UK address'),
+    postCode: '#field-postcode-lookup',
+    postCodeLookupSuggestions: '#field-postcode-address-suggestions',
+    postCodeLookupAddress1: '#field-address_1',
+    postCodeLookupAddress2: '#field-address_2',
+    postCodeLookupTown: '#field-address_town',
+    postCodeLookupCounty: '#field-address_county',
+    postCodeLookupCountry: '#field-address_country',
+    companyPostCode: '#field-registered_address_pcode_lookup',
+    companyPostCodeLookupSuggestions: '#field-registered_address_pcode_result',
+    companyPostCodeLookupAddress1: '#field-registered_address_1',
+    companyPostCodeLookupAddress2: '#field-registered_address_2',
+    companyPostCodeLookupTown: '#field-registered_address_town',
+    companyPostCodeLookupCounty: '#field-registered_address_county',
+  },
+  commands: [
+    {
+      getAddressInputValues (postcode, stateStore, suggestionsElem, callback) {
+        this
+          .setValue(`@${get(stateStore, 'postcode')}`, postcode)
+          .click('@postCodeLookupButton')
+          .wait() // wait for xhr to come back for postcode lookup
+          .api.perform((done) => {
+            this.getListOption(suggestionsElem, (addressOption) => {
+              this.setValue(suggestionsElem, addressOption)
+              done()
+            })
+          })
+          .perform((done) => {
+            const promises = []
+            // record information that has come from postcode lookup
+            // select elements
+            forEach(pick(stateStore, ['country']), (value, key) => {
+              promises.push(new Promise((resolve) => {
+                this.getValue(`@${value}`, (option) => {
+                  this.getText(`#field-address_country option[value="${option.value.trim()}"]`, (optionText) => {
+                    set(stateStore, key, optionText.value.trim())
+                    resolve()
+                  })
+                })
+              }))
+            })
+            // text inputs
+            forEach(pick(stateStore, ['address1', 'address2', 'county', 'town']), (value, key) => {
+              promises.push(new Promise((resolve) => {
+                this.getValue(`@${value}`, (textInput) => {
+                  set(stateStore, key, textInput.value.trim())
+                  resolve()
+                })
+              }))
+            })
+
+            Promise.all(promises)
+              .then(() => {
+                callback(assign({}, stateStore, { postcode }))
+                done()
+              })
+          })
+      },
+    },
+  ],
+}

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -3,6 +3,7 @@ const { assign } = require('lodash')
 
 const { getSelectorForElementWithText, getButtonWithText } = require('../../../helpers/selectors')
 const { appendUid } = require('../../../helpers/uuid')
+const { getAddress } = require('../../../helpers/address')
 
 const getDetailsTabSelector = (text) => getSelectorForElementWithText(
   text,
@@ -347,10 +348,9 @@ module.exports = {
                   .waitForElementPresent('@saveAndCreateButton')
                   .click('@saveAndCreateButton')
 
-                const { address1, town, postcode, country } = parentCompany
                 callback(assign({}, company, {
                   header: company.name,
-                  primaryAddress: `${address1}, ${town}, ${postcode}, ${country}`,
+                  primaryAddress: getAddress(parentCompany),
                 }))
               })
           })

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -44,7 +44,7 @@ defineSupportCode(({ Then, When }) => {
 
     await Company
       .createUkPrivateOrPublicLimitedCompany(
-        this.fixtures.company.companiesHouse,
+        get(this.fixtures, 'company.companiesHouse'),
         {},
         (company) => set(this.state, 'company', company),
       )

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -87,7 +87,7 @@ Feature: View collection of contacts
     Then the contacts should have been correctly sorted for text fields
 #    When the contacts are sorted by Last name: A-Z
 #    When the contacts are sorted by Last name: Z-A
-#    Then the contacts should have been correctly sorted for text fields TODO: potential bug being investigated
+#    Then the contacts should have been correctly sorted for text fields TODO: potential bug being investigated (is the problem when two are identical?)
     When the contacts are sorted by Country: A-Z
     When the contacts are sorted by Country: Z-A
     Then the contacts should have been correctly sorted for text fields

--- a/test/acceptance/features/contacts/create.feature
+++ b/test/acceptance/features/contacts/create.feature
@@ -5,7 +5,7 @@ Feature: Create New Contact
   So that I can collect contact data
 
   @contacts-create--companies-interaction
-  Scenario: Interaction fields from companies
+  Scenario: Contact form fields
 
     Given a company is created
     When navigating to the create company contact page

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -19,7 +19,7 @@ Feature: Create New Contact
     When the contact is clicked
     Then the contact details are displayed
 
-  @contacts-save--primary-new-company-address @ignore
+  @contacts-save--primary-new-company-address
   Scenario: Add a new primary contact with new company address
 
     Given a company is created
@@ -30,6 +30,8 @@ Feature: Create New Contact
     Then I see the success message
     When navigating to the company contacts
     Then the contact is displayed on the company contact tab
+    When the contact is clicked
+    Then the contact details are displayed
 
   @contacts-save--non-primary
   Scenario: Add a new non-primary contact

--- a/test/acceptance/features/contacts/step_definitions/create.js
+++ b/test/acceptance/features/contacts/step_definitions/create.js
@@ -24,7 +24,6 @@ defineSupportCode(({ Given, Then, When }) => {
     await Contact
       .createNewPrimaryContactWithNewCompanyAddress({}, (contact) => {
         set(this.state, 'contact', contact)
-        set(this.state, 'contact.type', 'Primary')
       })
   })
 

--- a/test/acceptance/features/contacts/step_definitions/details.js
+++ b/test/acceptance/features/contacts/step_definitions/details.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
@@ -28,7 +30,7 @@ defineSupportCode(({ Given, Then, When }) => {
       .assert.containsText('@phoneNumber', expectedTelephoneNumber)
       .assert.containsText('@email', emailAddress)
       .assert.containsText('@emailMarketing', acceptsEmailMarketingFromDit)
-      .assert.containsText('@address', expectedAddress)
+      .assert.containsText('@address', contactAddress)
       .assert.containsText('@alternativeTelephone', alternativePhoneNumber)
       .assert.containsText('@alternativeEmail', alternativeEmail)
       .assert.containsText('@notes', notes)

--- a/test/acceptance/features/contacts/step_definitions/details.js
+++ b/test/acceptance/features/contacts/step_definitions/details.js
@@ -1,11 +1,14 @@
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
+const { getAddress } = require('../../../helpers/address')
+
 defineSupportCode(({ Given, Then, When }) => {
   const Contact = client.page.Contact()
 
   Then(/^the contact details are displayed$/, async function () {
-    const { address1, town, country } = this.state.company
+    const contactAddress = getAddress(get(this.state, 'contact'))
+
     const {
       jobTitle,
       telephoneCountryCode,
@@ -17,7 +20,6 @@ defineSupportCode(({ Given, Then, When }) => {
       acceptsEmailMarketingFromDit,
     } = this.state.contact
 
-    const expectedAddress = `${address1}, ${town}, ${country}`
     const expectedTelephoneNumber = `(${telephoneCountryCode}) ${telephoneNumber}`
 
     await Contact

--- a/test/acceptance/features/search/step_definitions/search.js
+++ b/test/acceptance/features/search/step_definitions/search.js
@@ -116,17 +116,15 @@ defineSupportCode(function ({ Then, When }) {
 
   Then(/^I can view the company in the search results/, async function () {
     const {
-      address1,
-      town,
       name,
       sector,
+      primaryAddress,
     } = this.state.company
-    const registeredAddress = `${address1}, ${town}`
 
     await Search.section.firstCompanySearchResult
       .waitForElementPresent('@header')
       .assert.containsText('@header', name)
       .assert.containsText('@sector', sector)
-      .assert.containsText('@registeredAddress', registeredAddress)
+      .assert.containsText('@registeredAddress', primaryAddress)
   })
 })

--- a/test/acceptance/helpers/address.js
+++ b/test/acceptance/helpers/address.js
@@ -1,0 +1,31 @@
+const { title } = require('case')
+
+/**
+ *
+ * @param address1
+ * @param address2
+ * @param town
+ * @param county
+ * @param postcode
+ * @param country
+ * @returns {string}
+ */
+
+// FIXME - note use of title is because of its use in /src/lib/address.js this needs reviewing
+function getAddress ({ address1, address2, town, county, postcode, country }) {
+  return [
+    title(address1),
+    title(address2),
+    title(town),
+    title(county),
+    postcode,
+    title(country),
+  ].filter(details => details)
+    .join(', ')
+    .trim()
+    .replace(/\s+/g, ' ')
+}
+
+module.exports = {
+  getAddress,
+}


### PR DESCRIPTION
We had a bug in Acceptance tests that meant `postcode` was not being submitted to the BE. After an amount of debugging I found that `this.setValue()` in nightwatch will not set the value of a hidden input. As the previous work was setting the value of postcode to a hidden input this mean that when checking the address in state against the address rendered in the UI postcode was missing.
This all occurred due to making the address check check all fields. 


This work adds postcode via the postcode lookup.

## Of Note
It is a little rough around the edges and needs looking at again in the near future. It has also highlighted that the post code lookup itself needs some love.