### PR TITLE
Update typo in "categories"

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -69,7 +69,7 @@ const accountManagementDisplayLabels = {
 }
 
 const exportDetailsLabels = {
-  exportExperienceCategory: 'Export win cateogory',
+  exportExperienceCategory: 'Export win category',
   exportToCountries: 'Currently exporting to',
   futureInterestCountries: 'Future countries of interest',
 }

--- a/test/unit/apps/companies/controllers/exports.test.js
+++ b/test/unit/apps/companies/controllers/exports.test.js
@@ -143,7 +143,7 @@ describe('Company export controller', () => {
       expect(this.renderSpy.args[0][1]).to.have.property('exportDetailsLabels')
     })
 
-    it('send export experience cateogries options to view', () => {
+    it('send export experience categories options to view', () => {
       expect(this.renderSpy.args[0][1]).to.have.property('exportExperienceCategories')
       expect(this.renderSpy.args[0][1].exportExperienceCategories).to.deep.equal([{
         value: '73023b55-9568-4e3f-a134-53ec58451d3f',

--- a/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
@@ -24,7 +24,7 @@ describe('transformCompanyToExportDetailsView', () => {
     })
 
     it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win cateogory', null)
+      expect(this.viewRecord).to.have.property('Export win category', null)
     })
   })
 
@@ -58,7 +58,7 @@ describe('transformCompanyToExportDetailsView', () => {
     })
 
     it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win cateogory', this.exportExperienceCategory)
+      expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
     })
   })
 
@@ -98,7 +98,7 @@ describe('transformCompanyToExportDetailsView', () => {
     })
 
     it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win cateogory', this.exportExperienceCategory)
+      expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
     })
   })
 })


### PR DESCRIPTION
Oops, I am silly

Typo in "categories" in a surprisingly high number of places.