### PR TITLE
fix breaking company collection test

### DIFF
--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -23,6 +23,7 @@ module.exports = function transformCompanyToListItem ({
   registered_address_1,
   registered_address_2,
   companies_house_data,
+  modified_on,
 } = {}) {
   if (!id) { return }
 
@@ -64,6 +65,12 @@ module.exports = function transformCompanyToListItem ({
       value: get(trading_address_country, 'name') || get(registered_address_country, 'name'),
     })
   }
+
+  meta.push({
+    label: 'Updated',
+    type: 'datetime',
+    value: modified_on,
+  })
 
   if (uk_based) {
     meta.push({

--- a/test/acceptance/features/collection/page-objects/Collection.js
+++ b/test/acceptance/features/collection/page-objects/Collection.js
@@ -1,6 +1,10 @@
 const { lowerCase } = require('lodash')
 
-const { getSelectorForElementWithText, getButtonWithText } = require('../../../helpers/selectors')
+const {
+  getSelectorForElementWithText,
+  getButtonWithText,
+  getListItemMetaElementWithText,
+} = require('../../../helpers/selectors')
 
 const getSelectorForMetaListItemValue = (text) => {
   return getSelectorForElementWithText(text, {
@@ -24,14 +28,7 @@ module.exports = {
       },
       getSelectorForMetaListItemValue,
       getSelectorForBadgeWithText (text) {
-        return getSelectorForElementWithText(
-          text,
-          {
-            el: '//article[contains(@class, "c-collection")]//ol[contains(@class,"c-entity-list")]/li[1]//span',
-            className: 'c-meta-list__item-label',
-            child: '/following-sibling::span',
-          },
-        )
+        return getListItemMetaElementWithText(text)
       },
       getButtonSelectorWithText (text) {
         return getButtonWithText(text)

--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -57,8 +57,9 @@ Feature: View collection of companies
     Then I see the success message
     When I navigate to the Companies collection page
     And the companies are sorted by Recently updated
+    Then the companies should be sorted by Recently updated
     And the companies are sorted by Least recently updated
-    Then the companies should have been correctly sorted by updated date
+    Then the companies should be sorted by Least recently updated
     When the companies are sorted by Company name: A-Z
     And the companies are sorted by Company name: Z-A
     Then the companies should have been correctly sorted for text fields

--- a/test/acceptance/features/companies/page-objects/CompanyList.js
+++ b/test/acceptance/features/companies/page-objects/CompanyList.js
@@ -1,7 +1,7 @@
 const {
   getSelectorForElementWithText,
   getButtonWithText,
-  getMetaListItemValueSelector,
+  getListItemMetaElementWithText,
 } = require('../../../helpers/selectors')
 
 const getBadgeWithText = (text) => getSelectorForElementWithText(
@@ -12,6 +12,8 @@ const getBadgeWithText = (text) => getSelectorForElementWithText(
     child: '/following-sibling::span',
   },
 )
+const getFirstListItemMetaElementWithText = (text) => getListItemMetaElementWithText(text)
+const getSecondListItemMetaElementWithText = (text) => getListItemMetaElementWithText(text, 2)
 
 module.exports = {
   url: `${process.env.QA_HOST}/companies`,
@@ -27,7 +29,20 @@ module.exports = {
         header: {
           selector: '.c-entity__header a',
         },
-        companySector: getMetaListItemValueSelector('Sector'),
+        companySector: getFirstListItemMetaElementWithText('Sector'),
+        updated: getFirstListItemMetaElementWithText('Updated'),
+        countryBadge: getBadgeWithText('Country'),
+        ukRegionBadge: getBadgeWithText('UK region'),
+      },
+    },
+    secondCompanyInList: {
+      selector: '.c-entity-list li:nth-child(2)',
+      elements: {
+        header: {
+          selector: '.c-entity__header a',
+        },
+        companySector: getSecondListItemMetaElementWithText('Sector'),
+        updated: getSecondListItemMetaElementWithText('Updated'),
         countryBadge: getBadgeWithText('Country'),
         ukRegionBadge: getBadgeWithText('UK region'),
       },

--- a/test/acceptance/features/companies/step_definitions/collection.js
+++ b/test/acceptance/features/companies/step_definitions/collection.js
@@ -51,6 +51,7 @@ defineSupportCode(({ Given, Then, When }) => {
 
     await CompanyList
       .section.firstCompanyInList
+      .waitForElementPresent('@header')
       .getText('@header', (result) => {
         set(this.state, 'collection.firstItem.field', result.value)
       })
@@ -65,6 +66,7 @@ defineSupportCode(({ Given, Then, When }) => {
 
     await CompanyList
       .section.firstCompanyInList
+      .waitForElementPresent('@header')
       .getText('@header', (result) => {
         set(this.state, 'collection.lastItem.field', result.value)
       })

--- a/test/acceptance/features/companies/step_definitions/collection.js
+++ b/test/acceptance/features/companies/step_definitions/collection.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 const { get, set } = require('lodash')
@@ -105,14 +106,36 @@ defineSupportCode(({ Given, Then, When }) => {
       .assert.containsText('@ukRegionBadge', expectedBadgeText)
   })
 
-  Then(/^the companies should have been correctly sorted by updated date$/, async function () {
-    const firstItemField = get(this.state, 'collection.firstItem.field')
-    const lastItemField = get(this.state, 'collection.lastItem.field')
-    const expectedFirstItemField = get(this.state, 'company.heading')
-    const expectedLastItemField = this.fixtures.company.foreign.name
+  Then(/^the companies should be sorted by (Least recently|Recently) updated$/, async function (sortType) {
+    const updateValues = {
+      firstItem: null,
+      secondItem: null,
+    }
+    const formatDateString = (string) => {
+      return moment(string, 'DD MMM YYYY, h:mma')
+    }
 
-    client.expect(firstItemField).to.equal(expectedFirstItemField)
-    client.expect(lastItemField).to.equal(expectedLastItemField)
+    await CompanyList
+      .section.firstCompanyInList
+      .waitForElementPresent('@header')
+      .getText('@updated', (text) => {
+        set(updateValues, 'firstItem', formatDateString(text.value))
+      })
+
+    await CompanyList
+      .section.secondCompanyInList
+      .waitForElementPresent('@header')
+      .getText('@updated', (text) => {
+        set(updateValues, 'secondItem', formatDateString(text.value))
+      })
+
+    if (sortType === 'Recently') {
+      client.expect(updateValues.firstItem.isAfter(updateValues.secondItem)).to.be.true
+    }
+
+    if (sortType === 'Least recently') {
+      client.expect(updateValues.firstItem.isBefore(updateValues.secondItem)).to.be.true
+    }
   })
 
   Then(/^the companies should have been correctly sorted for text fields$/, async function () {

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -56,6 +56,20 @@ function getMetaListItemValueSelector (text) {
 }
 
 /**
+ * Gets XPath selector for getting a meta list item from a specific item in a collection item
+ * @param text
+ * @param [listItem=1]
+ */
+const getListItemMetaElementWithText = (text, listItem = 1) => getSelectorForElementWithText(
+  text,
+  {
+    el: `//article[contains(@class, "c-collection")]//ol[contains(@class,"c-entity-list")]/li[${listItem}]//span`,
+    className: 'c-meta-list__item-label',
+    child: '/following-sibling::span',
+  }
+)
+
+/**
  * Gets XPath selector for an anchor tag containing text
  * @param text
  * @param className
@@ -77,4 +91,5 @@ module.exports = {
   getDetailsTableRowValue,
   getMetaListItemValueSelector,
   getLinkWithText,
+  getListItemMetaElementWithText,
 }


### PR DESCRIPTION
The addition of [some data in fixtures](https://github.com/uktrade/data-hub-leeloo/pull/735) knocked our AT tests out.
This work: 

- Adds `modified_on` date to companies collections (was kind of weird we were sorting by it but you couldn't see the value in the UI)
- Update tests around checking sorting of companies by `modified_on` date to be more robust

### Of Note
This work has been `cherry-picked` from https://github.com/uktrade/data-hub-frontend/pull/1121

![screen shot 2018-01-03 at 18 35 30](https://user-images.githubusercontent.com/2305016/34534258-6d05862c-f0b5-11e7-8df8-93ba2cd36800.png)

  