### PR TITLE
Middleware naming

### DIFF
--- a/src/apps/omis/apps/create/router.js
+++ b/src/apps/omis/apps/create/router.js
@@ -9,7 +9,7 @@ const i18n = i18nFuture({
 const steps = require('./steps')
 const fields = require('../../fields')
 const { FormController } = require('../../controllers')
-const { getCompany } = require('../../middleware')
+const { setCompany } = require('../../middleware')
 
 const config = {
   controller: FormController,
@@ -19,7 +19,7 @@ const config = {
   translate: i18n.translate.bind(i18n),
 }
 
-router.param('companyId', getCompany)
+router.param('companyId', setCompany)
 
 router.use('/:companyId?', wizard(steps, fields, config))
 

--- a/src/apps/omis/apps/edit/router.js
+++ b/src/apps/omis/apps/edit/router.js
@@ -1,10 +1,10 @@
 const router = require('express').Router()
 
 const { editRedirect, editHandler, editLeadAssignee } = require('./controllers')
-const { getCompany, setOrderBreadcrumb } = require('../../middleware')
+const { setCompany, setOrderBreadcrumb } = require('../../middleware')
 
 router.use((req, res, next) => {
-  getCompany(req, res, next, res.locals.order.company.id)
+  setCompany(req, res, next, res.locals.order.company.id)
 })
 
 router.use(setOrderBreadcrumb)

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -4,7 +4,7 @@ const i18nFuture = require('i18n-future')
 
 const logger = require('../../../../../config/logger')
 const { Order } = require('../../models')
-const { getCompany } = require('../../middleware')
+const { setCompany: setCompanyMW } = require('../../middleware')
 const { getContact } = require('../../../contacts/repos')
 const { transformPaymentToView } = require('../../transformers')
 const editSteps = require('../edit/steps')
@@ -27,7 +27,7 @@ function setCompany (req, res, next) {
     return next()
   }
 
-  getCompany(req, res, next, res.locals.order.company.id)
+  setCompanyMW(req, res, next, res.locals.order.company.id)
 }
 
 async function setContact (req, res, next) {

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -5,7 +5,7 @@ const { getDitCompany } = require('../companies/repos')
 const { setHomeBreadcrumb } = require('../middleware')
 const { Order } = require('./models')
 
-async function getCompany (req, res, next, companyId) {
+async function setCompany (req, res, next, companyId) {
   try {
     res.locals.company = await getDitCompany(req.session.token, companyId)
     next()
@@ -51,7 +51,7 @@ function setArchivedDocumentsBaseUrl (req, res, next) {
 }
 
 module.exports = {
-  getCompany,
+  setCompany,
   setOrder,
   setOrderBreadcrumb,
   setArchivedDocumentsBaseUrl,

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -14,7 +14,7 @@ async function getCompany (req, res, next, companyId) {
   }
 }
 
-async function getOrder (req, res, next, orderId) {
+async function setOrder (req, res, next, orderId) {
   try {
     const order = await Order.getById(req.session.token, orderId)
 
@@ -52,7 +52,7 @@ function setArchivedDocumentsBaseUrl (req, res, next) {
 
 module.exports = {
   getCompany,
-  getOrder,
+  setOrder,
   setOrderBreadcrumb,
   setArchivedDocumentsBaseUrl,
 }

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -1,13 +1,13 @@
 const router = require('express').Router()
 
 const { setHomeBreadcrumb } = require('../middleware')
-const { getOrder } = require('./middleware')
+const { setOrder } = require('./middleware')
 const viewApp = require('./apps/view')
 const editApp = require('./apps/edit')
 const createApp = require('./apps/create')
 const listApp = require('./apps/list')
 
-router.param('orderId', getOrder)
+router.param('orderId', setOrder)
 
 router.use(listApp.mountpath, listApp.router)
 router.use(createApp.mountpath, setHomeBreadcrumb(createApp.displayName), createApp.router)

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -8,7 +8,7 @@ describe('OMIS View middleware', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
 
-    this.getCompanySpy = this.sandbox.spy()
+    this.setCompanySpy = this.sandbox.spy()
     this.loggerErrorSpy = this.sandbox.spy()
     this.getContactStub = this.sandbox.stub()
     this.getAssigneesStub = this.sandbox.stub()
@@ -39,7 +39,7 @@ describe('OMIS View middleware', () => {
 
     this.middleware = proxyquire('~/src/apps/omis/apps/view/middleware', {
       '../../middleware': {
-        getCompany: this.getCompanySpy,
+        setCompany: this.setCompanySpy,
       },
       '../../transformers': {
         transformPaymentToView: this.transformPaymentToViewStub,
@@ -110,7 +110,7 @@ describe('OMIS View middleware', () => {
       })
 
       it('should not call company middleware', () => {
-        expect(this.getCompanySpy).not.to.have.been.called
+        expect(this.setCompanySpy).not.to.have.been.called
       })
 
       it('should call next', () => {
@@ -127,8 +127,8 @@ describe('OMIS View middleware', () => {
       })
 
       it('should call company middleware with correct arguments', () => {
-        expect(this.getCompanySpy).to.have.been.calledOnce
-        expect(this.getCompanySpy).to.have.been.calledWith({}, this.resMock, this.nextSpy, 'company-id')
+        expect(this.setCompanySpy).to.have.been.calledOnce
+        expect(this.setCompanySpy).to.have.been.calledWith({}, this.resMock, this.nextSpy, 'company-id')
       })
 
       it('should not call next itself', () => {

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -100,7 +100,7 @@ describe('OMIS middleware', () => {
     })
   })
 
-  describe('getOrder()', () => {
+  describe('setOrder()', () => {
     beforeEach(() => {
       this.orderId = 'o-1234567890'
     })
@@ -111,13 +111,13 @@ describe('OMIS middleware', () => {
       })
 
       it('should call model methods with correct arguments', async () => {
-        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+        await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
         expect(this.getByIdStub).to.have.been.calledWith(this.reqMock.session.token, this.orderId)
       })
 
       it('should set a order property on locals', async () => {
-        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+        await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
         const order = Object.assign({}, orderData, {
           isEditable: true,
@@ -127,7 +127,7 @@ describe('OMIS middleware', () => {
       })
 
       it('should call next with no errors', async () => {
-        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+        await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
         expect(this.nextSpy).to.have.been.calledWith()
       })
@@ -141,7 +141,7 @@ describe('OMIS middleware', () => {
         })
 
         it('should set isEditable to true', async () => {
-          await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
           expect(this.resMock.locals.order.isEditable).to.equal(true)
         })
@@ -156,7 +156,7 @@ describe('OMIS middleware', () => {
         })
 
         it('should set isEditable to false', async () => {
-          await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+          await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
 
           expect(this.resMock.locals.order.isEditable).to.equal(false)
         })
@@ -170,7 +170,7 @@ describe('OMIS middleware', () => {
         }
         this.getByIdStub.rejects(this.error)
 
-        await this.middleware.getOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
+        await this.middleware.setOrder(this.reqMock, this.resMock, this.nextSpy, this.orderId)
       })
 
       it('should not set an order property on locals', () => {

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -48,7 +48,7 @@ describe('OMIS middleware', () => {
     this.sandbox.restore()
   })
 
-  describe('getCompany()', () => {
+  describe('setCompany()', () => {
     beforeEach(() => {
       this.companyId = 'c-1234567890'
     })
@@ -59,20 +59,20 @@ describe('OMIS middleware', () => {
       })
 
       it('should call getDitCompany() with correct arguments', async () => {
-        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+        await this.middleware.setCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
 
         expect(this.getDitCompanyStub).to.have.been.calledWith(this.reqMock.session.token, this.companyId)
       })
 
       it('should set a company property on locals', async () => {
-        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+        await this.middleware.setCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
 
         expect(this.resMock.locals).to.have.property('company')
         expect(this.resMock.locals.company).to.deep.equal(companyData)
       })
 
       it('should call next with no errors', async () => {
-        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+        await this.middleware.setCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
 
         expect(this.nextSpy).to.have.been.calledWith()
       })
@@ -87,13 +87,13 @@ describe('OMIS middleware', () => {
       })
 
       it('should call next with an error', async () => {
-        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+        await this.middleware.setCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
 
         expect(this.nextSpy).to.have.been.calledWith(this.error)
       })
 
       it('should not set a company property on locals', async () => {
-        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
+        await this.middleware.setCompany(this.reqMock, this.resMock, this.nextSpy, this.companyId)
 
         expect(this.resMock.locals).to.not.have.property('company')
       })


### PR DESCRIPTION
This makes changes to some middleware functions that used `get` instead of `set`.

Using set better describes the purpose of the method as it is not actually returning anything.

Their purpose is to set values on the locals property of the response.