### PR TITLE
DH-1398 Enable SSO on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
         image: ukti/docker-data-hub-base
         environment:
           - API_ROOT: http://localhost:8000
+          - MOCK_SSO_ROOT: http://localhost:8080
           - QA_HOST: http://localhost:3000
           - QA_SELENIUM_HOST: 127.0.0.1
           - QA_SELENIUM_PORT: 4444
@@ -99,8 +100,13 @@ jobs:
           - TZ: "/usr/share/zoneinfo/Europe/London"
           - LOG_LEVEL: debug
           - &oauth2_dev_token
-            OAUTH2_DEV_TOKEN: topSecretSquirrel
-            ARCHIVED_DOCUMENTS_BASE_URL: http://example-documents-url.io
+          - OAUTH2_DEV_TOKEN: topSecretSquirrel
+          - OAUTH2_TOKEN_FETCH_URL: http://localhost:8080/o/token
+          - OAUTH2_AUTH_URL: http://localhost:8080/o/authorize
+          - OAUTH2_REDIRECT_URL: http://localhost:3000/oauth/callback
+          - OAUTH2_CLIENT_SECRET: youAintSeenMyRight
+          - OAUTH2_CLIENT_ID: randomClientId
+          - ARCHIVED_DOCUMENTS_BASE_URL: http://example-documents-url.io
       - &docker_redis
         image: redis:3.2.10
       - &docker_elasticsearch
@@ -128,9 +134,15 @@ jobs:
           - ES_INDEX: test_index
           - ES5_URL: http://localhost:9200
           - POSTGRES_URL: tcp://postgres:5432
-          - SSO_ENABLED: 'False'
-          - *qa_user_email
-          - *oauth2_dev_token
+          - SSO_ENABLED: 'True'
+          - RESOURCE_SERVER_INTROSPECTION_URL: http://localhost:8080/o/introspect # required but not used as user has been created in backend
+          - RESOURCE_SERVER_AUTH_TOKEN: sso-token
+          - QA_USER_EMAIL: *qa_user_email
+          - OAUTH2_DEV_TOKEN: *oauth2_dev_token
+      - &mock-sso
+        image: ukti/mock-sso
+        environment:
+          - MOCK_SSO_SCOPE: 'data-hub:internal-front-end'
     parallelism: 6
     working_directory: ~/data-hub-frontend
     steps:
@@ -138,6 +150,9 @@ jobs:
       - run:
           name: Wait for data hub leeloo
           command: dockerize -wait ${API_ROOT}/admin/ -timeout 240s
+      - run:
+          name: Wait for mock sso
+          command: dockerize -wait ${MOCK_SSO_ROOT}/healthcheck -timeout 60s
       - restore_cache:
           name: Restore yarn dependencies cache
           key: yarn-dependency-{{ checksum "package.json" }}
@@ -191,6 +206,7 @@ jobs:
       - *docker_postgres
       - <<: *docker_data_hub_leeloo
         image: ukti/data-hub-leeloo:master
+      - *mock-sso
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 ## TODO discover why the wavy package is causing us problems and why we need to yarn add wavy with a fresh install
+
 version: 2
+aliases:
+  - &qa_user_email        circleci@datahub.com
+  - &oauth2_dev_token     topSecretSquirrel
+
 jobs:
   lockfile:
      docker:
@@ -94,13 +99,11 @@ jobs:
           - QA_HOST: http://localhost:3000
           - QA_SELENIUM_HOST: 127.0.0.1
           - QA_SELENIUM_PORT: 4444
-          - &qa_user_email
-          - QA_USER_EMAIL: circleci@datahub.com
+          - QA_USER_EMAIL: *qa_user_email
           - REDIS_HOST: localhost
           - TZ: "/usr/share/zoneinfo/Europe/London"
           - LOG_LEVEL: debug
-          - &oauth2_dev_token
-          - OAUTH2_DEV_TOKEN: topSecretSquirrel
+          - OAUTH2_DEV_TOKEN: *oauth2_dev_token
           - OAUTH2_TOKEN_FETCH_URL: http://localhost:8080/o/token
           - OAUTH2_AUTH_URL: http://localhost:8080/o/authorize
           - OAUTH2_REDIRECT_URL: http://localhost:3000/oauth/callback

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           path: coverage
   user_acceptance_tests: &user_acceptance_tests
     environment:
