### PR TITLE
Change company list items to display trading name below registered name

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   },
   "devDependencies": {
     "chai-as-promised": "^7.1.1",
+    "chai-subset": "^1.6.0",
     "chromedriver": "^2.33.1",
     "codeclimate-test-reporter": "^0.5.0",
     "cucumber": "^3.0.1",

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -24,9 +24,17 @@ module.exports = function transformCompanyToListItem ({
   registered_address_2,
   companies_house_data,
 } = {}) {
-  if (!id && !get(companies_house_data, 'company_number')) { return }
+  if (!id) { return }
 
   const meta = []
+
+  if (trading_name) {
+    meta.push({
+      label: 'Trading name',
+      value: trading_name,
+    })
+  }
+
   const isTradingAddress = trading_address_town && trading_address_postcode && trading_address_1
   let address
 
@@ -53,7 +61,7 @@ module.exports = function transformCompanyToListItem ({
   if (sector) {
     meta.push({
       label: 'Sector',
-      value: sector,
+      value: get(sector, 'name'),
     })
   }
 
@@ -69,7 +77,7 @@ module.exports = function transformCompanyToListItem ({
     meta.push({
       label: 'UK region',
       type: 'badge',
-      value: uk_region,
+      value: get(uk_region, 'name'),
     })
   }
 
@@ -81,13 +89,12 @@ module.exports = function transformCompanyToListItem ({
   }
 
   const url = id ? `/companies/${id}` : `/companies/view/ch/${companies_house_data.company_number}`
-  const displayName = trading_name || name
 
   return {
     id,
+    name,
     url,
     meta,
     type: 'company',
-    name: displayName,
   }
 }

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -11,7 +11,7 @@ Feature: Create a new company
 
     When a "UK private or public limited company" is created
     Then I see the success message
-    And the company is in the search results
+    And the company trading name is in the search results
     When the first search result is clicked
     Then the company details are displayed
 

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -81,4 +81,18 @@ defineSupportCode(({ Then, When }) => {
       .findCompany(getUid(companyName))
       .assert.containsText('@collectionResultsCompanyName', companyName)
   })
+
+  Then(/^the company trading name is in the search results$/, async function () {
+    const companyName = get(this.state, 'company.tradingName')
+
+    await client
+      .url(dashboardPage)
+
+    await Search
+      .navigate()
+      .search(companyName)
+      .section.firstCompanySearchResult
+      .waitForElementPresent('@tradingName')
+      .assert.containsText('@tradingName', companyName)
+  })
 })

--- a/test/acceptance/features/search/page-objects/Search.js
+++ b/test/acceptance/features/search/page-objects/Search.js
@@ -71,6 +71,7 @@ module.exports = {
         },
         sector: getSearchResultSelector('Sector'),
         registeredAddress: getSearchResultSelector('Registered address'),
+        tradingName: getSearchResultSelector('Trading name'),
       },
     },
     firstSearchResult: {

--- a/test/unit/apps/companies/transformers/company-to-list-item.test.js
+++ b/test/unit/apps/companies/transformers/company-to-list-item.test.js
@@ -1,77 +1,169 @@
-const { some } = require('lodash')
+const { assign } = require('lodash')
 
 const companyData = require('~/test/unit/data/company')
 const transformCompanyToListItem = require('~/src/apps/companies/transformers/company-to-list-item')
 
 describe('transformCompanyToListItem', () => {
-  it('should return undefined if there is no companies house data or datahub data', () => {
-    expect(transformCompanyToListItem()).to.be.undefined
-    expect(transformCompanyToListItem({ a: 'b' })).to.be.undefined
-    expect(transformCompanyToListItem({ first_name: 'Peter', last_name: 'Great' })).to.be.undefined
+  context('when there is no companies house data or datahub data', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem()
+    })
+
+    it('should return undefined', () => {
+      expect(this.listItem).to.be.undefined
+    })
   })
 
-  it('should return undefined if companies house is incomplete', () => {
-    expect(transformCompanyToListItem({ companies_house_data: {} })).to.be.undefined
+  context('when the object passed to the transformer is not a company', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem({ a: 'b' })
+    })
+
+    it('should return undefined', () => {
+      expect(this.listItem).to.be.undefined
+    })
   })
 
-  it('should return an object with data for company list item', () => {
-    const actual = transformCompanyToListItem(companyData)
+  context('when passed a company with no ID', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem({ a: 'b' })
+    })
 
-    expect(actual).to.have.property('id').to.be.a('string')
-    expect(actual).to.have.property('type').to.equal('company')
-    expect(actual).to.have.property('name').to.be.a('string')
-    expect(actual).to.have.property('url').to.be.equal(`/companies/${companyData.id}`)
+    it('should return undefined', () => {
+      expect(this.listItem).to.be.undefined
+    })
   })
 
-  it('should return have correct meta items for Uk company', () => {
-    const actual = transformCompanyToListItem(companyData)
+  context('when called with a fully populated company', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem(companyData)
+    })
 
-    expect(actual).to.have.property('meta').an('array').to.have.length(4)
-    expect(actual.meta[0]).to.have.property('label', 'Sector')
-    expect(actual.meta[1]).to.have.property('label', 'Country')
-    expect(actual.meta[2]).to.have.property('label', 'UK region')
-    expect(actual.meta[3]).to.have.property('label', 'Registered address')
+    it('should return the id of the company', () => {
+      expect(this.listItem).to.have.property('id', 'dcdabbc9-1781-e411-8955-e4115bead28a')
+    })
+
+    it('should return a type of company', () => {
+      expect(this.listItem).to.have.property('type', 'company')
+    })
+
+    it('should return the company name', () => {
+      expect(this.listItem).to.have.property('name', 'Wonka Industries')
+    })
+
+    it('should return a url to view the company', () => {
+      expect(this.listItem).to.have.property('url', '/companies/dcdabbc9-1781-e411-8955-e4115bead28a')
+    })
   })
 
