### PR TITLE
Remove disabled advisers from event organiser field.

### DIFF
--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -1,4 +1,4 @@
-const { assign } = require('lodash')
+const { get } = require('lodash')
 const config = require('../../../config')
 const logger = require('../../../config/logger')
 const authorisedRequest = require('../../lib/authorised-request')
@@ -9,9 +9,14 @@ const authorisedRequest = require('../../lib/authorised-request')
 // the back end to make this not necessary.
 function getAdvisers (token) {
   return authorisedRequest(token, `${config.apiRoot}/adviser/?limit=100000&offset=0`)
-    .then(data => assign({}, data, {
-      results: data.results.filter(adviser => Boolean(adviser.first_name || adviser.last_name)),
-    }))
+    .then(response => {
+      const results = response.results.filter(adviser => get(adviser, 'name', '').trim().length)
+
+      return {
+        results,
+        count: results.length,
+      }
+    })
 }
 
 function getAdviser (token, id) {

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -3,30 +3,42 @@ const { eventFormConfig } = require('../macros')
 const { transformEventResponseToFormBody } = require('../transformers')
 const { buildFormWithStateAndErrors } = require('../../builders')
 const { assign, merge, get, pickBy } = require('lodash')
+const { getAdvisers } = require('../../adviser/repos')
+const { filterDisabledOption } = require('../../filters')
 
-function renderEditPage (req, res) {
-  const eventData = transformEventResponseToFormBody(res.locals.event)
-  const advisers = get(res.locals, 'advisers.results')
-  const eventId = get(eventData, 'id', '')
-  const eventName = get(eventData, 'name')
-  const lead_team = eventData.lead_team || get(req, 'session.user.dit_team.id')
-  const mergedData = pickBy(merge({}, eventData, { lead_team }, res.locals.requestBody))
-  const eventForm =
-    buildFormWithStateAndErrors(
-      eventFormConfig({ eventId, advisers }),
-      mergedData,
-      get(res.locals, 'form.errors.messages'),
-    )
+async function getActiveAdvisers (token, currentAdviser) {
+  const allAdvisers = await getAdvisers(token)
+  return allAdvisers.results.filter(filterDisabledOption(currentAdviser))
+}
 
-  res
-    .breadcrumb(eventName, `/events/${eventId}`)
-    .breadcrumb(`${eventId ? 'Edit' : 'Add'} event`)
-    .render('events/views/edit', {
-      eventForm: assign(eventForm, {
-        returnLink: `/events/${eventId}`,
-        returnText: 'Cancel',
-      }),
-    })
+async function renderEditPage (req, res, next) {
+  try {
+    const eventData = transformEventResponseToFormBody(res.locals.event)
+    const advisers = await getActiveAdvisers(req.session.token, get(eventData, 'organiser.id'))
+    const eventId = get(eventData, 'id', '')
+    const eventName = get(eventData, 'name')
+    const lead_team = eventData.lead_team || get(req, 'session.user.dit_team.id')
+    const mergedData = pickBy(merge({}, eventData, { lead_team }, res.locals.requestBody))
+
+    const eventForm =
+      buildFormWithStateAndErrors(
+        eventFormConfig({ eventId, advisers }),
+        mergedData,
+        get(res.locals, 'form.errors.messages'),
+      )
+
+    res
+      .breadcrumb(eventName, `/events/${eventId}`)
+      .breadcrumb(`${eventId ? 'Edit' : 'Add'} event`)
+      .render('events/views/edit', {
+        eventForm: assign(eventForm, {
+          returnLink: `/events/${eventId}`,
+          returnText: 'Cancel',
+        }),
+      })
+  } catch (error) {
+    next(error)
+  }
 }
 
 module.exports = {

--- a/src/apps/events/controllers/list.js
+++ b/src/apps/events/controllers/list.js
@@ -1,32 +1,38 @@
 const { get, omit, merge, assign } = require('lodash')
 const { eventFiltersFields, eventSortForm } = require('../macros')
 const { buildSelectedFiltersSummary } = require('../../builders')
+const { getAdvisers } = require('../../adviser/repos')
 
-function renderEventList (req, res) {
-  const advisers = get(res.locals, 'advisers.results')
-  const sortForm = merge({}, eventSortForm, {
-    hiddenFields: assign({}, omit(req.query, 'sortby')),
-    children: [
-      { value: req.query.sortby },
-    ],
-  })
-  const filtersFields = eventFiltersFields({ advisers })
-  const selectedFilters = buildSelectedFiltersSummary(filtersFields, req.query)
-  const isUKSelected = get(selectedFilters, 'address_country.valueLabel') === 'United Kingdom'
+async function renderEventList (req, res, next) {
+  try {
+    const advisers = await getAdvisers(req.session.token)
+    const filtersFields = eventFiltersFields({ advisers: advisers.results })
+    const selectedFilters = buildSelectedFiltersSummary(filtersFields, req.query)
+    const isUKSelected = get(selectedFilters, 'address_country.valueLabel') === 'United Kingdom'
 
-  const visibleFiltersFields = filtersFields.filter(field => {
-    if (field.name === 'uk_region') {
-      return isUKSelected
-    }
-    return true
-  })
+    const sortForm = merge({}, eventSortForm, {
+      hiddenFields: assign({}, omit(req.query, 'sortby')),
+      children: [
+        { value: req.query.sortby },
+      ],
+    })
 
-  res.render('events/views/list', {
-    title: 'Events',
-    sortForm,
-    filtersFields: visibleFiltersFields,
-    selectedFilters,
-  })
+    const visibleFiltersFields = filtersFields.filter(field => {
+      if (field.name === 'uk_region') {
+        return isUKSelected
+      }
+      return true
+    })
+
+    res.render('events/views/list', {
+      sortForm,
+      title: 'Events',
+      filtersFields: visibleFiltersFields,
+      selectedFilters,
+    })
+  } catch (error) {
+    next(error)
+  }
 }
 
 module.exports = {

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -2,7 +2,6 @@ const { assign } = require('lodash')
 
 const { transformEventResponseToViewRecord, transformEventFormBodyToApiRequest } = require('../transformers')
 const { fetchEvent, saveEvent } = require('../repos')
-const { getAdvisers } = require('../../adviser/repos')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformEventFormBodyToApiRequest(req.body)
@@ -42,17 +41,7 @@ async function getEventDetails (req, res, next, eventId) {
   }
 }
 
-async function getAdviserDetails (req, res, next) {
-  try {
-    res.locals.advisers = await getAdvisers(req.session.token)
-    next()
-  } catch (err) {
-    next(err)
-  }
-}
-
 module.exports = {
   getEventDetails,
-  getAdviserDetails,
   postDetails,
 }

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -3,7 +3,7 @@ const router = require('express').Router()
 const { setDefaultQuery } = require('../middleware')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderEditPage } = require('./controllers/edit')
-const { postDetails, getEventDetails, getAdviserDetails } = require('./middleware/details')
+const { postDetails, getEventDetails } = require('./middleware/details')
 const { getRequestBody, getEventsCollection } = require('./middleware/collection')
 const { renderEventList } = require('./controllers/list')
 
@@ -15,14 +15,12 @@ router.param('id', getEventDetails)
 
 router.get('/',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
-  getAdviserDetails,
   getRequestBody,
   getEventsCollection,
   renderEventList,
 )
 
 router.route(['/create', '/:id/edit'])
-  .all(getAdviserDetails)
   .post(postDetails, renderEditPage)
   .get(renderEditPage)
 

--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -12,20 +12,34 @@ describe('Adviser repository', () => {
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, badAdviserData)
       })
+
       it('will be filtered out', async () => {
+        const expected = {
+          count: 4,
+          results: [
+            badAdviserData.results[1],
+            badAdviserData.results[2],
+            badAdviserData.results[3],
+            badAdviserData.results[4],
+          ],
+        }
+
         const actual = await repos.getAdvisers(123)
-        expect(actual.results.length).to.equal(4)
+
+        expect(actual).to.deep.equal(expected)
       })
     })
