### PR TITLE
Correct display of double border on subfield fieldset

### DIFF
--- a/assets/stylesheets/components/form/_form-fieldset.scss
+++ b/assets/stylesheets/components/form/_form-fieldset.scss
@@ -32,12 +32,13 @@
 
 // Modifiers
 fieldset.c-form-fieldset--subfield {
+  border-left: 0;
+  padding-left: $default-spacing-unit * 2;
   position: relative;
-  margin-left: $default-spacing-unit * 2;
 
   &::before {
     position: absolute;
-    left: 0;
+    left: $default-spacing-unit;
     top: 0;
     bottom: 0;
     border-left: 5px solid $grey-2;


### PR DESCRIPTION
In some cases two modifiers could be added to a fieldset element
which would produce a double border.

Using the form-group modifier wouldn't produce the border at the
correct height so this ensures there is no second border coming from
the form group styles if both modifiers are applied.

## Before
![image](https://user-images.githubusercontent.com/3327997/33182939-cc10798c-d06d-11e7-9fc1-31bddb14f716.png)

## After
![image](https://user-images.githubusercontent.com/3327997/33182932-c081053c-d06d-11e7-92d1-0fc14562ef01.png)
