### PR TITLE
Feature/filter company reference data

### DIFF
--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -1,4 +1,4 @@
-const { assign, find, get } = require('lodash')
+const { assign, find, get, isEmpty } = require('lodash')
 
 const { transformCompaniesHouseToView } = require('../transformers')
 
@@ -44,14 +44,17 @@ function renderForm (req, res) {
     })
   }
   const businessTypeLabel = getBusinessTypeLabel(
-    res.locals.companiesHouseCategory, isForeign, res.locals.businessType
+    res.locals.companiesHouseCategory, isForeign, get(res.locals, 'formData.business_type')
   )
+
+  const showTradingAddress = !isEmpty(get(res.locals, 'formData.trading_address_1'))
 
   res
     .breadcrumb(pageTitle)
     .render('companies/views/edit', {
       isForeign,
       businessTypeLabel,
+      showTradingAddress,
     })
 }
 

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -78,12 +78,12 @@ router
     '/add/:companyNumber',
   ])
   .get(populateForm, renderForm)
-  .post(populateForm, handleFormPost, renderForm)
+  .post(handleFormPost, populateForm, renderForm)
 
 router
   .route('/:companyId/edit')
   .get(setIsEditMode, populateForm, renderForm)
-  .post(setIsEditMode, populateForm, handleFormPost, renderForm)
+  .post(handleFormPost, setIsEditMode, populateForm, renderForm)
 
 router
   .route('/:companyId/account-management/edit')

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -224,7 +224,7 @@
           <div class="section">
             <h2 class="heading-medium">Country</h2>
             <p>United Kingdom</p>
-            <input type="hidden" name="trading_address_country" value="">
+            <input type="hidden" name="trading_address_country" value="{{ formData.trading_address_country }}">
           </div>
         {% else %}
           {{ MultipleChoiceField({

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -144,7 +144,7 @@
             name: 'registered_address_country',
             label: 'Country',
             initialOption: '-- Select country --',
-            options: countryOptions,
+            options: options.countries,
             value: formData.registered_address_country,
             error: errors.registered_address_country
           }) }}
@@ -232,7 +232,7 @@
             label: 'Country',
             disabled: true if not isForeign else false,
             initialOption: '-- Select country --',
-            options: countryOptions,
+            options: options.countries,
             value: formData.trading_address_country,
             error: errors.trading_address_country
           }) }}
@@ -245,7 +245,7 @@
         name: 'uk_region',
         label: 'UK region',
         initialOption: '-- Select region --',
-        options: regionOptions,
+        options: options.regions,
         value: formData.uk_region,
         error: errors.uk_region
       }) }}
@@ -255,7 +255,7 @@
       type: 'radio',
       name: 'headquarter_type',
       label: 'Headquarter type',
-      options: headquarterOptions,
+      options: options.headquarters,
       value: formData.headquarter_type,
       error: errors.headquarter_type
     }) }}
@@ -264,7 +264,7 @@
       name: 'sector',
       label: 'Sector',
       initialOption: '-- Select sector --',
-      options: sectorOptions,
+      options: options.sectors,
       value: formData.sector,
       error: errors.sector
     }) }}
@@ -290,7 +290,7 @@
       name: 'employee_range',
       label: 'Number of employees',
       optional: true,
-      options: employeeOptions,
+      options: options.employees,
       value: formData.employee_range,
       error: errors.employee_range
     }) }}
@@ -300,7 +300,7 @@
       name: 'turnover_range',
       label: 'Annual turnover',
       optional: true,
