### PR TITLE
Update investment landing transformer to use common date formatter

### DIFF
--- a/src/apps/investment-projects/transformers/landing.js
+++ b/src/apps/investment-projects/transformers/landing.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 const { get, isPlainObject } = require('lodash')
-const moment = require('moment')
+
+const { formatLongDate } = require('../../../../common/date')
 
 function transformInvestmentLandingForView (data) {
   if (!isPlainObject(data)) {
@@ -18,7 +19,7 @@ function transformInvestmentLandingForView (data) {
       data.uk_company.registered_address_county,
       data.uk_company.registered_address_postcode,
     ].filter((address) => address) : null,
-    investment_land_date: data.actual_land_date ? moment(data.actual_land_date).format('Do MMMM YYYY') : null,
+    investment_land_date: data.actual_land_date ? formatLongDate(data.actual_land_date) : null,
   }
 }
 

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -143,7 +143,7 @@ describe('Investment evaluation controller', () => {
         'LONDON',
         'E134 1HP',
       ],
-      'Land date': '21st July 2018',
+      'Land date': '21 July 2018',
     }
 
     this.controller.renderEvaluationPage({


### PR DESCRIPTION
Noticed that the date format in the evaluations screen was using its own date formatter, which is slightly different to the common one used throughout the application.
