### PR TITLE
One list account owner editing

### DIFF
--- a/src/apps/companies/controllers/account-management.js
+++ b/src/apps/companies/controllers/account-management.js
@@ -1,0 +1,30 @@
+const { get, merge, pickBy } = require('lodash')
+
+const { accountManagementFormConfig } = require('../macros')
+const { buildFormWithStateAndErrors } = require('../../builders')
+
+function renderAccountManagementEditPage (req, res) {
+  const { one_list_account_owner } = res.locals.company
+  const mergedCompanyData = pickBy(merge({}, { one_list_account_owner }, res.locals.requestBody))
+
+  const accountManagementForm =
+    buildFormWithStateAndErrors(
+      accountManagementFormConfig({
+        returnLink: `/companies/${res.locals.company.id}`,
+        advisers: res.locals.advisers,
+      }),
+      mergedCompanyData,
+      get(res.locals, 'form.errors.messages'),
+    )
+
+  res
+    .breadcrumb('Edit account management')
+    .title(`Edit account management for ${res.locals.company.name}`)
+    .render('companies/views/account-management-edit', {
+      accountManagementForm,
+    })
+}
+
+module.exports = {
+  renderAccountManagementEditPage,
+}

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -64,8 +64,8 @@ const hqLabels = {
   'ukhq': 'UK headquarters (UK HQ)',
 }
 const accountManagementDisplayLabels = {
-  oneListTier: 'One List tier',
-  oneListAccountManager: 'One List account manager',
+  one_list_tier: 'One List tier',
+  one_list_account_owner: 'One List account manager',
 }
 
 const exportDetailsLabels = {

--- a/src/apps/companies/macros.js
+++ b/src/apps/companies/macros.js
@@ -1,4 +1,8 @@
+const { assign } = require('lodash')
+
 const { globalFields } = require('../macros')
+const formLabels = require('./labels')
+const { transformObjectToOption } = require('../transformers')
 
 const companyFiltersFields = [
   {
@@ -45,7 +49,34 @@ const companySortForm = {
   ],
 }
 
+const accountManagementFormConfig = function ({
+  returnLink,
+  advisers = [],
+}) {
+  return {
+    returnLink,
+    buttonText: 'Save',
+    returnText: 'Cancel',
+    children: [
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'one_list_account_owner',
+        initialOption: '-- Select account manager --',
+        optional: true,
+        options () {
+          return advisers.map(transformObjectToOption)
+        },
+      },
+    ].map(field => {
+      return assign(field, {
+        label: formLabels.accountManagementDisplayLabels[field.name],
+      })
+    }),
+  }
+}
+
 module.exports = {
   companySortForm,
   companyFiltersFields,
+  accountManagementFormConfig,
 }

--- a/src/apps/companies/middleware/account-management.js
+++ b/src/apps/companies/middleware/account-management.js
@@ -1,5 +1,6 @@
 const { getAdvisers } = require('../../adviser/repos')
 const { filterActiveAdvisers } = require('../../adviser/filters')
+const { updateCompany } = require('../repos')
 
 async function populateAccountManagementForm (req, res, next) {
   try {
@@ -12,6 +13,23 @@ async function populateAccountManagementForm (req, res, next) {
   }
 }
 
+async function postAccountManagementDetails (req, res, next) {
+  const data = {
+    one_list_account_owner: req.body.one_list_account_owner,
+  }
+
+  try {
+    const result = await updateCompany(req.session.token, res.locals.company.id, data)
+
+    req.flash('success', 'Account management details updated')
+
+    res.redirect(`/companies/${result.id}`)
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
   populateAccountManagementForm,
+  postAccountManagementDetails,
 }

--- a/src/apps/companies/middleware/account-management.js
+++ b/src/apps/companies/middleware/account-management.js
@@ -1,0 +1,17 @@
+const { getAdvisers } = require('../../adviser/repos')
+const { filterActiveAdvisers } = require('../../adviser/filters')
+
+async function populateAccountManagementForm (req, res, next) {
+  try {
+    const advisers = await getAdvisers(req.session.token)
+    res.locals.advisers = filterActiveAdvisers({ advisers: advisers.results })
+
+    next()
+  } catch (err) {
+    next(err)
+  }
+}
+
+module.exports = {
+  populateAccountManagementForm,
+}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -22,6 +22,7 @@ const {
   renderExportEdit,
   handleEditFormPost,
 } = require('./controllers/exports')
+const { renderAccountManagementEditPage } = require('./controllers/account-management')
 
 const { setDefaultQuery, setLocalNav, redirectToFirstNavItem } = require('../middleware')
 const {
@@ -35,6 +36,7 @@ const { setCompanyContactRequestBody, getCompanyContactCollection } = require('.
 const { populateForm, handleFormPost, setIsEditMode } = require('./middleware/form')
 const { getCompany, getCompaniesHouseRecord } = require('./middleware/params')
 const { setInteractionsReturnUrl, setInteractionsEntityName } = require('./middleware/interactions')
+const { populateAccountManagementForm } = require('./middleware/account-management')
 
 const interactionsRouter = require('../interactions/router.sub-app')
 
@@ -82,6 +84,10 @@ router
   .route('/:companyId/edit')
   .get(setIsEditMode, populateForm, renderForm)
   .post(setIsEditMode, populateForm, handleFormPost, renderForm)
+
+router
+  .route('/:companyId/account-management/edit')
+  .get(populateAccountManagementForm, renderAccountManagementEditPage)
 
 router.post('/:companyId/archive', archiveCompany)
 router.get('/:companyId/unarchive', unarchiveCompany)

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -36,7 +36,7 @@ const { setCompanyContactRequestBody, getCompanyContactCollection } = require('.
 const { populateForm, handleFormPost, setIsEditMode } = require('./middleware/form')
 const { getCompany, getCompaniesHouseRecord } = require('./middleware/params')
 const { setInteractionsReturnUrl, setInteractionsEntityName } = require('./middleware/interactions')
-const { populateAccountManagementForm } = require('./middleware/account-management')
+const { populateAccountManagementForm, postAccountManagementDetails } = require('./middleware/account-management')
 
 const interactionsRouter = require('../interactions/router.sub-app')
 
@@ -88,6 +88,7 @@ router
 router
   .route('/:companyId/account-management/edit')
   .get(populateAccountManagementForm, renderAccountManagementEditPage)
+  .post(populateAccountManagementForm, postAccountManagementDetails, renderAccountManagementEditPage)
 
 router.post('/:companyId/archive', archiveCompany)
 router.get('/:companyId/unarchive', unarchiveCompany)

--- a/src/apps/companies/transformers/company-to-one-list-view.js
+++ b/src/apps/companies/transformers/company-to-one-list-view.js
@@ -6,8 +6,8 @@ const { accountManagementDisplayLabels } = require('../labels')
 
 module.exports = function transformCompanyToOneListView ({ one_list_account_owner, classification }) {
   const viewRecord = {
-    oneListAccountManager: get(one_list_account_owner, 'name', 'None'),
-    oneListTier: get(classification, 'name', 'None'),
+    one_list_account_owner: get(one_list_account_owner, 'name', 'None'),
+    one_list_tier: get(classification, 'name', 'None'),
   }
 
   return getDataLabels(viewRecord, accountManagementDisplayLabels)

--- a/src/apps/companies/views/account-management-edit.njk
+++ b/src/apps/companies/views/account-management-edit.njk
@@ -1,0 +1,5 @@
+{% extends "_layouts/datahub-base.njk" %}
+
+{% block body_main_content %}
+  {{ Form(accountManagementForm) }}
+{% endblock %}

--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -23,6 +23,7 @@
   <div class="section">
     <h2 class="heading-medium">Account management</h2>
     {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
+    <p><a href="/companies/{{company.id}}/account-management/edit" class="button button-secondary">Edit</a></p>
   </div>
 
   {% if company.id and not company.archived %}

--- a/test/unit/apps/companies/controllers/account-management.test.js
+++ b/test/unit/apps/companies/controllers/account-management.test.js
@@ -1,0 +1,58 @@
+describe('Companies account management controller', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.controller = require('~/src/apps/companies/controllers/account-management')
+    this.reqMock = {
+      session: {
+        token: 'abcd',
+      },
+      body: {},
+    }
+    this.resMock = {
+      breadcrumb: this.sandbox.stub().returnsThis(),
+      title: this.sandbox.stub().returnsThis(),
+      render: this.sandbox.spy(),
+      redirect: this.sandbox.spy(),
+      locals: {
+        entityName: 'company',
+        returnLink: 'return',
+        company: {
+          id: '1',
+          name: 'Company',
+        },
+        advisers: [],
+      },
+    }
+    this.nextSpy = this.sandbox.spy()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#renderAccountManagementEditPage', () => {
+    beforeEach(async () => {
+      await this.controller.renderAccountManagementEditPage(this.reqMock, this.resMock, this.nextSpy)
+    })
+
+    it('should add a breadcrumb', async () => {
+      expect(this.resMock.breadcrumb.firstCall).to.be.calledWith('Edit account management')
+      expect(this.resMock.breadcrumb).to.have.been.calledOnce
+    })
+
+    it('should add a title', async () => {
+      expect(this.resMock.title.firstCall).to.be.calledWith('Edit account management for Company')
+      expect(this.resMock.title).to.have.been.calledOnce
+    })
+
+    it('should render the account management page', async () => {
+      expect(this.resMock.render).to.be.calledWith('companies/views/account-management-edit')
+      expect(this.resMock.render).to.have.been.calledOnce
+    })
+
+    it('should render the account management page with a return link', async () => {
+      const actual = this.resMock.render.getCall(0).args[1].accountManagementForm.returnLink
+      expect(actual).to.equal('/companies/1')
+    })
+  })
+})

--- a/test/unit/apps/companies/middleware/account-management.test.js
+++ b/test/unit/apps/companies/middleware/account-management.test.js
@@ -1,0 +1,91 @@
+const accountManagementData = require('../../../data/interactions/new-interaction.json')
+const { assign, set, filter } = require('lodash')
+const nock = require('nock')
+
+const config = require('~/config')
+const adviserFilters = require('~/src/apps/adviser/filters')
+
+function createMiddleware (saveCompany, filterActiveAdvisers) {
+  return proxyquire('~/src/apps/companies/middleware/account-management', {
+    '../repos': {
+      saveCompany: saveCompany,
+    },
+    '../../adviser/filters': {
+      filterActiveAdvisers: filterActiveAdvisers,
+    },
+  })
+}
+
+describe('Companies account management middleware', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.saveCompanyStub = this.sandbox.stub()
+    this.filterActiveAdvisersSpy = this.sandbox.spy(adviserFilters, 'filterActiveAdvisers')
+    this.middleware = createMiddleware(this.saveCompanyStub.resolves({ id: '1' }), this.filterActiveAdvisersSpy)
+
+    this.reqMock = {
+      session: {
+        token: 'efgh',
+      },
+      flash: this.sandbox.spy(),
+      body: assign({}, accountManagementData),
+    }
+
+    this.resMock = {
+      breadcrumb: this.sandbox.stub().returnsThis(),
+      render: this.sandbox.spy(),
+      redirect: this.sandbox.spy(),
+      locals: {
+        company: {
+          id: '1',
+        },
+        returnLink: '/return/',
+      },
+    }
+
+    this.nextSpy = this.sandbox.spy()
+
+    this.activeInactiveAdviserData = {
+      count: 5,
+      results: [
+        { id: '1', name: 'Jeff Smith', is_active: true },
+        { id: '2', name: 'John Smith', is_active: true },
+        { id: '3', name: 'Zac Smith', is_active: true },
+        { id: '4', name: 'Fred Smith', is_active: false },
+        { id: '5', name: 'Jim Smith', is_active: false },
+      ],
+    }
+
+    // TODO fix this when https://github.com/uktrade/data-hub-frontend/pull/1056 is merged
+    nock(config.apiRoot, {
+      reqheaders: {
+        'Authorization': `Bearer ${this.reqMock.session.token}`,
+      },
+    })
+      .get('/adviser/?limit=100000&offset=0')
+      .reply(200, this.activeInactiveAdviserData)
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#populateAccountManagementForm', () => {
+    beforeEach(async () => {
+      this.currentAdviser = this.activeInactiveAdviserData.results[3]
+      set(this.resMock, 'locals.interaction.dit_adviser', this.currentAdviser)
+
+      await this.middleware.populateAccountManagementForm(this.reqMock, this.resMock, this.nextSpy)
+    })
+
+    it('should get active advisers and the current adviser', () => {
+      expect(this.filterActiveAdvisersSpy).to.be.calledOnce
+      expect(this.filterActiveAdvisersSpy).to.be.calledWith({ advisers: this.activeInactiveAdviserData.results })
+    })
+
+    it('should set the active advisers', () => {
+      const expectedAdvisers = filter(this.activeInactiveAdviserData.results, 'is_active')
+      expect(this.resMock.locals.advisers).to.deep.equal(expectedAdvisers)
+    })
+  })
+})

--- a/test/unit/apps/companies/middleware/account-management.test.js
+++ b/test/unit/apps/companies/middleware/account-management.test.js
@@ -5,10 +5,10 @@ const nock = require('nock')
 const config = require('~/config')
 const adviserFilters = require('~/src/apps/adviser/filters')
 
-function createMiddleware (saveCompany, filterActiveAdvisers) {
+function createMiddleware (updateCompany, filterActiveAdvisers) {
   return proxyquire('~/src/apps/companies/middleware/account-management', {
     '../repos': {
-      saveCompany: saveCompany,
+      updateCompany: updateCompany,
     },
     '../../adviser/filters': {
       filterActiveAdvisers: filterActiveAdvisers,
@@ -19,9 +19,9 @@ function createMiddleware (saveCompany, filterActiveAdvisers) {
 describe('Companies account management middleware', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
-    this.saveCompanyStub = this.sandbox.stub()
+    this.updateCompanyStub = this.sandbox.stub()
     this.filterActiveAdvisersSpy = this.sandbox.spy(adviserFilters, 'filterActiveAdvisers')
-    this.middleware = createMiddleware(this.saveCompanyStub.resolves({ id: '1' }), this.filterActiveAdvisersSpy)
+    this.middleware = createMiddleware(this.updateCompanyStub.resolves({ id: '1' }), this.filterActiveAdvisersSpy)
 
     this.reqMock = {
       session: {
@@ -86,6 +86,46 @@ describe('Companies account management middleware', () => {
     it('should set the active advisers', () => {
       const expectedAdvisers = filter(this.activeInactiveAdviserData.results, 'is_active')
       expect(this.resMock.locals.advisers).to.deep.equal(expectedAdvisers)
+    })
+  })
+
+  describe('#postAccountManagementDetails', () => {
+    context('when all fields are valid', () => {
+      beforeEach(async () => {
+        await this.middleware.postAccountManagementDetails(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should flash an updated message', async () => {
+        expect(this.reqMock.flash).to.be.calledWith('success', 'Account management details updated')
+        expect(this.reqMock.flash).to.be.calledOnce
+      })
+
+      it('should redirect', async () => {
+        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.resMock.locals.company.id}`)
+        expect(this.resMock.redirect).to.be.calledOnce
+      })
+    })
+
+    context('when there is an error', () => {
+      beforeEach(async () => {
+        this.error = new Error('Error')
+        const middleware = createMiddleware(this.updateCompanyStub.rejects(this.error), this.filterActiveAdvisersSpy)
+
+        await middleware.postAccountManagementDetails(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not flash an updated message', async () => {
+        expect(this.reqMock.flash).to.not.be.called
+      })
+
+      it('should not redirect', async () => {
+        expect(this.resMock.redirect).to.not.be.called
+      })
+
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+        expect(this.nextSpy).to.be.calledOnce
+      })
     })
   })
 })

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -98,7 +98,12 @@ describe('Interaction details middleware', () => {
       ],
     }
 
-    nock(config.apiRoot)
+    // TODO fix this when https://github.com/uktrade/data-hub-frontend/pull/1056 is merged
+    nock(config.apiRoot, {
+      reqheaders: {
+        'Authorization': `Bearer ${this.req.session.token}`,
+      },
+    })
       .get(`/adviser/?limit=100000&offset=0`)
       .reply(200, this.activeInactiveAdviserData)
   })

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -1,5 +1,6 @@
 const nock = require('nock')
 const { set } = require('lodash')
+const { assign, merge } = require('lodash')
 
 const config = require('~/config')
 const interactionData = require('../../../data/interactions/new-interaction.json')
@@ -8,11 +9,10 @@ const servicesData = [
   { id: '632b8708-28b6-e611-984a-e4115bead28a', name: 'Bank Referral' },
 ]
 const contactsData = require('~/test/unit/data/contacts/contacts.json')
+
 const eventsData = require('~/test/unit/data/events/collection.json')
 
 const adviserFilters = require('~/src/apps/adviser/filters')
-
-const { assign, merge } = require('lodash')
 
 const transformed = {
   id: '1',
@@ -24,7 +24,6 @@ describe('Interaction details middleware', () => {
     this.sandbox = sinon.sandbox.create()
     this.saveInteractionStub = this.sandbox.stub()
     this.fetchInteractionStub = this.sandbox.stub()
-    this.getAdvisersStub = this.sandbox.stub()
     this.transformInteractionFormBodyToApiRequestStub = this.sandbox.stub()
     this.transformInteractionResponseToViewRecordStub = this.sandbox.stub()
     this.getContactsForCompanyStub = this.sandbox.stub()
@@ -306,7 +305,10 @@ describe('Interaction details middleware', () => {
 
       it('should get active advisers and the current adviser', () => {
         expect(this.filterActiveAdvisersSpy).to.be.calledOnce
-        expect(this.filterActiveAdvisersSpy).to.be.calledWith({ advisers: this.activeInactiveAdviserData.results, includeAdviser: this.currentAdviser.id })
+        expect(this.filterActiveAdvisersSpy).to.be.calledWith({
+          advisers: this.activeInactiveAdviserData.results,
+          includeAdviser: this.currentAdviser.id,
+        })
       })
 
       it('should set the active advisers on the response object', () => {


### PR DESCRIPTION
This change introduces to ability to edit the One List account owner for a company.

## 1. Edit button
![screen shot 2017-12-04 at 14 47 06](https://user-images.githubusercontent.com/1150417/33558707-836859e6-d902-11e7-8748-6f250beadf67.png)

## 2. Edit account management
![screen shot 2017-12-04 at 14 47 29](https://user-images.githubusercontent.com/1150417/33558720-8d4bfa94-d902-11e7-8c7d-ca85977b331d.png)

## 3. New value is set
![screen shot 2017-12-04 at 14 47 44](https://user-images.githubusercontent.com/1150417/33558732-95bf9258-d902-11e7-8251-0b1cea6178f5.png)