### PR TITLE
Add logging when getting a random radio option

### DIFF
--- a/test/acceptance/commands/getRadioOption.js
+++ b/test/acceptance/commands/getRadioOption.js
@@ -4,14 +4,20 @@
  * @param callback
  */
 exports.command = function getRadioOption (name, callback) {
-  return this.elements('css selector', `input[name="${name}"] + label span`, (result) => {
-    const random = Math.floor(Math.random() * (result.value.length - 1))
+  const selector = `input[name="${name}"] + label span`
 
-    this.elementIdAttribute(result.value[random].ELEMENT, 'textContent', function (textContent) {
-      if (typeof callback === 'function') {
-        const id = `field-${name}-${random + 1}`
-        callback.call(this, { labelSelector: `label[for=${id}]`, text: textContent.value.trim() })
-      }
-    })
+  return this.elements('css selector', selector, (result) => {
+    if (result.value.length) {
+      const random = Math.floor(Math.random() * (result.value.length - 1))
+
+      this.elementIdAttribute(result.value[random].ELEMENT, 'textContent', function (textContent) {
+        if (typeof callback === 'function') {
+          const id = `field-${name}-${random + 1}`
+          callback.call(this, { labelSelector: `label[for=${id}]`, text: textContent.value.trim() })
+        }
+      })
+    } else {
+      this.log(`check the contents of the selector: ${selector}`)
+    }
   })
 }


### PR DESCRIPTION
To be consistent with other acceptance test commands, this change will add logging just in case a radio button list has not loaded correctly.