### PR TITLE
Unit tests tidy up sandbox usage

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -9,7 +9,8 @@
     "nock": true,
     "rootPath": true,
     "globalReq": true,
-    "globalRes": true
+    "globalRes": true,
+    "sandbox": true
   },
   "rules": {
     "no-unused-expressions": 0

--- a/test/unit/apps/api/controllers.test.js
+++ b/test/unit/apps/api/controllers.test.js
@@ -1,13 +1,12 @@
 describe('api controllers', () => {
   beforeEach(() => {
     this.req = { params: { postcode: 'dn21 6fg' } }
-    this.sandbox = sinon.sandbox.create()
     this.resMock = {
-      send: this.sandbox.spy(),
-      json: this.sandbox.spy(),
-      status: this.sandbox.stub().returnsThis(),
+      send: sandbox.spy(),
+      json: sandbox.spy(),
+      status: sandbox.stub().returnsThis(),
     }
-    this.lookupAddressStub = this.sandbox.stub().resolves([
+    this.lookupAddressStub = sandbox.stub().resolves([
       { country: 'united kingdom' },
     ])
     this.controller = proxyquire('~/src/apps/api/controllers', {
@@ -41,7 +40,7 @@ describe('api controllers', () => {
       beforeEach(async () => {
         this.statusCode = 400
         this.message = 'error'
-        this.lookupAddressStub = this.sandbox.stub().throws({
+        this.lookupAddressStub = sandbox.stub().throws({
           statusCode: this.statusCode, message: this.message,
         })
         await this.controller.postcodeLookupHandler(this.req, this.resMock)

--- a/test/unit/apps/api/controllers.test.js
+++ b/test/unit/apps/api/controllers.test.js
@@ -22,10 +22,6 @@ describe('api controllers', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('postcodeLookupHandler', () => {
     context('when the external api service returns successful response', () => {
       beforeEach(async () => {

--- a/test/unit/apps/audit/transformers.test.js
+++ b/test/unit/apps/audit/transformers.test.js
@@ -16,10 +16,6 @@ describe('Audit transformers', () => {
     this.transformer = this.transformers.transformAuditLogToListItem(contactAuditLabels)
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   it('should return a formatted audit history item when there are changes', () => {
     const transformedItem = this.transformer(auditLog.results[0])
 

--- a/test/unit/apps/audit/transformers.test.js
+++ b/test/unit/apps/audit/transformers.test.js
@@ -3,8 +3,6 @@ const auditLog = require('~/test/unit/data/audit/contact-audit.json')
 
 describe('Audit transformers', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.buildPaginationStub = sinon.sandbox.stub()
     this.transformers = proxyquire('~/src/apps/audit/transformers', {
       '../../lib/pagination': {

--- a/test/unit/apps/builders.test.js
+++ b/test/unit/apps/builders.test.js
@@ -277,9 +277,8 @@ describe('Global builders', () => {
   describe('#buildFormWithStateAndErrors', () => {
     beforeEach(() => {
       this.builders = rewire('~/src/apps/builders')
-      this.sandbox = sinon.sandbox.create()
-      this.buildFormWithStateSpy = this.sandbox.stub()
-      this.buildFormWithErrorsSpy = this.sandbox.stub()
+      this.buildFormWithStateSpy = sandbox.stub()
+      this.buildFormWithErrorsSpy = sandbox.stub()
       this.builders.__set__('buildFormWithState', this.buildFormWithStateSpy)
       this.builders.__set__('buildFormWithErrors', this.buildFormWithErrorsSpy)
     })
@@ -305,21 +304,19 @@ describe('Global builders', () => {
       this.builders.buildFormWithStateAndErrors(formObject, requestBody, errorsObject)
 
       expect(this.buildFormWithStateSpy).to.be.calledWith(formObject, requestBody)
-      expect(this.buildFormWithErrorsSpy).to.be.calledWith(this.sandbox.match.any, errorsObject)
+      expect(this.buildFormWithErrorsSpy).to.be.calledWith(sandbox.match.any, errorsObject)
     })
   })
 
   describe('#buildSelectedFiltersSummary', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
-
       this.fields = [
         {
           macroName: 'MultipleChoiceField',
           name: 'stage',
           label: 'State',
           type: 'checkbox',
-          options: this.sandbox.stub().returns([
+          options: sandbox.stub().returns([
             { value: 'a', label: 'A' },
             { value: 'b', label: 'B' },
             { value: 'c', label: 'C' },

--- a/test/unit/apps/builders.test.js
+++ b/test/unit/apps/builders.test.js
@@ -283,10 +283,6 @@ describe('Global builders', () => {
       this.builders.__set__('buildFormWithErrors', this.buildFormWithErrorsSpy)
     })
 
-    afterEach(() => {
-      this.sandbox.restore()
-    })
-
     it('should return form without calling any functions', () => {
       const formObject = {
         children: [

--- a/test/unit/apps/companies/controllers/account-management.test.js
+++ b/test/unit/apps/companies/controllers/account-management.test.js
@@ -1,6 +1,5 @@
 describe('Companies account management controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
     this.controller = require('~/src/apps/companies/controllers/account-management')
     this.reqMock = {
       session: {
@@ -9,10 +8,10 @@ describe('Companies account management controller', () => {
       body: {},
     }
     this.resMock = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      title: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
-      redirect: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      title: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      redirect: sandbox.spy(),
       locals: {
         entityName: 'company',
         returnLink: 'return',
@@ -23,11 +22,7 @@ describe('Companies account management controller', () => {
         advisers: [],
       },
     }
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#renderAccountManagementEditPage', () => {

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -20,7 +20,7 @@ const mockMetadataRepository = {
   ],
 }
 
-describe('Company add controller', function () {
+describe('Company add controller', () => {
   let searchLimitedCompaniesStub
   let getDisplayCHStub
   let getCHCompanyStub

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -26,7 +26,7 @@ describe('Company add controller', () => {
   let getCHCompanyStub
   let companyAddController
 
-  beforeEach(function () {
+  beforeEach(() => {
     searchLimitedCompaniesStub = sinon.stub().resolves(companiesHouseAndLtdCompanies)
     getDisplayCHStub = sinon.stub().resolves(displayHouseCompany)
     getCHCompanyStub = sinon.stub().resolves(companiesHouseCompany)
@@ -47,7 +47,7 @@ describe('Company add controller', () => {
     })
   })
 
-  describe('Get step 1', function () {
+  describe('Get step 1', () => {
     it('should return options for company types', function (done) {
       const req = { session: {} }
       const expected = [
@@ -109,8 +109,8 @@ describe('Company add controller', () => {
       companyAddController.renderAddStepOne(req, res, next)
     })
   })
-  describe('Post step 1', function () {
-    describe('forward to next page', function () {
+  describe('Post step 1', () => {
+    describe('forward to next page', () => {
       it('should forward the user to step 2 when adding a uk ltd.', function (done) {
         const req = {
           body: {
@@ -162,7 +162,7 @@ describe('Company add controller', () => {
         companyAddController.postAddStepOne(req, res, next)
       })
     })
-    describe('errors', function () {
+    describe('errors', () => {
       it('should show an error when no option selected', function (done) {
         const req = {
           body: {},

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -44,10 +44,6 @@ describe('Company controller, archive', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('archiveCompany()', () => {
     context('when no reason is supplied', () => {
       beforeEach(() => {

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -13,13 +13,11 @@ const companyMock = {
 
 describe('Company controller, archive', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.archiveCompanyStub = this.sandbox.stub()
-    this.unarchiveCompanyStub = this.sandbox.stub()
-    this.errorLoggerSpy = this.sandbox.spy()
-    this.redirectSpy = this.sandbox.spy()
-    this.flashSpy = this.sandbox.spy()
+    this.archiveCompanyStub = sandbox.stub()
+    this.unarchiveCompanyStub = sandbox.stub()
+    this.errorLoggerSpy = sandbox.spy()
+    this.redirectSpy = sandbox.spy()
+    this.flashSpy = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/companies/controllers/archive', {
       '../repos': {

--- a/test/unit/apps/companies/controllers/audit.test.js
+++ b/test/unit/apps/companies/controllers/audit.test.js
@@ -4,14 +4,12 @@ const tokenMock = '12345abcde'
 
 describe('Company audit controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.getCompanyAuditLogStub = this.sandbox.stub()
-    this.transformApiResponseToCollectionSpy = this.sandbox.spy()
-    this.transformAuditLogToListItemSpy = this.sandbox.spy()
-    this.breadcrumbStub = this.sandbox.stub().returnsThis()
-    this.renderSpy = this.sandbox.spy()
-    this.nextSpy = this.sandbox.spy()
+    this.getCompanyAuditLogStub = sandbox.stub()
+    this.transformApiResponseToCollectionSpy = sandbox.spy()
+    this.transformAuditLogToListItemSpy = sandbox.spy()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.renderSpy = sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/companies/controllers/audit', {
       '../repos': {

--- a/test/unit/apps/companies/controllers/audit.test.js
+++ b/test/unit/apps/companies/controllers/audit.test.js
@@ -38,10 +38,6 @@ describe('Company audit controller', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   context('when audit returns successfully', () => {
     beforeEach(() => {
       this.getCompanyAuditLogStub.resolves(auditLogMock)

--- a/test/unit/apps/companies/controllers/contacts.js
+++ b/test/unit/apps/companies/controllers/contacts.js
@@ -34,10 +34,6 @@ describe('Company contact list controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#renderContacts', () => {
     it('should render collection page with locals', () => {
       this.controller.renderContacts(this.reqMock, this.resMock, this.next)

--- a/test/unit/apps/companies/controllers/contacts.js
+++ b/test/unit/apps/companies/controllers/contacts.js
@@ -2,8 +2,7 @@ const { assign } = require('lodash')
 
 describe('Company contact list controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
     this.resMock = assign({}, globalRes, {
       locals: {
         company: {
@@ -11,8 +10,8 @@ describe('Company contact list controller', () => {
           name: 'mock company',
         },
       },
-      breadcrumb: function () { return this },
-      render: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
       query: {},
     })
     this.reqMock = assign({}, globalReq, {
@@ -20,7 +19,7 @@ describe('Company contact list controller', () => {
         token: 'abcd',
       },
     })
-    this.buildSelectedFiltersSummaryStub = this.sandbox.spy()
+    this.buildSelectedFiltersSummaryStub = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/companies/controllers/contacts', {
       '../../builders': {

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -22,10 +22,6 @@ describe('Company contacts controller', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('renderContacts()', () => {
     describe('all scenarios', () => {
       beforeEach(() => {

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -2,12 +2,9 @@ const companyMock = require('~/test/unit/data/companies/company.json')
 
 describe('Company contacts controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.nextSpy = this.sandbox.spy()
-    this.breadcrumbStub = this.sandbox.stub().returnsThis()
-    this.renderSpy = this.sandbox.spy()
-    this.transformContactToListItemSpy = this.sandbox.spy()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.renderSpy = sandbox.spy()
+    this.transformContactToListItemSpy = sandbox.spy()
 
     this.controller = require('~/src/apps/companies/controllers/contacts')
 

--- a/test/unit/apps/companies/controllers/details.test.js
+++ b/test/unit/apps/companies/controllers/details.test.js
@@ -20,10 +20,6 @@ describe('Companies details controller', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#renderDetails', () => {
     context('when the company contains companes house data', () => {
       beforeEach(() => {

--- a/test/unit/apps/companies/controllers/details.test.js
+++ b/test/unit/apps/companies/controllers/details.test.js
@@ -4,8 +4,6 @@ const { renderDetails } = require('~/src/apps/companies/controllers/details')
 
 describe('Companies details controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.req = {
       session: {
         token: '1234',
@@ -17,8 +15,8 @@ describe('Companies details controller', () => {
 
     this.res = {
       locals: {},
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.stub(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.stub(),
     }
   })
 

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -71,10 +71,6 @@ describe('Company export controller', () => {
     this.resMock = this.buildRes({})
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('getBusinessTypeLabel()', () => {
     it('should handle UK limited company', () => {
       const label = this.controller.getBusinessTypeLabel('limited company', false, null)

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -3,12 +3,11 @@ const { assign } = require('lodash')
 
 describe('Company export controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.saveCompany = this.sandbox.stub()
-    this.breadcrumbStub = this.sandbox.stub().returnsThis()
-    this.renderSpy = this.sandbox.spy()
-    this.nextSpy = this.sandbox.spy()
-    this.redirectSpy = this.sandbox.spy()
+    this.saveCompany = sandbox.stub()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.renderSpy = sandbox.spy()
+    this.nextSpy = sandbox.spy()
+    this.redirectSpy = sandbox.spy()
 
     const ukOtherCompanyOptions = [
       {

--- a/test/unit/apps/companies/controllers/exports.test.js
+++ b/test/unit/apps/companies/controllers/exports.test.js
@@ -3,13 +3,12 @@ const tokenMock = '12345abcde'
 
 describe('Company export controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.saveCompany = this.sandbox.stub()
-    this.breadcrumbStub = this.sandbox.stub().returnsThis()
-    this.renderSpy = this.sandbox.spy()
-    this.nextSpy = this.sandbox.spy()
-    this.redirectSpy = this.sandbox.spy()
-    this.transformerSpy = this.sandbox.spy()
+    this.saveCompany = sandbox.stub()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.renderSpy = sandbox.spy()
+    this.nextSpy = sandbox.spy()
+    this.redirectSpy = sandbox.spy()
+    this.transformerSpy = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/companies/controllers/exports', {
       '../repos': {

--- a/test/unit/apps/companies/controllers/exports.test.js
+++ b/test/unit/apps/companies/controllers/exports.test.js
@@ -45,10 +45,6 @@ describe('Company export controller', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('renderExports()', () => {
     beforeEach(() => {
       this.controller.renderExports(this.reqMock, this.resMock, this.nextSpy)

--- a/test/unit/apps/companies/controllers/investments.test.js
+++ b/test/unit/apps/companies/controllers/investments.test.js
@@ -4,14 +4,12 @@ const tokenMock = '12345abcde'
 
 describe('Company investments controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.getCompanyInvestmentProjectsStub = this.sandbox.stub()
-    this.transformInvestmentProjectToListItemSpy = this.sandbox.spy()
-    this.transformApiResponseToCollectionSpy = this.sandbox.spy()
-    this.breadcrumbStub = this.sandbox.stub().returnsThis()
-    this.renderSpy = this.sandbox.spy()
-    this.nextSpy = this.sandbox.spy()
+    this.getCompanyInvestmentProjectsStub = sandbox.stub()
+    this.transformInvestmentProjectToListItemSpy = sandbox.spy()
+    this.transformApiResponseToCollectionSpy = sandbox.spy()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.renderSpy = sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/companies/controllers/investments', {
       '../../investment-projects/repos': {

--- a/test/unit/apps/companies/controllers/investments.test.js
+++ b/test/unit/apps/companies/controllers/investments.test.js
@@ -38,10 +38,6 @@ describe('Company investments controller', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   context('when investments returns successfully', () => {
     beforeEach(() => {
       this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)

--- a/test/unit/apps/companies/controllers/orders.test.js
+++ b/test/unit/apps/companies/controllers/orders.test.js
@@ -4,14 +4,12 @@ const tokenMock = '12345abcde'
 
 describe('Company investments controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.searchStub = this.sandbox.stub()
-    this.transformOrderToListItemSpy = this.sandbox.spy()
-    this.transformApiResponseToCollectionSpy = this.sandbox.spy()
-    this.breadcrumbStub = this.sandbox.stub().returnsThis()
-    this.renderSpy = this.sandbox.spy()
-    this.nextSpy = this.sandbox.spy()
+    this.searchStub = sandbox.stub()
+    this.transformOrderToListItemSpy = sandbox.spy()
+    this.transformApiResponseToCollectionSpy = sandbox.spy()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.renderSpy = sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/companies/controllers/orders', {
       '../../search/services': {

--- a/test/unit/apps/companies/controllers/orders.test.js
+++ b/test/unit/apps/companies/controllers/orders.test.js
@@ -38,10 +38,6 @@ describe('Company investments controller', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   context('when investments returns successfully', () => {
     beforeEach(() => {
       this.searchStub.resolves(ordersMock.results)

--- a/test/unit/apps/companies/middleware/account-management.test.js
+++ b/test/unit/apps/companies/middleware/account-management.test.js
@@ -55,10 +55,6 @@ describe('Companies account management middleware', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#populateAccountManagementForm', () => {
     beforeEach(async () => {
       this.nockScope = nock(config.apiRoot)

--- a/test/unit/apps/companies/middleware/account-management.test.js
+++ b/test/unit/apps/companies/middleware/account-management.test.js
@@ -17,23 +17,22 @@ function createMiddleware (updateCompany, filterActiveAdvisers) {
 
 describe('Companies account management middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.updateCompanyStub = this.sandbox.stub()
-    this.filterActiveAdvisersSpy = this.sandbox.spy(adviserFilters, 'filterActiveAdvisers')
+    this.updateCompanyStub = sandbox.stub()
+    this.filterActiveAdvisersSpy = sandbox.spy(adviserFilters, 'filterActiveAdvisers')
     this.middleware = createMiddleware(this.updateCompanyStub.resolves({ id: '1' }), this.filterActiveAdvisersSpy)
 
     this.reqMock = {
       session: {
         token: 'efgh',
       },
-      flash: this.sandbox.spy(),
+      flash: sandbox.spy(),
       body: assign({}, accountManagementData),
     }
 
     this.resMock = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
-      redirect: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      redirect: sandbox.spy(),
       locals: {
         company: {
           id: '1',
@@ -42,7 +41,7 @@ describe('Companies account management middleware', () => {
       },
     }
 
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
     this.activeInactiveAdviserData = {
       count: 5,

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -4,7 +4,6 @@ const companiesHouseSearchResults = require('~/test/unit/data/companies/companie
 
 describe('Company collection middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
     this.mockCompanyResults = {
       count: 3,
       results: [
@@ -13,7 +12,7 @@ describe('Company collection middleware', () => {
         { id: '333', name: 'C' },
       ],
     }
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
     this.req = Object.assign({}, globalReq, {
       session: { token: 'abcd' },
     })
@@ -96,8 +95,8 @@ describe('Company collection middleware', () => {
   describe('#getLimitedCompaniesCollection', () => {
     context('when search returns results', () => {
       beforeEach(async () => {
-        this.searchStub = this.sandbox.stub().resolves(companiesHouseSearchResults)
-        this.transformerStub = this.sandbox.stub().returns({
+        this.searchStub = sandbox.stub().resolves(companiesHouseSearchResults)
+        this.transformerStub = sandbox.stub().returns({
           id: '1234',
           name: 'Freds',
           meta: [],

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -21,10 +21,6 @@ describe('Company collection middleware', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getCompanyCollection', () => {
     beforeEach(async () => {
       this.nockScope = nock(config.apiRoot)

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -7,11 +7,9 @@ const metadataMock = {
   countryOptions: [],
 }
 
-describe('Companies form middleware', function () {
+describe('Companies form middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
     this.reqMock = {
       query: {},
     }
@@ -86,10 +84,10 @@ describe('Companies form middleware', function () {
     }
 
     beforeEach(() => {
-      this.flashSpy = this.sandbox.spy()
-      this.breadcrumbStub = this.sandbox.stub().returnsThis()
-      this.redirectSpy = this.sandbox.spy()
-      this.saveCompanyFormStub = this.sandbox.stub()
+      this.flashSpy = sandbox.spy()
+      this.breadcrumbStub = sandbox.stub().returnsThis()
+      this.redirectSpy = sandbox.spy()
+      this.saveCompanyFormStub = sandbox.stub()
 
       this.reqMock = {
         body,

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -22,10 +22,6 @@ describe('Companies form middleware', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('populateForm()', () => {
     it('should include the required properties in the response', () => {
       this.middleware.populateForm(this.reqMock, this.resMock, this.nextSpy)

--- a/test/unit/apps/companies/middleware/interactions.test.js
+++ b/test/unit/apps/companies/middleware/interactions.test.js
@@ -1,6 +1,5 @@
 describe('Companies interactions middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
     this.middleware = require('~/src/apps/companies/middleware/interactions')
     this.req = {
       params: {
@@ -14,11 +13,7 @@ describe('Companies interactions middleware', () => {
         },
       },
     }
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#setInteractionsReturnUrl', () => {

--- a/test/unit/apps/companies/middleware/params.test.js
+++ b/test/unit/apps/companies/middleware/params.test.js
@@ -24,10 +24,6 @@ describe('Companies form middleware', function () {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('getCompany', () => {
     context('when the API returns a company without companies house data', () => {
       beforeEach(async () => {

--- a/test/unit/apps/companies/middleware/params.test.js
+++ b/test/unit/apps/companies/middleware/params.test.js
@@ -2,7 +2,7 @@ const companiesHouseCompany = require('~/test/unit/data/companies/companies-hous
 const datahubOnlyCompany = require('~/test/unit/data/companies/datahub-only-company.json')
 const companiesHouseRecord = require('~/test/unit/data/companies/companies-house.json')
 
-describe('Companies form middleware', function () {
+describe('Companies form middleware', () => {
   beforeEach(() => {
     this.nextSpy = sandbox.spy()
     this.getDitCompanyStub = sandbox.stub()

--- a/test/unit/apps/companies/middleware/params.test.js
+++ b/test/unit/apps/companies/middleware/params.test.js
@@ -4,10 +4,9 @@ const companiesHouseRecord = require('~/test/unit/data/companies/companies-house
 
 describe('Companies form middleware', function () {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
-    this.getDitCompanyStub = this.sandbox.stub()
-    this.getCHCompanyStub = this.sandbox.stub()
+    this.nextSpy = sandbox.spy()
+    this.getDitCompanyStub = sandbox.stub()
+    this.getCHCompanyStub = sandbox.stub()
     this.reqMock = { query: {}, session: { token: 2 } }
     this.resMock = { locals: {} }
 
@@ -17,7 +16,7 @@ describe('Companies form middleware', function () {
         getCHCompany: this.getCHCompanyStub,
       },
       '../transformers/shared': {
-        getCompanyAddress: this.sandbox.stub().returns({
+        getCompanyAddress: sandbox.stub().returns({
           label: 'label',
           value: 'address',
         }),

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -241,8 +241,7 @@ describe('Company repository', () => {
 
   describe('Update company', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
-      this.authorisedRequestStub = this.sandbox.stub().resolves(companyData)
+      this.authorisedRequestStub = sandbox.stub().resolves(companyData)
       this.repo = proxyquire('~/src/apps/companies/repos', {
         '../../lib/authorised-request': this.authorisedRequestStub,
         '../../../config': {

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -250,10 +250,6 @@ describe('Company repository', () => {
       })
     })
 
-    afterEach(() => {
-      this.sandbox.restore()
-    })
-
     it('should make the correct call to the API', () => {
       return this.repo.updateCompany('1234', '999', { account_manager: '8888' })
         .then(() => {

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -6,7 +6,7 @@ describe('Company repository', () => {
     describe('Handle response from server', () => {
       describe('Successfully save a company', () => {
         let companyRepository
-        const authorisedRequestStub = function () {
+        const authorisedRequestStub = () => {
           return new Promise((resolve) => {
             resolve({
               id: '1234',
@@ -31,7 +31,7 @@ describe('Company repository', () => {
       })
       describe('Save a company and get a 400', () => {
         let companyRepository
-        const authorisedRequestStub = function () {
+        const authorisedRequestStub = () => {
           return new Promise((resolve, reject) => {
             reject({
               error: {
@@ -86,7 +86,7 @@ describe('Company repository', () => {
       })
       describe('Save a company and get a formatted 500', () => {
         let companyRepository
-        const authorisedRequestStub = function () {
+        const authorisedRequestStub = () => {
           return new Promise((resolve, reject) => {
             reject({
               error: { 'detail': 'Service Unavailable' },
@@ -126,7 +126,7 @@ describe('Company repository', () => {
       })
       describe('Save a company and get a generic 500', () => {
         let companyRepository
-        const authorisedRequestStub = function () {
+        const authorisedRequestStub = () => {
           return new Promise((resolve, reject) => {
             reject({
               error: 'Service Unavailable',

--- a/test/unit/apps/companies/services/form.test.js
+++ b/test/unit/apps/companies/services/form.test.js
@@ -1,8 +1,8 @@
-describe('company form service', function () {
+describe('company form service', () => {
   let companyFormService
   let saveCompanyStub
 
-  beforeEach(function () {
+  beforeEach(() => {
     saveCompanyStub = sinon.stub().resolves({ id: '1234' })
 
     companyFormService = proxyquire('~/src/apps/companies/services/form', {
@@ -12,8 +12,8 @@ describe('company form service', function () {
     })
   })
 
-  describe('save', function () {
-    it('saves company data to repository', function () {
+  describe('save', () => {
+    it('saves company data to repository', () => {
       const company = {
         thing: 'yes',
         other: 'no',
@@ -23,7 +23,7 @@ describe('company form service', function () {
           expect(saveCompanyStub).to.be.called
         })
     })
-    it('converts yes/no to true/false', function () {
+    it('converts yes/no to true/false', () => {
       const company = {
         thing: 'yes',
         other: 'no',
@@ -33,7 +33,7 @@ describe('company form service', function () {
           expect(saveCompanyStub).to.be.calledWith('1234', { thing: true, other: false })
         })
     })
-    it('handles errors', function () {
+    it('handles errors', () => {
       saveCompanyStub = sinon.stub().rejects({ error: 'test' })
       companyFormService = proxyquire('~/src/apps/companies/services/form', {
         '../repos': {

--- a/test/unit/apps/contacts/controllers/archive.test.js
+++ b/test/unit/apps/contacts/controllers/archive.test.js
@@ -2,7 +2,7 @@ const next = function (error) {
   throw Error(error)
 }
 
-describe('Contact controller, archive', function () {
+describe('Contact controller, archive', () => {
   let contactRepositoryArchiveContactStub
   let contactRepositoryUnArchiveContactStub
   let flashStub
@@ -11,7 +11,7 @@ describe('Contact controller, archive', function () {
 
   let contactArchiveController
 
-  beforeEach(function () {
+  beforeEach(() => {
     contactRepositoryArchiveContactStub = sinon.stub().resolves(null)
     contactRepositoryUnArchiveContactStub = sinon.stub().resolves(null)
     contactArchiveController = proxyquire('~/src/apps/contacts/controllers/archive', {
@@ -31,7 +31,7 @@ describe('Contact controller, archive', function () {
     }
     const res = {
       locals: {},
-      redirect: function () {
+      redirect: () => {
         expect(contactRepositoryArchiveContactStub).to.be.calledWith(token, id, req.body.archived_reason)
         done()
       },
@@ -48,7 +48,7 @@ describe('Contact controller, archive', function () {
     }
     const res = {
       locals: {},
-      redirect: function () {
+      redirect: () => {
         expect(contactRepositoryArchiveContactStub).to.be.calledWith(token, id, req.body.archived_reason_other)
         done()
       },
@@ -99,7 +99,7 @@ describe('Contact controller, archive', function () {
     }
     const res = {
       locals: {},
-      redirect: function () {
+      redirect: () => {
         expect(contactRepositoryUnArchiveContactStub).to.be.calledWith(token, id)
         done()
       },
@@ -124,7 +124,7 @@ describe('Contact controller, archive', function () {
       flash: flashStub,
     }
     const res = {
-      render: function () {
+      render: () => {
         throw Error('Should have called next')
       },
     }
@@ -152,7 +152,7 @@ describe('Contact controller, archive', function () {
       flash: flashStub,
     }
     const res = {
-      render: function () {
+      render: () => {
         throw Error('Should have called next')
       },
     }

--- a/test/unit/apps/contacts/controllers/audit.test.js
+++ b/test/unit/apps/contacts/controllers/audit.test.js
@@ -3,18 +3,14 @@ const { contactAuditLabels } = require('~/src/apps/contacts/labels')
 
 describe('Contact audit controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.transformed = {}
-    this.getContactAuditLogStub = this.sandbox.stub().resolves(auditLog)
-    this.transformApiResponseToCollectionInnerStub = this.sandbox.stub().returns()
-    this.transformApiResponseToCollectionStub = this.sandbox.stub().returns(this.transformApiResponseToCollectionInnerStub)
-    this.generatedTransformer = this.sandbox.stub()
-    this.transformAuditLogToListItemStub = this.sandbox.stub().returns(this.generatedTransformer)
+    this.getContactAuditLogStub = sandbox.stub().resolves(auditLog)
+    this.transformApiResponseToCollectionInnerStub = sandbox.stub().returns()
+    this.transformApiResponseToCollectionStub = sandbox.stub().returns(this.transformApiResponseToCollectionInnerStub)
+    this.generatedTransformer = sandbox.stub()
+    this.transformAuditLogToListItemStub = sandbox.stub().returns(this.generatedTransformer)
 
-    this.breadcrumbStub = function () {
-      return this
-    }
+    this.breadcrumbStub = sandbox.stub().returnsThis()
 
     this.controller = proxyquire('~/src/apps/contacts/controllers/audit', {
       '../repos': {

--- a/test/unit/apps/contacts/controllers/audit.test.js
+++ b/test/unit/apps/contacts/controllers/audit.test.js
@@ -35,10 +35,6 @@ describe('Contact audit controller', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   it('should call the contact audit repository', (done) => {
     try {
       this.controller.getAudit(this.req, {

--- a/test/unit/apps/contacts/controllers/details.test.js
+++ b/test/unit/apps/contacts/controllers/details.test.js
@@ -4,12 +4,10 @@ const contact = require('~/test/unit/data/contacts/contact.json')
 
 describe('Contact controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
+    this.getContactStub = sandbox.stub().resolves(contact)
+    this.getDitCompanyStub = sandbox.stub().resolves(contact.company)
 
-    this.getContactStub = this.sandbox.stub().resolves(contact)
-    this.getDitCompanyStub = this.sandbox.stub().resolves(contact.company)
-
-    this.transformerStub = this.sandbox.stub()
+    this.transformerStub = sandbox.stub()
 
     this.contactController = proxyquire('~/src/apps/contacts/controllers/details', {
       '../repos': {
@@ -34,15 +32,11 @@ describe('Contact controller', () => {
 
     this.res = {
       locals: {},
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
     }
 
-    this.next = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.next = sandbox.spy()
   })
 
   describe('#getCommon', () => {

--- a/test/unit/apps/contacts/controllers/edit.test.js
+++ b/test/unit/apps/contacts/controllers/edit.test.js
@@ -3,7 +3,7 @@ const { render } = require('~/test/unit/nunjucks')
 const { expectField, expectRadioField, expectHiddenField } = require('~/test/unit/form-helpers')
 const contactLabels = require('~/src/apps/contacts/labels')
 
-describe('Contact controller, edit', function () {
+describe('Contact controller, edit', () => {
   let contactEditController
   let getDitCompanyStub
   let saveContactFormStub
@@ -14,7 +14,7 @@ describe('Contact controller, edit', function () {
     throw Error('error')
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     company = {
       id: '1234',
       name: 'Fred ltd.',
@@ -24,7 +24,7 @@ describe('Contact controller, edit', function () {
     getContactAsFormDataStub = sinon.stub().returns({ id: '1234', name: 'Thing' })
     saveContactFormStub = sinon.stub().returns({ id: '1234', first_name: 'Fred', last_name: 'Smith' })
 
-    this.breadcrumbStub = function () {
+    this.breadcrumbStub = () => {
       return this
     }
 
@@ -45,8 +45,8 @@ describe('Contact controller, edit', function () {
     })
   })
 
-  describe('get', function () {
-    describe('existing contact', function () {
+  describe('get', () => {
+    describe('existing contact', () => {
       let req
       let res
       let contact
@@ -55,7 +55,7 @@ describe('Contact controller, edit', function () {
         throw error
       }
 
-      beforeEach(function () {
+      beforeEach(() => {
         contact = {
           id: '12651151-2149-465e-871b-ac45bc568a62',
           created_on: '2017-02-14T14:49:17',
@@ -106,7 +106,7 @@ describe('Contact controller, edit', function () {
       })
 
       it('should create a form based on the existing contact', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(getContactAsFormDataStub).to.have.been.calledWith(contact)
           expect(res.locals).to.have.property('formData')
           done()
@@ -114,7 +114,7 @@ describe('Contact controller, edit', function () {
         contactEditController.editDetails(req, res, next)
       })
       it('should include an expanded company', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(getDitCompanyStub).to.have.been.calledWith(req.session.token, contact.company.id)
           expect(res.locals.company).to.deep.equal(company)
           done()
@@ -122,14 +122,14 @@ describe('Contact controller, edit', function () {
         contactEditController.editDetails(req, res, next)
       })
       it('should provide a back link to the contact', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(res.locals.backUrl).to.equal('/contacts/12651151-2149-465e-871b-ac45bc568a62')
           done()
         }
         contactEditController.editDetails(req, res, next)
       })
     })
-    describe('new contact for company', function () {
+    describe('new contact for company', () => {
       let req
       let res
 
@@ -137,7 +137,7 @@ describe('Contact controller, edit', function () {
         throw error
       }
 
-      beforeEach(function () {
+      beforeEach(() => {
         req = {
           session: {
             token: '321',
@@ -154,14 +154,14 @@ describe('Contact controller, edit', function () {
       })
 
       it('should return a form pre-populated with just the company id', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(res.locals.formData).to.deep.equal({ company: company.id })
           done()
         }
         contactEditController.editDetails(req, res, next)
       })
       it('should include an expanded company', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(getDitCompanyStub).to.have.been.calledWith(req.session.token, company.id)
           expect(res.locals.company).to.deep.equal(company)
           done()
@@ -169,14 +169,14 @@ describe('Contact controller, edit', function () {
         contactEditController.editDetails(req, res, next)
       })
       it('should provide a back link to the company', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(res.locals.backUrl).to.equal('/companies/1234/contacts')
           done()
         }
         contactEditController.editDetails(req, res, next)
       })
     })
-    describe('handle editing a form post that produced errors', function () {
+    describe('handle editing a form post that produced errors', () => {
       let req
       let body
       let res
@@ -184,7 +184,7 @@ describe('Contact controller, edit', function () {
         throw error
       }
 
-      beforeEach(function () {
+      beforeEach(() => {
         body = {
           id: '222',
           first_name: 'Fred',
@@ -207,14 +207,14 @@ describe('Contact controller, edit', function () {
         }
       })
       it('should use the pre posted form for edit', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(res.locals.formData).to.deep.equal(body)
           done()
         }
         contactEditController.editDetails(req, res, next)
       })
       it('should include an expanded company', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(getDitCompanyStub).to.have.been.calledWith(req.session.token, company.id)
           expect(res.locals.company).to.deep.equal(company)
           done()
@@ -222,23 +222,23 @@ describe('Contact controller, edit', function () {
         contactEditController.editDetails(req, res, next)
       })
       it('should provide a back link to the company', function (done) {
-        res.render = function () {
+        res.render = () => {
           expect(res.locals.backUrl).to.equal('/companies/1234/contacts')
           done()
         }
         contactEditController.editDetails(req, res, next)
       })
     })
-    it('common details', function () {
+    it('common details', () => {
       it('should include country options for drop down')
       it('should include labels')
       it('should include cross script token')
     })
   })
-  describe('render', function () {
+  describe('render', () => {
     const countryOptions = [{ id: '134', name: 'United Kingdom' }]
     let locals
-    beforeEach(function () {
+    beforeEach(() => {
       locals = {
         formData: {
           id: '321',
@@ -266,7 +266,7 @@ describe('Contact controller, edit', function () {
         contactLabels,
       }
     })
-    it('should render all the required fields on the page', function () {
+    it('should render all the required fields on the page', () => {
       return render('../../src/apps/contacts/views/edit.njk', locals)
         .then((document) => {
           expect(document.querySelector('[type=hidden][name=id]')).to.not.be.null
@@ -291,13 +291,13 @@ describe('Contact controller, edit', function () {
         })
     })
   })
-  describe('save', function () {
+  describe('save', () => {
     let body
     let flashStub
     let req
     let res
 
-    beforeEach(function () {
+    beforeEach(() => {
       flashStub = sinon.stub()
       res = {
         locals: {},
@@ -319,7 +319,7 @@ describe('Contact controller, edit', function () {
       req.body = body
     })
     it('should save the form data to the back end', function (done) {
-      res.redirect = function () {
+      res.redirect = () => {
         expect(saveContactFormStub).to.be.calledWith(req.session.token, body)
         done()
       }

--- a/test/unit/apps/contacts/controllers/list.test.js
+++ b/test/unit/apps/contacts/controllers/list.test.js
@@ -27,10 +27,6 @@ describe('Contact list controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#renderContactList', () => {
     it('should render collection page with locals', () => {
       this.controller.renderContactList(this.req, this.res, this.next)

--- a/test/unit/apps/contacts/controllers/list.test.js
+++ b/test/unit/apps/contacts/controllers/list.test.js
@@ -1,7 +1,6 @@
 describe('Contact list controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
     this.req = {
       session: {
         token: 'abcd',
@@ -9,11 +8,11 @@ describe('Contact list controller', () => {
       query: {},
     }
     this.res = {
-      render: this.sandbox.spy(),
+      render: sandbox.spy(),
       query: {},
     }
 
-    this.buildSelectedFiltersSummaryStub = this.sandbox.spy()
+    this.buildSelectedFiltersSummaryStub = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/contacts/controllers/list', {
       '../../builders': {

--- a/test/unit/apps/contacts/middleware/interactions.test.js
+++ b/test/unit/apps/contacts/middleware/interactions.test.js
@@ -2,8 +2,7 @@ const contactData = { company: { name: 'company' } }
 
 describe('Contacts interactions middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.getContactStub = this.sandbox.stub().returns(contactData)
+    this.getContactStub = sandbox.stub().returns(contactData)
     this.middleware = proxyquire('~/src/apps/contacts/middleware/interactions', {
       '../../contacts/repos': {
         getContact: this.getContactStub,
@@ -25,11 +24,7 @@ describe('Contacts interactions middleware', () => {
         },
       },
     }
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#setInteractionsReturnUrl', () => {

--- a/test/unit/apps/contacts/services/form.test.js
+++ b/test/unit/apps/contacts/services/form.test.js
@@ -1,12 +1,12 @@
 /* eslint prefer-promise-reject-errors: 0 */
 const { assign } = require('lodash')
 
-describe('contact form service', function () {
+describe('contact form service', () => {
   let contactFormService
   let postedData
   let throwError
 
-  beforeEach(function () {
+  beforeEach(() => {
     throwError = false
 
     contactFormService = proxyquire('~/src/apps/contacts/services/form', {
@@ -31,7 +31,7 @@ describe('contact form service', function () {
     })
   })
 
-  describe('convert API contact into form format', function () {
+  describe('convert API contact into form format', () => {
     const contactData = {
       id: '50680966-f5e1-e311-8a2b-e4115bead28a',
       name: 'Zac Baman',
@@ -72,7 +72,7 @@ describe('contact form service', function () {
       adviser: null,
     }
 
-    it('should convert a fully populated expanded contact into a flat form format', function () {
+    it('should convert a fully populated expanded contact into a flat form format', () => {
       const contact = assign({}, contactData)
 
       const expected = {
@@ -104,7 +104,7 @@ describe('contact form service', function () {
       expect(actual).to.deep.equal(expected)
     })
 
-    it('should handle blank and null fields', function () {
+    it('should handle blank and null fields', () => {
       const contact = assign({}, contactData, {
         last_name: null,
         job_title: null,
@@ -146,7 +146,7 @@ describe('contact form service', function () {
       expect(actual).to.deep.equal(expected)
     })
 
-    it('should handle a null contact', function () {
+    it('should handle a null contact', () => {
       expect(contactFormService.getContactAsFormData(null)).to.be.null
     })
 
@@ -162,7 +162,7 @@ describe('contact form service', function () {
       })
     })
   })
-  describe('save contact form', function () {
+  describe('save contact form', () => {
     const formData = {
       id: '50680966-f5e1-e311-8a2b-e4115bead28a',
       company: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
@@ -186,7 +186,7 @@ describe('contact form service', function () {
       notes: 'Some notes',
     }
 
-    it('should accept a fully populated contact and convert it to an api format', function () {
+    it('should accept a fully populated contact and convert it to an api format', () => {
       const expected = {
         id: '50680966-f5e1-e311-8a2b-e4115bead28a',
         company: {
@@ -223,7 +223,7 @@ describe('contact form service', function () {
         })
     })
 
-    it('should return a copy of the saved contact', function () {
+    it('should return a copy of the saved contact', () => {
       delete formData.id
 
       return contactFormService.saveContactForm('1234', formData)
@@ -232,7 +232,7 @@ describe('contact form service', function () {
         })
     })
 
-    it('should throw errors received from the repository if the save fails', function () {
+    it('should throw errors received from the repository if the save fails', () => {
       throwError = true
 
       return contactFormService.saveContactForm('1234', formData)

--- a/test/unit/apps/contacts/transformers.test.js
+++ b/test/unit/apps/contacts/transformers.test.js
@@ -8,7 +8,7 @@ const {
   transformContactToView,
 } = require('~/src/apps/contacts/transformers')
 
-describe('Contact transformers', function () {
+describe('Contact transformers', () => {
   describe('#transformContactToListItem', () => {
     it('should return undefined for unqualified result', () => {
       expect(transformContactToListItem()).to.be.undefined

--- a/test/unit/apps/dashboard/controllers.test.js
+++ b/test/unit/apps/dashboard/controllers.test.js
@@ -1,7 +1,5 @@
 describe('dashboard controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.reqMock = Object.assign({}, globalReq, {
       session: {
         token: 'abcd',
@@ -10,13 +8,13 @@ describe('dashboard controller', () => {
 
     this.resMock = {
       locals: {},
-      render: this.sandbox.spy(),
-      title: this.sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      title: sandbox.stub().returnsThis(),
     }
 
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
-    this.fetchHomepageDataStub = this.sandbox.stub()
+    this.fetchHomepageDataStub = sandbox.stub()
 
     this.controllers = proxyquire('~/src/apps/dashboard/controllers', {
       './repos': {

--- a/test/unit/apps/events/controllers/details.test.js
+++ b/test/unit/apps/events/controllers/details.test.js
@@ -1,7 +1,5 @@
 describe('Event details controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.controller = proxyquire('~/src/apps/events/controllers/details', {
       '../labels': {
         displayEventLabels: {
@@ -20,8 +18,8 @@ describe('Event details controller', () => {
     }
 
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
       locals: {
         event: {
           name: 'Dance',
@@ -29,11 +27,7 @@ describe('Event details controller', () => {
       },
     }
 
-    this.next = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.next = sandbox.spy()
   })
 
   describe('#renderDetailsPage', async () => {

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -8,9 +8,7 @@ describe('Event edit controller', () => {
   const currentUserTeam = 'team1'
 
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.filterActiveAdvisersSpy = this.sandbox.spy(adviserFilters, 'filterActiveAdvisers')
+    this.filterActiveAdvisersSpy = sandbox.spy(adviserFilters, 'filterActiveAdvisers')
 
     this.controller = proxyquire('~/src/apps/events/controllers/edit', {
       '../../adviser/filters': {
@@ -31,13 +29,13 @@ describe('Event edit controller', () => {
     }
 
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
-      redirect: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      redirect: sandbox.spy(),
       locals: { },
     }
 
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
 
     this.activeInactiveAdviserData = {
       count: 5,

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -57,10 +57,6 @@ describe('Event edit controller', () => {
       .reply(200, this.activeInactiveAdviserData)
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#renderEditPage', () => {
     context('when rendering the page', () => {
       beforeEach(async () => {

--- a/test/unit/apps/events/controllers/list.test.js
+++ b/test/unit/apps/events/controllers/list.test.js
@@ -66,10 +66,6 @@ describe('Event list controller', () => {
       .reply(200, { results: advisers })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#renderEventList', () => {
     beforeEach(async () => {
       this.eventFiltersFieldsStub.returns(standardMacros)

--- a/test/unit/apps/events/controllers/list.test.js
+++ b/test/unit/apps/events/controllers/list.test.js
@@ -26,8 +26,7 @@ const countryAndUkRegionMacros = [
 
 describe('Event list controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
     this.reqMock = {
       session: {
         token: 'abcd',
@@ -35,13 +34,13 @@ describe('Event list controller', () => {
       query: {},
     }
     this.resMock = {
-      render: this.sandbox.spy(),
+      render: sandbox.spy(),
       query: {},
       locals: {
         advisers: advisersData,
       },
     }
-    this.eventFiltersFieldsStub = this.sandbox.stub()
+    this.eventFiltersFieldsStub = sandbox.stub()
     this.controller = proxyquire('~/src/apps/events/controllers/list', {
       '../macros': {
         eventFiltersFields: this.eventFiltersFieldsStub,

--- a/test/unit/apps/events/middleware/collection.test.js
+++ b/test/unit/apps/events/middleware/collection.test.js
@@ -17,10 +17,6 @@ describe('Event collection middleware', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getEventsCollection', () => {
     beforeEach(() => {
       this.req.query = {

--- a/test/unit/apps/events/middleware/collection.test.js
+++ b/test/unit/apps/events/middleware/collection.test.js
@@ -3,13 +3,12 @@ const eventCollectionData = require('~/test/unit/data/events/collection.json')
 
 describe('Event collection middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
     this.req = assign({}, globalReq, {
       session: { token: 'abcd' },
     })
     this.res = assign({}, globalRes)
-    this.searchStub = this.sandbox.stub()
+    this.searchStub = sandbox.stub()
 
     this.controller = proxyquire('~/src/apps/events/middleware/collection', {
       '../../search/services': {

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -33,12 +33,11 @@ const expectedBody = {
 
 describe('Event details middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.saveEventStub = this.sandbox.stub()
-    this.fetchEventStub = this.sandbox.stub()
-    this.getAdvisersStub = this.sandbox.stub()
-    this.transformEventFormBodyToApiRequestStub = this.sandbox.stub()
-    this.transformEventResponseToViewRecordStub = this.sandbox.stub()
+    this.saveEventStub = sandbox.stub()
+    this.fetchEventStub = sandbox.stub()
+    this.getAdvisersStub = sandbox.stub()
+    this.transformEventFormBodyToApiRequestStub = sandbox.stub()
+    this.transformEventResponseToViewRecordStub = sandbox.stub()
     this.middleware = proxyquire('~/src/apps/events/middleware/details', {
       '../repos': {
         saveEvent: this.saveEventStub.resolves({ id: '1' }),
@@ -59,20 +58,16 @@ describe('Event details middleware', () => {
       session: {
         token: 'abcd',
       },
-      flash: this.sandbox.spy(),
+      flash: sandbox.spy(),
       body: assign({}, eventData),
     }
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
-      redirect: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      redirect: sandbox.spy(),
       locals: {},
     }
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#postDetails', () => {

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -15,10 +15,6 @@ describe('Event repos', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#saveEvent', () => {
     context('when POST request', () => {
       const eventMock = { name: 'Convention' }

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -5,9 +5,8 @@ const token = 'abcd'
 
 describe('Event repos', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.authorisedRequestStub = this.sandbox.stub().resolves()
-    this.searchSpy = this.sandbox.spy(search)
+    this.authorisedRequestStub = sandbox.stub().resolves()
+    this.searchSpy = sandbox.spy(search)
     this.repos = proxyquire('~/src/apps/events/repos', {
       '../../lib/authorised-request': this.authorisedRequestStub,
       '../search/services': {

--- a/test/unit/apps/healthcheck/controllers/healthcheck.test.js
+++ b/test/unit/apps/healthcheck/controllers/healthcheck.test.js
@@ -1,7 +1,6 @@
 describe('Health check controller', () => {
   describe('#getHandler with healthy service dependencies', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
       this.serviceDependencies = [
         {
           name: 'success',
@@ -10,23 +9,19 @@ describe('Health check controller', () => {
           },
         },
       ]
-      this.logger = this.sandbox.stub().returns({ error: this.sandbox.spy() })
+      this.logger = sandbox.stub().returns({ error: sandbox.spy() })
       this.controller = proxyquire.noCallThru().load('~/src/apps/healthcheck/controllers', {
         './serviceDependencies': this.serviceDependencies,
         '../../../config/logger': this.logger,
       })
       this.req = {}
       this.res = {
-        set: this.sandbox.spy(),
-        status: this.sandbox.stub().returns({
-          send: this.sandbox.spy(),
+        set: sandbox.spy(),
+        status: sandbox.stub().returns({
+          send: sandbox.spy(),
         }),
       }
-      this.next = this.sandbox.spy()
-    })
-
-    afterEach(() => {
-      this.sandbox.restore()
+      this.next = sandbox.spy()
     })
 
     it('should set cache control', async () => {
@@ -59,7 +54,6 @@ describe('Health check controller', () => {
 
   describe('#getHandler with unhealthy service dependencies', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
       this.serviceDependencyError = { name: 'example service dependency', error: Error('example error') }
       this.serviceDependencies = [
         {
@@ -69,23 +63,19 @@ describe('Health check controller', () => {
           },
         },
       ]
-      this.logger = { error: this.sandbox.spy() }
+      this.logger = { error: sandbox.spy() }
       this.controller = proxyquire.noCallThru().load('~/src/apps/healthcheck/controllers', {
         './serviceDependencies': this.serviceDependencies,
         '../../../config/logger': this.logger,
       })
       this.req = {}
       this.res = {
-        set: this.sandbox.spy(),
-        status: this.sandbox.stub().returns({
-          send: this.sandbox.spy(),
+        set: sandbox.spy(),
+        status: sandbox.stub().returns({
+          send: sandbox.spy(),
         }),
       }
-      this.next = this.sandbox.spy()
-    })
-
-    afterEach(() => {
-      this.sandbox.restore()
+      this.next = sandbox.spy()
     })
 
     it('should set cache control', async () => {
@@ -122,7 +112,6 @@ describe('Health check controller', () => {
 
   describe('#renderPingdomXml with healthy service dependencies', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
       this.serviceDependencies = [
         {
           name: 'success',
@@ -131,23 +120,19 @@ describe('Health check controller', () => {
           },
         },
       ]
-      this.logger = this.sandbox.stub().returns({ error: this.sandbox.spy() })
+      this.logger = sandbox.stub().returns({ error: sandbox.spy() })
       this.controller = proxyquire.noCallThru().load('~/src/apps/healthcheck/controllers', {
         './serviceDependencies': this.serviceDependencies,
         '../../../config/logger': this.logger,
       })
       this.req = {}
       this.res = {
-        set: this.sandbox.spy(),
-        status: this.sandbox.stub().returns({
-          send: this.sandbox.spy(),
+        set: sandbox.spy(),
+        status: sandbox.stub().returns({
+          send: sandbox.spy(),
         }),
       }
-      this.next = this.sandbox.spy()
-    })
-
-    afterEach(() => {
-      this.sandbox.restore()
+      this.next = sandbox.spy()
     })
 
     it('should set content type and cache control', async () => {
@@ -183,7 +168,6 @@ describe('Health check controller', () => {
 
   describe('#renderPingdomXml with unhealthy service dependencies', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
       this.serviceDependencyError = { name: 'example service dependency', error: Error('example error') }
       this.serviceDependencies = [
         {
@@ -193,23 +177,19 @@ describe('Health check controller', () => {
           },
         },
       ]
-      this.logger = { error: this.sandbox.spy() }
+      this.logger = { error: sandbox.spy() }
       this.controller = proxyquire.noCallThru().load('~/src/apps/healthcheck/controllers', {
         './serviceDependencies': this.serviceDependencies,
         '../../../config/logger': this.logger,
       })
       this.req = {}
       this.res = {
-        set: this.sandbox.spy(),
-        status: this.sandbox.stub().returns({
-          send: this.sandbox.spy(),
+        set: sandbox.spy(),
+        status: sandbox.stub().returns({
+          send: sandbox.spy(),
         }),
       }
-      this.next = this.sandbox.spy()
-    })
-
-    afterEach(() => {
-      this.sandbox.restore()
+      this.next = sandbox.spy()
     })
 
     it('should set content type and cache control', async () => {

--- a/test/unit/apps/interactions/controllers/create.test.js
+++ b/test/unit/apps/interactions/controllers/create.test.js
@@ -2,8 +2,7 @@ const { assign } = require('lodash')
 
 describe('Create interaction, step 1', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.selectKindFormConfigStub = this.sandbox.spy()
+    this.selectKindFormConfigStub = sandbox.spy()
 
     this.create = proxyquire('~/src/apps/interactions/controllers/create', {
       '../macros': {
@@ -11,7 +10,6 @@ describe('Create interaction, step 1', () => {
       },
     })
 
-    this.sandbox = sinon.sandbox.create()
     this.req = {
       query: {},
       session: {
@@ -21,15 +19,15 @@ describe('Create interaction, step 1', () => {
     }
 
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      redirect: this.sandbox.spy(),
-      render: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      redirect: sandbox.spy(),
+      render: sandbox.spy(),
       locals: {
         returnLink: '/return/',
       },
     }
 
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
   })
 
   describe('#postcreate', () => {

--- a/test/unit/apps/interactions/controllers/details.test.js
+++ b/test/unit/apps/interactions/controllers/details.test.js
@@ -3,8 +3,6 @@ const interactionData = require('~/test/unit/data/interactions/search-interactio
 
 describe('Interaction details controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.req = {
       params: {
         id: '1234',
@@ -15,18 +13,18 @@ describe('Interaction details controller', () => {
     }
 
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
       locals: {
         interaction: interactionData,
       },
     }
 
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
 
     this.transformedInteractionDataMock = {}
 
-    this.transformInteractionResponseToViewRecordStub = this.sandbox.stub().returns(this.transformedInteractionDataMock)
+    this.transformInteractionResponseToViewRecordStub = sandbox.stub().returns(this.transformedInteractionDataMock)
 
     this.controller = proxyquire('~/src/apps/interactions/controllers/details', {
       '../transformers': {

--- a/test/unit/apps/interactions/controllers/edit.test.js
+++ b/test/unit/apps/interactions/controllers/edit.test.js
@@ -6,7 +6,6 @@ describe('Interaction edit controller', () => {
   const currentUserTeam = 'team1'
 
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
     this.controller = require('~/src/apps/interactions/controllers/edit')
     this.req = {
       session: {
@@ -26,10 +25,10 @@ describe('Interaction edit controller', () => {
       },
     }
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      title: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
-      redirect: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      title: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      redirect: sandbox.spy(),
       locals: {
         entityName: 'company',
         returnLink: 'return',
@@ -38,11 +37,7 @@ describe('Interaction edit controller', () => {
         },
       },
     }
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#renderEditPage', () => {

--- a/test/unit/apps/interactions/middleware/collection.test.js
+++ b/test/unit/apps/interactions/middleware/collection.test.js
@@ -1,8 +1,6 @@
 const { assign } = require('lodash')
 describe('interaction collection middleware', () => {
   beforeEach(async () => {
-    this.sandbox = sinon.sandbox.create()
-
     this.req = {
       body: {},
       session: {
@@ -20,27 +18,23 @@ describe('interaction collection middleware', () => {
       },
     }
 
-    this.next = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.reset()
+    this.next = sandbox.spy()
   })
 
   describe('#getInteractionCollection', () => {
     beforeEach(async () => {
-      this.transformApiResponseToSearchCollectionStub = this.sandbox.stub()
+      this.transformApiResponseToSearchCollectionStub = sandbox.stub()
 
-      this.searchStub = this.sandbox.stub().resolves({
+      this.searchStub = sandbox.stub().resolves({
         count: 1,
         results: [{ id: '1' }],
       })
 
       this.transformedInteractionStub = { id: '1234' }
       this.transformedInteractionWithUrlPrefixStub = assign({}, this.transformedInteractionStub, { urlPrefix: 'return' })
-      this.transformInteractionToListItemStub = this.sandbox.stub().returns(this.transformedInteractionStub)
+      this.transformInteractionToListItemStub = sandbox.stub().returns(this.transformedInteractionStub)
       this.transformInteractionListItemToHaveUrlPrefixStub =
-        this.sandbox.stub().returns(() => { return this.transformedInteractionWithUrlPrefixStub })
+        sandbox.stub().returns(() => { return this.transformedInteractionWithUrlPrefixStub })
 
       this.middleware = proxyquire('~/src/apps/interactions/middleware/collection', {
         '../../search/services': {

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -97,10 +97,6 @@ describe('Interaction details middleware', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#postDetails', () => {
     context('when all fields are valid for creating', () => {
       beforeEach(async () => {

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -21,15 +21,14 @@ const transformed = {
 
 describe('Interaction details middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.saveInteractionStub = this.sandbox.stub()
-    this.fetchInteractionStub = this.sandbox.stub()
-    this.transformInteractionFormBodyToApiRequestStub = this.sandbox.stub()
-    this.transformInteractionResponseToViewRecordStub = this.sandbox.stub()
-    this.getContactsForCompanyStub = this.sandbox.stub()
-    this.getContactStub = this.sandbox.stub()
-    this.getDitCompanyStub = this.sandbox.stub()
-    this.filterActiveAdvisersSpy = this.sandbox.spy(adviserFilters, 'filterActiveAdvisers')
+    this.saveInteractionStub = sandbox.stub()
+    this.fetchInteractionStub = sandbox.stub()
+    this.transformInteractionFormBodyToApiRequestStub = sandbox.stub()
+    this.transformInteractionResponseToViewRecordStub = sandbox.stub()
+    this.getContactsForCompanyStub = sandbox.stub()
+    this.getContactStub = sandbox.stub()
+    this.getDitCompanyStub = sandbox.stub()
+    this.filterActiveAdvisersSpy = sandbox.spy(adviserFilters, 'filterActiveAdvisers')
 
     this.middleware = proxyquire('~/src/apps/interactions/middleware/details', {
       '../repos': {
@@ -51,7 +50,7 @@ describe('Interaction details middleware', () => {
         getContact: this.getContactStub,
       },
       '../../events/repos': {
-        getActiveEvents: this.sandbox.stub().resolves(eventsData.results),
+        getActiveEvents: sandbox.stub().resolves(eventsData.results),
       },
       '../../companies/repos': {
         getDitCompany: this.getDitCompanyStub,
@@ -62,7 +61,7 @@ describe('Interaction details middleware', () => {
       session: {
         token: 'abcd',
       },
-      flash: this.sandbox.spy(),
+      flash: sandbox.spy(),
       body: assign({}, interactionData),
       query: {
         company: '299e7412-d9ee-4ab0-a4cb-a8cc00922c91',
@@ -73,9 +72,9 @@ describe('Interaction details middleware', () => {
     }
 
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
-      redirect: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      redirect: sandbox.spy(),
       locals: {
         company: {
           id: '1',
@@ -84,7 +83,7 @@ describe('Interaction details middleware', () => {
       },
     }
 
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
     this.activeInactiveAdviserData = {
       count: 5,
@@ -141,9 +140,9 @@ describe('Interaction details middleware', () => {
     context('when all fields are valid for updating an interaction found from the top level navigation', () => {
       it('should redirect on success', async () => {
         const res = assign({}, this.res, {
-          breadcrumb: this.sandbox.stub().returnsThis(),
-          render: this.sandbox.spy(),
-          redirect: this.sandbox.spy(),
+          breadcrumb: sandbox.stub().returnsThis(),
+          render: sandbox.spy(),
+          redirect: sandbox.spy(),
           locals: {},
         })
 
@@ -189,7 +188,7 @@ describe('Interaction details middleware', () => {
   describe('#getInteractionDetails', () => {
     context('when provided an interaction with a company associated', () => {
       beforeEach(async () => {
-        this.company = this.sandbox.mock()
+        this.company = sandbox.mock()
         this.interaction = assign({}, interactionData, { company: this.company })
         this.fetchInteractionStub.resolves(this.interaction)
         await this.middleware.getInteractionDetails(this.req, this.res, this.nextSpy, '1')
@@ -221,7 +220,7 @@ describe('Interaction details middleware', () => {
           },
         })
 
-        this.company = this.sandbox.mock()
+        this.company = sandbox.mock()
         this.getDitCompanyStub.resolves(this.company)
 
         await this.middleware.getInteractionDetails(this.req, this.res, this.nextSpy, '1')

--- a/test/unit/apps/interactions/services/form.service.test.js
+++ b/test/unit/apps/interactions/services/form.service.test.js
@@ -1,6 +1,6 @@
 /* eslint handle-callback-err: 0, camelcase: 0 */
 
-describe('interaction form service', function () {
+describe('interaction form service', () => {
   let saveInteractionStub
   let company
   let contact
@@ -11,7 +11,7 @@ describe('interaction form service', function () {
   let dit_team
   let interactionFormService
 
-  beforeEach(function () {
+  beforeEach(() => {
     company = { id: '1234', name: 'Fred ltd' }
     contact = { id: '3321', name: 'Fred Smith', first_name: 'Fred', last_name: 'Smith', company }
     dit_adviser = { id: '4455', name: 'Fred Jones', first_name: 'Fred', last_name: 'Jones' }
@@ -45,8 +45,8 @@ describe('interaction form service', function () {
     })
   })
 
-  describe('Convert API to Form', function () {
-    it('should an existing API format interaction entity into a format for use with a HTML form', function () {
+  describe('Convert API to Form', () => {
+    it('should an existing API format interaction entity into a format for use with a HTML form', () => {
       const expected = {
         id: '999',
         company: company.id,
@@ -61,7 +61,7 @@ describe('interaction form service', function () {
       }
       expect(interactionFormService.getInteractionAsFormData(interaction)).to.deep.equal(expected)
     })
-    it('should handle new blank interactions being editing for the first time', function () {
+    it('should handle new blank interactions being editing for the first time', () => {
       const freshInteraction = {
         company,
         contact: null,

--- a/test/unit/apps/investment-projects/controllers/archive.test.js
+++ b/test/unit/apps/investment-projects/controllers/archive.test.js
@@ -1,20 +1,19 @@
 /* eslint camelcase: 0 */
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
 
-describe('Investment archive controller', function () {
+describe('Investment archive controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.stub()
+    this.next = sandbox.stub()
     this.token = '1234'
-    this.archiveInvestmentProject = this.sandbox.stub().resolves(investmentData)
-    this.unarchiveInvestmentProject = this.sandbox.stub().resolves(investmentData)
+    this.archiveInvestmentProject = sandbox.stub().resolves(investmentData)
+    this.unarchiveInvestmentProject = sandbox.stub().resolves(investmentData)
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/archive', {
       '../repos': {
         archiveInvestmentProject: this.archiveInvestmentProject,
         unarchiveInvestmentProject: this.unarchiveInvestmentProject,
       },
     })
-    this.flashStub = this.sandbox.stub()
+    this.flashStub = sandbox.stub()
     this.session = {
       token: this.token,
       user: {
@@ -115,7 +114,7 @@ describe('Investment archive controller', function () {
     it('should pass on the form values and error if validation failed.', (done) => {
       this.controller = proxyquire('~/src/apps/investment-projects/controllers/archive', {
         '../repos': {
-          archiveInvestmentProject: this.sandbox.stub().rejects({
+          archiveInvestmentProject: sandbox.stub().rejects({
             statusCode: 400,
             error: 'Some error',
           }),
@@ -147,7 +146,7 @@ describe('Investment archive controller', function () {
       const error = new Error()
       this.controller = proxyquire('~/src/apps/investment-projects/controllers/archive', {
         '../repos': {
-          archiveInvestmentProject: this.sandbox.stub().rejects(error),
+          archiveInvestmentProject: sandbox.stub().rejects(error),
           unarchiveInvestmentProject: this.unarchiveInvestmentProject,
         },
       })

--- a/test/unit/apps/investment-projects/controllers/associated.test.js
+++ b/test/unit/apps/investment-projects/controllers/associated.test.js
@@ -4,12 +4,11 @@ const investmentData = { investor_company: { name: 'company' } }
 
 describe('investment associated controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.updateInvestmentStub = this.sandbox.stub().resolves(investmentData)
-    this.searchStub = this.sandbox.stub().resolves(investmentCollection)
-    this.transformerStub = this.sandbox.stub()
-    this.transformInvestmentProjectToListItemStub = this.sandbox.stub()
-    this.transformInvestmentListItemToDisableMetaLinksStub = this.sandbox.stub().returns({ id: 1 })
+    this.updateInvestmentStub = sandbox.stub().resolves(investmentData)
+    this.searchStub = sandbox.stub().resolves(investmentCollection)
+    this.transformerStub = sandbox.stub()
+    this.transformInvestmentProjectToListItemStub = sandbox.stub()
+    this.transformInvestmentListItemToDisableMetaLinksStub = sandbox.stub().returns({ id: 1 })
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/associated', {
       '../repos': {
@@ -47,7 +46,7 @@ describe('investment associated controller', () => {
       session: {
         token: 'abcd',
       },
-      flash: this.sandbox.spy(),
+      flash: sandbox.spy(),
     }
     this.res = {
       locals: {
@@ -55,11 +54,11 @@ describe('investment associated controller', () => {
           name: 'investment',
         },
       },
-      render: this.sandbox.spy(),
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      redirect: this.sandbox.spy(),
+      render: sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      redirect: sandbox.spy(),
     }
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
   })
 
   describe('#selectAssociatedInvestmentProject', () => {
@@ -88,7 +87,7 @@ describe('investment associated controller', () => {
       context('server returns an error', () => {
         beforeEach(async () => {
           this.req.query.project = '1234'
-          this.error = this.sandbox.stub()
+          this.error = sandbox.stub()
 
           this.updateInvestmentStub.rejects(this.error)
 
@@ -170,7 +169,7 @@ describe('investment associated controller', () => {
 
       context('and search throw an error', () => {
         beforeEach(async () => {
-          this.error = this.sandbox.stub()
+          this.error = sandbox.stub()
           this.searchStub.rejects(this.error)
           await this.controller.searchForAssociatedInvestmentProject(this.req, this.res, this.next)
         })
@@ -223,7 +222,7 @@ describe('investment associated controller', () => {
 
     context('when there is an error removing the association from the investment', () => {
       beforeEach(async () => {
-        this.error = this.sandbox.stub()
+        this.error = sandbox.stub()
 
         this.updateInvestmentStub.rejects(this.error)
         await this.controller.removeAssociatedInvestmentProject(this.req, this.res, this.next)

--- a/test/unit/apps/investment-projects/controllers/audit.test.js
+++ b/test/unit/apps/investment-projects/controllers/audit.test.js
@@ -4,10 +4,9 @@ const token = 'abcd'
 
 describe('Investment audit controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.stub()
-    this.getInvestmentProjectAuditLog = this.sandbox.stub().resolves(investmentProjectAuditData.results)
-    this.breadcrumbStub = function () { return this }
+    this.next = sandbox.stub()
+    this.getInvestmentProjectAuditLog = sandbox.stub().resolves(investmentProjectAuditData.results)
+    this.breadcrumbStub = sandbox.stub().returnsThis()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/audit', {
       '../repos': {
@@ -85,7 +84,7 @@ describe('Investment audit controller', () => {
       },
     }]
 
-    this.getInvestmentProjectAuditLog = this.sandbox.stub().resolves(badDate)
+    this.getInvestmentProjectAuditLog = sandbox.stub().resolves(badDate)
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/audit', {
       '../repos': {
@@ -132,7 +131,7 @@ describe('Investment audit controller', () => {
       changes: null,
     }]
 
-    this.getInvestmentProjectAuditLog = this.sandbox.stub().resolves(nullChangeSet)
+    this.getInvestmentProjectAuditLog = sandbox.stub().resolves(nullChangeSet)
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/audit', {
       '../repos': {
@@ -179,7 +178,7 @@ describe('Investment audit controller', () => {
       changes: {},
     }]
 
-    this.getInvestmentProjectAuditLog = this.sandbox.stub().resolves(emptyChangeSet)
+    this.getInvestmentProjectAuditLog = sandbox.stub().resolves(emptyChangeSet)
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/audit', {
       '../repos': {

--- a/test/unit/apps/investment-projects/controllers/create/equity-source.test.js
+++ b/test/unit/apps/investment-projects/controllers/create/equity-source.test.js
@@ -39,10 +39,6 @@ describe('Investment start controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getHandler', () => {
     describe('when no company ID is present', () => {
       it('should render company details and search', (done) => {

--- a/test/unit/apps/investment-projects/controllers/create/equity-source.test.js
+++ b/test/unit/apps/investment-projects/controllers/create/equity-source.test.js
@@ -20,12 +20,11 @@ const searchResults = {
 
 describe('Investment start controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.stub()
-    this.getCompanyInvestmentProjects = this.sandbox.stub().resolves(investmentProjects)
-    this.searchForeignCompanies = this.sandbox.stub().resolves(searchResults)
-    this.buildPagination = this.sandbox.stub().returns(null)
-    this.breadcrumbStub = function () { return this }
+    this.next = sandbox.stub()
+    this.getCompanyInvestmentProjects = sandbox.stub().resolves(investmentProjects)
+    this.searchForeignCompanies = sandbox.stub().resolves(searchResults)
+    this.buildPagination = sandbox.stub().returns(null)
+    this.breadcrumbStub = sandbox.stub().returnsThis()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/create/equity-source', {
       '../../repos': {

--- a/test/unit/apps/investment-projects/controllers/create/project.js
+++ b/test/unit/apps/investment-projects/controllers/create/project.js
@@ -24,10 +24,6 @@ describe('Investment create controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#createGetHandler', () => {
     describe('when no company ID is provided', () => {
       it('should redirect to the start', (done) => {

--- a/test/unit/apps/investment-projects/controllers/create/project.js
+++ b/test/unit/apps/investment-projects/controllers/create/project.js
@@ -5,9 +5,8 @@ const mockInvestmentDetails = {
 
 describe('Investment create controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.stub()
-    this.breadcrumbStub = function () {
+    this.next = sandbox.stub()
+    this.breadcrumbStub = () => {
       return this
     }
 

--- a/test/unit/apps/investment-projects/controllers/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/details.test.js
@@ -2,15 +2,14 @@ const investmentData = require('~/test/unit/data/investment/investment-data.json
 
 describe('Investment details controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.stub()
-    this.transformInvestmentRequirementsForViewStub = this.sandbox.stub()
+    this.next = sandbox.stub()
+    this.transformInvestmentRequirementsForViewStub = sandbox.stub()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/details', {
       '../services/formatting': {
         transformInvestmentRequirementsForView: this.transformInvestmentRequirementsForViewStub,
-        transformInvestmentDataForView: this.sandbox.stub(),
-        transformInvestmentValueForView: this.sandbox.stub(),
+        transformInvestmentDataForView: sandbox.stub(),
+        transformInvestmentValueForView: sandbox.stub(),
       },
     })
   })
@@ -58,7 +57,7 @@ describe('Investment details controller', () => {
           locals: {
             investmentData,
           },
-          render: this.sandbox.stub(),
+          render: sandbox.stub(),
         }
 
         this.controller.detailsGetHandler(this.req, this.res, this.next)
@@ -92,7 +91,7 @@ describe('Investment details controller', () => {
           locals: {
             investmentData,
           },
-          render: this.sandbox.stub(),
+          render: sandbox.stub(),
         }
 
         this.controller.detailsGetHandler(this.req, this.res, this.next)
@@ -128,7 +127,7 @@ describe('Investment details controller', () => {
           locals: {
             investmentData,
           },
-          render: this.sandbox.stub(),
+          render: sandbox.stub(),
         }
 
         this.controller.detailsGetHandler(this.req, this.res, this.next)

--- a/test/unit/apps/investment-projects/controllers/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/details.test.js
@@ -14,10 +14,6 @@ describe('Investment details controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#detailsGetHandler', () => {
     it('should return investment details', (done) => {
       this.controller.detailsGetHandler({

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -11,11 +11,8 @@ const mockMetadataRepository = {
 
 describe('Investment evaluation controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.stub()
-    this.breadcrumbStub = function () {
-      return this
-    }
+    this.next = sandbox.stub()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/evaluation', {
       '../services/formatting': proxyquire('~/src/apps/investment-projects/services/formatting', {

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -21,10 +21,6 @@ describe('Investment evaluation controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#renderEvaluationPage', () => {
     it('should return evaluation details', (done) => {
       this.controller.renderEvaluationPage({

--- a/test/unit/apps/investment-projects/controllers/interactions.test.js
+++ b/test/unit/apps/investment-projects/controllers/interactions.test.js
@@ -3,12 +3,10 @@ const { transformInteractionToListItem } = require('~/src/apps/interactions/tran
 
 describe('Investment Interactions controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.transformedInteractions = {}
 
-    this.getInteractionsForInvestmentStub = this.sandbox.stub().resolves(interactionsListData)
-    this.transformApiResponseToCollectionStub = this.sandbox.stub().returns(this.transformedInteractions)
+    this.getInteractionsForInvestmentStub = sandbox.stub().resolves(interactionsListData)
+    this.transformApiResponseToCollectionStub = sandbox.stub().returns(this.transformedInteractions)
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/interactions', {
       '../../interactions/repos': {
@@ -30,16 +28,12 @@ describe('Investment Interactions controller', () => {
     }
 
     this.resMock = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
+      breadcrumb: sandbox.stub().returnsThis(),
       locals: {},
-      render: this.sandbox.spy(),
+      render: sandbox.spy(),
     }
 
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#renderInteractionList', () => {

--- a/test/unit/apps/investment-projects/controllers/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/list.test.js
@@ -1,7 +1,6 @@
 describe('Investment list controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
     this.req = {
       session: {
         token: 'abcd',
@@ -9,11 +8,11 @@ describe('Investment list controller', () => {
       query: {},
     }
     this.res = {
-      render: this.sandbox.spy(),
+      render: sandbox.spy(),
       query: {},
     }
 
-    this.buildSelectedFiltersSummaryStub = this.sandbox.spy()
+    this.buildSelectedFiltersSummaryStub = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/list', {
       '../../builders': {
@@ -28,17 +27,13 @@ describe('Investment list controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#renderInvestmentList', () => {
     it('should render collection page with locals', () => {
       this.controller.renderInvestmentList(this.req, this.res, this.next)
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('title'))
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('sortForm'))
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('filtersFields'))
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('selectedFilters'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('title'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('sortForm'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('filtersFields'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('selectedFilters'))
       expect(this.buildSelectedFiltersSummaryStub).to.have.been.calledWith([
         { macroName: 'useful' },
         { macroName: 'exciting' },

--- a/test/unit/apps/investment-projects/controllers/status.test.js
+++ b/test/unit/apps/investment-projects/controllers/status.test.js
@@ -2,8 +2,7 @@ const { merge, find } = require('lodash')
 
 describe('investment status controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.updateInvestmentStub = this.sandbox.stub().resolves()
+    this.updateInvestmentStub = sandbox.stub().resolves()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/status', {
       '../repos': {
@@ -19,14 +18,14 @@ describe('investment status controller', () => {
       params: {
         investmentId: '111',
       },
-      flash: this.sandbox.spy(),
+      flash: sandbox.spy(),
     }
 
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      title: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
-      redirect: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      title: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
+      redirect: sandbox.spy(),
       locals: {
         investmentData: {
           id: '111',
@@ -35,11 +34,7 @@ describe('investment status controller', () => {
       },
     }
 
-    this.next = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.next = sandbox.spy()
   })
 
   describe('#renderStatusPage', () => {
@@ -154,7 +149,7 @@ describe('investment status controller', () => {
 
     context('when a post causes form errors', () => {
       beforeEach(async () => {
-        this.error = this.sandbox.stub()
+        this.error = sandbox.stub()
 
         this.updateInvestmentStub.rejects({
           statusCode: 400,
@@ -175,7 +170,7 @@ describe('investment status controller', () => {
 
     context('when a post causes an unknown error', () => {
       beforeEach(async () => {
-        this.error = this.sandbox.stub()
+        this.error = sandbox.stub()
 
         this.updateInvestmentStub.rejects(this.error)
 

--- a/test/unit/apps/investment-projects/controllers/team/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/details.test.js
@@ -26,10 +26,6 @@ describe('Investment team details controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   it('should get formatted project management data', (done) => {
     const data = Object.assign({}, investmentData)
     this.controller.getDetailsHandler(this.reqStub, {

--- a/test/unit/apps/investment-projects/controllers/team/details.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/details.test.js
@@ -6,17 +6,16 @@ const {
 
 describe('Investment team details controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
-    this.reqStub = this.sandbox.stub()
-    this.nextStub = this.sandbox.stub()
+    this.nextStub = sandbox.stub()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
+    this.reqStub = sandbox.stub()
+    this.nextStub = sandbox.stub()
     this.clientRelationshipManagementData = { name: 'fred' }
     this.teamMembersData = { adviser: 'Fred' }
     this.projectManagementData = [{ name: 'fred' }]
-    this.transformProjectManagementForViewStub = this.sandbox.stub().returns(this.projectManagementData)
-    this.transformClientRelationshipManagementForViewStub = this.sandbox.stub().returns(this.clientRelationshipManagementData)
-    this.transformTeamMembersForViewStub = this.sandbox.stub().returns(this.teamMembersData)
+    this.transformProjectManagementForViewStub = sandbox.stub().returns(this.projectManagementData)
+    this.transformClientRelationshipManagementForViewStub = sandbox.stub().returns(this.clientRelationshipManagementData)
+    this.transformTeamMembersForViewStub = sandbox.stub().returns(this.teamMembersData)
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/team/details', {
       '../../services/formatting': {

--- a/test/unit/apps/investment-projects/controllers/team/edit-client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-client-relationship-management.test.js
@@ -14,10 +14,6 @@ describe('Investment project, client relationship management, edit controller', 
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getHandler', () => {
     it('should render edit client relationship management view', (done) => {
       this.controller.getHandler({

--- a/test/unit/apps/investment-projects/controllers/team/edit-client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-client-relationship-management.test.js
@@ -2,11 +2,10 @@ const investmentData = require('~/test/unit/data/investment/investment-data.json
 
 describe('Investment project, client relationship management, edit controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextStub = this.sandbox.stub()
-    this.flashStub = this.sandbox.stub()
-    this.getDataLabelsStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.nextStub = sandbox.stub()
+    this.flashStub = sandbox.stub()
+    this.getDataLabelsStub = sandbox.stub()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/team/edit-client-relationship-management', {
       '../../../../lib/controller-utils': {

--- a/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
@@ -27,10 +27,6 @@ describe('Investment project, project management team, edit controller', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getHandler', () => {
     it('should render edit project management view', async () => {
       await this.controller.getHandler(this.reqMock, assign({}, this.resMock, {

--- a/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-project-management.test.js
@@ -4,11 +4,10 @@ const { briefInvestmentSummaryLabels } = require('~/src/apps/investment-projects
 
 describe('Investment project, project management team, edit controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextStub = this.sandbox.stub()
-    this.flashStub = this.sandbox.stub()
-    this.getDataLabelsStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.nextStub = sandbox.stub()
+    this.flashStub = sandbox.stub()
+    this.getDataLabelsStub = sandbox.stub()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
     this.reqMock = assign({}, globalReq, {
       session: {
         token: '1234',
@@ -16,8 +15,8 @@ describe('Investment project, project management team, edit controller', () => {
       flash: this.flashStub,
     })
     this.resMock = assign({}, globalRes, {
-      redirect: this.sandbox.spy(),
-      render: this.sandbox.spy(),
+      redirect: sandbox.spy(),
+      render: sandbox.spy(),
       breadcrumb: this.breadcrumbStub,
     })
 

--- a/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
@@ -9,10 +9,6 @@ describe('Investment project, team members, edit controller', () => {
     this.controller = require('~/src/apps/investment-projects/controllers/team/edit-team-members')
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getHandler', () => {
     it('should render edit project management view', (done) => {
       this.controller.getHandler({

--- a/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
@@ -2,10 +2,9 @@ const investmentData = require('~/test/unit/data/investment/investment-data.json
 
 describe('Investment project, team members, edit controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextStub = this.sandbox.stub()
-    this.flashStub = this.sandbox.stub()
-    this.breadcrumbStub = function () { return this }
+    this.nextStub = sandbox.stub()
+    this.flashStub = sandbox.stub()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
 
     this.controller = require('~/src/apps/investment-projects/controllers/team/edit-team-members')
   })

--- a/test/unit/apps/investment-projects/controllers/ukcompany.test.js
+++ b/test/unit/apps/investment-projects/controllers/ukcompany.test.js
@@ -2,10 +2,9 @@ const investmentData = { investor_company: { name: 'company' } }
 
 describe('investment uk company', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.updateInvestmentStub = this.sandbox.stub().resolves(investmentData)
-    this.searchStub = this.sandbox.stub().resolves()
-    this.transformerStub = this.sandbox.stub()
+    this.updateInvestmentStub = sandbox.stub().resolves(investmentData)
+    this.searchStub = sandbox.stub().resolves()
+    this.transformerStub = sandbox.stub()
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/ukcompany', {
       '../../search/services': {
@@ -27,7 +26,7 @@ describe('investment uk company', () => {
       session: {
         token: 'abcd',
       },
-      flash: this.sandbox.spy(),
+      flash: sandbox.spy(),
     }
     this.res = {
       locals: {
@@ -35,11 +34,11 @@ describe('investment uk company', () => {
           name: 'investment',
         },
       },
-      render: this.sandbox.spy(),
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      redirect: this.sandbox.spy(),
+      render: sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      redirect: sandbox.spy(),
     }
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
   })
 
   describe('#selectUKCompany', () => {
@@ -69,7 +68,7 @@ describe('investment uk company', () => {
       context('server returns an error', () => {
         beforeEach(async () => {
           this.req.query.company = '1234'
-          this.error = this.sandbox.stub()
+          this.error = sandbox.stub()
 
           this.updateInvestmentStub.rejects(this.error)
 
@@ -158,7 +157,7 @@ describe('investment uk company', () => {
     context('when search causes an error', () => {
       beforeEach(async () => {
         this.req.query.term = 'test'
-        this.error = this.sandbox.stub()
+        this.error = sandbox.stub()
         this.searchStub.rejects(this.error)
         await this.controller.searchForUKCompany(this.req, this.res, this.next)
       })
@@ -210,7 +209,7 @@ describe('investment uk company', () => {
 
     context('when there is an error removing the company from the investment', () => {
       beforeEach(async () => {
-        this.error = this.sandbox.stub()
+        this.error = sandbox.stub()
 
         this.updateInvestmentStub.rejects(this.error)
         await this.controller.removeUKCompany(this.req, this.res, this.next)

--- a/test/unit/apps/investment-projects/helpers.js
+++ b/test/unit/apps/investment-projects/helpers.js
@@ -13,7 +13,6 @@ const formTwoMockLinkDetails = {
 
 describe('buildIncompleteFormList', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
     this.mockLinkDetails = {
       formOne: assign({}, formOneMockLinkDetails),
       formTwo: assign({}, formTwoMockLinkDetails),

--- a/test/unit/apps/investment-projects/helpers.js
+++ b/test/unit/apps/investment-projects/helpers.js
@@ -33,10 +33,6 @@ describe('buildIncompleteFormList', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   context('without arguments ', () => {
     it('should provide an empty array', () => {
       const expectedLinkObjects = buildIncompleteFormList()

--- a/test/unit/apps/investment-projects/middleware/collection.test.js
+++ b/test/unit/apps/investment-projects/middleware/collection.test.js
@@ -4,8 +4,7 @@ const investmentCollectioData = require('~/test/unit/data/investment/collection.
 
 describe('Investment projects collection middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
     this.req = Object.assign({}, globalReq, {
       session: { token: 'abcd' },
     })

--- a/test/unit/apps/investment-projects/middleware/collection.test.js
+++ b/test/unit/apps/investment-projects/middleware/collection.test.js
@@ -12,10 +12,6 @@ describe('Investment projects collection middleware', () => {
     this.controller = require('~/src/apps/investment-projects/middleware/collection')
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getInvestmentProjectsCollection', () => {
     beforeEach(async () => {
       this.nockScope = nock(config.apiRoot)

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -10,9 +10,8 @@ const { clientRelationshipManagementLabels } = require('~/src/apps/investment-pr
 describe('Investment form middleware - client relationship management', () => {
   describe('#populateForm', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
-      this.updateCompanyStub = this.sandbox.stub().resolves(companyData)
-      this.nextSpy = this.sandbox.spy()
+      this.updateCompanyStub = sandbox.stub().resolves(companyData)
+      this.nextSpy = sandbox.spy()
       this.resMock = {
         locals: {
           form: {},
@@ -174,10 +173,9 @@ describe('Investment form middleware - client relationship management', () => {
 
     describe('post with no errors', () => {
       beforeEach(() => {
-        this.sandbox = sinon.sandbox.create()
-        this.updateInvestmentStub = this.sandbox.stub().resolves(advisorData)
-        this.updateCompanyStub = this.sandbox.stub().resolves(companyData)
-        this.nextSpy = this.sandbox.spy()
+        this.updateInvestmentStub = sandbox.stub().resolves(advisorData)
+        this.updateCompanyStub = sandbox.stub().resolves(companyData)
+        this.nextSpy = sandbox.spy()
         this.resMock = {
           locals: {},
         }
@@ -244,11 +242,9 @@ describe('Investment form middleware - client relationship management', () => {
 
     describe('When a form is posted with errors', () => {
       beforeEach(() => {
-        this.sandbox = sinon.sandbox.create()
-
-        this.updateInvestmentStub = this.sandbox.stub()
-        this.updateCompanyStub = this.sandbox.stub().resolves(companyData)
-        this.nextSpy = this.sandbox.spy()
+        this.updateInvestmentStub = sandbox.stub()
+        this.updateCompanyStub = sandbox.stub().resolves(companyData)
+        this.nextSpy = sandbox.spy()
         this.resMock = {
           locals: {},
         }

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -39,10 +39,6 @@ describe('Investment form middleware - client relationship management', () => {
         })
     })
 
-    afterEach(() => {
-      this.sandbox.restore()
-    })
-
     it('should populate the form state with the existing client relationship management if there is data', (done) => {
       const expectedFormState = {
         client_relationship_manager: investmentData.client_relationship_manager.id,
@@ -190,10 +186,6 @@ describe('Investment form middleware - client relationship management', () => {
         })
       })
 
-      afterEach(() => {
-        this.sandbox.restore()
-      })
-
       it('updates the investment data', (done) => {
         this.controller.handleFormPost({
           session: {
@@ -260,10 +252,6 @@ describe('Investment form middleware - client relationship management', () => {
             updateCompany: this.updateCompanyStub,
           },
         })
-      })
-
-      afterEach(() => {
-        this.sandbox.restore()
       })
 
       it('should set form error data for the following controllers if form error', (done) => {

--- a/test/unit/apps/investment-projects/middleware/forms/details.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/details.test.js
@@ -8,12 +8,11 @@ const companyData = require('~/test/unit/data/companies/company.json')
 
 describe('investment details middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.stub()
+    this.next = sandbox.stub()
 
-    this.updateInvestmentStub = this.sandbox.stub().resolves({ id: '999' })
-    this.createInvestmentStub = this.sandbox.stub().resolves({ id: '888' })
-    this.getEquityCompanyDetailsStub = this.sandbox.stub().resolves(companyData)
+    this.updateInvestmentStub = sandbox.stub().resolves({ id: '999' })
+    this.createInvestmentStub = sandbox.stub().resolves({ id: '888' })
+    this.getEquityCompanyDetailsStub = sandbox.stub().resolves(companyData)
 
     this.req = {
       session: {
@@ -32,7 +31,7 @@ describe('investment details middleware', () => {
       locals: {
         form: {},
       },
-      redirect: this.sandbox.stub(),
+      redirect: sandbox.stub(),
     }
 
     this.detailsMiddleware = proxyquire('~/src/apps/investment-projects/middleware/forms/details', {

--- a/test/unit/apps/investment-projects/middleware/forms/details.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/details.test.js
@@ -55,10 +55,6 @@ describe('investment details middleware', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#handleFormPost', () => {
     context('when saving a new investment project', () => {
       beforeEach(async () => {

--- a/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
@@ -9,9 +9,8 @@ const { projectManagementLabels } = require('~/src/apps/investment-projects/labe
 describe('Investment form middleware - project magement', () => {
   describe('#populateForm', () => {
     beforeEach(() => {
-      this.sandbox = sinon.sandbox.create()
-      this.getAdvisersStub = this.sandbox.stub().resolves(advisorData)
-      this.nextSpy = this.sandbox.spy()
+      this.getAdvisersStub = sandbox.stub().resolves(advisorData)
+      this.nextSpy = sandbox.spy()
       this.resMock = {
         locals: {
           form: {},
@@ -125,9 +124,8 @@ describe('Investment form middleware - project magement', () => {
 
     describe('post with no errors', () => {
       beforeEach(() => {
-        this.sandbox = sinon.sandbox.create()
-        this.updateInvestmentStub = this.sandbox.stub().resolves(advisorData)
-        this.nextSpy = this.sandbox.spy()
+        this.updateInvestmentStub = sandbox.stub().resolves(advisorData)
+        this.nextSpy = sandbox.spy()
         this.resMock = {
           locals: {},
         }
@@ -176,10 +174,8 @@ describe('Investment form middleware - project magement', () => {
 
     describe('post with form errors', () => {
       beforeEach(() => {
-        this.sandbox = sinon.sandbox.create()
-
-        this.updateInvestmentStub = this.sandbox.stub()
-        this.nextSpy = this.sandbox.spy()
+        this.updateInvestmentStub = sandbox.stub()
+        this.nextSpy = sandbox.spy()
         this.resMock = {
           locals: {},
         }

--- a/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
@@ -34,10 +34,6 @@ describe('Investment form middleware - project magement', () => {
         })
     })
 
-    afterEach(() => {
-      this.sandbox.restore()
-    })
-
     it('should populate the form state with the existing project management team if there is data', (done) => {
       const expectedFormState = {
         project_manager: investmentData.project_manager.id,
@@ -137,10 +133,6 @@ describe('Investment form middleware - project magement', () => {
         })
       })
 
-      afterEach(() => {
-        this.sandbox.restore()
-      })
-
       it('updates the investment data', (done) => {
         this.controller.handleFormPost({
           session: {
@@ -185,10 +177,6 @@ describe('Investment form middleware - project magement', () => {
             updateInvestment: this.updateInvestmentStub,
           },
         })
-      })
-
-      afterEach(() => {
-        this.sandbox.restore()
       })
 
       it('sets form error data for the following controllers if form error', (done) => {

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -33,10 +33,6 @@ describe('Investment form middleware - team members', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#populateForm', () => {
     beforeEach(() => {
       this.nockScope = nock(config.apiRoot)

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -8,11 +8,9 @@ const { teamMembersLabels } = require('~/src/apps/investment-projects/labels')
 
 describe('Investment form middleware - team members', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
+    this.updateInvestmentTeamMembersStub = sandbox.stub().resolves({})
 
-    this.updateInvestmentTeamMembersStub = this.sandbox.stub().resolves({})
-
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
     this.reqMock = {
       session: {
         token: uuid(),

--- a/test/unit/apps/investment-projects/middleware/forms/value.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/value.test.js
@@ -23,10 +23,6 @@ describe('Investment form middleware - investment value', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   it('should set form labels', () => {
     this.controller.populateForm({}, this.resMock, this.nextSpy)
 

--- a/test/unit/apps/investment-projects/middleware/forms/value.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/value.test.js
@@ -9,9 +9,8 @@ const metadataRepositoryStub = {
 
 describe('Investment form middleware - investment value', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.getAdvisersStub = this.sandbox.stub().resolves(advisorData)
-    this.nextSpy = this.sandbox.spy()
+    this.getAdvisersStub = sandbox.stub().resolves(advisorData)
+    this.nextSpy = sandbox.spy()
     this.resMock = {
       locals: {},
     }

--- a/test/unit/apps/investment-projects/middleware/interactions.test.js
+++ b/test/unit/apps/investment-projects/middleware/interactions.test.js
@@ -2,8 +2,7 @@ const investmentData = { investor_company: { name: 'company' } }
 
 describe('Investment projects interactions middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.getInvestmentStub = this.sandbox.stub().returns(investmentData)
+    this.getInvestmentStub = sandbox.stub().returns(investmentData)
     this.middleware = proxyquire('~/src/apps/investment-projects/middleware/interactions', {
       '../repos': {
         getInvestment: this.getInvestmentStub,
@@ -24,11 +23,7 @@ describe('Investment projects interactions middleware', () => {
         },
       },
     }
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#setInteractionsReturnUrl', () => {

--- a/test/unit/apps/investment-projects/middleware/team.test.js
+++ b/test/unit/apps/investment-projects/middleware/team.test.js
@@ -2,8 +2,7 @@ const investmentData = require('~/test/unit/data/investment/investment-data.json
 
 describe('Investment team middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.transformBriefInvestmentSummaryStub = this.sandbox.stub()
+    this.transformBriefInvestmentSummaryStub = sandbox.stub()
     this.investmentData = Object.assign({}, investmentData, {
       team_members: [{
         adviser: {
@@ -25,8 +24,8 @@ describe('Investment team middleware', () => {
       },
     }
 
-    this.getAdviserStub = this.sandbox.stub().resolves(this.adviser)
-    this.nextSpy = this.sandbox.spy()
+    this.getAdviserStub = sandbox.stub().resolves(this.adviser)
+    this.nextSpy = sandbox.spy()
     this.reqMock = {}
     this.resMock = {
       locals: {

--- a/test/unit/apps/investment-projects/middleware/team.test.js
+++ b/test/unit/apps/investment-projects/middleware/team.test.js
@@ -43,10 +43,6 @@ describe('Investment team middleware', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getBriefInvestmentSummary', () => {
     it('should call brief investment summary formatter with expanded project', (done) => {
       this.teamMiddleware.getBriefInvestmentSummary({

--- a/test/unit/apps/investment-projects/repos.test.js
+++ b/test/unit/apps/investment-projects/repos.test.js
@@ -1,4 +1,3 @@
-
 const config = require('~/config')
 
 const {
@@ -15,14 +14,6 @@ const investmentData = require('~/test/unit/data/investment/investment-data.json
 const investmentProjectAuditData = require('~/test/unit/data/investment/audit-log.json')
 
 describe('Investment repository', () => {
-  beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#getCompanyInvestmentProjects', () => {
     beforeEach(async () => {
       this.nockScope = nock(config.apiRoot)

--- a/test/unit/apps/middleware.test.js
+++ b/test/unit/apps/middleware.test.js
@@ -1,13 +1,7 @@
 describe('Apps middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
     this.middleware = require('~/src/apps/middleware')
-
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('setLocalNav()', () => {
@@ -82,7 +76,7 @@ describe('Apps middleware', () => {
     }]
 
     it('should redirect to the first item', () => {
-      const redirectMock = this.sandbox.spy()
+      const redirectMock = sandbox.spy()
       const resMock = this.reqMock = Object.assign({}, globalRes, {
         redirect: redirectMock,
         locals: {
@@ -99,7 +93,7 @@ describe('Apps middleware', () => {
   describe('setDefaultQuery()', () => {
     beforeEach(() => {
       this.resMock = {
-        redirect: this.sandbox.spy(),
+        redirect: sandbox.spy(),
       }
     })
 

--- a/test/unit/apps/oauth/controllers/oauth.test.js
+++ b/test/unit/apps/oauth/controllers/oauth.test.js
@@ -3,26 +3,21 @@ const { assign, set } = require('lodash')
 
 describe('OAuth controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.mockUuid = this.sandbox.stub()
+    this.mockUuid = sandbox.stub()
     this.mockConfig = {}
     this.controller = proxyquire.noCallThru().load('~/src/apps/oauth/controllers', {
       './../../../config': this.mockConfig,
       'uuid': this.mockUuid,
     })
     this.resMock = assign({}, globalRes, {
-      redirect: this.sandbox.spy(),
-      render: this.sandbox.spy(),
-      clearCookie: this.sandbox.spy(),
+      redirect: sandbox.spy(),
+      render: sandbox.spy(),
+      clearCookie: sandbox.spy(),
     })
     this.reqMock = assign({}, globalReq, {
       session: {},
     })
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('#redirectOAuth', () => {

--- a/test/unit/apps/omis/apps/create/controllers/client-details.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/client-details.test.js
@@ -19,10 +19,6 @@ describe('OMIS create client details controller', () => {
     this.controller = new Controller({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('configure()', () => {
     beforeEach(() => {
       this.reqMock = Object.assign({}, globalReq, {

--- a/test/unit/apps/omis/apps/create/controllers/client-details.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/client-details.test.js
@@ -14,9 +14,8 @@ const contactsMockData = [{
 
 describe('OMIS create client details controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
-    this.breadcrumbStub = this.sandbox.stub().returnsThis()
+    this.nextSpy = sandbox.spy()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
     this.controller = new Controller({ route: '/' })
   })
 
@@ -43,7 +42,7 @@ describe('OMIS create client details controller', () => {
         },
       })
 
-      this.sandbox.spy(FormController.prototype, 'configure')
+      sandbox.spy(FormController.prototype, 'configure')
     })
 
     describe('when a company exists', () => {

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -29,9 +29,8 @@ const contactsMockData = [{
 
 describe('OMIS create confirm controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
-    this.orderSaveStub = this.sandbox.stub()
+    this.nextSpy = sandbox.spy()
+    this.orderSaveStub = sandbox.stub()
 
     this.ControllerClass = proxyquire('~/src/apps/omis/apps/create/controllers/confirm', {
       '../../../../../lib/metadata': {
@@ -110,14 +109,14 @@ describe('OMIS create confirm controller', () => {
 
   describe('successHandler()', () => {
     beforeEach(() => {
-      this.resetSpy = this.sandbox.spy()
-      this.destroySpy = this.sandbox.spy()
+      this.resetSpy = sandbox.spy()
+      this.destroySpy = sandbox.spy()
       this.reqMock = Object.assign({}, globalReq, {
         session: {
           token: 'token-12345',
         },
         sessionModel: {
-          toJSON: this.sandbox.stub().returns({
+          toJSON: sandbox.stub().returns({
             'csrf-secret': 'secret-key',
             errors: {},
             foo: 'bar',
@@ -168,7 +167,7 @@ describe('OMIS create confirm controller', () => {
 
       it('should save an order', (done) => {
         const resMock = {
-          redirect: this.sandbox.spy(),
+          redirect: sandbox.spy(),
         }
         const nextMock = (error) => {
           try {

--- a/test/unit/apps/omis/apps/create/controllers/confirm.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/confirm.test.js
@@ -47,10 +47,6 @@ describe('OMIS create confirm controller', () => {
     this.controller = new this.ControllerClass({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('getValues()', () => {
     beforeEach(() => {
       this.resMock = Object.assign({}, globalRes, {

--- a/test/unit/apps/omis/apps/create/controllers/market.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/market.test.js
@@ -20,8 +20,7 @@ const Controller = proxyquire('~/src/apps/omis/apps/create/controllers/market', 
 
 describe('OMIS create market controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
     this.controller = new Controller({ route: '/' })
   })
 
@@ -41,7 +40,7 @@ describe('OMIS create market controller', () => {
         },
       })
 
-      this.sandbox.spy(FormController.prototype, 'configure')
+      sandbox.spy(FormController.prototype, 'configure')
     })
 
     it('should set the list of markets', () => {

--- a/test/unit/apps/omis/apps/create/controllers/market.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/market.test.js
@@ -24,10 +24,6 @@ describe('OMIS create market controller', () => {
     this.controller = new Controller({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('configure()', () => {
     beforeEach(() => {
       this.reqMock = Object.assign({}, globalReq, {

--- a/test/unit/apps/omis/apps/create/controllers/sector.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/sector.test.js
@@ -19,8 +19,7 @@ const Controller = proxyquire('~/src/apps/omis/apps/create/controllers/sector', 
 
 describe('OMIS create sector controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
     this.controller = new Controller({ route: '/' })
   })
 
@@ -40,7 +39,7 @@ describe('OMIS create sector controller', () => {
         },
       })
 
-      this.sandbox.spy(FormController.prototype, 'configure')
+      sandbox.spy(FormController.prototype, 'configure')
     })
 
     it('should set the list of markets', () => {
@@ -82,7 +81,7 @@ describe('OMIS create sector controller', () => {
         },
       })
 
-      this.sandbox.stub(FormController.prototype, 'saveValues')
+      sandbox.stub(FormController.prototype, 'saveValues')
     })
 
     context('when using company\'s sector', () => {

--- a/test/unit/apps/omis/apps/create/controllers/sector.test.js
+++ b/test/unit/apps/omis/apps/create/controllers/sector.test.js
@@ -23,10 +23,6 @@ describe('OMIS create sector controller', () => {
     this.controller = new Controller({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('configure()', () => {
     beforeEach(() => {
       this.reqMock = Object.assign({}, globalReq, {

--- a/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
+++ b/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
@@ -8,12 +8,11 @@ const tokenMock = '12345abcde'
 
 describe('OMIS edit subscribers controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
-    this.getAdvisersStub = this.sandbox.stub().resolves(advisersMock)
-    this.getAssigneesStub = this.sandbox.stub().resolves(assigneesMock)
-    this.saveAssigneesStub = this.sandbox.stub().resolves(assigneesMock)
-    this.forceSaveAssigneesStub = this.sandbox.stub().resolves(assigneesMock)
+    this.nextSpy = sandbox.spy()
+    this.getAdvisersStub = sandbox.stub().resolves(advisersMock)
+    this.getAssigneesStub = sandbox.stub().resolves(assigneesMock)
+    this.saveAssigneesStub = sandbox.stub().resolves(assigneesMock)
+    this.forceSaveAssigneesStub = sandbox.stub().resolves(assigneesMock)
 
     const Controller = proxyquire('~/src/apps/omis/apps/edit/controllers/assignees', {
       '../../../../adviser/repos': {
@@ -55,7 +54,7 @@ describe('OMIS edit subscribers controller', () => {
         },
       })
 
-      this.sandbox.spy(FormController.prototype, 'configure')
+      sandbox.spy(FormController.prototype, 'configure')
     })
 
     context('when async calls resolve', () => {
@@ -162,10 +161,10 @@ describe('OMIS edit subscribers controller', () => {
 
   describe('successHandler()', () => {
     beforeEach(() => {
-      this.resetSpy = this.sandbox.spy()
-      this.destroySpy = this.sandbox.spy()
-      this.flashSpy = this.sandbox.spy()
-      this.redirectSpy = this.sandbox.spy()
+      this.resetSpy = sandbox.spy()
+      this.destroySpy = sandbox.spy()
+      this.flashSpy = sandbox.spy()
+      this.redirectSpy = sandbox.spy()
 
       this.reqMock = Object.assign({}, globalReq, {
         form: {

--- a/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
+++ b/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
@@ -30,10 +30,6 @@ describe('OMIS edit subscribers controller', () => {
     this.controller = new Controller({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('configure()', () => {
     beforeEach(() => {
       this.reqMock = Object.assign({}, globalReq, {

--- a/test/unit/apps/omis/apps/edit/controllers/subscribers.test.js
+++ b/test/unit/apps/omis/apps/edit/controllers/subscribers.test.js
@@ -28,10 +28,6 @@ describe('OMIS edit subscribers controller', () => {
     this.controller = new Controller({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('configure()', () => {
     beforeEach(() => {
       this.reqMock = Object.assign({}, globalReq, {

--- a/test/unit/apps/omis/apps/edit/controllers/subscribers.test.js
+++ b/test/unit/apps/omis/apps/edit/controllers/subscribers.test.js
@@ -8,11 +8,10 @@ const tokenMock = '12345abcde'
 
 describe('OMIS edit subscribers controller', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
-    this.getAdvisersStub = this.sandbox.stub().resolves(advisersMock)
-    this.getSubscribersStub = this.sandbox.stub().resolves(subscribersMock)
-    this.saveSubscribersStub = this.sandbox.stub().resolves(subscribersMock)
+    this.nextSpy = sandbox.spy()
+    this.getAdvisersStub = sandbox.stub().resolves(advisersMock)
+    this.getSubscribersStub = sandbox.stub().resolves(subscribersMock)
+    this.saveSubscribersStub = sandbox.stub().resolves(subscribersMock)
 
     const Controller = proxyquire('~/src/apps/omis/apps/edit/controllers/subscribers', {
       '../../../../adviser/repos': {
@@ -53,7 +52,7 @@ describe('OMIS edit subscribers controller', () => {
         },
       })
 
-      this.sandbox.spy(FormController.prototype, 'configure')
+      sandbox.spy(FormController.prototype, 'configure')
     })
 
     context('when async calls resolve', () => {
@@ -136,10 +135,10 @@ describe('OMIS edit subscribers controller', () => {
 
   describe('successHandler()', () => {
     beforeEach(() => {
-      this.resetSpy = this.sandbox.spy()
-      this.destroySpy = this.sandbox.spy()
-      this.flashSpy = this.sandbox.spy()
-      this.redirectSpy = this.sandbox.spy()
+      this.resetSpy = sandbox.spy()
+      this.destroySpy = sandbox.spy()
+      this.flashSpy = sandbox.spy()
+      this.redirectSpy = sandbox.spy()
 
       this.reqMock = Object.assign({}, globalReq, {
         form: {

--- a/test/unit/apps/omis/apps/list/controllers.test.js
+++ b/test/unit/apps/omis/apps/list/controllers.test.js
@@ -1,7 +1,5 @@
 describe('OMIS list controllers', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.req = {
       session: {
         token: 'abcd',
@@ -9,11 +7,11 @@ describe('OMIS list controllers', () => {
       query: {},
     }
     this.res = {
-      breadcrumb: this.sandbox.stub().returnsThis(),
-      render: this.sandbox.spy(),
+      breadcrumb: sandbox.stub().returnsThis(),
+      render: sandbox.spy(),
       query: {},
     }
-    this.buildSelectedFiltersSummaryStub = this.sandbox.spy()
+    this.buildSelectedFiltersSummaryStub = sandbox.spy()
 
     this.controller = proxyquire('~/src/apps/omis/apps/list/controllers', {
       '../../../builders': {
@@ -46,9 +44,9 @@ describe('OMIS list controllers', () => {
     })
 
     it('should pass the correct data to the view', () => {
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('sortForm'))
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('filtersFields'))
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('selectedFilters'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('sortForm'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('filtersFields'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('selectedFilters'))
     })
 
     it('should build filters summary', () => {
@@ -73,9 +71,9 @@ describe('OMIS list controllers', () => {
     })
 
     it('should pass the correct data to the view', () => {
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('sortForm'))
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('filtersFields'))
-      expect(this.res.render).to.have.been.calledWith(this.sandbox.match.any, this.sandbox.match.hasOwn('selectedFilters'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('sortForm'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('filtersFields'))
+      expect(this.res.render).to.have.been.calledWith(sandbox.match.any, sandbox.match.hasOwn('selectedFilters'))
     })
 
     it('should build filters summary', () => {

--- a/test/unit/apps/omis/apps/list/controllers.test.js
+++ b/test/unit/apps/omis/apps/list/controllers.test.js
@@ -30,10 +30,6 @@ describe('OMIS list controllers', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('renderCollectionList()', () => {
     beforeEach(() => {
       this.controller.renderCollectionList(this.req, this.res)

--- a/test/unit/apps/omis/apps/list/middleware.test.js
+++ b/test/unit/apps/omis/apps/list/middleware.test.js
@@ -15,10 +15,6 @@ describe('OMIS list middleware', () => {
     this.controller = require('~/src/apps/omis/apps/list/middleware')
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('Results', () => {
     beforeEach(() => {
       this.nockScope = nock(config.apiRoot)

--- a/test/unit/apps/omis/apps/list/middleware.test.js
+++ b/test/unit/apps/omis/apps/list/middleware.test.js
@@ -6,8 +6,7 @@ const orderCollectionData = require('~/test/unit/data/omis/collection.json')
 
 describe('OMIS list middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
+    this.next = sandbox.spy()
     this.req = assign({}, globalReq, {
       session: { token: 'abcd' },
     })

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -15,9 +15,7 @@ const transformerStub = (item) => {
 
 describe('OMIS View controllers', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.transformSubscriberToViewStub = this.sandbox.stub().returns(transformerStub)
+    this.transformSubscriberToViewStub = sandbox.stub().returns(transformerStub)
 
     this.controllers = proxyquire('~/src/apps/omis/apps/view/controllers', {
       '../../transformers': {
@@ -32,8 +30,8 @@ describe('OMIS View controllers', () => {
 
   describe('renderWorkOrder()', () => {
     beforeEach(() => {
-      this.breadcrumbSpy = this.sandbox.stub().returnsThis()
-      this.renderSpy = this.sandbox.spy()
+      this.breadcrumbSpy = sandbox.stub().returnsThis()
+      this.renderSpy = sandbox.spy()
 
       this.resMock = {
         breadcrumb: this.breadcrumbSpy,
@@ -83,8 +81,8 @@ describe('OMIS View controllers', () => {
 
   describe('renderQuote()', () => {
     beforeEach(() => {
-      this.breadcrumbSpy = this.sandbox.stub().returnsThis()
-      this.renderSpy = this.sandbox.spy()
+      this.breadcrumbSpy = sandbox.stub().returnsThis()
+      this.renderSpy = sandbox.spy()
 
       this.resMock = {
         breadcrumb: this.breadcrumbSpy,
@@ -105,9 +103,9 @@ describe('OMIS View controllers', () => {
 
   describe('renderPaymentReceipt()', () => {
     beforeEach(() => {
-      this.breadcrumbSpy = this.sandbox.stub().returnsThis()
-      this.renderSpy = this.sandbox.spy()
-      this.redirectSpy = this.sandbox.spy()
+      this.breadcrumbSpy = sandbox.stub().returnsThis()
+      this.renderSpy = sandbox.spy()
+      this.redirectSpy = sandbox.spy()
 
       this.resMock = {
         breadcrumb: this.breadcrumbSpy,

--- a/test/unit/apps/omis/apps/view/controllers.test.js
+++ b/test/unit/apps/omis/apps/view/controllers.test.js
@@ -24,10 +24,6 @@ describe('OMIS View controllers', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('renderWorkOrder()', () => {
     beforeEach(() => {
       this.breadcrumbSpy = sandbox.stub().returnsThis()

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -85,10 +85,6 @@ describe('OMIS View middleware', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('setTranslation()', () => {
     it('should set a translate method on locals', () => {
       this.middleware.setTranslation({}, this.resMock, this.nextSpy)

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -6,22 +6,20 @@ const subscribersMock = require('~/test/unit/data/omis/subscribers')
 
 describe('OMIS View middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.setCompanySpy = this.sandbox.spy()
-    this.loggerErrorSpy = this.sandbox.spy()
-    this.getContactStub = this.sandbox.stub()
-    this.getAssigneesStub = this.sandbox.stub()
-    this.getSubscribersStub = this.sandbox.stub()
-    this.previewQuoteStub = this.sandbox.stub()
-    this.getQuoteStub = this.sandbox.stub()
-    this.getInvoiceStub = this.sandbox.stub()
-    this.getPaymentsStub = this.sandbox.stub()
-    this.createQuoteStub = this.sandbox.stub()
-    this.cancelQuoteStub = this.sandbox.stub()
-    this.transformPaymentToViewStub = this.sandbox.stub().returnsArg(0)
-    this.flashSpy = this.sandbox.spy()
-    this.nextSpy = this.sandbox.spy()
+    this.setCompanySpy = sandbox.spy()
+    this.loggerErrorSpy = sandbox.spy()
+    this.getContactStub = sandbox.stub()
+    this.getAssigneesStub = sandbox.stub()
+    this.getSubscribersStub = sandbox.stub()
+    this.previewQuoteStub = sandbox.stub()
+    this.getQuoteStub = sandbox.stub()
+    this.getInvoiceStub = sandbox.stub()
+    this.getPaymentsStub = sandbox.stub()
+    this.createQuoteStub = sandbox.stub()
+    this.cancelQuoteStub = sandbox.stub()
+    this.transformPaymentToViewStub = sandbox.stub().returnsArg(0)
+    this.flashSpy = sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
     this.resMock = {
       locals: {

--- a/test/unit/apps/omis/controllers/edit.test.js
+++ b/test/unit/apps/omis/controllers/edit.test.js
@@ -18,10 +18,6 @@ describe('OMIS EditController', () => {
     this.controller = new this.ControllerClass({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('successHandler()', () => {
     beforeEach(() => {
       this.resetSpy = sandbox.spy()

--- a/test/unit/apps/omis/controllers/edit.test.js
+++ b/test/unit/apps/omis/controllers/edit.test.js
@@ -4,9 +4,8 @@ const updateMockData = {
 
 describe('OMIS EditController', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.stub()
-    this.orderUpdateStub = this.sandbox.stub()
+    this.nextSpy = sandbox.stub()
+    this.orderUpdateStub = sandbox.stub()
 
     this.ControllerClass = proxyquire('~/src/apps/omis/controllers/edit', {
       '../models': {
@@ -25,9 +24,9 @@ describe('OMIS EditController', () => {
 
   describe('successHandler()', () => {
     beforeEach(() => {
-      this.resetSpy = this.sandbox.spy()
-      this.destroySpy = this.sandbox.spy()
-      this.flashSpy = this.sandbox.spy()
+      this.resetSpy = sandbox.spy()
+      this.destroySpy = sandbox.spy()
+      this.flashSpy = sandbox.spy()
 
       this.reqMock = Object.assign({}, globalReq, {
         form: {
@@ -180,7 +179,7 @@ describe('OMIS EditController', () => {
 
       it('should save an order', (done) => {
         const resMock = {
-          redirect: this.sandbox.spy(),
+          redirect: sandbox.spy(),
         }
         const nextMock = (error) => {
           try {

--- a/test/unit/apps/omis/controllers/form.test.js
+++ b/test/unit/apps/omis/controllers/form.test.js
@@ -9,10 +9,6 @@ describe('OMIS FormController', () => {
     this.controller = new Controller({ route: '/' })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('configure()', () => {
     beforeEach(() => {
       this.breadcrumbSpy = sandbox.spy()

--- a/test/unit/apps/omis/controllers/form.test.js
+++ b/test/unit/apps/omis/controllers/form.test.js
@@ -4,9 +4,8 @@ const Controller = require('~/src/apps/omis/controllers/form')
 
 describe('OMIS FormController', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.stub()
-    this.redirectSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.stub()
+    this.redirectSpy = sandbox.spy()
     this.controller = new Controller({ route: '/' })
   })
 
@@ -16,7 +15,7 @@ describe('OMIS FormController', () => {
 
   describe('configure()', () => {
     beforeEach(() => {
-      this.breadcrumbSpy = this.sandbox.spy()
+      this.breadcrumbSpy = sandbox.spy()
       this.reqMock = Object.assign({}, globalReq, {
         form: {
           options: {},
@@ -164,7 +163,7 @@ describe('OMIS FormController', () => {
 
     context('when form submission is a save', () => {
       it('should call next()', () => {
-        const saveValuesSpy = this.sandbox.spy()
+        const saveValuesSpy = sandbox.spy()
         FormController.prototype.saveValues = saveValuesSpy
 
         this.controller.process(this.reqMock, this.resMock, this.nextSpy)
@@ -178,7 +177,7 @@ describe('OMIS FormController', () => {
   describe('saveValues()', () => {
     context('when form submission is a save', () => {
       beforeEach(() => {
-        this.saveValuesSpy = this.sandbox.spy()
+        this.saveValuesSpy = sandbox.spy()
         this.reqMock = Object.assign({}, globalReq, {
           form: {
             values: {
@@ -232,7 +231,7 @@ describe('OMIS FormController', () => {
 
   describe('getErrors()', () => {
     beforeEach(() => {
-      this.getErrorsStub = this.sandbox.stub()
+      this.getErrorsStub = sandbox.stub()
 
       FormController.prototype.getErrors = this.getErrorsStub
     })
@@ -301,9 +300,9 @@ describe('OMIS FormController', () => {
 
   describe('errorHandler()', () => {
     beforeEach(() => {
-      this.errorHandlerSpy = this.sandbox.spy()
-      this.breadcrumbSpy = this.sandbox.stub().returnsThis()
-      this.renderSpy = this.sandbox.spy()
+      this.errorHandlerSpy = sandbox.spy()
+      this.breadcrumbSpy = sandbox.stub().returnsThis()
+      this.renderSpy = sandbox.spy()
       this.resMock = Object.assign({}, globalRes, {
         redirect: this.redirectSpy,
         breadcrumb: this.breadcrumbSpy,
@@ -329,7 +328,7 @@ describe('OMIS FormController', () => {
 
     describe('when it returns missing prereq error', () => {
       beforeEach(() => {
-        this.getStub = this.sandbox.stub()
+        this.getStub = sandbox.stub()
         this.errorMock = new Error()
         this.errorMock.code = 'MISSING_PREREQ'
         this.reqMock = Object.assign({}, globalReq, {

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -37,10 +37,6 @@ describe('OMIS middleware', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('setCompany()', () => {
     beforeEach(() => {
       this.companyId = 'c-1234567890'

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -3,14 +3,12 @@ const orderData = require('~/test/unit/data/omis/simple-order.json')
 
 describe('OMIS middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.setHomeBreadcrumbReturnSpy = this.sandbox.spy()
-    this.setHomeBreadcrumbStub = this.sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
-    this.getDitCompanyStub = this.sandbox.stub()
-    this.getByIdStub = this.sandbox.stub()
-    this.loggerSpy = this.sandbox.spy()
-    this.nextSpy = this.sandbox.spy()
+    this.setHomeBreadcrumbReturnSpy = sandbox.spy()
+    this.setHomeBreadcrumbStub = sandbox.stub().returns(this.setHomeBreadcrumbReturnSpy)
+    this.getDitCompanyStub = sandbox.stub()
+    this.getByIdStub = sandbox.stub()
+    this.loggerSpy = sandbox.spy()
+    this.nextSpy = sandbox.spy()
 
     this.resMock = {
       locals: {},

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -15,10 +15,6 @@ describe('OMIS list transformers', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#transformOrderToListItem', () => {
     const simpleOrder = require('~/test/unit/data/omis/simple-order.json')
 

--- a/test/unit/apps/omis/transformers.test.js
+++ b/test/unit/apps/omis/transformers.test.js
@@ -1,9 +1,7 @@
 const { assign, merge } = require('lodash')
 
-describe('OMIS list transformers', function () {
+describe('OMIS list transformers', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.transformers = proxyquire('~/src/apps/omis/transformers', {
       './constants': {
         ORDER_STATES: [

--- a/test/unit/apps/search/controllers.test.js
+++ b/test/unit/apps/search/controllers.test.js
@@ -33,10 +33,6 @@ describe('Search Controller #renderSearchResults', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   context('for invalid paths', () => {
     it('should redirect to index', async () => {
       this.req.params.searchPath = 'dummy-path'

--- a/test/unit/apps/search/controllers.test.js
+++ b/test/unit/apps/search/controllers.test.js
@@ -15,10 +15,9 @@ describe('Search Controller #renderSearchResults', () => {
   }
 
   beforeEach(async () => {
-    this.sandbox = sinon.sandbox.create()
-    this.next = this.sandbox.spy()
-    this.renderFunction = this.sandbox.spy()
-    this.breadcrumbStub = function () { return this }
+    this.next = sandbox.spy()
+    this.renderFunction = sandbox.spy()
+    this.breadcrumbStub = sandbox.stub().returnsThis()
 
     this.req = {
       session: { token: 'abcd' },

--- a/test/unit/apps/search/services.test.js
+++ b/test/unit/apps/search/services.test.js
@@ -3,15 +3,7 @@ const { assign } = require('lodash')
 const config = require('~/config')
 const { search } = require('~/src/apps/search/services')
 
-describe('Search service', function () {
-  beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
+describe('Search service', () => {
   describe('#search', () => {
     const searchTerm = 'testTerm'
     const searchEntity = 'company'

--- a/test/unit/apps/search/transformers.test.js
+++ b/test/unit/apps/search/transformers.test.js
@@ -19,10 +19,6 @@ describe('Search transformers', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#transformApiResponseToSearchCollection', () => {
     it('should return a function when high-order function is called without arguments', () => {
       expect(this.transformers.transformApiResponseToSearchCollection()).to.be.a('function')

--- a/test/unit/apps/search/transformers.test.js
+++ b/test/unit/apps/search/transformers.test.js
@@ -1,9 +1,8 @@
 describe('Search transformers', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.transformApiResponseToCollectionInnerStub = this.sandbox.stub().returns()
-    this.transformApiResponseToCollectionStub = this.sandbox.stub().returns(this.transformApiResponseToCollectionInnerStub)
-    this.buildSearchAggregationStub = this.sandbox.stub()
+    this.transformApiResponseToCollectionInnerStub = sandbox.stub().returns()
+    this.transformApiResponseToCollectionStub = sandbox.stub().returns(this.transformApiResponseToCollectionInnerStub)
+    this.buildSearchAggregationStub = sandbox.stub()
 
     this.responseMock = {
       aggregations: {},
@@ -60,8 +59,8 @@ describe('Search transformers', () => {
     })
 
     it('should call transformApiResponseToCollection transformer with given transformers', () => {
-      const firstItemTransformerSpy = this.sandbox.spy()
-      const secondItemTransformerSpy = this.sandbox.spy()
+      const firstItemTransformerSpy = sandbox.spy()
+      const secondItemTransformerSpy = sandbox.spy()
 
       this.transformers.transformApiResponseToSearchCollection(
         undefined,

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -9,10 +9,6 @@ describe('Global transformers', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#transformObjectToOption', () => {
     it('should return value and label from id and name', () => {
       const actual = this.transformers.transformObjectToOption({

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -1,7 +1,6 @@
 describe('Global transformers', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.buildPaginationSpy = this.sandbox.spy()
+    this.buildPaginationSpy = sandbox.spy()
 
     this.transformers = proxyquire('~/src/apps/transformers', {
       '../lib/pagination': {
@@ -191,8 +190,8 @@ describe('Global transformers', () => {
     })
 
     it('should return a collection object with items transformed by given transformer with arguments', () => {
-      const itemTransformerInnerSpy = this.sandbox.spy()
-      const itemTransformerSpy = this.sandbox.stub().returns(itemTransformerInnerSpy)
+      const itemTransformerInnerSpy = sandbox.spy()
+      const itemTransformerSpy = sandbox.stub().returns(itemTransformerInnerSpy)
       const itemTransformerOptions = { query: { term: 'bobby' } }
 
       const actual = this.transformers.transformApiResponseToCollection(
@@ -206,8 +205,8 @@ describe('Global transformers', () => {
     })
 
     it('should return a collection object with items transformed by multiple transformers', () => {
-      const firstItemTransformerSpy = this.sandbox.spy()
-      const secondItemTransformerSpy = this.sandbox.spy()
+      const firstItemTransformerSpy = sandbox.spy()
+      const secondItemTransformerSpy = sandbox.spy()
 
       const actual = this.transformers.transformApiResponseToCollection(
         undefined,

--- a/test/unit/assets/javascripts/lib/xhr.test.js
+++ b/test/unit/assets/javascripts/lib/xhr.test.js
@@ -40,8 +40,8 @@ describe('XHR', () => {
       expect(history.location.search).to.equal('')
     })
     it('should perform page load if unable to pushState', () => {
-      this.sandbox.stub(history, 'push').throws('error')
-      this.sandbox.stub(window.location, 'assign')
+      sandbox.stub(history, 'push').throws('error')
+      sandbox.stub(window.location, 'assign')
       const res = { data: {} }
       const params = { a: 1, b: 2 }
       XHR.updateOutlet(res, params)

--- a/test/unit/assets/javascripts/lib/xhr.test.js
+++ b/test/unit/assets/javascripts/lib/xhr.test.js
@@ -19,11 +19,6 @@ describe('XHR', () => {
     XHR = proxyquire('~/assets/javascripts/lib/xhr', {
       'history': { createBrowserHistory: () => history },
     })
-    this.sandbox = sinon.sandbox.create()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
   })
 
   describe('updateOutlet', () => {

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -17,7 +17,7 @@ global.rootPath = `${process.cwd()}`
 global.rootPath = `${process.cwd()}`
 global.globalReq = reqres.req()
 global.globalRes = reqres.res()
-global.sandbox = sinon.sandbox.create()
+global.sandbox = null
 
 chai.config.truncateThreshold = 0
 

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -17,6 +17,7 @@ global.rootPath = `${process.cwd()}`
 global.rootPath = `${process.cwd()}`
 global.globalReq = reqres.req()
 global.globalRes = reqres.res()
+global.sandbox = sinon.sandbox.create()
 
 chai.config.truncateThreshold = 0
 

--- a/test/unit/components/archive-form.test.js
+++ b/test/unit/components/archive-form.test.js
@@ -28,10 +28,10 @@ const HTML = `
   </form>
 `
 const event = {
-  preventDefault: function () {},
+  preventDefault: () => {},
 }
 
-describe('archive form control', function () {
+describe('archive form control', () => {
   beforeEach(() => {
     const { window } = new JSDOM(HTML)
     this.document = window.document

--- a/test/unit/global-helpers.js
+++ b/test/unit/global-helpers.js
@@ -1,3 +1,7 @@
+beforeEach(() => {
+  sandbox = sinon.sandbox.create()
+})
+
 afterEach(() => {
   sandbox.restore()
   nock.cleanAll()

--- a/test/unit/global-helpers.js
+++ b/test/unit/global-helpers.js
@@ -1,3 +1,4 @@
-afterEach(() => {
+afterEach(function () {
+  sandbox.restore()
   nock.cleanAll()
 })

--- a/test/unit/global-helpers.js
+++ b/test/unit/global-helpers.js
@@ -1,4 +1,4 @@
-afterEach(function () {
+afterEach(() => {
   sandbox.restore()
   nock.cleanAll()
 })

--- a/test/unit/lib/address.test.js
+++ b/test/unit/lib/address.test.js
@@ -1,7 +1,7 @@
 const address = require('~/src/lib/address')
 
-describe('Address formatter', function () {
-  it('should format an address when it is fully populated.', function () {
+describe('Address formatter', () => {
+  it('should format an address when it is fully populated.', () => {
     const source = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       address_1: '10 The Street',
@@ -17,7 +17,7 @@ describe('Address formatter', function () {
     const actual = address.getFormattedAddress(source)
     expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL, Country')
   })
-  it('ignores blank address lines', function () {
+  it('ignores blank address lines', () => {
     const source = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       address_1: '10 The Street',
@@ -33,7 +33,7 @@ describe('Address formatter', function () {
     const actual = address.getFormattedAddress(source)
     expect(actual).equal('10 The Street, Big Town, LL1 1LL, Country')
   })
-  it('should add United Kingdom to the address if no country is provided.', function () {
+  it('should add United Kingdom to the address if no country is provided.', () => {
     const source = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       address_1: '10 The Street',
@@ -45,7 +45,7 @@ describe('Address formatter', function () {
     const actual = address.getFormattedAddress(source)
     expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL')
   })
-  it('should format an address with field names containing a prefix', function () {
+  it('should format an address with field names containing a prefix', () => {
     const source = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       trading_address_1: '10 The Street',
@@ -58,7 +58,7 @@ describe('Address formatter', function () {
     const actual = address.getFormattedAddress(source, 'trading')
     expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL')
   })
-  it('should return null when the address is empty', function () {
+  it('should return null when the address is empty', () => {
     const source = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       address_1: '',

--- a/test/unit/lib/controller-utils.test.js
+++ b/test/unit/lib/controller-utils.test.js
@@ -5,31 +5,31 @@ const {
   getDataLabels,
 } = require('~/src/lib/controller-utils')
 
-describe('isBlank', function () {
-  it('should detects undefined variables', function () {
+describe('isBlank', () => {
+  it('should detects undefined variables', () => {
     let e
     expect(isBlank(e)).to.be.true
   })
-  it('should detect passing an unknown key', function () {
+  it('should detect passing an unknown key', () => {
     let e = {}
     expect(isBlank(e.x)).to.be.true
   })
-  it('should detect an empty string', function () {
+  it('should detect an empty string', () => {
     expect(isBlank('')).to.be.true
   })
-  it('should detect undefined', function () {
+  it('should detect undefined', () => {
     expect(isBlank(undefined)).to.be.true
   })
-  it('should know when it is sent a valid string', function () {
+  it('should know when it is sent a valid string', () => {
     expect(isBlank('test')).to.be.false
   })
-  it('should know when it is sent a valid object', function () {
+  it('should know when it is sent a valid object', () => {
     expect(isBlank({ x: 1 })).to.be.false
   })
 })
 
-describe('transformV2Errors: Formatting V2 service delivery endpoint errors', function () {
-  it('Should warn if the Service Delivery triple does not exist', function () {
+describe('transformV2Errors: Formatting V2 service delivery endpoint errors', () => {
+  it('Should warn if the Service Delivery triple does not exist', () => {
     const source = [
       {
         'detail': 'This combination of service and service provider does not exist.',
@@ -42,7 +42,7 @@ describe('transformV2Errors: Formatting V2 service delivery endpoint errors', fu
     expect(actual.Alert).to.exist
     expect(actual.Alert).to.equal('This combination of service and service provider does not exist.')
   })
-  it('Should return multiple errors when presented with an array of errors', function () {
+  it('Should return multiple errors when presented with an array of errors', () => {
     const source = [
       {
         'detail': 'Required',
@@ -114,7 +114,7 @@ describe('transformV2Errors: Formatting V2 service delivery endpoint errors', fu
 
     expect(transformedErrors).to.deep.equal(expectedErrors)
   })
-  it('Should match keys not specially defined', function () {
+  it('Should match keys not specially defined', () => {
     const source = [
       {
         'detail': "{'data': {'type': 'Foo'}} has no key id",

--- a/test/unit/lib/property-helpers.test.js
+++ b/test/unit/lib/property-helpers.test.js
@@ -1,7 +1,7 @@
 const propertyHelpers = require('~/src/lib/property-helpers')
 
-describe('PropertyHelpers: Conversion of empty values to nulls in an object with nullEmptyFields', function () {
-  it('Should convert an empty string to a null', function () {
+describe('PropertyHelpers: Conversion of empty values to nulls in an object with nullEmptyFields', () => {
+  it('Should convert an empty string to a null', () => {
     const source = {
       foo: 'foo',
       bar: '',
@@ -10,7 +10,7 @@ describe('PropertyHelpers: Conversion of empty values to nulls in an object with
     expect(actual.foo).equal('foo')
     expect(actual.bar).be.null
   })
-  it('Should leave existing nulls alone', function () {
+  it('Should leave existing nulls alone', () => {
     const source = {
       foo: 'foo',
       bar: null,
@@ -21,8 +21,8 @@ describe('PropertyHelpers: Conversion of empty values to nulls in an object with
   })
 })
 
-describe('PropertyHelpers: Stripping fields with null values out of an object with deleteNulls', function () {
-  it('Removes fields that have null values from an object', function () {
+describe('PropertyHelpers: Stripping fields with null values out of an object with deleteNulls', () => {
+  it('Removes fields that have null values from an object', () => {
     const source = {
       foo: 'foo',
       bar: null,
@@ -31,7 +31,7 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
     expect(actual.foo).equal('foo')
     expect(actual).to.not.have.property('bar')
   })
-  it('Return an empty object if all fields are null', function () {
+  it('Return an empty object if all fields are null', () => {
     const source = {
       foo: null,
       bar: null,
@@ -39,7 +39,7 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
     const actual = propertyHelpers.deleteNulls(source)
     expect(actual).to.deep.equal({})
   })
-  it('Should ignore empty strings', function () {
+  it('Should ignore empty strings', () => {
     const source = {
       foo: 'foo',
       bar: '',
@@ -48,7 +48,7 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
     expect(actual.foo).to.equal('foo')
     expect(actual.bar).to.equal('')
   })
-  it('Should ignore false fields', function () {
+  it('Should ignore false fields', () => {
     const source = {
       foo: 'foo',
       bar: false,
@@ -59,8 +59,8 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
   })
 })
 
-describe('PropertyHelpers: Finding names in objects with getPropertyName', function () {
-  it('Should find a name in the first level of an object', function () {
+describe('PropertyHelpers: Finding names in objects with getPropertyName', () => {
+  it('Should find a name in the first level of an object', () => {
     const source = {
       foo: 'bar',
       data: {
@@ -71,7 +71,7 @@ describe('PropertyHelpers: Finding names in objects with getPropertyName', funct
     const actual = propertyHelpers.getPropertyName(source, 'data')
     expect(actual).to.equal('morph the cat')
   })
-  it('Should return undefined if the source property exists but does not have a name sub-property', function () {
+  it('Should return undefined if the source property exists but does not have a name sub-property', () => {
     const source = {
       foo: 'bar',
       data: {
@@ -82,7 +82,7 @@ describe('PropertyHelpers: Finding names in objects with getPropertyName', funct
     const actual = propertyHelpers.getPropertyName(source, 'data')
     expect(actual).to.eq(null)
   })
-  it('Should return null if the source property dows not exist', function () {
+  it('Should return null if the source property dows not exist', () => {
     const source = {
       foo: 'bar',
       picard: {
@@ -95,8 +95,8 @@ describe('PropertyHelpers: Finding names in objects with getPropertyName', funct
   })
 })
 
-describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function () {
-  it('Should find a name in the first level of an object', function () {
+describe('PropertyHelpers: Finding IDs in objects with getPropertyId', () => {
+  it('Should find a name in the first level of an object', () => {
     const source = {
       foo: 'bar',
       data: {
@@ -107,7 +107,7 @@ describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function 
     const actual = propertyHelpers.getPropertyId(source, 'data')
     expect(actual).to.equal('123456')
   })
-  it('Should return undefined if the source property exists but does not have a name sub-property', function () {
+  it('Should return undefined if the source property exists but does not have a name sub-property', () => {
     const source = {
       foo: 'bar',
       data: {
@@ -118,7 +118,7 @@ describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function 
     const actual = propertyHelpers.getPropertyId(source, 'data')
     expect(actual).to.equal(null)
   })
-  it('Should return null if the source property dows not exist', function () {
+  it('Should return null if the source property dows not exist', () => {
     const source = {
       foo: 'bar',
       picard: {
@@ -131,8 +131,8 @@ describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function 
   })
 })
 
-describe('PropertyHelpers: Convert Yes and No string to true and false with convertYesNoToBoolean', function () {
-  it('Should turn a Yes into a boolean true', function () {
+describe('PropertyHelpers: Convert Yes and No string to true and false with convertYesNoToBoolean', () => {
+  it('Should turn a Yes into a boolean true', () => {
     const source = {
       foo: 'Yes',
     }
@@ -141,7 +141,7 @@ describe('PropertyHelpers: Convert Yes and No string to true and false with conv
     expect(actual.foo).to.equal(true)
     expect(typeof actual.foo).to.equal('boolean')
   })
-  it('Should turn a No into a boolean false', function () {
+  it('Should turn a No into a boolean false', () => {
     const source = {
       foo: 'No',
     }
@@ -150,7 +150,7 @@ describe('PropertyHelpers: Convert Yes and No string to true and false with conv
     expect(actual.foo).to.equal(false)
     expect(typeof actual.foo).to.equal('boolean')
   })
-  it('Should ignore case', function () {
+  it('Should ignore case', () => {
     const source = {
       foo: 'yES',
       bar: 'nO',
@@ -164,8 +164,8 @@ describe('PropertyHelpers: Convert Yes and No string to true and false with conv
   })
 })
 
-describe('PropertyHelpers: Conversion of nested objects', function () {
-  it('Should convert an empty string to null', function () {
+describe('PropertyHelpers: Conversion of nested objects', () => {
+  it('Should convert an empty string to null', () => {
     const source = {
       foo: 'foo',
       bar: null,
@@ -173,7 +173,7 @@ describe('PropertyHelpers: Conversion of nested objects', function () {
     const actual = propertyHelpers.convertNestedObjects(source, ['bar'])
     expect(actual.bar).be.null
   })
-  it('Should convert a string to a nested object', function () {
+  it('Should convert a string to a nested object', () => {
     const source = {
       foo: 'foo',
       bar: 'some-id',
@@ -183,7 +183,7 @@ describe('PropertyHelpers: Conversion of nested objects', function () {
       id: 'some-id',
     })
   })
-  it('Should do nothing if props is not passed in', function () {
+  it('Should do nothing if props is not passed in', () => {
     const source = {
       foo: 'foo',
       bar: 'some-id',
@@ -191,7 +191,7 @@ describe('PropertyHelpers: Conversion of nested objects', function () {
     const actual = propertyHelpers.convertNestedObjects(source)
     expect(actual).to.deep.equal(source)
   })
-  it('Should do nothing if object and props are not passed in', function () {
+  it('Should do nothing if object and props are not passed in', () => {
     const actual = propertyHelpers.convertNestedObjects()
     expect(actual).to.deep.equal({})
   })

--- a/test/unit/lib/text-formatting.test.js
+++ b/test/unit/lib/text-formatting.test.js
@@ -1,20 +1,20 @@
 const textFormatting = require('~/src/lib/text-formatting')
 
-describe('Text formatting', function () {
-  describe('new line to br', function () {
-    it('should handle text with new lines', function () {
+describe('Text formatting', () => {
+  describe('new line to br', () => {
+    it('should handle text with new lines', () => {
       expect(textFormatting.newlineToBr('one\ntwo\nthree')).to.equal('one<br/>two<br/>three')
     })
-    it('should preserve text without newlines', function () {
+    it('should preserve text without newlines', () => {
       expect(textFormatting.newlineToBr('one two three')).to.equal('one two three')
     })
-    it('should handle a null', function () {
+    it('should handle a null', () => {
       expect(textFormatting.newlineToBr()).to.be.null
     })
-    it('should handle an empty string', function () {
+    it('should handle an empty string', () => {
       expect(textFormatting.newlineToBr('')).to.be.null
     })
-    it('should ignore none strings', function () {
+    it('should ignore none strings', () => {
       expect(textFormatting.newlineToBr({ test: 'test' })).to.be.null
     })
   })

--- a/test/unit/macros/common/local-header.test.js
+++ b/test/unit/macros/common/local-header.test.js
@@ -2,15 +2,9 @@ const { getMacros } = require('~/test/unit/macro-helper')
 
 describe('LocalHeader macro', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
     this.commonMacros = getMacros('common', {
-      getMessages: this.sandbox.stub(),
+      getMessages: sandbox.stub(),
     })
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
   })
 
   describe('invalid props', () => {

--- a/test/unit/middleware/auth.test.js
+++ b/test/unit/middleware/auth.test.js
@@ -3,12 +3,7 @@ const resMock = {}
 describe('Auth middleware', () => {
   beforeEach(() => {
     this.authMiddleware = require('~/src/middleware/auth')
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('authenticated/allowed requests', () => {
@@ -48,7 +43,7 @@ describe('Auth middleware', () => {
         session: {},
       }
       const resMock = {
-        redirect: this.sandbox.stub(),
+        redirect: sandbox.stub(),
       }
 
       this.authMiddleware(reqMock, resMock, this.nextSpy)

--- a/test/unit/middleware/breadcrumbs.test.js
+++ b/test/unit/middleware/breadcrumbs.test.js
@@ -2,9 +2,7 @@ const breadcrumbs = require('~/src/middleware/breadcrumbs')
 
 describe('breadcrumbs middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
     this.resMock = {}
   })
 
@@ -98,7 +96,7 @@ describe('breadcrumbs middleware', () => {
   describe('setHome()', () => {
     beforeEach(() => {
       this.init = breadcrumbs.init()
-      this.init({}, this.resMock, this.sandbox.spy())
+      this.init({}, this.resMock, sandbox.spy())
 
       this.setHome = breadcrumbs.setHome
     })

--- a/test/unit/middleware/breadcrumbs.test.js
+++ b/test/unit/middleware/breadcrumbs.test.js
@@ -6,10 +6,6 @@ describe('breadcrumbs middleware', () => {
     this.resMock = {}
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('init()', () => {
     beforeEach(() => {
       this.init = breadcrumbs.init()

--- a/test/unit/middleware/csrf-token.test.js
+++ b/test/unit/middleware/csrf-token.test.js
@@ -1,17 +1,12 @@
 describe('CRSF token', () => {
   beforeEach(() => {
     this.csrfMiddleware = require('~/src/middleware/csrf-token')()
-    this.sandbox = sinon.sandbox.create()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
   })
 
   describe('set a CSRF token', () => {
     it('should set the csrf token on response locals object', () => {
-      const csrfSpy = this.sandbox.spy()
-      const nextSpy = this.sandbox.spy()
+      const csrfSpy = sandbox.spy()
+      const nextSpy = sandbox.spy()
       const reqMock = { csrfToken: csrfSpy }
       const resMock = { locals: {} }
 

--- a/test/unit/middleware/errors.test.js
+++ b/test/unit/middleware/errors.test.js
@@ -7,9 +7,8 @@ const isDev = true
 
 describe('Error Middleware Test', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.winstonErrorStub = this.sandbox.stub()
-    this.winstonInfoStub = this.sandbox.stub()
+    this.winstonErrorStub = sandbox.stub()
+    this.winstonInfoStub = sandbox.stub()
 
     this.errorsStub = (isDev) => {
       return proxyquire('~/src/middleware/errors', {
@@ -24,13 +23,9 @@ describe('Error Middleware Test', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('notFound method', () => {
     it('should log a 404 and drop through to next middleware', () => {
-      const nextSpy = this.sandbox.spy()
+      const nextSpy = sandbox.spy()
       const mockResponse = {
         locals: {
           BREADCRUMBS: [],
@@ -48,9 +43,9 @@ describe('Error Middleware Test', () => {
 
   describe('catchAll method', () => {
     beforeEach(() => {
-      this.nextSpy = this.sandbox.spy()
-      this.statusStub = this.sandbox.stub().returnsThis()
-      this.renderSpy = this.sandbox.spy()
+      this.nextSpy = sandbox.spy()
+      this.statusStub = sandbox.stub().returnsThis()
+      this.renderSpy = sandbox.spy()
       this.error = new Error('A mock error')
 
       this.responseMock = {

--- a/test/unit/middleware/ssoBypass.test.js
+++ b/test/unit/middleware/ssoBypass.test.js
@@ -2,7 +2,6 @@ const { assign, set } = require('lodash')
 
 describe('SSO bypass middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
     this.mockConfig = {}
     this.ssoBypassMiddleware = proxyquire.noCallThru().load('~/src/middleware/sso-bypass', {
       '../../config': this.mockConfig,
@@ -10,11 +9,7 @@ describe('SSO bypass middleware', () => {
     this.reqMock = assign({}, globalReq, {
       session: {},
     })
-    this.nextSpy = this.sandbox.spy()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
+    this.nextSpy = sandbox.spy()
   })
 
   describe('without oauth bypass token', () => {

--- a/test/unit/middleware/store.test.js
+++ b/test/unit/middleware/store.test.js
@@ -7,10 +7,6 @@ describe('Store middleware', () => {
     }
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('store middleware sets up correctly', () => {
     it('req should have expected store methods', () => {
       this.storeMiddleware(this.reqMock, {}, this.nextSpy)

--- a/test/unit/middleware/store.test.js
+++ b/test/unit/middleware/store.test.js
@@ -1,8 +1,7 @@
 describe('Store middleware', () => {
   beforeEach(() => {
     this.storeMiddleware = require('~/src/middleware/store')()
-    this.sandbox = sinon.sandbox.create()
-    this.nextSpy = this.sandbox.spy()
+    this.nextSpy = sandbox.spy()
     this.reqMock = {
       session: {},
     }

--- a/test/unit/middleware/title.test.js
+++ b/test/unit/middleware/title.test.js
@@ -1,16 +1,11 @@
 describe('title middleware', () => {
   beforeEach(() => {
     this.title = require('~/src/middleware/title')()
-    this.sandbox = sinon.sandbox.create()
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
   })
 
   describe('set title', () => {
     it('should set title to the string passed', () => {
-      const nextSpy = this.sandbox.spy()
+      const nextSpy = sandbox.spy()
       const resMock = { locals: {} }
       const testTitle = 'Test title'
 

--- a/test/unit/middleware/user.test.js
+++ b/test/unit/middleware/user.test.js
@@ -8,9 +8,8 @@ const user = {
 
 describe('user middleware', () => {
   beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.authorisedRequestStub = this.sandbox.stub()
-    this.nextSpy = this.sandbox.spy()
+    this.authorisedRequestStub = sandbox.stub()
+    this.nextSpy = sandbox.spy()
 
     this.userMiddleware = proxyquire('~/src/middleware/user', {
       '../../config': {

--- a/test/unit/middleware/user.test.js
+++ b/test/unit/middleware/user.test.js
@@ -19,10 +19,6 @@ describe('user middleware', () => {
     })
   })
 
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   context('if user already exists on session', () => {
     beforeEach(() => {
       this.reqMock = {


### PR DESCRIPTION
As a follow up to https://github.com/uktrade/data-hub-frontend/pull/1056 this work tidies up the sandbox usage we have across unit tests.

- makes a `sinon.sandbox.create()` a global named `sandbox`
- resets this `sandbox` in the global `afterEach`
- makes all functions arrow functions as a tidy up