### PR TITLE
Remove logic around which address is used for OMIS orders

### DIFF
--- a/src/apps/omis/apps/edit/views/payment.njk
+++ b/src/apps/omis/apps/edit/views/payment.njk
@@ -39,15 +39,6 @@
     company.registered_address_country.name | escape
   ] | removeNilAndEmpty %}
 
-  {% set tradingAddress = [
-    company.trading_address_1 | escape,
-    company.trading_address_2 | escape,
-    company.trading_address_town | escape,
-    company.trading_address_county | escape,
-    company.trading_address_postcode | escape,
-    company.trading_address_country.name | escape
-  ] | removeNilAndEmpty %}
-
   <div class="c-form-group">
     <p class="c-form-group__label">
       <span class="c-form-group__label-text">
@@ -61,9 +52,9 @@
         <br>
         <a href="billing-address?returnUrl={{ CURRENT_PATH }}">Change address</a>
       {% else %}
-        {{ (tradingAddress if tradingAddress|length else registeredAddress) | join('<br>') | safe }}
+        {{ registeredAddress | join('<br>') | safe }}
         {% call Message({ type: 'muted' }) %}
-          The company's {{ 'trading' if tradingAddress|length else 'registered' }} address is currently being used for the invoice.
+          The company's registered address is currently being used for the invoice.
           <br>
           <a href="billing-address?returnUrl={{ CURRENT_PATH }}">Add a different billing address</a>
         {% endcall %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -217,25 +217,14 @@
     company.registered_address_country.name
   ] | removeNilAndEmpty %}
 
-  {% set tradingAddress = [
-    company.trading_address_1,
-    company.trading_address_2,
-    company.trading_address_town,
-    company.trading_address_county,
-    company.trading_address_postcode,
-    company.trading_address_country.name
-  ] | removeNilAndEmpty %}
-
-  {% set companyAddress = tradingAddress if tradingAddress|length else registeredAddress %}
-
   {% set addressValue %}
     {% if billingAddress | length %}
       {{ billingAddress | join(', ') }}
     {% else %}
-      <p>{{ companyAddress | join(', ') }}</p>
+      <p>{{ registeredAddress | join(', ') }}</p>
 
       {% call Message({ type: 'muted' }) %}
-        The company's {{ 'trading' if tradingAddress|length else 'registered' }} address is currently being used for the invoice.
+        The company’s registered address is currently being used for the invoice.
       {% endcall %}
     {% endif %}
   {% endset %}


### PR DESCRIPTION
We are not actually using the company's trading address by default
so we can remove the logic that surrounds this within the work
order and billing details.
