### PR TITLE
Add export win category to company export edit

### DIFF
--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -17,14 +17,17 @@ function renderExports (req, res) {
 }
 
 function populateExportForm (req, res, next) {
-  const { export_to_countries, future_interest_countries } = res.locals.company
+  const {
+    export_to_countries,
+    future_interest_countries,
+    export_experience_category,
+  } = res.locals.company
 
-  const savedValues = {
+  res.locals.formData = assign({}, {
+    export_experience_category,
     export_to_countries: export_to_countries.map(country => country.id),
     future_interest_countries: future_interest_countries.map(country => country.id),
-  }
-
-  res.locals.formData = assign({}, savedValues, req.body)
+  }, req.body)
 
   next()
 }
@@ -38,6 +41,7 @@ function renderExportEdit (req, res) {
     .breadcrumb('Edit')
     .render('companies/views/exports-edit', {
       exportDetailsLabels,
+      exportExperienceCategories: metadataRepo.exportExperienceCategory.map(transformObjectToOption),
       countryOptions: metadataRepo.countryOptions.map(transformObjectToOption),
     })
 }

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -51,6 +51,7 @@ async function handleEditFormPost (req, res, next) {
   const futureInterestCountries = flatten([req.body.future_interest_countries])
 
   const data = assign({}, res.locals.company, {
+    export_experience_category: req.body.export_experience_category,
     export_to_countries: filter(exportToCountries),
     future_interest_countries: filter(futureInterestCountries),
   })

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -69,6 +69,7 @@ const accountManagementDisplayLabels = {
 }
 
 const exportDetailsLabels = {
+  exportExperienceCategory: 'Export win cateogory',
   exportToCountries: 'Currently exporting to',
   futureInterestCountries: 'Future countries of interest',
 }

--- a/src/apps/companies/transformers/company-to-export-details-view.js
+++ b/src/apps/companies/transformers/company-to-export-details-view.js
@@ -5,10 +5,12 @@ const { getDataLabels } = require('../../../lib/controller-utils')
 const { exportDetailsLabels } = require('../labels')
 
 module.exports = function transformCompanyToExportDetailsView ({
+  export_experience_category,
   export_to_countries,
   future_interest_countries,
 }) {
   const viewRecord = {
+    exportExperienceCategory: export_experience_category,
     exportToCountries: flatten([export_to_countries])
       .map(country => (country.name || null))
       .join(', '),

--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -17,9 +17,17 @@
       id: company.id
     }
   }) %}
