### PR TITLE
use package.json as checksum for cache in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
        - checkout
        - restore_cache:
            name: Restore yarn dependencies cache
-           key: cache-lockfile-{{ checksum "yarn.lock" }}
+           key: cache-lockfile-{{ checksum "package.json" }}
        - run: yarn global add greenkeeper-lockfile@1
        - run: greenkeeper-lockfile-update
        - run: greenkeeper-lockfile-upload
        - save_cache:
           name: Save yarn dependencies cache
-          key: cache-lockfile-{{ checksum "yarn.lock" }}
+          key: cache-lockfile-{{ checksum "package.json" }}
           paths:
             - ~/.cache/yarn
   build:
@@ -26,12 +26,12 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore yarn dependencies cache
-          key: yarn-dependency-{{ checksum "yarn.lock" }}
+          key: yarn-dependency-{{ checksum "package.json" }}
       - run: yarn install
       - run: yarn add wavy # wavy module does not install correctly after a fresh yarn install, this causes Unit tests to fail
       - save_cache:
           name: Save yarn dependencies cache
-          key: yarn-dependency-{{ checksum "yarn.lock" }}
+          key: yarn-dependency-{{ checksum "package.json" }}
           paths:
             - ~/data-hub-frontend/node_modules
   lint_code:
@@ -42,7 +42,7 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore yarn dependencies cache
-          key: yarn-dependency-{{ checksum "yarn.lock" }}
+          key: yarn-dependency-{{ checksum "package.json" }}
       - run:
           name: Lint code
           command: |
@@ -64,7 +64,7 @@ jobs:
       - checkout
       - restore_cache:
           name: Restore yarn dependencies cache
-          key: yarn-dependency-{{ checksum "yarn.lock" }}
+          key: yarn-dependency-{{ checksum "package.json" }}
       - run:
           name: Run unit tests
           command: |
@@ -140,7 +140,7 @@ jobs:
           command: dockerize -wait ${API_ROOT}/admin/ -timeout 240s
       - restore_cache:
           name: Restore yarn dependencies cache
-          key: yarn-dependency-{{ checksum "yarn.lock" }}
+          key: yarn-dependency-{{ checksum "package.json" }}
       - run: yarn build
       - run:
           name: Start data hub frontend


### PR DESCRIPTION
This change is due to `cache not existing errors` with greenkeeper in circleCi because the cache is using the `yarn.lock` file for a checksum. Circle uses the `CIRCLE_SHA1` of the branch being tested and this does not contain the updated yarn.lock file that was updated via ``greenkeeper-lockfile-update` and `greenkeeper-lockfile-upload`

follow up PR to https://github.com/uktrade/data-hub-frontend/pull/1122
