### PR TITLE
Filter inactive events in interaction creation

### DIFF
--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -1,5 +1,7 @@
 const config = require('../../../config')
 const authorisedRequest = require('../../lib/authorised-request')
+const { search } = require('../search/services')
+const { filterDisabledOption } = require('../filters')
 
 function saveEvent (token, event) {
   const options = {
@@ -28,9 +30,29 @@ function getAllEvents (token) {
   return authorisedRequest(token, `${config.apiRoot}/v3/event?limit=100000&offset=0`)
 }
 
+/**
+ *
+ * @param {string} token Session token to use for API requests
+ * @param {string} currentEventId The id for an event that must be included in the list irrigardless of if is disabled or not (the current value)
+ *
+ * @returns {promise[Array]} Returns an array of event objects that have not been disabled or are the current event
+ */
+async function getActiveEvents (token, currentEventId) {
+  const eventsResponse = await search({
+    searchEntity: 'event',
+    requestBody: { sortby: 'name:asc' },
+    token: token,
+    limit: 100000,
+    isAggregation: false,
+  })
+
+  return eventsResponse.results.filter(filterDisabledOption(currentEventId))
+}
+
 module.exports = {
   saveEvent,
   fetchEvent,
   getEvents,
   getAllEvents,
+  getActiveEvents,
 }

--- a/src/apps/filters.js
+++ b/src/apps/filters.js
@@ -1,10 +1,10 @@
 /**
  *
- * @param {string} currentValue - The current value for a field so that the options filtered include the current
- *                                even if invalid
+ * @param {string} [currentValue] - The current value for a field so that the options filtered include the current
+ *                                  even if invalid
  * @returns {function} - a filter function that will filter out inactive or non-current values
  */
-function filterDisabledOption (currentValue) {
+function filterDisabledOption (currentValue = null) {
   return function (item) {
     return !item.disabled_on || item.id === currentValue
   }

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -27,7 +27,7 @@ function renderEditPage (req, res) {
           advisers: get(res.locals, 'advisers.results'),
           contacts: res.locals.contacts,
           services: res.locals.services,
-          events: get(res.locals, 'events.results'),
+          events: res.locals.events,
           hiddenFields: {
             id: get(res.locals, 'interaction.id'),
             company: res.locals.company.id,

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -1,4 +1,4 @@
-const { assign } = require('lodash')
+const { assign, get } = require('lodash')
 const { sentence } = require('case')
 
 const { transformInteractionFormBodyToApiRequest } = require('../transformers')
@@ -6,7 +6,7 @@ const { fetchInteraction, saveInteraction } = require('../repos')
 const metaDataRepository = require('../../../lib/metadata')
 const { getContactsForCompany } = require('../../contacts/repos')
 const { getAdvisers } = require('../../adviser/repos')
-const { search } = require('../../search/services')
+const { getActiveEvents } = require('../../events/repos')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -52,13 +52,7 @@ async function getInteractionOptions (req, res, next) {
     res.locals.services = await metaDataRepository.getServices(req.session.token)
 
     if (req.params.kind === 'service-delivery') {
-      res.locals.events = await search({
-        searchEntity: 'event',
-        requestBody: { sortby: 'name:asc' },
-        token: req.session.token,
-        limit: 100000,
-        isAggregation: false,
-      })
+      res.locals.events = await getActiveEvents(req.session.token, get(req.params, 'interactionId'))
     }
 
     next()

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -1,13 +1,21 @@
+const nock = require('nock')
+
 const config = require('~/config')
+const { search } = require('~/src/apps/search/services')
+
 const token = 'abcd'
 
 describe('Event repos', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.authorisedRequestStub = this.sandbox.stub().resolves()
+    this.searchSpy = this.sandbox.spy(search)
 
     this.repos = proxyquire('~/src/apps/events/repos', {
       '../../lib/authorised-request': this.authorisedRequestStub,
+      '../search/services': {
+        search: this.searchSpy,
+      },
     })
   })
 
@@ -62,6 +70,80 @@ describe('Event repos', () => {
       this.repos.fetchEvent(token, '123')
       expect(this.authorisedRequestStub)
         .to.be.calledWith(token, `${config.apiRoot}/v3/event/123`)
+    })
+  })
+
+  describe('#getActiveEvents', () => {
+    context('When there is a mix of active and inactive events', () => {
+      beforeEach(() => {
+        this.currentId = '3'
+
+        this.eventCollection = {
+          results: [{
+            id: '1',
+            disabled_on: '2017-01-01',
+          }, {
+            id: '2',
+            disabled_on: null,
+          }, {
+            id: '3',
+            disabled_on: '2017-01-01',
+          }],
+        }
+
+        nock(config.apiRoot)
+          .post('/v3/search/event')
+          .reply(200, this.eventCollection)
+      })
+
+      context('and no current event', () => {
+        beforeEach(async () => {
+          this.events = await this.repos.getActiveEvents('1234')
+        })
+
+        it('should call search to get the events', () => {
+          expect(this.searchSpy).to.be.calledWith({
+            searchEntity: 'event',
+            requestBody: { sortby: 'name:asc' },
+            token: '1234',
+            limit: 100000,
+            isAggregation: false,
+          })
+        })
+
+        it('should return only the active events', () => {
+          expect(this.events).to.deep.eq([{
+            id: '2',
+            disabled_on: null,
+          }])
+        })
+      })
+
+      context('and a current inactive event', () => {
+        beforeEach(async () => {
+          this.events = await this.repos.getActiveEvents('1234', this.currentId)
+        })
+
+        it('should call search to get the events', () => {
+          expect(this.searchSpy).to.be.calledWith({
+            searchEntity: 'event',
+            requestBody: { sortby: 'name:asc' },
+            token: '1234',
+            limit: 100000,
+            isAggregation: false,
+          })
+        })
+
+        it('should return active events and the current inactive one', () => {
+          expect(this.events).to.deep.eq([{
+            id: '2',
+            disabled_on: null,
+          }, {
+            id: '3',
+            disabled_on: '2017-01-01',
+          }])
+        })
+      })
     })
   })
 })

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -23,7 +23,6 @@ describe('Interaction details middleware', () => {
     this.transformInteractionFormBodyToApiRequestStub = this.sandbox.stub()
     this.transformInteractionResponseToViewRecordStub = this.sandbox.stub()
     this.getContactsForCompanyStub = this.sandbox.stub()
-    this.getAllEventsStub = this.sandbox.stub()
     this.middleware = proxyquire('~/src/apps/interactions/middleware/details', {
       '../repos': {
         saveInteraction: this.saveInteractionStub.resolves({ id: '1' }),
@@ -42,8 +41,8 @@ describe('Interaction details middleware', () => {
       '../../contacts/repos': {
         getContactsForCompany: this.getContactsForCompanyStub.returns(contactsData),
       },
-      '../../search/services': {
-        search: this.getAllEventsStub.returns(eventsData),
+      '../../events/repos': {
+        getActiveEvents: this.sandbox.stub().resolves(eventsData.results),
       },
     })
     this.req = {
@@ -221,7 +220,7 @@ describe('Interaction details middleware', () => {
       })
 
       it('should set events data on locals', async () => {
-        expect(this.res.locals.events).to.deep.equal(eventsData)
+        expect(this.res.locals.events).to.deep.equal(eventsData.results)
       })
     })
   })

--- a/test/unit/data/events/collection.json
+++ b/test/unit/data/events/collection.json
@@ -55,7 +55,8 @@
       "address_town": "plymouth",
       "address_county": "",
       "address_postcode": "PL1 4FG",
-      "notes": "mock example event"
+      "notes": "mock example event",
+      "disabled_on": null
     },
     {
       "id": "2f4cbd6e-9cc7-4b03-93fe-80a4d8cea4af",
@@ -103,7 +104,8 @@
       "address_county": "",
       "address_postcode": "",
       "uk_region": null,
-      "notes": "This is going to be an amazing event"
+      "notes": "This is going to be an amazing event",
+      "disabled_on": null
     },
     {
       "id": "4aa90860-ddb8-4cc0-8d5f-e0c26567abe4",
@@ -156,7 +158,8 @@
       "address_county": "country",
       "address_postcode": "",
       "uk_region": null,
-      "notes": "notes"
+      "notes": "notes",
+      "disabled_on": "2017-09-19"
     }
   ]
 }


### PR DESCRIPTION
When creating an interaction there is a drop-down to select the event associated. In production this list is 40,000 records long, whilst there are only 2,000 active events. Users are reporting that the full list is not shown in the browser.

Step 1 in making the users' life a bit easier is to filter the list of events in that dropdown so that it is only 2,000 active events instead of the full 40,000 are included.

I moved the code that got that events into the events repo and use a previously created filter to filter out the disabled entries.

Like a previous dropdown this also allows the dev to pass a current value in so if an existing record is associated with a disabled event, that is still on the options list.