### PR TITLE
Fix export revenue (and others) in investment project view

### DIFF
--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -55,7 +55,7 @@ describe('Investment evaluation controller', () => {
       'New-to-world tech': 'Has new-to-world tech, business model or IP',
       'Account tier': undefined,
       'New GHQ/EHQ': 'No',
-      'Export revenue': 'Yes, will create significant export revenue',
+      'Export revenue': 'No, will not create significant export revenue',
     }
     const expectFDI = {
       'Type of investment': 'Does not apply',
@@ -111,7 +111,7 @@ describe('Investment evaluation controller', () => {
       'New-to-world tech': 'Has new-to-world tech, business model or IP',
       'Account tier': 'Tier A - Strategic Account',
       'New GHQ/EHQ': 'Yes',
-      'Export revenue': 'Yes, will create significant export revenue',
+      'Export revenue': 'No, will not create significant export revenue',
     }
     const expectFDI = {
       'Type of investment': 'Tom',

--- a/test/unit/apps/investment-projects/formatting.test.js
+++ b/test/unit/apps/investment-projects/formatting.test.js
@@ -213,76 +213,181 @@ describe('Investment project formatting service', () => {
   })
 
   describe('#transformInvestmentValueForView', () => {
-    context('when a project says it is associated with a non-fdi r&d project', () => {
+    context('when all fields are not set', () => {
       beforeEach(() => {
-        this.investmentData = Object.assign({}, investmentData, {
+        this.actualInvestmentValue = formattingService.transformInvestmentValueForView({
+          client_cannot_provide_total_investment: true,
+          total_investment: null,
+          client_cannot_provide_foreign_investment: true,
+          foreign_equity_investment: null,
+          number_new_jobs: null,
+          number_safeguarded_jobs: null,
+          government_assistance: false,
+          r_and_d_budget: false,
+          average_salary: null,
+          new_tech_to_uk: false,
+          export_revenue: false,
+          sector: null,
+          investor_company: null,
+          business_activities: [],
+          non_fdi_r_and_d_budget: false,
           id: 1,
-          non_fdi_r_and_d_budget: true,
+          associated_non_fdi_r_and_d_project: null,
         })
       })
 
+      it('should correctly format the value view', () => {
+        const expectedInvestmentValue = {
+          total_investment: 'Client cannot provide this information',
+          foreign_equity_investment: 'Client cannot provide this information',
+          number_new_jobs: null,
+          number_safeguarded_jobs: null,
+          government_assistance: 'No government assistance',
+          r_and_d_budget: 'No R&D budget',
+          average_salary: undefined,
+          new_tech_to_uk: 'No new-to-world tech, business model or IP',
+          export_revenue: 'No, will not create significant export revenue',
+          sector_name: undefined,
+          account_tier: undefined,
+          business_activities: 'No',
+          associated_non_fdi_r_and_d_project: 'Not linked to a non-FDI R&D project',
+        }
+
+        expect(this.actualInvestmentValue).to.deep.equal(expectedInvestmentValue)
+      })
+    })
+
+    context('when all fields are set', () => {
+      beforeEach(() => {
+        this.actualInvestmentValue = formattingService.transformInvestmentValueForView({
+          client_cannot_provide_total_investment: false,
+          total_investment: 100000,
+          client_cannot_provide_foreign_investment: false,
+          foreign_equity_investment: 200000,
+          number_new_jobs: 100,
+          number_safeguarded_jobs: 200,
+          government_assistance: true,
+          r_and_d_budget: true,
+          average_salary: {
+            name: '£30,000 – £34,000',
+          },
+          new_tech_to_uk: true,
+          export_revenue: true,
+          sector: {
+            name: 'Renewable Energy : Wind : Renewable energy: Wind: Onshore',
+          },
+          investor_company: {
+            name: 'Venus Ltd',
+            classification: {
+              name: 'New hotel (Non-FDI)',
+            },
+          },
+          business_activities: [
+            {
+              name: 'European headquarters',
+            },
+          ],
+          non_fdi_r_and_d_budget: true,
+          id: 1,
+          associated_non_fdi_r_and_d_project: {
+            name: 'Freds',
+            id: 'ac035522-ad0b-4eeb-87f4-0ce964e4b999',
+            project_code: 'DHP-00000460',
+          },
+        })
+      })
+
+      it('should correctly format the value view', () => {
+        const expectedInvestmentValue = {
+          total_investment: '£100,000',
+          foreign_equity_investment: '£200,000',
+          number_new_jobs: '100 new jobs',
+          number_safeguarded_jobs: '200 safeguarded jobs',
+          government_assistance: 'Has government assistance',
+          r_and_d_budget: 'Has R&D budget',
+          average_salary: '£30,000 – £34,000',
+          new_tech_to_uk: 'Has new-to-world tech, business model or IP',
+          export_revenue: 'Yes, will create significant export revenue',
+          sector_name: 'Renewable Energy : Wind : Renewable energy: Wind: Onshore',
+          account_tier: 'New hotel (Non-FDI)',
+          business_activities: 'Yes',
+          associated_non_fdi_r_and_d_project: {
+            name: 'Freds',
+            actions: [
+              {
+                label: 'Edit project',
+                url: '/investment-projects/1/edit-associated?term=DHP-00000460',
+              },
+              {
+                label: 'Remove association',
+                url: '/investment-projects/1/remove-associated',
+              },
+            ],
+          },
+        }
+
+        expect(this.actualInvestmentValue).to.deep.equal(expectedInvestmentValue)
+      })
+    })
+
+    context('when an investment project is associated with a non-FDI R&D project', () => {
       context('and has no associated project yet', () => {
         beforeEach(() => {
-          this.investmentData = Object.assign({}, this.investmentData, {
+          this.actualInvestmentValue = formattingService.transformInvestmentValueForView({
+            client_cannot_provide_total_investment: false,
+            total_investment: 100000,
+            client_cannot_provide_foreign_investment: false,
+            foreign_equity_investment: 200000,
+            number_new_jobs: 100,
+            number_safeguarded_jobs: 200,
+            government_assistance: true,
+            r_and_d_budget: true,
+            average_salary: {
+              name: '£30,000 – £34,000',
+            },
+            new_tech_to_uk: true,
+            export_revenue: true,
+            sector: {
+              name: 'Renewable Energy : Wind : Renewable energy: Wind: Onshore',
+            },
+            investor_company: {
+              name: 'Venus Ltd',
+            },
+            business_activities: [
+              {
+                name: 'European headquarters',
+              },
+            ],
+            non_fdi_r_and_d_budget: true,
+            id: 1,
             associated_non_fdi_r_and_d_project: null,
           })
-
-          this.transformedInvestmentValues = formattingService.transformInvestmentValueForView(this.investmentData)
         })
 
         it('should display a link to find the associated investment project', () => {
-          expect(this.transformedInvestmentValues.associated_non_fdi_r_and_d_project).to.deep.equal({
+          expect(this.actualInvestmentValue.associated_non_fdi_r_and_d_project).to.deep.equal({
             name: 'Find project',
             url: `/investment-projects/1/edit-associated`,
           })
         })
       })
-
-      context('and has an associated r&d project', () => {
-        beforeEach(() => {
-          this.investmentData = Object.assign({}, this.investmentData, {
-            associated_non_fdi_r_and_d_project: {
-              name: 'Freds',
-              id: 'ac035522-ad0b-4eeb-87f4-0ce964e4b999',
-              project_code: 'DHP-00000460',
-            },
-          })
-
-          this.transformedInvestmentValues = formattingService.transformInvestmentValueForView(this.investmentData)
-        })
-
-        it('should show the name of the project associated with this one', () => {
-          expect(this.transformedInvestmentValues.associated_non_fdi_r_and_d_project.name).to.equal('Freds')
-        })
-
-        it('should display an action to edit the associated project', () => {
-          expect(this.transformedInvestmentValues.associated_non_fdi_r_and_d_project.actions[0]).to.deep.equal({
-            label: 'Edit project',
-            url: `/investment-projects/1/edit-associated?term=DHP-00000460`,
-          })
-        })
-
-        it('should display an action to remove the associated project', () => {
-          expect(this.transformedInvestmentValues.associated_non_fdi_r_and_d_project.actions[1]).to.deep.equal({
-            label: 'Remove association',
-            url: `/investment-projects/1/remove-associated`,
-          })
-        })
-      })
     })
 
-    context('when a project says it is not associated with a non-fdi r&d project', () => {
+    context('when government assistance is true and all other booleans are false', () => {
       beforeEach(() => {
-        this.investmentData = Object.assign({}, investmentData, {
-          id: 1,
-          non_fdi_r_and_d_budget: false,
-        })
-
-        this.transformedInvestmentValues = formattingService.transformInvestmentValueForView(this.investmentData)
+        this.transformedInvestmentValues = formattingService.transformInvestmentValueForView(assign({}, investmentData, {
+          government_assistance: true,
+          r_and_d_budget: false,
+          new_tech_to_uk: false,
+          export_revenue: false,
+        }))
       })
 
-      it('should indicate there is no non-fdi r&d project', () => {
-        expect(this.transformedInvestmentValues.associated_non_fdi_r_and_d_project).to.equal('Not linked to a non-FDI R&D project')
+      it('should transform the data correctly', () => {
+        expect(this.transformedInvestmentValues.government_assistance).to.equal('Has government assistance')
+        expect(this.transformedInvestmentValues.r_and_d_budget).to.equal('No R&D budget')
+        expect(this.transformedInvestmentValues.new_tech_to_uk).to.equal('No new-to-world tech, business model or IP')
+        expect(this.transformedInvestmentValues.export_revenue).to.equal('No, will not create significant export revenue')
       })
     })
   })

--- a/test/unit/mocha.opts
+++ b/test/unit/mocha.opts
@@ -1,3 +1,4 @@
+test/unit/global-helpers.js
 --require test/unit/common.js
 --ui bdd
 --recursive


### PR DESCRIPTION
A bug means that certain booleans are not being presented correctly in the `Value` key value table for investment projects.

Note that acceptance tests will be in the next PR.

# Before

<img width="672" alt="bad" src="https://user-images.githubusercontent.com/1150417/34255079-dc710dd4-e646-11e7-9acf-4c9779c984a8.png">

<img width="681" alt="screen shot 2017-12-21 at 11 51 16" src="https://user-images.githubusercontent.com/1150417/34255076-dbd2744e-e646-11e7-9414-c118f3fc61df.png">


# After

<img width="668" alt="good" src="https://user-images.githubusercontent.com/1150417/34255089-e5610e3a-e646-11e7-9ba7-ef5872a0d335.png">