### PR TITLE
Feature/temporary oauth logging

### DIFF
--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -1,9 +1,12 @@
 const request = require('request-promise')
 const queryString = require('query-string')
 const uuid = require('uuid')
+
 const { get, set } = require('lodash')
 
 const config = require('./../../../config')
+// @TODO remove this once we've diagnosed the cause of the mismatches
+const logger = require('./../../../config/logger')
 
 function getAccessToken (oauthCode) {
   const options = {
@@ -32,7 +35,12 @@ async function callbackOAuth (req, res, next) {
   }
 
   if (sessionOAuthState !== stateQueryParam) {
-    return next(Error('There has been an OAuth stateId mismatch'))
+    // @TODO remove this once we've diagnosed the cause of the mismatches
+    logger.error('OAuth mismatch')
+    logger.error(`sessionOAuthState: ${stateQueryParam}`)
+    logger.error(`stateQueryParam: ${stateQueryParam}`)
+    logger.error(`Original URL: ${req.originalUrl}`)
+    return next(Error('There has been an OAuth stateId mismatch sessionOAuthState'))
   }
 
   try {

--- a/test/unit/apps/oauth/controllers/oauth.test.js
+++ b/test/unit/apps/oauth/controllers/oauth.test.js
@@ -63,7 +63,7 @@ describe('OAuth controller', () => {
         this.controller.callbackOAuth(this.reqMock, this.resMock, this.nextSpy)
         expect(this.nextSpy.calledOnce).to.be.true
         expect(this.nextSpy.args[0][0] instanceof Error).to.be.true
-        expect(this.nextSpy.args[0][0].message).to.equal('There has been an OAuth stateId mismatch')
+        expect(this.nextSpy.args[0][0].message).to.have.string('There has been an OAuth stateId mismatch')
       })
 
       it('should proceed when state values match', async () => {


### PR DESCRIPTION
Adds a few lines to the syslog to expose what's happening when we get the OAuth state mismatch