### PR TITLE
Fix investment transformer tests and improve investment details transformer

### DIFF
--- a/src/apps/investment-projects/transformers/project.js
+++ b/src/apps/investment-projects/transformers/project.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { get, isPlainObject, mapValues } = require('lodash')
+const { castArray, get, isEmpty, isPlainObject, mapValues } = require('lodash')
 const format = require('date-fns/format')
 const moment = require('moment')
 
@@ -101,25 +101,42 @@ function transformFromApi (body) {
   return Object.assign({}, body, formatted)
 }
 
-function transformInvestmentDataForView (data) {
-  if (!isPlainObject(data)) { return }
-
-  const businessActivities = data.business_activities.slice()
-  if (data.other_business_activity) {
-    businessActivities.push({ name: data.other_business_activity })
+function transformInvestmentDataForView ({
+  business_activities,
+  other_business_activity,
+  investment_type,
+  fdi_type,
+  sector,
+  client_contacts,
+  description,
+  anonymous_description,
+  investor_company,
+  investor_type,
+  level_of_involvement,
+  specific_programme,
+  estimated_land_date,
+} = {}) {
+  const businessActivities = castArray(business_activities).map(i => i.name)
+  if (!isEmpty(other_business_activity)) {
+    businessActivities.push(other_business_activity)
   }
 
-  return Object.assign({}, data, {
-    investor_company: {
-      name: data.investor_company.name,
-      url: `/companies/${data.investor_company.id}`,
-    },
-    investment_type: getInvestmentTypeDetails(data.investment_type, data.fdi_type),
-    sector: get(data, 'sector.name', null),
-    business_activities: businessActivities.map(i => i.name).join(', '),
-    client_contacts: data.client_contacts.map(i => i.name).join(', '),
-    estimated_land_date: data.estimated_land_date ? moment(data.estimated_land_date).format('MMMM YYYY') : null,
-  })
+  return {
+    investor_company: isPlainObject(investor_company) ? {
+      name: get(investor_company, 'name'),
+      url: `/companies/${investor_company.id}`,
+    } : null,
+    investment_type: getInvestmentTypeDetails(investment_type, fdi_type),
+    sector,
+    business_activities: businessActivities.join(', '),
+    client_contacts: castArray(client_contacts).map(i => i.name).join(', '),
+    description,
+    anonymous_description,
+    investor_type,
+    level_of_involvement,
+    specific_programme,
+    estimated_land_date: !isEmpty(estimated_land_date) ? moment(estimated_land_date, 'YYYY-MM-DD').format('MMMM YYYY') : null,
+  }
 }
 
 function transformBriefInvestmentSummary (data) {
@@ -128,7 +145,6 @@ function transformBriefInvestmentSummary (data) {
   const investorCompany = data.investor_company
   const competitorCountries = data.competitor_countries || []
   const regionLocations = data.uk_region_locations || []
-  const date = moment(data.estimated_land_date, 'YYYY-MM-DD')
 
   return {
     sector: get(data, 'sector.name', null),
@@ -143,7 +159,7 @@ function transformBriefInvestmentSummary (data) {
     account_tier: (investorCompany.classification && investorCompany.classification !== null && investorCompany.classification.name) ? investorCompany.classification.name : 'None',
     uk_region_locations: regionLocations.map(region => region.name).join(', '),
     competitor_countries: competitorCountries.map(country => country.name).join(', '),
-    estimated_land_date: date.isValid() ? date.format('MMMM YYYY') : null,
+    estimated_land_date: !isEmpty(data.estimated_land_date) ? moment(data.estimated_land_date, 'YYYY-MM-DD').format('MMMM YYYY') : null,
     total_investment: formatCurrency(data.total_investment),
   }
 }

--- a/test/unit/apps/investment-projects/transformers/project.test.js
+++ b/test/unit/apps/investment-projects/transformers/project.test.js
@@ -3,6 +3,7 @@ const { assign } = require('lodash')
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
 const {
   transformBriefInvestmentSummary,
+  transformInvestmentDataForView,
 } = require('~/src/apps/investment-projects/transformers/project')
 
 describe('Investment project transformers', () => {
@@ -266,20 +267,6 @@ describe('Investment project transformers', () => {
       })
     })
 
-    context('when a malformed estimated land date is provided', () => {
-      beforeEach(() => {
-        const data = assign({}, investmentData, {
-          estimated_land_date: 'dog',
-        })
-
-        this.result = transformBriefInvestmentSummary(data)
-      })
-
-      it('should set estimated land date to null', () => {
-        expect(this.result).to.have.property('estimated_land_date', null)
-      })
-    })
-
     context('when a total investment is provided', () => {
       beforeEach(() => {
         const data = assign({}, investmentData, {
@@ -305,6 +292,381 @@ describe('Investment project transformers', () => {
 
       it('should set total investment to null', () => {
         expect(this.result).to.have.property('total_investment', null)
+      })
+    })
+  })
+
+  describe('#transformInvestmentDataForView', () => {
+    context('when called with a fully populated investment', () => {
+      beforeEach(() => {
+        this.result = transformInvestmentDataForView(investmentData)
+      })
+
+      it('should include all the required properties', () => {
+        expect(Object.keys(this.result)).to.deep.equal([
+          'investor_company',
+          'investment_type',
+          'sector',
+          'business_activities',
+          'client_contacts',
+          'description',
+          'anonymous_description',
+          'investor_type',
+          'level_of_involvement',
+          'specific_programme',
+          'estimated_land_date',
+        ])
+      })
+    })
+
+    context('when called with an investor company', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_company: {
+            name: 'test',
+            id: '1234',
+          },
+        })
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should provide the investor company as a link', () => {
+        expect(this.result.investor_company).to.deep.equal({
+          name: 'test',
+          url: '/companies/1234',
+        })
+      })
+    })
+
+    context('when called with an investment type', () => {
+      beforeEach(() => {
+        this.result = transformInvestmentDataForView(investmentData)
+      })
+
+      it('should return a formatted investment type value', () => {
+        expect(this.result).to.have.property('investment_type', 'FDI, Capital only')
+      })
+    })
+
+    context('when a sector is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          sector: {
+            id: '1234',
+            name: 'test',
+          },
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include the sector name', () => {
+        expect(this.result.sector).to.deep.equal({
+          id: '1234',
+          name: 'test',
+        })
+      })
+    })
+
+    context('when a sector isn\'t provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          sector: null,
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include a null sector', () => {
+        expect(this.result).to.have.property('sector', null)
+      })
+    })
+
+    context('when there is are business activities but no other activities', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          business_activities: [{
+            name: 'Call centre',
+            id: '410da69e-0247-48cf-9f72-fbc10ed7a4fc',
+          }, {
+            name: 'Sales',
+            id: '410da69e-0247-48cf-9f72-fbc10ed7a4fd',
+          }],
+          other_business_activity: '',
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should return business activities formatted as a string list', () => {
+        expect(this.result).to.have.property('business_activities', 'Call centre, Sales')
+      })
+    })
+
+    context('when there are no business activies but there is another activity', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          business_activities: [],
+          other_business_activity: 'Surfing',
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should return business activities formatted as a string list', () => {
+        expect(this.result).to.have.property('business_activities', 'Surfing')
+      })
+    })
+
+    context('when there no business activities and no other activities', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          business_activities: [],
+          other_business_activity: '',
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should return business activities as an empty string', () => {
+        expect(this.result).to.have.property('business_activities', '')
+      })
+    })
+
+    context('when there are client contacts to show', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          client_contacts: [{
+            name: 'Allen Connelly',
+            id: '7aac69c2-7af4-4c79-9622-f25eb7690f36',
+          }, {
+            name: 'John Brown',
+            id: '7aac69c2-7ae4-4c79-9622-f25eb7690f36',
+          }],
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should return the contact list as a string list', () => {
+        expect(this.result).to.have.property('client_contacts', 'Allen Connelly, John Brown')
+      })
+    })
+
+    context('when there is a single client contact', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          client_contacts: [{
+            name: 'Allen Connelly',
+            id: '7aac69c2-7af4-4c79-9622-f25eb7690f36',
+          }],
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should return the contact', () => {
+        expect(this.result).to.have.property('client_contacts', 'Allen Connelly')
+      })
+    })
+
+    context('when there are no client contacts to show', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          client_contacts: [],
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should return an empty client contact', () => {
+        expect(this.result).to.have.property('client_contacts', '')
+      })
+    })
+
+    context('when a description is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          description: 'My description',
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include the description', () => {
+        expect(this.result).to.have.property('description', 'My description')
+      })
+    })
+
+    context('when a description isn\'t provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          description: null,
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include a null description', () => {
+        expect(this.result).to.have.property('description', null)
+      })
+    })
+
+    context('when an anonymous description is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          anonymous_description: 'My description',
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include the description', () => {
+        expect(this.result).to.have.property('anonymous_description', 'My description')
+      })
+    })
+
+    context('when an anonymous description isn\'t provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          anonymous_description: null,
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include a null anonymous description', () => {
+        expect(this.result).to.have.property('anonymous_description', null)
+      })
+    })
+
+    context('when a investor type is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_type: {
+            name: 'Existing Investor',
+            id: '40e33f91-f565-4b89-8e18-cfefae192245',
+          },
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include the description', () => {
+        expect(this.result.investor_type).to.deep.equal({
+          name: 'Existing Investor',
+          id: '40e33f91-f565-4b89-8e18-cfefae192245',
+        })
+      })
+    })
+
+    context('when an investor type isn\'t provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_type: null,
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include a null anonymous description', () => {
+        expect(this.result).to.have.property('investor_type', null)
+      })
+    })
+
+    context('when level of involvement is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          level_of_involvement: {
+            name: 'HQ Only',
+            id: '9c22137d-648e-4ecb-8fe7-652ac6a4f53a',
+          },
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include the level of involvement', () => {
+        expect(this.result.level_of_involvement).to.deep.equal({
+          name: 'HQ Only',
+          id: '9c22137d-648e-4ecb-8fe7-652ac6a4f53a',
+        })
+      })
+    })
+
+    context('when a level of involvement isn\'t provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          level_of_involvement: null,
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include a null level of involvement', () => {
+        expect(this.result).to.have.property('level_of_involvement', null)
+      })
+    })
+
+    context('when a specific programme is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          specific_programme: {
+            name: 'Screen Production Investment',
+            id: 'ba042912-cd42-41b3-b813-b9f26a913331',
+          },
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include the specific programme', () => {
+        expect(this.result.specific_programme).to.deep.equal({
+          name: 'Screen Production Investment',
+          id: 'ba042912-cd42-41b3-b813-b9f26a913331',
+        })
+      })
+    })
+
+    context('when a specific programme isn\'t provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          specific_programme: null,
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include a null for specific programme', () => {
+        expect(this.result).to.have.property('specific_programme', null)
+      })
+    })
+
+    context('when an estimated land date is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          estimated_land_date: '2017-01-07',
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should include the estimated land date formatted as Month Year', () => {
+        expect(this.result).to.have.property('estimated_land_date', 'January 2017')
+      })
+    })
+
+    context('when an estimated land date is not provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          estimated_land_date: null,
+        })
+
+        this.result = transformInvestmentDataForView(data)
+      })
+
+      it('should set the estimated land date as null', () => {
+        expect(this.result).to.have.property('estimated_land_date', null)
       })
     })
   })

