### PR TITLE
remove No JavaScript param

### DIFF
--- a/src/templates/_includes/google-tag-manager-no-script.njk
+++ b/src/templates/_includes/google-tag-manager-no-script.njk
@@ -1,6 +1,6 @@
 {% if GOOGLE_TAG_MANAGER_KEY %}
 <noscript>
-  <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_KEY }}&no_javascript=true"
+  <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_KEY }}"
           height="0" width="0"
           style="display: none; visibility: hidden;"
   ></iframe>


### PR DESCRIPTION
detection is now being done on just using Google Tag Manager

