### PR TITLE
Smarter event filter for interaction edit

### DIFF
--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -29,18 +29,15 @@ function getAllEvents (token) {
   return authorisedRequest(token, `${config.apiRoot}/v3/event?limit=100000&offset=0`)
 }
 
-/**
- *
- * @param {string} token Session token to use for API requests
- *
- * @returns {promise[Array]} Returns an array of event objects that have not been disabled or are the current event
- */
-async function getActiveEvents (token) {
+async function getActiveEvents (token, createdOn) {
   const eventsResponse = await search({
     searchEntity: 'event',
     requestBody: {
       sortby: 'name:asc',
-      disabled_on_exists: false,
+      disabled_on: {
+        after: createdOn || (new Date()).toISOString(),
+        exists: false,
+      },
     },
     token: token,
     limit: 100000,

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -66,6 +66,7 @@ async function getInteractionDetails (req, res, next, interactionId) {
 
 async function getInteractionOptions (req, res, next) {
   try {
+    const interaction = res.locals.interaction
     const token = req.session.token
     const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
     const company = get(res.locals, 'company.id')
@@ -78,7 +79,7 @@ async function getInteractionOptions (req, res, next) {
     })
 
     if (req.params.kind === 'service-delivery') {
-      res.locals.events = await getActiveEvents(token)
+      res.locals.events = await getActiveEvents(token, interaction.created_on)
     }
 
     next()

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -79,7 +79,7 @@ async function getInteractionOptions (req, res, next) {
     })
 
     if (req.params.kind === 'service-delivery') {
-      res.locals.events = await getActiveEvents(token, interaction.created_on)
+      res.locals.events = await getActiveEvents(token, get(interaction, 'created_on'))
     }
 
     next()

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -82,19 +82,55 @@ describe('Event repos', () => {
           .reply(200, this.eventCollection)
       })
 
-      context('and no current event', () => {
+      context('and when asked for all active events', () => {
         beforeEach(async () => {
-          this.events = await this.repos.getActiveEvents('1234')
+          const now = new Date()
+          this.clock = sinon.useFakeTimers(now.getTime())
+
+          this.currentFormattedTime = now.toISOString()
+
+          this.events = await this.repos.getActiveEvents(token)
         })
 
-        it('should call search to get the active events', () => {
+        afterEach(() => {
+          this.clock.restore()
+        })
+
+        it('should call search to get all active events today', () => {
           expect(this.searchSpy).to.be.calledWith({
             searchEntity: 'event',
             requestBody: {
               sortby: 'name:asc',
-              disabled_on_exists: false,
+              disabled_on: {
+                exists: false,
+                after: this.currentFormattedTime,
+              },
             },
-            token: '1234',
+            token,
+            limit: 100000,
+            isAggregation: false,
+          })
+        })
+      })
+
+      context('and when asked for all active events at a point in time', () => {
+        beforeEach(async () => {
+          const now = new Date()
+          this.createdOn = now.toISOString()
+          this.events = await this.repos.getActiveEvents(token, this.createdOn)
+        })
+
+        it('should call search to get all active events on the specified date', () => {
+          expect(this.searchSpy).to.be.calledWith({
+            searchEntity: 'event',
+            requestBody: {
+              sortby: 'name:asc',
+              disabled_on: {
+                exists: false,
+                after: this.createdOn,
+              },
+            },
+            token,
             limit: 100000,
             isAggregation: false,
           })


### PR DESCRIPTION
The current version of service delivery editing simply filters out any events that are disabled, but this can cause issues when editing a service delivery after it's associated event has been disabled.

The improved version uses a new event filter that allows the API server to filter events based on when they were disabled. The form options function now asks for events enabled at the time the service delivery was created (or today).