### PR TITLE
Minify HTML in production

### DIFF
--- a/assets/stylesheets/components/_breadcrumb.scss
+++ b/assets/stylesheets/components/_breadcrumb.scss
@@ -7,7 +7,7 @@
   background: url("../../images/separator.png") left center no-repeat;
   background-size: 6px 11px;
   display: inline-block;
-  margin: 0 0 0 $default-spacing-unit / 2;
+  margin: 0 0 0 ($default-spacing-unit - 6);
   padding: 0 0 0 $default-spacing-unit;
 
   @include device-pixel-ratio(2) {

--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -9,7 +9,7 @@
   display: inline-block;
 
   & + & {
-    margin-left: $baseline-grid-unit;
+    margin-left: $default-spacing-unit / 2;
   }
 }
 

--- a/assets/stylesheets/components/_pagination.scss
+++ b/assets/stylesheets/components/_pagination.scss
@@ -10,6 +10,7 @@
   .c-pagination__label--next {
     float: left;
     font-size: 24px;
+    margin: 0;
   }
 
   .c-pagination__label--next {
@@ -29,6 +30,10 @@
 
 .c-pagination__list-item {
   display: inline-block;
+
+  & + & {
+    margin-left: $baseline-grid-unit * 1.5;
+  }
 }
 
 .c-pagination__label {
@@ -52,6 +57,14 @@
     color: $text-colour;
     text-decoration: none;
   }
+}
+
+.c-pagination__label--prev {
+  margin-right: $baseline-grid-unit * 1.5;
+}
+
+.c-pagination__label--next {
+  margin-left: $baseline-grid-unit * 1.5;
 }
 
 .c-pagination__label--truncation {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "express": "^4.16.2",
+    "express-minify-html": "^0.12.0",
     "express-session": "^1.15.6",
     "express-sslify": "^1.2.0",
     "extract-text-webpack-plugin": "^3.0.2",

--- a/src/apps/components/views/pagination.njk
+++ b/src/apps/components/views/pagination.njk
@@ -5,13 +5,14 @@
     {{
       Pagination({
         totalPages: 3,
-        currentPage: 1,
-        prev: null,
-        next: '?term=samsung&page=2',
+        currentPage: 2,
+        prev: '?term=samsung&page=1',
+        next: '?term=samsung&page=3',
         pages: [
           { label: 1, url: '?term=samsung&page=1' },
           { label: 2, url: '?term=samsung&page=2' },
-          { label: 3, url: '?term=samsung&page=3' }
+          { label: 3, url: '?term=samsung&page=3' },
+          { label: 4, url: '?term=samsung&page=4' }
         ]
       })
     }}

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ const churchill = require('churchill')
 const enforce = require('express-sslify')
 const favicon = require('serve-favicon')
 const cookieParser = require('cookie-parser')
+const minifyHTML = require('express-minify-html')
 const i18n = require('i18n-future').middleware()
 
 const title = require('./middleware/title')
@@ -69,6 +70,20 @@ app.use(i18n)
 
 app.set('view engine', 'njk')
 nunjucks(app, config)
+
+app.use(minifyHTML({
+  override: true,
+  exception_url: false,
+  htmlMinifier: {
+    removeComments: true,
+    collapseInlineTagWhitespace: false,
+    collapseWhitespace: true,
+    collapseBooleanAttributes: true,
+    removeAttributeQuotes: true,
+    removeEmptyAttributes: true,
+    minifyJS: true,
+  },
+}))
 
 // Static files
 app.use(favicon(path.join(config.root, 'public/images', 'favicon.ico')))

--- a/src/templates/_components/archive-form.njk
+++ b/src/templates/_components/archive-form.njk
@@ -17,7 +17,13 @@
 {% set radioOptions = options | concat('Other') | arrayToLabelValues %}
 {% set radioOptionsPrefix = optionsPrefix %}
 
-<form class="archive-form js-archiveForm" method="POST" {% if url %}action="{{ url }}{% endif %}">
+<form
+  class="archive-form js-archiveForm"
+  method="POST"
+  {% if url %}
+    action="{{ url }}"
+  {% endif %}
+>
   <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
   {{ MultipleChoiceField({

--- a/src/templates/_macros/common/breadcrumbs.njk
+++ b/src/templates/_macros/common/breadcrumbs.njk
@@ -17,7 +17,7 @@
   {% if props.items|length > 1 %}
     <nav class="c-breadcrumb" aria-label="Breadcrumbs">
       <ul class="c-breadcrumb__list" itemscope itemtype="http://schema.org/BreadcrumbList">
-        {% for breadcrumb in props.items %}
+        {% for breadcrumb in props.items -%}
           <li class="c-breadcrumb__list-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
             {% if loop.last %}
               <a href="#main-content" class="c-breadcrumb__link is-active" itemprop="url">
@@ -29,7 +29,7 @@
               </a>
             {% endif %}
           </li>
-        {% endfor %}
+        {%- endfor %}
       </ul>
     </nav>
   {% endif %}

--- a/src/templates/_macros/common/pagination.njk
+++ b/src/templates/_macros/common/pagination.njk
@@ -26,29 +26,29 @@
       class="c-pagination {{ 'c-pagination--pageless' if not showPages }}"
       aria-label="pagination: total {{ pagination.totalPages }} pages"
     >
-      {% if pagination.prev %}
+      {% if pagination.prev -%}
         <a href="{{ pagination.prev }}" class="c-pagination__label c-pagination__label--prev">Previous</a>
-      {% endif %}
-      {% if showPages %}
+      {%- endif %}
+      {% if showPages -%}
         <ul class="c-pagination__list">
-          {% for page in pagination.pages %}
+          {% for page in pagination.pages -%}
             <li class="c-pagination__list-item">
-              {% if page.url %}
+              {% if page.url -%}
                 <a href="{{ page.url }}" class="c-pagination__label {{ 'is-current' if page.label == pagination.currentPage }}">
-                  {{ page.label }}
+                  {{- page.label -}}
                 </a>
-              {% else %}
+              {% else -%}
                 <span class="c-pagination__label c-pagination__label--truncation">
-                  {{ page.label }}
+                  {{- page.label -}}
                 </span>
-              {% endif %}
+              {%- endif %}
             </li>
-          {% endfor %}
+          {%- endfor %}
         </ul>
-      {% endif %}
-      {% if pagination.next %}
+      {%- endif %}
+      {% if pagination.next -%}
         <a href="{{ pagination.next }}" class="c-pagination__label c-pagination__label--next">Next</a>
-      {% endif %}
+      {%- endif %}
     </nav>
   {% endif %}
 {% endmacro %}

--- a/src/templates/_macros/entity/meta-item.njk
+++ b/src/templates/_macros/entity/meta-item.njk
@@ -39,7 +39,7 @@
     <div class="{{ 'c-meta-list__item' | applyClassModifiers(props.modifier) }}">
       {% if props.label %}
         <span class="c-meta-list__item-label {{ 'u-visually-hidden' if isLabelHidden or props.type === 'badge' }}">
-          {{ props.label }}
+          {{- props.label -}}
         </span>
       {% endif %}
       {% if props.url and not props.isInert and not props.urlLabel %}
@@ -51,10 +51,10 @@
         </a>
       {% else %}
         <span class="{{ itemValueClass }}">
-          {{ value }}
-          {% if props.url and props.urlLabel %}
-            - <a href="{{ props.url }}">{{ props.urlLabel }}</a>
-          {% endif %}
+          {{- value -}}
+          {% if props.url and props.urlLabel -%}
+          &nbsp;- <a href="{{ props.url }}">{{ props.urlLabel }}</a>
+          {%- endif %}
         </span>
       {% endif %}
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,6 +1385,13 @@ callsites@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-1.0.1.tgz#c14c24188ce8e1d6a030b4c3c942e6ba895b6a1a"
 
+camel-case@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -1584,6 +1591,12 @@ classlist.js@^1.1.20150312:
   version "1.1.20150312"
   resolved "https://registry.yarnpkg.com/classlist.js/-/classlist.js-1.1.20150312.tgz#1d70842f7022f08d9ac086ce69e5b250f2c57789"
 
+clean-css@4.1.x:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
+  dependencies:
+    source-map "0.5.x"
+
 clean-css@~1.0.4:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-1.0.12.tgz#e6e0d977860466363d9110a17423d27cd6874300"
@@ -1767,15 +1780,15 @@ commander@1.3.x:
   dependencies:
     keypress "0.1.x"
 
+commander@2.12.x, commander@^2.11.0, commander@~2.12.1:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
 commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
-
-commander@^2.11.0:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
 commander@~2.1.0:
   version "2.1.0"
@@ -3304,6 +3317,13 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+express-minify-html@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/express-minify-html/-/express-minify-html-0.12.0.tgz#43a9b5a0a04f1161a3e2367ae0b4af8bc7d68328"
+  dependencies:
+    html-minifier "3.5.7"
+    lodash.merge "4.6.0"
+
 express-session@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.15.6.tgz#47b4160c88f42ab70fe8a508e31cbff76757ab0a"
@@ -4430,7 +4450,7 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-he@1.1.1:
+he@1.1.1, he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -4522,6 +4542,19 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+html-minifier@3.5.7:
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.7.tgz#511e69bb5a8e7677d1012ebe03819aa02ca06208"
+  dependencies:
+    camel-case "3.0.x"
+    clean-css "4.1.x"
+    commander "2.12.x"
+    he "1.1.x"
+    ncname "1.0.x"
+    param-case "2.1.x"
+    relateurl "0.2.x"
+    uglify-js "3.2.x"
 
 html5shiv@^3.7.3:
   version "3.7.3"
@@ -5869,7 +5902,7 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.merge@^4.0:
+lodash.merge@4.6.0, lodash.merge@^4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
@@ -6416,6 +6449,12 @@ nan@^2.3.0, nan@^2.3.2:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+ncname@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
+  dependencies:
+    xml-char-classes "^1.0.0"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -6983,6 +7022,12 @@ pad-right@^0.2.2:
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+
+param-case@2.1.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  dependencies:
+    no-case "^2.2.0"
 
 parse-asn1@^5.0.0:
   version "5.1.0"
@@ -7992,6 +8037,10 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
+relateurl@0.2.x:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
+
 remove-trailing-separator@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
@@ -8752,6 +8801,10 @@ source-map@0.5.6, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, sourc
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@0.5.x, source-map@^0.5.7, source-map@~0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 source-map@^0.1.38:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
@@ -8764,11 +8817,7 @@ source-map@^0.4.2, source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.7, source-map@~0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
-source-map@^0.6.1:
+source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -9439,6 +9488,13 @@ uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
+uglify-js@3.2.x:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.2.2.tgz#870e4b34ed733d179284f9998efd3293f7fd73f6"
+  dependencies:
+    commander "~2.12.1"
+    source-map "~0.6.1"
+
 uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -9606,7 +9662,7 @@ update-notifier@^2.3.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-upper-case@^1.0.3:
+upper-case@^1.0.3, upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
@@ -10016,6 +10072,10 @@ wtf-8@1.0.0:
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+
+xml-char-classes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
 
 xml-name-validator@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
A lot of our macros are creating unnecessary white space and when
these macros are used in repetition some documents can be quite
large.

This removes the unnecessary whitespace when the app is in production.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
