### PR TITLE
Change edit action label to reflect actual action

### DIFF
--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -73,7 +73,7 @@
     heading: 'Advisers in the market',
     actions: [{
       url: 'edit/assignees' if order.canEditAdvisers,
-      label: 'Add or remove'
+      label: 'Add or remove' if order.canEditOrder else 'Add'
     }, {
       url: 'edit/assignee-time' if order.canEditOrder,
       label: 'Estimate hours'


### PR DESCRIPTION
During later states advisers in the market can only be added. The current text suggested they could also remove.

This changes the text to be conditional based on the state of the order.