### PR TITLE
Feature/redirect back to details form

### DIFF
--- a/src/apps/investment-projects/controllers/team/edit-project-management.js
+++ b/src/apps/investment-projects/controllers/team/edit-project-management.js
@@ -19,7 +19,7 @@ function postHandler (req, res, next) {
     return next()
   }
   req.flash('success', 'Investment details updated')
-  return res.redirect(`/investment-projects/${res.locals.investmentData.id}/team`)
+  return next()
 }
 
 module.exports = {

--- a/src/apps/investment-projects/controllers/team/edit-project-management.js
+++ b/src/apps/investment-projects/controllers/team/edit-project-management.js
@@ -1,4 +1,4 @@
-const { isEmpty } = require('lodash')
+const { get, isEmpty } = require('lodash')
 
 const { briefInvestmentSummaryLabels } = require('../../labels')
 const { getDataLabels } = require('../../../../lib/controller-utils')
@@ -15,10 +15,16 @@ function getHandler (req, res, next) {
 }
 
 function postHandler (req, res, next) {
-  if (!isEmpty(res.locals.form.errors)) {
+  const returnUrl = get(req.body, 'returnUrl')
+
+  if (!isEmpty(get(res.locals, 'form.errors'))) {
     return next()
   }
+
   req.flash('success', 'Investment details updated')
+  if (returnUrl) {
+    return res.redirect(returnUrl)
+  }
   return next()
 }
 

--- a/src/apps/investment-projects/controllers/team/edit-project-management.js
+++ b/src/apps/investment-projects/controllers/team/edit-project-management.js
@@ -25,7 +25,7 @@ function postHandler (req, res, next) {
   if (returnUrl) {
     return res.redirect(returnUrl)
   }
-  return next()
+  return res.redirect(`/investment-projects/${res.locals.investmentData.id}/team`)
 }
 
 module.exports = {

--- a/src/apps/investment-projects/middleware/forms/project-management.js
+++ b/src/apps/investment-projects/middleware/forms/project-management.js
@@ -22,6 +22,9 @@ async function populateForm (req, res, next) {
       },
       buttonText: 'Save',
       returnLink: `/investment-projects/${investmentData.id}/team`,
+      hiddenFields: {
+        returnUrl: get(req.query, 'returnUrl'),
+      },
     })
 
     next()

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -150,8 +150,7 @@ router
     getBriefInvestmentSummary,
     projectManagementFormMiddleware.populateForm,
     projectManagementFormMiddleware.handleFormPost,
-    team.editProjectManagement.postHandler,
-    team.details.getDetailsHandler
+    team.editProjectManagement.postHandler
   )
 
 router

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -150,7 +150,8 @@ router
     getBriefInvestmentSummary,
     projectManagementFormMiddleware.populateForm,
     projectManagementFormMiddleware.handleFormPost,
-    team.editProjectManagement.postHandler
+    team.editProjectManagement.postHandler,
+    team.editProjectManagement.getHandler
   )
 
 router

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -151,7 +151,7 @@ router
     projectManagementFormMiddleware.populateForm,
     projectManagementFormMiddleware.handleFormPost,
     team.editProjectManagement.postHandler,
-    team.editProjectManagement.getHandler
+    team.details.getDetailsHandler
   )
 
 router

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -66,7 +66,7 @@
             <ul class="list-disc">
               {% for form in investmentStatus.currentStage.incompleteFields  %}
                 <li>
-                    <a href="{{ form.url }}">{{ form.text }}</a>
+                    <a href="{{ form.url }}?returnUrl={{ CANONICAL_URL }}">{{ form.text }}</a>
                 </li>
               {% endfor %}
             </ul>

--- a/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
@@ -1,3 +1,4 @@
+const { assign } = require('lodash')
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
 const { briefInvestmentSummaryLabels } = require('~/src/apps/investment-projects/labels')
 
