### PR TITLE
Use correct status content for listing badges

### DIFF
--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
-const { get } = require('lodash')
-const Case = require('case')
+const { find, get } = require('lodash')
+
+const { ORDER_STATES } = require('./constants')
 
 function transformOrderToListItem ({
   id,
@@ -15,6 +16,8 @@ function transformOrderToListItem ({
 } = {}) {
   if (!id || !reference) { return }
 
+  const orderState = find(ORDER_STATES, { value: status })
+
   const item = {
     id,
     type: 'order',
@@ -24,7 +27,7 @@ function transformOrderToListItem ({
       {
         label: 'Status',
         type: 'badge',
-        value: Case.sentence(status),
+        value: get(orderState, 'label'),
       },
       {
         label: 'Market',

--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -69,7 +69,6 @@ function transformOrderToListItem ({
 function transformOrderToTableItem ({
   id,
   reference,
-  status,
   payment_due_date,
   company,
   subtotal_cost,
@@ -80,7 +79,6 @@ function transformOrderToTableItem ({
   return {
     id,
     reference,
-    status,
     payment_due_date,
     company: get(company, 'name'),
     subtotal_cost: parseInt(subtotal_cost) / 100,

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -114,7 +114,6 @@ describe('OMIS list transformers', function () {
 
         expect(actual).to.have.property('id').a('string')
         expect(actual).to.have.property('reference').a('string')
-        expect(actual).to.have.property('status').a('string')
         expect(actual).to.have.property('subtotal_cost').a('number')
         expect(actual).to.have.property('total_cost').a('number')
         expect(actual).to.have.property('company').a('string')


### PR DESCRIPTION
When using the new content for OMIS order statuses the listing badge
wasn't updated.

This change updates the status badge to match the filters.