### PR TITLE
improve the robustness of the search feature

### DIFF
--- a/test/acceptance/features/search/page-objects/Search.js
+++ b/test/acceptance/features/search/page-objects/Search.js
@@ -47,6 +47,7 @@ module.exports = {
         },
       ],
       elements: {
+        isActive: '.is-active',
         company: getSearchResultsTabSelector('Companies'),
         contact: getSearchResultsTabSelector('Contacts'),
         event: getSearchResultsTabSelector('Events'),

--- a/test/acceptance/features/search/step_definitions/search.js
+++ b/test/acceptance/features/search/step_definitions/search.js
@@ -78,6 +78,7 @@ defineSupportCode(function ({ Then, When }) {
     await Search.section.tabs
       .api.useXpath()
       .waitForElementPresent(searchTabSelector.selector)
+      .waitForElementPresent('@isActive')
       .assert.cssClassPresent(searchTabSelector.selector, 'is-active')
       .useCss()
   })


### PR DESCRIPTION
I am seeing [failures around this work on CircleCi](https://14274-83823675-gh.circle-artifacts.com/3/root/data-hub-frontend/cucumber/report.html). Added a `waitForElementPresent` to make sure the element is on the page before it asserts which tab it is on.