### PR TITLE
Fix/fix investment team edit

### DIFF
--- a/src/apps/investment-projects/controllers/team/edit-team-members.js
+++ b/src/apps/investment-projects/controllers/team/edit-team-members.js
@@ -1,22 +1,10 @@
-const { isEmpty } = require('lodash')
-
-function getHandler (req, res, next) {
+function renderTeamEdit (req, res, next) {
   res
     .breadcrumb('Project team', 'team')
     .breadcrumb('Team members')
     .render('investment-projects/views/team/edit-team-members')
 }
 
-function postHandler (req, res, next) {
-  if (isEmpty(res.locals.form.errors)) {
-    req.flash('success', 'Investment details updated')
-    return res.redirect(`/investment-projects/${res.locals.investmentData.id}/team`)
-  }
-
-  return next()
-}
-
 module.exports = {
-  getHandler,
-  postHandler,
+  renderTeamEdit,
 }

--- a/src/apps/investment-projects/repos.js
+++ b/src/apps/investment-projects/repos.js
@@ -68,24 +68,11 @@ function unarchiveInvestmentProject (token, investmentId) {
 }
 
 async function updateInvestmentTeamMembers (token, investmentId, investmentTeamMembers) {
-  // Delete all existing records before saving
-  await authorisedRequest(token, {
+  return authorisedRequest(token, {
     url: `${config.apiRoot}/v3/investment/${investmentId}/team-member`,
-    method: 'DELETE',
+    method: 'PUT',
+    body: investmentTeamMembers,
   })
-
-  // Loop through each of the team members, saving it
-  for (const investmentTeamMember of investmentTeamMembers) {
-    await authorisedRequest(token, {
-      url: `${config.apiRoot}/v3/investment/${investmentId}/team-member`,
-      method: 'POST',
-      body: {
-        investment_project: investmentId,
-        adviser: investmentTeamMember.adviser,
-        role: investmentTeamMember.role,
-      },
-    })
-  }
 }
 
 module.exports = {

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -28,7 +28,6 @@ const {
   projectStageFormMiddleware,
   requirementsFormMiddleware,
   valueFormMiddleware,
-  teamMembersFormMiddleware,
 } = require('./middleware/forms')
 
 const { renderInvestmentList } = require('./controllers/list')
@@ -36,6 +35,9 @@ const { renderInteractionList } = require('./controllers/interactions')
 
 const { getInvestmentProjectsCollection, getRequestBody } = require('./middleware/collection')
 const { setInteractionsReturnUrl, setInteractionsEntityName, setCompanyDetails } = require('./middleware/interactions')
+
+const { renderTeamEdit } = require('./controllers/team/edit-team-members')
+const { populateTeamEditForm, postTeamEdit } = require('./middleware/forms/team-members')
 
 const {
   renderStatusPage,
@@ -155,16 +157,8 @@ router
 
 router
   .route('/:investmentId/edit-team-members')
-  .get(
-    teamMembersFormMiddleware.populateForm,
-    team.editTeamMembers.getHandler
-  )
-  .post(
-    teamMembersFormMiddleware.populateForm,
-    teamMembersFormMiddleware.handleFormPost,
-    team.editTeamMembers.postHandler,
-    team.editTeamMembers.getHandler
-  )
+  .get(populateTeamEditForm, renderTeamEdit)
+  .post(postTeamEdit, renderTeamEdit)
 
 router.get('/:investmentId/interactions', setInteractionsReturnUrl, renderInteractionList)
 

--- a/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
+++ b/test/unit/apps/investment-projects/controllers/team/edit-team-members.test.js
@@ -9,9 +9,9 @@ describe('Investment project, team members, edit controller', () => {
     this.controller = require('~/src/apps/investment-projects/controllers/team/edit-team-members')
   })
 
-  describe('#getHandler', () => {
-    it('should render edit project management view', (done) => {
-      this.controller.getHandler({
+  describe('#renderTeamEdit', () => {
+    it('should render edit team management view', (done) => {
+      this.controller.renderTeamEdit({
         session: {
           token: 'abcd',
         },
@@ -29,57 +29,6 @@ describe('Investment project, team members, edit controller', () => {
           }
         },
       }, this.nextStub)
-    })
-  })
-
-  describe('#postHandler', () => {
-    describe('without errors', () => {
-      it('should redirect to the product team details page', (done) => {
-        this.controller.postHandler({
-          session: {
-            token: 'abcd',
-          },
-          flash: this.flashStub,
-        }, {
-          locals: {
-            form: {
-              errors: {},
-            },
-            investmentData,
-          },
-          breadcrumb: this.breadcrumbStub,
-          redirect: (url) => {
-            try {
-              expect(url).to.equal(`/investment-projects/${investmentData.id}/team`)
-              expect(this.flashStub).to.calledWith('success', 'Investment details updated')
-              done()
-            } catch (e) {
-              done(e)
-            }
-          },
-        }, this.nextStub)
-      })
-    })
-
-    describe('when form errors exist', () => {
-      it('should pass the error onto the edit form', () => {
-        this.controller.postHandler({
-          session: {
-            token: 'abcd',
-          },
-        }, {
-          locals: {
-            form: {
-              errors: {
-                subject: 'example error',
-              },
-            },
-          },
-          breadcrumb: this.breadcrumbStub,
-        }, this.nextStub)
-
-        expect(this.nextStub).to.be.calledOnce
-      })
     })
   })
 })

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -5,32 +5,27 @@ const uuid = require('uuid')
 const config = require('~/config')
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
 const { teamMembersLabels } = require('~/src/apps/investment-projects/labels')
+const teamMembersController = require('~/src/apps/investment-projects/middleware/forms/team-members')
 
 describe('Investment form middleware - team members', () => {
   beforeEach(() => {
-    this.updateInvestmentTeamMembersStub = sandbox.stub().resolves({})
-
-    this.nextSpy = sandbox.spy()
+    this.nextStub = sandbox.stub()
     this.reqMock = {
       session: {
         token: uuid(),
       },
+      params: {
+        investmentId: investmentData.id,
+      },
+      flash: sandbox.stub(),
     }
 
     this.resMock = {
       locals: {
-        form: {
-          state: {},
-        },
         investmentData,
       },
+      redirect: sandbox.stub(),
     }
-
-    this.controller = proxyquire('~/src/apps/investment-projects/middleware/forms/team-members', {
-      '../../repos': {
-        updateInvestmentTeamMembers: this.updateInvestmentTeamMembersStub,
-      },
-    })
   })
 
   describe('#populateForm', () => {
@@ -58,7 +53,7 @@ describe('Investment form middleware - team members', () => {
           }],
         })
 
-        await this.controller.populateForm(this.reqMock, this.resMock, this.nextSpy)
+        await teamMembersController.populateTeamEditForm(this.reqMock, this.resMock, this.nextStub)
       })
 
       it('should include transformed team members', () => {
@@ -130,7 +125,7 @@ describe('Investment form middleware - team members', () => {
           team_members: [],
         })
 
-        await this.controller.populateForm(this.reqMock, this.resMock, this.nextSpy)
+        await teamMembersController.populateTeamEditForm(this.reqMock, this.resMock, this.nextStub)
       })
 
       it('should include a blank team member with no id', () => {
@@ -170,108 +165,191 @@ describe('Investment form middleware - team members', () => {
     })
   })
 
-  describe('#handleFormpost', () => {
-    beforeEach(() => {
-      this.body = {
-        adviser: ['1', '2'],
-        role: ['manager', 'supervisor'],
-      }
-    })
-
-    describe('post with no errors', () => {
-      it('updates the investment data', (done) => {
-        this.controller.handleFormPost({
-          session: {
-            token: 'mock-token',
-          },
+  describe('#postTeamEdit', () => {
+    context('when posted with valid data', () => {
+      beforeEach(async () => {
+        this.reqMock = assign({}, this.reqMock, {
           params: {
             investmentId: investmentData.id,
           },
-          body: this.body,
-        }, this.resMock, () => {
-          expect(this.updateInvestmentTeamMembersStub).to.be.calledWith('mock-token', investmentData.id, [{
+          body: {
+            adviser: ['1', '2'],
+            role: ['manager', 'supervisor'],
+          },
+        })
+
+        this.nockScope = nock(config.apiRoot)
+          .put(`/v3/investment/${investmentData.id}/team-member`, [{
             adviser: '1',
             role: 'manager',
           }, {
             adviser: '2',
             role: 'supervisor',
           }])
-          done()
-        })
+          .reply(200, {})
+
+        await teamMembersController.postTeamEdit(this.reqMock, this.resMock, this.nextStub)
       })
 
-      it('continues onto the next middleware with no errors', (done) => {
-        this.controller.handleFormPost({
-          session: {
-            token: 'mock-token',
-          },
-          params: {
-            investmentId: investmentData.id,
-          },
-          body: this.body,
-        }, this.resMock, (error) => {
-          expect(error).to.equal(undefined)
-          done()
-        })
+      it('should call the api with the correct parameters', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+
+      it('should redirect back to the details page', () => {
+        expect(this.resMock.redirect).to.be.calledWith('/investment-projects/f22ae6ac-b269-4fe5-aeba-d6a605b9a7a7/team')
+      })
+
+      it('should not carry onto the next middleware', () => {
+        expect(this.nextStub.callCount).to.eq(0)
+      })
+
+      it('should not pass any error or form data to the next middleware', () => {
+        expect(this.resMock.locals).to.not.have.property('form.errors')
       })
     })
 
-    describe('When a form is posted with errors', () => {
-      it('should set form error data for the following controllers if form error', (done) => {
-        this.error = {
-          statusCode: 400,
-          error: {
-            role: ['This field is required'],
-          },
-        }
-        const resMock = assign({}, this.resMock)
+    context('when a form is posted with a missing role', () => {
+      beforeEach(async () => {
+        const error = [
+          {},
+          { role: ['This field may not be blank.'] },
+        ]
 
-        this.updateInvestmentTeamMembersStub.rejects(this.error)
-
-        this.controller.handleFormPost({
-          session: {
-            token: 'mock-token',
-          },
+        this.reqMock = assign({}, this.reqMock, {
           params: {
             investmentId: investmentData.id,
           },
           body: {
-            adviser: ['1', '2', '3'],
-            role: ['manager', 'supervisor', ''],
+            adviser: ['1', '2'],
+            role: ['manager', undefined],
           },
-        }, resMock, (error) => {
-          expect(error).to.equal(undefined)
-          expect(resMock.locals.form.state.teamMembers).to.deep.equal([
-            { adviser: '1', role: 'manager' },
-            { adviser: '2', role: 'supervisor' },
-            { adviser: '3', role: '' },
-          ])
-          expect(this.resMock.locals.form.errors.messages).to.deep.equal({
-            'role-2': ['This field is required'],
-          })
-          done()
         })
+
+        this.nockScope = nock(config.apiRoot)
+          .get(`/adviser/?limit=100000&offset=0`)
+          .reply(200, {
+            count: 5,
+            results: [
+              { id: '1', name: 'Jeff Smith', is_active: true },
+              { id: '2', name: 'John Smith', is_active: true },
+              { id: '3', name: 'Zac Smith', is_active: true },
+              { id: '4', name: 'Fred Smith', is_active: false },
+              { id: '5', name: 'Jim Smith', is_active: false },
+            ],
+          })
+          .put(`/v3/investment/${investmentData.id}/team-member`, [{
+            adviser: '1',
+            role: 'manager',
+          }, {
+            adviser: '2',
+          }])
+          .reply(400, error)
+
+        await teamMembersController.postTeamEdit(this.reqMock, this.resMock, this.nextStub)
       })
 
-      it('should pass a none form error to next middleware', (done) => {
-        this.error = {
-          statusCode: 500,
+      it('should call the next middleware', () => {
+        expect(this.nextStub.callCount).to.eq(1)
+        expect(this.nextStub.firstCall.args.length).to.eq(0)
+      })
+
+      it('should indicate which field has the error', () => {
+        expect(this.resMock.locals.form.errors.messages['role-1']).to.eq('This field may not be blank.')
+      })
+
+      it('should pass through the form state for re-rendering', () => {
+        expect(this.resMock.locals.form.fields.teamMembers).to.deep.equal([
+          {
+            adviser: '1',
+            role: 'manager',
+            options: [
+              { label: 'Jeff Smith', value: '1' },
+              { label: 'John Smith', value: '2' },
+              { label: 'Zac Smith', value: '3' },
+            ],
+          },
+          {
+            adviser: '2',
+            role: undefined,
+            options: [
+              { label: 'Jeff Smith', value: '1' },
+              { label: 'John Smith', value: '2' },
+              { label: 'Zac Smith', value: '3' },
+            ],
+          },
+        ])
+      })
+    })
+
+    context('when a form is posted with a none field error', () => {
+      beforeEach(async () => {
+        const error = {
+          'non_field_errors': ['No data provided'],
         }
 
-        this.updateInvestmentTeamMembersStub.rejects(this.error)
-
-        this.controller.handleFormPost({
-          session: {
-            token: 'mock-token',
-          },
+        this.reqMock = assign({}, this.reqMock, {
           params: {
             investmentId: investmentData.id,
           },
-          body: this.body,
-        }, this.resMock, (error) => {
-          expect(error).to.deep.equal(this.error)
-          done()
+          body: {
+            adviser: ['1', '2'],
+            role: ['manager', undefined],
+          },
         })
+
+        this.nockScope = nock(config.apiRoot)
+          .get(`/adviser/?limit=100000&offset=0`)
+          .reply(200, {
+            count: 5,
+            results: [
+              { id: '1', name: 'Jeff Smith', is_active: true },
+              { id: '2', name: 'John Smith', is_active: true },
+              { id: '3', name: 'Zac Smith', is_active: true },
+              { id: '4', name: 'Fred Smith', is_active: false },
+              { id: '5', name: 'Jim Smith', is_active: false },
+            ],
+          })
+          .put(`/v3/investment/${investmentData.id}/team-member`, [{
+            adviser: '1',
+            role: 'manager',
+          }, {
+            adviser: '2',
+          }])
+          .reply(400, error)
+
+        await teamMembersController.postTeamEdit(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should call the next middleware', () => {
+        expect(this.nextStub.callCount).to.eq(1)
+        expect(this.nextStub.firstCall.args.length).to.eq(0)
+      })
+
+      it('should indicate the generic error', () => {
+        expect(this.resMock.locals.form.errors.messages['non_field_errors-0']).to.eq('No data provided')
+      })
+
+      it('should pass through the form state for re-rendering', () => {
+        expect(this.resMock.locals.form.fields.teamMembers).to.deep.equal([
+          {
+            adviser: '1',
+            role: 'manager',
+            options: [
+              { label: 'Jeff Smith', value: '1' },
+              { label: 'John Smith', value: '2' },
+              { label: 'Zac Smith', value: '3' },
+            ],
+          },
+          {
+            adviser: '2',
+            role: undefined,
+            options: [
+              { label: 'Jeff Smith', value: '1' },
+              { label: 'John Smith', value: '2' },
+              { label: 'Zac Smith', value: '3' },
+            ],
+          },
+        ])
       })
     })
   })
@@ -288,7 +366,7 @@ describe('Investment form middleware - team members', () => {
         role: 'Director',
       }]
 
-      const actual = this.controller.transformDataToTeamMemberArray(body)
+      const actual = teamMembersController.transformFormToTeamMemberArray(body)
 
       expect(actual).to.deep.equal(expected)
     })
@@ -307,7 +385,7 @@ describe('Investment form middleware - team members', () => {
         role: 'Manager',
       }]
 
-      const actual = this.controller.transformDataToTeamMemberArray(body)
+      const actual = teamMembersController.transformFormToTeamMemberArray(body)
 
       expect(actual).to.deep.equal(expected)
     })
@@ -323,7 +401,7 @@ describe('Investment form middleware - team members', () => {
         role: 'manager',
       }]
 
-      const actual = this.controller.transformDataToTeamMemberArray(body)
+      const actual = teamMembersController.transformFormToTeamMemberArray(body)
 
       expect(actual).to.deep.equal(expected)
     })
@@ -336,7 +414,7 @@ describe('Investment form middleware - team members', () => {
 
       const expected = []
 
-      const actual = this.controller.transformDataToTeamMemberArray(body)
+      const actual = teamMembersController.transformFormToTeamMemberArray(body)
 
       expect(actual).to.deep.equal(expected)
     })
@@ -346,9 +424,28 @@ describe('Investment form middleware - team members', () => {
 
       const expected = []
 
-      const actual = this.controller.transformDataToTeamMemberArray(body)
+      const actual = teamMembersController.transformFormToTeamMemberArray(body)
 
       expect(actual).to.deep.equal(expected)
+    })
+  })
+
+  describe('#transformErrorResponseToFormErrors', () => {
+    context('Called with a missing role', () => {
+      beforeEach(() => {
+        const error = [
+          {},
+          { role: ['This field may not be blank.'] },
+        ]
+
+        this.errorMessages = teamMembersController.transformErrorResponseToFormErrors(error)
+      })
+
+      it('should convert the error into the correct format for the form', () => {
+        expect(this.errorMessages).to.deep.equal({
+          'role-1': 'This field may not be blank.',
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
DH-1417

* Fix bug when LEP's saved investment team changes it would wipe out all team members
* Switch to use new PUT endpoint in the API to save team members
* Fix bug when a user had an error editing an investment team the form would not re-render properly and loose adviser selections
* Refactor investment team routing to be simpler and follow pattern of saving and passing errors to common render controller
* Refactor investment team middleware to fix bugs mentioned above and better structured
* Improved unit testing related to investment team middleware