--- a/test/unit/apps/investment-projects/transformers/project.test.js
+++ b/test/unit/apps/investment-projects/transformers/project.test.js
@@ -1,17 +1,19 @@
 const { assign } = require('lodash')
 
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
-const { transformBriefInvestmentSummary } = require('~/src/apps/investment-projects/transformers/project')
+const {
+  transformBriefInvestmentSummary,
+} = require('~/src/apps/investment-projects/transformers/project')
 
 describe('Investment project transformers', () => {
   describe('#transformBriefInvestmentSummary', () => {
     context('when a project contains data', () => {
       beforeEach(() => {
-        this.investmentSummary = transformBriefInvestmentSummary(investmentData)
+        this.result = transformBriefInvestmentSummary(investmentData)
       })
 
-      it('sound contain the properties required of an investment summary', () => {
-        expect(Object.keys(this.investmentSummary)).to.deep.equal([
+      it('sound contain the properties required of a brief investment summary', () => {
+        expect(Object.keys(this.result)).to.deep.equal([
           'sector',
           'investor_company',
           'website',
@@ -22,25 +24,25 @@ describe('Investment project transformers', () => {
           'total_investment',
         ])
       })
+    })
 
-      it('should provide the investor company as a link', () => {
-        beforeEach(() => {
-          const data = assign({}, investmentData, {
-            investor_company: {
-              id: '1234',
-              name: 'test',
-            },
-          })
-
-          this.investmentSummary = transformBriefInvestmentSummary(data)
-        })
-
-        it('should include the sector name', () => {
-          expect(this.investmentSummary).to.have.deep.property('investment_company', {
+    context('when an investment company is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          investor_company: {
             id: '1234',
             name: 'test',
-            url: '/companies/1234',
-          })
+            website: 'http://www.test.com',
+          },
+        })
+
+        this.result = transformBriefInvestmentSummary(data)
+      })
+
+      it('should provide the investor company as a link', () => {
+        expect(this.result.investor_company).to.deep.equal({
+          name: 'test',
+          url: '/companies/1234',
         })
       })
     })
@@ -54,11 +56,11 @@ describe('Investment project transformers', () => {
           },
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
       it('should include the sector name', () => {
-        expect(this.investmentSummary).to.have.property('sector', 'test')
+        expect(this.result).to.have.property('sector', 'test')
       })
     })
 
@@ -68,11 +70,11 @@ describe('Investment project transformers', () => {
           sector: null,
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
       it('should include a null sector', () => {
-        expect(this.investmentSummary).to.have.property('sector', null)
+        expect(this.result).to.have.property('sector', null)
       })
     })
 
@@ -86,11 +88,11 @@ describe('Investment project transformers', () => {
           },
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
       it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.deep.property('website', {
+        expect(this.result).to.have.deep.property('website', {
           name: 'http://www.test.com',
           url: 'http://www.test.com',
         })
@@ -107,11 +109,11 @@ describe('Investment project transformers', () => {
           },
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('website', null)
+      it('should include a null for the website', () => {
+        expect(this.result).to.have.property('website', null)
       })
     })
 
@@ -123,11 +125,11 @@ describe('Investment project transformers', () => {
           },
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
       it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('account_tier', 'None')
+        expect(this.result).to.have.property('account_tier', 'None')
       })
     })
 
@@ -141,11 +143,11 @@ describe('Investment project transformers', () => {
           },
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('account_tier', 'None')
+      it('should indicate no account tier', () => {
+        expect(this.result).to.have.property('account_tier', 'None')
       })
     })
 
@@ -160,11 +162,11 @@ describe('Investment project transformers', () => {
           },
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('account_tier', 'Test')
+      it('should include the account tier', () => {
+        expect(this.result).to.have.property('account_tier', 'Test')
       })
     })
 
@@ -180,11 +182,11 @@ describe('Investment project transformers', () => {
           }],
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('uk_region_locations', 'Region 1, Region 2')
+      it('should include the uk regions as a string list', () => {
+        expect(this.result).to.have.property('uk_region_locations', 'Region 1, Region 2')
       })
     })
 
@@ -194,11 +196,11 @@ describe('Investment project transformers', () => {
           uk_region_locations: null,
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('uk_region_locations', '')
+      it('should include an empty value for uk regions', () => {
+        expect(this.result).to.have.property('uk_region_locations', '')
       })
     })
 
@@ -214,11 +216,11 @@ describe('Investment project transformers', () => {
           }],
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('competitor_countries', 'Country 1, Country 2')
+      it('should include the competitor countries formatted as a string list', () => {
+        expect(this.result).to.have.property('competitor_countries', 'Country 1, Country 2')
       })
     })
 
