### PR TITLE
Fix issue with parsing field values into date formats

### DIFF
--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -43,6 +43,8 @@ class EditController extends FormController {
     delete sessionValues.errorValues
     delete sessionValues.errors
 
+    const dateFields = ['delivery_date']
+
     const orderValues = mapValues(req.form.options.fields, (fieldOptions, key) => {
       const newValue = get(res.locals, `order.${key}`)
 
@@ -62,23 +64,16 @@ class EditController extends FormController {
         return flatten([newValue])
       }
 
+      const parsedDate = dateFns.parse(newValue)
+      if (dateFields.includes(key) && dateFns.isValid(parsedDate)) {
+        return dateFns.format(parsedDate, longDateFormat)
+      }
+
       return newValue
     })
 
-    const exemptFields = ['vat_number', 'po_number', 'amount']
     // combine order values and error values
-    let combinedValues = Object.assign({}, orderValues, sessionValues, errorValues)
-    // convert dates to default format
-    combinedValues = mapValues(combinedValues, (value, key) => {
-      if (typeof value === 'string' && !exemptFields.includes(key)) {
-        const parsedDate = dateFns.parse(value.toString())
-        if (dateFns.isValid(parsedDate)) {
-          return dateFns.format(parsedDate, longDateFormat)
-        }
-      }
-
-      return value
-    })
+    const combinedValues = Object.assign({}, orderValues, sessionValues, errorValues)
 
     const filtered = pickBy(combinedValues, (value) => {
       return !isUndefined(value) && !isNull(value)

--- a/test/unit/apps/omis/controllers/edit.test.js
+++ b/test/unit/apps/omis/controllers/edit.test.js
@@ -201,6 +201,7 @@ describe('OMIS EditController', () => {
             fields: {
               foo: {},
               fizz: {},
+              delivery_date: {},
             },
           },
         },
@@ -315,8 +316,48 @@ describe('OMIS EditController', () => {
       })
     })
 
-    context('when a value contains a date', () => {
+    context('when a field marked as a date field contains a date', () => {
       it('should format it using the config format', (done) => {
+        const resMock = {
+          locals: {
+            order: {
+              delivery_date: '2017-01-10',
+            },
+          },
+        }
+        const nextMock = (e, values) => {
+          expect(values).to.deep.equal({
+            delivery_date: '10 January 2017',
+          })
+          done()
+        }
+
+        this.controller.getValues(this.reqMock, resMock, nextMock)
+      })
+    })
+
+    context('when a field marked as a date field doesn\'t contain a valid date', () => {
+      it('should return the value', (done) => {
+        const resMock = {
+          locals: {
+            order: {
+              delivery_date: 'not-a-date',
+            },
+          },
+        }
+        const nextMock = (e, values) => {
+          expect(values).to.deep.equal({
+            delivery_date: 'not-a-date',
+          })
+          done()
+        }
+
+        this.controller.getValues(this.reqMock, resMock, nextMock)
+      })
+    })
+
+    context('when a field not marked as a date field contains a date', () => {
+      it('should return the value', (done) => {
         const resMock = {
           locals: {
             order: {
@@ -326,27 +367,7 @@ describe('OMIS EditController', () => {
         }
         const nextMock = (e, values) => {
           expect(values).to.deep.equal({
-            foo: '10 January 2017',
-          })
-          done()
-        }
-
-        this.controller.getValues(this.reqMock, resMock, nextMock)
-      })
-    })
-
-    context('when a value doesn\'t contain a date', () => {
-      it('should return the value', (done) => {
-        const resMock = {
-          locals: {
-            order: {
-              foo: 'not-a-date',
-            },
-          },
-        }
-        const nextMock = (e, values) => {
-          expect(values).to.deep.equal({
-            foo: 'not-a-date',
+            foo: '2017-01-10',
           })
           done()
         }


### PR DESCRIPTION
Previously all fields were checked whether they were a date and if so
they would be formatted in the default date format when displaying
within a form.

The logic also contained exempt fields that could have returned
true incorrectly.

This change adjust that logic to only parse specified date fields
rather than checking all.