### PR TITLE
Order status content

### DIFF
--- a/src/apps/omis/apps/list/macros.js
+++ b/src/apps/omis/apps/list/macros.js
@@ -108,7 +108,7 @@ const reconciliationSortForm = assign({}, collectionSortForm, {
       modifier: ['small', 'inline', 'light'],
       options: [
         { value: 'payment_due_date:asc', label: 'Earliest payment due date' },
-        { value: 'payment_due_date:desc', label: 'Lastest payment due date' },
+        { value: 'payment_due_date:desc', label: 'Latest payment due date' },
       ],
     },
   ],

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -42,7 +42,7 @@
 
 {% block local_header %}
   {% set statusText %}
-    {{ order.status | sentenceCase }}
+    {{ translate('status.' + order.status) }}
 
     {%- if order.status === 'quote_awaiting_acceptance' -%}
       <br>

--- a/src/apps/omis/constants.js
+++ b/src/apps/omis/constants.js
@@ -13,11 +13,11 @@ const ORDER_STATES = [
   },
   {
     value: 'paid',
-    label: 'Paid',
+    label: 'Payment received',
   },
   {
     value: 'complete',
-    label: 'Complete',
+    label: 'Completed',
   },
   {
     value: 'cancelled',

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -128,5 +128,13 @@
     "isGreaterThanAmount": "must be equal to or larger than the invoice amount",
     "validEUVatNumber": "must be a valid EU VAT number including the country code, for example ATU12345678 for Austria",
     "default": "is required"
+  },
+  "status": {
+    "draft": "Draft",
+    "quote_awaiting_acceptance": "Quote awaiting acceptance",
+    "quote_accepted": "Quote accepted",
+    "paid": "Payment received",
+    "complete": "Completed",
+    "cancelled": "Cancelled"
   }
 }


### PR DESCRIPTION
The order states that are returned from the API aren't all consistent.

The best way to solve this is to create a mapping for the states to the correct content on the frontend.

This change uses a combination of constants and the i18n library to create this correct content.