### PR TITLE
DH-1266 Investment type not displaying in evaluations screen

### DIFF
--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -42,7 +42,7 @@ Feature: Investment projects evaluations details
       | Export revenue                    | Yes, will create significant export revenue    |                                         |
     And the FDI (Test A) details are displayed
       | key                               | value                                          |
-      | Type of investment                | Does not apply                                 |
+      | Type of investment                | investmentProject.typeAndSubType               |
       | Foreign investor                  | Lambda plc                                     |
       | Foreign country                   | France                                         |
       | UK company                        | Not Known                                      |
@@ -96,7 +96,7 @@ Feature: Investment projects evaluations details
       | Export revenue                    | No, will not create significant export revenue |                                         |
     And the FDI (Test A) details are displayed
       | key                               | value                                          |
-      | Type of investment                | Does not apply                                 |
+      | Type of investment                | investmentProject.typeAndSubType               |
       | Foreign investor                  | Lambda plc                                     |
       | Foreign country                   | France                                         |
       | UK company                        | Not Known                                      |

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -58,7 +58,7 @@ describe('Investment evaluation controller', () => {
       'Export revenue': 'No, will not create significant export revenue',
     }
     const expectFDI = {
-      'Type of investment': 'Does not apply',
+      'Type of investment': 'FDI, Capital only',
       'Foreign investor': {
         name: 'Omnicorp SDS',
         url: '/companies/6c388e5b-a098-e211-a939-e4115bead28a',
@@ -114,7 +114,7 @@ describe('Investment evaluation controller', () => {
       'Export revenue': 'No, will not create significant export revenue',
     }
     const expectFDI = {
-      'Type of investment': 'Tom',
+      'Type of investment': 'FDI, Creation of new site or activity',
       'Foreign investor': {
         name: 'amazing tables Ltd.',
         url: '/companies/6c997f91-a098-e211-a939-e4115bead28a',


### PR DESCRIPTION
DH-1266

This change shows the correct investment type on the evaluations screen. Including acceptance tests.

# Before
![screen shot 2018-01-05 at 23 23 50](https://user-images.githubusercontent.com/1150417/34632841-c540fa04-f26f-11e7-8a73-095d2bdba031.png)

# After
![screen shot 2018-01-05 at 23 22 27](https://user-images.githubusercontent.com/1150417/34632843-c7d31554-f26f-11e7-83a2-681c93d7c71b.png)
