### PR TITLE
DH-1421 Add role for viewing investment project documents

### DIFF
--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -40,6 +40,9 @@ const LOCAL_NAV = [
   {
     path: 'documents',
     label: 'Documents',
+    permissions: [
+      'investment.read_investmentproject_document',
+    ],
   },
 ]
 


### PR DESCRIPTION
DH-1421

LEPs should not be able to view `Documents` under `Investment projects`. A new role has been introduced into the backend. This change will make sure only users who have this role can view the `Documents`.

# Before

<img width="941" alt="screen shot 2018-01-09 at 16 51 03" src="https://user-images.githubusercontent.com/1150417/34732602-a72bf4a6-f55d-11e7-94b7-cd8bb7571efb.png">

# After

<img width="928" alt="screen shot 2018-01-09 at 16 50 41" src="https://user-images.githubusercontent.com/1150417/34732638-bd929d26-f55d-11e7-895a-3ea83cb214cb.png">

