### PR TITLE
add messages to be shown before moving to the next stage

### DIFF
--- a/src/apps/investment-projects/helpers.js
+++ b/src/apps/investment-projects/helpers.js
@@ -36,7 +36,7 @@ const formFields = {
 const linkDetails = {
   requirements: {
     url: 'edit-requirements',
-    text: 'Requirements and location',
+    text: 'Requirements and location form',
   },
   value: {
     url: 'edit-value',
@@ -44,12 +44,25 @@ const linkDetails = {
   },
   projectManagement: {
     url: 'edit-project-management',
-    text: 'Assign project management',
+    text: 'Assign project management form',
   },
   associatedNonFdiRandDProject: {
     url: 'edit-associated',
-    text: 'Associated project Non-FDI R&D project',
+    text: 'Associated project Non-FDI R&D project form',
   },
+}
+
+const toCompleteStageMessages = {
+  prospect: [
+    {
+      text: 'Contact the "Trade and Investment Analysis and Performance team"',
+    },
+  ],
+  active: [
+    {
+      html: 'Upload evidence documents on the <a href="https://ukticonnect.sharepoint.com/int-ti/Value/FDI-teamsite/Pages/default.aspx" aria-labelledby="external-link-label">Evidence teamsite</a> <span id="external-link-label">(will open another website)</span>',
+    },
+  ],
 }
 
 function buildFormLinks (forms, links) {
@@ -78,4 +91,5 @@ function buildIncompleteFormList (incompleteFields = [], formContents = formFiel
 
 module.exports = {
   buildIncompleteFormList,
+  toCompleteStageMessages,
 }

--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -1,7 +1,7 @@
-const { get, upperFirst } = require('lodash')
+const { get, upperFirst, lowerCase } = require('lodash')
 
 const metadata = require('../../../lib/metadata')
-const { buildIncompleteFormList } = require('../helpers')
+const { buildIncompleteFormList, toCompleteStageMessages } = require('../helpers')
 const { isValidGuid } = require('../../../lib/controller-utils')
 const { getDitCompany } = require('../../companies/repos')
 const { getAdviser } = require('../../adviser/repos')
@@ -35,6 +35,7 @@ async function getInvestmentDetails (req, res, next) {
     const investorCompany = await getDitCompany(req.session.token, get(investmentData, 'investor_company.id'))
     const ukCompanyId = get(investmentData, 'uk_company.id')
     const clientRelationshipManagerId = get(investmentData, 'client_relationship_manager.id')
+    const stageName = investmentData.stage.name
 
     investmentData.investor_company = Object.assign({}, investmentData.investor_company, investorCompany)
 
@@ -75,11 +76,12 @@ async function getInvestmentDetails (req, res, next) {
         url: `/companies/${get(investmentData, 'investor_company.id')}`,
       },
       currentStage: {
-        name: investmentData.stage.name,
+        name: stageName,
         isComplete: investmentData.team_complete && investmentData.requirements_complete && investmentData.value_complete,
         incompleteFields: buildIncompleteFormList(get(investmentData, 'incomplete_fields', [])),
+        messages: get(toCompleteStageMessages, lowerCase(stageName), []),
       },
-      nextStage: getNextStage(investmentData.stage.name, investmentProjectStages),
+      nextStage: getNextStage(stageName, investmentProjectStages),
     }
 
     res.breadcrumb({

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -45,13 +45,28 @@
         }
       }) %}
           {% if investmentStatus.currentStage.isComplete %}
-            <p>You have added all required information to complete this stage.</p>
+            {% if investmentStatus.currentStage.messages %}
+              <p>Before you move to the {{ investmentStatus.nextStage.name }} stage:</p>
+              <ul class="list-disc">
+                {% for message in investmentStatus.currentStage.messages  %}
+                  <li>
+                    {% if message.html %}
+                      {{ message.html | safe }}
+                    {% else %}
+                      {{ message.text }}
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p>You have added all required information to complete this stage.</p>
+            {% endif %}
           {% else %}
             <p>To move to the {{ investmentStatus.nextStage.name }} stage complete the following:</p>
             <ul class="list-disc">
               {% for form in investmentStatus.currentStage.incompleteFields  %}
                 <li>
-                  <a href="{{ form.url }}">{{ form.text }} form</a>
+                    <a href="{{ form.url }}">{{ form.text }}</a>
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
This is the second part of the messages for moving between stages on Investment Projects:

It adds a message after you have completed the required steps on a stage and before you move to the next stage. Currently there is messages for 
- `prospect` > `assign PM`
- `active` > `verify win`

## Of note
I don't think these message work particularly well and have cut them down quite a bit from copy. We also could do with linking to somewhere for the `The Trade and Investment Analysis and Performance team` but I don't have an email of web url for them.

## Prospect > Assign PM
![stage](https://user-images.githubusercontent.com/2305016/33231456-ac98e338-d1ed-11e7-854a-966112d1b68a.gif)


![screen shot 2017-11-25 at 14 22 33](https://user-images.githubusercontent.com/2305016/33231478-efab86ee-d1ed-11e7-9f1a-011c1325abc7.png)


## Active > Verify win
![screen shot 2017-11-25 at 14 24 12](https://user-images.githubusercontent.com/2305016/33231466-c663a9d8-d1ed-11e7-8ee0-68ca8e2a7590.png)