@@ -228,53 +230,53 @@ describe('Investment project transformers', () => {
           competitor_countries: null,
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('competitor_countries', '')
+      it('should include am empty competitor countries value', () => {
+        expect(this.result).to.have.property('competitor_countries', '')
       })
     })
 
-    context('when a land date is provided', () => {
+    context('when an estimated land date is provided', () => {
       beforeEach(() => {
         const data = assign({}, investmentData, {
           estimated_land_date: '2017-01-07',
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('estimated_land_date', 'January 2017')
+      it('should include the estimated land date formatted as Month Year', () => {
+        expect(this.result).to.have.property('estimated_land_date', 'January 2017')
       })
     })
 
-    context('when a land date is not provided', () => {
+    context('when an estimated land date is not provided', () => {
       beforeEach(() => {
         const data = assign({}, investmentData, {
           estimated_land_date: null,
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('estimated_land_date', null)
+      it('should set the estimated land date as null', () => {
+        expect(this.result).to.have.property('estimated_land_date', null)
       })
     })
 
-    context('when a malformed land date is provided', () => {
+    context('when a malformed estimated land date is provided', () => {
       beforeEach(() => {
         const data = assign({}, investmentData, {
           estimated_land_date: 'dog',
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('estimated_land_date', null)
+      it('should set estimated land date to null', () => {
+        expect(this.result).to.have.property('estimated_land_date', null)
       })
     })
 
@@ -284,25 +286,25 @@ describe('Investment project transformers', () => {
           total_investment: '100.24',
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('total_investment', '£100.24')
+      it('should include the total investment value', () => {
+        expect(this.result).to.have.property('total_investment', '£100.24')
       })
     })
 
-    context('when a cotal investment is not provided', () => {
+    context('when a total investment is not provided', () => {
       beforeEach(() => {
         const data = assign({}, investmentData, {
           total_investment: null,
         })
 
-        this.investmentSummary = transformBriefInvestmentSummary(data)
+        this.result = transformBriefInvestmentSummary(data)
       })
 
-      it('should include the website and a link', () => {
-        expect(this.investmentSummary).to.have.property('total_investment', null)
+      it('should set total investment to null', () => {
+        expect(this.result).to.have.property('total_investment', null)
       })
     })
   })


### PR DESCRIPTION
The project transformation tests for investment had many issues, this fix:
* Fixes description for many of the tests that were incorrect due to cut and paste errors.
* Reformat tests for the brief summary to use context
* Adds tests for investment project summary in details page

Also refactored the transformer for investment project details to clean it up in preparation for adding another field.
