### PR TITLE
Updates the interaction/service form to include active options.

### DIFF
--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-const { get, merge, pickBy, lowerCase, snakeCase } = require('lodash')
+const { get, merge, pickBy, lowerCase, snakeCase, assign } = require('lodash')
 
 const { transformInteractionResponseToForm } = require('../transformers')
 const { transformDateStringToDateObject } = require('../../transformers')
@@ -22,19 +22,15 @@ function renderEditPage (req, res) {
   const interactionForm =
     buildFormWithStateAndErrors(
       formConfigs[req.params.kind](
-        {
+        assign({}, res.locals.options, {
           returnLink: res.locals.returnLink,
-          advisers: res.locals.advisers,
-          contacts: res.locals.contacts,
-          services: res.locals.services,
-          events: res.locals.events,
           hiddenFields: {
             id: get(res.locals, 'interaction.id'),
             company: res.locals.company.id,
             investment_project: get(res.locals, 'investmentData.id'),
             kind: snakeCase(req.params.kind),
           },
-        }),
+        })),
       mergedInteractionData,
       get(res.locals, 'form.errors.messages'),
     )

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -1,11 +1,17 @@
 const { getAdvisers } = require('../../adviser/repos')
 const { interactionFiltersFieldConfig } = require('../macros')
 const { buildSelectedFiltersSummary } = require('../../builders')