@@ -8,6 +9,17 @@ describe('Investment project, project management team, edit controller', () => {
     this.flashStub = this.sandbox.stub()
     this.getDataLabelsStub = this.sandbox.stub()
     this.breadcrumbStub = function () { return this }
+    this.reqMock = assign({}, globalReq, {
+      session: {
+        token: '1234',
+      },
+      flash: this.flashStub,
+    })
+    this.resMock = assign({}, globalRes, {
+      redirect: this.sandbox.spy(),
+      render: this.sandbox.spy(),
+      breadcrumb: this.breadcrumbStub,
+    })
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/team/edit-project-management', {
       '../../../../lib/controller-utils': {
@@ -21,84 +33,75 @@ describe('Investment project, project management team, edit controller', () => {
   })
 
   describe('#getHandler', () => {
-    it('should render edit project management view', (done) => {
-      this.controller.getHandler({
-        session: {
-          token: 'abcd',
-        },
-      }, {
+    it('should render edit project management view', async () => {
+      await this.controller.getHandler(this.reqMock, assign({}, this.resMock, {
         locals: {
           investmentData,
         },
-        breadcrumb: this.breadcrumbStub,
-        render: (template) => {
-          try {
-            expect(template).to.equal('investment-projects/views/team/edit-project-management')
-            done()
-          } catch (e) {
-            done(e)
-          }
-        },
-      }, this.nextStub)
+      }), this.nextStub)
+
+      expect(this.resMock.render).to.have.been.calledWith('investment-projects/views/team/edit-project-management')
     })
 
-    it('should get formatted data for summary view', (done) => {
-      const briefInvestmentSummaryData = {
-        id: 1,
-      }
+    it('should get formatted data for summary view', async () => {
+      const briefInvestmentSummaryData = { id: 1 }
 
-      this.controller.getHandler({
-        session: {
-          token: 'abcd',
-        },
-      }, {
+      await this.controller.getHandler(this.reqMock, assign({}, this.resMock, {
         locals: {
           investmentData,
           briefInvestmentSummaryData,
         },
-        breadcrumb: this.breadcrumbStub,
-        render: (template) => {
-          try {
-            expect(this.getDataLabelsStub).to.be.calledWith(briefInvestmentSummaryData, briefInvestmentSummaryLabels.view)
-            done()
-          } catch (e) {
-            done(e)
-          }
-        },
-      }, this.nextStub)
+      }), this.nextStub)
+
+      expect(this.getDataLabelsStub).to.be.calledWith(briefInvestmentSummaryData, briefInvestmentSummaryLabels.view)
     })
   })
 
   describe('#postHandler', () => {
-    describe('without errors', () => {
-      it('should redirect to the product team details page', async () => {
-        await this.controller.postHandler({
-          session: {
-            token: 'abcd',
-          },
-          flash: this.flashStub,
-        }, {
+    context('without errors', () => {
+      it('should redirect to the project details page', async () => {
+        await this.controller.postHandler(this.reqMock, assign({}, this.resMock, {
           locals: {
             form: {
               errors: {},
             },
             investmentData,
           },
-          breadcrumb: this.breadcrumbStub,
-        }, this.nextStub)
+        }), this.nextStub)
 
+        expect(this.resMock.redirect).to.not.be.called
         expect(this.flashStub).to.calledWith('success', 'Investment details updated')
         expect(this.nextStub).to.be.calledOnce
       })
     })
 
-    describe('when form errors exist', () => {
-      it('should pass the error onto the edit form', () => {
-        this.controller.postHandler({
-          session: {
-            token: 'abcd',
+    context('without errors and returnUrl query', () => {
+      it('should redirect to the returnUrl page', async () => {
+        const mockReturnUrl = 'mock-url'
+
+        await this.controller.postHandler(assign({}, this.reqMock, {
+          body: {
+            returnUrl: mockReturnUrl,
           },
-        }, {
+        }),
+        assign({}, this.resMock, {
+          locals: {
+            form: {
+              errors: {},
+            },
+            investmentData,
+          },
+        }), this.nextStub)
+
+        expect(this.flashStub).to.calledWith('success', 'Investment details updated')
+        expect(this.resMock.redirect).to.be.calledWith(mockReturnUrl)
+        expect(this.nextStub).to.not.be.called
+      })
+    })
+
+    context('when form errors exist', () => {
+      it('should pass the error onto the edit form', () => {
+        this.controller.postHandler(this.reqMock, assign({}, this.resMock, {
           locals: {
             form: {
               errors: {
@@ -106,8 +109,7 @@ describe('Investment project, project management team, edit controller', () => {
               },
             },
           },
-          breadcrumb: this.breadcrumbStub,
-        }, this.nextStub)
+        }), this.nextStub)
 
         expect(this.nextStub).to.be.calledOnce
       })

--- a/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
@@ -69,9 +69,8 @@ describe('Investment project, project management team, edit controller', () => {
           },
         }), this.nextStub)
 
-        expect(this.resMock.redirect).to.not.be.called
+        expect(this.resMock.redirect).to.be.calledWith(`/investment-projects/${investmentData.id}/team`)
         expect(this.flashStub).to.calledWith('success', 'Investment details updated')
-        expect(this.nextStub).to.be.calledOnce
       })
     })
 
@@ -95,7 +94,6 @@ describe('Investment project, project management team, edit controller', () => {
 
         expect(this.flashStub).to.calledWith('success', 'Investment details updated')
         expect(this.resMock.redirect).to.be.calledWith(mockReturnUrl)
-        expect(this.nextStub).to.not.be.called
       })
     })
 

--- a/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
@@ -71,8 +71,8 @@ describe('Investment project, project management team, edit controller', () => {
 
   describe('#postHandler', () => {
     describe('without errors', () => {
-      it('should redirect to the product team details page', (done) => {
-        this.controller.postHandler({
+      it('should redirect to the product team details page', async () => {
+        await this.controller.postHandler({
           session: {
             token: 'abcd',
           },
@@ -85,16 +85,10 @@ describe('Investment project, project management team, edit controller', () => {
             investmentData,
           },
           breadcrumb: this.breadcrumbStub,
-          redirect: (url) => {
-            try {
-              expect(url).to.equal(`/investment-projects/${investmentData.id}/team`)
-              expect(this.flashStub).to.calledWith('success', 'Investment details updated')
-              done()
-            } catch (e) {
-              done(e)
-            }
-          },
         }, this.nextStub)
+
+        expect(this.flashStub).to.calledWith('success', 'Investment details updated')
+        expect(this.nextStub).to.be.calledOnce
       })
     })
 


### PR DESCRIPTION
When users click through to nested forms and post results they are not returned to the details page. This work enables the redirection of a form to a url specified in the `returnToUrl` query param.
Currently this is just for the `edit-project-management` form but I can see it being useful elsewhere.

![redirect](https://user-images.githubusercontent.com/2305016/33239644-13c6bb42-d29e-11e7-8ad9-c08d8e3367a6.gif)
