### PR TITLE
Add ability to disallow removal of items

### DIFF
--- a/assets/javascripts/modules/add-items.js
+++ b/assets/javascripts/modules/add-items.js
@@ -19,6 +19,7 @@ const removeButtonClass = 'js-AddItems__remove'
  *
  * Settings can be passed using data attributes to customise how the module behaves:
  *
+ * @param {boolean} [canRemove=true] - Whether any items can be removed
  * @param {boolean} [canRemoveAll=false] - Whether all items can be removed
  * @param {string} [itemSelector='.js-AddItems__item'] - The piece of HTML that should be duplicated
  * @param {string} [itemName='item'] - Name to use when adding/removing items
@@ -42,6 +43,7 @@ const removeButtonClass = 'js-AddItems__remove'
  */
 const AddItems = {
   defaults: {
+    canRemove: true,
     canRemoveAll: false,
     itemSelector: '.js-AddItems__item',
     itemName: 'item',
@@ -74,7 +76,9 @@ const AddItems = {
 
   render () {
     this.insertAddButton()
-    this.insertRemoveButtons()
+    if (this.settings.canRemove) {
+      this.insertRemoveButtons()
+    }
 
     this.decorateButtons()
     this.updateButtonState()
@@ -171,7 +175,9 @@ const AddItems = {
   },
 
   removeItem (item) {
-    item.parentNode.removeChild(item)
+    if (this.settings.canRemove) {
+      item.parentNode.removeChild(item)
+    }
   },
 }
 
@@ -181,6 +187,7 @@ module.exports = {
 
     elements.forEach((element) => {
       const settings = {
+        canRemove: !element.hasAttribute('data-can-remove') || (element.getAttribute('data-can-remove') === 'true'),
         canRemoveAll: element.hasAttribute('data-can-remove-all'),
         itemSelector: element.getAttribute('data-item-selector'),
         itemName: element.getAttribute('data-item-name'),
@@ -195,7 +202,9 @@ module.exports = {
           value: page,
         },
       })
-      addItems.init(element, pickBy(settings))
+      addItems.init(element, pickBy(settings, (setting) => {
+        return setting !== null && setting !== undefined
+      }))
     })
   },
 }

--- a/test/unit/assets/javascripts/modules/add-items.test.js
+++ b/test/unit/assets/javascripts/modules/add-items.test.js
@@ -16,7 +16,7 @@ const selectMarkup = `<div id="group-field-adviser" class="c-form-group js-advis
   </div>
 </div>`
 
-function makeSingleFieldset (allowDeleteAll = false) {
+function makeSingleFieldset (allowDeleteAll = false, allowDelete = true) {
   const fieldset = formMacros.renderWithCallerToDom('Fieldset')(
     formMacros.render('MultipleChoiceField', {
       label: 'Test label',
@@ -37,6 +37,7 @@ function makeSingleFieldset (allowDeleteAll = false) {
   const HTML = `
     <div class="js-AddItems"
       data-item-selector=".c-form-fieldset"
+      ${allowDelete ? '' : 'data-can-remove="false"'}
       ${allowDeleteAll ? 'data-can-remove-all' : ''}>${fieldset}</div>`
 
   const { window } = new JSDOM(HTML)
@@ -47,7 +48,7 @@ function makeSingleFieldset (allowDeleteAll = false) {
   return { document, wrapper }
 }
 
-function makeMultipleFieldset (allowDeleteAll = false) {
+function makeMultipleFieldset (allowDeleteAll = false, allowDelete = true) {
   const fieldset = formMacros.renderWithCallerToDom('Fieldset')(
     formMacros.render('MultipleChoiceField', {
       label: 'Test label',
@@ -68,6 +69,7 @@ function makeMultipleFieldset (allowDeleteAll = false) {
   const HTML = `
     <div class="js-AddItems"
       data-item-selector=".c-form-fieldset"
+      ${allowDelete ? '' : 'data-can-remove="false"'}
       ${allowDeleteAll ? 'data-can-remove-all' : ''}>${fieldset}${fieldset}</div>`
 
   const { window } = new JSDOM(HTML)
@@ -206,21 +208,8 @@ describe('Add another', () => {
 
       describe('(allow remove all)', () => {
         beforeEach(() => {
-          const { document, wrapper } = makeMultipleFieldset(true)
-          this.document = document
+          const { wrapper } = makeMultipleFieldset(true)
           this.wrapper = wrapper
-        })
-
-        it('should add a remove button when there is only one fragment', () => {
-          const { document, wrapper } = makeSingleFieldset(true)
-          this.document = document
-          this.wrapper = wrapper
-
-          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(1)
-        })
-
-        it('should add a remove button when there is more than one fragment', () => {
-          expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
         })
 
         it('should remove an element if the remove button is pressed', () => {
@@ -238,6 +227,47 @@ describe('Add another', () => {
           addButtonElement.click()
 
           expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(3)
+        })
+
+        context('when multiple items', () => {
+          it('should add multiple remove button', () => {
+            expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(2)
+          })
+        })
+
+        context('when only one item', () => {
+          beforeEach(() => {
+            const { wrapper } = makeSingleFieldset(true)
+            this.wrapper = wrapper
+          })
+
+          it('should add one remove button', () => {
+            expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(1)
+          })
+        })
+      })
+
+      describe('(disallow remove any)', () => {
+        context('when only one item', () => {
+          beforeEach(() => {
+            const { wrapper } = makeSingleFieldset(false, false)
+            this.wrapper = wrapper
+          })
+
+          it('should not add a remove button', () => {
+            expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(0)
+          })
+        })
+
+        context('when multiple items', () => {
+          beforeEach(() => {
+            const { wrapper } = makeMultipleFieldset(false, false)
+            this.wrapper = wrapper
+          })
+
+          it('should not add a remove button', () => {
+            expect(getVisibleRemoveButtons(this.wrapper)).to.have.length(0)
+          })
         })
       })
     })


### PR DESCRIPTION
This adds a setting to not allow items to be removed from a repeatable
items module.

The purpose for this is a scenario in OMIS orders where we do not want advisers to be removed
after a certain point.

This adds the ability to do this by passing an option to this module.