### PR TITLE
DH-1013 Add one or more actual landed regions to investment project

### DIFF
--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -1,5 +1,3 @@
-const { get } = require('lodash')
-
 function editDetailsGet (req, res) {
   res
     .breadcrumb('Edit details')
@@ -12,7 +10,7 @@ function editValueGet (req, res) {
     .render('investment-projects/views/value-edit')
 }
 
-function editRequirementsGet (req, res) {
+function renderRequirementsForm (req, res) {
   res.render('investment-projects/views/requirements-edit')
 }
 
@@ -34,19 +32,10 @@ function editValuePost (req, res) {
   return res.redirect(`/investment-projects/${res.locals.projectId}/details`)
 }
 
-function editRequirementsPost (req, res) {
-  if (get(res.locals, 'requirementsForm.errors')) {
-    return res.render('investment-projects/views/requirements-edit')
-  }
-  req.flash('success', 'Investment requirements updated')
-  return res.redirect(`/investment-projects/${res.locals.projectId}/details`)
-}
-
 module.exports = {
   editDetailsGet,
   editValueGet,
-  editRequirementsGet,
+  renderRequirementsForm,
   editDetailsPost,
   editValuePost,
-  editRequirementsPost,
 }

--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -53,6 +53,7 @@ const labels = {
       client_requirements: 'Client requirements',
       competitor_countries: 'Competitor countries',
       uk_region_locations: 'Possible UK locations',
+      actual_uk_regions: 'UK regions landed',
       uk_company: 'UK recipient company',
     },
     edit: {
@@ -60,6 +61,7 @@ const labels = {
       client_considering_other_countries: 'Is the client considering other countries?',
       uk_region_locations: 'Possible UK locations for this investment',
       site_decided: 'Has the UK location (site address) for this investment been decided yet?',
+      actual_uk_regions: 'UK regions landed',
     },
   },
   evaluationValueLabels: {

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -206,6 +206,24 @@ const requirementsFormConfig = ({
           },
         ],
       },
+      {
+        macroName: 'AddAnother',
+        buttonName: 'add_item',
+        name: 'actual_uk_regions',
+        label: requirementsLabels.edit.actual_uk_regions,
+        condition: {
+          name: 'site_decided',
+          value: 'true',
+        },
+        children: [
+          assign({}, globalFields.ukRegions, {
+            label: labels.actual_uk_regions,
+            isLabelHidden: true,
+            name: 'actual_uk_regions',
+            options: ukRegions,
+          }),
+        ],
+      },
     ].map(field => {
       return assign(field, {
         label: requirementsLabels.edit[field.name],

--- a/src/apps/investment-projects/middleware/forms/requirements.js
+++ b/src/apps/investment-projects/middleware/forms/requirements.js
@@ -47,6 +47,7 @@ async function handleFormPost (req, res, next) {
       strategic_drivers: cleanArray(req.body.strategic_drivers),
       competitor_countries: req.body.client_considering_other_countries === 'true' ? cleanArray(req.body.competitor_countries) : [],
       uk_region_locations: cleanArray(req.body.uk_region_locations),
+      actual_uk_regions: req.body.site_decided === 'true' ? cleanArray(req.body.actual_uk_regions) : [],
     })
 
     // if called with the add item instruction, simply re-render the form and it will add extra fields as needed

--- a/src/apps/investment-projects/middleware/forms/requirements.js
+++ b/src/apps/investment-projects/middleware/forms/requirements.js
@@ -1,4 +1,4 @@
-const { assign, flatten, get } = require('lodash')
+const { assign, castArray, compact, get } = require('lodash')
 
 const { updateInvestment } = require('../../repos')
 const { requirementsFormConfig } = require('../../macros')
@@ -11,6 +11,15 @@ async function getFormOptions (token, createdOn) {
     countries: await getOptions(token, 'country', { createdOn }),
     ukRegions: await getOptions(token, 'uk-region', { createdOn }),
   }
+}
+
+function formatBody (body) {
+  return assign({}, body, {
+    strategic_drivers: compact(castArray(body.strategic_drivers)),
+    competitor_countries: body.client_considering_other_countries === 'true' ? compact(castArray(body.competitor_countries)) : [],
+    uk_region_locations: compact(castArray(body.uk_region_locations)),
+    actual_uk_regions: body.site_decided === 'true' ? compact(castArray(body.actual_uk_regions)) : [],
+  })
 }
 
 async function populateForm (req, res, next) {
@@ -32,25 +41,12 @@ async function populateForm (req, res, next) {
   next()
 }
 
-// Strips out empty entries so they are not posted (which result in errors)
-// and when an error is thrown it doesn't mean yet another is added
-function cleanArray (values) {
-  return flatten([values])
-    .filter(item => item)
-}
-
 async function handleFormPost (req, res, next) {
   try {
     const investmentId = req.params.investmentId
 
-    res.locals.formattedBody = assign({}, req.body, {
-      strategic_drivers: cleanArray(req.body.strategic_drivers),
-      competitor_countries: req.body.client_considering_other_countries === 'true' ? cleanArray(req.body.competitor_countries) : [],
-      uk_region_locations: cleanArray(req.body.uk_region_locations),
-      actual_uk_regions: req.body.site_decided === 'true' ? cleanArray(req.body.actual_uk_regions) : [],
-    })
+    res.locals.formattedBody = formatBody(req.body)
 
-    // if called with the add item instruction, simply re-render the form and it will add extra fields as needed
     if (req.body.add_item) {
       return next()
     }

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -128,8 +128,8 @@ router
 
 router
   .route('/:investmentId/edit-requirements')
-  .get(requirementsFormMiddleware.populateForm, edit.editRequirementsGet)
-  .post(requirementsFormMiddleware.populateForm, requirementsFormMiddleware.handleFormPost, edit.editRequirementsPost)
+  .get(requirementsFormMiddleware.populateForm, edit.renderRequirementsForm)
+  .post(requirementsFormMiddleware.handleFormPost, requirementsFormMiddleware.populateForm, edit.renderRequirementsForm)
 
 router.get('/:investmentId/team', expandTeamMembers, team.details.getDetailsHandler)
 

--- a/src/apps/investment-projects/transformers/requirements.js
+++ b/src/apps/investment-projects/transformers/requirements.js
@@ -1,41 +1,48 @@
 /* eslint-disable camelcase */
-const { assign, get, isPlainObject } = require('lodash')
+const { isPlainObject, map } = require('lodash')
 
-function transformUKCompany (data) {
-  if (isPlainObject(data.uk_company)) {
+function transformUKCompany (investmentId, ukCompany) {
+  if (!isPlainObject(ukCompany)) {
     return {
-      name: data.uk_company.name,
-      actions: [{
-        label: 'Edit company',
-        url: `/investment-projects/${data.id}/edit-ukcompany?term=${encodeURIComponent(data.uk_company.name)}`,
-      }, {
-        label: 'Remove company',
-        url: `/investment-projects/${data.id}/remove-ukcompany`
-        ,
-      }],
+      name: 'Find company',
+      url: `/investment-projects/${investmentId}/edit-ukcompany`,
     }
   }
 
+  const { name } = ukCompany
+
   return {
-    name: 'Find company',
-    url: `/investment-projects/${data.id}/edit-ukcompany`,
+    name,
+    actions: [
+      {
+        label: 'Edit company',
+        url: `/investment-projects/${investmentId}/edit-ukcompany?term=${encodeURIComponent(name)}`,
+      },
+      {
+        label: 'Remove company',
+        url: `/investment-projects/${investmentId}/remove-ukcompany`,
+      },
+    ],
   }
 }
 
-function transformInvestmentRequirementsForView (data) {
-  if (!isPlainObject(data)) { return }
-
-  const strategicDrivers = get(data, 'strategic_drivers', [])
-  const competitorCountries = get(data, 'competitor_countries', [])
-  const regionLocations = get(data, 'uk_region_locations', [])
-  const uk_company = transformUKCompany(data)
-
-  return assign({}, data, {
-    strategic_drivers: strategicDrivers.map(driver => driver.name).join(', '),
-    competitor_countries: competitorCountries.map(country => country.name).join(', '),
-    uk_region_locations: regionLocations.map(region => region.name).join(', '),
-    uk_company,
-  })
+function transformInvestmentRequirementsForView ({
+  actual_uk_regions,
+  client_requirements,
+  competitor_countries,
+  id,
+  strategic_drivers,
+  uk_company,
+  uk_region_locations,
+} = {}) {
+  return {
+    strategic_drivers: map(strategic_drivers, 'name').join(', '),
+    client_requirements,
+    competitor_countries: map(competitor_countries, 'name').join(', '),
+    uk_region_locations: map(uk_region_locations, 'name').join(', '),
+    actual_uk_regions: map(actual_uk_regions, 'name').join(', '),
+    uk_company: transformUKCompany(id, uk_company),
+  }
 }
 
 module.exports = { transformInvestmentRequirementsForView }

--- a/test/unit/apps/investment-projects/middleware/forms/requirements.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/requirements.test.js
@@ -1,0 +1,744 @@
+const uuid = require('uuid')
+const moment = require('moment')
+const { assign } = require('lodash')
+
+const investmentData = require('~/test/unit/data/investment/investment-data.json')
+const config = require('~/config')
+const { handleFormPost, populateForm } = require('~/src/apps/investment-projects/middleware/forms/requirements')
+
+const yesterday = moment().subtract(1, 'days').toISOString()
+
+const metadataMock = {
+  strategicDriversOptions: [
+    { id: '1', name: 'ehq', disabled_on: null },
+    { id: '2', name: 'ghq', disabled_on: yesterday },
+    { id: '3', name: 'ukhq', disabled_on: null },
+  ],
+  regionOptions: [
+    { id: '1', name: 'r1', disabled_on: null },
+    { id: '2', name: 'r2', disabled_on: yesterday },
+    { id: '3', name: 'r3', disabled_on: null },
+  ],
+  countryOptions: [
+    { id: '9999', name: 'United Kingdom', disabled_on: null },
+    { id: '8888', name: 'Test', disabled_on: yesterday },
+  ],
+}
+
+function getFieldValue (form, name) {
+  const fields = form.children || []
+
+  const field = fields.find(item => item.name === name)
+
+  if (field) {
+    return field.value
+  }
+
+  return null
+}
+
+function getFieldError (form, name) {
+  const fields = form.children || []
+
+  const field = fields.find(item => item.name === name)
+
+  if (field) {
+    return field.error
+  }
+
+  return null
+}
+
+describe('Investment requirements form middleware', () => {
+  beforeEach(() => {
+    this.reqMock = {
+      body: {},
+      session: {
+        token: uuid(),
+        user: {
+          id: '4321',
+          name: 'Julie Brown',
+        },
+      },
+      params: {
+        investmentId: '1234',
+      },
+      query: {},
+      flash: sandbox.stub(),
+    }
+
+    this.resMock = {
+      locals: {},
+      redirect: sandbox.stub(),
+    }
+
+    this.nextStub = sandbox.stub()
+  })
+
+  describe('#populateForm', () => {
+    beforeEach(() => {
+      this.resMock.locals = assign({}, this.reqMock.locals, { investmentData })
+
+      this.nockScope = nock(config.apiRoot)
+        .get('/metadata/uk-region/')
+        .reply(200, metadataMock.regionOptions)
+        .get('/metadata/country/')
+        .reply(200, metadataMock.countryOptions)
+        .get('/metadata/investment-strategic-driver/')
+        .reply(200, metadataMock.strategicDriversOptions)
+    })
+
+    context('when called without posted data', () => {
+      beforeEach(async () => {
+        await populateForm(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should get options', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+
+      it('should build the form with the investment data', () => {
+        const clientRequirments = getFieldValue(this.resMock.locals.requirementsForm, 'client_requirements')
+        expect(clientRequirments).to.eq('Some interesting requirements here')
+      })
+
+      it('should set the return link', () => {
+        expect(this.resMock.locals.requirementsForm).to.have.property('returnLink', '/investment-projects/1234')
+      })
+    })
+
+    context('when called with posted data', () => {
+      beforeEach(async () => {
+        this.resMock.locals = assign({}, this.resMock.locals, {
+          formattedBody: {
+            strategic_drivers: ['844cd12a-6095-e211-a939-e4115bead28a'],
+            client_requirements: 'some requirements',
+          },
+        })
+
+        await populateForm(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should get the options', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+
+      it('should build the form with the posted data', () => {
+        const clientRequirments = getFieldValue(this.resMock.locals.requirementsForm, 'client_requirements')
+        expect(clientRequirments).to.eq('some requirements')
+      })
+
+      it('should set the return link', () => {
+        expect(this.resMock.locals.requirementsForm).to.have.property('returnLink', '/investment-projects/1234')
+      })
+    })
+
+    context('when called with called with errors', () => {
+      beforeEach(async () => {
+        this.resMock.locals = assign({}, this.resMock.locals, {
+          errors: {
+            client_requirements: ['required'],
+          },
+        })
+
+        await populateForm(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should build the form with the errors', () => {
+        const error = getFieldError(this.resMock.locals.requirementsForm, 'client_requirements')
+        expect(error).to.deep.eq(['required'])
+      })
+    })
+  })
+
+  describe('#handleFormPost', () => {
+    context('when called with multiple strategic drivers', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .patch('/v3/investment/1234', {
+            strategic_drivers: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+            actual_uk_regions: [],
+            competitor_countries: [],
+            uk_region_locations: [],
+          })
+          .reply(200, {})
+
+        const body = {
+          strategic_drivers: [
+            '844cd12a-6095-e211-a939-e4115bead28a',
+            '844cd12a-6095-e211-a939-e4115bead28b',
+          ],
+          client_requirements: 'some requirements',
+        }
+
+        this.reqMock = assign({}, this.reqMock, { body })
+        await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should call the API with transformed data', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+
+      it('should redirect the user to the details screen', () => {
+        expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+      })
+
+      it('should send a flash message to inform the user of the change', () => {
+        expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+      })
+    })
+
+    context('when called with a single strategic driver', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .patch('/v3/investment/1234', {
+            actual_uk_regions: [],
+            competitor_countries: [],
+            uk_region_locations: [],
+            strategic_drivers: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+            ],
+            client_requirements: 'some requirements',
+          })
+          .reply(200, {})
+
+        const body = {
+          strategic_drivers: '844cd12a-6095-e211-a939-e4115bead28a',
+          client_requirements: 'some requirements',
+        }
+
+        this.reqMock = assign({}, this.reqMock, { body })
+
+        await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should call the API with transformed data', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+
+      it('should redirect the user to the details screen', () => {
+        expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+      })
+
+      it('should send a flash message to inform the user of the change', () => {
+        expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+      })
+    })
+
+    context('when client is considering competitor countries', () => {
+      beforeEach(() => {
+        this.reqMock.body = assign({}, this.reqMock.body, {
+          client_considering_other_countries: 'true',
+        })
+      })
+
+      context('when called with multiple competitor countries', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              client_considering_other_countries: 'true',
+              competitor_countries: [
+                '844cd12a-6095-e211-a939-e4115bead28a',
+                '844cd12a-6095-e211-a939-e4115bead28b',
+              ],
+              client_requirements: 'some requirements',
+              actual_uk_regions: [],
+              strategic_drivers: [],
+              uk_region_locations: [],
+            })
+            .reply(200, {})
+
+          const body = {
+            client_considering_other_countries: 'true',
+            competitor_countries: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+
+      context('when called with a single competitor country', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              client_considering_other_countries: 'true',
+              actual_uk_regions: [],
+              strategic_drivers: [],
+              uk_region_locations: [],
+              competitor_countries: [
+                '844cd12a-6095-e211-a939-e4115bead28a',
+              ],
+              client_requirements: 'some requirements',
+            })
+            .reply(200, {})
+
+          const body = {
+            competitor_countries: '844cd12a-6095-e211-a939-e4115bead28a',
+            client_considering_other_countries: 'true',
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+    })
+
+    context('when client is not considering competitor countries', () => {
+      beforeEach(() => {
+        this.reqMock.body = assign({}, this.reqMock.body, {
+          client_considering_other_countries: 'false',
+        })
+      })
+
+      context('when called with multiple competitor countries', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              client_considering_other_countries: 'false',
+              competitor_countries: [],
+              client_requirements: 'some requirements',
+              actual_uk_regions: [],
+              strategic_drivers: [],
+              uk_region_locations: [],
+            })
+            .reply(200, {})
+
+          const body = {
+            client_considering_other_countries: 'false',
+            competitor_countries: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+
+      context('when called with a single competitor country', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              client_considering_other_countries: 'false',
+              actual_uk_regions: [],
+              strategic_drivers: [],
+              uk_region_locations: [],
+              competitor_countries: [],
+              client_requirements: 'some requirements',
+            })
+            .reply(200, {})
+
+          const body = {
+            competitor_countries: '844cd12a-6095-e211-a939-e4115bead28a',
+            client_considering_other_countries: 'false',
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+    })
+
+    context('when called with multiple uk regions', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .patch('/v3/investment/1234', {
+            uk_region_locations: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+            actual_uk_regions: [],
+            strategic_drivers: [],
+            competitor_countries: [],
+          })
+          .reply(200, {})
+
+        const body = {
+          uk_region_locations: [
+            '844cd12a-6095-e211-a939-e4115bead28a',
+            '844cd12a-6095-e211-a939-e4115bead28b',
+          ],
+          client_requirements: 'some requirements',
+        }
+
+        this.reqMock = assign({}, this.reqMock, { body })
+        await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should call the API with transformed data', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+
+      it('should redirect the user to the details screen', () => {
+        expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+      })
+
+      it('should send a flash message to inform the user of the change', () => {
+        expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+      })
+    })
+
+    context('when called with a single uk region', () => {
+      beforeEach(async () => {
+        this.nockScope = nock(config.apiRoot)
+          .patch('/v3/investment/1234', {
+            actual_uk_regions: [],
+            strategic_drivers: [],
+            competitor_countries: [],
+            uk_region_locations: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+            ],
+            client_requirements: 'some requirements',
+          })
+          .reply(200, {})
+
+        const body = {
+          uk_region_locations: '844cd12a-6095-e211-a939-e4115bead28a',
+          client_requirements: 'some requirements',
+        }
+
+        this.reqMock = assign({}, this.reqMock, { body })
+
+        await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should call the API with transformed data', () => {
+        expect(this.nockScope.isDone()).to.be.true
+      })
+
+      it('should redirect the user to the details screen', () => {
+        expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+      })
+
+      it('should send a flash message to inform the user of the change', () => {
+        expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+      })
+    })
+
+    context('when uk location has been decided', () => {
+      context('when called with multiple actual landed regions', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              site_decided: 'true',
+              actual_uk_regions: [
+                '844cd12a-6095-e211-a939-e4115bead28a',
+                '844cd12a-6095-e211-a939-e4115bead28b',
+              ],
+              client_requirements: 'some requirements',
+              strategic_drivers: [],
+              competitor_countries: [],
+              uk_region_locations: [],
+            })
+            .reply(200, {})
+
+          const body = {
+            site_decided: 'true',
+            actual_uk_regions: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+
+      context('when called with a single actual landed region', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              site_decided: 'true',
+              strategic_drivers: [],
+              competitor_countries: [],
+              uk_region_locations: [],
+              actual_uk_regions: ['844cd12a-6095-e211-a939-e4115bead28a'],
+              client_requirements: 'some requirements',
+            })
+            .reply(200, {})
+
+          const body = {
+            site_decided: 'true',
+            actual_uk_regions: '844cd12a-6095-e211-a939-e4115bead28a',
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+    })
+
+    context('when uk location has not been decided', () => {
+      context('when called with multiple actual landed regions', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              site_decided: 'false',
+              actual_uk_regions: [],
+              client_requirements: 'some requirements',
+              strategic_drivers: [],
+              competitor_countries: [],
+              uk_region_locations: [],
+            })
+            .reply(200, {})
+
+          const body = {
+            site_decided: 'false',
+            actual_uk_regions: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+
+      context('when called with a single actual landed region', () => {
+        beforeEach(async () => {
+          this.nockScope = nock(config.apiRoot)
+            .patch('/v3/investment/1234', {
+              site_decided: 'false',
+              strategic_drivers: [],
+              competitor_countries: [],
+              uk_region_locations: [],
+              actual_uk_regions: [],
+              client_requirements: 'some requirements',
+            })
+            .reply(200, {})
+
+          const body = {
+            site_decided: 'false',
+            actual_uk_regions: '844cd12a-6095-e211-a939-e4115bead28a',
+            client_requirements: 'some requirements',
+          }
+
+          this.reqMock = assign({}, this.reqMock, { body })
+
+          await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+        })
+
+        it('should call the API with transformed data', () => {
+          expect(this.nockScope.isDone()).to.be.true
+        })
+
+        it('should redirect the user to the details screen', () => {
+          expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
+        })
+
+        it('should send a flash message to inform the user of the change', () => {
+          expect(this.reqMock.flash).to.be.calledWith('success', 'Investment requirements updated')
+        })
+      })
+    })
+
+    context('when called with form errors', () => {
+      beforeEach(async () => {
+        this.error = [
+          {},
+          { client_requirements: ['This field may not be blank.'] },
+        ]
+
+        this.nockScope = nock(config.apiRoot)
+          .patch('/v3/investment/1234', {
+            site_decided: 'true',
+            strategic_drivers: [],
+            competitor_countries: [],
+            uk_region_locations: [],
+            actual_uk_regions: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+          })
+          .reply(400, this.error)
+
+        const body = {
+          site_decided: 'true',
+          client_requirements: 'some requirements',
+          actual_uk_regions: [
+            '844cd12a-6095-e211-a939-e4115bead28a',
+            '844cd12a-6095-e211-a939-e4115bead28b',
+          ],
+        }
+
+        this.reqMock = assign({}, this.reqMock, { body })
+
+        await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should pass the request to the next middleware', () => {
+        expect(this.nextStub).to.be.called
+      })
+
+      it('should set the errors on the response object', () => {
+        expect(this.resMock.locals.errors).to.deep.equal(this.error)
+      })
+    })
+
+    context('when called to add another', async () => {
+      beforeEach(async () => {
+        this.error = [
+          {},
+          { client_requirements: ['This field may not be blank.'] },
+        ]
+
+        this.nockScope = nock(config.apiRoot)
+          .patch('/v3/investment/1234', {
+            strategic_drivers: [],
+            competitor_countries: [],
+            uk_region_locations: [],
+            actual_uk_regions: [
+              '844cd12a-6095-e211-a939-e4115bead28a',
+              '844cd12a-6095-e211-a939-e4115bead28b',
+            ],
+            client_requirements: 'some requirements',
+          })
+          .reply(400, this.error)
+
+        const body = {
+          site_decided: 'true',
+          actual_uk_regions: [
+            '844cd12a-6095-e211-a939-e4115bead28a',
+            '844cd12a-6095-e211-a939-e4115bead28b',
+          ],
+          add_item: 'true',
+          client_requirements: 'some requirements',
+        }
+
+        this.reqMock = assign({}, this.reqMock, { body })
+
+        await handleFormPost(this.reqMock, this.resMock, this.nextStub)
+      })
+
+      it('should pass the request to the next middleware', () => {
+        expect(this.nextStub).to.be.called
+      })
+
+      it('should set the transformed form body on the response', () => {
+        expect(this.resMock.locals.formattedBody).to.deep.equal({
+          site_decided: 'true',
+          add_item: 'true',
+          strategic_drivers: [],
+          competitor_countries: [],
+          uk_region_locations: [],
+          actual_uk_regions: [
+            '844cd12a-6095-e211-a939-e4115bead28a',
+            '844cd12a-6095-e211-a939-e4115bead28b',
+          ],
+          client_requirements: 'some requirements',
+        })
+      })
+
+      it('should not try and save the record', () => {
+        expect(this.nockScope.isDone()).to.be.false
+      })
+    })
+  })
+})

--- a/test/unit/apps/investment-projects/transformers/requirements.test.js
+++ b/test/unit/apps/investment-projects/transformers/requirements.test.js
@@ -1,16 +1,257 @@
-const investmentData = require('~/test/unit/data/investment/investment-data.json')
+const { assign } = require('lodash')
+
 const { transformInvestmentRequirementsForView } = require('~/src/apps/investment-projects/transformers/requirements')
 
 describe('Investment project transformers', () => {
   describe('#transformInvestmentRequirementsForView', () => {
+    beforeEach(() => {
+      this.investmentData = {
+        actual_uk_regions: [{ id: 'a1', name: 'region 1' }],
+        client_requirements: 'requirements',
+        competitor_countries: [{ id: 'c1', name: 'country 1' }],
+        id: 'inv1',
+        strategic_drivers: [{ id: 'sd1', name: 'strategic driver 1' }],
+        uk_company: {
+          id: 'company1',
+          name: 'Test company',
+        },
+        uk_region_locations: [{ id: 'rl1', name: 'region location 1' }],
+      }
+    })
+
+    context('when called with a fully populated investment', () => {
+      beforeEach(() => {
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(this.investmentData)
+      })
+
+      it('should return the required properties', () => {
+        expect(Object.keys(this.transformedInvestmentRequirements)).to.deep.equal([
+          'strategic_drivers',
+          'client_requirements',
+          'competitor_countries',
+          'uk_region_locations',
+          'actual_uk_regions',
+          'uk_company',
+        ])
+      })
+    })
+
+    context('when there are no strategic drivers', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          strategic_drivers: [],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return an empty string for strategic drivers', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('strategic_drivers', '')
+      })
+    })
+
+    context('when there is one strategic driver', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          strategic_drivers: [{ id: 'sd1', name: 'strategic driver 1' }],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the strategic driver', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('strategic_drivers', 'strategic driver 1')
+      })
+    })
+
+    context('when there are multiple strategic drivers', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          strategic_drivers: [
+            { id: 'sd1', name: 'strategic driver 1' },
+            { id: 'sd2', name: 'strategic driver 2' },
+          ],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the strategic drivers as a string list', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('strategic_drivers', 'strategic driver 1, strategic driver 2')
+      })
+    })
+
+    context('when there are client requirements', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          client_requirements: 'Client requirement',
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the client requirement', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('client_requirements', 'Client requirement')
+      })
+    })
+
+    context('when client requirements is empty', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          client_requirements: '',
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the client requirement', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('client_requirements', '')
+      })
+    })
+
+    context('when there are no competitor countries', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          competitor_countries: [],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return an empty string for competitor countries', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('competitor_countries', '')
+      })
+    })
+
+    context('when there is one competitor country', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          competitor_countries: [{ id: 'c1', name: 'country 1' }],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the competitor country', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('competitor_countries', 'country 1')
+      })
+    })
+
+    context('when there are multiple competitor countries', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          competitor_countries: [
+            { id: 'c1', name: 'country 1' },
+            { id: 'c2', name: 'country 2' },
+          ],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the competitor countries as a string list', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('competitor_countries', 'country 1, country 2')
+      })
+    })
+
+    context('when there are no uk region locations', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          uk_region_locations: [],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return an empty string for uk region locations', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('uk_region_locations', '')
+      })
+    })
+
+    context('when there is one uk region location', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          uk_region_locations: [{ id: 'rl1', name: 'region location 1' }],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the uk region location', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('uk_region_locations', 'region location 1')
+      })
+    })
+
+    context('when there are multiple uk region locations', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          uk_region_locations: [
+            { id: 'rl1', name: 'region location 1' },
+            { id: 'rl2', name: 'region location 2' },
+          ],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the uk region locations as a string list', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('uk_region_locations', 'region location 1, region location 2')
+      })
+    })
+
+    context('when there are no action uk regions', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          actual_uk_regions: [],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return an empty string for actual uk regions', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('actual_uk_regions', '')
+      })
+    })
+
+    context('when there is one actual uk region', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          actual_uk_regions: [{ id: 'a1', name: 'region 1' }],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return the uk region location', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('actual_uk_regions', 'region 1')
+      })
+    })
+
+    context('when there are multiple uk region locations', () => {
+      beforeEach(() => {
+        const data = assign({}, this.investmentData, {
+          actual_uk_regions: [
+            { id: 'a1', name: 'region 1' },
+            { id: 'a2', name: 'region 2' },
+          ],
+        })
+
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
+      })
+
+      it('should return theactual uk regions as a string list', () => {
+        expect(this.transformedInvestmentRequirements).to.have.property('actual_uk_regions', 'region 1, region 2')
+      })
+    })
+
     context('when no uk company is provided', () => {
       beforeEach(() => {
-        this.investmentData = Object.assign({}, investmentData, {
+        const data = assign({}, this.investmentData, {
           id: 1,
           uk_company: null,
         })
 
-        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(this.investmentData)
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
       })
 
       it('should set the investment details to display a link to find a company', () => {
@@ -23,7 +264,7 @@ describe('Investment project transformers', () => {
 
     context('when a uk company has previously been set', () => {
       beforeEach(() => {
-        this.investmentData = Object.assign({}, investmentData, {
+        const data = assign({}, this.investmentData, {
           id: 1,
           uk_company: {
             id: '1234',
@@ -31,7 +272,7 @@ describe('Investment project transformers', () => {
           },
         })
 
-        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(this.investmentData)
+        this.transformedInvestmentRequirements = transformInvestmentRequirementsForView(data)
       })
 
       it('should set the investment details to display the company name', () => {


### PR DESCRIPTION
* Refactored the investment requirements form to simplify and improve performance
* Added missing unit test coverage for investment requirements form and details
* Added ability to add one or more regions an investment project was landed

- [ ] Run AT to confirm all is good
- [x]  Capture movie of feature in action due to missing AT test coverage in this area

## Waiting for Leeloo PR https://github.com/uktrade/data-hub-leeloo/pull/760 to be merged 

![investregion](https://user-images.githubusercontent.com/56056/35003700-7a0b3b0c-fae5-11e7-856f-48f1eeb0c13f.gif)
