### PR TITLE
Route based permissions

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -1,3 +1,8 @@
+const DEFAULT_COLLECTION_QUERY = {
+  sortby: 'modified_on:desc',
+  archived: false,
+}
+
 const LOCAL_NAV = [
   {
     path: 'details',
@@ -48,11 +53,6 @@ const LOCAL_NAV = [
     ],
   },
 ]
-
-const DEFAULT_COLLECTION_QUERY = {
-  sortby: 'modified_on:desc',
-  archived: false,
-}
 
 module.exports = {
   LOCAL_NAV,

--- a/src/apps/companies/controllers/documents.js
+++ b/src/apps/companies/controllers/documents.js
@@ -1,12 +1,8 @@
-const { get, isUndefined } = require('lodash')
+const { get } = require('lodash')
 
 function renderDocuments (req, res, next) {
   const { id: companyId, name: companyName } = get(res.locals, 'company')
   const archivedDocumentPath = get(res.locals, 'company.archived_documents_url_path')
-
-  if (isUndefined(archivedDocumentPath)) {
-    return next({ statusCode: 403 })
-  }
 
   return res
     .breadcrumb(companyName, `/companies/${companyId}`)

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -25,7 +25,7 @@ const {
 } = require('./controllers/exports')
 const { renderAccountManagementEditPage } = require('./controllers/account-management')
 
-const { setDefaultQuery, setLocalNav, redirectToFirstNavItem } = require('../middleware')
+const { setDefaultQuery, setLocalNav, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
 const {
   getInteractionCollection,
   getInteractionsRequestBody,
@@ -79,7 +79,7 @@ router
 router.post('/:companyId/archive', archiveCompany)
 router.get('/:companyId/unarchive', unarchiveCompany)
 
-router.use('/:companyId', setLocalNav(LOCAL_NAV))
+router.use('/:companyId', handleRoutePermissions(LOCAL_NAV), setLocalNav(LOCAL_NAV))
 
 router.get('/:companyId', redirectToFirstNavItem)
 router.get('/:companyId/details', renderDetails)

--- a/src/apps/contacts/constants.js
+++ b/src/apps/contacts/constants.js
@@ -1,3 +1,8 @@
+const DEFAULT_COLLECTION_QUERY = {
+  sortby: 'modified_on:desc',
+  archived: false,
+}
+
 const LOCAL_NAV = [
   {
     path: 'details',
@@ -22,11 +27,6 @@ const LOCAL_NAV = [
     ],
   },
 ]
-
-const DEFAULT_COLLECTION_QUERY = {
-  sortby: 'modified_on:desc',
-  archived: false,
-}
 
 module.exports = {
   LOCAL_NAV,

--- a/src/apps/contacts/controllers/documents.js
+++ b/src/apps/contacts/controllers/documents.js
@@ -1,11 +1,7 @@
-const { get, isUndefined } = require('lodash')
+const { get } = require('lodash')
 
 function renderDocuments (req, res, next) {
   const archivedDocumentPath = get(res.locals, 'contact.archived_documents_url_path')
-
-  if (isUndefined(archivedDocumentPath)) {
-    return next({ statusCode: 403 })
-  }
 
   return res
     .breadcrumb('Documents')

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -1,7 +1,8 @@
 const router = require('express').Router()
 
 const { LOCAL_NAV, DEFAULT_COLLECTION_QUERY } = require('./constants')
-const { setLocalNav, setDefaultQuery, redirectToFirstNavItem } = require('../middleware')
+
+const { setLocalNav, setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
 const { getContactsCollection, getRequestBody } = require('./middleware/collection')
 const { getCommon, getDetails } = require('./controllers/details')
 const { renderContactList } = require('./controllers/list')
@@ -27,7 +28,7 @@ router
   .get(editDetails)
   .post(postDetails)
 
-router.use('/:contactId', getCommon, setLocalNav(LOCAL_NAV))
+router.use('/:contactId', handleRoutePermissions(LOCAL_NAV), getCommon, setLocalNav(LOCAL_NAV))
 
 router.get('/:contactId', redirectToFirstNavItem)
 router.get('/:contactId/details', getDetails)

--- a/src/apps/dashboard/controllers.js
+++ b/src/apps/dashboard/controllers.js
@@ -1,7 +1,13 @@
+const { get } = require('lodash')
+
+const { GLOBAL_NAV_ITEMS } = require('../constants')
+
+const { isPermittedRoute } = require('../middleware')
 const { fetchHomepageData } = require('./repos')
 
 async function renderDashboard (req, res, next) {
   try {
+    const userPermissions = get(res, 'locals.user.permissions')
     const {
       contacts,
       interactions,
@@ -12,6 +18,7 @@ async function renderDashboard (req, res, next) {
       .render('dashboard/views/dashboard', {
         contacts,
         interactions,
+        interactionsPermitted: isPermittedRoute('/interactions', GLOBAL_NAV_ITEMS, userPermissions),
       })
   } catch (error) {
     next(error)

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -13,27 +13,30 @@
 
 {% block body_main_content %}
   <div class="grid-row dashboard">
-    <div class="column-half">
-      <div class="dashboard-section">
-        <h2 class="dashboard-section-title">My latest interactions</h2>
-        {% if interactions.length %}
-          <ol class="dashboard-list">
-            {% for interaction in interactions %}
-              <li>
-                {% if interaction.company.name %}
-                  <a href="/companies/{{ interaction.company.id }}">{{ interaction.company.name }}</a>
-                  &ndash;
-                {% endif %}
-                <a href="/interactions/{{ interaction.id }}">{{ interaction.subject }}</a>
-              </li>
-            {% endfor %}
-          </ol>
-        {% else %}
-          <p>No interactions have been added.</p>
-        {% endif %}
-        <p><a href="/interactions">See all interactions</a></p>
+    {% if interactionsPermitted %}
+      <div class="column-half">
+        <div class="dashboard-section">
+          <h2 class="dashboard-section-title">My latest interactions</h2>
+          {% if interactions.length %}
+            <ol class="dashboard-list">
+              {% for interaction in interactions %}
+                <li>
+                  {% if interaction.company.name %}
+                    <a href="/companies/{{ interaction.company.id }}">{{ interaction.company.name }}</a>
+                    &ndash;
+                  {% endif %}
+                  <a href="/interactions/{{ interaction.id }}">{{ interaction.subject }}</a>
+                </li>
+              {% endfor %}
+            </ol>
+          {% else %}
+            <p>No interactions have been added.</p>
+          {% endif %}
+          <p><a href="/interactions">See all interactions</a></p>
+        </div>
       </div>
-    </div>
+    {% endif %}
+
 
     <div class="column-half">
       <div class="dashboard-section">

--- a/src/apps/events/constants.js
+++ b/src/apps/events/constants.js
@@ -1,0 +1,7 @@
+const DEFAULT_COLLECTION_QUERY = {
+  sortby: 'modified_on:desc',
+}
+
+module.exports = {
+  DEFAULT_COLLECTION_QUERY,
+}

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,15 +1,13 @@
 const router = require('express').Router()
 
-const { setDefaultQuery } = require('../middleware')
-const { GLOBAL_NAV_ITEMS } = require('../constants')
 const { DEFAULT_COLLECTION_QUERY } = require('./constants')
 
+const { setDefaultQuery } = require('../middleware')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderEditPage } = require('./controllers/edit')
 const { postDetails, getEventDetails } = require('./middleware/details')
 const { getRequestBody, getEventsCollection } = require('./middleware/collection')
 const { renderEventList } = require('./controllers/list')
-
 
 router.param('id', getEventDetails)
 

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,15 +1,15 @@
 const router = require('express').Router()
 
 const { setDefaultQuery } = require('../middleware')
+const { GLOBAL_NAV_ITEMS } = require('../constants')
+const { DEFAULT_COLLECTION_QUERY } = require('./constants')
+
 const { renderDetailsPage } = require('./controllers/details')
 const { renderEditPage } = require('./controllers/edit')
 const { postDetails, getEventDetails } = require('./middleware/details')
 const { getRequestBody, getEventsCollection } = require('./middleware/collection')
 const { renderEventList } = require('./controllers/list')
 
-const DEFAULT_COLLECTION_QUERY = {
-  sortby: 'modified_on:desc',
-}
 
 router.param('id', getEventDetails)
 

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -1,0 +1,7 @@
+const DEFAULT_COLLECTION_QUERY = {
+  sortby: 'date:desc',
+}
+
+module.exports = {
+  DEFAULT_COLLECTION_QUERY,
+}

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -1,6 +1,5 @@
 const router = require('express').Router()
 
-const { GLOBAL_NAV_ITEMS } = require('../constants')
 const { DEFAULT_COLLECTION_QUERY } = require('./constants')
 
 const { renderEditPage } = require('./controllers/edit')
@@ -15,7 +14,6 @@ const {
 } = require('./middleware/collection')
 
 const { postDetails, getInteractionOptions, getInteractionDetails } = require('./middleware/details')
-
 
 router.param('interactionId', getInteractionDetails)
 

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -1,5 +1,8 @@
 const router = require('express').Router()
 
+const { GLOBAL_NAV_ITEMS } = require('../constants')
+const { DEFAULT_COLLECTION_QUERY } = require('./constants')
+
 const { renderEditPage } = require('./controllers/edit')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderInteractionList } = require('./controllers/list')
@@ -13,9 +16,6 @@ const {
 
 const { postDetails, getInteractionOptions, getInteractionDetails } = require('./middleware/details')
 
-const DEFAULT_COLLECTION_QUERY = {
-  sortby: 'date:desc',
-}
 
 router.param('interactionId', getInteractionDetails)
 

--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -1,0 +1,21 @@
+const currentYear = (new Date()).getFullYear()
+
+const LOCAL_NAV = [
+  { path: 'details', label: 'Project details' },
+  { path: 'team', label: 'Project team' },
+  { path: 'interactions', label: 'Interactions' },
+  { path: 'evaluation', label: 'Evaluations' },
+  { path: 'audit', label: 'Audit history' },
+  { path: 'documents', label: 'Documents' },
+]
+
+const DEFAULT_COLLECTION_QUERY = {
+  estimated_land_date_after: `${currentYear}-04-05`,
+  estimated_land_date_before: `${currentYear + 1}-04-06`,
+  sortby: 'estimated_land_date:asc',
+}
+
+module.exports = {
+  LOCAL_NAV,
+  DEFAULT_COLLECTION_QUERY,
+}

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,9 +1,8 @@
 const router = require('express').Router()
 
-const { setLocalNav, setDefaultQuery, redirectToFirstNavItem } = require('../middleware')
-const { GLOBAL_NAV_ITEMS } = require('../constants')
 const { DEFAULT_COLLECTION_QUERY, LOCAL_NAV } = require('./constants')
 
+const { setLocalNav, setDefaultQuery, redirectToFirstNavItem } = require('../middleware')
 const { shared } = require('./middleware')
 const {
   getBriefInvestmentSummary,
@@ -59,6 +58,7 @@ const {
 
 const interactionsRouter = require('../interactions/router.sub-app')
 
+router.use('/:investmentId', setLocalNav(LOCAL_NAV))
 
 router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,6 +1,9 @@
 const router = require('express').Router()
 
 const { setLocalNav, setDefaultQuery, redirectToFirstNavItem } = require('../middleware')
+const { GLOBAL_NAV_ITEMS } = require('../constants')
+const { DEFAULT_COLLECTION_QUERY, LOCAL_NAV } = require('./constants')
+
 const { shared } = require('./middleware')
 const {
   getBriefInvestmentSummary,
@@ -56,23 +59,6 @@ const {
 
 const interactionsRouter = require('../interactions/router.sub-app')
 
-const LOCAL_NAV = [
-  { path: 'details', label: 'Project details' },
-  { path: 'team', label: 'Project team' },
-  { path: 'interactions', label: 'Interactions' },
-  { path: 'evaluation', label: 'Evaluations' },
-  { path: 'audit', label: 'Audit history' },
-  { path: 'documents', label: 'Documents' },
-]
-
-const currentYear = (new Date()).getFullYear()
-const DEFAULT_COLLECTION_QUERY = {
-  estimated_land_date_after: `${currentYear}-04-05`,
-  estimated_land_date_before: `${currentYear + 1}-04-06`,
-  sortby: 'estimated_land_date:asc',
-}
-
-router.use('/:investmentId', setLocalNav(LOCAL_NAV))
 
 router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -1,7 +1,10 @@
 const router = require('express').Router()
 
+const { GLOBAL_NAV_ITEMS } = require('../constants')
+
 const { setHomeBreadcrumb, removeBreadcrumb } = require('../middleware')
 const { setOrder, setOrderBreadcrumb } = require('./middleware')
+
 const viewApp = require('./apps/view')
 const editApp = require('./apps/edit')
 const createApp = require('./apps/create')

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -1,7 +1,5 @@
 const router = require('express').Router()
 
-const { GLOBAL_NAV_ITEMS } = require('../constants')
-
 const { setHomeBreadcrumb, removeBreadcrumb } = require('../middleware')
 const { setOrder, setOrderBreadcrumb } = require('./middleware')
 

--- a/src/apps/search/router.js
+++ b/src/apps/search/router.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
 const queryString = require('query-string')
 
+const { ENTITIES } = require('./constants')
 const { renderSearchResults } = require('./controllers')
 
 function redirectToCompaniesSearch (req, res) {

--- a/src/apps/search/router.js
+++ b/src/apps/search/router.js
@@ -2,11 +2,14 @@ const router = require('express').Router()
 const queryString = require('query-string')
 
 const { ENTITIES } = require('./constants')
+const { handleRoutePermissions } = require('../middleware')
 const { renderSearchResults } = require('./controllers')
 
 function redirectToCompaniesSearch (req, res) {
   res.redirect(`/search/companies?${queryString.stringify(req.query)}`)
 }
+
+router.use(handleRoutePermissions(ENTITIES))
 
 router.get('/', redirectToCompaniesSearch)
 router.get('/:searchPath?', renderSearchResults)

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ const favicon = require('serve-favicon')
 const cookieParser = require('cookie-parser')
 const i18n = require('i18n-future').middleware()
 
+const { GLOBAL_NAV_ITEMS } = require('./apps/constants')
 const title = require('./middleware/title')
 const breadcrumbs = require('./middleware/breadcrumbs')
 const nunjucks = require('../config/nunjucks')
@@ -28,6 +29,7 @@ const errors = require('./middleware/errors')
 const sessionStore = require('./middleware/session-store')
 const ssoBypass = require('./middleware/sso-bypass')
 const logger = require('../config/logger')
+const { handleRoutePermissions } = require('./apps/middleware')
 
 const routers = require('./apps/routers')
 
@@ -95,6 +97,7 @@ app.use(csrfToken())
 
 // routing
 app.use(slashify())
+app.use(handleRoutePermissions(GLOBAL_NAV_ITEMS))
 app.use(routers)
 
 // Raven error handler must come before other error middleware

--- a/test/unit/apps/companies/controllers/documents.test.js
+++ b/test/unit/apps/companies/controllers/documents.test.js
@@ -23,20 +23,6 @@ describe('Companies documents controller', () => {
   })
 
   describe('#renderDocuments', () => {
-    context('when documents path is undefined', () => {
-      beforeEach(() => {
-        renderDocuments(this.reqMock, this.resMock, this.nextSpy)
-      })
-
-      it('should call next', () => {
-        expect(this.nextSpy).to.be.calledOnce
-      })
-
-      it('should pass 403 object to next', () => {
-        expect(this.nextSpy).to.be.calledWith({ statusCode: 403 })
-      })
-    })
-
     context('when documents path is an empty string', () => {
       beforeEach(() => {
         set(this.resMock, 'locals.company.archived_documents_url_path', '')

--- a/test/unit/apps/contacts/controllers/documents.test.js
+++ b/test/unit/apps/contacts/controllers/documents.test.js
@@ -14,20 +14,6 @@ describe('Contacts documents controller', () => {
   })
 
   describe('#renderDocuments', () => {
-    context('when documents path is undefined', () => {
-      beforeEach(() => {
-        renderDocuments(this.reqMock, this.resMock, this.nextSpy)
-      })
-
-      it('should call next', () => {
-        expect(this.nextSpy).to.be.calledOnce
-      })
-
-      it('should pass 403 object to next', () => {
-        expect(this.nextSpy).to.be.calledWith({ statusCode: 403 })
-      })
-    })
-
     context('when documents path is an empty string', () => {
       beforeEach(() => {
         set(this.resMock, 'locals.contact.archived_documents_url_path', '')


### PR DESCRIPTION
Follow up pr to https://github.com/uktrade/data-hub-frontend/pull/1079

This work:

- Will render a `403` at the routing level, rather than hitting the API for a `403`. Uses previous permissions in the frontend application
- Only shows `Interactions` on the dashboard if user has correct permissions
- Renders a `403` if user tries to go to search url without correct permissions, rather than empty results
- Moves the documents permissions to routes


## LEP
#### Dashboard
![lep-dashboard](https://user-images.githubusercontent.com/2305016/34384437-1c0c4162-eb14-11e7-8ff7-0b55855af238.png)

#### Events search
![screen shot 2017-12-27 at 14 39 38](https://user-images.githubusercontent.com/2305016/34384465-3ceebad6-eb14-11e7-9feb-3de8cee3f203.png)

## DA
#### Dashboard
![da-dashboard](https://user-images.githubusercontent.com/2305016/34384481-4a8749c4-eb14-11e7-9ab5-f3b25669d18b.png)

#### Events search
![da-events-search](https://user-images.githubusercontent.com/2305016/34384490-52dc5d62-eb14-11e7-94b4-e3b0df348808.png)

## DIT staff
#### Dashboard
![dit_user-dashboard](https://user-images.githubusercontent.com/2305016/34384499-602fbfb8-eb14-11e7-803d-b655fbf99e01.png)

#### Events search
![screen shot 2017-12-27 at 14 44 35](https://user-images.githubusercontent.com/2305016/34384520-7fb6b60c-eb14-11e7-88a8-f159e4783772.png)



