### PR TITLE
Feature/change running of circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,7 @@ workflows:
             branches:
               ignore:
                 - master
+                - /^skip-tests.*/
       - user_acceptance_tests_master:
           requires:
             - lint_code
@@ -202,3 +203,4 @@ workflows:
             branches:
               only:
                 - master
+                - /^release.*/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ and be provided with a back end server to provide the API, data storage and sear
 
     - [Ignoring features](#ignoring-features)
 - [Continuous Integration](#continuous-integration)
+  - [Running CI jobs](#running-ci-jobs)
   - [Base docker image](#base-docker-image)
   - [Data hub backend docker image](#data-hub-backend-docker-image)
   - [Job failure](#job-failure)
@@ -378,6 +379,11 @@ You can tell `nightwatch.js` not to run a feature by adding the tag `@ignore`.
 
 ## Continuous Integration
 Data hub uses [CircleCI](https://circleci.com/) for continuous integration.
+
+### Running CI jobs
+- All branches run the `lint_code`, `unit_tests` and `user_acceptance_tests` CI jobs
+- You can skip the `user_acceptance_tests` CI job by using a branch starting with `/^skip-tests.*/`
+- The `user_acceptance_tests_master` job will run on branches that match the regex `release.*` or the `master` branch. This job runs a branch against the `master` branch of [data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo/tree/master) 
 
 ### Base docker image
 The acceptance tests `user_acceptance_tests` job uses the docker image `ukti/docker-data-hub-base` as a base for running a selenium server and data hub frontend


### PR DESCRIPTION
So I would like to propose a change to the way we run Acceptance tests on CircleCi

- Turn off **Only build pull requests** (see note below)
- Run `lint_code`, `unit_tests`and `user_acceptance_tests` jobs on all branches
- Skip running the `user_acceptance_tests` by using a branch that matches the regex `/^skip-tests.*/`
- Run Acceptance Tests on branches that match the regex `/^release.*/` or the `master` branch against `master` of [data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo/tree/master) 

This will enable us to:
- Run releases against `master` of [data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo/tree/master)
- Merge work into `develop` without having to run Acceptance Tests, useful for small changes

## TODO
[ ] - turn off **Only build pull requests** in CircleCi

## Of Note
a)
Why turn off **Only build pull requests**? Because CircleCi will currently only run against our default branch which is `develop` and any PR's. Not being able to specify multiple default branches is a limitation of [CircleCi](https://discuss.circleci.com/t/option-to-enable-build-on-several-default-branches/13543) at present. 
This means `master` does not have Circle jobs ran against it. Which means we are not testing `master` `data-hub-frontend` running with `master` `data-hub-leeoo` before releasing.

![screen shot 2017-11-28 at 18 18 45](https://user-images.githubusercontent.com/2305016/33336832-18b8aecc-d469-11e7-8536-4fcbb6cee2d4.png)

b)
We will have to take ownership if your branch breaks `develop` because you haven't ran Acceptance tests. I need to play some work that will expose this more to us all.



### feature job
A job with a branch name that does not match `/^skip-tests.*/`, `/^release.*/`, `master`**note they have acceptance tests**

![screen shot 2017-11-30 at 11 15 33](https://user-images.githubusercontent.com/2305016/33428395-88cf1176-d5c0-11e7-920b-05327a7872ec.png)


### NON feature job
A job with a branch name that not matches `/^skip-tests.*/` **note it has NO acceptance tests**

![screen shot 2017-11-30 at 11 16 53](https://user-images.githubusercontent.com/2305016/33428485-ef9737f8-d5c0-11e7-8ed8-76f27f561e36.png)


### release job
A job that is running on a *non* `release.*` branch or `master` **note it has MASTER acceptance tests**

![screen shot 2017-11-28 at 17 49 37](https://user-images.githubusercontent.com/2305016/33335376-d0aa574c-d464-11e7-9bbf-eb08f144875f.png)


