### PR TITLE
Correct error border styles

### DIFF
--- a/assets/stylesheets/components/form/_form-fieldset.scss
+++ b/assets/stylesheets/components/form/_form-fieldset.scss
@@ -47,6 +47,7 @@ fieldset.c-form-fieldset--subfield {
   }
 
   &.has-error {
+    border-left: 0;
     padding-left: $default-spacing-unit * 2;
 
     &::before {

--- a/assets/stylesheets/components/form/_form-group.scss
+++ b/assets/stylesheets/components/form/_form-group.scss
@@ -51,8 +51,24 @@
 
 // States
 .c-form-group.has-error {
-  border-left-color: $error-colour;
+  border-left: 5px solid $error-colour;
   padding-left: $default-spacing-unit;
+}
+
+fieldset.c-form-group.has-error {
+  border-left: 0;
+  padding-left: $default-spacing-unit + 5;
+  position: relative;
+
+  &::before {
+    position: absolute;
+    left: $default-spacing-unit;
+    top: 0;
+    bottom: 0;
+    border-left: 5px solid $error-colour;
+    margin-left: -$default-spacing-unit;
+    content: "";
+  }
 }
 
 .c-form-group:target {


### PR DESCRIPTION
The error border on form groups was no longer being shown.

This replaces the border back for form group errors and provides
a different way to style the border on fieldsets so that it includes
the legend element too.

## Before

![image](https://user-images.githubusercontent.com/3327997/33439018-529b0e92-d5e4-11e7-8d8b-8a7e9899c9d6.png)

![image](https://user-images.githubusercontent.com/3327997/33439257-e3c2515a-d5e4-11e7-91b9-31e1d58d9e0b.png)

## After

![image](https://user-images.githubusercontent.com/3327997/33438825-be7da724-d5e3-11e7-8ecc-a5ad6b624dfa.png)

![image](https://user-images.githubusercontent.com/3327997/33439228-cffb1b52-d5e4-11e7-9361-0d2f251d5964.png)
