### PR TITLE
Correct use of secondary modifier for investment buttons

### DIFF
--- a/src/apps/investment-projects/views/details.njk
+++ b/src/apps/investment-projects/views/details.njk
@@ -2,7 +2,7 @@
 
 {% macro renderButton(endpoint, label, isSecondary) %}
   <p>
-    <a href="edit-{{ endpoint }}" class="button{{ '-secondary' if isSecondary }}">
+    <a href="edit-{{ endpoint }}" class="button{{ '--secondary' if isSecondary }}">
       {{ label }}
     </a>
   </p>


### PR DESCRIPTION
During the change to button modifiers the investment button macro was
missed.