### PR TITLE
Filter disabled on date

### DIFF
--- a/src/apps/filters.js
+++ b/src/apps/filters.js
@@ -1,12 +1,15 @@
-/**
- *
- * @param {string} [currentValue] - The current value for a field so that the options filtered include the current
- *                                  even if invalid
- * @returns {function} - a filter function that will filter out inactive or non-current values
- */
-function filterDisabledOption (currentValue = null) {
+function filterDisabledOption ({ currentValue = null, createdOn } = {}) {
+  const createdOnTime = Date.parse(createdOn) || Date.now()
+
   return function (item) {
-    return !item.disabled_on || item.id === currentValue
+    if (!item.disabled_on) {
+      return true
+    }
+
+    const isDisabled = Date.parse(item.disabled_on) > createdOnTime
+    const isCurrentValue = item.id === currentValue
+
+    return (isDisabled || isCurrentValue)
   }
 }
 

--- a/src/apps/investment-projects/middleware/forms/details.js
+++ b/src/apps/investment-projects/middleware/forms/details.js
@@ -27,6 +27,8 @@ async function populateForm (req, res, next) {
 
   try {
     const investmentData = transformFromApi(res.locals.investmentData)
+    const createdOn = get(investmentData, 'created_on')
+
     const {
       equityCompany,
       equityCompanyInvestment,
@@ -76,13 +78,22 @@ async function populateForm (req, res, next) {
         primarySectors: metadata.sectorOptions.map(transformObjectToOption),
         businessActivities: metadata.businessActivityOptions.map(transformObjectToOption),
         investmentSpecificProgramme: metadata.investmentSpecificProgrammeOptions
-          .filter(filterDisabledOption(state.specific_programme))
+          .filter(filterDisabledOption({
+            createdOn,
+            currentValue: state.specific_programme,
+          }))
           .map(transformObjectToOption),
         investmentInvestorType: metadata.investmentInvestorTypeOptions
-          .filter(filterDisabledOption(state.investor_type))
+          .filter(filterDisabledOption({
+            createdOn,
+            currentValue: state.investor_type,
+          }))
           .map(transformObjectToOption),
         investmentInvolvement: metadata.investmentInvolvementOptions
-          .filter(filterDisabledOption(state.level_of_involvement))
+          .filter(filterDisabledOption({
+            createdOn,
+            currentValue: state.level_of_involvement,
+          }))
           .map(transformObjectToOption),
       },
     })

--- a/test/unit/apps/filters.test.js
+++ b/test/unit/apps/filters.test.js
@@ -1,46 +1,146 @@
+const moment = require('moment')
+
 const { filterDisabledOption } = require('~/src/apps/filters')
 
+const lastMonth = moment().subtract(1, 'months').toISOString()
+const nextMonth = moment().add(1, 'months').toISOString()
+
 describe('#filterDisabledOption', () => {
-  beforeEach(() => {
-    this.options = [{
-      id: 'ac035522-ad0b-4eeb-87f4-0ce964e4b104',
-      name: 'Acquisition',
-      disabled_on: '2017-01-01T11:00:00.000000Z',
-    }, {
-      id: '840f62c1-bbcb-44e4-b6d4-a258d2ffa07d',
-      name: 'Capital only',
-      disabled_on: null,
-    }, {
-      id: 'f8447013-cfdc-4f35-a146-6619665388b3',
-      name: 'Creation of new site or activity',
-      disabled_on: null,
-    }, {
-      id: 'd08a2f07-c366-4133-9a7e-35b6c88a3270',
-      name: 'Expansion of existing site or activity',
-      disabled_on: null,
-    }, {
-      id: 'a7dbf6b3-9c04-43a7-9be9-d3072f138fab',
-      name: 'Joint venture',
-      disabled_on: '2017-01-01T11:00:00.000000Z',
-    }, {
-      id: '32018db0-fd2d-4b8c-aee4-a931bde3abe8',
-      name: 'Merger',
-      disabled_on: null,
-    }, {
-      id: '0657168e-8a58-4f37-914f-ec541556fc28',
-      name: 'Retention',
-      disabled_on: '2017-01-01T11:00:00.000000Z',
-    }]
+  context('when an option was disabled in the past', () => {
+    beforeEach(() => {
+      this.options = [{
+        id: '1234',
+        name: 'Freds',
+        disabled_on: lastMonth,
+      }]
+    })
+
+    context('when the option is not the current field value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption({
+          currentValue: '3',
+          createdOn: lastMonth,
+        }))
+      })
+
+      it('should not include the option', () => {
+        expect(this.filteredOptions).to.have.length(0)
+      })
+    })
+
+    context('when the option is the current field value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption({
+          currentValue: '1234',
+          createdOn: lastMonth,
+        }))
+      })
+
+      it('should include the option', () => {
+        expect(this.filteredOptions).to.have.length(1)
+      })
+    })
+
+    context('when there is no current value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption())
+      })
+
+      it('should not include the option', () => {
+        expect(this.filteredOptions).to.have.length(0)
+      })
+    })
   })
 
-  it('should filter out disabled options', () => {
-    const filtered = this.options.filter(filterDisabledOption())
-    expect(filtered).to.have.length(4)
+  context('when an option is disabled in the future', () => {
+    beforeEach(() => {
+      this.options = [{
+        id: '1234',
+        name: 'Freds',
+        disabled_on: nextMonth,
+      }]
+    })
+
+    context('when the option is not the current field value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption({
+          currentValue: '3',
+          createdOn: lastMonth,
+        }))
+      })
+
+      it('should include the option', () => {
+        expect(this.filteredOptions).to.have.length(1)
+      })
+    })
+
+    context('when the option is the current field value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption({
+          currentValue: '1234',
+          createdOn: lastMonth,
+        }))
+      })
+
+      it('should include the option', () => {
+        expect(this.filteredOptions).to.have.length(1)
+      })
+    })
+
+    context('when there is no current value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption())
+      })
+
+      it('should include the option', () => {
+        expect(this.filteredOptions).to.have.length(1)
+      })
+    })
   })
 
-  it('should include the current value if it is provided', () => {
-    const filtered = this.options.filter(filterDisabledOption('a7dbf6b3-9c04-43a7-9be9-d3072f138fab'))
-    expect(filtered).to.have.length(5)
-    expect(filtered[3]).to.deep.equal(this.options[4])
+  context('when an option is not disabled', () => {
+    beforeEach(() => {
+      this.options = [{
+        id: '1234',
+        name: 'Freds',
+        disabled_on: null,
+      }]
+    })
+
+    context('when the option is not the current field value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption({
+          currentValue: '3',
+          createdOn: lastMonth,
+        }))
+      })
+
+      it('should include the option', () => {
+        expect(this.filteredOptions).to.have.length(1)
+      })
+    })
+
+    context('when the option is the current field value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption({
+          currentValue: '1234',
+          createdOn: lastMonth,
+        }))
+      })
+
+      it('should include the option', () => {
+        expect(this.filteredOptions).to.have.length(1)
+      })
+    })
+
+    context('when there is no current value', () => {
+      beforeEach(() => {
+        this.filteredOptions = this.options.filter(filterDisabledOption())
+      })
+
+      it('should include the option', () => {
+        expect(this.filteredOptions).to.have.length(1)
+      })
+    })
   })
 })


### PR DESCRIPTION
Improves the disabled on filter so that rather than simply test for the presence of a value it filters items marked as disabled after a given date or the current date.

By using the filter in this manner the front end can build a list of items that were enabled at a given point in time, such as the creation date and time of a record being created.