### PR TITLE
Clarify investment land date labels

### DIFF
--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -92,7 +92,7 @@ const labels = {
       uk_company: 'UK company',
       company_number: 'Companies House Number',
       registered_address: 'Registered Address',
-      investment_land_date: 'Land date',
+      actual_land_date: 'Actual land date',
     },
   },
   projectManagementLabels: {
@@ -142,7 +142,7 @@ const labels = {
     stage: 'Stage',
     investment_type: 'Investment type',
     investor_company: 'Investor',
-    estimated_land_date: 'Land date',
+    estimated_land_date: 'Estimated land date',
     sector: 'Sector',
   },
 }

--- a/src/apps/investment-projects/transformers/landing.js
+++ b/src/apps/investment-projects/transformers/landing.js
@@ -19,7 +19,7 @@ function transformInvestmentLandingForView (data) {
       data.uk_company.registered_address_county,
       data.uk_company.registered_address_postcode,
     ].filter((address) => address) : null,
-    investment_land_date: data.actual_land_date ? formatLongDate(data.actual_land_date) : null,
+    actual_land_date: data.actual_land_date ? formatLongDate(data.actual_land_date) : null,
   }
 }
 

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -36,10 +36,10 @@ Feature: View a list of Investment Projects
       | Specific investment programme | investmentProject.specificInvestmentProgramme |
     When I navigate to the Investment Projects source of equity investment
     Then I can view the Investment project in the collection
-      | text            | expected                            |
-      | Investor        | investmentProject.equitySource.name |
-      | Sector          | investmentProject.primarySector     |
-      | Land date       | investmentProject.estimatedLandDate |
+      | text                | expected                            |
+      | Investor            | investmentProject.equitySource.name |
+      | Sector              | investmentProject.primarySector     |
+      | Estimated land date | investmentProject.estimatedLandDate |
     And the Investment project has badges
       | text            | expected                            |
       | Stage           | investmentProject.stage             |

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -55,7 +55,7 @@ Feature: Investment projects evaluations details
       | UK company                        | Not Known                                      |
       | Companies House Number            | Not Known                                      |
       | Registered Address                | Not Known                                      |
-      | Land date                         | Not Known                                      |
+      | Actual land date                  | Not Known                                      |
 
   @investment-projects-evaluations-details--value-no
   Scenario: View investment project evaluations after user selects all no for value details
@@ -109,4 +109,4 @@ Feature: Investment projects evaluations details
       | UK company                        | Not Known                                      |
       | Companies House Number            | Not Known                                      |
       | Registered Address                | Not Known                                      |
-      | Land date                         | Not Known                                      |
+      | Actual land date                  | Not Known                                      |

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -74,7 +74,7 @@ describe('Investment evaluation controller', () => {
       'UK company': null,
       'Companies House Number': undefined,
       'Registered Address': null,
-      'Land date': null,
+      'Actual land date': null,
     }
 
     this.controller.renderEvaluationPage({
@@ -143,7 +143,7 @@ describe('Investment evaluation controller', () => {
         'LONDON',
         'E134 1HP',
       ],
-      'Land date': '21 July 2018',
+      'Actual land date': '21 July 2018',
     }
 
     this.controller.renderEvaluationPage({


### PR DESCRIPTION
Made it clear in the labels which land date field is being displayed (expected or actual)