+
     context('when all advisers have names', () => {
       beforeEach(() => {
         nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, adviserData)
       })
+
       it('will not filter out any advisers', async () => {
         const actual = await repos.getAdvisers(123)
-        expect(actual.results.length).to.equal(5)
+        expect(actual).to.deep.equal(adviserData)
       })
     })
   })

--- a/test/unit/apps/events/controllers/list.test.js
+++ b/test/unit/apps/events/controllers/list.test.js
@@ -1,3 +1,6 @@
+const nock = require('nock')
+
+const config = require('~/config')
 const advisersData = require('../../../data/advisers/advisers')
 
 const standardMacros = [
@@ -46,6 +49,24 @@ describe('Event list controller', () => {
         eventFiltersFields: this.eventFiltersFieldsStub,
       },
     })
+
+    const advisers = [{
+      id: '1',
+      name: 'Fred Flintstone',
+      disabled_on: '2017-01-01',
+    }, {
+      id: '2',
+      name: 'Wilma Flintstone',
+      disabled_on: '2017-01-01',
+    }, {
+      id: '3',
+      name: 'Barney Rubble',
+      disabled_on: null,
+    }]
+
+    nock(config.apiRoot)
+      .get(`/adviser/?limit=100000&offset=0`)
+      .reply(200, { results: advisers })
   })
 
   afterEach(() => {
@@ -53,12 +74,12 @@ describe('Event list controller', () => {
   })
 
   describe('#renderEventList', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       this.eventFiltersFieldsStub.returns(standardMacros)
+      await this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
     })
 
     it('should render collection page as expected', () => {
-      this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('title'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('filtersFields'))
@@ -71,9 +92,9 @@ describe('Event list controller', () => {
       this.eventFiltersFieldsStub.returns(countryAndUkRegionMacros)
     })
 
-    it('should render collection without region if non-UK country is selected', () => {
+    it('should render collection without region if non-UK country is selected', async () => {
       this.reqMock.query = { address_country: 'non-uk' }
-      this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
+      await this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
 
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('title'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
@@ -87,9 +108,9 @@ describe('Event list controller', () => {
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
     })
 
-    it('should render collection with region if UK is selected', () => {
+    it('should render collection with region if UK is selected', async () => {
       this.reqMock.query = { address_country: 'uk' }
-      this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
+      await this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
 
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('title'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -258,15 +258,5 @@ describe('Event details middleware', () => {
         expect(this.res.locals.eventViewRecord).to.have.property('data', 'transformed')
       })
     })
-
-    describe('#getAdviserDetails', () => {
-      context('when success', () => {
-        it('should set event data on locals', async () => {
-          await this.middleware.getAdviserDetails(this.req, this.res, this.nextSpy)
-
-          expect(this.res.locals.advisers).to.deep.equal(advisersData)
-        })
-      })
-    })
   })
 })

--- a/test/unit/data/advisers/advisers-with-bad-data.json
+++ b/test/unit/data/advisers/advisers-with-bad-data.json
@@ -1,5 +1,5 @@
 {
-  "count": 6,
+  "count": 5,
   "results": [
     {
       "id": "a0dae366-1134-e411-985c-e4115bead28b",


### PR DESCRIPTION
Made some improvement to the adviser repo and tests

Refactored the event sub app to get all advisers for filter forms and filter out disabled advisers in the organiser field in the edit/create form.