### PR TITLE
Fix service delivery events dropdown with > 10k events

### DIFF
--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -1,7 +1,6 @@
 const config = require('../../../config')
 const authorisedRequest = require('../../lib/authorised-request')
 const { search } = require('../search/services')
-const { filterDisabledOption } = require('../filters')
 
 function saveEvent (token, event) {
   const options = {
@@ -33,20 +32,22 @@ function getAllEvents (token) {
 /**
  *
  * @param {string} token Session token to use for API requests
- * @param {string} currentEventId The id for an event that must be included in the list irrigardless of if is disabled or not (the current value)
  *
  * @returns {promise[Array]} Returns an array of event objects that have not been disabled or are the current event
  */
-async function getActiveEvents (token, currentEventId) {
+async function getActiveEvents (token) {
   const eventsResponse = await search({
     searchEntity: 'event',
-    requestBody: { sortby: 'name:asc' },
+    requestBody: {
+      sortby: 'name:asc',
+      disabled_on_exists: false,
+    },
     token: token,
     limit: 100000,
     isAggregation: false,
   })
 
-  return eventsResponse.results.filter(filterDisabledOption(currentEventId))
+  return eventsResponse.results
 }
 
 module.exports = {

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -76,7 +76,7 @@ async function getInteractionOptions (req, res, next) {
     res.locals.services = await metaDataRepository.getServices(req.session.token)
 
     if (req.params.kind === 'service-delivery') {
-      res.locals.events = await getActiveEvents(req.session.token, get(req.params, 'interactionId'))
+      res.locals.events = await getActiveEvents(req.session.token)
     }
 
     next()

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -74,20 +74,14 @@ describe('Event repos', () => {
   })
 
   describe('#getActiveEvents', () => {
-    context('When there is a mix of active and inactive events', () => {
+    context('When there is a mix of active and inactive events on the server', () => {
       beforeEach(() => {
         this.currentId = '3'
 
         this.eventCollection = {
           results: [{
-            id: '1',
-            disabled_on: '2017-01-01',
-          }, {
             id: '2',
             disabled_on: null,
-          }, {
-            id: '3',
-            disabled_on: '2017-01-01',
           }],
         }
 
@@ -101,47 +95,17 @@ describe('Event repos', () => {
           this.events = await this.repos.getActiveEvents('1234')
         })
 
-        it('should call search to get the events', () => {
+        it('should call search to get the active events', () => {
           expect(this.searchSpy).to.be.calledWith({
             searchEntity: 'event',
-            requestBody: { sortby: 'name:asc' },
+            requestBody: {
+              sortby: 'name:asc',
+              disabled_on_exists: false,
+            },
             token: '1234',
             limit: 100000,
             isAggregation: false,
           })
-        })
-
-        it('should return only the active events', () => {
-          expect(this.events).to.deep.eq([{
-            id: '2',
-            disabled_on: null,
-          }])
-        })
-      })
-
-      context('and a current inactive event', () => {
-        beforeEach(async () => {
-          this.events = await this.repos.getActiveEvents('1234', this.currentId)
-        })
-
-        it('should call search to get the events', () => {
-          expect(this.searchSpy).to.be.calledWith({
-            searchEntity: 'event',
-            requestBody: { sortby: 'name:asc' },
-            token: '1234',
-            limit: 100000,
-            isAggregation: false,
-          })
-        })
-
-        it('should return active events and the current inactive one', () => {
-          expect(this.events).to.deep.eq([{
-            id: '2',
-            disabled_on: null,
-          }, {
-            id: '3',
-            disabled_on: '2017-01-01',
-          }])
         })
       })
     })


### PR DESCRIPTION
Elastic search can only return 10K records, when filtering disabled events out in the front end it was only getting the first 10K to filter, so the whole dataset wasn't visible.

This change uses elastic search to filter out ANY disabled items in elastic search, so the front end just passes that through.

This change has the side effect that a person could try to edit an old service delivery containing an event that has been disabled. Because it isn't in the drop down the event would be potentially be deleted from the record.

A follow-up PR will remove the event field from service delivery editing.

TODO - Discuss with front and back-end the details of using the strategy to filter out only the items that were disabled on a date after the record was created.