### PR TITLE
Add acceptance tests around Investment Project Evaluations (includes bug fix)

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -11,6 +11,8 @@ const {
   isArray,
   isFunction,
   isPlainObject,
+  isBoolean,
+  isInteger,
   isEmpty,
   isNull,
   isString,
@@ -19,6 +21,7 @@ const {
   reject,
   isNil,
   keys,
+  forEach,
   values,
   flatten,
   map,
@@ -107,23 +110,24 @@ const filters = {
   },
 
   collectionDefault: (collection, defaultValue = 'Not found') => {
-    const isEmptyObjOrArray = (value) => {
-      return ((isPlainObject(value) || isArray(value)) && isEmpty(value))
+    const hasPresentableValue = (element) => {
+      return !isEmpty(element) || isBoolean(element) || isInteger(element)
     }
 
     if (isArray(collection)) {
       return collection.slice().map((element) => {
-        return !element || isEmptyObjOrArray(element) ? defaultValue : element
+        return !hasPresentableValue(element) ? defaultValue : element
       })
     }
     if (isPlainObject(collection)) {
-      const obj = Object.assign({}, collection)
+      const obj = assign({}, collection)
 
-      Object.keys(obj).forEach((key) => {
-        if (!obj[key] || isEmptyObjOrArray(obj[key])) {
+      forEach(keys(obj), (key) => {
+        if (!hasPresentableValue(obj[key])) {
           obj[key] = defaultValue
         }
       })
+
       return obj
     }
   },

--- a/test/acceptance/features/details/step_definitions/details.js
+++ b/test/acceptance/features/details/step_definitions/details.js
@@ -4,6 +4,12 @@ const { get, includes } = require('lodash')
 
 const { getDetailsTableRowValue } = require('../../../helpers/selectors')
 
+const formatters = {
+  formatEuropeanOrGlobalHeadquarters (value) {
+    return /^(european|global) headquarters$/i.test(value) ? 'Yes' : 'No'
+  },
+}
+
 function getExpectedValue (row, state) {
   if (includes(row.value, '.') && !includes(row.value, ' ')) {
     const expectedText = get(state, row.value)
@@ -17,6 +23,10 @@ function getExpectedValue (row, state) {
   }
 
   return row.value
+}
+
+function formatExpectedValue (row, expectedValue) {
+  return row.format ? formatters[row.format](expectedValue) : expectedValue
 }
 
 defineSupportCode(({ Then }) => {
@@ -104,12 +114,12 @@ defineSupportCode(({ Then }) => {
 
       const rowValueSelector = getDetailsTableRowValue(row.key)
       const detailsTableRowValueXPathSelector = detailsTableSelector.selector + rowValueSelector.selector
-
       const expectedValue = getExpectedValue(row, this.state)
+      const formattedExpectedValue = formatExpectedValue(row, expectedValue)
       await Details
         .api.useXpath()
         .waitForElementPresent(detailsTableRowValueXPathSelector)
-        .assert.containsText(detailsTableRowValueXPathSelector, expectedValue)
+        .assert.containsText(detailsTableRowValueXPathSelector, formattedExpectedValue)
         .useCss()
     }
   })

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -14,24 +14,35 @@ Feature: Investment projects evaluations details
     Then I see the success message
     When I click the "Add value" link
     And I populate the create investment project value form all Yes
-      | key                        | value  |
-      | Number of new jobs         | 100    |
-      | Number of safeguarded jobs | 200    |
-      | Total investment           | 100000 |
-      | Foreign equity investment  | 200000 |
+      | key                               | value                                          |
+      | Number of new jobs                | 100                                            |
+      | Number of safeguarded jobs        | 200                                            |
+      | Total investment                  | 100000                                         |
+      | Foreign equity investment         | 200000                                         |
     Then I see the success message
     When I click the Evaluations local nav link
-    Then the FDI (Test A) details are displayed
-      | key                               | value                |
-      | Type of investment                | Does not apply       |
-      | Foreign investor                  | Lambda plc           |
-      | Foreign country                   | France               |
-      | UK company                        | Not Known            |
-      | Foreign equity investment         | £200,000             |
-      | Investor retains 10% voting power | No                   |
-      | New jobs                          | 100 new jobs         |
-      | Safeguarded jobs                  | 200 safeguarded jobs |
-
+    Then the Project value (Test D) details are displayed
+      | key                               | value                                          | format                             |
+      | Primary sector                    | investmentProject.primarySector                |                                    |
+      | Total investment                  | £100,000                                       |                                    |
+      | New jobs                          | 100 new jobs                                   |                                    |
+      | Average salary of new jobs        | investmentProject.value.averageSalary          |                                    |
+      | R&D budget                        | Has R&D budget                                 |                                    |
+      | Non-FDI R&D project               | Not Known                                      |                                    |
+      | New-to-world tech                 | Has new-to-world tech, business model or IP    |                                    |
+      | Account tier                      | Not Known                                      |                                    |
+      | New GHQ/EHQ                       | investmentProject.businessActivity             | formatEuropeanOrGlobalHeadquarters |
+      | Export revenue                    | Yes, will create significant export revenue    |                                    |
+    And the FDI (Test A) details are displayed
+      | key                               | value                                          |
+      | Type of investment                | Does not apply                                 |
+      | Foreign investor                  | Lambda plc                                     |
+      | Foreign country                   | France                                         |
+      | UK company                        | Not Known                                      |
+      | Foreign equity investment         | £200,000                                       |
+      | Investor retains 10% voting power | No                                             |
+      | New jobs                          | 100 new jobs                                   |
+      | Safeguarded jobs                  | 200 safeguarded jobs                           |
 
   @investment-projects-evaluations-details--value-no
   Scenario: View investment project evaluations after user selects all no for value details
@@ -46,18 +57,30 @@ Feature: Investment projects evaluations details
     Then I see the success message
     When I click the "Add value" link
     And I populate the create investment project value form all No
-      | key                        | value  |
-      | Number of new jobs         | 0      |
-      | Number of safeguarded jobs | 0      |
+      | key                               | value                                          |
+      | Number of new jobs                | 0                                              |
+      | Number of safeguarded jobs        | 0                                              |
     Then I see the success message
     When I click the Evaluations local nav link
-    Then the FDI (Test A) details are displayed
-      | key                               | value                                  |
-      | Type of investment                | Does not apply                         |
-      | Foreign investor                  | Lambda plc                             |
-      | Foreign country                   | France                                 |
-      | UK company                        | Not Known                              |
-      | Foreign equity investment         | Client cannot provide this information |
-      | Investor retains 10% voting power | No                                     |
-      | New jobs                          | 0                                      |
-      | Safeguarded jobs                  | 0                                      |
+    Then the Project value (Test D) details are displayed
+      | key                               | value                                          | format                             |
+      | Primary sector                    | investmentProject.primarySector                |                                    |
+      | Total investment                  | Client cannot provide this information         |                                    |
+      | New jobs                          | 0                                              |                                    |
+      | Average salary of new jobs        | investmentProject.value.averageSalary          |                                    |
+      | R&D budget                        | No R&D budget                                  |                                    |
+      | Non-FDI R&D project               | Not Known                                      |                                    |
+      | New-to-world tech                 | No new-to-world tech, business model or IP     |                                    |
+      | Account tier                      | Not Known                                      |                                    |
+      | New GHQ/EHQ                       | investmentProject.businessActivity             | formatEuropeanOrGlobalHeadquarters |
+      | Export revenue                    | No, will not create significant export revenue |                                    |
+    And the FDI (Test A) details are displayed
+      | key                               | value                                          |
+      | Type of investment                | Does not apply                                 |
+      | Foreign investor                  | Lambda plc                                     |
+      | Foreign country                   | France                                         |
+      | UK company                        | Not Known                                      |
+      | Foreign equity investment         | Client cannot provide this information         |
+      | Investor retains 10% voting power | No                                             |
+      | New jobs                          | 0                                              |
+      | Safeguarded jobs                  | 0                                              |

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -13,12 +13,19 @@ Feature: Investment projects evaluations details
     And I populate the create Investment Project form
     Then I see the success message
     When I click the "Add value" link
-    And I populate the create investment project value form all Yes
+    And I populate the create investment project value form
       | key                               | value                                          |
-      | Number of new jobs                | 100                                            |
-      | Number of safeguarded jobs        | 200                                            |
+      | Total investment radio            | Yes                                            |
       | Total investment                  | 100000                                         |
+      | Foreign equity investment radio   | Yes                                            |
       | Foreign equity investment         | 200000                                         |
+      | New jobs                          | 100                                            |
+      | Safeguarded jobs                  | 200                                            |
+      | Government assistance radio       | Yes                                            |
+      | R&D budget radio                  | Yes                                            |
+      | Non-FDI R&D project radio         | Yes                                            |
+      | New-to-world tech radio           | Yes                                            |
+      | Export revenue radio              | Yes                                            |
     Then I see the success message
     When I click the Evaluations local nav link
     Then the Project value (Test D) details are displayed
@@ -62,10 +69,17 @@ Feature: Investment projects evaluations details
     And I populate the create Investment Project form
     Then I see the success message
     When I click the "Add value" link
-    And I populate the create investment project value form all No
+    And I populate the create investment project value form
       | key                               | value                                          |
-      | Number of new jobs                | 0                                              |
-      | Number of safeguarded jobs        | 0                                              |
+      | Total investment radio            | No                                             |
+      | Foreign equity investment radio   | No                                             |
+      | New jobs                          | 0                                              |
+      | Safeguarded jobs                  | 0                                              |
+      | Government assistance radio       | No                                             |
+      | R&D budget radio                  | No                                             |
+      | Non-FDI R&D project radio         | No                                             |
+      | New-to-world tech radio           | No                                             |
+      | Export revenue radio              | No                                             |
     Then I see the success message
     When I click the Evaluations local nav link
     Then the Project value (Test D) details are displayed

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -1,0 +1,63 @@
+@investment-projects-evaluations-details
+Feature: Investment projects evaluations details
+
+  @investment-projects-evaluations-details--value-yes
+  Scenario: View investment project evaluations after user selects all yes for value details
+
+    Given I navigate to company fixture Lambda plc
+    When I click the Investment local nav link
+    And I click the "Add investment project" link
+    Then I am taken to the "Add investment project" page
+    When I select FDI as the Investment project type
+    And I choose Yes for "Will this company be the source of foreign equity investment?"
+    And I populate the create Investment Project form
+    Then I see the success message
+    When I click the "Add value" link
+    And I populate the create investment project value form all Yes
+      | key                        | value  |
+      | Number of new jobs         | 100    |
+      | Number of safeguarded jobs | 200    |
+      | Total investment           | 100000 |
+      | Foreign equity investment  | 200000 |
+    Then I see the success message
+    When I click the Evaluations local nav link
+    Then the FDI (Test A) details are displayed
+      | key                               | value                |
+      | Type of investment                | Does not apply       |
+      | Foreign investor                  | Lambda plc           |
+      | Foreign country                   | France               |
+      | UK company                        | Not Known            |
+      | Foreign equity investment         | £200,000             |
+      | Investor retains 10% voting power | No                   |
+      | New jobs                          | 100 new jobs         |
+      | Safeguarded jobs                  | 200 safeguarded jobs |
+
+
+  @investment-projects-evaluations-details--value-no
+  Scenario: View investment project evaluations after user selects all no for value details
+
+    Given I navigate to company fixture Lambda plc
+    When I click the Investment local nav link
+    And I click the "Add investment project" link
+    Then I am taken to the "Add investment project" page
+    When I select FDI as the Investment project type
+    And I choose Yes for "Will this company be the source of foreign equity investment?"
+    And I populate the create Investment Project form
+    Then I see the success message
+    When I click the "Add value" link
+    And I populate the create investment project value form all No
+      | key                        | value  |
+      | Number of new jobs         | 0      |
+      | Number of safeguarded jobs | 0      |
+    Then I see the success message
+    When I click the Evaluations local nav link
+    Then the FDI (Test A) details are displayed
+      | key                               | value                                  |
+      | Type of investment                | Does not apply                         |
+      | Foreign investor                  | Lambda plc                             |
+      | Foreign country                   | France                                 |
+      | UK company                        | Not Known                              |
+      | Foreign equity investment         | Client cannot provide this information |
+      | Investor retains 10% voting power | No                                     |
+      | New jobs                          | 0                                      |
+      | Safeguarded jobs                  | 0                                      |

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -43,6 +43,12 @@ Feature: Investment projects evaluations details
       | Investor retains 10% voting power | No                                             |
       | New jobs                          | 100 new jobs                                   |
       | Safeguarded jobs                  | 200 safeguarded jobs                           |
+    And the Project Landing (Test C) details are displayed
+      | key                               | value                                          |
+      | UK company                        | Not Known                                      |
+      | Companies House Number            | Not Known                                      |
+      | Registered Address                | Not Known                                      |
+      | Land date                         | Not Known                                      |
 
   @investment-projects-evaluations-details--value-no
   Scenario: View investment project evaluations after user selects all no for value details
@@ -84,3 +90,9 @@ Feature: Investment projects evaluations details
       | Investor retains 10% voting power | No                                             |
       | New jobs                          | 0                                              |
       | Safeguarded jobs                  | 0                                              |
+    And the Project Landing (Test C) details are displayed
+      | key                               | value                                          |
+      | UK company                        | Not Known                                      |
+      | Companies House Number            | Not Known                                      |
+      | Registered Address                | Not Known                                      |
+      | Land date                         | Not Known                                      |

--- a/test/acceptance/features/investment-projects/step_definitions/value.js
+++ b/test/acceptance/features/investment-projects/step_definitions/value.js
@@ -12,10 +12,10 @@ const {
 defineSupportCode(({ When }) => {
   const InvestmentValue = client.page.InvestmentValue()
 
-  When(/^I populate the create investment project value form all (Yes|No)$/, async function (answer, dataTable) {
+  When(/^I populate the create investment project value form$/, async function (dataTable) {
     const details = fromPairs(map(dataTable.hashes(), hash => [camelCase(hash.key), hash.value]))
     await InvestmentValue
-      .add(details, answer, (value) => {
+      .add(details, (value) => {
         const investmentProject = get(this.state, 'investmentProject')
         set(this.state, 'investmentProject', assign({}, investmentProject, { value }))
       })

--- a/test/acceptance/features/investment-projects/value-add.feature
+++ b/test/acceptance/features/investment-projects/value-add.feature
@@ -7,12 +7,19 @@ Feature: Add value to investment project
     Given I navigate to investment project fixture New hotel (commitment to invest)
     When I click the "Add value" link
     Then I am taken to the "New hotel (commitment to invest)" page
-    When I populate the create investment project value form all Yes
-      | key                        | value  |
-      | Number of new jobs         | 100    |
-      | Number of safeguarded jobs | 200    |
-      | Total investment           | 100000 |
-      | Foreign equity investment  | 200000 |
+    When I populate the create investment project value form
+      | key                               | value                                          |
+      | Total investment radio            | Yes                                            |
+      | Total investment                  | 100000                                         |
+      | Foreign equity investment radio   | Yes                                            |
+      | Foreign equity investment         | 200000                                         |
+      | New jobs                          | 100                                            |
+      | Safeguarded jobs                  | 200                                            |
+      | Government assistance radio       | Yes                                            |
+      | R&D budget radio                  | Yes                                            |
+      | Non-FDI R&D project radio         | Yes                                            |
+      | New-to-world tech radio           | Yes                                            |
+      | Export revenue radio              | Yes                                            |
     Then I see the success message
     And the Value details are displayed
       | key                        | value                                           |
@@ -34,10 +41,17 @@ Feature: Add value to investment project
     Given I navigate to investment project fixture New hotel (commitment to invest)
     When I click the "Edit value" link
     Then I am taken to the "New hotel (commitment to invest)" page
-    When I populate the create investment project value form all No
-      | key                        | value  |
-      | Number of new jobs         | 0      |
-      | Number of safeguarded jobs | 0      |
+    When I populate the create investment project value form
+      | key                               | value                                          |
+      | Total investment radio            | No                                             |
+      | Foreign equity investment radio   | No                                             |
+      | New jobs                          | 0                                              |
+      | Safeguarded jobs                  | 0                                              |
+      | Government assistance radio       | No                                             |
+      | R&D budget radio                  | No                                             |
+      | Non-FDI R&D project radio         | No                                             |
+      | New-to-world tech radio           | No                                             |
+      | Export revenue radio              | No                                             |
     Then I see the success message
     And the Value details are displayed
       | key                        | value                                           |

--- a/test/unit/config/nunjucks/filters.test.js
+++ b/test/unit/config/nunjucks/filters.test.js
@@ -268,6 +268,7 @@ describe('nunjucks filters', () => {
       g: false,
       h: [],
       i: {},
+      j: 0,
     }
     const mockArrayWithEmpties = Object.values(mockObjectWithEmpties)
 
@@ -279,9 +280,10 @@ describe('nunjucks filters', () => {
         d: 'false',
         e: 'value',
         f: expectedDefault,
-        g: expectedDefault,
+        g: false,
         h: expectedDefault,
         i: expectedDefault,
+        j: 0,
       }
 
       if (isArray) {


### PR DESCRIPTION
DH-1279

This will pre-empt some investment project work coming in the next sprint. We currently do not have any coverage around the Evaluations page for investment projects.

A bug has also been fixed as part of this change. The bug is around the display of `New jobs` and `Safeguarded jobs` when the value is `0`.

# Before
![screen shot 2017-12-29 at 11 38 35](https://user-images.githubusercontent.com/1150417/34436347-f37e5936-ec8c-11e7-8fdf-740c3b322e5d.png)

# After
![screen shot 2017-12-29 at 11 37 56](https://user-images.githubusercontent.com/1150417/34436350-fbb35a7a-ec8c-11e7-9c3c-b1f44afb1c25.png)
