### PR TITLE
Tidy up nock use

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -6,6 +6,7 @@
     "expect": true,
     "proxyquire": true,
     "sinon": true,
+    "nock": true,
     "rootPath": true,
     "globalReq": true,
     "globalRes": true

--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const adviserData = require('~/test/unit/data/advisers/advisers.json')
 const badAdviserData = require('~/test/unit/data/advisers/advisers-with-bad-data.json')
 const config = require('~/config')

--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -7,10 +7,11 @@ const repos = require('~/src/apps/adviser/repos')
 describe('Adviser repository', () => {
   describe('getAdvisers', () => {
     context('when an adviser without a name is encountered', () => {
-      beforeEach(() => {
-        nock(config.apiRoot)
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, badAdviserData)
+        this.advisers = await repos.getAdvisers(123)
       })
 
       it('will be filtered out', async () => {
@@ -24,22 +25,28 @@ describe('Adviser repository', () => {
           ],
         }
 
-        const actual = await repos.getAdvisers(123)
+        expect(this.advisers).to.deep.equal(expected)
+      })
 
-        expect(actual).to.deep.equal(expected)
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
       })
     })
 
     context('when all advisers have names', () => {
-      beforeEach(() => {
-        nock(config.apiRoot)
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, adviserData)
+        this.advisers = await repos.getAdvisers(123)
       })
 
-      it('will not filter out any advisers', async () => {
-        const actual = await repos.getAdvisers(123)
-        expect(actual).to.deep.equal(adviserData)
+      it('will not filter out any advisers', () => {
+        expect(this.advisers).to.deep.equal(adviserData)
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -5,27 +5,15 @@ const companiesHouseSearchResults = require('~/test/unit/data/companies/companie
 
 describe('Company collection middleware', () => {
   beforeEach(() => {
-    nock(config.apiRoot)
-      .post(`/v3/search/company`)
-      .reply(200, {
-        count: 3,
-        results: [
-          {
-            id: '111',
-            name: 'A',
-          },
-          {
-            id: '222',
-            name: 'B',
-          },
-          {
-            id: '333',
-            name: 'C',
-          },
-        ],
-      })
-
     this.sandbox = sinon.sandbox.create()
+    this.mockCompanyResults = {
+      count: 3,
+      results: [
+        { id: '111', name: 'A' },
+        { id: '222', name: 'B' },
+        { id: '333', name: 'C' },
+      ],
+    }
     this.next = this.sandbox.spy()
     this.req = Object.assign({}, globalReq, {
       session: { token: 'abcd' },
@@ -41,6 +29,10 @@ describe('Company collection middleware', () => {
 
   describe('#getCompanyCollection', () => {
     beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .post(`/v3/search/company`)
+        .reply(200, this.mockCompanyResults)
+
       this.req.query = {
         stage: 'i1',
         sector: 's1',
@@ -56,6 +48,10 @@ describe('Company collection middleware', () => {
       expect(actual).to.have.property('pagination')
       expect(actual.count).to.equal(3)
       expect(this.next).to.have.been.calledOnce
+    })
+
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const config = require('~/config')
 const { getRequestBody, getCompanyCollection } = require('~/src/apps/companies/middleware/collection')
 const companiesHouseSearchResults = require('~/test/unit/data/companies/companies-house-search.json')

--- a/test/unit/apps/contacts/repos.test.js
+++ b/test/unit/apps/contacts/repos.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const config = require('~/config')
 
 const {

--- a/test/unit/apps/contacts/repos.test.js
+++ b/test/unit/apps/contacts/repos.test.js
@@ -10,14 +10,19 @@ const companyId = '23232323'
 
 describe('Investment repository', () => {
   describe('#getContactsForCompany', () => {
-    nock(config.apiRoot)
-      .get(`/v3/contact?company_id=${companyId}&limit=500`)
-      .reply(200, contactsApiResult)
+    beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .get(`/v3/contact?company_id=${companyId}&limit=500`)
+        .reply(200, contactsApiResult)
+      this.contacts = await getContactsForCompany('token', companyId)
+    })
 
     it('should return company contacts array', async () => {
-      const actual = await getContactsForCompany('token', companyId)
+      expect(this.contacts).to.deep.equal(contactsApiResult.results)
+    })
 
-      return expect(actual).to.deep.equal(contactsApiResult.results)
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 })

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -1,5 +1,4 @@
 const { assign, find } = require('lodash')
-const nock = require('nock')
 
 const config = require('~/config')
 const eventData = require('~/test/unit/data/events/event.json')

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -51,8 +51,12 @@ describe('Event edit controller', () => {
       ],
     }
 
-    nock(config.apiRoot)
-      .get(`/adviser/?limit=100000&offset=0`)
+    this.nockScope = nock(config.apiRoot)
+      .get('/adviser/')
+      .query({
+        limit: 100000,
+        offset: 0,
+      })
       .reply(200, this.activeInactiveAdviserData)
   })
 
@@ -61,28 +65,32 @@ describe('Event edit controller', () => {
   })
 
   describe('#renderEditPage', () => {
-    it('should render the event page', async () => {
-      await this.controller.renderEditPage(this.req, this.res, this.next)
+    context('when rendering the page', () => {
+      beforeEach(async () => {
+        await this.controller.renderEditPage(this.req, this.res, this.next)
+      })
 
-      expect(this.res.render).to.be.calledWith('events/views/edit')
-      expect(this.res.render).to.have.been.calledOnce
-    })
+      it('should render the event page', () => {
+        expect(this.res.render).to.be.calledWith('events/views/edit')
+        expect(this.res.render).to.have.been.calledOnce
+      })
 
-    it('should render the event page with an event form', async () => {
-      await this.controller.renderEditPage(this.req, this.res, this.next)
+      it('should render the event page with an event form', () => {
+        const actual = this.res.render.getCall(0).args[1].eventForm
 
-      const actual = this.res.render.getCall(0).args[1].eventForm
+        expect(actual).to.be.an('object').and.have.property('hiddenFields').and.have.property('id')
+      })
 
-      expect(actual).to.be.an('object').and.have.property('hiddenFields').and.have.property('id')
-    })
+      it('should prepopulate the team hosting the event with the current user team', () => {
+        const eventForm = this.res.render.getCall(0).args[1].eventForm
+        const actual = find(eventForm.children, { name: 'lead_team' }).value
 
-    it('should prepopulate the team hosting the event with the current user team', async () => {
-      await this.controller.renderEditPage(this.req, this.res, this.next)
+        expect(actual).to.equal(currentUserTeam)
+      })
 
-      const eventForm = this.res.render.getCall(0).args[1].eventForm
-      const actual = find(eventForm.children, { name: 'lead_team' }).value
-
-      expect(actual).to.equal(currentUserTeam)
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
     })
 
     context('when adding an event', () => {
@@ -112,6 +120,10 @@ describe('Event edit controller', () => {
         const formOrganizerFieldOptions = getOrganiserFieldOptions(this.res)
         expect(formOrganizerFieldOptions).to.deep.equal(expectedOptions)
       })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
     })
 
     context('when editing an event', () => {
@@ -124,6 +136,7 @@ describe('Event edit controller', () => {
 
         expect(this.res.breadcrumb.firstCall).to.be.calledWith('name', '/events/123')
         expect(this.res.breadcrumb.secondCall).to.be.calledWith('Edit event')
+        expect(this.nockScope.isDone()).to.be.true
       })
 
       context('and when the organiser is active', () => {
@@ -154,6 +167,10 @@ describe('Event edit controller', () => {
 
           const formOrganizerFieldOptions = getOrganiserFieldOptions(this.res)
           expect(formOrganizerFieldOptions).to.deep.equal(expectedOptions)
+        })
+
+        it('nock mocked scope has been called', () => {
+          expect(this.nockScope.isDone()).to.be.true
         })
       })
     })
@@ -190,6 +207,7 @@ describe('Event edit controller', () => {
         }
 
         expect(actualErrors).to.deep.equal(expectedErrors)
+        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/events/controllers/list.test.js
+++ b/test/unit/apps/events/controllers/list.test.js
@@ -64,7 +64,7 @@ describe('Event list controller', () => {
       disabled_on: null,
     }]
 
-    nock(config.apiRoot)
+    this.nockScope = nock(config.apiRoot)
       .get(`/adviser/?limit=100000&offset=0`)
       .reply(200, { results: advisers })
   })
@@ -84,6 +84,10 @@ describe('Event list controller', () => {
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('filtersFields'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
+    })
+
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 
@@ -122,6 +126,11 @@ describe('Event list controller', () => {
         )
       )
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
+    })
+
+    it('nock mocked scope has been called', async () => {
+      await this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 })

--- a/test/unit/apps/events/controllers/list.test.js
+++ b/test/unit/apps/events/controllers/list.test.js
@@ -1,5 +1,3 @@
-const nock = require('nock')
-
 const config = require('~/config')
 const advisersData = require('../../../data/advisers/advisers')
 

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -10,7 +10,6 @@ describe('Event repos', () => {
     this.sandbox = sinon.sandbox.create()
     this.authorisedRequestStub = this.sandbox.stub().resolves()
     this.searchSpy = this.sandbox.spy(search)
-
     this.repos = proxyquire('~/src/apps/events/repos', {
       '../../lib/authorised-request': this.authorisedRequestStub,
       '../search/services': {
@@ -85,7 +84,7 @@ describe('Event repos', () => {
           }],
         }
 
-        nock(config.apiRoot)
+        this.nockScope = nock(config.apiRoot)
           .post('/v3/search/event')
           .reply(200, this.eventCollection)
       })
@@ -106,6 +105,10 @@ describe('Event repos', () => {
             limit: 100000,
             isAggregation: false,
           })
+        })
+
+        it('nock mocked scope has been called', () => {
+          expect(this.nockScope.isDone()).to.be.true
         })
       })
     })

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -1,5 +1,3 @@
-const nock = require('nock')
-
 const config = require('~/config')
 const { search } = require('~/src/apps/search/services')
 

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -96,15 +96,6 @@ describe('Interaction details middleware', () => {
         { id: '5', name: 'Jim Smith', is_active: false },
       ],
     }
-
-    // TODO fix this when https://github.com/uktrade/data-hub-frontend/pull/1056 is merged
-    nock(config.apiRoot, {
-      reqheaders: {
-        'Authorization': `Bearer ${this.req.session.token}`,
-      },
-    })
-      .get(`/adviser/?limit=100000&offset=0`)
-      .reply(200, this.activeInactiveAdviserData)
   })
 
   afterEach(() => {
@@ -248,6 +239,10 @@ describe('Interaction details middleware', () => {
 
   describe('#getInteractionOOptions', () => {
     beforeEach(() => {
+      this.nockScope = nock(config.apiRoot)
+        .get(`/adviser/?limit=100000&offset=0`)
+        .reply(200, this.activeInactiveAdviserData)
+
       this.res.locals.interaction = assign({}, interactionData, {
         dit_adviser: {
           id: this.activeInactiveAdviserData.results[4].id,
@@ -282,6 +277,10 @@ describe('Interaction details middleware', () => {
 
       it('should not set events data on locals', async () => {
         expect(this.res.locals.events).to.be.undefined
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
       })
     })
 
@@ -322,6 +321,10 @@ describe('Interaction details middleware', () => {
 
       it('should set events data on locals', async () => {
         expect(this.res.locals.events).to.deep.equal(eventsData.results)
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -1,4 +1,4 @@
-const nock = require('nock')
+
 const { set } = require('lodash')
 const { assign, merge } = require('lodash')
 

--- a/test/unit/apps/investment-projects/middleware/collection.test.js
+++ b/test/unit/apps/investment-projects/middleware/collection.test.js
@@ -1,4 +1,4 @@
-const nock = require('nock')
+
 const config = require('~/config')
 const investmentCollectioData = require('~/test/unit/data/investment/collection.json')
 

--- a/test/unit/apps/investment-projects/middleware/collection.test.js
+++ b/test/unit/apps/investment-projects/middleware/collection.test.js
@@ -4,17 +4,12 @@ const investmentCollectioData = require('~/test/unit/data/investment/collection.
 
 describe('Investment projects collection middleware', () => {
   beforeEach(() => {
-    nock(config.apiRoot)
-      .post(`/v3/search/investment_project`)
-      .reply(200, investmentCollectioData)
-
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.spy()
     this.req = Object.assign({}, globalReq, {
       session: { token: 'abcd' },
     })
     this.res = Object.assign({}, globalRes)
-
     this.controller = require('~/src/apps/investment-projects/middleware/collection')
   })
 
@@ -24,6 +19,9 @@ describe('Investment projects collection middleware', () => {
 
   describe('#getInvestmentProjectsCollection', () => {
     beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .post(`/v3/search/investment_project`)
+        .reply(200, investmentCollectioData)
       this.req.query = {
         stage: 'i1',
         sector: 's1',
@@ -39,6 +37,10 @@ describe('Investment projects collection middleware', () => {
       expect(actual).to.have.property('pagination')
       expect(actual.count).to.equal(3)
       expect(this.next).to.have.been.calledOnce
+    })
+
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 

--- a/test/unit/apps/investment-projects/repos.test.js
+++ b/test/unit/apps/investment-projects/repos.test.js
@@ -1,4 +1,4 @@
-const nock = require('nock')
+
 const config = require('~/config')
 
 const {

--- a/test/unit/apps/investment-projects/repos.test.js
+++ b/test/unit/apps/investment-projects/repos.test.js
@@ -15,73 +15,115 @@ const investmentData = require('~/test/unit/data/investment/investment-data.json
 const investmentProjectAuditData = require('~/test/unit/data/investment/audit-log.json')
 
 describe('Investment repository', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
   describe('#getCompanyInvestmentProjects', () => {
-    nock(config.apiRoot)
-      .get(`/v3/investment?investor_company_id=${companyData.id}&limit=10&offset=0`)
-      .reply(200, companyData)
+    beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .get(`/v3/investment?investor_company_id=${companyData.id}&limit=10&offset=0`)
+        .reply(200, companyData)
+      this.investmentProjects = await getCompanyInvestmentProjects('token', companyData.id)
+    })
 
     it('should return a company object', () => {
-      const actual = getCompanyInvestmentProjects('token', companyData.id)
+      expect(this.investmentProjects).to.deep.equal(companyData)
+    })
 
-      return expect(actual).to.eventually.deep.equal(companyData)
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 
   describe('#getInvestment', () => {
-    nock(config.apiRoot)
-      .get(`/v3/investment/${investmentData.id}`)
-      .reply(200, investmentData)
+    beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .get(`/v3/investment/${investmentData.id}`)
+        .reply(200, investmentData)
+      this.investmentProject = await getInvestment('token', investmentData.id)
+    })
 
     it('should return an investment object', () => {
-      const actual = getInvestment('token', investmentData.id)
+      expect(this.investmentProject).to.deep.equal(investmentData)
+    })
 
-      return expect(actual).to.eventually.deep.equal(investmentData)
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 
   describe('#createInvestmentProject', () => {
-    nock(config.apiRoot)
-      .post(`/v3/investment`)
-      .reply(200, { id: '12345' })
+    beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .post(`/v3/investment`)
+        .reply(200, { id: '12345' })
+      this.investmentProject = await createInvestmentProject('token', { foo: 'bar' })
+    })
 
     it('should return an investment requirements object', () => {
-      const actual = createInvestmentProject('token', { foo: 'bar' })
+      expect(this.investmentProject).to.deep.equal({ id: '12345' })
+    })
 
-      return expect(actual).to.eventually.deep.equal({ id: '12345' })
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 
   describe('#updateInvestment', () => {
     const appendedData = { foo: 'bar' }
 
-    nock(config.apiRoot)
-      .patch(`/v3/investment/${investmentData.id}`)
-      .reply(200, investmentData)
+    beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .patch(`/v3/investment/${investmentData.id}`)
+        .reply(200, investmentData)
+      this.investmentProject = await updateInvestment('token', investmentData.id, appendedData)
+    })
 
-    it('should return an investment requirements object', () => {
-      const actual = updateInvestment('token', investmentData.id, appendedData)
+    it('should return an investment requirements object', async () => {
+      expect(this.investmentProject).to.deep.equal(investmentData)
+    })
 
-      return expect(actual).to.eventually.deep.equal(investmentData)
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 
   describe('#archiveInvestmentProject', () => {
-    nock(config.apiRoot)
-      .post(`/v3/investment/${investmentData.id}/archive`, { reason: 'test' })
-      .reply(200, investmentProjectAuditData)
+    beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .post(`/v3/investment/${investmentData.id}/archive`, { reason: 'test' })
+        .reply(200, investmentProjectAuditData)
+      this.investmentProjectAuditData = await archiveInvestmentProject('token', investmentData.id, 'test')
+    })
 
     it('should call archive url and post reason', () => {
-      return archiveInvestmentProject('token', investmentData.id, 'test')
+      expect(this.investmentProjectAuditData).to.deep.equal(investmentProjectAuditData)
+    })
+
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 
-  describe('#unarchiveInvestmentProject', () => {
-    nock(config.apiRoot)
-      .post(`/v3/investment/${investmentData.id}/unarchive`)
-      .reply(200, investmentProjectAuditData)
+  describe('#unarchiveInvestmentProject', async () => {
+    beforeEach(async () => {
+      this.nockScope = nock(config.apiRoot)
+        .post(`/v3/investment/${investmentData.id}/unarchive`)
+        .reply(200, investmentProjectAuditData)
+      this.investmentProjectAuditData = await unarchiveInvestmentProject('token', investmentData.id)
+    })
 
-    it('should call unarchive url', () => {
-      return unarchiveInvestmentProject('token', investmentData.id)
+    it('should call unarchive url', async () => {
+      expect(this.investmentProjectAuditData).to.deep.equal(investmentProjectAuditData)
+    })
+
+    it('nock mocked scope has been called', () => {
+      expect(this.nockScope.isDone()).to.be.true
     })
   })
 })

--- a/test/unit/apps/oauth/controllers/oauth.test.js
+++ b/test/unit/apps/oauth/controllers/oauth.test.js
@@ -87,7 +87,7 @@ describe('OAuth controller', () => {
         })
         set(this.reqMock, 'session.oauth.state', mockState)
 
-        nock(mockFetchUrl.host)
+        this.nockScope = nock(mockFetchUrl.host)
           .post(mockFetchUrl.path)
           .reply(200, { access_token: mockOauthAccessToken })
 
@@ -96,6 +96,11 @@ describe('OAuth controller', () => {
         expect(this.resMock.redirect).to.have.been.calledOnce
         expect(this.resMock.redirect.args[0][0]).to.equal('/')
         expect(this.reqMock.session.token).to.equal(mockOauthAccessToken)
+      })
+
+      it('nock mocked scope has been called', async () => {
+        await this.controller.callbackOAuth(this.reqMock, this.resMock, this.nextSpy)
+        expect(this.nockScope.isDone()).to.be.true
       })
     })
 
@@ -137,7 +142,7 @@ describe('OAuth controller', () => {
       })
 
       it('should show redirect to root page url', async () => {
-        nock(mockFetchUrl.host)
+        this.nockScope = nock(mockFetchUrl.host)
           .post(mockFetchUrl.path)
           .reply(200, { access_token: mockOauthAccessToken })
 
@@ -152,7 +157,7 @@ describe('OAuth controller', () => {
         const returnToUrl = 'return/to/url'
         set(this.reqMock, 'session.returnTo', returnToUrl)
 
-        nock(mockFetchUrl.host)
+        this.nockScope = nock(mockFetchUrl.host)
           .post(mockFetchUrl.path)
           .reply(200, { access_token: mockOauthAccessToken })
 
@@ -166,7 +171,7 @@ describe('OAuth controller', () => {
       it('should handle error as expected', async () => {
         const returnedError = 'terrible things happen in the upside down'
 
-        nock(mockFetchUrl.host)
+        this.nockScope = nock(mockFetchUrl.host)
           .post(mockFetchUrl.path)
           .replyWithError(returnedError)
 
@@ -175,6 +180,11 @@ describe('OAuth controller', () => {
         expect(this.nextSpy).to.have.been.calledOnce
         expect(this.nextSpy.args[0][0].message).to.equal(`Error: ${returnedError}`)
         expect(this.reqMock.session.token).to.be.undefined
+      })
+
+      it('nock mocked scope has been called', async () => {
+        await this.controller.callbackOAuth(this.reqMock, this.resMock, this.nextSpy)
+        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/oauth/controllers/oauth.test.js
+++ b/test/unit/apps/oauth/controllers/oauth.test.js
@@ -1,4 +1,4 @@
-const nock = require('nock')
+
 const queryString = require('query-string')
 const { assign, set } = require('lodash')
 

--- a/test/unit/apps/omis/apps/list/middleware.test.js
+++ b/test/unit/apps/omis/apps/list/middleware.test.js
@@ -1,4 +1,4 @@
-const nock = require('nock')
+
 const { assign } = require('lodash')
 
 const config = require('~/config')

--- a/test/unit/apps/omis/apps/list/middleware.test.js
+++ b/test/unit/apps/omis/apps/list/middleware.test.js
@@ -6,10 +6,6 @@ const orderCollectionData = require('~/test/unit/data/omis/collection.json')
 
 describe('OMIS list middleware', () => {
   beforeEach(() => {
-    nock(config.apiRoot)
-      .post(`/v3/search/order`)
-      .reply(200, orderCollectionData)
-
     this.sandbox = sinon.sandbox.create()
     this.next = this.sandbox.spy()
     this.req = assign({}, globalReq, {
@@ -24,43 +20,59 @@ describe('OMIS list middleware', () => {
     this.sandbox.restore()
   })
 
-  describe('#setCollectionResults', () => {
-    beforeEach(async () => {
-      this.req.query = {
-        status: 'draft',
-        company_name: 'samsung',
-        sortby: 'name:asc',
-      }
-      await this.controller.setCollectionResults(this.req, this.res, this.next)
+  describe('Results', () => {
+    beforeEach(() => {
+      this.nockScope = nock(config.apiRoot)
+        .post(`/v3/search/order`)
+        .reply(200, orderCollectionData)
     })
 
-    it('should set results property on locals with pagination', () => {
-      const actual = this.res.locals.results
-      expect(actual).to.have.property('count')
-      expect(actual).to.have.property('items')
-      expect(actual).to.have.property('pagination')
-      expect(actual.count).to.equal(3)
-      expect(this.next).to.have.been.calledOnce
-    })
-  })
+    context('#setCollectionResults', () => {
+      beforeEach(async () => {
+        this.req.query = {
+          status: 'draft',
+          company_name: 'samsung',
+          sortby: 'name:asc',
+        }
+        await this.controller.setCollectionResults(this.req, this.res, this.next)
+      })
 
-  describe('#setReconciliationResults', () => {
-    beforeEach(async () => {
-      this.req.query = {
-        status: 'draft',
-        company_name: 'samsung',
-        sortby: 'name:asc',
-      }
-      await this.controller.setCollectionResults(this.req, this.res, this.next)
+      it('should set results property on locals with pagination', () => {
+        const actual = this.res.locals.results
+        expect(actual).to.have.property('count')
+        expect(actual).to.have.property('items')
+        expect(actual).to.have.property('pagination')
+        expect(actual.count).to.equal(3)
+        expect(this.next).to.have.been.calledOnce
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
     })
 
-    it('should set results property on locals with pagination', () => {
-      const actual = this.res.locals.results
-      expect(actual).to.have.property('count')
-      expect(actual).to.have.property('items')
-      expect(actual).to.have.property('pagination')
-      expect(actual.count).to.equal(3)
-      expect(this.next).to.have.been.calledOnce
+    context('#setReconciliationResults', () => {
+      beforeEach(async () => {
+        this.req.query = {
+          status: 'draft',
+          company_name: 'samsung',
+          sortby: 'name:asc',
+        }
+        await this.controller.setCollectionResults(this.req, this.res, this.next)
+      })
+
+      it('should set results property on locals with pagination', () => {
+        const actual = this.res.locals.results
+        expect(actual).to.have.property('count')
+        expect(actual).to.have.property('items')
+        expect(actual).to.have.property('pagination')
+        expect(actual.count).to.equal(3)
+        expect(this.next).to.have.been.calledOnce
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
     })
   })
 

--- a/test/unit/apps/search/controllers.test.js
+++ b/test/unit/apps/search/controllers.test.js
@@ -1,4 +1,4 @@
-const nock = require('nock')
+
 const config = require('~/config')
 const { renderSearchResults } = require('~/src/apps/search/controllers')
 

--- a/test/unit/apps/search/services.test.js
+++ b/test/unit/apps/search/services.test.js
@@ -1,6 +1,5 @@
 const { assign } = require('lodash')
 
-const nock = require('nock')
 const config = require('~/config')
 const { search } = require('~/src/apps/search/services')
 

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -2,6 +2,7 @@ const chai = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const reqres = require('reqres')
+const nock = require('nock')
 
 chai.use(require('sinon-chai'))
 chai.use(require('chai-as-promised'))
@@ -11,6 +12,7 @@ chai.use(require('chai-subset'))
 global.expect = chai.expect
 global.sinon = sinon
 global.proxyquire = proxyquire
+global.nock = nock
 global.rootPath = `${process.cwd()}`
 global.rootPath = `${process.cwd()}`
 global.globalReq = reqres.req()

--- a/test/unit/global-helpers.js
+++ b/test/unit/global-helpers.js
@@ -1,0 +1,3 @@
+afterEach(() => {
+  nock.cleanAll()
+})


### PR DESCRIPTION
This Work includes:
- Tidy up use of nock to avoid leaky global http mocks,
- Just mock http on tests where it is required,
- Introduce this.nockScope,
- Introduce "expect(this.nockScope.isDone()).to.be.true" assertions,
- Refactor a number of tests
- Make `nock` a global in unit tests
- Introduce `global-helpers.js` and include a global `afterEach` that clears down nock usage via `nock.cleanAll()`