### PR TITLE
Tidy up browsing to event list within acceptance tests

### DIFF
--- a/test/acceptance/features/dashboard/step_definitions/dashboard.js
+++ b/test/acceptance/features/dashboard/step_definitions/dashboard.js
@@ -1,6 +1,5 @@
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
-const { camelCase } = require('lodash')
 
 defineSupportCode(({ When, Then }) => {
   const Dashboard = client.page.Dashboard()
@@ -9,11 +8,6 @@ defineSupportCode(({ When, Then }) => {
     await Dashboard
       .navigate()
       .waitForElementPresent('@term')
-  })
-
-  When(/^the (.+) link in the global nav is clicked$/, async (link) => {
-    await Dashboard.section.globalNav
-      .click(`@${camelCase(link)}`)
   })
 
   Then(/^there should be global nav links$/, async () => {

--- a/test/acceptance/features/events/collection.feature
+++ b/test/acceptance/features/events/collection.feature
@@ -7,8 +7,8 @@ Feature: View a list of events
   @events-collection--add
   Scenario: Add event
 
-    Given I navigate to the event list page
-    When I click the "Add event" link
+    When I click the Events global nav link
+    And I click the "Add event" link
     Then I am taken to the "Add event" page
 
   @events-collection--view
@@ -56,12 +56,12 @@ Feature: View a list of events
   @events-collection--filter
   Scenario: Filter event list
 
-    Given I navigate to the event list page
-    When I click the "Add event" link
+    When I click the Events global nav link
+    And I click the "Add event" link
     And I populate the create event form
     And I click the save button
     Then I see the success message
-    When I navigate to the event list page
+    When I click the Events global nav link
     And I filter the events list by name
     Then I can view the event
     And I filter the events list by organiser
@@ -76,17 +76,17 @@ Feature: View a list of events
   @events-collection--sort
   Scenario: Sort event list
 
-    Given I navigate to the event list page
-    When I click the "Add event" link
+    When I click the Events global nav link
+    And I click the "Add event" link
     And I populate the create event form
     And I click the save button
     Then I see the success message
-    When I navigate to the event list page
+    When I click the Events global nav link
     And I click the "Add event" link
     And I populate the create event form
     When I click the save button
     Then I see the success message
-    When I navigate to the event list page
+    When I click the Events global nav link
     And I sort the events list name A-Z
     Then I see the list in A-Z alphabetical order
     And I sort the events list name Z-A

--- a/test/acceptance/features/events/save.feature
+++ b/test/acceptance/features/events/save.feature
@@ -14,8 +14,8 @@ Feature: Save a new Event in Data hub
   @events-save--mandatory-fields
   Scenario: Verify event mandatory fields
 
-    Given I navigate to the event list page
-    When I click the "Add event" link
+    When I click the Events global nav link
+    And I click the "Add event" link
     And I click the save button
     Then the event fields have error messages
     And I see form error summary
@@ -23,9 +23,9 @@ Feature: Save a new Event in Data hub
   @events-save--uk-region
   Scenario: Verify event UK region mandatory field
 
-    Given I navigate to the event list page
-    When I click the "Add event" link
-    When I populate the create event form with United Kingdom and without a region
+    When I click the Events global nav link
+    And I click the "Add event" link
+    And I populate the create event form with United Kingdom and without a region
     And I click the save button
     And I verify the event UK region has an error message
     Then I see form error summary

--- a/test/acceptance/features/events/step_definitions/collections.js
+++ b/test/acceptance/features/events/step_definitions/collections.js
@@ -9,13 +9,6 @@ defineSupportCode(({ Then, When }) => {
   const EventList = client.page.EventList()
   const Event = client.page.Event()
 
-  // TODO feels like this can be DRY'd up (see location)
-  When(/^I navigate to the event list page$/, async () => {
-    await EventList
-      .navigate()
-      .waitForElementPresent('@h1Element')
-  })
-
   When(/^I populate the create event form$/, async function () {
     await Event
       .populateCreateEventForm({}, true, (event) => {

--- a/test/acceptance/features/location/page-objects/Location.js
+++ b/test/acceptance/features/location/page-objects/Location.js
@@ -40,5 +40,20 @@ module.exports = {
         documents: getDetailsTabSelector('Documents'),
       },
     },
+    globalNav: {
+      selector: '.c-global-nav',
+      commands: [
+        {
+          getGlobalNavLinkSelector (text) {
+            return getSelectorForElementWithText(text,
+              {
+                el: '//a',
+                className: 'c-global-nav__link',
+              }
+            )
+          },
+        },
+      ],
+    },
   },
 }

--- a/test/acceptance/features/location/step_definitions/location.js
+++ b/test/acceptance/features/location/step_definitions/location.js
@@ -31,6 +31,18 @@ defineSupportCode(({ Given, When, Then }) => {
       .assert.containsText('@header', fixtureName)
   })
 
+  When(/^I click the (.+) global nav link/, async (globalNavLinkText) => {
+    const globalNavLinkSelector = Location.section.globalNav.getGlobalNavLinkSelector(globalNavLinkText)
+
+    await Location
+      .navigate()
+      .section.globalNav
+      .api.useXpath()
+      .waitForElementVisible(globalNavLinkSelector.selector)
+      .click(globalNavLinkSelector.selector)
+      .useCss()
+  })
+
   When(/^I click the (.+) local nav link$/, async (localNavLinkText) => {
     const localNavLinkSelector = Location.section.localNav.getLocalNavLinkSelector(localNavLinkText)
 

--- a/test/acceptance/features/location/step_definitions/location.js
+++ b/test/acceptance/features/location/step_definitions/location.js
@@ -2,7 +2,7 @@ const { find, assign, set, get, camelCase } = require('lodash')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
-defineSupportCode(({ Given, Then }) => {
+defineSupportCode(({ Given, When, Then }) => {
   const Location = client.page.Location()
   const Search = client.page.Search()
 
@@ -31,7 +31,7 @@ defineSupportCode(({ Given, Then }) => {
       .assert.containsText('@header', fixtureName)
   })
 
-  Then(/^I click the (.+) local nav link$/, async (localNavLinkText) => {
+  When(/^I click the (.+) local nav link$/, async (localNavLinkText) => {
     const localNavLinkSelector = Location.section.localNav.getLocalNavLinkSelector(localNavLinkText)
 
     await Location.section.localNav

--- a/test/acceptance/features/search/search.feature
+++ b/test/acceptance/features/search/search.feature
@@ -7,8 +7,8 @@ Feature: Search
   @search--events
   Scenario: Search events
 
-    Given I navigate to the event list page
-    When I click the "Add event" link
+    When I click the Events global nav link
+    And I click the "Add event" link
     And I populate the create event form
     And I click the save button
     Then I see the success message


### PR DESCRIPTION
This change reuses a global nav clicking step found in the location step definitions. There is also some other general tidy up.