-      options: turnoverOptions,
+      options: options.turnovers,
       value: formData.turnover_range,
       error: errors.turnover_range
     }) }}

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,0 +1,25 @@
+const config = require('../../config')
+const authorisedRequest = require('../lib/authorised-request')
+const { filterDisabledOption } = require('../apps/filters')
+const { transformObjectToOption } = require('../apps/transformers')
+const logger = require('../../config/logger')
+
+async function getOptions (token, key, { createdOn, currentValue, includeDisabled = false } = {}) {
+  try {
+    const url = `${config.apiRoot}/metadata/${key}/`
+    let options = await authorisedRequest(token, url)
+
+    if (!includeDisabled) {
+      options = options.filter(filterDisabledOption({ currentValue, createdOn }))
+    }
+
+    return options.map(transformObjectToOption)
+  } catch (error) {
+    logger.error(error)
+    return []
+  }
+}
+
+module.exports = {
+  getOptions,
+}

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -166,7 +166,9 @@ describe('Company export controller', () => {
     it('should treat non-uk company as foreign', () => {
       const reqMock = this.buildReq({ query: { country: 'non-uk' } })
       const resMock = this.buildRes({
-        locals: {},
+        locals: {
+          formData: {},
+        },
       })
       this.controller.renderForm(reqMock, resMock, this.nextSpy)
       expect(this.renderSpy.args[0][1].isForeign).to.equal(true)
@@ -177,7 +179,9 @@ describe('Company export controller', () => {
       const resMock = this.buildRes({
         locals: {
           company: { 'uk_based': false },
-          businessType: '9ad14e94-5d95-e211-a939-e4115bead28a',
+          formData: {
+            business_type: '9ad14e94-5d95-e211-a939-e4115bead28a',
+          },
         },
         companiesHouseRecord: { country: 'fr' },
       })
@@ -190,6 +194,7 @@ describe('Company export controller', () => {
       const resMock = this.buildRes({
         locals: {
           company: { 'uk_based': true },
+          formData: {},
         },
       })
       this.controller.renderForm(reqMock, resMock, this.nextSpy)
@@ -201,10 +206,39 @@ describe('Company export controller', () => {
       const resMock = this.buildRes({
         locals: {
           companiesHouseCategory: 'limited company',
+          formData: {},
         },
       })
       this.controller.renderForm(reqMock, resMock, this.nextSpy)
       expect(this.renderSpy.args[0][1].businessTypeLabel).to.equal('UK limited company')
+    })
+
+    it('should hide the trading address if there is\'t one', () => {
+      const reqMock = this.buildReq({ query: {} })
+      const resMock = this.buildRes({
+        locals: {
+          companiesHouseCategory: 'limited company',
+          formData: {},
+        },
+      })
+      this.controller.renderForm(reqMock, resMock, this.nextSpy)
+
+      expect(this.renderSpy.args[0][1].showTradingAddress).to.eq(false)
+    })
+
+    it('should show the trading address if there is one', () => {
+      const reqMock = this.buildReq({ query: {} })
+      const resMock = this.buildRes({
+        locals: {
+          companiesHouseCategory: 'limited company',
+          formData: {
+            trading_address_1: 'test',
+          },
+        },
+      })
+      this.controller.renderForm(reqMock, resMock, this.nextSpy)
+
+      expect(this.renderSpy.args[0][1].showTradingAddress).to.eq(true)
     })
   })
 })

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -1,197 +1,434 @@
+const nock = require('nock')
+const { assign } = require('lodash')
+const moment = require('moment')
+
+const config = require('~/config')
+const companiesHouseRecord = require('~/test/unit/data/companies/companies-house.json')
+const companyRecord = require('~/test/unit/data/companies/datahub-only-company.json')
+
+const yesterday = moment().subtract(1, 'days').toISOString()
+const middleware = require('~/src/apps/companies/middleware/form')
+const formService = require('~/src/apps/companies/services/form')
+
+const metadata = require('~/src/lib/metadata')
+
 const metadataMock = {
-  headquarterOptions: [],
-  regionOptions: [],
-  sectorOptions: [],
-  employeeOptions: [],
-  turnoverOptions: [],
-  countryOptions: [],
+  headquarterOptions: [
+    { id: '1', name: 'ehq', disabled_on: null },
+    { id: '2', name: 'ghq', disabled_on: yesterday },
+    { id: '3', name: 'ukhq', disabled_on: null },
+  ],
+  regionOptions: [
+    { id: '1', name: 'r1', disabled_on: null },
+    { id: '2', name: 'r2', disabled_on: yesterday },
+    { id: '3', name: 'r3', disabled_on: null },
+  ],
+  sectorOptions: [
+    { id: '1', name: 's1', disabled_on: null },
+    { id: '2', name: 's2', disabled_on: yesterday },
+    { id: '3', name: 's3', disabled_on: null },
+  ],
+  employeeOptions: [
+    { id: '1', name: 'e1', disabled_on: null },
+    { id: '2', name: 'e2', disabled_on: yesterday },
+    { id: '3', name: 'e3', disabled_on: null },
+  ],
+  turnoverOptions: [
+    { id: '1', name: 't1', disabled_on: null },
+    { id: '2', name: 't2', disabled_on: yesterday },
+    { id: '3', name: 't3', disabled_on: null },
+  ],
+  countryOptions: [
+    { id: '9999', name: 'United Kingdom', disabled_on: null },
+    { id: '8888', name: 'Test', disabled_on: yesterday },
+  ],
+  businessTypeOptions: [
+    { id: '12345', name: 'example-bussiness-type-id-12345' },
+    { id: '33333', name: 'Private Limited Company' },
+  ],
 }
 
 describe('Companies form middleware', () => {
   beforeEach(() => {
+    this.flashSpy = sandbox.spy()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.redirectSpy = sandbox.spy()
     this.nextSpy = sandbox.spy()
+
     this.reqMock = {
       query: {},
+      session: {
+        token: '1234',
+      },
+      flash: this.flashSpy,
     }
+
     this.resMock = {
       locals: {},
+      breadcrumb: this.breadcrumbStub,
+      redirect: this.redirectSpy,
     }
-
-    this.middleware = proxyquire('~/src/apps/companies/middleware/form', {
-      '../../../lib/metadata': metadataMock,
-    })
   })
 
-  describe('populateForm()', () => {
-    it('should include the required properties in the response', () => {
-      this.middleware.populateForm(this.reqMock, this.resMock, this.nextSpy)
-
-      expect(this.resMock.locals).to.have.property('regionOptions')
-      expect(this.resMock.locals).to.have.property('sectorOptions')
-      expect(this.resMock.locals).to.have.property('employeeOptions')
-      expect(this.resMock.locals).to.have.property('turnoverOptions')
-      expect(this.resMock.locals).to.have.property('headquarterOptions')
-      expect(this.resMock.locals).to.have.property('countryOptions')
-      expect(this.resMock.locals).to.have.property('businessType')
-      expect(this.resMock.locals).to.have.property('showTradingAddress')
+  describe('#populateForm()', () => {
+    beforeEach(() => {
+      metadata.businessTypeOptions = metadataMock.businessTypeOptions
+      this.nockScope = nock(config.apiRoot)
+        .get('/metadata/uk-region/')
+        .reply(200, metadataMock.regionOptions)
+        .get('/metadata/headquarter-type/')
+        .reply(200, metadataMock.headquarterOptions)
+        .get('/metadata/sector/')
+        .reply(200, metadataMock.sectorOptions)
+        .get('/metadata/employee-range/')
+        .reply(200, metadataMock.employeeOptions)
+        .get('/metadata/turnover/')
+        .reply(200, metadataMock.turnoverOptions)
+        .get('/metadata/country/')
+        .reply(200, metadataMock.countryOptions)
+        .get('/metadata/business-type/')
+        .reply(200, metadataMock.businessTypeOptions)
     })
 
-    it('should call next with no arguments', () => {
-      this.middleware.populateForm(this.reqMock, this.resMock, this.nextSpy)
-
-      expect(this.nextSpy).to.be.calledWith()
+    afterEach(() => {
+      delete metadata.businessTypeOption
     })
 
-    context('when query contains business_type', () => {
-      beforeEach(() => {
-        this.reqMock = {
-          query: {
-            business_type: 'example-bussiness-type-id-12345',
-          },
-        }
-
-        this.middlware = proxyquire('~/src/apps/companies/middleware/form', {
-          '../../../lib/metadata': Object.assign({}, metadataMock, {
-            businessTypeOptions: [{
-              name: 'Charity',
-              id: 'example-bussiness-type-id-12345',
-            }],
-          }),
-        })
+    context('when creating any new company', () => {
+      beforeEach(async () => {
+        await middleware.populateForm(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should add it to form state', () => {
-        this.middlware.populateForm(this.reqMock, this.resMock, this.nextSpy)
+      it('should include the active region options for use in the form', () => {
+        expect(this.resMock.locals.options.regions).to.deep.equal([
+          { value: '1', label: 'r1' },
+          { value: '3', label: 'r3' },
+        ])
+      })
 
-        expect(this.resMock.locals.form.state).to.have.property('business_type', 'example-bussiness-type-id-12345')
+      it('should include the active sector options for use in the form', () => {
+        expect(this.resMock.locals.options.sectors).to.deep.equal([
+          { value: '1', label: 's1' },
+          { value: '3', label: 's3' },
+        ])
+      })
+
+      it('should include the active employee options for use in the form', () => {
+        expect(this.resMock.locals.options.employees).to.deep.equal([
+          { value: '1', label: 'e1' },
+          { value: '3', label: 'e3' },
+        ])
+      })
+
+      it('should include the active turnover options for use in the form', () => {
+        expect(this.resMock.locals.options.turnovers).to.deep.equal([
+          { value: '1', label: 't1' },
+          { value: '3', label: 't3' },
+        ])
+      })
+
+      it('should include the active country options for use in the form', () => {
+        expect(this.resMock.locals.options.countries).to.deep.equal([{ value: '9999', label: 'United Kingdom' }])
+      })
+
+      it('should include headquarter options that have had label substituted and an option for not a headquarters', () => {
+        expect(this.resMock.locals.options.headquarters).to.deep.equal([
+          { value: 'not_headquarters', label: 'Not a headquarters' },
+          { value: '1', label: 'European headquarters (EHQ)' },
+          { value: '3', label: 'UK headquarters (UK HQ)' },
+        ])
+      })
+    })
+
+    context('when creating a new company from companies house', () => {
+      beforeEach(async () => {
+        this.resMock.locals.companiesHouseRecord = companiesHouseRecord
+        await middleware.populateForm(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should pre-populate the form with companies house values', () => {
+        const formData = this.resMock.locals.formData
+        expect(formData).to.have.property('name', 'Mercury Trading Ltd')
+        expect(formData).to.have.property('business_type', '33333')
+        expect(formData).to.have.property('company_number', '99919')
+        expect(formData).to.have.property('registered_address_1', '64 Ermin Street')
+        expect(formData).to.have.property('registered_address_town', 'Y Ffor')
+        expect(formData).to.have.property('registered_address_postcode', 'LL53 5RN')
+      })
+    })
+
+    context('when editing an existing company', () => {
+      beforeEach(async () => {
+        this.resMock.locals.company = assign({}, companyRecord, {
+          uk_region: { id: 'r2' },
+          sector: { id: 's2' },
+          employee_range: { id: 'e2' },
+          turnover_range: { id: 't2' },
+          trading_address_country: { id: '8888' },
+        })
+        await middleware.populateForm(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should pre-populate the form with company values', () => {
+        const formData = this.resMock.locals.formData
+        expect(formData).to.have.property('name', 'SAMSUNG BIOEPIS UK LIMITED')
+        expect(formData).to.have.property('business_type', '6f75408b-03e7-e611-bca1-e4115bead28a')
+        expect(formData).to.have.property('registered_address_1', '5TH FLOOR, PROFILE WEST')
+        expect(formData).to.have.property('registered_address_town', 'BRENTFORD')
+        expect(formData).to.have.property('registered_address_postcode', 'TW8 9ES')
+      })
+
+      it('should include the active region options for use in the form and the current option', () => {
+        expect(this.resMock.locals.options.regions).to.deep.equal([
+          { value: '1', label: 'r1' },
+          { value: '2', label: 'r2' },
+          { value: '3', label: 'r3' },
+        ])
+      })
+
+      it('should include the active sector options for use in the form and the current option', () => {
+        expect(this.resMock.locals.options.sectors).to.deep.equal([
+          { value: '1', label: 's1' },
+          { value: '2', label: 's2' },
+          { value: '3', label: 's3' },
+        ])
+      })
+
+      it('should include the active employee options for use in the form and the current option', () => {
+        expect(this.resMock.locals.options.employees).to.deep.equal([
+          { value: '1', label: 'e1' },
+          { value: '2', label: 'e2' },
+          { value: '3', label: 'e3' },
+        ])
+      })
+
+      it('should include the active turnover options for use in the form and the current option', () => {
+        expect(this.resMock.locals.options.turnovers).to.deep.equal([
+          { value: '1', label: 't1' },
+          { value: '2', label: 't2' },
+          { value: '3', label: 't3' },
+        ])
+      })
+
+      it('should include the active country options for use in the form and the current option', () => {
+        expect(this.resMock.locals.options.countries).to.deep.equal([
+          { value: '9999', label: 'United Kingdom' },
+          { value: '8888', label: 'Test' },
+        ])
+      })
+    })
+
+    context('when populating a company for for a previous failed save', () => {
+      beforeEach(async () => {
+        this.resMock.locals.company = companyRecord
+        this.reqMock.body = {
+          name: 'Fred Bloggs Pies',
+        }
+
+        await middleware.populateForm(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should pre-populate the form with posted data', () => {
+        const formData = this.resMock.locals.formData
+        expect(formData).to.have.property('name', 'Fred Bloggs Pies')
       })
     })
   })
 
   describe('handleFormPost()', () => {
-    const token = 'abcd1234'
-    const company = {
-      id: '12345abcde',
-      name: 'foo',
-    }
-    const body = {
-      id: '12345abcde',
-      name: 'bar',
-    }
-
     beforeEach(() => {
-      this.flashSpy = sandbox.spy()
-      this.breadcrumbStub = sandbox.stub().returnsThis()
-      this.redirectSpy = sandbox.spy()
-      this.saveCompanyFormStub = sandbox.stub()
-
-      this.reqMock = {
-        body,
-        session: {
-          token,
-        },
-        flash: this.flashSpy,
-      }
-      this.resMock = {
-        locals: {},
-        breadcrumb: this.breadcrumbStub,
-        redirect: this.redirectSpy,
-      }
-
-      this.formMiddleware = proxyquire('~/src/apps/companies/middleware/form', {
-        '../services/form': {
-          saveCompanyForm: this.saveCompanyFormStub,
-        },
-      })
+      this.saveCompanyFormSpy = sandbox.spy(formService, 'saveCompanyForm')
     })
 
-    context('when save resolves', () => {
-      beforeEach(() => {
-        this.saveCompanyFormStub.resolves(company)
+    context('when saving a new company works', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .post('/v3/company')
+          .reply(200, companyRecord)
+
+        this.reqMock.body = {
+          name: 'Fred Bloggs Ltd',
+        }
+
+        await middleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should call save company service', async () => {
-        await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-        expect(this.saveCompanyFormStub).to.have.been.calledWith(token, body)
+      it('should call save company service', () => {
+        expect(this.saveCompanyFormSpy).to.have.been.calledWith(this.reqMock.session.token, this.reqMock.body)
       })
 
-      it('should call flash message', async () => {
-        await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
+      it('should call flash message', () => {
         expect(this.flashSpy).to.have.been.calledOnce
       })
 
-      it('should redirect to the entity', async () => {
-        await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-        expect(this.redirectSpy).to.have.been.calledWith(`/companies/${company.id}`)
+      it('should redirect to the entity', () => {
+        expect(this.redirectSpy).to.have.been.calledWith(`/companies/${companyRecord.id}`)
       })
 
-      it('should not call next', async () => {
-        await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
+      it('should not call next', () => {
         expect(this.nextSpy).not.to.have.been.called
       })
     })
 
-    context('when save rejects', () => {
-      context('when API returns errors', () => {
-        beforeEach(() => {
-          this.error = {
-            errors: {
-              foo: 'is required',
-            },
-          }
-          this.saveCompanyFormStub.rejects(this.error)
-        })
+    context('when saving a new company fails validation', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .post('/v3/company')
+          .reply(500, {
+            errors: 'error',
+          })
 
-        it('should set error on locals', async () => {
-          await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-          expect(this.resMock.locals).to.have.property('errors')
-        })
+        this.reqMock.body = {
+          name: 'Fred Bloggs Ltd',
+        }
 
-        it('should call next with no argument', async () => {
-          await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-          expect(this.nextSpy).to.have.been.calledWith()
-        })
+        await middleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      context('when API returns errors', () => {
-        beforeEach(() => {
-          this.error = {
-            errors: {
-              errors: {
-                foo: 'is required',
-              },
-            },
-          }
-          this.saveCompanyFormStub.rejects(this.error)
-        })
-
-        it('should set error on locals', async () => {
-          await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-          expect(this.resMock.locals).to.have.property('errors')
-        })
-
-        it('should call next with no argument', async () => {
-          await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-          expect(this.nextSpy).to.have.been.calledWith()
-        })
+      it('should set the error on the response', () => {
+        expect(this.resMock.locals).to.have.property('errors', 'error')
       })
 
-      context('when catch returns other error', () => {
-        beforeEach(() => {
-          this.error = {
-            statusCode: 500,
-          }
-          this.saveCompanyFormStub.rejects(this.error)
-        })
+      it('should call next to continue along the chain', () => {
+        expect(this.nextSpy).to.have.been.calledOnce
+      })
+    })
 
-        it('should not set error on locals', async () => {
-          await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-          expect(this.resMock.locals).not.to.have.property('errors')
-        })
+    context('when saving an existing company works', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .patch(`/v3/company/${companyRecord.id}`)
+          .reply(200, companyRecord)
 
-        it('should call next with error as argument', async () => {
-          await this.formMiddleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
-          expect(this.nextSpy).to.have.been.calledWith(this.error)
+        this.reqMock.body = {
+          id: companyRecord.id,
+          name: 'Fred Bloggs Ltd',
+        }
+
+        await middleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call save company service', () => {
+        expect(this.saveCompanyFormSpy).to.have.been.calledWith(this.reqMock.session.token, this.reqMock.body)
+      })
+
+      it('should call flash message', () => {
+        expect(this.flashSpy).to.have.been.calledOnce
+      })
+
+      it('should redirect to the entity', () => {
+        expect(this.redirectSpy).to.have.been.calledWith(`/companies/${companyRecord.id}`)
+      })
+
+      it('should not call next', () => {
+        expect(this.nextSpy).not.to.have.been.called
+      })
+    })
+
+    context('when saving an existing company fails', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .patch(`/v3/company/${companyRecord.id}`)
+          .reply(500, {
+            errors: 'error',
+          })
+
+        this.reqMock.body = {
+          id: companyRecord.id,
+          name: 'Fred Bloggs Ltd',
+        }
+
+        await middleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should set the error on the response', () => {
+        expect(this.resMock.locals).to.have.property('errors', 'error')
+      })
+
+      it('should call next to continue along the chain', () => {
+        expect(this.nextSpy).to.have.been.calledOnce
+      })
+    })
+
+    context('when saving a uk company with just a registered address', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .post('/v3/company')
+          .reply(200, companyRecord)
+          .get('/metadata/country/')
+          .reply(200, metadataMock.countryOptions)
+
+        this.reqMock.query = {
+          country: 'uk',
+        }
+
+        this.reqMock.body = {
+          name: 'Fred Boggs Ltd',
+          registered_address_1: 'street',
+        }
+
+        await middleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('sets the registered address country to the uk', () => {
+        expect(this.saveCompanyFormSpy).to.have.been.calledWith(this.reqMock.session.token, {
+          name: 'Fred Boggs Ltd',
+          registered_address_1: 'street',
+          registered_address_country: '9999',
+        })
+      })
+    })
+
+    context('when saving a uk company with a trading and registered address', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .post('/v3/company')
+          .reply(200, companyRecord)
+          .get('/metadata/country/')
+          .reply(200, metadataMock.countryOptions)
+
+        this.reqMock.query = {
+          country: 'uk',
+        }
+
+        this.reqMock.body = {
+          name: 'Fred Boggs Ltd',
+          registered_address_1: 'street',
+          trading_address_1: 'another street',
+        }
+
+        await middleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('sets the registered and trading address country to the uk', () => {
+        expect(this.saveCompanyFormSpy).to.have.been.calledWith(this.reqMock.session.token, {
+          name: 'Fred Boggs Ltd',
+          registered_address_1: 'street',
+          registered_address_country: '9999',
+          trading_address_1: 'another street',
+          trading_address_country: '9999',
+        })
+      })
+    })
+
+    context('when the user indicates the company is not a headquarters', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .post('/v3/company')
+          .reply(200, companyRecord)
+
+        this.reqMock.body = {
+          name: 'Fred Boggs Ltd',
+          headquarter_type: 'not_headquarters',
+        }
+
+        await middleware.handleFormPost(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('Removes the headquarter type value', () => {
+        expect(this.saveCompanyFormSpy).to.have.been.calledWith(this.reqMock.session.token, {
+          name: 'Fred Boggs Ltd',
+          headquarter_type: '',
         })
       })
     })
@@ -200,7 +437,7 @@ describe('Companies form middleware', () => {
   describe('setIsEditMode', () => {
     it('should set edit mode', () => {
       expect(this.resMock.locals.isEditMode).to.equal(undefined)
-      this.middleware.setIsEditMode(this.reqMock, this.resMock, this.nextSpy)
+      middleware.setIsEditMode(this.reqMock, this.resMock, this.nextSpy)
       expect(this.resMock.locals.isEditMode).to.equal(true)
       expect(this.nextSpy).to.have.been.calledOnce
     })

--- a/test/unit/lib/options.test.js
+++ b/test/unit/lib/options.test.js
@@ -1,0 +1,78 @@
+const nock = require('nock')
+const moment = require('moment')
+
+const config = require('~/config')
+const yesterday = moment().subtract(1, 'days').toISOString()
+const lastWeek = moment().subtract(1, 'weeks').toISOString()
+const today = moment().toISOString()
+
+const { getOptions } = require('~/src/lib/options')
+
+const regionOptions = [
+  { id: '1', name: 'r1', disabled_on: null },
+  { id: '2', name: 'r2', disabled_on: yesterday },
+  { id: '3', name: 'r3', disabled_on: null },
+]
+
+describe('#options', () => {
+  beforeEach(() => {
+    this.nockScope = nock(config.apiRoot)
+      .get('/metadata/uk-region/')
+      .reply(200, regionOptions)
+  })
+
+  context('when asking for options for a new record', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region')
+    })
+
+    it('should return just active options', () => {
+      expect(this.options).to.deep.equal([
+        { label: 'r1', value: '1' },
+        { label: 'r3', value: '3' },
+      ])
+    })
+  })
+
+  context('when asking for options for an existing record using disabled value', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', { currentValue: '2', createdOn: today })
+    })
+
+    it('should return just active options', () => {
+      expect(this.options).to.deep.equal([
+        { label: 'r1', value: '1' },
+        { label: 'r2', value: '2' },
+        { label: 'r3', value: '3' },
+      ])
+    })
+  })
+
+  context('when asking for options for an existing record created before option disabled', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', { currentValue: '1', createdOn: lastWeek })
+    })
+
+    it('should return just active options', () => {
+      expect(this.options).to.deep.equal([
+        { label: 'r1', value: '1' },
+        { label: 'r2', value: '2' },
+        { label: 'r3', value: '3' },
+      ])
+    })
+  })
+
+  context('when asking for all options for a filter form', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', { includeDisabled: true })
+    })
+
+    it('should return just active options', () => {
+      expect(this.options).to.deep.equal([
+        { label: 'r1', value: '1' },
+        { label: 'r2', value: '2' },
+        { label: 'r3', value: '3' },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Refactor of company edit middleware and the introduction of a new options fetcher that will replace metadata.

The refactoring of the middleware:
- Simplifies the code and makes it easier to read and follow
- Introduces filtered options
- Fixes a bug saving UK addresses in some cases

The change also allows the middleware order to change so that form population and option fetching only happens if it needs to, instead of being called and ignored.