### PR TITLE
change to default parrallel spliter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           name: Split tests for parallelisation and then run acceptance tests
           command: |
             # split .features for parallelisation
-            FEATURES="$(circleci tests glob "test/acceptance/features/**/*.feature" | circleci tests split --split-by=filesize)"
+            FEATURES="$(circleci tests glob "test/acceptance/features/**/*.feature" | circleci tests split)"
 
             # move groups of .features to folder
             mkdir -p ~/data-hub-frontend/test/acceptance/features_${CIRCLE_NODE_INDEX}


### PR DESCRIPTION
I have noticed that box `0` never has any tests. This PR changes to the default splitter by name to see if tests are split over all boxes