### PR TITLE
add tag manager tracking for no javascript page views

### DIFF
--- a/src/templates/_includes/google-tag-manager-no-script.njk
+++ b/src/templates/_includes/google-tag-manager-no-script.njk
@@ -1,5 +1,8 @@
 {% if GOOGLE_TAG_MANAGER_KEY %}
 <noscript>
-  <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_KEY }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_KEY }}&no_javascript=true"
+          height="0" width="0"
+          style="display: none; visibility: hidden;"
+  ></iframe>
 </noscript>
 {% endif %}


### PR DESCRIPTION
Add a variable to be read by Google Tag Manager so we can see how many `no JavaScript` view we are having