### PR TITLE
Fix breadcrumb display problems

### DIFF
--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -7,9 +7,11 @@ const { transformCompanyToExportDetailsView } = require('../transformers')
 const { exportDetailsLabels } = require('../labels')
 
 function renderExports (req, res) {
+  const { id, name } = res.locals.company
   const exportDetails = transformCompanyToExportDetailsView(res.locals.company)
 
   res
+    .breadcrumb(name, `/companies/${id}`)
     .breadcrumb('Exports')
     .render('companies/views/exports-view', {
       exportDetails,

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -41,18 +41,17 @@ router
 router.use('/:contactId', getCommon, setLocalNav(LOCAL_NAV))
 
 router.get('/:contactId', redirectToFirstNavItem)
-router.get('/:contactId/details', getCommon, getDetails)
+router.get('/:contactId/details', getDetails)
 
 router
   .route('/:contactId/edit')
-  .get(getCommon, editDetails)
-  .post(getCommon, postDetails)
+  .get(editDetails)
+  .post(postDetails)
 
 router.post('/:id/archive', archiveContact)
 router.get('/:id/unarchive', unarchiveContact)
 
 router.get('/:contactId/interactions',
-  getCommon,
   setInteractionsReturnUrl,
   getInteractionsRequestBody,
   getInteractionCollection,
@@ -60,10 +59,10 @@ router.get('/:contactId/interactions',
   renderInteractions
 )
 
-router.get('/:contactId/audit', getCommon, getAudit)
+router.get('/:contactId/audit', getAudit)
 
 router.get('/:contactId/documents', renderDocuments)
 
-router.use('/:contactId', getCommon, setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails, interactionsRouter)
+router.use('/:contactId', setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails, interactionsRouter)
 
 module.exports = router

--- a/src/middleware/breadcrumbs.js
+++ b/src/middleware/breadcrumbs.js
@@ -8,7 +8,7 @@ const {
   each,
   extend,
   find,
-  findIndex,
+  includes,
 } = require('lodash')
 
 /**
@@ -21,48 +21,42 @@ const {
  * @return {Function}
  */
 function init () {
-  let breadcrumbs = []
+  return function (req, res, next) {
+    let breadcrumbs = []
 
-  function exists (breadcrumb) {
-    return findIndex(breadcrumbs, breadcrumb) !== -1
-  }
-
-  function addBreadcrumbs (name, url) {
-    if (arguments.length === 1) {
-      if (isArray(name)) {
-        each(name, (breadcrumb) => {
-          if (!exists(breadcrumb)) {
-            breadcrumbs.push(breadcrumb)
-          }
-        })
-      } else if (isObject(name)) {
-        if (!exists(name)) {
-          breadcrumbs.push(name)
-        }
-      } else {
-        if (!exists(name)) {
-          breadcrumbs.push({ name: name })
-        }
+    function addBreadcrumb (item) {
+      if (!includes(breadcrumbs, item)) {
+        breadcrumbs.push(item)
       }
-    } else if (arguments.length === 2) {
-      if (!exists(name)) {
-        breadcrumbs.push({
+    }
+
+    function addBreadcrumbs (name, url) {
+      if (arguments.length === 0) {
+        return breadcrumbs
+      }
+
+      if (arguments.length === 1) {
+        if (isArray(name)) {
+          each(name, addBreadcrumb)
+        } else if (isObject(name)) {
+          addBreadcrumb(name)
+        } else {
+          addBreadcrumb({ name })
+        }
+      } else if (arguments.length === 2) {
+        addBreadcrumb({
           name: name,
           url: url,
         })
       }
-    } else {
-      return breadcrumbs
+
+      return this
     }
 
-    return this
-  }
+    function cleanBreadcrumbs () {
+      breadcrumbs = []
+    }
 
-  function cleanBreadcrumbs () {
-    breadcrumbs = []
-  }
-
-  return function (req, res, next) {
     cleanBreadcrumbs()
     res.breadcrumb = addBreadcrumbs
     next()


### PR DESCRIPTION
Previously the position of the breadcrumbs variable meant that it
could be set from other requests and would show the incorrect set of
items for a page.

Nesting the methods within the return functions keeps these values
isolated to that request.

This change also addresses a duplicate call to middleware within the contacts
sub-app.