### PR TITLE
Content updates to VAT status

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -166,7 +166,7 @@ const editFields = merge({}, globalFields, {
       value: 'eu',
     },
     dependent: {
-      name: 'vat_status',
+      field: 'vat_status',
       value: 'eu',
     },
   },

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -64,7 +64,7 @@
       "label": "VAT number"
     },
     "vat_verified": {
-      "label": "Has a valid VAT number valid been supplied?",
+      "label": "Has a valid VAT number been supplied?",
       "options": {
         "unverified": "Not verified",
         "valid": "Valid",

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -118,8 +118,8 @@
     }
   },
   "validation": {
-    "required": "cannot not be blank",
-    "arrayRequired": "cannot not be blank",
+    "required": "cannot be blank",
+    "arrayRequired": "cannot be blank",
     "numeric": "can only contain numbers",
     "date": "must be a valid date",
     "after": "must be in the future",


### PR DESCRIPTION
This fixes a few small issues with content and validation on the VAT status of an OMIS order.

Fixes use of double words in some content areas and ensures conditional validation is occurring correctly for subfields.