### PR TITLE
EU VAT number validation

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -1,4 +1,5 @@
 const { isArray, flatten, merge } = require('lodash')
+const FormController = require('hmpo-form-controller')
 
 const globalFields = require('../../fields')
 
@@ -29,6 +30,12 @@ function arrayRequired (value) {
   })
 
   return invalidItems.length === 0
+}
+
+function validEUVatNumber (value) {
+  const regex = /^(ATU[0-9]{8}|BE0[0-9]{9}|BG[0-9]{9,10}|CY[0-9]{8}L|CZ[0-9]{8,10}|DE[0-9]{9}|DK[0-9]{8}|EE[0-9]{9}|EL|GR[0-9]{9}|ES[0-9A-Z][0-9]{7}[0-9A-Z]|FI[0-9]{8}|FR[0-9A-Z]{2}[0-9]{9}|GB([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})|HU[0-9]{8}|IE[0-9]S[0-9]{5}L|IT[0-9]{11}|LT([0-9]{9}|[0-9]{12})|LU[0-9]{8}|LV[0-9]{11}|MT[0-9]{8}|NL[0-9]{9}B[0-9]{2}|PL[0-9]{10}|PT[0-9]{9}|RO[0-9]{2,10}|SE[0-9]{12}|SI[0-9]{8}|SK[0-9]{10})$/
+
+  return value === '' || FormController.validators.regex(value, regex)
 }
 
 const editFields = merge({}, globalFields, {
@@ -132,6 +139,7 @@ const editFields = merge({}, globalFields, {
     fieldType: 'TextField',
     label: 'fields.vat_number.label',
     modifier: ['subfield', 'medium'],
+    validate: [validEUVatNumber],
     condition: {
       name: 'vat_status',
       value: 'eu',

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -143,6 +143,7 @@ const editFields = merge({}, globalFields, {
     type: 'radio',
     modifier: ['inline', 'subfield'],
     label: 'fields.vat_verified.label',
+    validate: ['required'],
     options: [{
       value: 'true',
       label: 'Yes',

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -124,6 +124,7 @@
     "before": "must be in the past",
     "isDuration": "must be a whole number, for example 1",
     "isGreaterThanAmount": "must be equal to or larger than the invoice amount",
+    "validEUVatNumber": "must be a valid EU VAT number including the country code, for example ATU12345678 for Austria",
     "default": "is required"
   }
 }


### PR DESCRIPTION
This change validates the EU VAT number to make sure it includes the country code.

We need to play this back using the correct country code on the customer invoice so need to ensure the correct format is entered.