### PR TITLE
Fix active adviser filter

### DIFF
--- a/src/apps/adviser/filters.js
+++ b/src/apps/adviser/filters.js
@@ -1,0 +1,10 @@
+const { get } = require('lodash')
+
+function filterActiveAdvisers ({ advisers = [], includeAdviser }) {
+  return advisers.filter((adviser) => {
+    return get(adviser, 'is_active', true) || adviser.id === includeAdviser
+  })
+}
+module.exports = {
+  filterActiveAdvisers,
+}

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -1,20 +1,20 @@
 /* eslint camelcase: 0 */
+const { assign, merge, get, pickBy } = require('lodash')
+
 const { eventFormConfig } = require('../macros')
 const { transformEventResponseToFormBody } = require('../transformers')
 const { buildFormWithStateAndErrors } = require('../../builders')
-const { assign, merge, get, pickBy } = require('lodash')
 const { getAdvisers } = require('../../adviser/repos')
-const { filterDisabledOption } = require('../../filters')
-
-async function getActiveAdvisers (token, currentAdviser) {
-  const allAdvisers = await getAdvisers(token)
-  return allAdvisers.results.filter(filterDisabledOption(currentAdviser))
-}
+const { filterActiveAdvisers } = require('../../adviser/filters')
 
 async function renderEditPage (req, res, next) {
   try {
     const eventData = transformEventResponseToFormBody(res.locals.event)
-    const advisers = await getActiveAdvisers(req.session.token, get(eventData, 'organiser.id'))
+
+    const currentAdviser = get(eventData, 'organiser.id')
+    const advisers = await getAdvisers(req.session.token)
+    const activeAdvisers = filterActiveAdvisers({ advisers: advisers.results, includeAdviser: currentAdviser })
+
     const eventId = get(eventData, 'id', '')
     const eventName = get(eventData, 'name')
     const lead_team = eventData.lead_team || get(req, 'session.user.dit_team.id')
@@ -22,7 +22,7 @@ async function renderEditPage (req, res, next) {
 
     const eventForm =
       buildFormWithStateAndErrors(
-        eventFormConfig({ eventId, advisers }),
+        eventFormConfig({ eventId, advisers: activeAdvisers }),
         mergedData,
         get(res.locals, 'form.errors.messages'),
       )

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -6,14 +6,9 @@ const { fetchInteraction, saveInteraction } = require('../repos')
 const metaDataRepository = require('../../../lib/metadata')
 const { getContactsForCompany, getContact } = require('../../contacts/repos')
 const { getAdvisers } = require('../../adviser/repos')
+const { filterActiveAdvisers } = require('../../adviser/filters')
 const { getActiveEvents } = require('../../events/repos')
 const { getDitCompany } = require('../../companies/repos')
-const { filterDisabledOption } = require('../../filters')
-
-async function getActiveAdvisers (token, currentAdviser) {
-  const allAdvisers = await getAdvisers(token)
-  return allAdvisers.results.filter(filterDisabledOption(currentAdviser))
-}
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -71,12 +66,19 @@ async function getInteractionDetails (req, res, next, interactionId) {
 
 async function getInteractionOptions (req, res, next) {
   try {
-    res.locals.advisers = await getActiveAdvisers(req.session.token, get(res.locals, 'interaction.dit_adviser.id'))
-    res.locals.contacts = await getContactsForCompany(req.session.token, res.locals.company.id)
-    res.locals.services = await metaDataRepository.getServices(req.session.token)
+    const token = req.session.token
+    const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
+    const company = get(res.locals, 'company.id')
+    const advisers = await getAdvisers(token)
+
+    res.locals = assign({}, res.locals, {
+      advisers: filterActiveAdvisers({ advisers: advisers.results, includeAdviser: currentAdviser }),
+      contacts: await getContactsForCompany(token, company),
+      services: await metaDataRepository.getServices(token),
+    })
 
     if (req.params.kind === 'service-delivery') {
-      res.locals.events = await getActiveEvents(req.session.token)
+      res.locals.events = await getActiveEvents(token)
     }
 
     next()

--- a/test/unit/apps/adviser/filters.test.js
+++ b/test/unit/apps/adviser/filters.test.js
@@ -1,0 +1,104 @@
+const adviserFilters = require('~/src/apps/adviser/filters')
+
+describe('adviser filters', () => {
+  describe('#filterActiveAdvisers', () => {
+    beforeEach(() => {
+      this.activeInactiveAdviserData = [{
+        id: '1',
+        name: 'Jeff Smith',
+        is_active: true,
+      }, {
+        id: '2',
+        name: 'John Smith',
+        is_active: true,
+      }, {
+        id: '3',
+        name: 'Zac Smith',
+        is_active: true,
+      }, {
+        id: '4',
+        name: 'Fred Smith',
+        is_active: false,
+      }, {
+        id: '5',
+        name: 'Jim Smith',
+        is_active: false,
+      }]
+    })
+
+    context('when no current adviser is specified', () => {
+      beforeEach(() => {
+        this.activeAdvisers = adviserFilters.filterActiveAdvisers({ advisers: this.activeInactiveAdviserData })
+      })
+
+      it('should exlude records not active', () => {
+        const expectedAdvisers = [{
+          id: '1',
+          name: 'Jeff Smith',
+          is_active: true,
+        }, {
+          id: '2',
+          name: 'John Smith',
+          is_active: true,
+        }, {
+          id: '3',
+          name: 'Zac Smith',
+          is_active: true,
+        }]
+
+        expect(this.activeAdvisers).to.deep.equal(expectedAdvisers)
+      })
+    })
+
+    context('when a current adviser is specified', () => {
+      beforeEach(() => {
+        const currentAdviser = this.activeInactiveAdviserData[3].id
+
+        this.activeAdvisers = adviserFilters.filterActiveAdvisers({
+          advisers: this.activeInactiveAdviserData,
+          includeAdviser: currentAdviser,
+        })
+      })
+
+      it('should include active records and the current adviser', () => {
+        const expectedAdvisers = [{
+          id: '1',
+          name: 'Jeff Smith',
+          is_active: true,
+        }, {
+          id: '2',
+          name: 'John Smith',
+          is_active: true,
+        }, {
+          id: '3',
+          name: 'Zac Smith',
+          is_active: true,
+        }, {
+          id: '4',
+          name: 'Fred Smith',
+          is_active: false,
+        }]
+
+        expect(this.activeAdvisers).to.deep.equal(expectedAdvisers)
+      })
+    })
+
+    context('when adviser data has no is_active property', () => {
+      beforeEach(() => {
+        this.badAdviserData = [{
+          id: '1',
+          name: 'Jeff Smith',
+        }, {
+          id: '2',
+          name: 'John Smith',
+        }]
+
+        this.activeAdvisers = adviserFilters.filterActiveAdvisers({ advisers: this.badAdviserData })
+      })
+
+      it('should include adviser', () => {
+        expect(this.activeAdvisers).to.deep.equal(this.badAdviserData)
+      })
+    })
+  })
+})

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -1,10 +1,16 @@
+const nock = require('nock')
+const { set } = require('lodash')
+
+const config = require('~/config')
 const interactionData = require('../../../data/interactions/new-interaction.json')
 const servicesData = [
   { id: '9484b82b-3499-e211-a939-e4115bead28a', name: 'Account Management' },
   { id: '632b8708-28b6-e611-984a-e4115bead28a', name: 'Bank Referral' },
 ]
-const contactsData = require('../../../data/contacts/contacts.json')
-const eventsData = require('../../../data/events/collection.json')
+const contactsData = require('~/test/unit/data/contacts/contacts.json')
+const eventsData = require('~/test/unit/data/events/collection.json')
+
+const adviserFilters = require('~/src/apps/adviser/filters')
 
 const { assign, merge } = require('lodash')
 
@@ -24,23 +30,7 @@ describe('Interaction details middleware', () => {
     this.getContactsForCompanyStub = this.sandbox.stub()
     this.getContactStub = this.sandbox.stub()
     this.getDitCompanyStub = this.sandbox.stub()
-
-    const advisersData = {
-      count: 3,
-      results: [{
-        id: '1',
-        name: 'Fred Flintstone',
-        disabled_on: '2017-01-01',
-      }, {
-        id: '2',
-        name: 'Wilma Flintstone',
-        disabled_on: '2017-01-01',
-      }, {
-        id: '3',
-        name: 'Barney Rubble',
-        disabled_on: null,
-      }],
-    }
+    this.filterActiveAdvisersSpy = this.sandbox.spy(adviserFilters, 'filterActiveAdvisers')
 
     this.middleware = proxyquire('~/src/apps/interactions/middleware/details', {
       '../repos': {
@@ -51,8 +41,8 @@ describe('Interaction details middleware', () => {
         transformInteractionFormBodyToApiRequest: this.transformInteractionFormBodyToApiRequestStub.returns(transformed),
         transformInteractionResponseToViewRecord: this.transformInteractionResponseToViewRecordStub.returns(transformed),
       },
-      '../../adviser/repos': {
-        getAdvisers: this.getAdvisersStub.resolves(advisersData),
+      '../../adviser/filters': {
+        filterActiveAdvisers: this.filterActiveAdvisersSpy,
       },
       '../../../lib/metadata': {
         getServices: () => { return servicesData },
@@ -96,6 +86,21 @@ describe('Interaction details middleware', () => {
     }
 
     this.nextSpy = this.sandbox.spy()
+
+    this.activeInactiveAdviserData = {
+      count: 5,
+      results: [
+        { id: '1', name: 'Jeff Smith', is_active: true },
+        { id: '2', name: 'John Smith', is_active: true },
+        { id: '3', name: 'Zac Smith', is_active: true },
+        { id: '4', name: 'Fred Smith', is_active: false },
+        { id: '5', name: 'Jim Smith', is_active: false },
+      ],
+    }
+
+    nock(config.apiRoot)
+      .get(`/adviser/?limit=100000&offset=0`)
+      .reply(200, this.activeInactiveAdviserData)
   })
 
   afterEach(() => {
@@ -237,17 +242,19 @@ describe('Interaction details middleware', () => {
     })
   })
 
-  describe('#getInteractionOptions', () => {
+  describe('#getInteractionOOptions', () => {
     beforeEach(() => {
       this.res.locals.interaction = assign({}, interactionData, {
         dit_adviser: {
-          id: '2',
+          id: this.activeInactiveAdviserData.results[4].id,
         },
       })
     })
 
     context('when interaction', () => {
       beforeEach(async () => {
+        this.currentAdviser = this.activeInactiveAdviserData.results[3]
+        set(this.res.locals, 'interaction.dit_adviser', this.currentAdviser)
         await this.middleware.getInteractionOptions(this.req, this.res, this.nextSpy)
       })
 
@@ -255,17 +262,13 @@ describe('Interaction details middleware', () => {
         expect(this.res.locals.contacts).to.deep.equal(contactsData)
       })
 
-      it('should set adviser to only active and current advisers', () => {
-        const expectedAdvisers = [{
-          id: '2',
-          name: 'Wilma Flintstone',
-          disabled_on: '2017-01-01',
-        }, {
-          id: '3',
-          name: 'Barney Rubble',
-          disabled_on: null,
-        }]
+      it('should get active advisers and the current adviser', () => {
+        expect(this.filterActiveAdvisersSpy).to.be.calledOnce
+        expect(this.filterActiveAdvisersSpy).to.be.calledWith({ advisers: this.activeInactiveAdviserData.results, includeAdviser: this.currentAdviser.id })
+      })
 
+      it('should set the active advisers on the response object', () => {
+        const expectedAdvisers = this.activeInactiveAdviserData.results.slice(0, 4)
         expect(this.res.locals.advisers).to.deep.equal(expectedAdvisers)
       })
 
@@ -280,29 +283,29 @@ describe('Interaction details middleware', () => {
 
     context('when service delivery', () => {
       beforeEach(async () => {
-        const req = merge({}, this.req, {
+        this.req = assign({}, this.req, {
           params: {
             kind: 'service-delivery',
           },
         })
-        await this.middleware.getInteractionOptions(req, this.res, this.nextSpy)
+
+        this.currentAdviser = this.activeInactiveAdviserData.results[3]
+        this.res.locals.interaction.dit_adviser = this.currentAdviser
+
+        await this.middleware.getInteractionOptions(this.req, this.res, this.nextSpy)
       })
 
       it('should set contacts on locals', () => {
         expect(this.res.locals.contacts).to.deep.equal(contactsData)
       })
 
-      it('shuld set adviser to only active and current advisers', () => {
-        const expectedAdvisers = [{
-          id: '2',
-          name: 'Wilma Flintstone',
-          disabled_on: '2017-01-01',
-        }, {
-          id: '3',
-          name: 'Barney Rubble',
-          disabled_on: null,
-        }]
+      it('should get active advisers and the current adviser', () => {
+        expect(this.filterActiveAdvisersSpy).to.be.calledOnce
+        expect(this.filterActiveAdvisersSpy).to.be.calledWith({ advisers: this.activeInactiveAdviserData.results, includeAdviser: this.currentAdviser.id })
+      })
 
+      it('should set the active advisers on the response object', () => {
+        const expectedAdvisers = this.activeInactiveAdviserData.results.slice(0, 4)
         expect(this.res.locals.advisers).to.deep.equal(expectedAdvisers)
       })
 

--- a/test/unit/data/advisers/advisers.json
+++ b/test/unit/data/advisers/advisers.json
@@ -21,6 +21,7 @@
     {
       "id": "e13209b8-8d61-e311-8255-e4115bead28a",
       "name": "Aaron Mr",
+      "is_active": true,
       "last_login": null,
       "first_name": "Aaron",
       "last_name": "Mr",
@@ -38,6 +39,7 @@
     {
       "id": "b9d6b3dc-7af4-e411-bcbe-e4115bead28a",
       "name": "Mr Benjamin",
+      "is_active": true,
       "last_login": null,
       "first_name": "Mr",
       "last_name": "Benjamin",
@@ -55,6 +57,7 @@
     {
       "id": "0119a99e-9798-e211-a939-e4115bead28a",
       "name": "George Chan",
+      "is_active": false,
       "last_login": null,
       "first_name": "George",
       "last_name": "Chan",
@@ -72,6 +75,7 @@
     {
       "id": "0919a99e-9798-e211-a939-e4115bead28a",
       "name": "Fred Rafters",
+      "is_active": false,
       "last_login": null,
       "first_name": "Fred",
       "last_name": "Rafters",


### PR DESCRIPTION
Fixes the issue using the wrong field to filter out inactive advisers.

Created a common function to fetch advisers and filter out inactive entries.
Allow caller to pass in an adviser collection to save multiple API calls if filtering multiple adviser fields
Guards against non-existence of 'is_active' property.

Updates the event edit and interaction edit screens to use this new feature.

And YES! I tested this manually