### PR TITLE
Move subscribers field to edit definition

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -33,8 +33,14 @@ function arrayRequired (value) {
 
 const editFields = merge({}, globalFields, {
   subscribers: {
-    hint: 'fields.subscribers.hint.edit',
-    optional: false,
+    fieldType: 'MultipleChoiceField',
+    legend: 'fields.subscribers.legend',
+    label: 'fields.subscribers.label',
+    hint: 'fields.subscribers.hint',
+    addButtonText: 'fields.subscribers.addButtonText',
+    repeatable: true,
+    initialOption: '-- Select adviser --',
+    options: [],
   },
   service_types: {
     fieldType: 'MultipleChoiceField',

--- a/src/apps/omis/fields.js
+++ b/src/apps/omis/fields.js
@@ -47,15 +47,4 @@ module.exports = {
       value: 'false',
     },
   },
-  subscribers: {
-    fieldType: 'MultipleChoiceField',
-    legend: 'fields.subscribers.legend',
-    label: 'fields.subscribers.label',
-    hint: 'fields.subscribers.hint.create',
-    addButtonText: 'fields.subscribers.addButtonText',
-    optional: true,
-    repeatable: true,
-    initialOption: '-- Select adviser --',
-    options: [],
-  },
 }

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -8,10 +8,7 @@
     },
     "subscribers": {
       "legend": "Advisers",
-      "hint": {
-        "create": "For example International trade advisers or language advisers. They will be informed of the order once you submit it.",
-        "edit": "For example International trade advisers or language advisers"
-      },
+      "hint": "For example International trade advisers or language advisers",
       "addButtonText": "Add another adviser",
       "label": "Adviser"
     },


### PR DESCRIPTION
This field is not used within the create journey anymore so should
sit within the list of fields in the edit journey.