+    {{ MultipleChoiceField({
+      name: 'export_experience_category',
+      label: exportDetailsLabels.exportExperienceCategory,
+      value: formData.export_experience_category,
+      options: exportExperienceCategories,
+      initialOption: '-- Select category --'
+    }) }}
+
     {# TODO: Make these work without JavaScript #}
     {% set exportCountries = formData.export_to_countries if formData.export_to_countries.length else ['']%}
-    <div class="js-AddItems" data-item-selector=".c-form-group--AddItems">
+    <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
       <label class="c-form-group__label">
         <span class="c-form-group__label-text">
           Select a market this company currently exports to (optional)
@@ -43,7 +51,7 @@
 
     {# TODO: Make these work without JavaScript #}
     {% set futureCountries = formData.future_interest_countries if formData.future_interest_countries.length else ['']%}
-    <div class="js-AddItems" data-item-selector=".c-form-group--AddItems">
+    <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
       <label class="c-form-group__label">
         <span class="c-form-group__label-text">
           Future markets of interest (optional)

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -92,6 +92,7 @@ const metadataItems = [
   ['investment-specific-programme', 'investmentSpecificProgrammeOptions'],
   ['investment-investor-type', 'investmentInvestorTypeOptions'],
   ['investment-involvement', 'investmentInvolvementOptions'],
+  ['export-experience-category', 'exportExperienceCategory'],
 ]
 
 const restrictedServiceKeys = [

--- a/test/unit/apps/companies/controllers/exports.test.js
+++ b/test/unit/apps/companies/controllers/exports.test.js
@@ -20,6 +20,10 @@ describe('Company export controller', () => {
           id: '1234',
           name: 'France',
         }],
+        exportExperienceCategory: [{
+          id: '73023b55-9568-4e3f-a134-53ec58451d3f',
+          name: 'Export growth',
+        }],
       },
       '../transformers': {
         transformCompanyToExportDetailsView: this.transformerSpy,
@@ -78,6 +82,10 @@ describe('Company export controller', () => {
       it('should populate formData on locals', () => {
         expect(this.resMock.locals).to.have.property('formData')
         expect(this.resMock.locals.formData).to.deep.equal({
+          export_experience_category: {
+            id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
+            name: 'Increasing export markets',
+          },
           export_to_countries: ['1234', '2234'],
           future_interest_countries: ['4321', '5678'],
         })
@@ -101,6 +109,10 @@ describe('Company export controller', () => {
       it('should populate formData on locals', () => {
         expect(this.resMock.locals).to.have.property('formData')
         expect(this.resMock.locals.formData).to.deep.equal({
+          export_experience_category: {
+            id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
+            name: 'Increasing export markets',
+          },
           export_to_countries: ['09876'],
           future_interest_countries: ['67890'],
         })
@@ -131,7 +143,15 @@ describe('Company export controller', () => {
       expect(this.renderSpy.args[0][1]).to.have.property('exportDetailsLabels')
     })
 
-    it('should exports to view', () => {
+    it('send export experience cateogries options to view', () => {
+      expect(this.renderSpy.args[0][1]).to.have.property('exportExperienceCategories')
+      expect(this.renderSpy.args[0][1].exportExperienceCategories).to.deep.equal([{
+        value: '73023b55-9568-4e3f-a134-53ec58451d3f',
+        label: 'Export growth',
+      }])
+    })
+
+    it('send country options to view', () => {
       expect(this.renderSpy.args[0][1]).to.have.property('countryOptions')
       expect(this.renderSpy.args[0][1].countryOptions).to.deep.equal([{
         value: '1234',

--- a/test/unit/apps/companies/controllers/exports.test.js
+++ b/test/unit/apps/companies/controllers/exports.test.js
@@ -163,8 +163,9 @@ describe('Company export controller', () => {
   describe('handleEditFormPost()', () => {
     beforeEach(() => {
       this.reqMock.body = {
-        export_to_countries: '123456',
-        future_interest_countries: ['67890', 'abcde'],
+        export_experience_category: '111',
+        export_to_countries: '222',
+        future_interest_countries: ['333', '444'],
       }
     })
 
@@ -180,10 +181,10 @@ describe('Company export controller', () => {
       })
 
       it('should call save method with flattened body data', () => {
-        expect(this.saveCompany.args[0][1]).to.have.property('export_to_countries')
-        expect(this.saveCompany.args[0][1].export_to_countries).to.deep.equal(['123456'])
-        expect(this.saveCompany.args[0][1]).to.have.property('future_interest_countries')
-        expect(this.saveCompany.args[0][1].future_interest_countries).to.deep.equal(['67890', 'abcde'])
+        const actualData = this.saveCompany.args[0][1]
+        expect(actualData.export_experience_category).to.equal('111')
+        expect(actualData.export_to_countries).to.deep.equal(['222'])
+        expect(actualData.future_interest_countries).to.deep.equal(['333', '444'])
       })
 
       it('should redirect to exports routes', () => {

--- a/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
@@ -4,9 +4,38 @@ const minimalCompany = require('~/test/unit/data/companies/minimal-company.json'
 const { transformCompanyToExportDetailsView } = require('~/src/apps/companies/transformers')
 
 describe('transformCompanyToExportDetailsView', () => {
-  context('when the company is exporting to one country', () => {
+  context('when no export market information has been entered', () => {
     beforeEach(() => {
       const company = assign({}, minimalCompany, {
+        export_experience_category: null,
+        export_to_countries: [],
+        future_interest_countries: [],
+      })
+
+      this.viewRecord = transformCompanyToExportDetailsView(company)
+    })
+
+    it('should show the country currently exporting to', () => {
+      expect(this.viewRecord).to.have.property('Currently exporting to', '')
+    })
+
+    it('should not show the country the company wants to export to', () => {
+      expect(this.viewRecord).to.have.property('Future countries of interest', '')
+    })
+
+    it('should show the export win category', () => {
+      expect(this.viewRecord).to.have.property('Export win cateogory', null)
+    })
+  })
+
+  context('when single values have been selected for drop down fields', () => {
+    beforeEach(() => {
+      this.exportExperienceCategory = {
+        id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
+        name: 'Increasing export markets',
+      }
+      const company = assign({}, minimalCompany, {
+        export_experience_category: this.exportExperienceCategory,
         export_to_countries: [{
           id: '1234',
           name: 'France',
@@ -20,62 +49,33 @@ describe('transformCompanyToExportDetailsView', () => {
       this.viewRecord = transformCompanyToExportDetailsView(company)
     })
 
-    it('Should show the country currently exporting to', () => {
+    it('should show the country currently exporting to', () => {
       expect(this.viewRecord).to.have.property('Currently exporting to', 'France')
+    })
+
+    it('should not show the country the company wants to export to', () => {
+      expect(this.viewRecord).to.have.property('Future countries of interest', 'Germany')
+    })
+
+    it('should show the export win category', () => {
+      expect(this.viewRecord).to.have.property('Export win cateogory', this.exportExperienceCategory)
     })
   })
 
-  context('when the company is exporting to multiple countries', () => {
+  context('when multiple values have been selected for drop down fields', () => {
     beforeEach(() => {
+      this.exportExperienceCategory = {
+        id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
+        name: 'Increasing export markets',
+      }
       const company = assign({}, minimalCompany, {
+        export_experience_category: this.exportExperienceCategory,
         export_to_countries: [{
           id: '1234',
           name: 'France',
         }, {
           id: '5511',
           name: 'Spain',
-        }],
-        future_interest_countries: [{
-          id: '4321',
-          name: 'Germany',
-        }],
-      })
-
-      this.viewRecord = transformCompanyToExportDetailsView(company)
-    })
-
-    it('Should show the countries currently exporting to', () => {
-      expect(this.viewRecord).to.have.property('Currently exporting to', 'France, Spain')
-    })
-  })
-
-  context('when the company wants to export to one country', () => {
-    beforeEach(() => {
-      const company = assign({}, minimalCompany, {
-        export_to_countries: [{
-          id: '1234',
-          name: 'France',
-        }],
-        future_interest_countries: [{
-          id: '4321',
-          name: 'Germany',
-        }],
-      })
-
-      this.viewRecord = transformCompanyToExportDetailsView(company)
-    })
-
-    it('Should show the country the company wants to export to', () => {
-      expect(this.viewRecord).to.have.property('Future countries of interest', 'Germany')
-    })
-  })
-
-  context('when the company wants to export to multiple countries', () => {
-    beforeEach(() => {
-      const company = assign({}, minimalCompany, {
-        export_to_countries: [{
-          id: '1234',
-          name: 'France',
         }],
         future_interest_countries: [{
           id: '4321',
@@ -89,8 +89,16 @@ describe('transformCompanyToExportDetailsView', () => {
       this.viewRecord = transformCompanyToExportDetailsView(company)
     })
 
-    it('Should show the coiuntries the company wants to export to', () => {
+    it('should show the country currently exporting to', () => {
+      expect(this.viewRecord).to.have.property('Currently exporting to', 'France, Spain')
+    })
+
+    it('should not show the country the company wants to export to', () => {
       expect(this.viewRecord).to.have.property('Future countries of interest', 'Germany, Sweden')
+    })
+
+    it('should show the export win category', () => {
+      expect(this.viewRecord).to.have.property('Export win cateogory', this.exportExperienceCategory)
     })
   })
 })

--- a/test/unit/data/api-response-intermediary-company.json
+++ b/test/unit/data/api-response-intermediary-company.json
@@ -155,6 +155,10 @@
         "name": "Argentina"
       }
     ],
+    "export_experience_category": {
+      "id": "8b05e8c7-1812-46bf-bab7-a0096ab5689f",
+      "name": "Increasing export markets"
+    },
     "uk_based": true,
     "account_manager": null,
     "registered_address_1": "Annexe -  Blackthorn Cottage",


### PR DESCRIPTION
This change:
- adds export win category to company exports details edit form
- presents export win category on company exports details screen

Changes are covered by unit tests and acceptance tests to follow.

<img width="750" alt="screen shot 2017-11-29 at 15 45 38" src="https://user-images.githubusercontent.com/1150417/33383946-999faf32-d51c-11e7-8184-4d472a319f01.png">

<img width="547" alt="screen shot 2017-11-29 at 15 46 09" src="https://user-images.githubusercontent.com/1150417/33383951-9f5b06d8-d51c-11e7-9d7d-87f3746d9436.png">

