### PR TITLE
Fix issue with date edit macro

### DIFF
--- a/src/templates/_macros/form/date-fieldset.njk
+++ b/src/templates/_macros/form/date-fieldset.njk
@@ -12,7 +12,7 @@
  #}
 {% macro DateFieldset(props) %}
   {% set fieldId = 'field-' + props.name if props.name %}
-  {% set value = props.value | default('') %}
+  {% set value = props.value | default('', true) %}
 
   {% if value | isPlainObject  %}
     {% set dateObj = props.value %}


### PR DESCRIPTION
The date display macro used 'default' to set a default as an empty string if no value was passed in. The default behaviour for this only applies the default for 'undefined'. When a null was passed in it would not be defaulted which caused the date control to fail.
