### PR TITLE
Canonical URL

### DIFF
--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -66,7 +66,7 @@
             <ul class="list-disc">
               {% for form in investmentStatus.currentStage.incompleteFields  %}
                 <li>
-                    <a href="{{ form.url }}?returnUrl={{ CANONICAL_URL }}">{{ form.text }}</a>
+                    <a href="{{ form.url }}?returnUrl={{ ORIGINAL_URL }}">{{ form.text }}</a>
                 </li>
               {% endfor %}
             </ul>

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -21,7 +21,7 @@
         {% for stepUrl, stepData in incompleteFields %}
           {% for field in stepData.errors %}
             <li>
-              <a href="/omis/{{ order.id }}/edit{{ stepUrl }}?returnUrl=/omis/{{ order.id }}/quote#field-{{ field }}">
+              <a href="/omis/{{ order.id }}/edit{{ stepUrl }}?returnUrl={{ ORIGINAL_URL }}#field-{{ field }}">
                 {{ translate('errors.quote.' + field) }}
               </a>
             </li>

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -24,6 +24,7 @@ module.exports = function locals (req, res, next) {
 
   res.locals = Object.assign({}, res.locals, {
     BASE_URL: baseUrl,
+    CANONICAL_URL: baseUrl + req.path,
     ORIGINAL_URL: baseUrl + req.originalUrl,
     CURRENT_PATH: req.path,
     ARCHIVED_DOCUMENT_BASE_URL: config.archivedDocumentsBaseUrl,

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -24,7 +24,7 @@ module.exports = function locals (req, res, next) {
 
   res.locals = Object.assign({}, res.locals, {
     BASE_URL: baseUrl,
-    CANONICAL_URL: baseUrl + req.originalUrl,
+    ORIGINAL_URL: baseUrl + req.originalUrl,
     CURRENT_PATH: req.path,
     ARCHIVED_DOCUMENT_BASE_URL: config.archivedDocumentsBaseUrl,
     GOOGLE_TAG_MANAGER_KEY: config.googleTagManagerKey,

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -11,6 +11,10 @@
         <meta name="description" content="{{ description }}">
       {% endif -%}
 
+      {% if CANONICAL_URL %}
+        <link rel="canonical" href="{{ CANONICAL_URL }}">
+      {% endif %}
+
       {% block head_content %}
         <!--[if IE]><link rel="shortcut icon" href="{{ getAssetPath('images/favicon.ico') }}" type="image/x-icon"><![endif]-->
         <!-- Touch Icons - iOS and Android 2.1+ 180x180 pixels in size. -->

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -10,7 +10,7 @@
   {% block form %}
     {% call MultiStepForm(options | assign({
       buttonText: options.buttonText or 'Continue',
-      returnLink: backLink,
+      returnLink: options.backLink,
       errors: errors
     })) %}
 


### PR DESCRIPTION
This adds support for canonical URLs so that analytics doesn't get flooded with multiple items
when the URL contains query string parameters.