### PR TITLE
Removed excess 'o' from category

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -69,7 +69,7 @@ const accountManagementDisplayLabels = {
 }
 
 const exportDetailsLabels = {
-  exportExperienceCategory: 'Export win cateogory',
+  exportExperienceCategory: 'Export win category',
   exportToCountries: 'Currently exporting to',
   futureInterestCountries: 'Future countries of interest',
 }

--- a/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
@@ -24,7 +24,7 @@ describe('transformCompanyToExportDetailsView', () => {
     })
 
     it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win cateogory', null)
+      expect(this.viewRecord).to.have.property('Export win category', null)
     })
   })
 
@@ -58,7 +58,7 @@ describe('transformCompanyToExportDetailsView', () => {
     })
 
     it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win cateogory', this.exportExperienceCategory)
+      expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
     })
   })
 
@@ -98,7 +98,7 @@ describe('transformCompanyToExportDetailsView', () => {
     })
 
     it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win cateogory', this.exportExperienceCategory)
+      expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
     })
   })
 })


### PR DESCRIPTION
The export wins category is misspelled consistently in the work as 'cateogory'. This corrects that.