### PR TITLE
Only apply bold style to non-muted message components

### DIFF
--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -7,7 +7,7 @@
 }
 
 .c-message {
-  @include bold-font(20);
+  @include core-font(20);
   border: 5px solid;
   padding: $default-spacing-unit;
   position: relative;
@@ -22,10 +22,6 @@
   * {
     margin-top: 0;
     margin-bottom: 0;
-
-    &:not(button) {
-      font-weight: 700;
-    }
   }
 
   > *:not([type="hidden"]) + * {
@@ -49,6 +45,19 @@
 
   &:hover {
     text-decoration: underline;
+  }
+}
+
+.c-message--info,
+.c-message--success,
+.c-message--warning,
+.c-message--error {
+  font-weight: 700;
+
+  * {
+    &:not(button) {
+      font-weight: 700;
+    }
   }
 }
 
@@ -77,11 +86,4 @@
   border-color: $grey-2;
   background: $grey-4;
   font-size: inherit;
-  font-weight: inherit;
-
-  * {
-    &:not(button) {
-      font-weight: inherit;
-    }
-  }
 }

--- a/src/apps/components/views/messages.njk
+++ b/src/apps/components/views/messages.njk
@@ -2,10 +2,22 @@
 
 {% block body_main_content %}
   {% call Example('Individual message') %}
-    {{ Message({
-      text: 'An information message',
-      type: 'info'
-    }) }}
+    {% call Message({
+      type: 'info',
+      element: 'div'
+    }) %}
+      <p>A message with <a href="">a link</a> and <strong>strong text</strong>.</p>
+      <p><button class="button">button</button></p>
+    {% endcall %}
+
+    {% call Message({
+      type: 'muted',
+      element: 'div'
+    }) %}
+      <p>A message with <strong>strong text</strong>.</p>
+      <p><a href="">A link</a></p>
+      <p><button class="button">button</button></p>
+    {% endcall %}
   {% endcall %}
 
   {% call Example('Message list (dismissable)') %}
@@ -14,7 +26,8 @@
         info: ['An information message'],
         success: ['A success message'],
         warning: ['A warning message'],
-        error: ['An error message']
+        error: ['An error message'],
+        muted: ['An muted informational message']
       }
     }) }}
   {% endcall %}


### PR DESCRIPTION
Previously bold was set on all message components and then overridden
to normal weight on muted message types.

This caused some problems with elements like strong as they were set
to a normal font weight.

This change removes the bold on all and only applies it to the types
necessary.

## Before
![image](https://user-images.githubusercontent.com/3327997/33189598-4a95e5d4-d09c-11e7-9e9e-97d21a2c6f39.png)

## After
![image](https://user-images.githubusercontent.com/3327997/33189593-355beed4-d09c-11e7-96cd-b6dc25387480.png)
