### PR TITLE
Convert expiry date to a datetime with 23:59:59 as expiry time

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -84,9 +84,10 @@ async function setQuoteSummary (req, res, next) {
   if (orderStatus === 'quote_awaiting_acceptance') {
     try {
       const quote = await Order.getQuote(req.session.token, orderId)
+      quote.expires_on = new Date(quote.expires_on + 'T23:59:59')
 
       res.locals.quote = assign({}, quote, {
-        expired: new Date(quote.expires_on) < new Date(),
+        expired: quote.expires_on < new Date(),
       })
     } catch (error) {
       logger.error(error)
@@ -108,7 +109,10 @@ async function setQuotePreview (req, res, next) {
   }
 
   try {
-    res.locals.quote = await Order.previewQuote(req.session.token, id)
+    const quote = await Order.previewQuote(req.session.token, id)
+    quote.expires_on = new Date(quote.expires_on + 'T23:59:59')
+
+    res.locals.quote = quote
   } catch (error) {
     if (error.statusCode !== 400) {
       logger.error(error)
@@ -144,9 +148,10 @@ async function setQuote (req, res, next) {
 
   try {
     const quote = await Order.getQuote(req.session.token, res.locals.order.id)
+    quote.expires_on = new Date(quote.expires_on + 'T23:59:59')
 
     res.locals.quote = assign({}, quote, {
-      expired: new Date(quote.expires_on) < new Date(),
+      expired: quote.expires_on < new Date(),
     })
   } catch (error) {
     if (error.statusCode !== 404) {

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -41,7 +41,7 @@
       {% endset %}
 
       {% set expiryValue %}
-        {{ quote.expires_on | formatDate }} ({{ quote.expires_on | fromNow }})
+        {{ quote.expires_on | formatDateTime }} ({{ quote.expires_on | fromNow }})
       {% endset %}
 
       {% if order.status in ['draft', 'quote_awaiting_acceptance'] %}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -336,6 +336,7 @@ describe('OMIS View middleware', () => {
             this.getQuoteStub.resolves({
               id: '12345',
               content: 'Quote content',
+              expires_on: '2017-08-02',
             })
 
             await this.middleware.setQuoteSummary(this.reqMock, this.resMock, this.nextSpy)
@@ -350,6 +351,7 @@ describe('OMIS View middleware', () => {
             expect(this.resMock.locals.quote).to.deep.equal({
               id: '12345',
               expired: false,
+              expires_on: new Date('2017-08-02T23:59:59'),
               content: 'Quote content',
             })
           })
@@ -374,7 +376,7 @@ describe('OMIS View middleware', () => {
             expect(this.resMock.locals.quote).to.deep.equal({
               id: '12345',
               expired: true,
-              expires_on: '2017-07-10',
+              expires_on: new Date('2017-07-10T23:59:59'),
             })
           })
         })
@@ -433,6 +435,7 @@ describe('OMIS View middleware', () => {
           this.previewQuoteStub.resolves({
             id: '12345',
             content: 'Quote content',
+            expires_on: '2017-07-10',
           })
 
           await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
@@ -443,6 +446,7 @@ describe('OMIS View middleware', () => {
           expect(this.resMock.locals.quote).to.deep.equal({
             id: '12345',
             content: 'Quote content',
+            expires_on: new Date('2017-07-10T23:59:59'),
           })
         })
 
@@ -598,12 +602,20 @@ describe('OMIS View middleware', () => {
     context('when quote does not exist on locals', () => {
       context('when quote resolves', () => {
         beforeEach(async () => {
+          const mockDate = new Date('2017-08-01')
+
+          this.clock = sinon.useFakeTimers(mockDate.getTime())
           this.getQuoteStub.resolves({
             id: '12345',
             content: 'Quote content',
+            expires_on: '2017-08-10',
           })
 
           await this.middleware.setQuote(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        afterEach(() => {
+          this.clock.restore()
         })
 
         it('should set response as quote property on locals', () => {
@@ -611,6 +623,7 @@ describe('OMIS View middleware', () => {
           expect(this.resMock.locals.quote).to.deep.equal({
             id: '12345',
             expired: false,
+            expires_on: new Date('2017-08-10T23:59:59'),
             content: 'Quote content',
           })
         })


### PR DESCRIPTION
This ensures that the relative time displayed is until the end of the
current day and that the quote does not show expired if the current
date is the expiry date.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
