### PR TITLE
Make project badge settable from env vars and add demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This file expects the following environment variables:
 | OAUTH2_REDIRECT_URL | OAuth callback url
 | OAUTH2_DEV_TOKEN | Token used to bypass OAuth for development purposes
 | POSTCODE_KEY | Part of the frontend looks up addresses for postcodes using [getaddress.io](https://getaddress.io/). Obtain a key for the service and set it here |
+| PROJECT_PHASE | Which badge to display in header: 'Alpha', 'Beta' or 'Demo' - defaults to 'Beta' @TODO - remove when Demo site is decommissioned|
 | PROXY | URL of a proxy to use to contact the API through. Useful for debugging |
 | QA_HOST | URL of the app under test |
 | QA_SELENIUM_HOST | URL of the Selenium server |

--- a/config/index.js
+++ b/config/index.js
@@ -42,6 +42,8 @@ const config = {
   zenImpact: process.env.ZEN_IMPACT,
   zenService: process.env.ZEN_SERVICE,
   zenServiceChannel: process.env.ZEN_SERVICE_CHANNEL || 'datahub',
+  // @TODO - remove when demo site is decommissioned
+  projectPhase: process.env.PROJECT_PHASE || 'beta',
   sentryDsn: process.env.SENTRY_DSN,
   currencyFormat: '$0,0.00',
   longDateFormat: 'D MMMM YYYY',

--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -1,10 +1,11 @@
 const nunjucks = require('nunjucks')
 const { assign, omit, isFunction, isArray, map } = require('lodash')
 const queryString = require('query-string')
+const config = require('../../config')
 
 module.exports = {
   serviceTitle: 'Data Hub',
-  projectPhase: 'beta',
+  projectPhase: config.projectPhase,
   description: 'Data Hub is a customer relationship, project management and analytical tool for Department for International Trade.',
   feedbackLink: '/support',
 

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -82,7 +82,7 @@
                     {% endif %}
                   </span>
                 </a>
-                {% if not phaseBanner and projectPhase|lower in ['alpha', 'beta'] %}
+                {% if not phaseBanner and projectPhase|lower in ['alpha', 'beta', 'demo'] %}
                   <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
                 {% endif %}
               </div>
@@ -96,7 +96,7 @@
         <main class="main-content" id="main-content">
           {% block body_main_header %}
             {% block body_main_phase_banner %}
-              {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta'] or feedbackLink) %}
+              {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta', 'demo'] or feedbackLink) %}
                 <div class="phase-banner">
                   <div class="l-container">
                     <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>


### PR DESCRIPTION
So this is in response to a request from Live Services so that users can distinguish between 'demo', which will continue for a few weeks after we push the main system live, and Data Hub production