+const { transformObjectToOption } = require('../../transformers')
+const { getOptions } = require('../../../lib/options')
 
 async function renderInteractionList (req, res, next) {
   try {
-    const { results: advisers } = await getAdvisers(req.session.token)
-    const filtersFields = interactionFiltersFieldConfig(advisers)
+    const token = req.session.token
+    const { results: advisers } = await getAdvisers(token)
+    const adviserOptions = advisers.map(transformObjectToOption)
+    const channelOptions = await getOptions(token, 'communication-channel', { includeDisabled: true })
+
+    const filtersFields = interactionFiltersFieldConfig(adviserOptions, channelOptions)
     const selectedFilters = buildSelectedFiltersSummary(filtersFields, req.query)
 
     res.render('interactions/views/list', {

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -1,9 +1,6 @@
 const { assign } = require('lodash')
 
 const formLabels = require('./labels')
-const metaData = require('../../lib/metadata')
-const { transformContactToOption, transformObjectToOption } = require('../transformers')
-
 const currentYear = (new Date()).getFullYear()
 
 const interactionSortForm = {
@@ -66,27 +63,23 @@ const interactionFields = {
       macroName: 'MultipleChoiceField',
       name: 'contact',
       initialOption: '-- Select contact --',
-      options () {
-        return contacts.map(transformContactToOption)
-      },
+      options: contacts,
     }
   },
-  provider: {
-    macroName: 'MultipleChoiceField',
-    name: 'dit_team',
-    initialOption: '-- Select provider --',
-    options () {
-      return metaData.teams.map(transformObjectToOption)
-    },
+  provider (teams) {
+    return {
+      macroName: 'MultipleChoiceField',
+      name: 'dit_team',
+      initialOption: '-- Select provider --',
+      options: teams,
+    }
   },
   service (services) {
     return {
       macroName: 'MultipleChoiceField',
       name: 'service',
       initialOption: '-- Select service --',
-      options () {
-        return services.map(transformObjectToOption)
-      },
+      options: services,
     }
   },
   subject: {
@@ -107,18 +100,16 @@ const interactionFields = {
       macroName: 'MultipleChoiceField',
       name: 'dit_adviser',
       initialOption: '-- Select adviser --',
-      options () {
-        return advisers.map(transformContactToOption)
-      },
+      options: advisers,
     }
   },
-  communicationChannel: {
-    macroName: 'MultipleChoiceField',
-    name: 'communication_channel',
-    initialOption: '-- Select communication channel --',
-    options () {
-      return metaData.communicationChannelOptions.map(transformObjectToOption)
-    },
+  communicationChannel (channels) {
+    return {
+      macroName: 'MultipleChoiceField',
+      name: 'communication_channel',
+      initialOption: '-- Select communication channel --',
+      options: channels,
+    }
   },
 }
 
@@ -168,6 +159,8 @@ const interactionFormConfig = function ({
   contacts = [],
   advisers = [],
   services = [],
+  teams = [],
+  channels = [],
   hiddenFields,
 }) {
   return {
@@ -177,13 +170,13 @@ const interactionFormConfig = function ({
     hiddenFields,
     children: [
       interactionFields.contact(contacts),
-      interactionFields.provider,
+      interactionFields.provider(teams),
       interactionFields.service(services),
       interactionFields.subject,
       interactionFields.notes,
       interactionFields.date,
       interactionFields.adviser(advisers),
-      interactionFields.communicationChannel,
+      interactionFields.communicationChannel(channels),
     ].map(field => {
       return assign(field, {
         label: formLabels.interaction[field.name],
@@ -197,6 +190,7 @@ const serviceDeliveryFormConfig = function ({
   contacts = [],
   advisers = [],
   services = [],
+  teams = [],
   events = [],
   hiddenFields,
 }) {
@@ -207,7 +201,7 @@ const serviceDeliveryFormConfig = function ({
     hiddenFields,
     children: [
       interactionFields.contact(contacts),
-      interactionFields.provider,
+      interactionFields.provider(teams),
       interactionFields.adviser(advisers),
       // TODO this will be going once interactions are within events
       {
@@ -231,9 +225,7 @@ const serviceDeliveryFormConfig = function ({
         macroName: 'MultipleChoiceField',
         name: 'event',
         initialOption: '-- Select event --',
-        options () {
-          return events.map(transformObjectToOption)
-        },
+        options: events,
         modifier: 'subfield',
         condition: {
           name: 'is_event',

--- a/src/apps/interactions/macros.js
+++ b/src/apps/interactions/macros.js
@@ -113,7 +113,7 @@ const interactionFields = {
   },
 }
 
-const interactionFiltersFieldConfig = function (advisers) {
+const interactionFiltersFieldConfig = function (advisers = [], channels = []) {
   return [
     {
       macroName: 'MultipleChoiceField',
@@ -126,7 +126,7 @@ const interactionFiltersFieldConfig = function (advisers) {
     },
     assign(
       {},
-      interactionFields.communicationChannel,
+      interactionFields.communicationChannel(channels),
       { initialOption: '-- All channels --' }
     ),
     assign(

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -3,12 +3,13 @@ const { sentence } = require('case')
 
 const { transformInteractionFormBodyToApiRequest } = require('../transformers')
 const { fetchInteraction, saveInteraction } = require('../repos')
-const metaDataRepository = require('../../../lib/metadata')
 const { getContactsForCompany, getContact } = require('../../contacts/repos')
 const { getAdvisers } = require('../../adviser/repos')
 const { filterActiveAdvisers } = require('../../adviser/filters')
 const { getActiveEvents } = require('../../events/repos')
 const { getDitCompany } = require('../../companies/repos')
+const { transformObjectToOption, transformContactToOption } = require('../../transformers')
+const { getOptions } = require('../../../lib/options')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -66,20 +67,30 @@ async function getInteractionDetails (req, res, next, interactionId) {
 
 async function getInteractionOptions (req, res, next) {
   try {
-    const interaction = res.locals.interaction
     const token = req.session.token
-    const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
-    const company = get(res.locals, 'company.id')
-    const advisers = await getAdvisers(token)
+    const createdOn = get(res.locals, 'interaction.created_on')
 
-    res.locals = assign({}, res.locals, {
-      advisers: filterActiveAdvisers({ advisers: advisers.results, includeAdviser: currentAdviser }),
-      contacts: await getContactsForCompany(token, company),
-      services: await metaDataRepository.getServices(token),
+    const companyId = get(res.locals, 'company.id')
+    const contacts = await getContactsForCompany(token, companyId)
+
+    const advisers = await getAdvisers(token)
+    const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
+    const activeAdvisers = filterActiveAdvisers({
+      advisers: advisers.results,
+      includeAdviser: currentAdviser,
     })
 
+    res.locals.options = {
+      advisers: activeAdvisers.map(transformObjectToOption),
+      contacts: contacts.map(transformContactToOption),
+      services: await getOptions(token, 'service', { createdOn }),
+      teams: await getOptions(token, 'team', { createdOn }),
+      channels: await getOptions(token, 'communication-channel', { createdOn }),
+    }
+
     if (req.params.kind === 'service-delivery') {
-      res.locals.events = await getActiveEvents(token, get(interaction, 'created_on'))
+      const activeEvents = await getActiveEvents(token, createdOn)
+      res.locals.options.events = activeEvents.map(transformObjectToOption)
     }
 
     next()

--- a/test/unit/apps/interactions/macros.test.js
+++ b/test/unit/apps/interactions/macros.test.js
@@ -1,70 +1,117 @@
-const sampleOptions = [
-  { id: 'master', name: 'Master' },
-  { id: 'voland', name: 'Voland' },
-]
+const { find } = require('lodash')
 
-describe('Interaction macros', () => {
-  beforeEach(() => {
-    this.transformContactToOptionSpy = sinon.spy()
-    this.transformObjectToOptionSpy = sinon.spy()
+const macros = require('~/src/apps/interactions/macros')
 
-    this.macros = proxyquire('~/src/apps/interactions/macros', {
-      '../transformers': {
-        transformContactToOption: this.transformContactToOptionSpy,
-        transformObjectToOption: this.transformObjectToOptionSpy,
-      },
-      '../../lib/metadata': {
-        teams: [
-          { id: 'alpha', name: 'Alpha' },
-          { id: 'omega', name: 'Omega' },
-        ],
-      },
-    })
+function getFormFieldOptions (form, fieldName) {
+  const formFields = form.children
+
+  const field = find(formFields, (field) => {
+    return field.name === fieldName
   })
 
+  return field.options || field.children[0].options
+}
+
+describe('Interaction macros', () => {
   describe('#interactionFormConfig', () => {
-    it('should return object with specified returnLink present', () => {
-      const returnLink = '/companies/1/interactions'
-      const actual = this.macros.interactionFormConfig({ returnLink })
+    context('when called with interaction options', () => {
+      beforeEach(() => {
+        this.formParams = {
+          returnLink: 'test',
+          contacts: [],
+          advisers: [],
+          services: [],
+          teams: [],
+          channels: [],
+          hiddenFields: [],
+        }
 
-      expect(actual.returnLink).to.deep.equal(returnLink)
-    })
+        this.form = macros.interactionFormConfig(this.formParams)
+      })
 
-    it('should return object with transformed contact options', () => {
-      const actual = this.macros.interactionFormConfig({ contacts: sampleOptions })
-      actual.children.find(x => x.name === 'contact').options()
+      it('should return object with specified returnLink present', () => {
+        expect(this.form).to.have.property('returnLink', this.formParams.returnLink)
+      })
 
-      expect(this.transformContactToOptionSpy).to.have.callCount(2)
-    })
+      it('should return object with specified hidden fields', () => {
+        expect(this.form).to.have.property('hiddenFields', this.formParams.hiddenFields)
+      })
 
-    it('should return object with transformed dit_adviser options', () => {
-      const actual = this.macros.interactionFormConfig({ advisers: sampleOptions })
-      actual.children.find(x => x.name === 'dit_adviser').options()
+      it('should return object with contact options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'contact')
+        expect(fieldOptions).to.deep.equal(this.formParams.contacts)
+      })
 
-      expect(this.transformContactToOptionSpy).to.have.callCount(2)
-    })
+      it('should return object with provider options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'dit_team')
+        expect(fieldOptions).to.deep.equal(this.formParams.teams)
+      })
 
-    it('should return object with transformed service options', () => {
-      const actual = this.macros.interactionFormConfig({ services: sampleOptions })
-      actual.children.find(x => x.name === 'service').options()
+      it('should return object with service options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'service')
+        expect(fieldOptions).to.deep.equal(this.formParams.services)
+      })
 
-      expect(this.transformObjectToOptionSpy).to.have.callCount(2)
-    })
+      it('should return object with adviser options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'dit_adviser')
+        expect(fieldOptions).to.deep.equal(this.formParams.advisers)
+      })
 
-    it('should return object with transformed dit_team options', () => {
-      const actual = this.macros.interactionFormConfig({ dit_team: sampleOptions })
-      actual.children.find(x => x.name === 'dit_team').options()
-
-      expect(this.transformObjectToOptionSpy).to.have.callCount(2)
+      it('should return object with communication channel options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'communication_channel')
+        expect(fieldOptions).to.deep.equal(this.formParams.channels)
+      })
     })
   })
 
   describe('#serviceDeliveryFormConfig', () => {
-    it('should return object with transformed event options', () => {
-      const actual = this.macros.serviceDeliveryFormConfig({ events: sampleOptions })
-      actual.children.find(x => x.name === 'event').options()
+    context('when called with service delivery options', () => {
+      beforeEach(() => {
+        this.formParams = {
+          returnLink: 'test',
+          contacts: [],
+          advisers: [],
+          services: [],
+          teams: [],
+          events: [],
+          hiddenFields: [],
+        }
 
-      expect(this.transformObjectToOptionSpy).to.have.callCount(2)
+        this.form = macros.serviceDeliveryFormConfig(this.formParams)
+      })
+
+      it('should return object with specified returnLink present', () => {
+        expect(this.form).to.have.property('returnLink', this.formParams.returnLink)
+      })
+
+      it('should return object with specified hidden fields', () => {
+        expect(this.form).to.have.property('hiddenFields', this.formParams.hiddenFields)
+      })
+
+      it('should return object with contact options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'contact')
+        expect(fieldOptions).to.deep.equal(this.formParams.contacts)
+      })
+
+      it('should return object with provider options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'dit_team')
+        expect(fieldOptions).to.deep.equal(this.formParams.teams)
+      })
+
+      it('should return object with service options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'service')
+        expect(fieldOptions).to.deep.equal(this.formParams.services)
+      })
+
+      it('should return object with adviser options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'dit_adviser')
+        expect(fieldOptions).to.deep.equal(this.formParams.advisers)
+      })
+
+      it('should return object with event options', () => {
+        const fieldOptions = getFormFieldOptions(this.form, 'event')
+        expect(fieldOptions).to.deep.equal(this.formParams.events)
+      })
     })
   })
 })


### PR DESCRIPTION
DH-1332

Changed the interaction/service middleware to get active options instead of all of them, and put all options in an options property.
Simplified the controller a little when calling the form builder.
Updated the interaction form builder to use options passed into it.