### PR TITLE
fix for dates that were giving errors in circle

### DIFF
--- a/test/acceptance/helpers/date.js
+++ b/test/acceptance/helpers/date.js
@@ -21,7 +21,7 @@ const generateFutureDate = () => {
   const nextYear = getYear(addYears(Date.now(), 1))
   const year = faker.random.number({ min: nextYear, max: nextYear + 40 })
   const month = faker.random.number({ min: 1, max: 12 })
-  const day = faker.random.number({ min: 1, max: getDaysInMonth(new Date(year, month)) })
+  const day = faker.random.number({ min: 1, max: getDaysInMonth(new Date(year, (month - 1))) })
 
   return {
     year,


### PR DESCRIPTION
So we have been getting random errors around dates in [circle](https://12536-83823675-gh.circle-artifacts.com/4/root/data-hub-frontend/cucumber/report.html)
![download 1](https://user-images.githubusercontent.com/2305016/33188379-51882f1a-d091-11e7-947c-252d28b880c0.png)


I think this is because of the work in this pr setting the wrong date
There is not 31 days in November. Even in 2042!

### Circle CI data hub frontend logs
![screen shot 2017-11-23 at 20 53 32](https://user-images.githubusercontent.com/2305016/33188287-a2627482-d090-11e7-9a16-33edeeade795.png)
