### PR TITLE
Fix/contact list transformer

### DIFF
--- a/src/apps/contacts/transformers.js
+++ b/src/apps/contacts/transformers.js
@@ -27,7 +27,7 @@ function transformContactToListItem ({
   company_sector,
   primary,
 } = {}) {
-  if (!id || !first_name || !last_name) { return }
+  if (!id || (!first_name && !last_name)) { return }
 
   const metaItems = [
     { key: 'company', value: get(company, 'name') },

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -5,6 +5,8 @@ const {
   snakeCase,
   isPlainObject,
   isFunction,
+  isEmpty,
+  assign,
 } = require('lodash')
 const { isValid, format, parse } = require('date-fns')
 
@@ -92,10 +94,12 @@ function transformApiResponseToCollection (options = {}, ...itemTransformers) {
 
     itemTransformers.forEach(transformer => {
       if (!isFunction(transformer)) { return }
-      items = items.map(transformer)
+      items = items
+        .map(transformer)
+        .filter(item => !isEmpty(item))
     })
 
-    return Object.assign({}, {
+    return assign({}, {
       items,
       count: response.count,
       pagination: buildPagination(options.query, response),

--- a/test/unit/apps/contacts/transformers.test.js
+++ b/test/unit/apps/contacts/transformers.test.js
@@ -17,6 +17,10 @@ describe('Contact transformers', () => {
       expect(transformContactToListItem({ first_name: 'Peter', last_name: 'Great' })).to.be.undefined
     })
 
+    it('should return an object for a partially populated contact', () => {
+      expect(transformContactToListItem({ id: 'abcd', first_name: '', last_name: 'Smith' })).to.be.ok
+    })
+
     it('should return an object with data for active contact list item', () => {
       const actual = transformContactToListItem(contactSearchResult)
 

--- a/test/unit/apps/contacts/transformers.test.js
+++ b/test/unit/apps/contacts/transformers.test.js
@@ -10,56 +10,115 @@ const {
 
 describe('Contact transformers', () => {
   describe('#transformContactToListItem', () => {
-    it('should return undefined for unqualified result', () => {
-      expect(transformContactToListItem()).to.be.undefined
-      expect(transformContactToListItem({ a: 'b' })).to.be.undefined
-      expect(transformContactToListItem({ id: 'abcd' })).to.be.undefined
-      expect(transformContactToListItem({ first_name: 'Peter', last_name: 'Great' })).to.be.undefined
-    })
-
-    it('should return an object for a partially populated contact', () => {
-      expect(transformContactToListItem({ id: 'abcd', first_name: '', last_name: 'Smith' })).to.be.ok
-    })
-
-    it('should return an object with data for active contact list item', () => {
-      const actual = transformContactToListItem(contactSearchResult)
-
-      expect(actual).to.have.property('id').a('string')
-      expect(actual).to.have.property('type').a('string')
-      expect(actual).to.have.property('name').a('string')
-      expect(actual).to.have.property('isArchived').a('boolean').to.be.false
-      expect(actual).to.have.property('meta').an('array').to.deep.equal([
-        { label: 'Company', value: 'Fred ltd' },
-        { label: 'Job title', value: 'Director' },
-        { label: 'Sector', value: 'Aerospace' },
-        { label: 'Country', value: 'United Kingdom' },
-        { label: 'Updated on', type: 'datetime', value: '2017-02-14T14:49:17' },
-        { label: 'Contact type', type: 'badge', value: 'Primary', badgeModifier: 'secondary' },
-      ])
-    })
-
-    it('should return an object with data for archived contact list item', () => {
-      const archivedContact = Object.assign({}, contactSearchResult, {
-        archived: true,
-        archived_on: '2017-03-14T14:49:17',
-        archived_by: 'Sam Smith',
-        archived_reason: 'Left job',
+    context('when no object is provided as a parameter', () => {
+      beforeEach(() => {
+        this.transformedContact = transformContactToListItem()
       })
-      const actual = transformContactToListItem(archivedContact)
 
-      expect(actual).to.have.property('id').a('string')
-      expect(actual).to.have.property('type').a('string')
-      expect(actual).to.have.property('name').a('string')
-      expect(actual).to.have.property('isArchived').a('boolean').to.be.true
-      expect(actual).to.have.property('meta').an('array').to.deep.equal([
-        { label: 'Company', value: 'Fred ltd' },
-        { label: 'Job title', value: 'Director' },
-        { label: 'Sector', value: 'Aerospace' },
-        { label: 'Country', value: 'United Kingdom' },
-        { label: 'Updated on', type: 'datetime', value: '2017-02-14T14:49:17' },
-        { label: 'Contact type', type: 'badge', value: 'Primary', badgeModifier: 'secondary' },
-        { label: 'Status', type: 'badge', value: 'Archived' },
-      ])
+      it('should return undefined', () => {
+        expect(this.transformedContact).to.be.undefined
+      })
+    })
+
+    context('when a none contact object is provided as a parameter', () => {
+      beforeEach(() => {
+        this.transformedContact = transformContactToListItem({ a: 'b' })
+      })
+
+      it('should return undefined', () => {
+        expect(this.transformedContact).to.be.undefined
+      })
+    })
+
+    context('when the contact object parameter does not contain an ID', () => {
+      beforeEach(() => {
+        this.transformedContact = transformContactToListItem({
+          first_name: 'Fred',
+          last_name: 'Smith',
+        })
+      })
+
+      it('should return undefined', () => {
+        expect(this.transformedContact).to.be.undefined
+      })
+    })
+
+    context('when the contact object parameter does not contain a name', () => {
+      beforeEach(() => {
+        this.transformedContact = transformContactToListItem({ id: '1234' })
+      })
+
+      it('should return undefined', () => {
+        expect(this.transformedContact).to.be.undefined
+      })
+    })
+
+    context('when the contact object parameter contains only a partial name', () => {
+      beforeEach(() => {
+        this.transformedContact = transformContactToListItem({
+          id: '1234',
+          first_name: 'Fred',
+          last_name: 'Smith',
+        })
+      })
+
+      it('should return undefined', () => {
+        expect(this.transformedContact).to.be.ok
+      })
+    })
+
+    context('when the contact object parameter contains a valid contact', () => {
+      beforeEach(() => {
+        this.transformedContact = transformContactToListItem(contactSearchResult)
+      })
+
+      it('should return a transformed contact list item', () => {
+        expect(this.transformedContact).to.deep.equal({
+          id: '12651151-2149-465e-871b-ac45bc568a62',
+          type: 'contact',
+          name: 'Fred Smith',
+          isArchived: false,
+          meta: [
+            { label: 'Company', value: 'Fred ltd' },
+            { label: 'Job title', value: 'Director' },
+            { label: 'Sector', value: 'Aerospace' },
+            { label: 'Country', value: 'United Kingdom' },
+            { label: 'Updated on', type: 'datetime', value: '2017-02-14T14:49:17' },
+            { label: 'Contact type', type: 'badge', value: 'Primary', badgeModifier: 'secondary' },
+          ],
+        })
+      })
+    })
+
+    context('when the contact object parameter contains an archived contact', () => {
+      beforeEach(() => {
+        const archivedContact = Object.assign({}, contactSearchResult, {
+          archived: true,
+          archived_on: '2017-03-14T14:49:17',
+          archived_by: 'Sam Smith',
+          archived_reason: 'Left job',
+        })
+
+        this.transformedContact = transformContactToListItem(archivedContact)
+      })
+
+      it('should return a transformed contact list item', () => {
+        expect(this.transformedContact).to.deep.equal({
+          id: '12651151-2149-465e-871b-ac45bc568a62',
+          type: 'contact',
+          name: 'Fred Smith',
+          isArchived: true,
+          meta: [
+            { label: 'Company', value: 'Fred ltd' },
+            { label: 'Job title', value: 'Director' },
+            { label: 'Sector', value: 'Aerospace' },
+            { label: 'Country', value: 'United Kingdom' },
+            { label: 'Updated on', type: 'datetime', value: '2017-02-14T14:49:17' },
+            { label: 'Contact type', type: 'badge', value: 'Primary', badgeModifier: 'secondary' },
+            { label: 'Status', type: 'badge', value: 'Archived' },
+          ],
+        })
+      })
     })
   })
 

--- a/test/unit/apps/investment-projects/controllers/associated.test.js
+++ b/test/unit/apps/investment-projects/controllers/associated.test.js
@@ -7,7 +7,7 @@ describe('investment associated controller', () => {
     this.updateInvestmentStub = sandbox.stub().resolves(investmentData)
     this.searchStub = sandbox.stub().resolves(investmentCollection)
     this.transformerStub = sandbox.stub()
-    this.transformInvestmentProjectToListItemStub = sandbox.stub()
+    this.transformInvestmentProjectToListItemStub = sandbox.stub().returns({ id: 1 })
     this.transformInvestmentListItemToDisableMetaLinksStub = sandbox.stub().returns({ id: 1 })
 
     this.controller = proxyquire('~/src/apps/investment-projects/controllers/associated', {


### PR DESCRIPTION
DH-1418

Contact search results or contact lists that contain contacts with only a first or last name caused the server to throw a 500 error.

There were 2 issues that cause this. The first was the contact list item transformer would only transform a contact with both first and last name, if either was missing it would return undefined.

The 2nd issue is that in `transformApiResponseToCollection`  if an item transformer returns undefined for an item it is passed to any other transformers in the chain and the function calling the transformer.

This fix corrects the contact list item transformer to look for either first or last name and this is followed up by a filter that removes undefined items between calls to transformers in the chain.


