### PR TITLE
Allow advisers to be edited after a quote has been sent

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -7,30 +7,32 @@ const { Order } = require('../../../models')
 
 class EditAssigneesController extends EditController {
   async configure (req, res, next) {
-    const orderId = get(res.locals, 'order.id')
-    const canEditOrder = get(res.locals, 'order.canEditOrder')
-    const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
-    const token = get(req.session, 'token')
-    const advisers = await getAdvisers(token)
-    const assignees = await Order.getAssignees(token, orderId)
-    const options = advisers.results.map(transformObjectToOption)
+    try {
+      const orderId = get(res.locals, 'order.id')
+      const canEditOrder = get(res.locals, 'order.canEditOrder')
+      const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
+      const token = get(req.session, 'token')
+      const advisers = await getAdvisers(token)
+      const assignees = await Order.getAssignees(token, orderId)
+      const options = advisers.results.map(transformObjectToOption)
 
-    req.form.options.fields.assignees.options = sortBy(options, 'label')
-    req.form.options.fields.assignees.canRemove = canEditOrder
-    req.form.options.disableFormAction = !canEditAdvisers
+      req.form.options.fields.assignees.options = sortBy(options, 'label')
+      req.form.options.fields.assignees.canRemove = canEditOrder
+      req.form.options.disableFormAction = !canEditAdvisers
 
-    res.locals.order.assignees = assignees
+      res.locals.order.assignees = assignees
 
-    super.configure(req, res, next)
+      super.configure(req, res, next)
+    } catch (error) {
+      next(error)
+    }
   }
 
   async successHandler (req, res, next) {
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
     const assignees = data.assignees.map((id) => {
       return {
-        adviser: {
-          id,
-        },
+        adviser: { id },
       }
     })
 

--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -33,8 +33,16 @@ class EditAssigneesController extends EditController {
     })
 
     try {
-      await Order.forceSaveAssignees(req.session.token, res.locals.order.id, assignees)
-      const nextUrl = req.form.options.next || `/omis/${res.locals.order.id}`
+      const orderId = get(res.locals, 'order.id')
+      const canEditOrder = get(res.locals, 'order.canEditOrder')
+      const token = get(req.session, 'token')
+      const nextUrl = get(req, 'form.options.next') || `/omis/${orderId}`
+
+      if (canEditOrder) {
+        await Order.forceSaveAssignees(token, orderId, assignees)
+      } else {
+        await Order.saveAssignees(token, orderId, assignees)
+      }
 
       req.journeyModel.reset()
       req.journeyModel.destroy()

--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -8,6 +8,7 @@ const { Order } = require('../../../models')
 class EditAssigneesController extends EditController {
   async configure (req, res, next) {
     const orderId = get(res.locals, 'order.id')
+    const canEditOrder = get(res.locals, 'order.canEditOrder')
     const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
     const token = get(req.session, 'token')
     const advisers = await getAdvisers(token)
@@ -15,6 +16,7 @@ class EditAssigneesController extends EditController {
     const options = advisers.results.map(transformObjectToOption)
 
     req.form.options.fields.assignees.options = sortBy(options, 'label')
+    req.form.options.fields.assignees.canRemove = canEditOrder
     req.form.options.disableFormAction = !canEditAdvisers
 
     res.locals.order.assignees = assignees

--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -8,13 +8,17 @@ const { Order } = require('../../../models')
 class EditAssigneesController extends EditController {
   async configure (req, res, next) {
     const orderId = get(res.locals, 'order.id')
+    const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
     const token = get(req.session, 'token')
     const advisers = await getAdvisers(token)
     const assignees = await Order.getAssignees(token, orderId)
     const options = advisers.results.map(transformObjectToOption)
 
-    res.locals.order.assignees = assignees
     req.form.options.fields.assignees.options = sortBy(options, 'label')
+    req.form.options.disableFormAction = !canEditAdvisers
+
+    res.locals.order.assignees = assignees
+
     super.configure(req, res, next)
   }
 

--- a/src/apps/omis/apps/edit/controllers/edit-handler.js
+++ b/src/apps/omis/apps/edit/controllers/edit-handler.js
@@ -18,7 +18,7 @@ function editHandler (req, res, next) {
   const defaults = {
     buttonText: 'Save and return',
     returnText: 'Return without saving',
-    disableFormAction: !order.isEditable,
+    disableFormAction: !order.canEditOrder,
     journeyName: 'edit',
     name: 'edit',
     route: '/edit',

--- a/src/apps/omis/apps/edit/controllers/subscribers.js
+++ b/src/apps/omis/apps/edit/controllers/subscribers.js
@@ -8,11 +8,13 @@ const { Order } = require('../../../models')
 class EditSubscribersController extends EditController {
   async configure (req, res, next) {
     const orderId = get(res.locals, 'order.id')
+    const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
     const token = get(req.session, 'token')
     const advisers = await getAdvisers(token)
     const subscribers = await Order.getSubscribers(token, orderId)
     const options = advisers.results.map(transformObjectToOption)
 
+    req.form.options.disableFormAction = !canEditAdvisers
     req.form.options.fields.subscribers.options = sortBy(options, 'label')
 
     res.locals.order.subscribers = subscribers

--- a/src/apps/omis/apps/edit/controllers/subscribers.js
+++ b/src/apps/omis/apps/edit/controllers/subscribers.js
@@ -7,19 +7,23 @@ const { Order } = require('../../../models')
 
 class EditSubscribersController extends EditController {
   async configure (req, res, next) {
-    const orderId = get(res.locals, 'order.id')
-    const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
-    const token = get(req.session, 'token')
-    const advisers = await getAdvisers(token)
-    const subscribers = await Order.getSubscribers(token, orderId)
-    const options = advisers.results.map(transformObjectToOption)
+    try {
+      const orderId = get(res.locals, 'order.id')
+      const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
+      const token = get(req.session, 'token')
+      const advisers = await getAdvisers(token)
+      const subscribers = await Order.getSubscribers(token, orderId)
+      const options = advisers.results.map(transformObjectToOption)
 
-    req.form.options.disableFormAction = !canEditAdvisers
-    req.form.options.fields.subscribers.options = sortBy(options, 'label')
+      req.form.options.disableFormAction = !canEditAdvisers
+      req.form.options.fields.subscribers.options = sortBy(options, 'label')
 
-    res.locals.order.subscribers = subscribers
+      res.locals.order.subscribers = subscribers
 
-    super.configure(req, res, next)
+      super.configure(req, res, next)
+    } catch (error) {
+      next(error)
+    }
   }
 
   async successHandler (req, res, next) {

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -54,7 +54,7 @@
   {{ AnswersSummary({
     heading: 'Client contact details',
     actions: [{
-      url: 'edit/client-details' if order.isEditable
+      url: 'edit/client-details' if order.canEditOrder
     }],
     items: [{
       label: 'Name',
@@ -72,10 +72,10 @@
     id: 'assignees',
     heading: 'Advisers in the market',
     actions: [{
-      url: 'edit/assignees' if order.isEditable,
+      url: 'edit/assignees' if order.canEditOrders,
       label: 'Add or remove'
     }, {
-      url: 'edit/assignee-time' if order.isEditable,
+      url: 'edit/assignee-time' if order.canEditOrder,
       label: 'Estimate hours'
     }]
   }) %}
@@ -89,7 +89,7 @@
             {% endif %}
           </th>
           <td class="c-answers-summary__content c-answers-summary__control">
-            {% if not assignee.is_lead %}
+            {% if not assignee.is_lead and order.canEditOrder %}
               {% call Form ({
                 action: 'edit/lead-assignee',
                 hideFormActions: true,
@@ -130,7 +130,7 @@
   {{ AnswersSummary({
     heading: 'Advisers in the UK',
     actions: [{
-      url: 'edit/subscribers' if order.isEditable,
+      url: 'edit/subscribers' if order.canEditOrders,
       label: 'Add or remove'
     }],
     items: values.subscribers,
@@ -140,7 +140,7 @@
   {{ AnswersSummary({
     heading: 'Information for the quote',
     actions: [{
-      url: 'edit/quote-details' if order.isEditable
+      url: 'edit/quote-details' if order.canEditOrder
     }],
     items: [{
       label: 'Delivery date',
@@ -156,7 +156,7 @@
   {{ AnswersSummary({
     heading: 'Internal use only',
     actions: [{
-      url: 'edit/internal-details' if order.isEditable
+      url: 'edit/internal-details' if order.canEditOrder
     }],
     items: [{
       label: 'Service type' | pluralise(values.service_types.length),
@@ -245,7 +245,7 @@
   {{ AnswersSummary({
     heading: 'Invoice details',
     actions: [{
-      url: 'edit/payment' if order.isEditable
+      url: 'edit/payment' if order.canEditOrder
     }],
     items: [{
       label: 'Price',

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -72,7 +72,7 @@
     id: 'assignees',
     heading: 'Advisers in the market',
     actions: [{
-      url: 'edit/assignees' if order.canEditOrders,
+      url: 'edit/assignees' if order.canEditAdvisers,
       label: 'Add or remove'
     }, {
       url: 'edit/assignee-time' if order.canEditOrder,
@@ -130,7 +130,7 @@
   {{ AnswersSummary({
     heading: 'Advisers in the UK',
     actions: [{
-      url: 'edit/subscribers' if order.canEditOrders,
+      url: 'edit/subscribers' if order.canEditAdvisers,
       label: 'Add or remove'
     }],
     items: values.subscribers,

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -18,7 +18,7 @@ async function setOrder (req, res, next, orderId) {
     const order = await Order.getById(req.session.token, orderId)
 
     res.locals.order = assign({}, order, {
-      isEditable: order.status === 'draft',
+      canEditOrder: order.status === 'draft',
     })
 
     const currencyFields = [

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -19,6 +19,7 @@ async function setOrder (req, res, next, orderId) {
 
     res.locals.order = assign({}, order, {
       canEditOrder: order.status === 'draft',
+      canEditAdvisers: !['cancelled', 'complete'].includes(order.status),
     })
 
     const currencyFields = [

--- a/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
+++ b/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
@@ -1,0 +1,298 @@
+const FormController = require('~/src/apps/omis/controllers/form')
+
+const orderMock = require('~/test/unit/data/omis/simple-order.json')
+const assigneesMock = require('~/test/unit/data/omis/assignees.json')
+const advisersMock = require('~/test/unit/data/advisers/advisers.json')
+
+const tokenMock = '12345abcde'
+
+describe('OMIS edit subscribers controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.getAdvisersStub = this.sandbox.stub().resolves(advisersMock)
+    this.getAssigneesStub = this.sandbox.stub().resolves(assigneesMock)
+    this.saveAssigneesStub = this.sandbox.stub().resolves(assigneesMock)
+    this.forceSaveAssigneesStub = this.sandbox.stub().resolves(assigneesMock)
+
+    const Controller = proxyquire('~/src/apps/omis/apps/edit/controllers/assignees', {
+      '../../../../adviser/repos': {
+        getAdvisers: this.getAdvisersStub,
+      },
+      '../../../models': {
+        Order: {
+          getAssignees: this.getAssigneesStub,
+          saveAssignees: this.saveAssigneesStub,
+          forceSaveAssignees: this.forceSaveAssigneesStub,
+        },
+      },
+    })
+
+    this.controller = new Controller({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('configure()', () => {
+    beforeEach(() => {
+      this.reqMock = Object.assign({}, globalReq, {
+        session: {
+          token: tokenMock,
+        },
+        form: {
+          options: {
+            fields: {
+              assignees: {},
+            },
+          },
+        },
+      })
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          order: orderMock,
+        },
+      })
+
+      this.sandbox.spy(FormController.prototype, 'configure')
+    })
+
+    context('when async calls resolve', () => {
+      beforeEach(async () => {
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set advisers as field options', () => {
+        expect(this.reqMock.form.options.fields.assignees.options).to.have.lengthOf(5)
+        expect(this.reqMock.form.options.fields.assignees.options).to.deep.equal([{
+          value: 'e13209b8-8d61-e311-8255-e4115bead28a',
+          label: 'Aaron Mr',
+        },
+        {
+          value: '0919a99e-9798-e211-a939-e4115bead28a',
+          label: 'Fred Rafters',
+        },
+        {
+          value: '0119a99e-9798-e211-a939-e4115bead28a',
+          label: 'George Chan',
+        },
+        {
+          value: 'a0dae366-1134-e411-985c-e4115bead28a',
+          label: 'Jeff Smith',
+        },
+        {
+          value: 'b9d6b3dc-7af4-e411-bcbe-e4115bead28a',
+          label: 'Mr Benjamin',
+        }])
+      })
+
+      it('should set assignees on the order object', () => {
+        expect(this.resMock.locals.order).to.have.property('assignees')
+        expect(this.resMock.locals.order.assignees).to.deep.equal(assigneesMock)
+      })
+
+      it('should call the parent method', () => {
+        expect(FormController.prototype.configure).to.be.calledOnce
+        expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, this.resMock, this.nextSpy)
+      })
+    })
+
+    context('when order is editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditOrder = true
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should allow assignees to be removed', () => {
+        expect(this.reqMock.form.options.fields.assignees.canRemove).to.equal(true)
+      })
+    })
+
+    context('when order is not editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditOrder = false
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not allow assignees to be removed', () => {
+        expect(this.reqMock.form.options.fields.assignees.canRemove).to.equal(false)
+      })
+    })
+
+    context('when advisers are editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditAdvisers = true
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not disable the form action', () => {
+        expect(this.reqMock.form.options.disableFormAction).to.equal(false)
+      })
+    })
+
+    context('when advisers are not editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditAdvisers = false
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should disable the form action', () => {
+        expect(this.reqMock.form.options.disableFormAction).to.equal(true)
+      })
+    })
+
+    context('when an async call rejects', () => {
+      beforeEach(async () => {
+        this.error = new Error('Async error')
+        this.getAdvisersStub.rejects(this.error)
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+    })
+  })
+
+  describe('successHandler()', () => {
+    beforeEach(() => {
+      this.resetSpy = this.sandbox.spy()
+      this.destroySpy = this.sandbox.spy()
+      this.flashSpy = this.sandbox.spy()
+      this.redirectSpy = this.sandbox.spy()
+
+      this.reqMock = Object.assign({}, globalReq, {
+        form: {
+          options: {
+            fields: {
+              assignees: {},
+              fizz: {},
+            },
+          },
+        },
+        session: {
+          token: tokenMock,
+        },
+        sessionModel: {
+          toJSON: () => {
+            return {
+              'csrf-secret': 'secret-key',
+              errors: {},
+              assignees: [
+                '33736be0-3e6b-4d4e-9fa8-32f23d0ba55e',
+                '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+              ],
+              fizz: 'buzz',
+            }
+          },
+          reset: this.resetSpy,
+          destroy: this.destroySpy,
+        },
+        journeyModel: {
+          reset: this.resetSpy,
+          destroy: this.destroySpy,
+        },
+        flash: this.flashSpy,
+      })
+
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          order: {
+            id: orderMock.id,
+          },
+        },
+        redirect: this.redirectSpy,
+      })
+    })
+
+    context('when an async call rejects', () => {
+      beforeEach(async () => {
+        this.error = new Error('Async error')
+        this.saveAssigneesStub.rejects(this.error)
+
+        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+    })
+
+    context('when order is editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditOrder = true
+
+        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should force save assignees', () => {
+        expect(this.saveAssigneesStub).not.to.have.been.called
+
+        expect(this.forceSaveAssigneesStub).to.have.been.calledOnce
+        expect(this.forceSaveAssigneesStub).to.have.been.calledWith(tokenMock, orderMock.id, [{
+          adviser: {
+            id: '33736be0-3e6b-4d4e-9fa8-32f23d0ba55e',
+          },
+        }, {
+          adviser: {
+            id: '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+          },
+        }])
+      })
+
+      it('should reset the models', () => {
+        expect(this.resetSpy).to.have.been.calledTwice
+        expect(this.destroySpy).to.have.been.calledTwice
+      })
+
+      it('should set a flash message', () => {
+        expect(this.flashSpy).to.have.been.calledOnce
+      })
+
+      it('should redirect back to the order', () => {
+        expect(this.redirectSpy).to.have.been.calledOnce
+        expect(this.redirectSpy).to.have.been.calledWith(`/omis/${orderMock.id}`)
+      })
+    })
+
+    context('when order is editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditOrder = false
+
+        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not force save assignees', () => {
+        expect(this.forceSaveAssigneesStub).not.to.have.been.called
+
+        expect(this.saveAssigneesStub).to.have.been.calledOnce
+        expect(this.saveAssigneesStub).to.have.been.calledWith(tokenMock, orderMock.id, [{
+          adviser: {
+            id: '33736be0-3e6b-4d4e-9fa8-32f23d0ba55e',
+          },
+        }, {
+          adviser: {
+            id: '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+          },
+        }])
+      })
+    })
+
+    context('when next is set', () => {
+      it('should redirect back to returnUrl', async () => {
+        this.reqMock.form.options.next = '/custom-return-url'
+
+        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+
+        expect(this.redirectSpy).to.have.been.calledOnce
+        expect(this.redirectSpy).to.have.been.calledWith('/custom-return-url')
+      })
+    })
+  })
+})

--- a/test/unit/apps/omis/apps/edit/controllers/subscribers.test.js
+++ b/test/unit/apps/omis/apps/edit/controllers/subscribers.test.js
@@ -1,0 +1,243 @@
+const FormController = require('~/src/apps/omis/controllers/form')
+
+const orderMock = require('~/test/unit/data/omis/simple-order.json')
+const subscribersMock = require('~/test/unit/data/omis/subscribers.json')
+const advisersMock = require('~/test/unit/data/advisers/advisers.json')
+
+const tokenMock = '12345abcde'
+
+describe('OMIS edit subscribers controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.getAdvisersStub = this.sandbox.stub().resolves(advisersMock)
+    this.getSubscribersStub = this.sandbox.stub().resolves(subscribersMock)
+    this.saveSubscribersStub = this.sandbox.stub().resolves(subscribersMock)
+
+    const Controller = proxyquire('~/src/apps/omis/apps/edit/controllers/subscribers', {
+      '../../../../adviser/repos': {
+        getAdvisers: this.getAdvisersStub,
+      },
+      '../../../models': {
+        Order: {
+          getSubscribers: this.getSubscribersStub,
+          saveSubscribers: this.saveSubscribersStub,
+        },
+      },
+    })
+
+    this.controller = new Controller({ route: '/' })
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('configure()', () => {
+    beforeEach(() => {
+      this.reqMock = Object.assign({}, globalReq, {
+        session: {
+          token: tokenMock,
+        },
+        form: {
+          options: {
+            fields: {
+              subscribers: {},
+            },
+          },
+        },
+      })
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          order: orderMock,
+        },
+      })
+
+      this.sandbox.spy(FormController.prototype, 'configure')
+    })
+
+    context('when async calls resolve', () => {
+      beforeEach(async () => {
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set advisers as field options', () => {
+        expect(this.reqMock.form.options.fields.subscribers.options).to.have.lengthOf(5)
+        expect(this.reqMock.form.options.fields.subscribers.options).to.deep.equal([{
+          value: 'e13209b8-8d61-e311-8255-e4115bead28a',
+          label: 'Aaron Mr',
+        },
+        {
+          value: '0919a99e-9798-e211-a939-e4115bead28a',
+          label: 'Fred Rafters',
+        },
+        {
+          value: '0119a99e-9798-e211-a939-e4115bead28a',
+          label: 'George Chan',
+        },
+        {
+          value: 'a0dae366-1134-e411-985c-e4115bead28a',
+          label: 'Jeff Smith',
+        },
+        {
+          value: 'b9d6b3dc-7af4-e411-bcbe-e4115bead28a',
+          label: 'Mr Benjamin',
+        }])
+      })
+
+      it('should set subscribers on the order object', () => {
+        expect(this.resMock.locals.order).to.have.property('subscribers')
+        expect(this.resMock.locals.order.subscribers).to.deep.equal(subscribersMock)
+      })
+
+      it('should call the parent method', () => {
+        expect(FormController.prototype.configure).to.be.calledOnce
+        expect(FormController.prototype.configure).to.be.calledWith(this.reqMock, this.resMock, this.nextSpy)
+      })
+    })
+
+    context('when advisers are editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditAdvisers = true
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not disable the form action', () => {
+        expect(this.reqMock.form.options.disableFormAction).to.equal(false)
+      })
+    })
+
+    context('when advisers are not editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditAdvisers = false
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should disable the form action', () => {
+        expect(this.reqMock.form.options.disableFormAction).to.equal(true)
+      })
+    })
+
+    context('when an async call rejects', () => {
+      beforeEach(async () => {
+        this.error = new Error('Async error')
+        this.getAdvisersStub.rejects(this.error)
+
+        await this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+    })
+  })
+
+  describe('successHandler()', () => {
+    beforeEach(() => {
+      this.resetSpy = this.sandbox.spy()
+      this.destroySpy = this.sandbox.spy()
+      this.flashSpy = this.sandbox.spy()
+      this.redirectSpy = this.sandbox.spy()
+
+      this.reqMock = Object.assign({}, globalReq, {
+        form: {
+          options: {
+            fields: {
+              subscribers: {},
+              fizz: {},
+            },
+          },
+        },
+        session: {
+          token: tokenMock,
+        },
+        sessionModel: {
+          toJSON: () => {
+            return {
+              'csrf-secret': 'secret-key',
+              errors: {},
+              subscribers: [
+                '33736be0-3e6b-4d4e-9fa8-32f23d0ba55e',
+                '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+              ],
+              fizz: 'buzz',
+            }
+          },
+          reset: this.resetSpy,
+          destroy: this.destroySpy,
+        },
+        journeyModel: {
+          reset: this.resetSpy,
+          destroy: this.destroySpy,
+        },
+        flash: this.flashSpy,
+      })
+
+      this.resMock = Object.assign({}, globalRes, {
+        locals: {
+          order: {
+            id: orderMock.id,
+          },
+        },
+        redirect: this.redirectSpy,
+      })
+    })
+
+    context('when an async call rejects', () => {
+      beforeEach(async () => {
+        this.error = new Error('Async error')
+        this.saveSubscribersStub.rejects(this.error)
+
+        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+    })
+
+    context('when order is editable', () => {
+      beforeEach(async () => {
+        this.resMock.locals.order.canEditOrder = true
+
+        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should force save assignees', () => {
+        expect(this.saveSubscribersStub).to.have.been.calledOnce
+        expect(this.saveSubscribersStub).to.have.been.calledWith(tokenMock, orderMock.id, [{
+          id: '33736be0-3e6b-4d4e-9fa8-32f23d0ba55e',
+        }, {
+          id: '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+        }])
+      })
+
+      it('should reset the models', () => {
+        expect(this.resetSpy).to.have.been.calledTwice
+        expect(this.destroySpy).to.have.been.calledTwice
+      })
+
+      it('should set a flash message', () => {
+        expect(this.flashSpy).to.have.been.calledOnce
+      })
+
+      it('should redirect back to the order', () => {
+        expect(this.redirectSpy).to.have.been.calledOnce
+        expect(this.redirectSpy).to.have.been.calledWith(`/omis/${orderMock.id}`)
+      })
+    })
+
+    context('when next is set', () => {
+      it('should redirect back to returnUrl', async () => {
+        this.reqMock.form.options.next = '/custom-return-url'
+
+        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+
+        expect(this.redirectSpy).to.have.been.calledOnce
+        expect(this.redirectSpy).to.have.been.calledWith('/custom-return-url')
+      })
+    })
+  })
+})

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -115,7 +115,7 @@ describe('OMIS middleware', () => {
         await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
         const order = Object.assign({}, orderData, {
-          isEditable: true,
+          canEditOrder: true,
         })
         expect(this.resMock.locals).to.have.property('order')
         expect(this.resMock.locals.order).to.deep.equal(order)
@@ -135,10 +135,10 @@ describe('OMIS middleware', () => {
           this.getByIdStub.resolves(draftOrder)
         })
 
-        it('should set isEditable to true', async () => {
+        it('should set canEditOrder to true', async () => {
           await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
-          expect(this.resMock.locals.order.isEditable).to.equal(true)
+          expect(this.resMock.locals.order.canEditOrder).to.equal(true)
         })
       })
 
@@ -150,10 +150,10 @@ describe('OMIS middleware', () => {
           this.getByIdStub.resolves(quoteOrder)
         })
 
-        it('should set isEditable to false', async () => {
+        it('should set canEditOrder to false', async () => {
           await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
-          expect(this.resMock.locals.order.isEditable).to.equal(false)
+          expect(this.resMock.locals.order.canEditOrder).to.equal(false)
         })
       })
     })

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -116,6 +116,7 @@ describe('OMIS middleware', () => {
 
         const order = Object.assign({}, orderData, {
           canEditOrder: true,
+          canEditAdvisers: true,
         })
         expect(this.resMock.locals).to.have.property('order')
         expect(this.resMock.locals.order).to.deep.equal(order)
@@ -128,32 +129,78 @@ describe('OMIS middleware', () => {
       })
 
       context('when order is in draft', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           const draftOrder = Object.assign({}, orderData, {
             status: 'draft',
           })
           this.getByIdStub.resolves(draftOrder)
+
+          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
         })
 
-        it('should set canEditOrder to true', async () => {
-          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
-
+        it('should be able to edit order', () => {
           expect(this.resMock.locals.order.canEditOrder).to.equal(true)
+        })
+
+        it('should be able to edit advisers', () => {
+          expect(this.resMock.locals.order.canEditAdvisers).to.equal(true)
         })
       })
 
       context('when order is not in draft', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           const quoteOrder = Object.assign({}, orderData, {
             status: 'quote_awaiting_acceptance',
           })
           this.getByIdStub.resolves(quoteOrder)
+
+          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
         })
 
-        it('should set canEditOrder to false', async () => {
-          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
-
+        it('should not be able to edit order', () => {
           expect(this.resMock.locals.order.canEditOrder).to.equal(false)
+        })
+
+        it('should be able to edit advisers', () => {
+          expect(this.resMock.locals.order.canEditAdvisers).to.equal(true)
+        })
+      })
+
+      context('when order is complete', () => {
+        beforeEach(async () => {
+          const quoteOrder = Object.assign({}, orderData, {
+            status: 'complete',
+          })
+          this.getByIdStub.resolves(quoteOrder)
+
+          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+        })
+
+        it('should not be able to edit order', () => {
+          expect(this.resMock.locals.order.canEditOrder).to.equal(false)
+        })
+
+        it('should not be able to edit advisers', () => {
+          expect(this.resMock.locals.order.canEditAdvisers).to.equal(false)
+        })
+      })
+
+      context('when order is cancelled', () => {
+        beforeEach(async () => {
+          const quoteOrder = Object.assign({}, orderData, {
+            status: 'cancelled',
+          })
+          this.getByIdStub.resolves(quoteOrder)
+
+          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+        })
+
+        it('should not be able to edit order', () => {
+          expect(this.resMock.locals.order.canEditOrder).to.equal(false)
+        })
+
+        it('should not be able to edit advisers', () => {
+          expect(this.resMock.locals.order.canEditAdvisers).to.equal(false)
         })
       })
     })


### PR DESCRIPTION
Previously we stopped anything being edited when an order is not in draft. There has been a need to change the list of people on an order past this point though.

This set of changes allows assignees (advisers in the market) and subscribers (advisers in the UK) to be edited after this point. We still don't allow them to be changed if an order is cancelled or completed though.

Due to hours and lead assignee being used as part of the quote we need to stop lead adviser being changed and not allow assignees to be removed when an order is not in draft state.

## Before
![localhost_3000_omis_9e9d23d4-f1e3-4116-b0c3-cc4cf4538525_work-order 1](https://user-images.githubusercontent.com/3327997/33174239-1a2a2682-d04f-11e7-986b-c6168fccc33e.png)

## After
![localhost_3000_omis_9e9d23d4-f1e3-4116-b0c3-cc4cf4538525_work-order](https://user-images.githubusercontent.com/3327997/33174229-02d917f4-d04f-11e7-8fdf-8b25f2dfd31b.png)
