### PR TITLE
DH-1384 Acceptance tests around LEP/DA collections

### DIFF
--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -23,6 +23,20 @@ Feature: View collection of companies
       | Country            | company.country           |
       | UK region          | company.ukRegion          |
 
+  @companies-collection--view--lep @lep
+  Scenario: View companies collection as LEP
+
+    When I navigate to the Companies collection page
+    Then I confirm I am on the Companies page
+    And the results count header for companies is present
+
+  @companies-collection--view--da @da
+  Scenario: View companies collection as DA
+
+    When I navigate to the Companies collection page
+    Then I confirm I am on the Companies page
+    And the results count header for companies is present
+
   @companies-collection--filter
   Scenario: Filter companies list
 

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -30,6 +30,20 @@ Feature: View collection of contacts
       | text         | expected           |
       | Contact type | contact.type       |
 
+  @contacts-collection--view--lep @lep
+  Scenario: View contact collection as LEP
+
+    When I navigate to the Contacts collection page
+    Then I confirm I am on the Contacts page
+    And the results count header for contacts is present
+
+  @contacts-collection--view--da @da
+  Scenario: View contact collection as DA
+
+    When I navigate to the Contacts collection page
+    Then I confirm I am on the Contacts page
+    And the results count header for contacts is present
+
   @contacts-collection--filter
   Scenario: Filter contact list
 

--- a/test/acceptance/features/events/collection.feature
+++ b/test/acceptance/features/events/collection.feature
@@ -96,3 +96,14 @@ Feature: View a list of events
     And I sort the events list by least recently updated
     Then I see the list in ascending recently updated order
 
+  @events-collection--lep @lep
+  Scenario: Navigate to events shows 403 for LEPs
+
+    Given I navigate to /events
+    Then I see the 403 error page
+
+  @events-collection--da @da
+  Scenario: Navigate to events shows 403 for DAs
+
+    Given I navigate to /events
+    Then I see the 403 error page

--- a/test/acceptance/features/interactions/collection.feature
+++ b/test/acceptance/features/interactions/collection.feature
@@ -53,14 +53,26 @@ Feature: View collection of contacts
   @interactions-collection--filter
   Scenario: filter interaction list
 
-  Given I navigate to company fixture Venus Ltd
-  When I click the Interactions local nav link
-  And I click the "Add interaction" link
-  And selecting interaction
-  And an interaction is added
-  Then I see the success message
-  When I navigate to the Interactions and services collection page
-  Then I confirm I am on the Interactions page
-  And the results count header for interactions is present
-  Then I filter the interactions list by service provider
-  Then the interactions should be filtered by service provider
+    Given I navigate to company fixture Venus Ltd
+    When I click the Interactions local nav link
+    And I click the "Add interaction" link
+    And selecting interaction
+    And an interaction is added
+    Then I see the success message
+    When I navigate to the Interactions and services collection page
+    Then I confirm I am on the Interactions page
+    And the results count header for interactions is present
+    Then I filter the interactions list by service provider
+    Then the interactions should be filtered by service provider
+
+  @interactions-collection--lep @lep
+  Scenario: Navigate to interactions shows 403 for LEPs
+
+    Given I navigate to /interactions
+    Then I see the 403 error page
+
+  @interactions-collection--da @da
+  Scenario: Navigate to interactions shows 403 for DAs
+
+    Given I navigate to /interactions
+    Then I see the 403 error page

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -44,3 +44,17 @@ Feature: View a list of Investment Projects
       | text            | expected                            |
       | Stage           | investmentProject.stage             |
       | Investment type | investmentProject.type              |
+
+  @investment-projects-collection--view--lep @lep
+  Scenario: View Investment Projects list as LEP
+
+    When I navigate to the Investment projects collection page
+    Then I confirm I am on the Investment projects page
+    And the results count header for projects is present
+
+  @investment-projects-collection--view--da @da
+  Scenario: View Investment Projects list as DA
+
+    When I navigate to the Investment projects collection page
+    Then I confirm I am on the Investment projects page
+    And the results count header for projects is present

--- a/test/acceptance/features/location/page-objects/Location.js
+++ b/test/acceptance/features/location/page-objects/Location.js
@@ -70,4 +70,11 @@ module.exports = {
       ],
     },
   },
+  commands: [
+    {
+      getHeading (el, text) {
+        return getSelectorForElementWithText(text, { el })
+      },
+    },
+  ],
 }

--- a/test/acceptance/features/location/step_definitions/location.js
+++ b/test/acceptance/features/location/step_definitions/location.js
@@ -48,6 +48,10 @@ defineSupportCode(({ Given, When, Then }) => {
       .assert.containsText('@header', fixtureName)
   })
 
+  Given(/^I navigate to ([^\s]+)$/, async function (path) {
+    await client.url(process.env.QA_HOST + path)
+  })
+
   When(/^I click the (.+) global nav link/, async (globalNavLinkText) => {
     const globalNavLinkSelector = Location.section.globalNav.getGlobalNavLinkSelector(globalNavLinkText)
 
@@ -120,5 +124,14 @@ defineSupportCode(({ Given, When, Then }) => {
         })
         .useCss()
     }
+  })
+
+  Then(/^I see the ([0-9]+) error page$/, async function (statusCode) {
+    const headingSelector = Location.getHeading('//h3', statusCode).selector
+
+    await Location
+      .api.useXpath()
+      .assert.visible(headingSelector)
+      .useCss()
   })
 })

--- a/test/acceptance/features/omis/collection.feature
+++ b/test/acceptance/features/omis/collection.feature
@@ -1,0 +1,8 @@
+@omis-collection
+Feature: OMIS collection
+
+  @omis-collection--lep @lep
+  Scenario: Navigate to OMIS shows 403 for LEPs
+
+    Given I navigate to /omis
+    Then I see the 403 error page


### PR DESCRIPTION
DH-1384

This change adds acceptance tests for LEP/DA visibility of collections and asserting a 403 when they do not have permission to view a resource.