-      BASH_ENV: "/usr/local/nvm/nvm.sh"
+      BASH_ENV: "/usr/local/nvm/nvm.sh" # make node, npm and yarn commands available in run command
     docker:
       - &docker_dat_hub_base
         image: ukti/docker-data-hub-base

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Data Hub frontend
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/uktrade/data-hub-frontend.svg)](https://greenkeeper.io/)
-
 [![CircleCI](https://circleci.com/gh/uktrade/data-hub-frontend.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-frontend)
 [![Dependency Status](https://gemnasium.com/badges/github.com/uktrade/data-hub-frontend.svg)](https://gemnasium.com/github.com/uktrade/data-hub-frontend)
 
@@ -25,8 +24,13 @@ and be provided with a back end server to provide the API, data storage and sear
   - [Installation](#installation)
     - [Run in production mode](#run-in-production-mode)
     - [Run in development mode](#run-in-development-mode)
-    - [OAuth](#oauth)
+  - [OAuth](#oauth)
     - [Bypassing OAuth in development mode](#bypassing-oauth-in-development-mode)
+    - [Using SSO when developing](#using-sso-when-developing)
+    - [SSO development providers](#sso-development-providers)
+      - [SSO mock](#sso-mock)
+      - [UAT SSO](#uat-sso)
+      - [Local checkout of staff SSO](#local-checkout-of-staff-sso)
   - [Other Scripts](#other-scripts)
 - [Making changes](#making-changes)
 - [Components](#components)
@@ -42,12 +46,12 @@ and be provided with a back end server to provide the API, data storage and sear
       - [Filenames](#filenames)
       - [Feature tags](#feature-tags)
       - [Scenario tags](#scenario-tags)
-
     - [Ignoring features](#ignoring-features)
 - [Continuous Integration](#continuous-integration)
   - [Running CI jobs](#running-ci-jobs)
   - [Base docker image](#base-docker-image)
   - [Data hub backend docker image](#data-hub-backend-docker-image)
+  - [Mock SSO docker build](#mock-sso-docker-build)
   - [Job failure](#job-failure)
 - [Deployment](#deployment)
 
@@ -78,13 +82,14 @@ This file expects the following environment variables:
 | METADATA_TTL | How long to store dropdown data etc for, in seconds. Defaults to 15 minutes |
 | NODE_ENV | Whether to run the app in dev mode. Set to `production` in production, otherwise don't set for dev behaviour |
 | OMIS_ARCHIVED_DOCUMENTS_BASE_URL | The base URL for the OMIS archived document store. Holds archived quotes and deliverables |
-| OAUTH2_TOKEN_FETCH_URL | OAuth fetch token url
-| OAUTH2_USER_PROFILE_URL | OAuth user profile url
-| OAUTH2_AUTH_URL | OAuth auth url
-| OAUTH2_CLIENT_ID | OAuth client id
-| OAUTH2_CLIENT_SECRET | OAuth client secret
-| OAUTH2_REDIRECT_URL | OAuth callback url
-| OAUTH2_DEV_TOKEN | Token used to bypass OAuth for development purposes
+| OAUTH2_TOKEN_FETCH_URL | OAuth fetch token url |
+| OAUTH2_USER_PROFILE_URL | OAuth user profile url |
+| OAUTH2_AUTH_URL | OAuth auth url |
+| OAUTH2_CLIENT_ID | OAuth client id |
+| OAUTH2_CLIENT_SECRET | OAuth client secret |
+| OAUTH2_REDIRECT_URL | OAuth callback url |
+| OAUTH2_BYPASS_SSO | If a developer wishes to bypass OAuth locally then set this to true - defaults to `false` |
+| OAUTH2_DEV_TOKEN | Token used for working with OAuth locally whilst developing |
 | POSTCODE_KEY | Part of the frontend looks up addresses for postcodes using [getaddress.io](https://getaddress.io/). Obtain a key for the service and set it here |
 | PROJECT_PHASE | Which badge to display in header: 'Alpha', 'Beta' or 'Demo' - defaults to 'Beta' @TODO - remove when Demo site is decommissioned|
 | PROXY | URL of a proxy to use to contact the API through. Useful for debugging |
@@ -178,16 +183,46 @@ or Visual Studio Code.
 yarn run develop
 ```
 
-#### OAuth
+### OAuth
 Data hub uses [uktrade/staff-sso](https://github.com/uktrade/staff-sso) for OAuth. Details of the required environment
-variables needed to setup OAuth can be seen in the env section of this README. For further information about how to 
-setup OAuth please speak to the [#technology-sso](https://ditdigitalteam.slack.com/messages/C5FLP2DSM/details/) team.
+variables needed to setup OAuth can be seen in the [Environment Variables](#environment-variables) section.
+For further information about how to setup OAuth:
+- Look in confluence for details on setting up SSO for developers. Instructions can be found in
+  `Data Hub team > Technical Documentation > Frontend > SSO for developers`.
 
 #### Bypassing OAuth in development mode
-Developers can bypass SSO functionality by providing a valid `OAUTH2_DEV_TOKEN` environment variable. This Access token
-needs to either by from the OAuth provider or from our Backend. Developers can also tests SSO functionality locally by 
-removing the `OAUTH2_DEV_TOKEN` environment variable. To use OAuth locally you will then need to setup SSO. You can do 
-this by speaking with the [#technology-sso](https://ditdigitalteam.slack.com/messages/C5FLP2DSM/details/) team.
+If you wish to completely bypass SSO functionality locally you can by setting the environment variable:
+```
+export OAUTH2_BYPASS_SSO=true
+```
+and providing a valid `OAUTH2_DEV_TOKEN` environment variable. This Access token needs to be valid for the SSO provider
+the application is pointed at.
+
+#### Using SSO when developing
+Developers can also test SSO functionality locally by removing the `OAUTH2_DEV_TOKEN` environment variable and making
+sure that `OAUTH2_BYPASS_SSO` is set to false (it is by default). To use Oauth locally you will then need to set up the 
+correct access and SSO details for the SSO provider you are using.
+
+##### SSO development providers
+
+###### SSO mock
+You could use the [uktrade/mock-sso](https://github.com/uktrade/mock-sso) repo. You will need to set up the following 
+environment variables:
+```
+export OAUTH2_DEV_TOKEN=exampleDevToken
+export OAUTH2_TOKEN_FETCH_URL=http://localhost:8080/o/token
+export OAUTH2_AUTH_URL=http://localhost:8080/o/authorize
+```
+data-hub-frontend will then use mock-sso to simply pass your `OAUTH2_DEV_TOKEN` between SSO and the application.
+
+###### UAT SSO
+You could point data-hub-frontend to the UAT SSO environment. If you wish to please speak to the 
+[#technology-sso](https://ditdigitalteam.slack.com/messages/C5FLP2DSM/details/) team to set up the correct access and 
+SSO details required.
+
+###### Local checkout of staff SSO
+You could checkout [uktrade/staff-sso](https://github.com/uktrade/staff-sso) locally and point data-hub-frontend
+at that.
 
 ### Other Scripts
 
@@ -397,6 +432,14 @@ The `uktrade/data-hub-leeloo` docker image and tags that is used is automaticall
 
 - `user_acceptance_tests` job uses `ukti/data-hub-leeloo:latest`
 - `user_acceptance_tests_master` job uses `ukti/data-hub-leeloo:master`
+
+### Mock SSO docker build
+The acceptance tests `user_acceptance_tests` job on circleCi uses [uktrade/mock-sso](https://github.com/uktrade/mock-sso)
+to run the application through the SSO workflow. The `uktrade/mock-sso` docker image and tag that is used is
+automatically built via a Docker hub automated job. Details can be found [https://hub.docker.com/r/ukti/mock-sso](https://hub.docker.com/r/ukti/mock-ssoo).
+
+- `user_acceptance_tests` job uses `uktrade/mock-sso:latest`
+- `user_acceptance_tests_master` job uses `uktrade/mock-sso:latest`
 
 ### Job failure
 CircleCI has been configured to show you a summary report of what has failed on the following workflows:

--- a/config/index.js
+++ b/config/index.js
@@ -64,6 +64,7 @@ const config = {
     tokenFetchUrl: process.env.OAUTH2_TOKEN_FETCH_URL,
     logoutUrl: process.env.OAUTH2_LOGOUT_URL,
     devToken: process.env.OAUTH2_DEV_TOKEN,
+    bypassSSO: process.env.OAUTH2_BYPASS_SSO || false,
   },
 }
 

--- a/config/index.js
+++ b/config/index.js
@@ -62,8 +62,8 @@ const config = {
     clientSecret: process.env.OAUTH2_CLIENT_SECRET,
     redirectUri: process.env.OAUTH2_REDIRECT_URL,
     tokenFetchUrl: process.env.OAUTH2_TOKEN_FETCH_URL,
-    token: process.env.OAUTH2_DEV_TOKEN,
     logoutUrl: process.env.OAUTH2_LOGOUT_URL,
+    devToken: process.env.OAUTH2_DEV_TOKEN,
   },
 }
 

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -23,6 +23,7 @@ module.exports = function transformCompanyToListItem ({
   registered_address_1,
   registered_address_2,
   companies_house_data,
+  modified_on,
 } = {}) {
   if (!id) { return }
 
@@ -64,6 +65,12 @@ module.exports = function transformCompanyToListItem ({
       value: get(trading_address_country, 'name') || get(registered_address_country, 'name'),
     })
   }
+
+  meta.push({
+    label: 'Updated',
+    type: 'datetime',
+    value: modified_on,
+  })
 
   if (uk_based) {
     meta.push({

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -65,6 +65,15 @@ function redirectOAuth (req, res) {
 
   // @TODO remove this once we've diagnosed the cause of the mismatches
   logger.error(`Host redirected from: ${req.hostname}`)
+  // As you are here you have not byPassed SSO and if the oAuthDevToken is present then pass it to the code parameter
+  // that is sent to the SSO provider. When using the mock-sso app, the oAuthDevToken is simply passed through the
+  // SSO journey
+  const oAuthDevToken = get(config, 'oauth.devToken')
+
+  if (oAuthDevToken) {
+    set(url, 'code', oAuthDevToken)
+  }
+
 
   set(req.session, 'oauth.state', stateId) // used to check the callback received contains matching state param
   return res.redirect(`${config.oauth.url}?${queryString.stringify(url)}`)

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -55,7 +55,7 @@ async function callbackOAuth (req, res, next) {
 
 function redirectOAuth (req, res) {
   const stateId = uuid()
-  const url = {
+  const urlParams = {
     response_type: 'code',
     client_id: config.oauth.clientId,
     redirect_uri: config.oauth.redirectUri,
@@ -71,11 +71,11 @@ function redirectOAuth (req, res) {
   const oAuthDevToken = get(config, 'oauth.devToken')
 
   if (oAuthDevToken) {
-    set(url, 'code', oAuthDevToken)
+    set(urlParams, 'code', oAuthDevToken)
   }
 
   set(req.session, 'oauth.state', stateId) // used to check the callback received contains matching state param
-  return res.redirect(`${config.oauth.url}?${queryString.stringify(url)}`)
+  return res.redirect(`${config.oauth.url}?${queryString.stringify(urlParams)}`)
 }
 
 function renderHelpPage (req, res, next) {

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -5,8 +5,7 @@ const uuid = require('uuid')
 const { get, set } = require('lodash')
 
 const config = require('./../../../config')
-// @TODO remove this once we've diagnosed the cause of the mismatches
-const logger = require('./../../../config/logger')
+const logger = require('./../../../config/logger') // @TODO remove this once we've diagnosed the cause of the mismatches
 
 function getAccessToken (oauthCode) {
   const options = {
@@ -41,6 +40,7 @@ async function callbackOAuth (req, res, next) {
     logger.error(`stateQueryParam: ${stateQueryParam}`)
     logger.error(`Host: ${req.hostname}`)
     logger.error(`Original URL: ${req.originalUrl}`)
+    // END @TODO
     return next(Error('There has been an OAuth stateId mismatch sessionOAuthState'))
   }
 
@@ -63,8 +63,8 @@ function redirectOAuth (req, res) {
     idp: 'cirrus',
   }
 
-  // @TODO remove this once we've diagnosed the cause of the mismatches
-  logger.error(`Host redirected from: ${req.hostname}`)
+  logger.error(`Host redirected from: ${req.hostname}`) // @TODO remove this once we've diagnosed the cause of the mismatches
+
   // As you are here you have not byPassed SSO and if the oAuthDevToken is present then pass it to the code parameter
   // that is sent to the SSO provider. When using the mock-sso app, the oAuthDevToken is simply passed through the
   // SSO journey
@@ -73,7 +73,6 @@ function redirectOAuth (req, res) {
   if (oAuthDevToken) {
     set(url, 'code', oAuthDevToken)
   }
-
 
   set(req.session, 'oauth.state', stateId) // used to check the callback received contains matching state param
   return res.redirect(`${config.oauth.url}?${queryString.stringify(url)}`)

--- a/src/middleware/sso-bypass.js
+++ b/src/middleware/sso-bypass.js
@@ -2,17 +2,18 @@ const { get } = require('lodash')
 const config = require('../../config')
 
 /**
- * If a development bearer token has been provided then assign that to req.session.token
- * so SSO functionality can be bypassed for developers.
+ * If a developer wishes to bypass SSO via config and has also provided a development bearer token, then assign
+ * that to token to req.session.token. Allowing SSO functionality to be bypassed.
  * @returns {Function}
  */
 
 const ssoBypass = () => {
   return function (req, res, next) {
-    const token = get(config, 'oauth.token')
+    const bypassSSO = get(config, 'oauth.bypassSSO')
+    const oAuthDevToken = get(config, 'oauth.devToken')
 
-    if (token) {
-      req.session.token = token
+    if (bypassSSO) {
+      req.session.token = oAuthDevToken
     }
     next()
   }

--- a/test/acceptance/features/collection/page-objects/Collection.js
+++ b/test/acceptance/features/collection/page-objects/Collection.js
@@ -1,6 +1,10 @@
 const { lowerCase } = require('lodash')
 
-const { getSelectorForElementWithText, getButtonWithText } = require('../../../helpers/selectors')
+const {
+  getSelectorForElementWithText,
+  getButtonWithText,
+  getListItemMetaElementWithText,
+} = require('../../../helpers/selectors')
 
 const getSelectorForMetaListItemValue = (text) => {
   return getSelectorForElementWithText(text, {
@@ -24,14 +28,7 @@ module.exports = {
       },
       getSelectorForMetaListItemValue,
       getSelectorForBadgeWithText (text) {
-        return getSelectorForElementWithText(
-          text,
-          {
-            el: '//article[contains(@class, "c-collection")]//ol[contains(@class,"c-entity-list")]/li[1]//span',
-            className: 'c-meta-list__item-label',
-            child: '/following-sibling::span',
-          },
-        )
+        return getListItemMetaElementWithText(text)
       },
       getButtonSelectorWithText (text) {
         return getButtonWithText(text)

--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -57,8 +57,9 @@ Feature: View collection of companies
     Then I see the success message
     When I navigate to the Companies collection page
     And the companies are sorted by Recently updated
+    Then the companies should be sorted by Recently updated
     And the companies are sorted by Least recently updated
-    Then the companies should have been correctly sorted by updated date
+    Then the companies should be sorted by Least recently updated
     When the companies are sorted by Company name: A-Z
     And the companies are sorted by Company name: Z-A
     Then the companies should have been correctly sorted for text fields

--- a/test/acceptance/features/companies/page-objects/CompanyList.js
+++ b/test/acceptance/features/companies/page-objects/CompanyList.js
@@ -1,7 +1,7 @@
 const {
   getSelectorForElementWithText,
   getButtonWithText,
-  getMetaListItemValueSelector,
+  getListItemMetaElementWithText,
 } = require('../../../helpers/selectors')
 
 const getBadgeWithText = (text) => getSelectorForElementWithText(
@@ -12,6 +12,8 @@ const getBadgeWithText = (text) => getSelectorForElementWithText(
     child: '/following-sibling::span',
   },
 )
+const getFirstListItemMetaElementWithText = (text) => getListItemMetaElementWithText(text)
+const getSecondListItemMetaElementWithText = (text) => getListItemMetaElementWithText(text, 2)
 
 module.exports = {
   url: `${process.env.QA_HOST}/companies`,
@@ -27,7 +29,20 @@ module.exports = {
         header: {
           selector: '.c-entity__header a',
         },
-        companySector: getMetaListItemValueSelector('Sector'),
+        companySector: getFirstListItemMetaElementWithText('Sector'),
+        updated: getFirstListItemMetaElementWithText('Updated'),
+        countryBadge: getBadgeWithText('Country'),
+        ukRegionBadge: getBadgeWithText('UK region'),
+      },
+    },
+    secondCompanyInList: {
+      selector: '.c-entity-list li:nth-child(2)',
+      elements: {
+        header: {
+          selector: '.c-entity__header a',
+        },
+        companySector: getSecondListItemMetaElementWithText('Sector'),
+        updated: getSecondListItemMetaElementWithText('Updated'),
         countryBadge: getBadgeWithText('Country'),
         ukRegionBadge: getBadgeWithText('UK region'),
       },

--- a/test/acceptance/features/companies/step_definitions/collection.js
+++ b/test/acceptance/features/companies/step_definitions/collection.js
@@ -51,6 +51,7 @@ defineSupportCode(({ Given, Then, When }) => {
 
     await CompanyList
       .section.firstCompanyInList
+      .waitForElementPresent('@header')
       .getText('@header', (result) => {
         set(this.state, 'collection.firstItem.field', result.value)
       })
@@ -65,6 +66,7 @@ defineSupportCode(({ Given, Then, When }) => {
 
     await CompanyList
       .section.firstCompanyInList
+      .waitForElementPresent('@header')
       .getText('@header', (result) => {
         set(this.state, 'collection.lastItem.field', result.value)
       })

--- a/test/acceptance/features/companies/step_definitions/collection.js
+++ b/test/acceptance/features/companies/step_definitions/collection.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 const { get, set } = require('lodash')
@@ -105,14 +106,36 @@ defineSupportCode(({ Given, Then, When }) => {
       .assert.containsText('@ukRegionBadge', expectedBadgeText)
   })
 
-  Then(/^the companies should have been correctly sorted by updated date$/, async function () {
-    const firstItemField = get(this.state, 'collection.firstItem.field')
-    const lastItemField = get(this.state, 'collection.lastItem.field')
-    const expectedFirstItemField = get(this.state, 'company.heading')
-    const expectedLastItemField = this.fixtures.company.foreign.name
+  Then(/^the companies should be sorted by (Least recently|Recently) updated$/, async function (sortType) {
+    const updateValues = {
+      firstItem: null,
+      secondItem: null,
+    }
+    const formatDateString = (string) => {
+      return moment(string, 'DD MMM YYYY, h:mma')
+    }
 
-    client.expect(firstItemField).to.equal(expectedFirstItemField)
-    client.expect(lastItemField).to.equal(expectedLastItemField)
+    await CompanyList
+      .section.firstCompanyInList
+      .waitForElementPresent('@header')
+      .getText('@updated', (text) => {
+        set(updateValues, 'firstItem', formatDateString(text.value))
+      })
+
+    await CompanyList
+      .section.secondCompanyInList
+      .waitForElementPresent('@header')
+      .getText('@updated', (text) => {
+        set(updateValues, 'secondItem', formatDateString(text.value))
+      })
+
+    if (sortType === 'Recently') {
+      client.expect(updateValues.firstItem.isAfter(updateValues.secondItem)).to.be.true
+    }
+
+    if (sortType === 'Least recently') {
+      client.expect(updateValues.firstItem.isBefore(updateValues.secondItem)).to.be.true
+    }
   })
 
   Then(/^the companies should have been correctly sorted for text fields$/, async function () {

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -56,6 +56,20 @@ function getMetaListItemValueSelector (text) {
 }
 
 /**
+ * Gets XPath selector for getting a meta list item from a specific item in a collection item
+ * @param text
+ * @param [listItem=1]
+ */
+const getListItemMetaElementWithText = (text, listItem = 1) => getSelectorForElementWithText(
+  text,
+  {
+    el: `//article[contains(@class, "c-collection")]//ol[contains(@class,"c-entity-list")]/li[${listItem}]//span`,
+    className: 'c-meta-list__item-label',
+    child: '/following-sibling::span',
+  }
+)
+
+/**
  * Gets XPath selector for an anchor tag containing text
  * @param text
  * @param className
@@ -77,4 +91,5 @@ module.exports = {
   getDetailsTableRowValue,
   getMetaListItemValueSelector,
   getLinkWithText,
+  getListItemMetaElementWithText,
 }

--- a/test/unit/middleware/ssoBypass.test.js
+++ b/test/unit/middleware/ssoBypass.test.js
@@ -12,23 +12,61 @@ describe('SSO bypass middleware', () => {
     this.nextSpy = sandbox.spy()
   })
 
-  describe('without oauth bypass token', () => {
-    it('should call the next middleware without setting the session token', () => {
-      this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
+  context('Oauth bypass token set to false', () => {
+    beforeEach(() => {
+      set(this.mockConfig, 'oauth.bypassSSO', false)
+    })
 
-      expect(this.nextSpy.calledOnce).to.be.true
-      expect(this.reqMock.session).to.be.an('object').and.empty
+    context('and without a developer token set', () => {
+      beforeEach(() => {
+        this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
+      })
+
+      it('should call the next middleware', () => {
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
+
+      it('should not set the session token', () => {
+        expect(this.reqMock.session).to.be.an('object').and.empty
+      })
+    })
+
+    context('and with a developer token set', () => {
+      beforeEach(() => {
+        this.mockDevToken = 'mockDevToken'
+        set(this.mockConfig, 'oauth.devToken', this.mockDevToken)
+        this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
+      })
+
+      it('should call the next middleware', () => {
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
+
+      it('should not set the session token', () => {
+        expect(this.reqMock.session).to.be.an('object').and.empty
+      })
     })
   })
 
-  describe('with oauth bypass token', () => {
-    it('should set the session token', () => {
-      const mockToken = 'mockToken'
-      set(this.mockConfig, 'oauth.token', 'mockToken')
-      this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
+  context('Oauth bypass token set to true', () => {
+    beforeEach(() => {
+      set(this.mockConfig, 'oauth.bypassSSO', true)
+    })
 
-      expect(this.nextSpy.calledOnce).to.be.true
-      expect(this.reqMock.session.token).to.equal(mockToken)
+    context('and with a developer token set', () => {
+      beforeEach(() => {
+        this.mockDevToken = 'mockDevToken'
+        set(this.mockConfig, 'oauth.devToken', this.mockDevToken)
+        this.ssoBypassMiddleware()(this.reqMock, {}, this.nextSpy)
+      })
+
+      it('should call the next middleware', () => {
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
+
+      it('should set the session token', () => {
+        expect(this.reqMock.session.token).to.equal(this.mockDevToken)
+      })
     })
   })
 })


### PR DESCRIPTION
**TL;DR** This work enables `SSO` on CircleCi. 

This is part 1 of an amount of [Yak shaving](https://en.wiktionary.org/wiki/yak_shaving) required to test different user permissions in Acceptance tests.

I have created [uktrade/mock-sso](https://github.com/uktrade/mock-sso) nodeJs app. This app is built into a docker container via its [automated build](https://hub.docker.com/r/ukti/mock-sso/). This docker is then used in our [Acceptance tests](https://circleci.com/gh/uktrade/data-hub-frontend/15238) to run `data-hub-frontend` and `datahub-leeloo` through the `SSO` process.

### Of note
This work introduces a new environment variable `OAUTH2_BYPASS_SSO`. This is used in conjunction with `OAUTH2_DEV_TOKEN` for developers who wish to byPass SSO locally.
