### PR TITLE
Always show uk company in invest requirements

### DIFF
--- a/src/apps/investment-projects/controllers/details.js
+++ b/src/apps/investment-projects/controllers/details.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash')
+const { get, pickBy, isNotEmpty, keys, has } = require('lodash')
 
 const {
   detailsLabels,
@@ -18,10 +18,22 @@ function detailsGetHandler (req, res, next) {
     const transformedValue = transformInvestmentValueForView(res.locals.investmentData)
     const transformedRequirements = transformInvestmentRequirementsForView(res.locals.investmentData)
 
+    // When getting requirements, strip out empty or null rows
+    // Then if there are no requirements, or the only one is the uk company,
+    // set a flag so the user is told to add requirements, otherwise just show them and the edit button
+    const requirements = pickBy(getDataLabels(transformedRequirements, requirementsLabels.view), isNotEmpty)
+    const requirementKeyCount = keys(requirements).length
+    let isRequirementsStarted = false
+
+    if (requirementKeyCount > 1 || (requirementKeyCount === 1 && !has(requirements, requirementsLabels.view.uk_company))) {
+      isRequirementsStarted = true
+    }
+
     return res.render('investment-projects/views/details', {
+      requirements,
+      isRequirementsStarted,
       details: getDataLabels(transformedDetails, detailsLabels.view),
       values: getDataLabels(transformedValue, valueLabels.view),
-      requirements: getDataLabels(transformedRequirements, requirementsLabels.view),
     })
   }
   return next()

--- a/src/apps/investment-projects/views/details.njk
+++ b/src/apps/investment-projects/views/details.njk
@@ -20,14 +20,16 @@
   {{ renderButton('details', 'Edit summary', true) }}
 
   <h2 class="heading-medium">Requirements and location</h2>
-  {% if requirements | removeNilAndEmpty | length > 1 %}
-    {% component 'key-value-table', items=requirements, variant='striped' %}
+  {% component 'key-value-table', items=requirements, variant='striped' %}
+
+  {% if isRequirementsStarted %}
     {{ renderButton('requirements', 'Edit requirements', true) }}
   {% else %}
     {{ Message({
       type: 'muted',
       text: 'Please complete this section to move to Assign PM stage'
     }) }}
+
     {{ renderButton('requirements', 'Add requirements') }}
   {% endif %}
 

--- a/test/unit/apps/investment-projects/controllers/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/details.test.js
@@ -4,8 +4,15 @@ describe('Investment details controller', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.stub()
+    this.transformInvestmentRequirementsForViewStub = this.sandbox.stub()
 
-    this.controller = require('~/src/apps/investment-projects/controllers/details')
+    this.controller = proxyquire('~/src/apps/investment-projects/controllers/details', {
+      '../services/formatting': {
+        transformInvestmentRequirementsForView: this.transformInvestmentRequirementsForViewStub,
+        transformInvestmentDataForView: this.sandbox.stub(),
+        transformInvestmentValueForView: this.sandbox.stub(),
+      },
+    })
   })
 
   afterEach(() => {
@@ -31,6 +38,113 @@ describe('Investment details controller', () => {
           }
         },
       }, this.next)
+    })
+
+    context('when there are no requirements', () => {
+      beforeEach(() => {
+        this.transformInvestmentRequirementsForViewStub.returns({
+          'one': 'two',
+          'uk_company': null,
+          'strategic_drivers': null,
+        })
+
+        this.req = {
+          session: {
+            token: 'abcd',
+          },
+        }
+
+        this.res = {
+          locals: {
+            investmentData,
+          },
+          render: this.sandbox.stub(),
+        }
+
+        this.controller.detailsGetHandler(this.req, this.res, this.next)
+        this.renderOptions = this.res.render.firstCall.args[1]
+      })
+
+      it('show the add requirements message', () => {
+        expect(this.renderOptions.isRequirementsStarted).to.eq(false)
+      })
+
+      it('strip out null values', () => {
+        expect(this.renderOptions.requirements).to.deep.equal({})
+      })
+    })
+
+    context('when there is just a uk company requirement property', () => {
+      beforeEach(() => {
+        this.transformInvestmentRequirementsForViewStub.returns({
+          'one': 'two',
+          'uk_company': 'test company',
+          'strategic_drivers': null,
+        })
+
+        this.req = {
+          session: {
+            token: 'abcd',
+          },
+        }
+
+        this.res = {
+          locals: {
+            investmentData,
+          },
+          render: this.sandbox.stub(),
+        }
+
+        this.controller.detailsGetHandler(this.req, this.res, this.next)
+        this.renderOptions = this.res.render.firstCall.args[1]
+      })
+
+      it('show the add requirements message', () => {
+        expect(this.renderOptions.isRequirementsStarted).to.eq(false)
+      })
+
+      it('strip out null values', () => {
+        expect(this.renderOptions.requirements).to.deep.equal({
+          'UK recipient company': 'test company',
+        })
+      })
+    })
+
+    context('when requirements is fully populated', () => {
+      beforeEach(() => {
+        this.transformInvestmentRequirementsForViewStub.returns({
+          'strategic_drivers': 'Some drivers',
+          'uk_company': 'test company',
+          'client_requirements': null,
+        })
+
+        this.req = {
+          session: {
+            token: 'abcd',
+          },
+        }
+
+        this.res = {
+          locals: {
+            investmentData,
+          },
+          render: this.sandbox.stub(),
+        }
+
+        this.controller.detailsGetHandler(this.req, this.res, this.next)
+        this.renderOptions = this.res.render.firstCall.args[1]
+      })
+
+      it('show the edit requirements message', () => {
+        expect(this.renderOptions.isRequirementsStarted).to.eq(true)
+      })
+
+      it('strip out null values', () => {
+        expect(this.renderOptions.requirements).to.deep.equal({
+          'UK recipient company': 'test company',
+          'Strategic drivers': 'Some drivers',
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Currently, the investment details screen does not show the UK company if there are no other requirements details.

This change splits the decision to show the requirements table from the decision to show the add requirements message.

In addition, the logic for this decision, and the removal of empty values have moved into the controller so different combinations can be tested.

The result is if there is just a UK company in the requirements section, it is shown with the add button/message if there are more details the edit button is correctly shown.

Before
![before](https://user-images.githubusercontent.com/56056/33380666-c42f579c-d513-11e7-908e-7555c419497f.png)


After
![after](https://user-images.githubusercontent.com/56056/33380671-c826e306-d513-11e7-9863-b999bc14e942.png)

Also just to prove it works when there are requirements
![company furher along](https://user-images.githubusercontent.com/56056/33380697-d43f4bba-d513-11e7-80fd-d067f034f02b.png)

