### PR TITLE
DH-1447 : Fix issue handling empty expected land dates

### DIFF
--- a/src/apps/investment-projects/transformers/project.js
+++ b/src/apps/investment-projects/transformers/project.js
@@ -55,11 +55,15 @@ function transformToApi (body) {
     return { id: value }
   })
 
-  formatted['estimated_land_date'] = [
-    body['estimated_land_date_year'],
-    body['estimated_land_date_month'],
-    '01',
-  ].join('-')
+  if (body['estimated_land_date_year'] || body['estimated_land_date_month']) {
+    formatted['estimated_land_date'] = [
+      body['estimated_land_date_year'],
+      body['estimated_land_date_month'],
+      '01',
+    ].join('-')
+  } else {
+    formatted['estimated_land_date'] = null
+  }
 
   formatted['actual_land_date'] = transformDateObjectToDateString('actual_land_date')(body)
 

--- a/test/unit/apps/investment-projects/transformers/project.test.js
+++ b/test/unit/apps/investment-projects/transformers/project.test.js
@@ -727,7 +727,7 @@ describe('Investment project transformers', () => {
         })
       })
 
-      it('should return a malformed date which will be picked up by the API validator', () => {
+      it('should return a malformed date for incomplete dates', () => {
         expect(this.result).to.have.property('actual_land_date', '2016--1')
       })
     })
@@ -742,6 +742,43 @@ describe('Investment project transformers', () => {
       it('should set the actual land date value to null', () => {
         expect(this.result).to.have.property('actual_land_date', null)
       })
+    })
+  })
+
+  context('when called with an estimated land date', () => {
+    beforeEach(() => {
+      this.result = transformToApi({
+        estimated_land_date_month: '10',
+        estimated_land_date_year: '2016',
+      })
+    })
+
+    it('should convert the field values into a date value', () => {
+      expect(this.result).to.have.property('estimated_land_date', '2016-10-01')
+    })
+  })
+
+  context('when called with a partial estimated land date', () => {
+    beforeEach(() => {
+      this.result = transformToApi({
+        estimated_land_date_year: '2016',
+      })
+    })
+
+    it('should return a malformed date', () => {
+      expect(this.result).to.have.property('estimated_land_date', '2016--01')
+    })
+  })
+
+  context('when called with no estimated land date', () => {
+    beforeEach(() => {
+      this.result = transformToApi({
+        name: 'fred',
+      })
+    })
+
+    it('should set the estimated land date value to null', () => {
+      expect(this.result).to.have.property('estimated_land_date', null)
     })
   })
 })


### PR DESCRIPTION
Previous if no land date was provided an empty string was sent to the server which parsed it and turned it into a date in Jan 1970, if there is no expected land date the server expects a null value. Updated the form handler to accommodate this, and this makes it consistent with actual land date.
