### PR TITLE
Fix error styles for subfield fieldsets

### DIFF
--- a/assets/stylesheets/components/form/_form-fieldset.scss
+++ b/assets/stylesheets/components/form/_form-fieldset.scss
@@ -45,4 +45,12 @@ fieldset.c-form-fieldset--subfield {
     margin-left: -$default-spacing-unit;
     content: "";
   }
+
+  &.has-error {
+    padding-left: $default-spacing-unit * 2;
+
+    &::before {
+      border-left-color: $error-colour;
+    }
+  }
 }

--- a/assets/stylesheets/components/form/_form-group.scss
+++ b/assets/stylesheets/components/form/_form-group.scss
@@ -51,7 +51,7 @@
 
 // States
 .c-form-group.has-error {
-  border-left: 5px solid $error-colour;
+  border-left-color: $error-colour;
   padding-left: $default-spacing-unit;
 }
 


### PR DESCRIPTION
This is a follow up to fixing the double border issue. There was also
an issue with double border when that fieldset now contained the error
state class.

## Before
![image](https://user-images.githubusercontent.com/3327997/33208833-103d4f34-d10b-11e7-8815-c46f15f323fc.png)

## After
![image](https://user-images.githubusercontent.com/3327997/33208822-05907fb6-d10b-11e7-9792-1ddbe51a9cd0.png)
