### PR TITLE
DH-1328 active event options

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -11,7 +11,10 @@ const { transformObjectToOption } = require('../../transformers')
 
 async function getEditOptions (token, createdOn, currentAdviser) {
   const advisers = await getAdvisers(token)
-  const activeAdvisers = filterActiveAdvisers({ advisers: advisers.results, includeAdviser: currentAdviser })
+  const activeAdvisers = filterActiveAdvisers({
+    advisers: advisers.results,
+    includeAdviser: currentAdviser,
+  })
 
   return {
     advisers: activeAdvisers.map(transformObjectToOption),

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -6,23 +6,40 @@ const { transformEventResponseToFormBody } = require('../transformers')
 const { buildFormWithStateAndErrors } = require('../../builders')
 const { getAdvisers } = require('../../adviser/repos')
 const { filterActiveAdvisers } = require('../../adviser/filters')
+const { getOptions } = require('../../../lib/options')
+const { transformObjectToOption } = require('../../transformers')
+
+async function getEditOptions (token, createdOn, currentAdviser) {
+  const advisers = await getAdvisers(token)
+  const activeAdvisers = filterActiveAdvisers({ advisers: advisers.results, includeAdviser: currentAdviser })
+
+  return {
+    advisers: activeAdvisers.map(transformObjectToOption),
+    eventTypes: await getOptions(token, 'event-type', { createdOn }),
+    locationTypes: await getOptions(token, 'location-type', { createdOn }),
+    countries: await getOptions(token, 'country', { createdOn }),
+    teams: await getOptions(token, 'team', { createdOn }),
+    services: await getOptions(token, 'service', { createdOn }),
+    programmes: await getOptions(token, 'programme', { createdOn }),
+    ukRegions: await getOptions(token, 'uk-region', { createdOn }),
+  }
+}
 
 async function renderEditPage (req, res, next) {
   try {
     const eventData = transformEventResponseToFormBody(res.locals.event)
-
-    const currentAdviser = get(eventData, 'organiser.id')
-    const advisers = await getAdvisers(req.session.token)
-    const activeAdvisers = filterActiveAdvisers({ advisers: advisers.results, includeAdviser: currentAdviser })
 
     const eventId = get(eventData, 'id', '')
     const eventName = get(eventData, 'name')
     const lead_team = eventData.lead_team || get(req, 'session.user.dit_team.id')
     const mergedData = pickBy(merge({}, eventData, { lead_team }, res.locals.requestBody))
 
+    const currentAdviser = get(eventData, 'organiser.id')
+    const options = await getEditOptions(req.session.token, mergedData.created_on, currentAdviser)
+
     const eventForm =
       buildFormWithStateAndErrors(
-        eventFormConfig({ eventId, advisers: activeAdvisers }),
+        eventFormConfig(assign({}, { eventId }, options)),
         mergedData,
         get(res.locals, 'form.errors.messages'),
       )

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -1,9 +1,17 @@
 const { assign } = require('lodash')
-
 const { globalFields } = require('../../macros')
-const { transformObjectToOption } = require('../../transformers')
 
-const eventFormConfig = ({ eventId, advisers }) => {
+const eventFormConfig = ({
+  eventId,
+  advisers,
+  eventTypes,
+  locationTypes,
+  countries,
+  teams,
+  services,
+  programmes,
+  ukRegions,
+}) => {
   return {
     method: 'post',
     buttonText: 'Save',
@@ -16,7 +24,9 @@ const eventFormConfig = ({ eventId, advisers }) => {
         name: 'name',
         label: 'Event name',
       },
-      globalFields.eventTypes,
+      assign({}, globalFields.eventTypes, {
+        options: eventTypes,
+      }),
       {
         macroName: 'DateFieldset',
         name: 'start_date',
@@ -30,6 +40,7 @@ const eventFormConfig = ({ eventId, advisers }) => {
       assign({}, globalFields.locationTypes, {
         label: 'Event location type',
         optional: true,
+        options: locationTypes,
       }),
       {
         macroName: 'TextField',
@@ -61,12 +72,14 @@ const eventFormConfig = ({ eventId, advisers }) => {
       },
       assign({}, globalFields.countries, {
         name: 'address_country',
+        options: countries,
       }),
       assign({}, globalFields.ukRegions, {
         condition: {
           name: 'address_country',
           value: '80756b9a-5d95-e211-a939-e4115bead28a',
         },
+        options: ukRegions,
       }),
       {
         macroName: 'TextField',
@@ -79,15 +92,18 @@ const eventFormConfig = ({ eventId, advisers }) => {
         name: 'lead_team',
         label: 'Team hosting the event',
         optional: true,
+        options: teams,
       }),
-      globalFields.serviceDeliveryServices,
+      assign({}, globalFields.serviceDeliveryServices, {
+        options: services,
+      }),
       {
         macroName: 'MultipleChoiceField',
         name: 'organiser',
         label: 'Organiser',
         optional: true,
         initialOption: '-- Select organiser --',
-        options: advisers.map(transformObjectToOption),
+        options: advisers,
       },
       {
         macroName: 'MultipleChoiceField',
@@ -119,6 +135,7 @@ const eventFormConfig = ({ eventId, advisers }) => {
             isLabelHidden: true,
             persistsConditionalValue: true,
             optional: true,
+            options: teams,
           }),
         ],
         modifier: 'subfield',
@@ -138,6 +155,7 @@ const eventFormConfig = ({ eventId, advisers }) => {
             label: 'Related programmes',
             isLabelHidden: true,
             optional: true,
+            options: programmes,
           }),
         ],
       },

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -2,22 +2,16 @@ const config = require('../../config')
 const authorisedRequest = require('../lib/authorised-request')
 const { filterDisabledOption } = require('../apps/filters')
 const { transformObjectToOption } = require('../apps/transformers')
-const logger = require('../../config/logger')
 
 async function getOptions (token, key, { createdOn, currentValue, includeDisabled = false } = {}) {
-  try {
-    const url = `${config.apiRoot}/metadata/${key}/`
-    let options = await authorisedRequest(token, url)
+  const url = `${config.apiRoot}/metadata/${key}/`
+  let options = await authorisedRequest(token, url)
 
-    if (!includeDisabled) {
-      options = options.filter(filterDisabledOption({ currentValue, createdOn }))
-    }
-
-    return options.map(transformObjectToOption)
-  } catch (error) {
-    logger.error(error)
-    return []
+  if (!includeDisabled) {
+    options = options.filter(filterDisabledOption({ currentValue, createdOn }))
   }
+
+  return options.map(transformObjectToOption)
 }
 
 module.exports = {

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -45,6 +45,13 @@ const metadataMock = {
   ],
 }
 
+function getFormFieldOptions (res, fieldName) {
+  const renderOptions = res.render.firstCall.args[1]
+  const formFields = renderOptions.eventForm.children
+  const field = find(formFields, field => field.name === fieldName)
+  return field.options || field.children[0].options
+}
+
 describe('Event edit controller', () => {
   const currentUserTeam = 'team1'
 
@@ -348,11 +355,4 @@ describe('Event edit controller', () => {
       })
     })
   })
-
-  function getFormFieldOptions (res, fieldName) {
-    const renderOptions = res.render.firstCall.args[1]
-    const formFields = renderOptions.eventForm.children
-    const field = find(formFields, field => field.name === fieldName)
-    return field.options || field.children[0].options
-  }
 })

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -1,8 +1,49 @@
 const { assign, find } = require('lodash')
+const moment = require('moment')
 
 const config = require('~/config')
 const eventData = require('~/test/unit/data/events/event.json')
 const adviserFilters = require('~/src/apps/adviser/filters')
+
+const yesterday = moment().subtract(1, 'days').toISOString()
+const lastMonth = moment().subtract(1, 'months').toISOString()
+
+const metadataMock = {
+  eventTypes: [
+    { id: '1', name: 'et1', disabled_on: null },
+    { id: '2', name: 'et2', disabled_on: yesterday },
+    { id: '3', name: 'et3', disabled_on: null },
+  ],
+  locationTypes: [
+    { id: '1', name: 'lt1', disabled_on: null },
+    { id: '2', name: 'lt2', disabled_on: yesterday },
+    { id: '3', name: 'lt3', disabled_on: null },
+  ],
+  countryOptions: [
+    { id: '9999', name: 'United Kingdom', disabled_on: null },
+    { id: '8888', name: 'Test', disabled_on: yesterday },
+  ],
+  teamOptions: [
+    { id: '1', name: 'te1', disabled_on: null },
+    { id: '2', name: 'te2', disabled_on: yesterday },
+    { id: '3', name: 'te3', disabled_on: null },
+  ],
+  serviceOptions: [
+    { id: '1', name: 'sv1', disabled_on: null },
+    { id: '2', name: 'sv2', disabled_on: yesterday },
+    { id: '3', name: 'sv3', disabled_on: null },
+  ],
+  programmeOptions: [
+    { id: '1', name: 'p1', disabled_on: null },
+    { id: '2', name: 'p2', disabled_on: yesterday },
+    { id: '3', name: 'p3', disabled_on: null },
+  ],
+  regionOptions: [
+    { id: '1', name: 'r1', disabled_on: null },
+    { id: '2', name: 'r2', disabled_on: yesterday },
+    { id: '3', name: 'r3', disabled_on: null },
+  ],
+}
 
 describe('Event edit controller', () => {
   const currentUserTeam = 'team1'
@@ -47,17 +88,30 @@ describe('Event edit controller', () => {
         { id: '5', name: 'Jim Smith', is_active: false },
       ],
     }
-
-    this.nockScope = nock(config.apiRoot)
-      .get('/adviser/')
-      .query({
-        limit: 100000,
-        offset: 0,
-      })
-      .reply(200, this.activeInactiveAdviserData)
   })
 
   describe('#renderEditPage', () => {
+    beforeEach(() => {
+      this.nockScope = nock(config.apiRoot)
+        .get('/adviser/')
+        .query({ limit: 100000, offset: 0 })
+        .reply(200, this.activeInactiveAdviserData)
+        .get('/metadata/event-type/')
+        .reply(200, metadataMock.eventTypes)
+        .get('/metadata/location-type/')
+        .reply(200, metadataMock.locationTypes)
+        .get('/metadata/country/')
+        .reply(200, metadataMock.countryOptions)
+        .get('/metadata/team/')
+        .reply(200, metadataMock.teamOptions)
+        .get('/metadata/service/')
+        .reply(200, metadataMock.serviceOptions)
+        .get('/metadata/programme/')
+        .reply(200, metadataMock.programmeOptions)
+        .get('/metadata/uk-region/')
+        .reply(200, metadataMock.regionOptions)
+    })
+
     context('when rendering the page', () => {
       beforeEach(async () => {
         await this.controller.renderEditPage(this.req, this.res, this.next)
@@ -110,60 +164,150 @@ describe('Event edit controller', () => {
           { label: 'Zac Smith', value: '3' },
         ]
 
-        const formOrganizerFieldOptions = getOrganiserFieldOptions(this.res)
+        const formOrganizerFieldOptions = getFormFieldOptions(this.res, 'organiser')
         expect(formOrganizerFieldOptions).to.deep.equal(expectedOptions)
       })
 
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
+      it('should get all active event type options', () => {
+        const options = getFormFieldOptions(this.res, 'event_type')
+        expect(options).to.deep.equal([
+          { label: 'et1', value: '1' },
+          { label: 'et3', value: '3' },
+        ])
+      })
+
+      it('should get all active location type options', () => {
+        const options = getFormFieldOptions(this.res, 'location_type')
+        expect(options).to.deep.equal([
+          { label: 'lt1', value: '1' },
+          { label: 'lt3', value: '3' },
+        ])
+      })
+
+      it('should get all active country type options', () => {
+        const options = getFormFieldOptions(this.res, 'address_country')
+        expect(options).to.deep.equal([
+          { label: 'United Kingdom', value: '9999' },
+        ])
+      })
+
+      it('should get all active team options', () => {
+        const options = getFormFieldOptions(this.res, 'lead_team')
+        expect(options).to.deep.equal([
+          { label: 'te1', value: '1' },
+          { label: 'te3', value: '3' },
+        ])
+      })
+
+      it('should get all active service options', () => {
+        const options = getFormFieldOptions(this.res, 'service')
+        expect(options).to.deep.equal([
+          { label: 'sv1', value: '1' },
+          { label: 'sv3', value: '3' },
+        ])
+      })
+
+      it('should get all active programme options', () => {
+        const options = getFormFieldOptions(this.res, 'related_programmes')
+        expect(options).to.deep.equal([
+          { label: 'p1', value: '1' },
+          { label: 'p3', value: '3' },
+        ])
+      })
+
+      it('should get all active uk region options', () => {
+        const options = getFormFieldOptions(this.res, 'uk_region')
+        expect(options).to.deep.equal([
+          { label: 'r1', value: '1' },
+          { label: 'r3', value: '3' },
+        ])
       })
     })
 
     context('when editing an event', () => {
-      beforeEach(() => {
-        this.res.locals.event = eventData
+      beforeEach(async () => {
+        this.currentAdviser = this.activeInactiveAdviserData.results[3]
+
+        this.res.locals.event = assign({}, eventData, {
+          created_on: lastMonth,
+          organiser: this.currentAdviser,
+        })
+
+        await this.controller.renderEditPage(this.req, this.res, this.next)
       })
 
-      it('should add a breadcrumb', async () => {
-        await this.controller.renderEditPage(this.req, this.res, this.next)
-
+      it('should add a breadcrumb', () => {
         expect(this.res.breadcrumb.firstCall).to.be.calledWith('name', '/events/123')
         expect(this.res.breadcrumb.secondCall).to.be.calledWith('Edit event')
         expect(this.nockScope.isDone()).to.be.true
       })
 
-      context('and when the organiser is active', () => {
-        beforeEach(async () => {
-          this.currentAdviser = this.activeInactiveAdviserData.results[3]
+      it('should get all active event type options when the event was created', () => {
+        const options = getFormFieldOptions(this.res, 'event_type')
+        expect(options).to.deep.equal([
+          { label: 'et1', value: '1' },
+          { label: 'et2', value: '2' },
+          { label: 'et3', value: '3' },
+        ])
+      })
 
-          this.res.locals.event = assign({}, eventData, {
-            organiser: this.currentAdviser,
-          })
+      it('should get all active location type options when the event was created', () => {
+        const options = getFormFieldOptions(this.res, 'location_type')
+        expect(options).to.deep.equal([
+          { label: 'lt1', value: '1' },
+          { label: 'lt2', value: '2' },
+          { label: 'lt3', value: '3' },
+        ])
+      })
 
-          await this.controller.renderEditPage(this.req, this.res, this.next)
-        })
+      it('should get all active country type options when the event was created', () => {
+        const options = getFormFieldOptions(this.res, 'address_country')
+        expect(options).to.deep.equal([
+          { label: 'United Kingdom', value: '9999' },
+          { label: 'Test', value: '8888' },
+        ])
+      })
 
-        it('should filters the advisers and include the current one', () => {
-          expect(this.filterActiveAdvisersSpy).to.be.calledWith({
-            advisers: this.activeInactiveAdviserData.results,
-            includeAdviser: this.currentAdviser.id,
-          })
-        })
+      it('should get all active team options when the event was created', () => {
+        const options = getFormFieldOptions(this.res, 'lead_team')
+        expect(options).to.deep.equal([
+          { label: 'te1', value: '1' },
+          { label: 'te2', value: '2' },
+          { label: 'te3', value: '3' },
+        ])
+      })
 
-        it('should render the form with the active advisers', () => {
-          const expectedOptions = [
-            { label: 'Jeff Smith', value: '1' },
-            { label: 'John Smith', value: '2' },
-            { label: 'Zac Smith', value: '3' },
-            { label: 'Fred Smith', value: '4' },
-          ]
+      it('should get all active service options when the event was created', () => {
+        const options = getFormFieldOptions(this.res, 'service')
+        expect(options).to.deep.equal([
+          { label: 'sv1', value: '1' },
+          { label: 'sv2', value: '2' },
+          { label: 'sv3', value: '3' },
+        ])
+      })
 
-          const formOrganizerFieldOptions = getOrganiserFieldOptions(this.res)
-          expect(formOrganizerFieldOptions).to.deep.equal(expectedOptions)
-        })
+      it('should get all active programme options when the event was created', () => {
+        const options = getFormFieldOptions(this.res, 'related_programmes')
+        expect(options).to.deep.equal([
+          { label: 'p1', value: '1' },
+          { label: 'p2', value: '2' },
+          { label: 'p3', value: '3' },
+        ])
+      })
 
-        it('nock mocked scope has been called', () => {
-          expect(this.nockScope.isDone()).to.be.true
+      it('should get all active uk region options when the event was created', () => {
+        const options = getFormFieldOptions(this.res, 'uk_region')
+        expect(options).to.deep.equal([
+          { label: 'r1', value: '1' },
+          { label: 'r2', value: '2' },
+          { label: 'r3', value: '3' },
+        ])
+      })
+
+      it('should get all active adviser options and the current one', () => {
+        expect(this.filterActiveAdvisersSpy).to.be.calledWith({
+          advisers: this.activeInactiveAdviserData.results,
+          includeAdviser: this.currentAdviser.id,
         })
       })
     })
@@ -205,10 +349,10 @@ describe('Event edit controller', () => {
     })
   })
 
-  function getOrganiserFieldOptions (res) {
+  function getFormFieldOptions (res, fieldName) {
     const renderOptions = res.render.firstCall.args[1]
     const formFields = renderOptions.eventForm.children
-    const organiserField = find(formFields, field => field.name === 'organiser')
-    return organiserField.options
+    const field = find(formFields, field => field.name === fieldName)
+    return field.options || field.children[0].options
   }
 })


### PR DESCRIPTION
Set active options for event edit form.

Also discovered that don't need to set the `currentValue` parameter when calling getActiveOptions, as the option will be available because it was available at the creation time.

Will go back and modify company and contact to match.