### PR TITLE
Use consistent content for adding an OMIS order

### DIFF
--- a/src/apps/omis/apps/create/index.js
+++ b/src/apps/omis/apps/create/index.js
@@ -1,7 +1,7 @@
 const router = require('./router')
 
 module.exports = {
-  displayName: 'Create an order',
+  displayName: 'Add order',
   mountpath: '/create',
   router,
 }

--- a/src/apps/omis/apps/create/views/client-details.njk
+++ b/src/apps/omis/apps/create/views/client-details.njk
@@ -17,6 +17,6 @@
   {{ super() }}
 
   {% call Message({ type: 'muted' }) %}
-    If the contact you are looking for is not listed you can <a href="/contacts/create?company={{ company.id }}">create a new one</a>.
+    If the contact you are looking for is not listed you can <a href="/contacts/create?company={{ company.id }}">add a new contact</a>.
   {% endcall %}
 {% endblock %}


### PR DESCRIPTION
This tidies up some inconsistent with the use of create vs add.

Elsewhere in data hub we use add so this ensures we use the correct
term for OMIS orders.