### PR TITLE
Hide disabled advisers for interaction advisers drop-down

### DIFF
--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -24,7 +24,7 @@ function renderEditPage (req, res) {
       formConfigs[req.params.kind](
         {
           returnLink: res.locals.returnLink,
-          advisers: get(res.locals, 'advisers.results'),
+          advisers: res.locals.advisers,
           contacts: res.locals.contacts,
           services: res.locals.services,
           events: res.locals.events,

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -8,6 +8,12 @@ const { getContactsForCompany, getContact } = require('../../contacts/repos')
 const { getAdvisers } = require('../../adviser/repos')
 const { getActiveEvents } = require('../../events/repos')
 const { getDitCompany } = require('../../companies/repos')
+const { filterDisabledOption } = require('../../filters')
+
+async function getActiveAdvisers (token, currentAdviser) {
+  const allAdvisers = await getAdvisers(token)
+  return allAdvisers.results.filter(filterDisabledOption(currentAdviser))
+}
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -65,7 +71,7 @@ async function getInteractionDetails (req, res, next, interactionId) {
 
 async function getInteractionOptions (req, res, next) {
   try {
-    res.locals.advisers = await getAdvisers(req.session.token)
+    res.locals.advisers = await getActiveAdvisers(req.session.token, get(res.locals, 'interaction.dit_adviser.id'))
     res.locals.contacts = await getContactsForCompany(req.session.token, res.locals.company.id)
     res.locals.services = await metaDataRepository.getServices(req.session.token)
 

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -1,4 +1,3 @@
-const advisersData = require('../../../data/advisers/advisers')
 const interactionData = require('../../../data/interactions/new-interaction.json')
 const servicesData = [
   { id: '9484b82b-3499-e211-a939-e4115bead28a', name: 'Account Management' },
@@ -25,6 +24,23 @@ describe('Interaction details middleware', () => {
     this.getContactsForCompanyStub = this.sandbox.stub()
     this.getContactStub = this.sandbox.stub()
     this.getDitCompanyStub = this.sandbox.stub()
+
+    const advisersData = {
+      count: 3,
+      results: [{
+        id: '1',
+        name: 'Fred Flintstone',
+        disabled_on: '2017-01-01',
+      }, {
+        id: '2',
+        name: 'Wilma Flintstone',
+        disabled_on: '2017-01-01',
+      }, {
+        id: '3',
+        name: 'Barney Rubble',
+        disabled_on: null,
+      }],
+    }
 
     this.middleware = proxyquire('~/src/apps/interactions/middleware/details', {
       '../repos': {
@@ -222,6 +238,14 @@ describe('Interaction details middleware', () => {
   })
 
   describe('#getInteractionOptions', () => {
+    beforeEach(() => {
+      this.res.locals.interaction = assign({}, interactionData, {
+        dit_adviser: {
+          id: '2',
+        },
+      })
+    })
+
     context('when interaction', () => {
       beforeEach(async () => {
         await this.middleware.getInteractionOptions(this.req, this.res, this.nextSpy)
@@ -231,8 +255,18 @@ describe('Interaction details middleware', () => {
         expect(this.res.locals.contacts).to.deep.equal(contactsData)
       })
 
-      it('should set advisers on locals', () => {
-        expect(this.res.locals.advisers).to.deep.equal(advisersData)
+      it('should set adviser to only active and current advisers', () => {
+        const expectedAdvisers = [{
+          id: '2',
+          name: 'Wilma Flintstone',
+          disabled_on: '2017-01-01',
+        }, {
+          id: '3',
+          name: 'Barney Rubble',
+          disabled_on: null,
+        }]
+
+        expect(this.res.locals.advisers).to.deep.equal(expectedAdvisers)
       })
 
       it('should set services data on locals', async () => {
@@ -258,8 +292,18 @@ describe('Interaction details middleware', () => {
         expect(this.res.locals.contacts).to.deep.equal(contactsData)
       })
 
-      it('should set advisers on locals', () => {
-        expect(this.res.locals.advisers).to.deep.equal(advisersData)
+      it('shuld set adviser to only active and current advisers', () => {
+        const expectedAdvisers = [{
+          id: '2',
+          name: 'Wilma Flintstone',
+          disabled_on: '2017-01-01',
+        }, {
+          id: '3',
+          name: 'Barney Rubble',
+          disabled_on: null,
+        }]
+
+        expect(this.res.locals.advisers).to.deep.equal(expectedAdvisers)
       })
 
       it('should set services data on locals', async () => {


### PR DESCRIPTION
Excludes advisers marked as disabled in the adviser dropdown in the interaction edit form, though includes the current one from the interaction record if it is disabled.