### PR TITLE
Ensure assignee time is always processed as an array

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -18,6 +18,11 @@ class EditAssigneeTimeController extends EditController {
     super.configure(req, res, next)
   }
 
+  process (req, res, next) {
+    req.form.values.assignee_time = flatten([req.form.values.assignee_time])
+    next()
+  }
+
   async successHandler (req, res, next) {
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
     const timeValues = flatten([data.assignee_time])

--- a/src/apps/omis/apps/edit/controllers/complete-order.js
+++ b/src/apps/omis/apps/edit/controllers/complete-order.js
@@ -27,6 +27,11 @@ class CompleteOrderController extends EditController {
     super.configure(req, res, next)
   }
 
+  process (req, res, next) {
+    req.form.values.assignee_actual_time = flatten([req.form.values.assignee_actual_time])
+    next()
+  }
+
   async successHandler (req, res, next) {
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
     const timeValues = flatten([data.assignee_actual_time])


### PR DESCRIPTION
If there was only one assignee the value for assignee_time would be
a string rather than an array of strings.

This meant that if an invalid value was returned the string would be
split when played back.

This change ensures that it is always processed as an array.

The same applies for actual assignee time when completing an order.

## Example

In both cases `1.4` was entered in the field.

### Before
![image](https://user-images.githubusercontent.com/3327997/33192029-270b6aa6-d0b7-11e7-897b-be0022a26ed4.png)

### After
![image](https://user-images.githubusercontent.com/3327997/33192019-18f16c7c-d0b7-11e7-8815-c310f23c79f8.png)
