### PR TITLE
DH-1432 Prevent moving to the next stage when actual land date is incomplete

### DIFF
--- a/src/apps/investment-projects/middleware/shared.js
+++ b/src/apps/investment-projects/middleware/shared.js
@@ -55,6 +55,12 @@ async function getInvestmentDetails (req, res, next) {
     res.locals.equityCompany = investmentData.investor_company
     res.locals.investmentProjectStages = investmentProjectStages.map((stage) => stage.name)
 
+    const incompleteFields = buildIncompleteFormList(get(investmentData, 'incomplete_fields', []))
+    const isCurrentStageComplete = investmentData.team_complete &&
+      investmentData.requirements_complete &&
+      investmentData.value_complete &&
+      !incompleteFields.length
+
     res.locals.investmentStatus = {
       id: investmentData.id,
       meta: [
@@ -82,9 +88,9 @@ async function getInvestmentDetails (req, res, next) {
         url: `/companies/${get(investmentData, 'investor_company.id')}`,
       },
       currentStage: {
+        incompleteFields,
         name: stageName,
-        isComplete: investmentData.team_complete && investmentData.requirements_complete && investmentData.value_complete,
-        incompleteFields: buildIncompleteFormList(get(investmentData, 'incomplete_fields', [])),
+        isComplete: isCurrentStageComplete,
         messages: get(toCompleteStageMessages, camelCase(stageName), []),
       },
       nextStage: getNextStage(stageName, investmentProjectStages),

--- a/test/unit/apps/investment-projects/helpers.js
+++ b/test/unit/apps/investment-projects/helpers.js
@@ -1,102 +1,90 @@
-const { assign } = require('lodash')
-
-const { buildIncompleteFormList } = require('~/src/apps/investment-projects/helpers')
-
-const formOneMockLinkDetails = {
-  url: 'mock-url-form-one',
-  text: 'Mock text form one',
-}
-const formTwoMockLinkDetails = {
-  url: 'mock-url-form-two',
-  text: 'Mock text form two',
-}
-
 describe('buildIncompleteFormList', () => {
   beforeEach(() => {
-    this.mockLinkDetails = {
-      formOne: assign({}, formOneMockLinkDetails),
-      formTwo: assign({}, formTwoMockLinkDetails),
-    }
-    this.mockFormFields = {
-      formOne: [
-        'exampleLink',
-        'exampleLinkA',
-        'exampleLinkB',
-        'exampleLinkC',
-      ],
-      formTwo: [
-        'exampleLinkOther',
-        'exampleLinkOtherA',
-        'exampleLinkOtherB',
-        'exampleLinkOtherC',
-      ],
-    }
+    this.loggerSpy = sandbox.spy()
+    this.helpers = proxyquire('~/src/apps/investment-projects/helpers', {
+      '../../../config/logger': {
+        error: this.loggerSpy,
+      },
+    })
   })
 
-  context('without arguments ', () => {
+  context('when there are no incomplete fields', () => {
+    beforeEach(() => {
+      this.actual = this.helpers.buildIncompleteFormList()
+    })
+
+    it('should provide an array', () => {
+      expect(this.actual).to.be.an('array')
+    })
+
     it('should provide an empty array', () => {
-      const expectedLinkObjects = buildIncompleteFormList()
-
-      expect(expectedLinkObjects).to.be.an('array')
-      expect(expectedLinkObjects.length).to.equal(0)
+      expect(this.actual.length).to.equal(0)
     })
   })
 
-  context('with arguments ', () => {
-    it('should provide expected link object', () => {
-      const expectedLinkObjects = buildIncompleteFormList(
-        ['exampleLink'],
-        this.mockFormFields,
-        this.mockLinkDetails
-      )
-
-      expect(expectedLinkObjects).to.be.an('array')
-      expect(expectedLinkObjects.length).to.equal(1)
-      expect(expectedLinkObjects).to.deep.equal([
-        formOneMockLinkDetails,
-      ])
+  context('when the incomplete field does not exist in the lookup', () => {
+    beforeEach(() => {
+      this.actual = this.helpers.buildIncompleteFormList([ 'field_does_not_exist', 'actual_land_date' ])
     })
 
-    it('should provide expected link objects', () => {
-      const expectedLinkObjects = buildIncompleteFormList(
-        [
-          'exampleLink',
-          'exampleLinkOtherB',
-        ],
-        this.mockFormFields,
-        this.mockLinkDetails
-      )
-
-      expect(expectedLinkObjects).to.be.an('array')
-      expect(expectedLinkObjects.length).to.equal(2)
-      expect(expectedLinkObjects).to.deep.equal([
-        formOneMockLinkDetails,
-        formTwoMockLinkDetails,
-      ])
+    it('should provide an array', () => {
+      expect(this.actual).to.be.an('array')
     })
 
-    it('should not provide duplicate links when there are multiple fields in the same form', () => {
-      const expectedLinkObjects = buildIncompleteFormList(
-        [
-          'exampleLink',
-          'exampleLinkA',
-          'exampleLinkB',
-          'exampleLinkC',
-          'exampleLinkOther',
-          'exampleLinkOtherA',
-          'exampleLinkOtherB',
-          'exampleLinkOtherC',
-        ],
-        this.mockFormFields,
-        this.mockLinkDetails
-      )
+    it('should provide an array with one element', () => {
+      expect(this.actual.length).to.equal(1)
+    })
 
-      expect(expectedLinkObjects).to.be.an('array')
-      expect(expectedLinkObjects.length).to.equal(2)
-      expect(expectedLinkObjects).to.deep.equal([
-        formOneMockLinkDetails,
-        formTwoMockLinkDetails,
-      ])
+    it('should provide an array with the existing field', () => {
+      const expected = [
+        {
+          url: 'edit-details',
+          text: 'Actual land date in Investment project summary form',
+        },
+      ]
+
+      expect(this.actual).to.deep.equal(expected)
+    })
+
+    it('should log an error', () => {
+      expect(this.loggerSpy.args[0][0]).to.equal('Could not find form field link for field_does_not_exist')
+    })
+
+    it('should log once', () => {
+      expect(this.loggerSpy).to.be.calledOnce
+    })
+  })
+
+  context('when there are three incomplete fields', () => {
+    beforeEach(() => {
+      this.actual = this.helpers.buildIncompleteFormList([ 'number_new_jobs', 'actual_land_date', 'number_safeguarded_jobs' ])
+    })
+
+    it('should provide an array', () => {
+      expect(this.actual).to.be.an('array')
+    })
+
+    it('should provide an array with three elements', () => {
+      expect(this.actual.length).to.equal(3)
+    })
+
+    it('should group together the fields from the same form', () => {
+      const expected = [
+        {
+          url: 'edit-details',
+          text: 'Actual land date in Investment project summary form',
+        },
+        {
+          url: 'edit-value',
+          text: 'Number of new jobs in Value form',
+        },
+        {
+          url: 'edit-value',
+          text: 'Number of safeguarded jobs in Value form',
+        },
+      ]
+
+      expect(this.actual).to.deep.equal(expected)
     })
   })
 })


### PR DESCRIPTION
DH-1432

Current issues is that the investment project `Move to x stage` button is enabled when `actual_land_date` has not been set.

This change does the following:
- disables the button when the `actual_land_date` has not been set
- alters the feedback in the callout so that it is clear what needs to be done with links e.g. `Field x in y form`

![screen shot 2018-01-21 at 22 09 46](https://user-images.githubusercontent.com/1150417/35199595-20956fb8-fef8-11e7-9e55-1e9ba1a5949e.png)
