### PR TITLE
Add support for displaying and filtering UK region on orders

### DIFF
--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -43,7 +43,13 @@
 
     <h2 class="heading-medium">What happens next</h2>
 
-    <p>Continuing with the order will notify the post manager for {{ values.primary_market.name }}.</p>
+    <p>
+      Continuing with the order will notify the post manager for {{ values.primary_market.name }}
+      {%- if company.uk_region -%}
+        &nbsp;and the region manager for {{ company.uk_region.name }}
+      {%- endif -%}
+      .
+    </p>
 
     <p>You will not be able to edit the company or market (country) after this point.</p>
 

--- a/src/apps/omis/apps/list/macros.js
+++ b/src/apps/omis/apps/list/macros.js
@@ -42,6 +42,15 @@ const collectionFiltersFields = flatten([
     options () {
       return metadataRepo.omisMarketOptions.map(transformObjectToOption)
     },
+  },
+  {
+    macroName: 'MultipleChoiceField',
+    label: 'UK region',
+    name: 'uk_region',
+    initialOption: 'All regions',
+    options () {
+      return metadataRepo.regionOptions.map(transformObjectToOption)
+    },
   }],
 ]).map(filter => {
   return assign({}, filter, {

--- a/src/apps/omis/apps/list/middleware.js
+++ b/src/apps/omis/apps/list/middleware.js
@@ -51,6 +51,7 @@ function setRequestBody (req, res, next) {
     'company_name',
     'contact_name',
     'primary_market',
+    'uk_region',
     'reference',
     'total_cost',
     'net_cost',

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -63,7 +63,8 @@
     {{ MetaList({
       items: [
         { label: 'Client company', value: companyText | safe },
-        { label: 'Market (country)', value: order.primary_market }
+        { label: 'Market (country)', value: order.primary_market },
+        { label: 'UK region', value: order.uk_region }
       ],
       itemModifier: 'stacked'
     }) }}

--- a/src/apps/omis/transformers.js
+++ b/src/apps/omis/transformers.js
@@ -10,6 +10,7 @@ function transformOrderToListItem ({
   company,
   contact,
   primary_market,
+  uk_region,
   delivery_date,
   modified_on,
   created_on,
@@ -51,6 +52,10 @@ function transformOrderToListItem ({
         label: 'Updated',
         type: 'datetime',
         value: modified_on,
+      },
+      {
+        label: 'UK region',
+        value: uk_region,
       },
     ],
   }

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -43,6 +43,7 @@ describe('OMIS list transformers', () => {
             { label: 'Created', type: 'datetime', value: '2017-07-26T14:08:36.380979' },
             { label: 'Contact', value: 'Jenny Cakeman' },
             { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
+            { label: 'UK region', value: 'London' },
           ])
         })
       })
@@ -61,6 +62,7 @@ describe('OMIS list transformers', () => {
             { label: 'Created', type: 'datetime', value: '2017-07-26T14:08:36.380979' },
             { label: 'Contact', value: 'Jenny Cakeman' },
             { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
+            { label: 'UK region', value: 'London' },
           ])
         })
       })
@@ -83,6 +85,7 @@ describe('OMIS list transformers', () => {
             { label: 'Created', type: 'datetime', value: '2017-07-26T14:08:36.380979' },
             { label: 'Contact', value: 'Jenny Cakeman' },
             { label: 'Updated', type: 'datetime', value: '2017-08-16T14:18:28.328729' },
+            { label: 'UK region', value: 'London' },
             { label: 'Delivery date', type: 'date', value: '2018-10-16T14:18:28.328729' },
           ])
         })

--- a/test/unit/data/omis/simple-order.json
+++ b/test/unit/data/omis/simple-order.json
@@ -64,5 +64,6 @@
   "net_cost": 0,
   "subtotal_cost": 0,
   "vat_cost": 0,
-  "total_cost": 0
+  "total_cost": 0,
+  "uk_region": "London"
 }


### PR DESCRIPTION
This adds the display of the UK region associated with an order to
the order overview and support for filtering on the region to the
collection page.

## What it looks like

### Order overview
![localhost_3001_omis_81fe292f-8427-4cce-a056-0c6191a2057c_work-order](https://user-images.githubusercontent.com/3327997/33843424-3ea1efdc-de95-11e7-8eb6-7780cda31081.png)

### Listing page

![localhost_3001_omis_sortby created_on 3adesc](https://user-images.githubusercontent.com/3327997/33843584-b4c6c110-de95-11e7-93ec-d8ba3dc1dc22.png)
