### PR TITLE
Features/more related documents

### DIFF
--- a/src/apps/companies/controllers/documents.js
+++ b/src/apps/companies/controllers/documents.js
@@ -1,0 +1,17 @@
+const { get } = require('lodash')
+
+async function renderDocuments (req, res, next) {
+  const { id: companyId, name: companyName } = get(res.locals, 'company')
+  const archivedDocumentPath = get(res.locals, 'company.archived_documents_url_path')
+
+  return res
+    .breadcrumb(companyName, `/companies/${companyId}`)
+    .breadcrumb('Documents')
+    .render('companies/views/documents', {
+      archivedDocumentPath,
+    })
+}
+
+module.exports = {
+  renderDocuments,
+}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -1,7 +1,5 @@
 const router = require('express').Router()
-const { get } = require('lodash')
 
-const { archivedDocumentsBaseUrl } = require('../../../config')
 const {
   renderAddStepOne,
   postAddStepOne,
@@ -17,6 +15,7 @@ const { renderAuditLog } = require('./controllers/audit')
 const { renderInteractions } = require('./controllers/interactions')
 const { archiveCompany, unarchiveCompany } = require('./controllers/archive')
 const { renderContacts } = require('./controllers/contacts')
+const { renderDocuments } = require('./controllers/documents')
 const {
   renderExports,
   populateExportForm,
@@ -47,6 +46,7 @@ const LOCAL_NAV = [
   { path: 'investments', label: 'Investment' },
   { path: 'orders', label: 'Orders (OMIS)' },
   { path: 'audit', label: 'Audit history' },
+  { path: 'documents', label: 'Documents' },
 ]
 const DEFAULT_COLLECTION_QUERY = {
   sortby: 'modified_on:desc',
@@ -86,20 +86,7 @@ router
 router.post('/:companyId/archive', archiveCompany)
 router.get('/:companyId/unarchive', unarchiveCompany)
 
-router.use('/:companyId', (req, res, next) => {
-  const archivedDocumentsUrlPath = get(res.locals, 'company.archived_documents_url_path')
-  const localNav = LOCAL_NAV.slice()
-
-  if (archivedDocumentsUrlPath) {
-    localNav.push({
-      label: 'Documents',
-      url: archivedDocumentsBaseUrl + archivedDocumentsUrlPath,
-      isExternal: true,
-    })
-  }
-
-  setLocalNav(localNav)(req, res, next)
-})
+router.use('/:companyId', setLocalNav(LOCAL_NAV))
 
 router.get('/:companyId', redirectToFirstNavItem)
 router.get('/:companyId/details', renderDetails)
@@ -121,6 +108,7 @@ router.get('/:companyId/exports', renderExports)
 router.get('/:companyId/investments', renderInvestments)
 router.get('/:companyId/orders', renderOrders)
 router.get('/:companyId/audit', renderAuditLog)
+router.get('/:companyId/documents', renderDocuments)
 
 router.use('/:companyId', setInteractionsReturnUrl, setInteractionsEntityName, interactionsRouter)
 

--- a/src/apps/companies/views/documents.njk
+++ b/src/apps/companies/views/documents.njk
@@ -1,0 +1,17 @@
+{% extends "./_layout-view.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Documents</h2>
+  <p>
+    {% if archivedDocumentPath %}
+      <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
+        View files and documents
+      </a>
+      <br>
+      <span id="external-link-label">(will open another website)</span>
+    {% else %}
+      There are no files or documents
+    {% endif %}
+  </p>
+
+{% endblock %}

--- a/src/apps/contacts/controllers/documents.js
+++ b/src/apps/contacts/controllers/documents.js
@@ -1,0 +1,15 @@
+const { get } = require('lodash')
+
+async function renderDocuments (req, res, next) {
+  const archivedDocumentPath = get(res.locals, 'contact.archived_documents_url_path')
+
+  return res
+    .breadcrumb('Documents')
+    .render('contacts/views/documents', {
+      archivedDocumentPath,
+    })
+}
+
+module.exports = {
+  renderDocuments,
+}

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -6,6 +6,7 @@ const { getCommon, getDetails } = require('./controllers/details')
 const { renderContactList } = require('./controllers/list')
 const { postDetails, editDetails } = require('./controllers/edit')
 const { archiveContact, unarchiveContact } = require('./controllers/archive')
+const { renderDocuments } = require('./controllers/documents')
 const { renderInteractions } = require('./controllers/interactions')
 const { getAudit } = require('./controllers/audit')
 
@@ -22,6 +23,7 @@ const LOCAL_NAV = [
   { path: 'details', label: 'Details' },
   { path: 'interactions', label: 'Interactions' },
   { path: 'audit', label: 'Audit history' },
+  { path: 'documents', label: 'Documents' },
 ]
 
 const DEFAULT_COLLECTION_QUERY = {
@@ -36,7 +38,8 @@ router
   .get(editDetails)
   .post(postDetails)
 
-router.use('/:contactId', setLocalNav(LOCAL_NAV))
+router.use('/:contactId', getCommon, setLocalNav(LOCAL_NAV))
+
 router.get('/:contactId', redirectToFirstNavItem)
 router.get('/:contactId/details', getCommon, getDetails)
 
@@ -58,6 +61,8 @@ router.get('/:contactId/interactions',
 )
 
 router.get('/:contactId/audit', getCommon, getAudit)
+
+router.get('/:contactId/documents', renderDocuments)
 
 router.use('/:contactId', getCommon, setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails, interactionsRouter)
 

--- a/src/apps/contacts/views/documents.njk
+++ b/src/apps/contacts/views/documents.njk
@@ -1,0 +1,17 @@
+{% extends "./_layout.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Documents</h2>
+  <p>
+    {% if archivedDocumentPath %}
+      <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
+        View files and documents
+      </a>
+      <br>
+      <span id="external-link-label">(will open another website)</span>
+    {% else %}
+      There are no files or documents
+    {% endif %}
+  </p>
+
+{% endblock %}

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -3,6 +3,7 @@ const { assign, get, reject, castArray, compact, uniq } = require('lodash')
 
 const { getFormattedAddress } = require('../../lib/address')
 const { transformDateObjectToDateString } = require('../transformers')
+const config = require('../../../config')
 
 const castToArrayAndRemoveEmpty = (value) => compact(castArray(value))
 
@@ -108,6 +109,7 @@ function transformEventResponseToViewRecord ({
   teams,
   related_programmes,
   service,
+  archived_documents_url_path,
 }) {
   teams = teams || []
   related_programmes = related_programmes || []
@@ -134,7 +136,7 @@ function transformEventResponseToViewRecord ({
 
   const otherTeams = lead_team ? reject(teams, lead_team) : teams
 
-  return Object.assign(transformedEvent, {
+  const viewRecord = assign({}, transformedEvent, {
     'Event location type': location_type,
     'Address': getFormattedAddress({
       address_1,
@@ -149,10 +151,24 @@ function transformEventResponseToViewRecord ({
     'Lead team': lead_team,
     'Organiser': organiser,
     'Other teams': otherTeams.map(x => x.name),
-    'Related programmes': related_programmes
-      .map(item => item.name),
+    'Related programmes': related_programmes.map(item => item.name),
     'Service': service,
   })
+
+  viewRecord['Documents'] = {
+    name: 'There are no files or documents',
+  }
+
+  if (archived_documents_url_path) {
+    viewRecord['Documents'] = {
+      url: config.archivedDocumentsBaseUrl + archived_documents_url_path,
+      name: 'View files and documents',
+      hint: '(will open another website)',
+      hintId: 'external-link-label',
+    }
+  }
+
+  return viewRecord
 }
 
 function transformEventResponseToFormBody (props = {}) {

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -3,6 +3,7 @@ const { get, assign, isNil } = require('lodash')
 const { format, isValid } = require('date-fns')
 
 const { transformDateObjectToDateString } = require('../transformers')
+const config = require('../../../config')
 
 function transformInteractionResponseToForm ({
   id,
@@ -99,6 +100,7 @@ function transformInteractionResponseToViewRecord ({
   communication_channel,
   event,
   kind,
+  archived_documents_url_path,
 }) {
   const contactLink = contact ? {
     url: `/contacts/${contact.id}`,
@@ -114,6 +116,19 @@ function transformInteractionResponseToViewRecord ({
     url: `/investment-projects/${investment_project.id}`,
     name: investment_project.name,
   } : null
+
+  let documentsLink = {
+    name: 'There are no files or documents',
+  }
+
+  if (archived_documents_url_path) {
+    documentsLink = {
+      url: config.archivedDocumentsBaseUrl + archived_documents_url_path,
+      name: 'View files and documents',
+      hint: '(will open another website)',
+      hintId: 'external-link-label',
+    }
+  }
 
   const viewRecord = {
     'Company': companyLink,
@@ -137,6 +152,10 @@ function transformInteractionResponseToViewRecord ({
     } : 'No'
   } else {
     viewRecord['Communication channel'] = communication_channel
+  }
+
+  if (documentsLink) {
+    viewRecord['Documents'] = documentsLink
   }
 
   return viewRecord

--- a/src/apps/investment-projects/controllers/documents.js
+++ b/src/apps/investment-projects/controllers/documents.js
@@ -1,0 +1,15 @@
+const { get } = require('lodash')
+
+async function renderDocuments (req, res, next) {
+  const archivedDocumentPath = get(res.locals, 'investmentData.archived_documents_url_path')
+
+  return res
+    .breadcrumb('Documents')
+    .render('investment-projects/views/documents', {
+      archivedDocumentPath,
+    })
+}
+
+module.exports = {
+  renderDocuments,
+}

--- a/src/apps/investment-projects/controllers/index.js
+++ b/src/apps/investment-projects/controllers/index.js
@@ -2,6 +2,7 @@ const create = require('./create')
 const archive = require('./archive')
 const audit = require('./audit')
 const details = require('./details')
+const documents = require('./documents')
 const edit = require('./edit')
 const evaluation = require('./evaluation')
 const interactions = require('./interactions')
@@ -12,6 +13,7 @@ module.exports = {
   archive,
   audit,
   details,
+  documents,
   edit,
   evaluation,
   interactions,

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -12,6 +12,7 @@ const {
   archive,
   audit,
   details,
+  documents,
   edit,
   evaluation,
   team,
@@ -61,6 +62,7 @@ const LOCAL_NAV = [
   { path: 'interactions', label: 'Interactions' },
   { path: 'evaluation', label: 'Evaluations' },
   { path: 'audit', label: 'Audit history' },
+  { path: 'documents', label: 'Documents' },
 ]
 
 const currentYear = (new Date()).getFullYear()
@@ -70,7 +72,7 @@ const DEFAULT_COLLECTION_QUERY = {
   sortby: 'estimated_land_date:asc',
 }
 
-router.use('/:investmentId/', setLocalNav(LOCAL_NAV))
+router.use('/:investmentId', setLocalNav(LOCAL_NAV))
 
 router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)
@@ -206,5 +208,7 @@ router.get('/:investmentId/edit-associated',
 )
 
 router.get('/:investmentId/remove-associated', removeAssociatedInvestmentProject)
+
+router.get('/:investmentId/documents', documents.renderDocuments)
 
 module.exports = router

--- a/src/apps/investment-projects/views/documents.njk
+++ b/src/apps/investment-projects/views/documents.njk
@@ -1,0 +1,17 @@
+{% extends "./_layout.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Documents</h2>
+  <p>
+    {% if archivedDocumentPath %}
+      <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
+        View files and documents
+      </a>
+      <br>
+      <span id="external-link-label">(will open another website)</span>
+    {% else %}
+      There are no files or documents
+    {% endif %}
+  </p>
+
+{% endblock %}

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -1,10 +1,7 @@
 const router = require('express').Router()
 
 const { setLocalNav, redirectToFirstNavItem } = require('../../../middleware')
-const {
-  setOrderBreadcrumb,
-  setArchivedDocumentsBaseUrl,
-} = require('../../middleware')
+const { setOrderBreadcrumb } = require('../../middleware')
 const {
   renderWorkOrder,
   renderQuote,
@@ -38,7 +35,6 @@ router.use(setTranslation)
 router.use(setCompany)
 router.use(setOrderBreadcrumb)
 router.use(setQuoteSummary)
-router.use(setArchivedDocumentsBaseUrl)
 
 router.get('/', redirectToFirstNavItem)
 router.get('/work-order', setContact, setAssignees, setSubscribers, renderWorkOrder)

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -15,7 +15,7 @@
 
   {% if order.archived_documents_url_path %}
     <p class="c-local-header__action">
-      <a href="{{ archivedDocumentsBaseUrl }}{{ order.archived_documents_url_path }}" aria-labelledby="external-docs-label">View files and documents</a>
+      <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ order.archived_documents_url_path }}" aria-labelledby="external-docs-label">View files and documents</a>
       <br>
       <span id="external-docs-label">(will open another website)</span>
     </p>

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,6 +1,5 @@
 const { assign, get } = require('lodash')
 
-const config = require('../../../config')
 const { getDitCompany } = require('../companies/repos')
 const { setHomeBreadcrumb } = require('../middleware')
 const { Order } = require('./models')
@@ -45,14 +44,8 @@ function setOrderBreadcrumb (req, res, next) {
   return setHomeBreadcrumb(reference)(req, res, next)
 }
 
-function setArchivedDocumentsBaseUrl (req, res, next) {
-  res.locals.archivedDocumentsBaseUrl = config.archivedDocumentsBaseUrl
-  next()
-}
-
 module.exports = {
   setCompany,
   setOrder,
   setOrderBreadcrumb,
-  setArchivedDocumentsBaseUrl,
 }

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -26,6 +26,7 @@ module.exports = function locals (req, res, next) {
     BASE_URL: baseUrl,
     CANONICAL_URL: baseUrl + req.originalUrl,
     CURRENT_PATH: req.path,
+    ARCHIVED_DOCUMENT_BASE_URL: config.archivedDocumentsBaseUrl,
     GOOGLE_TAG_MANAGER_KEY: config.googleTagManagerKey,
     BREADCRUMBS: breadcrumbItems,
     IS_XHR: req.xhr,

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -16,11 +16,24 @@
   <table class="table--key-value{{ ' table--' + variant if variant }}">
     <tbody>
       {% for label, data in items %}
+        {% set id = data.id %}
         <tr>
           <th>{{ label }}</th>
           <td>
             {% if data.url %}
-              <a href="{{ data.url }}">{{ data.name }}</a>
+              <a
+                {% if data.hintId %}aria-labelledby="{{ data.hintId }}"{% endif %}
+                href="{{ data.url }}"
+              >
+                {{- data.name -}}
+              </a>
+              {% if data.hint %}
+                <span
+                  {% if data.hintId %}id="{{ data.hintId }}"{% endif %}
+                >
+                  {{- data.hint -}}
+                </span>
+              {% endif  %}
             {% elif data | isArray %}
               <ul>
                {% for item in data | removeNilAndEmpty %}

--- a/test/acceptance/features/audit/step_definitions/contact.js
+++ b/test/acceptance/features/audit/step_definitions/contact.js
@@ -16,6 +16,7 @@ defineSupportCode(({ Given, Then, When }) => {
   const AuditContact = client.page.AuditContact()
   const AuditList = client.page.AuditList()
   const InvestmentStage = client.page.InvestmentStage()
+  const Location = client.page.Location()
 
   Given(/^I archive an existing contact record$/, async function () {
     await Company
@@ -46,7 +47,7 @@ defineSupportCode(({ Given, Then, When }) => {
       .section.firstCompanySearchResult
       .click('@header')
 
-    await Company.section.detailsTabs
+    await Location.section.detailsTabs
       .waitForElementVisible('@contacts')
       .click('@contacts')
 

--- a/test/acceptance/features/collection/step_definitions/collection.js
+++ b/test/acceptance/features/collection/step_definitions/collection.js
@@ -13,8 +13,6 @@ defineSupportCode(({ When, Then }) => {
     await client
       .url(url)
 
-    // Todo - Also capture the default filters selected if there are
-    // any and change the reset filters function to use that state.
     await Collection
       .captureResultCount((count) => {
         set(this.state, 'collection.resultCount', count)

--- a/test/acceptance/features/companies/contacts-collection.feature
+++ b/test/acceptance/features/companies/contacts-collection.feature
@@ -9,7 +9,7 @@ Feature: View collection of contacts for a company
   Scenario: View companies contact collection
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the companies contacts page
+    When I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     And I submit the form
@@ -32,7 +32,7 @@ Feature: View collection of contacts for a company
   Scenario: Filter companies contact list
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the companies contacts page
+    When I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact with new company address is added
     When I submit the form
@@ -68,7 +68,7 @@ Feature: View collection of contacts for a company
   Scenario: Sort companies contact list
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the companies contacts page
+    When I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form

--- a/test/acceptance/features/companies/details.feature
+++ b/test/acceptance/features/companies/details.feature
@@ -1,4 +1,4 @@
-@companies-details
+@companies-details @details
 Feature: Company details
 
   @companies-details--cdms-reference
@@ -16,6 +16,8 @@ Feature: Company details
       | Audit history               |
       | Documents                   |
     And the company details CDMS reference is displayed
+    When I click the Documents local nav link
+    Then view should contain the Documents link
 
   @companies-details--no-cdms-reference
   Scenario: Company does not have CDMS reference
@@ -30,7 +32,10 @@ Feature: Company details
       | Investment                  |
       | Orders (OMIS)               |
       | Audit history               |
+      | Documents                   |
     And the company details CDMS reference is not displayed
+    When I click the Documents local nav link
+    Then view should not contain the Documents link
 
 
 

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -5,14 +5,6 @@ const { getSelectorForElementWithText, getButtonWithText } = require('../../../h
 const { appendUid } = require('../../../helpers/uuid')
 const { getAddress } = require('../../../helpers/address')
 
-const getDetailsTabSelector = (text) => getSelectorForElementWithText(
-  text,
-  {
-    el: '//a',
-    className: 'c-local-nav__link',
-  }
-)
-
 const getMetaListItemValueSelector = (text) => getSelectorForElementWithText(
   text,
   {
@@ -382,17 +374,6 @@ module.exports = {
     },
   ],
   sections: {
-    detailsTabs: {
-      selector: '.c-local-nav',
-      elements: {
-        details: getDetailsTabSelector('Details'),
-        contacts: getDetailsTabSelector('Contacts'),
-        interactions: getDetailsTabSelector('Interactions'),
-        export: getDetailsTabSelector('Export'),
-        investment: getDetailsTabSelector('Investment'),
-        auditHistory: getDetailsTabSelector('Audit history'),
-      },
-    },
     firstCompanySearchResult: {
       selector: '.c-collection > .c-entity-list li:first-child',
       elements: {

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -3,9 +3,6 @@ Feature: Create a new company
   As an existing user
   I would like to create a new company in various locations
 
-  # Disables test due to issue with lack of support for ch search in backend
-  # re-enable to prove back end once complete and split into 2 tests
-  # One for selecting CH entry and another for selecting existing datahub entry
   @companies-save--uk-private-or-public-ltd-company
   Scenario: Create a UK private or public limited company
 

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -29,7 +29,7 @@ defineSupportCode(({ Then, When }) => {
       .assert.containsText('@header', companyName)
   })
 
-  When(/^I navigate to the companies (.+) page$/, async function (pageName) {
+  When(/^I navigate to the companies (.+) page$/, async function (pageName) { // TODO please use work in Location (remove this)
     const tag = `@${pageName}`
 
     await Location

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -32,7 +32,7 @@ defineSupportCode(({ Then, When }) => {
   When(/^I navigate to the companies (.+) page$/, async function (pageName) {
     const tag = `@${pageName}`
 
-    await Company
+    await Location
       .section.detailsTabs
       .waitForElementPresent(tag)
       .click(tag)

--- a/test/acceptance/features/contacts/details.feature
+++ b/test/acceptance/features/contacts/details.feature
@@ -1,0 +1,28 @@
+@contact-details  @details
+Feature: Contact details
+
+  @contact-details--documents-link
+  Scenario: Contact has Documents link
+
+    When browsing to contact fixture Johnny Cakeman
+    Then there should be a local nav
+      | text                        |
+      | Details                     |
+      | Interactions                |
+      | Audit history               |
+      | Documents                   |
+    When I click the Documents local nav link
+    Then view should contain the Documents link
+
+  @contact-details--no-documents-link
+  Scenario: Contact does not have Documents link
+
+    When browsing to contact fixture Georgina Clark
+    Then there should be a local nav
+      | text                        |
+      | Details                     |
+      | Interactions                |
+      | Audit history               |
+      | Documents                   |
+    When I click the Documents local nav link
+    And view should not contain the Documents link

--- a/test/acceptance/features/contacts/page-objects/Contact.js
+++ b/test/acceptance/features/contacts/page-objects/Contact.js
@@ -13,15 +13,6 @@ function generateEmail (firstName, lastName, isAlternative) {
   return emailParts.join('.') + suffix
 }
 
-const getDetailsTabSelector = (text) =>
-  getSelectorForElementWithText(
-    text,
-    {
-      el: '//a',
-      className: 'c-local-nav__link',
-    }
-  )
-
 const getMetaListItemValueSelector = (text) => getSelectorForElementWithText(
   text,
   {
@@ -196,14 +187,6 @@ module.exports = {
     },
   ],
   sections: {
-    detailsTabs: {
-      selector: '.c-local-nav',
-      elements: {
-        details: getDetailsTabSelector('Details'),
-        interactions: getDetailsTabSelector('Interactions'),
-        auditHistory: getDetailsTabSelector('Audit history'),
-      },
-    },
     firstContactSearchResult: {
       selector: '.c-entity-list li:first-child',
       elements: {

--- a/test/acceptance/features/contacts/step_definitions/create.js
+++ b/test/acceptance/features/contacts/step_definitions/create.js
@@ -11,6 +11,7 @@ defineSupportCode(({ Given, Then, When }) => {
   const Contact = client.page.Contact()
   const Search = client.page.Search()
   const Dashboard = client.page.Dashboard()
+  const Location = client.page.Location()
 
   When(/^a primary contact is added$/, async function () {
     await Contact
@@ -45,7 +46,7 @@ defineSupportCode(({ Given, Then, When }) => {
       .section.firstCompanySearchResult
       .click('@header')
 
-    await Company.section.detailsTabs
+    await Location.section.detailsTabs
       .waitForElementVisible('@contacts')
       .click('@contacts')
 
@@ -64,7 +65,7 @@ defineSupportCode(({ Given, Then, When }) => {
       .section.firstCompanySearchResult
       .click('@header')
 
-    await Company.section.detailsTabs
+    await Location.section.detailsTabs
       .waitForElementVisible('@contacts')
       .click('@contacts')
 

--- a/test/acceptance/features/contacts/step_definitions/details.js
+++ b/test/acceptance/features/contacts/step_definitions/details.js
@@ -2,11 +2,23 @@ const { get } = require('lodash')
 
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
+const { map, find, set } = require('lodash')
 
 const { getAddress } = require('../../../helpers/address')
 
 defineSupportCode(({ Given, Then, When }) => {
   const Contact = client.page.Contact()
+
+  When(/^browsing to contact fixture (.+)$/, async function (contactName) {
+    const contacts = map(this.fixtures.contact, (contact) => { return contact })
+    const contact = find(contacts, { name: contactName })
+    const url = this.urls.contacts.getDetails(contact.pk)
+
+    set(this.state, 'contact', contact)
+
+    await client
+      .url(url)
+  })
 
   Then(/^the contact details are displayed$/, async function () {
     const contactAddress = getAddress(get(this.state, 'contact'))

--- a/test/acceptance/features/details/page-objects/Details.js
+++ b/test/acceptance/features/details/page-objects/Details.js
@@ -3,13 +3,14 @@ const { getSelectorForElementWithText } = require('../../../helpers/selectors')
 module.exports = {
   elements: {
     heading: '.c-local-header__heading',
+    localNav: '.c-local-nav',
   },
   commands: [
     {
       getDetailFor (label) {
         return getSelectorForElementWithText(label, { el: '//th', child: '/following-sibling::td' })
       },
-      getDetailsTabSelector (text) {
+      getLocalNavItemSelector (text) {
         return getSelectorForElementWithText(
           text,
           {

--- a/test/acceptance/features/details/page-objects/Details.js
+++ b/test/acceptance/features/details/page-objects/Details.js
@@ -4,6 +4,11 @@ module.exports = {
   elements: {
     heading: '.c-local-header__heading',
     localNav: '.c-local-nav',
+    documentsLink: {
+      selector: '//a[contains(.,"View files and documents")][contains(@aria-labelledby,"external-link-label")]',
+      locateStrategy: 'xpath',
+    },
+    noDocumentsMessage: getSelectorForElementWithText('There are no files or documents', { el: '//article//p' }),
   },
   commands: [
     {

--- a/test/acceptance/features/details/step_definitions/details.js
+++ b/test/acceptance/features/details/step_definitions/details.js
@@ -47,4 +47,9 @@ defineSupportCode(({ Then }) => {
         .useCss()
     }
   })
+
+  Then(/^there should not be a local nav$/, async () => {
+    await Details
+      .assert.elementNotPresent('@localNav')
+  })
 })

--- a/test/acceptance/features/details/step_definitions/details.js
+++ b/test/acceptance/features/details/step_definitions/details.js
@@ -52,4 +52,12 @@ defineSupportCode(({ Then }) => {
     await Details
       .assert.elementNotPresent('@localNav')
   })
+
+  Then(/^view should (not\s?)?contain the Documents link$/, async (noDocumentsLink) => {
+    const tag = noDocumentsLink ? '@noDocumentsMessage' : '@documentsLink'
+
+    await Details
+      .waitForElementPresent(tag)
+      .assert.visible(tag)
+  })
 })

--- a/test/acceptance/features/details/step_definitions/details.js
+++ b/test/acceptance/features/details/step_definitions/details.js
@@ -40,10 +40,10 @@ defineSupportCode(({ Then }) => {
     })
 
     for (const row of expectedLocalNav) {
-      const detailsTabSelector = Details.getDetailsTabSelector(row.text)
+      const localNavItemSelector = Details.getLocalNavItemSelector(row.text)
       await Details
         .api.useXpath()
-        .assert.visible(detailsTabSelector.selector)
+        .assert.visible(localNavItemSelector.selector)
         .useCss()
     }
   })

--- a/test/acceptance/features/events/details.feature
+++ b/test/acceptance/features/events/details.feature
@@ -1,0 +1,16 @@
+@events-details @details
+Feature: Event details
+
+  @events-details--documents-link
+  Scenario: Event has Documents link
+
+    When browsing to event fixture One-day exhibition
+    Then there should not be a local nav
+    And details view data for "Documents" should contain "View files and documents (will open another website)"
+
+  @events-details--no-documents-link
+  Scenario: Event does not have Documents link
+
+    When browsing to event fixture Grand exhibition
+    Then there should not be a local nav
+    And details view data for "Documents" should contain "There are no files or documents"

--- a/test/acceptance/features/events/page-objects/Event.js
+++ b/test/acceptance/features/events/page-objects/Event.js
@@ -2,8 +2,15 @@ const faker = require('faker')
 const { addWeeks, format } = require('date-fns')
 const { get, camelCase, isNull, pickBy, keys, assign } = require('lodash')
 
-const { getButtonWithText } = require('../../../helpers/selectors')
+const { getButtonWithText, getSelectorForElementWithText } = require('../../../helpers/selectors')
 const { getDateFor } = require('../../../helpers/date')
+
+const getLinkWithText = (text) => getSelectorForElementWithText(
+  text,
+  {
+    el: '//a',
+  },
+)
 
 module.exports = {
   url: `${process.env.QA_HOST}/events/create`,
@@ -147,4 +154,12 @@ module.exports = {
       },
     },
   ],
+  sections: {
+    details: {
+      selector: '.table--key-value',
+      elements: {
+        documentsLink: getLinkWithText('Documents'),
+      },
+    },
+  },
 }

--- a/test/acceptance/features/events/step_definitions/create.js
+++ b/test/acceptance/features/events/step_definitions/create.js
@@ -14,7 +14,7 @@ defineSupportCode(function ({ Given, Then, When }) {
       .wait() // wait for backend to sync
   })
 
-  Given(/^I navigate to the create an event page$/, async () => {
+  Given(/^I navigate to the create an event page$/, async () => { // TODO this can be dried up please see Location
     await Event
       .navigate()
   })

--- a/test/acceptance/features/events/step_definitions/details.js
+++ b/test/acceptance/features/events/step_definitions/details.js
@@ -1,0 +1,16 @@
+const { client } = require('nightwatch-cucumber')
+const { defineSupportCode } = require('cucumber')
+const { map, find, set } = require('lodash')
+
+defineSupportCode(({ When }) => {
+  When(/^browsing to event fixture (.+)$/, async function (eventName) { // TODO can this be DRY'd up?
+    const events = map(this.fixtures.event, (event) => { return event })
+    const event = find(events, { name: eventName })
+    const url = this.urls.events.getDetails(event.pk)
+
+    set(this.state, 'event', event)
+
+    await client
+      .url(url)
+  })
+})

--- a/test/acceptance/features/interactions/create.feature
+++ b/test/acceptance/features/interactions/create.feature
@@ -10,7 +10,7 @@ Feature: Save an Interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     And I submit the form
@@ -27,7 +27,7 @@ Feature: Save an Interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     And I submit the form
@@ -44,7 +44,7 @@ Feature: Save an Interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     And I submit the form
@@ -61,7 +61,7 @@ Feature: Save an Interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     And I submit the form
@@ -78,7 +78,7 @@ Feature: Save an Interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     And I submit the form
@@ -95,7 +95,7 @@ Feature: Save an Interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     And I submit the form

--- a/test/acceptance/features/interactions/details.feature
+++ b/test/acceptance/features/interactions/details.feature
@@ -1,0 +1,16 @@
+@interactions-details  @details
+Feature: Interaction details
+
+  @interactions-details--documents-link
+  Scenario: Interaction has Documents link
+
+    When browsing to interaction fixture Attended gamma event
+    Then there should not be a local nav
+    And details view data for "Documents" should contain "View files and documents (will open another website)"
+
+  @interactions-details--no-documents-link
+  Scenario: Interaction does not have Documents link
+
+    When browsing to interaction fixture Provided funding information
+    Then there should not be a local nav
+    And details view data for "Documents" should contain "There are no files or documents"

--- a/test/acceptance/features/interactions/page-objects/Interaction.js
+++ b/test/acceptance/features/interactions/page-objects/Interaction.js
@@ -13,6 +13,13 @@ const getRadioButtonWithText = (text) =>
     },
   )
 
+const getLinkWithText = (text) => getSelectorForElementWithText(
+  text,
+  {
+    el: '//a',
+  },
+)
+
 module.exports = {
   props: {},
   elements: {
@@ -169,6 +176,12 @@ module.exports = {
         serviceDelivery: 'label[for=field-kind-2]',
         dateFrom: '#field-date_after',
         dateTo: '#field-date_before',
+      },
+    },
+    details: {
+      selector: '.table--key-value',
+      elements: {
+        documentsLink: getLinkWithText('Documents'),
       },
     },
   },

--- a/test/acceptance/features/interactions/save.feature
+++ b/test/acceptance/features/interactions/save.feature
@@ -10,7 +10,7 @@ Feature: Save a new interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     And I submit the form
@@ -27,7 +27,7 @@ Feature: Save a new interaction in Data hub
     Given a company is created
     When I search for the company
     And the first search result is clicked
-    And I navigate to the companies contacts page
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     When a primary contact is added
     When I submit the form

--- a/test/acceptance/features/interactions/step_definitions/create.js
+++ b/test/acceptance/features/interactions/step_definitions/create.js
@@ -12,6 +12,7 @@ defineSupportCode(({ Given, When, Then }) => {
   const Interaction = client.page.Interaction()
   const Contact = client.page.Contact()
   const Search = client.page.Search()
+  const Location = client.page.Location()
 
   Given(/^a company investment project is created for interactions$/, async function () {
   })
@@ -55,7 +56,7 @@ defineSupportCode(({ Given, When, Then }) => {
       .section.firstCompanySearchResult
       .click('@header')
 
-    await Company.section.detailsTabs
+    await Location.section.detailsTabs
       .waitForElementVisible('@interactions')
       .click('@interactions')
 
@@ -76,7 +77,7 @@ defineSupportCode(({ Given, When, Then }) => {
       .section.firstContactSearchResult
       .click('@header')
 
-    await Contact.section.detailsTabs
+    await Location.section.detailsTabs
       .waitForElementVisible('@interactions')
       .click('@interactions')
 

--- a/test/acceptance/features/interactions/step_definitions/details.js
+++ b/test/acceptance/features/interactions/step_definitions/details.js
@@ -1,0 +1,30 @@
+const { client } = require('nightwatch-cucumber')
+const { defineSupportCode } = require('cucumber')
+const { map, find, set } = require('lodash')
+
+defineSupportCode(({ Given, Then, When }) => {
+  const Interaction = client.page.Interaction()
+
+  When(/^browsing to interaction fixture (.+)$/, async function (interactionSubject) {
+    const interactions = map(this.fixtures.interaction, (interaction) => { return interaction })
+    const interaction = find(interactions, { subject: interactionSubject })
+    const url = this.urls.interactionsAndServices.getDetails(interaction.pk)
+
+    set(this.state, 'interaction', interaction)
+
+    await client
+      .url(url)
+  })
+
+  Then(/^the interaction details Documents link is displayed$/, async function () {
+    await Interaction
+      .section.details
+      .assert.visible('@documentsLink')
+  })
+
+  Then(/^the interaction details Documents link is not displayed$/, async function () {
+    await Interaction
+      .section.details
+      .assert.elementNotPresent('@documentsLink')
+  })
+})

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -8,7 +8,7 @@ Feature: View a list of Investment Projects
   Scenario: View Investment Projects list
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the Investment Projects investment page
+    When I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -7,7 +7,7 @@ Feature: Create a new Investment project
   Scenario: Verify Add Investment project option
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the investment page
+    When I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
 
@@ -15,7 +15,7 @@ Feature: Create a new Investment project
   Scenario: Add a Foreign Direct Investment (FDI) Investment project
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the investment page
+    When I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -28,7 +28,7 @@ Feature: Create a new Investment project
   Scenario: Add a Foreign Direct Investment (FDI) Investment project with a separate company as the source of foreign equity
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the investment page
+    When I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -49,7 +49,7 @@ Feature: Create a new Investment project
   Scenario: Add a Non Foreign Direct Investment (Non-FDI) Investment project
 
     Given I navigate to the Company Venus Ltd
-    When I navigate to the investment page
+    When I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select Non FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -7,7 +7,7 @@ Feature: Create a new Investment project
   Scenario: Verify Add Investment project option
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the companies investment page
+    When I navigate to the investment page
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
 
@@ -15,7 +15,7 @@ Feature: Create a new Investment project
   Scenario: Add a Foreign Direct Investment (FDI) Investment project
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the companies investment page
+    When I navigate to the investment page
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -28,7 +28,7 @@ Feature: Create a new Investment project
   Scenario: Add a Foreign Direct Investment (FDI) Investment project with a separate company as the source of foreign equity
 
     Given I navigate to the Company Lambda plc
-    When I navigate to the companies investment page
+    When I navigate to the investment page
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -49,7 +49,7 @@ Feature: Create a new Investment project
   Scenario: Add a Non Foreign Direct Investment (Non-FDI) Investment project
 
     Given I navigate to the Company Venus Ltd
-    When I navigate to the companies investment page
+    When I navigate to the investment page
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select Non FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/details.feature
+++ b/test/acceptance/features/investment-projects/details.feature
@@ -1,0 +1,32 @@
+@investment-projects-details  @details
+Feature: Investment project details
+
+  @investment-projects-details--documents-link
+  Scenario: Investment project has Documents link
+
+    When browsing to investment project fixture New hotel (commitment to invest)
+    Then there should be a local nav
+      | text                        |
+      | Project details             |
+      | Project team                |
+      | Interactions                |
+      | Evaluations                 |
+      | Audit history               |
+      | Documents                   |
+    When I click the Documents local nav link
+    Then view should contain the Documents link
+
+  @investment-projects-details--no-documents-link
+  Scenario: Investment project does not have Documents link
+
+    When browsing to investment project fixture New rollercoaster
+    Then there should be a local nav
+      | text                        |
+      | Project details             |
+      | Project team                |
+      | Interactions                |
+      | Evaluations                 |
+      | Audit history               |
+      | Documents                   |
+    When I click the Documents local nav link
+    And view should not contain the Documents link

--- a/test/acceptance/features/investment-projects/page-objects/InvestmentProject.js
+++ b/test/acceptance/features/investment-projects/page-objects/InvestmentProject.js
@@ -9,11 +9,6 @@ const {
   storeRadioSubFieldValues,
 } = require('../../../helpers/state')
 
-const getDetailsTabSelector = (text) => getSelectorForElementWithText(text, {
-  el: '//a',
-  className: 'c-local-nav__link',
-})
-
 const getHeaderSelector = (text) => getSelectorForElementWithText(text, {
   el: '//h2',
   className: 'heading-medium',
@@ -242,12 +237,6 @@ module.exports = {
           selector: '//ol[contains(@class,"c-progress-bar")]/li[contains(@class,"is-active")]/span',
           locateStrategy: 'xpath',
         },
-      },
-    },
-    detailsTabs: {
-      selector: '.c-local-nav',
-      elements: {
-        investment: getDetailsTabSelector('Investment'),
       },
     },
     projectDetails: {

--- a/test/acceptance/features/investment-projects/step_definitions/create.js
+++ b/test/acceptance/features/investment-projects/step_definitions/create.js
@@ -6,15 +6,7 @@ const { getDateFor } = require('../../../helpers/date')
 
 defineSupportCode(({ Given, Then, When }) => {
   const InvestmentProject = client.page.InvestmentProject()
-
-  Given(/^I navigate to the Investment Projects (.+) page$/, async function (pageName) {
-    const tag = `@${pageName}`
-
-    await InvestmentProject
-      .section.detailsTabs
-      .waitForElementPresent(tag)
-      .click(tag)
-  })
+  const Location = client.page.Location()
 
   When(/^I select (.+) as the Investment project type$/, async function (investmentType) {
     if (lowerCase(investmentType) === 'fdi') {
@@ -127,7 +119,7 @@ defineSupportCode(({ Given, Then, When }) => {
       .waitForElementPresent('@header')
       .assert.containsText('@header', equitySource)
 
-    await InvestmentProject
+    await Location
       .section.detailsTabs
       .waitForElementPresent('@investment')
       .click('@investment')

--- a/test/acceptance/features/investment-projects/step_definitions/details.js
+++ b/test/acceptance/features/investment-projects/step_definitions/details.js
@@ -1,0 +1,16 @@
+const { client } = require('nightwatch-cucumber')
+const { defineSupportCode } = require('cucumber')
+const { map, find, set } = require('lodash')
+
+defineSupportCode(({ When }) => {
+  When(/^browsing to investment project fixture (.+)$/, async function (investmentProjectName) {
+    const investmentProjects = map(this.fixtures.investmentProject, (investmentProject) => { return investmentProject })
+    const investmentProject = find(investmentProjects, { name: investmentProjectName })
+    const url = this.urls.investmentProjects.getDetails(investmentProject.pk)
+
+    set(this.state, 'investmentProject', investmentProject)
+
+    await client
+      .url(url)
+  })
+})

--- a/test/acceptance/features/location/page-objects/Location.js
+++ b/test/acceptance/features/location/page-objects/Location.js
@@ -1,3 +1,12 @@
+const { getSelectorForElementWithText } = require('../../../helpers/selectors')
+
+const getDetailsTabSelector = (text) => getSelectorForElementWithText(text,
+  {
+    el: '//a',
+    className: 'c-local-nav__link',
+  }
+)
+
 module.exports = {
   url: process.env.QA_HOST,
   sections: {
@@ -5,6 +14,18 @@ module.exports = {
       selector: '.c-local-header',
       elements: {
         header: '.c-local-header__heading',
+      },
+    },
+    detailsTabs: {
+      selector: '.c-local-nav',
+      elements: {
+        details: getDetailsTabSelector('Details'),
+        contacts: getDetailsTabSelector('Contacts'),
+        interactions: getDetailsTabSelector('Interactions'),
+        export: getDetailsTabSelector('Export'),
+        investment: getDetailsTabSelector('Investment'),
+        auditHistory: getDetailsTabSelector('Audit history'),
+        documents: getDetailsTabSelector('Documents'),
       },
     },
   },

--- a/test/acceptance/features/location/step_definitions/location.js
+++ b/test/acceptance/features/location/step_definitions/location.js
@@ -1,8 +1,20 @@
+const { lowerCase } = require('lodash')
+
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
 defineSupportCode(({ When, Then }) => {
   const Location = client.page.Location()
+
+  Then(/^I click the (.+) local nav link$/, async (navItemText) => {
+    const tag = `@${lowerCase(navItemText)}`
+
+    await Location
+      .section.detailsTabs
+      .waitForElementPresent(tag)
+      .assert.containsText(tag, navItemText)
+      .click(tag)
+  })
 
   Then(/^I am taken to the "(.+)" page$/, async (text) => {
     await Location

--- a/test/acceptance/features/support/fixtures.js
+++ b/test/acceptance/features/support/fixtures.js
@@ -39,7 +39,12 @@ module.exports = {
   },
   contact: {
     georginaClark: {
+      pk: '048f2edc-e7ed-4881-b1cc-29142a80238a',
       name: 'Georgina Clark',
+    },
+    johnnyCakeman: {
+      pk: '9b1138ab-ec7b-497f-b8c3-27fed21694ef',
+      name: 'Johnny Cakeman',
     },
   },
 }

--- a/test/acceptance/features/support/fixtures.js
+++ b/test/acceptance/features/support/fixtures.js
@@ -57,6 +57,16 @@ module.exports = {
       name: 'Grand exhibition',
     },
   },
+  interaction: {
+    attendedGammaEvent: {
+      pk: 'ec4a46ef-6e50-4a5c-bba0-e311f0471312',
+      subject: 'Attended gamma event',
+    },
+    grandExhibition: {
+      pk: '0dcb3748-c097-4f20-b84f-0114bbb1a8e0',
+      subject: 'Provided funding information',
+    },
+  },
   investmentProject: {
     newHotelCommitmentToInvest: {
       pk: 'fb5b5006-56af-40e0-8615-7aba53e0e4bf',

--- a/test/acceptance/features/support/fixtures.js
+++ b/test/acceptance/features/support/fixtures.js
@@ -47,4 +47,24 @@ module.exports = {
       name: 'Johnny Cakeman',
     },
   },
+  event: {
+    oneDayExhibition: {
+      pk: 'b93d4273-36fe-4008-ac40-fbc197910791',
+      name: 'One-day exhibition',
+    },
+    grandExhibition: {
+      pk: 'bda12a57-433c-4a0c-a7ce-5ebd080e09e8',
+      name: 'Grand exhibition',
+    },
+  },
+  investmentProject: {
+    newHotelCommitmentToInvest: {
+      pk: 'fb5b5006-56af-40e0-8615-7aba53e0e4bf',
+      name: 'New hotel (commitment to invest)',
+    },
+    newRollercoaster: {
+      pk: '0e686ea4-b8a2-4337-aec4-114d92ad4588',
+      name: 'New rollercoaster',
+    },
+  },
 }

--- a/test/acceptance/features/support/urls.js
+++ b/test/acceptance/features/support/urls.js
@@ -28,6 +28,9 @@ const urls = {
   },
   events: {
     collection: 'events',
+    getDetails (id) {
+      return `${host}/events/${id}`
+    },
   },
   interactionsAndServices: {
     collection: 'interactions',

--- a/test/acceptance/features/support/urls.js
+++ b/test/acceptance/features/support/urls.js
@@ -34,6 +34,9 @@ const urls = {
   },
   interactionsAndServices: {
     collection: 'interactions',
+    getDetails (id) {
+      return `${host}/interactions/${id}`
+    },
   },
   investmentProjects: {
     collection: 'investment-projects',

--- a/test/acceptance/features/support/urls.js
+++ b/test/acceptance/features/support/urls.js
@@ -22,6 +22,9 @@ const urls = {
   },
   contacts: {
     collection: 'contacts',
+    getDetails (id) {
+      return `${host}/contacts/${id}/details`
+    },
   },
   events: {
     collection: 'events',

--- a/test/acceptance/features/support/urls.js
+++ b/test/acceptance/features/support/urls.js
@@ -40,6 +40,9 @@ const urls = {
   },
   investmentProjects: {
     collection: 'investment-projects',
+    getDetails (id) {
+      return `${host}/investment-projects/${id}/details`
+    },
   },
 }
 

--- a/test/unit/apps/events/transformers.test.js
+++ b/test/unit/apps/events/transformers.test.js
@@ -1,13 +1,18 @@
 /* eslint camelcase: 0 */
 const { assign } = require('lodash')
 
+const mockEvent = require('~/test/unit/data/events/event-data')
+const archivedDocumentsBaseUrl = 'http://base'
+
 const {
   transformEventToListItem,
   transformEventResponseToViewRecord,
   transformEventFormBodyToApiRequest,
-} = require('~/src/apps/events/transformers')
-
-const mockEvent = require('~/test/unit/data/events/event-data')
+} = proxyquire('~/src/apps/events/transformers', {
+  '../../../config': {
+    archivedDocumentsBaseUrl,
+  },
+})
 
 describe('Event transformers', () => {
   describe('#transformEventToListItem', () => {
@@ -106,6 +111,10 @@ describe('Event transformers', () => {
             id: '9484b82b-3499-e211-a939-e4115bead28a',
             name: 'Account Management',
           },
+          'Documents': {
+            url: 'http://base/documents/123',
+            name: 'Documents',
+          },
         })
       })
     })
@@ -135,6 +144,58 @@ describe('Event transformers', () => {
           'Other teams': [],
           'Region': null,
           'Service': null,
+        })
+      })
+    })
+
+    context('when there is not an archived documents URL path', () => {
+      beforeEach(() => {
+        const event = assign({}, mockEvent, { archived_documents_url_path: '' })
+        this.transformedEvent = transformEventResponseToViewRecord(event)
+      })
+
+      it('should transform to a display event', () => {
+        expect(this.transformedEvent).to.deep.equal({
+          'Address': '1 Uk Street, The Lane, Plymouth, Devon, PL1 3FG, United Kingdom',
+          'Event end date': {
+            type: 'date',
+            name: '2017-11-11',
+          },
+          'Type of event': {
+            id: '6031f993-a689-49af-9a11-942a8413a779',
+            name: 'Outward mission',
+          },
+          'Lead team': {
+            id: '42f12898-9698-e211-a939-e4115bead28a',
+            name: 'Association of Dogs',
+          },
+          'Event location type': {
+            id: 'cf45bf02-8ea7-4e53-af0e-b5676a30cb96',
+            name: 'Other',
+          },
+          'Notes': 'An example event for testing',
+          'Organiser': {
+            id: '0919a99e-9798-e211-a939-e4115bead28a',
+            first_name: 'Jeff',
+            last_name: 'Smith',
+            name: 'Jeff Smith',
+          },
+          'Related programmes': ['Example Programme'],
+          'Event start date': {
+            type: 'date',
+            name: '2017-11-10',
+          },
+          'Other teams': [
+            'Association of Cats',
+          ],
+          'Region': {
+            id: '804cd12a-6095-e211-a939-e4115bead28a',
+            name: 'FDI Hub',
+          },
+          'Service': {
+            id: '9484b82b-3499-e211-a939-e4115bead28a',
+            name: 'Account Management',
+          },
         })
       })
     })

--- a/test/unit/apps/events/transformers.test.js
+++ b/test/unit/apps/events/transformers.test.js
@@ -112,8 +112,10 @@ describe('Event transformers', () => {
             name: 'Account Management',
           },
           'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
             url: 'http://base/documents/123',
-            name: 'Documents',
           },
         })
       })
@@ -128,6 +130,9 @@ describe('Event transformers', () => {
       it('should transform to a display event', () => {
         expect(this.transformedEvent).to.deep.equal({
           'Address': '1 Uk Street, Plymouth, Devon, PL1 3FG, United Kingdom',
+          'Documents': {
+            name: 'There are no files or documents',
+          },
           'Type of event': {
             id: '6031f993-a689-49af-9a11-942a8413a779',
             name: 'Outward mission',
@@ -157,6 +162,9 @@ describe('Event transformers', () => {
       it('should transform to a display event', () => {
         expect(this.transformedEvent).to.deep.equal({
           'Address': '1 Uk Street, The Lane, Plymouth, Devon, PL1 3FG, United Kingdom',
+          'Documents': {
+            name: 'There are no files or documents',
+          },
           'Event end date': {
             type: 'date',
             name: '2017-11-11',

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -274,6 +274,12 @@ describe('Interaction transformers', () => {
             type: 'date',
             name: '2017-05-31T00:00:00',
           },
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
           'DIT adviser': {
             id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
             first_name: 'Test',
@@ -287,10 +293,6 @@ describe('Interaction transformers', () => {
           'Communication channel': {
             id: '72c226d7-5d95-e211-a939-e4115bead28a',
             name: 'Telephone',
-          },
-          'Documents': {
-            url: 'http://base/documents/123',
-            name: 'Documents',
           },
         })
       })
@@ -319,6 +321,12 @@ describe('Interaction transformers', () => {
           },
           'Subject': 'Test interactions',
           'Notes': 'lorem ipsum',
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
           'Interaction date': {
             type: 'date',
             name: '2017-05-31T00:00:00',
@@ -368,6 +376,12 @@ describe('Interaction transformers', () => {
             type: 'date',
             name: '2017-05-31T00:00:00',
           },
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
           'DIT adviser': {
             id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
             first_name: 'Test',
@@ -412,6 +426,12 @@ describe('Interaction transformers', () => {
           },
           'Subject': 'Test interactions',
           'Notes': 'lorem ipsum',
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
           'Interaction date': {
             type: 'date',
             name: '2017-05-31T00:00:00',
@@ -480,6 +500,12 @@ describe('Interaction transformers', () => {
             url: '/investment-projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
             name: 'Test project',
           },
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
           'Event': {
             url: '/events/4444',
             name: 'Event title',
@@ -535,6 +561,12 @@ describe('Interaction transformers', () => {
             name: 'Test project',
           },
           'Event': 'No',
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
         })
       })
     })
@@ -565,6 +597,9 @@ describe('Interaction transformers', () => {
           },
           'Subject': 'Test interactions',
           'Notes': 'lorem ipsum',
+          'Documents': {
+            name: 'There are no files or documents',
+          },
           'Interaction date': {
             type: 'date',
             name: '2017-05-31T00:00:00',

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -1,5 +1,6 @@
 const { assign } = require('lodash')
 const mockInteraction = require('~/test/unit/data/interactions/search-interaction.json')
+const archivedDocumentsBaseUrl = 'http://base'
 
 const {
   transformInteractionResponseToForm,
@@ -7,7 +8,11 @@ const {
   transformInteractionFormBodyToApiRequest,
   transformInteractionResponseToViewRecord,
   transformInteractionListItemToHaveUrlPrefix,
-} = require('~/src/apps/interactions/transformers')
+} = proxyquire('~/src/apps/interactions/transformers', {
+  '../../../config': {
+    archivedDocumentsBaseUrl,
+  },
+})
 
 describe('Interaction transformers', () => {
   describe('#transformInteractionResponseToForm', () => {
@@ -283,6 +288,10 @@ describe('Interaction transformers', () => {
             id: '72c226d7-5d95-e211-a939-e4115bead28a',
             name: 'Telephone',
           },
+          'Documents': {
+            url: 'http://base/documents/123',
+            name: 'Documents',
+          },
         })
       })
     })
@@ -526,6 +535,54 @@ describe('Interaction transformers', () => {
             name: 'Test project',
           },
           'Event': 'No',
+        })
+      })
+    })
+
+    context('when there is not an archived documents URL path', () => {
+      beforeEach(() => {
+        const interaction = assign({}, mockInteraction, { archived_documents_url_path: '' })
+        this.transformed = transformInteractionResponseToViewRecord(interaction)
+      })
+
+      it('should transform to display format', () => {
+        expect(this.transformed).to.deep.equal({
+          'Company': {
+            url: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a',
+            name: 'Samsung',
+          },
+          'Contact': {
+            url: '/contacts/b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+            name: 'Jackson Whitfield',
+          },
+          'Service provider': {
+            id: '222',
+            name: 'Team',
+          },
+          'Service': {
+            id: '1231231231312',
+            name: 'Test service',
+          },
+          'Subject': 'Test interactions',
+          'Notes': 'lorem ipsum',
+          'Interaction date': {
+            type: 'date',
+            name: '2017-05-31T00:00:00',
+          },
+          'DIT adviser': {
+            id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+            first_name: 'Test',
+            last_name: 'CMU 1',
+            name: 'Test CMU 1',
+          },
+          'Investment project': {
+            url: '/investment-projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
+            name: 'Test project',
+          },
+          'Communication channel': {
+            id: '72c226d7-5d95-e211-a939-e4115bead28a',
+            name: 'Telephone',
+          },
         })
       })
     })

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -1,8 +1,6 @@
 const companyData = require('~/test/unit/data/company.json')
 const orderData = require('~/test/unit/data/omis/simple-order.json')
 
-const archivedDocumentsBaseUrl = 'http://docs-base-url'
-
 describe('OMIS middleware', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
@@ -26,9 +24,6 @@ describe('OMIS middleware', () => {
     this.middleware = proxyquire('~/src/apps/omis/middleware', {
       '../companies/repos': {
         getDitCompany: this.getDitCompanyStub,
-      },
-      '../../../config': {
-        archivedDocumentsBaseUrl,
       },
       '../../../config/logger': {
         error: this.loggerSpy,
@@ -199,18 +194,6 @@ describe('OMIS middleware', () => {
 
       expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledOnce
       expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, this.resMock, this.nextSpy)
-    })
-  })
-
-  describe('setArchivedDocumentsBaseUrl()', () => {
-    it('should call setHomeBreadcrumb with order reference', () => {
-      this.middleware.setArchivedDocumentsBaseUrl({}, this.resMock, this.nextSpy)
-
-      expect(this.resMock.locals).to.have.property('archivedDocumentsBaseUrl')
-      expect(this.resMock.locals.archivedDocumentsBaseUrl).to.equal(archivedDocumentsBaseUrl)
-
-      expect(this.nextSpy).to.have.been.calledOnce
-      expect(this.nextSpy).to.have.been.calledWith()
     })
   })
 })

--- a/test/unit/components/key-value-table.test.js
+++ b/test/unit/components/key-value-table.test.js
@@ -28,20 +28,50 @@ describe('Key/value table component', () => {
   })
 
   it('should render a table with link', () => {
+    const name = '#1 label content'
+    const url = '/label-1'
     const component = renderComponentToDom(
       'key-value-table',
       {
         items: {
           'First label': {
-            name: '#1 label content',
-            url: '/label-1',
+            name,
+            url,
           },
         },
       }
     )
 
-    expect(component.querySelector('td').innerHTML.trim())
-      .to.equal('<a href="/label-1">#1 label content</a>')
+    expect(component.querySelector('td').innerHTML
+      .trim()
+      .replace(/\s+/g, ' '))
+      .to.equal(`<a href="${url}">${name}</a>`)
+  })
+
+  it('should render a table with link containing hint', () => {
+    const hint = 'example hint'
+    const hintId = 'mock-id'
+    const name = '#1 label content'
+    const url = '/label-1'
+
+    const component = renderComponentToDom(
+      'key-value-table',
+      {
+        items: {
+          'First label': {
+            name,
+            url,
+            hint,
+            hintId,
+          },
+        },
+      }
+    )
+
+    expect(component.querySelector('td').innerHTML
+      .trim()
+      .replace(/\s+/g, ' '))
+      .to.equal(`<a aria-labelledby="${hintId}" href="${url}">${name}</a> <span id="${hintId}">${hint}</span>`)
   })
 
   it('should render a table with an object with a name', () => {

--- a/test/unit/data/events/event-data.json
+++ b/test/unit/data/events/event-data.json
@@ -52,5 +52,6 @@
   "address_town": "plymouth",
   "address_county": "devon",
   "address_postcode": "PL1 3FG",
-  "notes": "An example event for testing"
+  "notes": "An example event for testing",
+  "archived_documents_url_path": "/documents/123"
 }

--- a/test/unit/data/interactions/search-interaction.json
+++ b/test/unit/data/interactions/search-interaction.json
@@ -37,5 +37,6 @@
     "id": "bac18331-ca4d-4501-960e-a1bd68b5d47e",
     "name": "Test project"
   },
-  "kind": "interaction"
+  "kind": "interaction",
+  "archived_documents_url_path": "/documents/123"
 }


### PR DESCRIPTION
I have reworked the documents work as it was overly complicated code wise and doing things that our left nav does not currently do.
We also had no way of communicating to a user that the link opens a new website.
Also this gives documents a permanent place in the navigation as before sometimes the `Documents` navigation was there sometimes it wasn't. Which felt incorrect.

This work is based on the work originally from @yeahfro and has associated fixtures in https://github.com/uktrade/data-hub-leeloo/pull/674

This work:
- Makes Documents a page for:
  - companies
  - events
  - interactions
  - contacts
  - investment projects
- Simplifies the approach to `Documents` in the local nav by always having it there
- Adds the ability to add a hint in the key value table
- DRY's up some AT work

It also adds in the text `(will open another website)` which means this link is now telling users what will happen. This matches up with the work from @teneightfive 

It displays a link if the entity has a documents link
![screen shot 2017-11-25 at 10 07 58](https://user-images.githubusercontent.com/2305016/33229542-a3f4836a-d1c8-11e7-9c10-a42a049cac77.png)


Otherwise it displays a message that there are not documents
![screen shot 2017-11-25 at 10 08 28](https://user-images.githubusercontent.com/2305016/33229544-a93377a0-d1c8-11e7-8355-96630e39b932.png)

![documents](https://user-images.githubusercontent.com/2305016/33229604-674bdeee-d1c9-11e7-8f08-6a1d1d7f4377.gif)
