### PR TITLE
DH-1409 Add UK branch of foreign company feature

### DIFF
--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -4,9 +4,9 @@ const { buildUkOtherCompanyOptions, buildForeignOtherCompanyOptions } = require(
 const { isBlank } = require('../../../lib/controller-utils')
 const { companyDetailsLabels, companyTypeOptions } = require('../labels')
 
-function renderAddStepOne (req, res) {
-  const ukOtherCompanyOptions = buildUkOtherCompanyOptions()
-  const foreignOtherCompanyOptions = buildForeignOtherCompanyOptions()
+async function renderAddStepOne (req, res) {
+  const ukOtherCompanyOptions = await buildUkOtherCompanyOptions(req.session.token)
+  const foreignOtherCompanyOptions = await buildForeignOtherCompanyOptions(req.session.token)
 
   res.render('companies/views/add-step-1.njk', {
     ukOtherCompanyOptions,

--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -2,6 +2,7 @@ const { assign, find, get, isEmpty } = require('lodash')
 
 const { transformCompaniesHouseToView } = require('../transformers')
 const { buildUkOtherCompanyOptions, buildForeignOtherCompanyOptions } = require('../options')
+const UK_BRANCH_OF_FOREIGN_COMPANY_ID = 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98'
 
 async function getBusinessTypeOption (token, businessTypeId) {
   const ukOtherCompanyOptions = await buildUkOtherCompanyOptions(token)
@@ -56,6 +57,7 @@ async function renderForm (req, res) {
       isForeign,
       businessTypeLabel,
       showTradingAddress,
+      showCompanyNumber: businessType === UK_BRANCH_OF_FOREIGN_COMPANY_ID,
     })
 }
 

--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -31,6 +31,13 @@ function isForeignCompany (req, res) {
   return req.query.country === 'non-uk'
 }
 
+function getHeading (company, isForeign) {
+  const action = company ? 'Edit' : 'Add'
+  const type = isForeign ? 'foreign' : 'UK'
+
+  return `${action} ${type} company`
+}
+
 async function renderForm (req, res) {
   if (res.locals.companiesHouseRecord) {
     res.locals = assign({}, res.locals, {
@@ -58,6 +65,7 @@ async function renderForm (req, res) {
       businessTypeLabel,
       showTradingAddress,
       showCompanyNumber: businessType === UK_BRANCH_OF_FOREIGN_COMPANY_ID,
+      heading: getHeading(res.locals.company, isForeign),
     })
 }
 

--- a/src/apps/companies/options.js
+++ b/src/apps/companies/options.js
@@ -1,43 +1,34 @@
-const { filter, map } = require('lodash')
-const { sentence } = require('case')
+const { assign, filter, includes } = require('lodash')
 
-const metadataRepository = require('../../lib/metadata')
-const ukOtherBusinessTypeNames = [
-  'Charity',
-  'Government Dept',
-  'Intermediary',
-  'Limited partnership',
-  'Partnership',
-  'Sole Trader',
-]
-const foreignOtherBusinessTypeNames = [
-  'Company',
-  ...ukOtherBusinessTypeNames,
-]
+const { getOptions } = require('../../lib/options')
 
-/**
- * extract businessOptions from metadata by name and build an options list with
- * @param requestedProperties
- * @param metaDataOptions
- * @returns {{label: String, id: String}[]}
- */
-const buildBusinessTypeOptions = (requestedProperties, metaDataOptions) => {
-  return map(filter(metaDataOptions, (option) => {
-    return requestedProperties.indexOf(option.name) >= 0
-  }), (option) => {
-    return {
-      value: option.id,
-      label: sentence(option.name.replace('Dept', 'department'), []),
-    }
+const ukOtherBusinessTypeWhitelist = {
+  charity: '9dd14e94-5d95-e211-a939-e4115bead28a',
+  governmentDepartment: '9cd14e94-5d95-e211-a939-e4115bead28a',
+  intermediary: '9bd14e94-5d95-e211-a939-e4115bead28a',
+  limitedPartnership: '8b6eaf7e-03e7-e611-bca1-e4115bead28a',
+  partnership: '9ad14e94-5d95-e211-a939-e4115bead28a',
+  soleTrader: '99d14e94-5d95-e211-a939-e4115bead28a',
+  ukBranchOfForeignCompany: 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98',
+}
+
+const foreignOtherBusinessTypeWhitelist = assign({}, ukOtherBusinessTypeWhitelist, {
+  company: '98d14e94-5d95-e211-a939-e4115bead28a',
+})
+
+const buildBusinessTypeOptions = async (token, whitelist) => {
+  const businessTypeOptions = await getOptions(token, 'business-type')
+  return filter(businessTypeOptions, (businessTypeOption) => {
+    return includes(whitelist, businessTypeOption.value)
   })
 }
 
-const buildUkOtherCompanyOptions = () => {
-  return buildBusinessTypeOptions(ukOtherBusinessTypeNames, metadataRepository.businessTypeOptions)
+const buildUkOtherCompanyOptions = async (token) => {
+  return buildBusinessTypeOptions(token, ukOtherBusinessTypeWhitelist)
 }
 
-const buildForeignOtherCompanyOptions = () => {
-  return buildBusinessTypeOptions(foreignOtherBusinessTypeNames, metadataRepository.businessTypeOptions)
+const buildForeignOtherCompanyOptions = async (token) => {
+  return buildBusinessTypeOptions(token, foreignOtherBusinessTypeWhitelist)
 }
 
 module.exports = {

--- a/src/apps/companies/views/_layout-edit.njk
+++ b/src/apps/companies/views/_layout-edit.njk
@@ -2,7 +2,7 @@
 
 {% block local_header %}
   {{ LocalHeader({
-    heading: 'Edit company' if isEditMode else 'Add company',
+    heading: heading,
     modifier: 'light-banner'
   }) }}
 {% endblock %}

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -63,6 +63,15 @@
         error: errors.name
       }) }}
 
+      {% if showCompanyNumber %}
+        {{ TextField({
+          name: 'company_number',
+          label: 'BR Companies House number',
+          value: formData.company_number,
+          error: errors.company_number
+        }) }}
+      {% endif %}
+
       {{ TextField({
         name: 'trading_name',
         label: 'Trading name',

--- a/test/acceptance/features/companies/page-objects/Company.js
+++ b/test/acceptance/features/companies/page-objects/Company.js
@@ -31,6 +31,7 @@ module.exports = {
     foreignOrganisationOption: 'label[for=field-business_type-3]',
     foreignOrganisationOptionBusinessType: 'select[name="business_type_for_other"]',
     name: '#field-name',
+    companyNumber: '#field-company_number',
     tradingName: '#field-trading_name',
     ukRegion: 'select[name="uk_region"]',
     address1: '#field-registered_address_1',
@@ -181,7 +182,9 @@ module.exports = {
               .click('@otherTypeOfUKOrganisationOption')
               .api.perform((done) => {
                 this.getListOption('@otherTypeOfUKOrganisationBusinessType', (businessType) => {
-                  companyStep1.businessType = businessType
+                  companyStep1.businessType = businessType === 'UK branch of foreign company (BR)'
+                    ? 'Limited partnership'
+                    : businessType
                   this.setValue(`@otherTypeOfUKOrganisationBusinessType`, businessType)
                   done()
                 })
@@ -356,6 +359,115 @@ module.exports = {
                 }))
               })
           })
+      },
+
+      createUkBranchOfForeignCompany (details = {}, callback) {
+        const companyStep1 = {}
+        const companyStep2 = assign({}, {
+          name: appendUid(faker.company.companyName()),
+          companyNumber: `BR${faker.random.number({ min: 100000 })}`,
+          website: faker.internet.url(),
+          description: faker.lorem.sentence(),
+        }, details)
+        const companyStep2RadioOptions = {}
+        const postcodeLookup = {
+          postcode: 'companyPostCode',
+          address1: 'companyPostCodeLookupAddress1',
+          address2: 'companyPostCodeLookupAddress2',
+          town: 'companyPostCodeLookupTown',
+          county: 'companyPostCodeLookupCounty',
+        }
+
+        this
+          .click('@addCompanyButton')
+          .waitForElementPresent('@otherTypeOfUKOrganisationBusinessType')
+          .api.perform((done) => {
+            // step 1
+            this
+              .click('@otherTypeOfUKOrganisationOption')
+              .api.perform(() => {
+                this.clickListOption('business_type_uk_other', 'UK branch of foreign company (BR)')
+              })
+
+            // step 2
+            this
+              .waitForElementPresent('@continueButton')
+              .click('@continueButton')
+
+            this.api.page.Location().section.localHeader
+              .waitForElementPresent('@header')
+
+            this
+              .api.perform((done) => {
+                this.getListOption('@ukRegion', (ukRegion) => {
+                  companyStep2.ukRegion = ukRegion
+                  done()
+                })
+              })
+              .perform((done) => {
+                this.getListOption('@sector', (sector) => {
+                  companyStep2.sector = sector
+                  done()
+                })
+              })
+              .perform((done) => {
+                this.getRadioOption('headquarter_type', (result) => {
+                  companyStep2RadioOptions.headquarterType = result
+                  done()
+                })
+              })
+              .perform((done) => {
+                this.getRadioOption('employee_range', (result) => {
+                  companyStep2RadioOptions.employeeRange = result
+                  done()
+                })
+              })
+              .perform((done) => {
+                this.getRadioOption('turnover_range', (result) => {
+                  companyStep2RadioOptions.turnoverRange = result
+                  done()
+                })
+              })
+              .perform((done) => {
+                for (const key in companyStep2) {
+                  if (companyStep2[key]) {
+                    this.setValue(`@${key}`, companyStep2[key])
+                  }
+                }
+                for (const key in companyStep2RadioOptions) {
+                  this.api.useCss().click(companyStep2RadioOptions[key].labelSelector)
+                  companyStep2[key] = companyStep2RadioOptions[key].text
+                }
+                done()
+              })
+
+            this.api
+              .perform((done) => {
+                this.api
+                  .page.Address()
+                  .getAddressInputValues('GL11 4DH', postcodeLookup, '@companyPostCodeLookupSuggestions', (addressInputValues) => {
+                    const country = 'United Kingdom'
+                    const primaryAddress = getAddress(assign({}, companyStep2, addressInputValues, { country }))
+
+                    this
+                      .waitForElementPresent('@saveAndCreateButton')
+                      .click('@saveAndCreateButton')
+
+                    callback(assign({}, companyStep1, companyStep2, {
+                      addressInputValues,
+                      heading: companyStep2.name,
+                      primaryAddress,
+                      country,
+                      uniqueSearchTerm: getUid(companyStep2.name),
+                    }))
+
+                    done()
+                  })
+              })
+            done()
+          })
+
+        return this
       },
 
       searchForCompanyInCollection (companyName) {

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -59,3 +59,22 @@ Feature: Create a new company
       | Number of employees   | company.employeeRange            |
       | Annual turnover       | company.turnoverRange            |
       | Country               | company.registeredAddressCountry |
+
+  @companies-save--foreign-uk-branch
+  Scenario: Create a UK branch of a foreign company
+
+    When a "UK branch of a foreign company" is created
+    Then I see the success message
+    And the company is in the search results
+    When the first search result is clicked
+    Then the Company summary details are displayed
+      | key                   | value                            |
+      | Business type         | company.businessType             |
+      | Primary address       | company.primaryAddress           |
+      | UK region             | company.ukRegion                 |
+      | Headquarters          | company.headquarterType          |
+      | Sector                | company.sector                   |
+      | Website               | company.website                  |
+      | Business description  | company.description              |
+      | Number of employees   | company.employeeRange            |
+      | Annual turnover       | company.turnoverRange            |

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -44,6 +44,15 @@ defineSupportCode(({ When, Then }) => {
       .wait() // wait for backend to sync
   })
 
+  When(/^a "UK branch of a foreign company" is created$/, async function () {
+    await client
+      .url(companySearchPage)
+
+    await Company
+      .createUkBranchOfForeignCompany({}, (company) => set(this.state, 'company', company))
+      .wait() // wait for backend to sync
+  })
+
   Then(/^the company is in the search results$/, async function () {
     const companyName = get(this.state, 'company.name', get(this.state, 'company.tradingName'))
 

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -1,21 +1,23 @@
 const companiesHouseAndLtdCompanies = require('~/test/unit/data/search/companiesHouseAndLtdCompanies')
 const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company')
 const displayHouseCompany = require('~/test/unit/data/companies/display-companies-house')
+const config = require('~/config')
 
 const next = function (error) {
   throw Error(error)
 }
 
-const mockMetadataRepository = {
+const metaDataMock = {
   businessTypeOptions: [
     { name: 'Not Expected', id: '33243434-343656' },
-    { name: 'Charity', id: '1234-5678' },
-    { name: 'Government Dept', id: '3434-343' },
-    { name: 'Intermediary', id: '5656-5656' },
-    { name: 'Limited partnership', id: '7878-7878' },
-    { name: 'Partnership', id: '8989-898-9' },
-    { name: 'Sole Trader', id: '3434-5656' },
-    { name: 'Company', id: '1212-3454567' },
+    { name: 'Charity', id: '9dd14e94-5d95-e211-a939-e4115bead28a' },
+    { name: 'Government Dept', id: '9cd14e94-5d95-e211-a939-e4115bead28a' },
+    { name: 'Intermediary', id: '9bd14e94-5d95-e211-a939-e4115bead28a' },
+    { name: 'Limited partnership', id: '8b6eaf7e-03e7-e611-bca1-e4115bead28a' },
+    { name: 'Partnership', id: '9ad14e94-5d95-e211-a939-e4115bead28a' },
+    { name: 'Sole Trader', id: '99d14e94-5d95-e211-a939-e4115bead28a' },
+    { name: 'UK branch of foreign company (BR)', id: 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98' },
+    { name: 'Company', id: '98d14e94-5d95-e211-a939-e4115bead28a' },
     { name: 'Random', id: '34343434-343656' },
   ],
 }
@@ -41,37 +43,40 @@ describe('Company add controller', () => {
       '../services/formatting': {
         getDisplayCH: getDisplayCHStub,
       },
-      '../options': proxyquire('~/src/apps/companies/options.js', {
-        '../../lib/metadata': mockMetadataRepository,
-      }),
     })
   })
 
   describe('Get step 1', () => {
-    it('should return options for company types', function (done) {
+    beforeEach(() => {
+      this.nockScope = nock(config.apiRoot)
+        .get('/metadata/business-type/')
+        .twice().reply(200, metaDataMock.businessTypeOptions)
+    })
+
+    it('should return options for company types', async function () {
       const req = { session: {} }
       const expected = [
-        { label: 'Charity', value: '1234-5678' },
-        { label: 'Government department', value: '3434-343' },
-        { label: 'Intermediary', value: '5656-5656' },
-        { label: 'Limited partnership', value: '7878-7878' },
-        { label: 'Partnership', value: '8989-898-9' },
-        { label: 'Sole trader', value: '3434-5656' },
+        { label: 'Charity', value: '9dd14e94-5d95-e211-a939-e4115bead28a' },
+        { label: 'Government Dept', value: '9cd14e94-5d95-e211-a939-e4115bead28a' },
+        { label: 'Intermediary', value: '9bd14e94-5d95-e211-a939-e4115bead28a' },
+        { label: 'Limited partnership', value: '8b6eaf7e-03e7-e611-bca1-e4115bead28a' },
+        { label: 'Partnership', value: '9ad14e94-5d95-e211-a939-e4115bead28a' },
+        { label: 'Sole Trader', value: '99d14e94-5d95-e211-a939-e4115bead28a' },
+        { label: 'UK branch of foreign company (BR)', value: 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98' },
       ]
-      const expectedForeign = [ ...expected, { label: 'Company', value: '1212-3454567' } ]
+      const expectedForeign = [ ...expected, { label: 'Company', value: '98d14e94-5d95-e211-a939-e4115bead28a' } ]
       const res = {
         locals: {},
         render: function (template, options) {
           const allOptions = mergeLocals(res, options)
           expect(allOptions.ukOtherCompanyOptions).to.deep.equal(expected)
           expect(allOptions.foreignOtherCompanyOptions).to.deep.equal(expectedForeign)
-          done()
         },
       }
 
-      companyAddController.renderAddStepOne(req, res, next)
+      await companyAddController.renderAddStepOne(req, res)
     })
-    it('should return labels for the types and error messages', function (done) {
+    it('should return labels for the types and error messages', function () {
       const req = { session: {} }
       const res = {
         locals: {},
@@ -83,13 +88,12 @@ describe('Company add controller', () => {
             foreign: 'Foreign organisation',
           })
           expect(allOptions.companyDetailsLabels.business_type).to.equal('Business type')
-          done()
         },
       }
 
-      companyAddController.renderAddStepOne(req, res, next)
+      companyAddController.renderAddStepOne(req, res)
     })
-    it('should pass through the request body to show previosuly selected options', function (done) {
+    it('should pass through the request body to show previosuly selected options', function () {
       const body = { business_type: '1231231231232' }
       const req = { body, session: {} }
       const res = {
@@ -102,11 +106,10 @@ describe('Company add controller', () => {
             foreign: 'Foreign organisation',
           })
           expect(allOptions.company).to.deep.equal(body)
-          done()
         },
       }
 
-      companyAddController.renderAddStepOne(req, res, next)
+      companyAddController.renderAddStepOne(req, res)
     })
   })
   describe('Post step 1', () => {

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -1,244 +1,356 @@
-const companyMock = require('~/test/unit/data/api-response-intermediary-company.json')
 const { assign } = require('lodash')
 
-describe('Company export controller', () => {
+const companyMock = require('~/test/unit/data/api-response-intermediary-company.json')
+const config = require('~/config')
+
+const metaDataMock = {
+  businessTypeOptions: [
+    {
+      id: '9dd14e94-5d95-e211-a939-e4115bead28a',
+      name: 'Charity',
+    },
+    {
+      id: '9cd14e94-5d95-e211-a939-e4115bead28a',
+      name: 'Government department',
+    },
+    {
+      id: '9bd14e94-5d95-e211-a939-e4115bead28a',
+      name: 'Intermediary',
+    },
+    {
+      id: '8b6eaf7e-03e7-e611-bca1-e4115bead28a',
+      name: 'Limited partnership',
+    },
+    {
+      id: '9ad14e94-5d95-e211-a939-e4115bead28a',
+      name: 'Partnership',
+    },
+    {
+      id: '6f75408b-03e7-e611-bca1-e4115bead28a',
+      name: 'Private limited company',
+    },
+    {
+      id: 'dac8c591-03e7-e611-bca1-e4115bead28a',
+      name: 'Public limited company',
+    },
+    {
+      id: '99d14e94-5d95-e211-a939-e4115bead28a',
+      name: 'Sole Trader',
+    },
+    {
+      id: 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98',
+      name: 'UK branch of foreign company (BR)',
+    },
+    {
+      id: '98d14e94-5d95-e211-a939-e4115bead28a',
+      name: 'Company',
+    },
+  ],
+}
+
+describe('Company edit controller', () => {
   beforeEach(() => {
-    this.saveCompany = sandbox.stub()
     this.breadcrumbStub = sandbox.stub().returnsThis()
     this.renderSpy = sandbox.spy()
     this.nextSpy = sandbox.spy()
     this.redirectSpy = sandbox.spy()
 
-    const ukOtherCompanyOptions = [
-      {
-        value: '9dd14e94-5d95-e211-a939-e4115bead28a',
-        label: 'Charity',
+    this.controller = require('~/src/apps/companies/controllers/edit')
+
+    this.reqMock = {
+      session: {
+        token: 'abcd',
       },
-      {
-        value: '9cd14e94-5d95-e211-a939-e4115bead28a',
-        label: 'Government Dept',
+    }
+    this.resMock = {
+      breadcrumb: this.breadcrumbStub,
+      render: this.renderSpy,
+      redirect: this.redirectSpy,
+      locals: {
+        company: companyMock,
       },
-      {
-        value: '9bd14e94-5d95-e211-a939-e4115bead28a',
-        label: 'Intermediary',
-      },
-      {
-        value: '8b6eaf7e-03e7-e611-bca1-e4115bead28a',
-        label: 'Limited partnership',
-      },
-      { value: '9ad14e94-5d95-e211-a939-e4115bead28a',
-        label: 'Partnership',
-      },
-      {
-        value: '6f75408b-03e7-e611-bca1-e4115bead28a',
-        label: 'Private limited company',
-      },
-      {
-        value: 'dac8c591-03e7-e611-bca1-e4115bead28a',
-        label: 'Public limited company',
-      },
-      {
-        value: '99d14e94-5d95-e211-a939-e4115bead28a',
-        label: 'Sole Trader',
-      },
-    ]
-    const foreignOtherCompanyOptions = ukOtherCompanyOptions.concat([{
-      value: '98d14e94-5d95-e211-a939-e4115bead28a',
-      label: 'Company',
-    }])
-
-    this.controller = proxyquire('~/src/apps/companies/controllers/edit', {
-      '../options': {
-        buildUkOtherCompanyOptions: () => ukOtherCompanyOptions,
-        buildForeignOtherCompanyOptions: () => foreignOtherCompanyOptions,
-      },
-    })
-
-    this.buildReq = extra => assign({}, extra)
-    this.buildRes = extra => assign(
-      {
-        breadcrumb: this.breadcrumbStub,
-        render: this.renderSpy,
-        redirect: this.redirectSpy,
-        locals: {
-          company: companyMock,
-        },
-      },
-      extra
-    )
-
-    this.reqMock = this.buildReq({})
-    this.resMock = this.buildRes({})
-  })
-
-  describe('getBusinessTypeLabel()', () => {
-    it('should handle UK limited company', () => {
-      const label = this.controller.getBusinessTypeLabel('limited company', false, null)
-      expect(label).to.equal('UK limited company')
-    })
-
-    it('should handle UK charity', () => {
-      const uuid = '9dd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
-      expect(label).to.equal('UK Charity')
-    })
-
-    it('should handle UK government department', () => {
-      const uuid = '9cd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
-      expect(label).to.equal('UK Government Dept')
-    })
-
-    it('should handle UK Intermediary', () => {
-      const uuid = '9bd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
-      expect(label).to.equal('UK Intermediary')
-    })
-
-    it('should handle UK Limited partnership', () => {
-      const uuid = '8b6eaf7e-03e7-e611-bca1-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
-      expect(label).to.equal('UK Limited partnership')
-    })
-
-    it('should handle UK Partnership', () => {
-      const uuid = '9ad14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
-      expect(label).to.equal('UK Partnership')
-    })
-
-    it('should handle UK Sole trader', () => {
-      const uuid = '99d14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, false, uuid)
-      expect(label).to.equal('UK Sole Trader')
-    })
-
-    it('should handle Foreign charity', () => {
-      const uuid = '9dd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal('Foreign Charity')
-    })
-
-    it('should handle Foreign government department', () => {
-      const uuid = '9cd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal('Foreign Government Dept')
-    })
-
-    it('should handle Foreign Intermediary', () => {
-      const uuid = '9bd14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal('Foreign Intermediary')
-    })
-
-    it('should handle Foreign Limited partnership', () => {
-      const uuid = '8b6eaf7e-03e7-e611-bca1-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal('Foreign Limited partnership')
-    })
-
-    it('should handle Foreign Partnership', () => {
-      const uuid = '9ad14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal('Foreign Partnership')
-    })
-
-    it('should handle Foreign Sole trader', () => {
-      const uuid = '99d14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal('Foreign Sole Trader')
-    })
-
-    it('should handle Foreign Company', () => {
-      const uuid = '98d14e94-5d95-e211-a939-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal('Foreign Company')
-    })
-
-    it('should handle unrecognised uuids', () => {
-      const uuid = '98d14e94-milk-eggs-beef-e4115bead28a'
-      const label = this.controller.getBusinessTypeLabel(undefined, true, uuid)
-      expect(label).to.equal(undefined)
-    })
+    }
   })
 
   describe('renderForm', () => {
-    it('should treat non-uk company as foreign', () => {
-      const reqMock = this.buildReq({ query: { country: 'non-uk' } })
-      const resMock = this.buildRes({
-        locals: {
-          formData: {},
-        },
-      })
-      this.controller.renderForm(reqMock, resMock, this.nextSpy)
-      expect(this.renderSpy.args[0][1].isForeign).to.equal(true)
+    beforeEach(() => {
+      this.nockScope = nock(config.apiRoot)
+        .get('/metadata/business-type/')
+        .twice().reply(200, metaDataMock.businessTypeOptions)
     })
 
-    it('should treat uk company based overseas as foreign', () => {
-      const reqMock = this.buildReq({ query: {} })
-      const resMock = this.buildRes({
-        locals: {
-          company: { 'uk_based': false },
-          formData: {
-            business_type: '9ad14e94-5d95-e211-a939-e4115bead28a',
+    context('when adding a UK branch of a foreign company', () => {
+      beforeEach(async () => {
+        const reqMock = assign(this.reqMock, {
+          query: {
+            country: 'uk',
           },
-        },
-        companiesHouseRecord: { country: 'fr' },
-      })
-      this.controller.renderForm(reqMock, resMock, this.nextSpy)
-      expect(this.renderSpy.args[0][1].isForeign).to.equal(true)
-    })
-
-    it('should treat uk company based in the UK is domestic', () => {
-      const reqMock = this.buildReq({ query: {} })
-      const resMock = this.buildRes({
-        locals: {
-          company: { 'uk_based': true },
-          formData: {},
-        },
-      })
-      this.controller.renderForm(reqMock, resMock, this.nextSpy)
-      expect(this.renderSpy.args[0][1].isForeign).to.equal(false)
-    })
-
-    it('should expose businessTypeLabel', () => {
-      const reqMock = this.buildReq({ query: {} })
-      const resMock = this.buildRes({
-        locals: {
-          companiesHouseCategory: 'limited company',
-          formData: {},
-        },
-      })
-      this.controller.renderForm(reqMock, resMock, this.nextSpy)
-      expect(this.renderSpy.args[0][1].businessTypeLabel).to.equal('UK limited company')
-    })
-
-    it('should hide the trading address if there is\'t one', () => {
-      const reqMock = this.buildReq({ query: {} })
-      const resMock = this.buildRes({
-        locals: {
-          companiesHouseCategory: 'limited company',
-          formData: {},
-        },
-      })
-      this.controller.renderForm(reqMock, resMock, this.nextSpy)
-
-      expect(this.renderSpy.args[0][1].showTradingAddress).to.eq(false)
-    })
-
-    it('should show the trading address if there is one', () => {
-      const reqMock = this.buildReq({ query: {} })
-      const resMock = this.buildRes({
-        locals: {
-          companiesHouseCategory: 'limited company',
-          formData: {
-            trading_address_1: 'test',
+        })
+        const resMock = assign(this.resMock, {
+          locals: {
+            formData: {
+              business_type: 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98',
+            },
           },
-        },
-      })
-      this.controller.renderForm(reqMock, resMock, this.nextSpy)
+        })
 
-      expect(this.renderSpy.args[0][1].showTradingAddress).to.eq(true)
+        await this.controller.renderForm(reqMock, resMock, this.nextSpy)
+      })
+
+      it('should render the edit page', () => {
+        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+      })
+
+      it('should set the add breadcrumb', () => {
+        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Add')
+      })
+
+      it('should set heading', () => {
+        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Add UK company')
+      })
+
+      it('should set isForeign', () => {
+        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+      })
+
+      it('should set businessTypeLabel', () => {
+        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('UK branch of foreign company (BR)')
+      })
+
+      it('should show the company number field', () => {
+        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.true
+      })
+
+      it('should not show the trading address fields', () => {
+        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+    })
+
+    context('when editing a UK branch of a foreign company', () => {
+      beforeEach(async () => {
+        const reqMock = assign(this.reqMock, {
+          query: {
+            country: 'uk',
+          },
+        })
+        const resMock = assign(this.resMock, {
+          locals: {
+            formData: {
+              business_type: 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98',
+            },
+            company: {
+              id: 1,
+              name: 'Existing UK branch of foreign company',
+              uk_based: true,
+            },
+          },
+        })
+
+        await this.controller.renderForm(reqMock, resMock, this.nextSpy)
+      })
+
+      it('should render the edit page', () => {
+        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+      })
+
+      it('should set the company breadcrumb text', () => {
+        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Existing UK branch of foreign company')
+      })
+
+      it('should set the company breadcrumb link', () => {
+        expect(this.resMock.breadcrumb.getCall(0).args[1]).to.equal('/companies/1')
+      })
+
+      it('should set the edit breadcrumb', () => {
+        expect(this.resMock.breadcrumb.getCall(1).args[0]).to.equal('Edit')
+      })
+
+      it('should set heading', () => {
+        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Edit UK company')
+      })
+
+      it('should set isForeign', () => {
+        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+      })
+
+      it('should set businessTypeLabel', () => {
+        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('UK branch of foreign company (BR)')
+      })
+
+      it('should show the company number field', () => {
+        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.true
+      })
+
+      it('should not show the trading address fields', () => {
+        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+    })
+
+    context('when adding a UK sole trader', () => {
+      beforeEach(async () => {
+        const reqMock = assign(this.reqMock, {
+          query: {
+            country: 'uk',
+          },
+        })
+        const resMock = assign(this.resMock, {
+          locals: {
+            formData: {
+              business_type: '99d14e94-5d95-e211-a939-e4115bead28a',
+            },
+          },
+        })
+
+        await this.controller.renderForm(reqMock, resMock, this.nextSpy)
+      })
+
+      it('should render the edit page', () => {
+        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+      })
+
+      it('should set the add breadcrumb', () => {
+        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Add')
+      })
+
+      it('should set heading', () => {
+        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Add UK company')
+      })
+
+      it('should set isForeign', () => {
+        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+      })
+
+      it('should set businessTypeLabel', () => {
+        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('Sole Trader')
+      })
+
+      it('should not show the company number field', () => {
+        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.false
+      })
+
+      it('should not show the trading address fields', () => {
+        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+    })
+
+    context('when adding a foreign sole trader', () => {
+      beforeEach(async () => {
+        const reqMock = assign(this.reqMock, {
+          query: {
+            country: 'non-uk',
+          },
+        })
+        const resMock = assign(this.resMock, {
+          locals: {
+            formData: {
+              business_type: '99d14e94-5d95-e211-a939-e4115bead28a',
+            },
+          },
+        })
+
+        await this.controller.renderForm(reqMock, resMock, this.nextSpy)
+      })
+
+      it('should render the edit page', () => {
+        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+      })
+
+      it('should set the add breadcrumb', () => {
+        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Add')
+      })
+
+      it('should set heading', () => {
+        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Add foreign company')
+      })
+
+      it('should set isForeign', () => {
+        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.true
+      })
+
+      it('should set businessTypeLabel', () => {
+        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('Sole Trader')
+      })
+
+      it('should not show the company number field', () => {
+        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.false
+      })
+
+      it('should not show the trading address fields', () => {
+        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+    })
+
+    context('when editing a government department with a trading address', () => {
+      beforeEach(async () => {
+        const reqMock = assign(this.reqMock, {
+          query: {
+            country: 'uk',
+          },
+        })
+        const resMock = assign(this.resMock, {
+          locals: {
+            formData: {
+              business_type: '9cd14e94-5d95-e211-a939-e4115bead28a',
+              trading_address_1: 'address',
+            },
+            company: {
+              id: 1,
+              name: 'Existing government department',
+              uk_based: true,
+            },
+          },
+        })
+
+        await this.controller.renderForm(reqMock, resMock, this.nextSpy)
+      })
+
+      it('should render the edit page', () => {
+        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+      })
+
+      it('should set the add breadcrumb', () => {
+        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Existing government department')
+      })
+
+      it('should set heading', () => {
+        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Edit UK company')
+      })
+
+      it('should set isForeign', () => {
+        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+      })
+
+      it('should set businessTypeLabel', () => {
+        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('Government department')
+      })
+
+      it('should not show the company number field', () => {
+        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.false
+      })
+
+      it('should not show the trading address fields', () => {
+        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.true
+      })
+
+      it('nock mocked scope has been called', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
     })
   })
 })


### PR DESCRIPTION
DH-1409

This change depends on [Add UK establishment business type](https://github.com/uktrade/data-hub-leeloo/pull/737) in Leeloo.

This change primarily introduces the `add` `UK branch of a foreign company` feature. Change includes:
- refactor of existing mapping code
- adding the field
- associated acceptance tests
- significant refactor of unit tests around company edit controller

# 1. New option
<img width="741" alt="screen shot 2018-01-15 at 17 13 19" src="https://user-images.githubusercontent.com/1150417/34954264-b5d0a9d4-fa17-11e7-9979-20a2f79fd768.png">

# 2. New field
<img width="708" alt="screen shot 2018-01-15 at 17 16 00" src="https://user-images.githubusercontent.com/1150417/34954336-ed18cab6-fa17-11e7-9cc9-ad009d38883e.png">

# 3. Updated heading
This was changed because the business type value read `UK UK branch of foreign company (BR)`.

<img width="911" alt="screen shot 2018-01-15 at 17 16 10" src="https://user-images.githubusercontent.com/1150417/34954390-2da18956-fa18-11e7-8d80-522586dcd898.png">

