### PR TITLE
Ensure the hint text is shown on the field

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -118,6 +118,7 @@ const editFields = merge({}, globalFields, {
     fieldType: 'MultipleChoiceField',
     type: 'radio',
     label: 'fields.vat_status.label',
+    hint: 'fields.vat_status.hint',
     options: [
       {
         value: 'outside_eu',


### PR DESCRIPTION
The value of the hint text was set in the i18n doc but wasn't being
displayed on the field. This adds the property required to do that.