### PR TITLE
Fix spacing in local header with headings

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -23,6 +23,12 @@ $_first-element-spacing: $default-spacing-unit * 3;
 
   .c-message-list {
     margin-bottom: $default-spacing-unit;
+
+    &+.grid-row {
+      .c-local-header__heading:first-child {
+        margin-top: 0;
+      }
+    }
   }
 
   .c-entity-search {


### PR DESCRIPTION
When the local header heading appeared next to a message list it
was causing extra spacing to appear.

This change ensures that when next to a message list component the
spacing is removed.

## Before
![image](https://user-images.githubusercontent.com/3327997/33189984-103e76ea-d0a0-11e7-9177-9079ad9b50df.png)

## After
![image](https://user-images.githubusercontent.com/3327997/33189973-ff5f92d2-d09f-11e7-817d-31ab44672b63.png)