-  it('should return have correct meta items for non-UK company', () => {
-    const actual = transformCompanyToListItem(Object.assign({}, companyData, {
-      uk_based: false,
-    }))
+  context('when the company is based in the uk', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem(companyData)
+    })
 
-    expect(actual).to.have.property('meta').an('array').to.have.length(3)
-    expect(some(actual.meta, { label: 'UK region' })).to.be.false
+    it('should return the business sector for the company', () => {
+      expect(this.listItem.meta).to.containSubset([{
+        label: 'Sector',
+        value: 'ICT',
+      }])
+    })
+
+    it('should return the country', () => {
+      expect(this.listItem.meta).to.containSubset([{
+        label: 'Country',
+        type: 'badge',
+        value: 'United Kingdom',
+      }])
+    })
+
+    it('should return the UK region', () => {
+      expect(this.listItem.meta).to.containSubset([{
+        label: 'UK region',
+        type: 'badge',
+        value: 'Yorkshire and The Humber',
+      }])
+    })
   })
 
-  it('should return have correct meta items for company with trading address', () => {
-    const actual = transformCompanyToListItem(Object.assign({}, companyData, {
-      trading_address_postcode: 'W1C 2BA',
-      trading_address_town: 'London',
-      trading_address_1: '100 Bolton Road',
-    }))
+  context('when called with a non-UK company', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem(assign({}, companyData, {
+        uk_based: false,
+      }))
+    })
 
-    expect(actual).to.have.property('meta').an('array').to.have.length(4)
-    expect(some(actual.meta, { label: 'Registered address' })).to.be.false
-    expect(some(actual.meta, { label: 'Trading address' })).to.be.true
+    it('should return the business sector for the company', () => {
+      expect(this.listItem.meta).to.containSubset([{
+        label: 'Sector',
+        value: 'ICT',
+      }])
+    })
+
+    it('should return the country', () => {
+      expect(this.listItem.meta).to.containSubset([{
+        label: 'Country',
+        type: 'badge',
+        value: 'United Kingdom',
+      }])
+    })
+
+    it('should not return the region', () => {
+      expect(this.listItem.meta).to.not.containSubset([{
+        label: 'UK region',
+        type: 'badge',
+        value: 'Yorkshire and The Humber',
+      }])
+    })
   })
 
-  it('should return correct URL for Companies House company', () => {
-    const actual = transformCompanyToListItem(Object.assign({}, companyData, {
-      id: null,
-      companies_house_data: {
-        company_number: 10203040,
-      },
-    }))
+  context('when the company has a trading address', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem(assign({}, companyData, {
+        trading_address_postcode: 'W1C 2BA',
+        trading_address_town: 'London',
+        trading_address_1: '100 Bolton Road',
+        trading_address_country: {
+          id: '123',
+          name: 'United Kingdom',
+        },
+      }))
+    })
 
-    expect(actual).to.have.property('url', '/companies/view/ch/10203040')
+    it('should include the trading address in the result', () => {
+      expect(this.listItem.meta).to.containSubset([{
+        label: 'Trading address',
+        value: '100 Bolton Road, London, W1C 2BA, United Kingdom',
+      }])
+    })
+
+    it('does not include the registered address', () => {
+      expect(this.listItem.meta).to.not.containSubset([{
+        label: 'Registered address',
+        value: 'Leeds City Centre, Leeds, EX1 2PM, United Kingdom',
+      }])
+    })
   })
 
-  it('should return correct URL for company with both datahub and companies house data', () => {
-    const actual = transformCompanyToListItem(Object.assign({}, companyData, {
-      companies_house_data: {
-        company_number: 10203040,
-      },
-    }))
+  context('when the company does not have a trading address', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem(assign({}, companyData, {
+        trading_address_postcode: null,
+        trading_address_town: null,
+        trading_address_1: null,
+      }))
+    })
 
-    expect(actual).to.have.property('url').to.be.equal(`/companies/${companyData.id}`)
+    it('should not include the trading address in the result', () => {
+      expect(this.listItem.meta).to.not.containSubset([{
+        label: 'Trading address',
+      }])
+    })
+
+    it('returns a formatted registered address', () => {
+      expect(this.listItem.meta).to.containSubset([{
+        label: 'Registered address',
+        value: 'Leeds City Centre, Leeds, EX1 2PL, United Kingdom',
+      }])
+    })
   })
 })

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -5,6 +5,7 @@ const reqres = require('reqres')
 
 chai.use(require('sinon-chai'))
 chai.use(require('chai-as-promised'))
+chai.use(require('chai-subset'))
 
 // mocha globals
 global.expect = chai.expect

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,6 +1355,10 @@ chai-nightwatch@~0.1.x:
     assertion-error "1.0.0"
     deep-eql "0.1.3"
 
+chai-subset@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
+
 "chai@>=1.9.2 <4.0.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"


### PR DESCRIPTION
Previously the transformer would pick the trading name as the link if it was present, or show the registered name, but never both. This changes the list item now so the main name appears at the link and if there is a registered name it is shown below. This behaviour is consistent with how the details view works.

While working on the ticket I rewrote the unit tests to use `context` and removed tests associated with companies house results as they no longer appear in company search results.

![screencapture-localhost-3000-companies-1511461461727](https://user-images.githubusercontent.com/56056/33185746-a8ef7f70-d07c-11e7-8b3f-aa2eb307df76.png)
