### PR TITLE
Export win heading/label

### DIFF
--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -20,7 +20,8 @@
       label: exportDetailsLabels.exportExperienceCategory,
       value: formData.export_experience_category,
       options: exportExperienceCategories,
-      initialOption: '-- Select category --'
+      initialOption: '-- Select category --',
+      optional: true
     }) }}
 
     {# TODO: Make these work without JavaScript #}

--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -8,8 +8,6 @@
 {% endblock %}
 
 {% block main_grid_right_column %}
-  <h2 class="heading-medium">Add export market(s)</h2>
-
   {% call Form({
     buttonText: 'Update',
     returnLink: '/companies/' + company.id + '/exports',

--- a/test/unit/apps/companies/controllers/exports.test.js
+++ b/test/unit/apps/companies/controllers/exports.test.js
@@ -143,7 +143,7 @@ describe('Company export controller', () => {
       expect(this.renderSpy.args[0][1]).to.have.property('exportDetailsLabels')
     })
 
-    it('send export experience cateogries options to view', () => {
+    it('send export experience categories options to view', () => {
       expect(this.renderSpy.args[0][1]).to.have.property('exportExperienceCategories')
       expect(this.renderSpy.args[0][1].exportExperienceCategories).to.deep.equal([{
         value: '73023b55-9568-4e3f-a134-53ec58451d3f',


### PR DESCRIPTION
This change:
- removes unnecessary title
- adds `optional` label to export win category label

<img width="718" alt="screen shot 2017-11-30 at 16 29 42" src="https://user-images.githubusercontent.com/1150417/33442005-f127d3d6-d5eb-11e7-8e7e-5b85e5508d64.png">
