### PR TITLE
Filter OMIS sector list

### DIFF
--- a/src/apps/omis/apps/create/controllers/market.js
+++ b/src/apps/omis/apps/create/controllers/market.js
@@ -1,15 +1,16 @@
-const { filter } = require('lodash')
-
-const metadataRepo = require('../../../../../lib/metadata')
+const { getOptions } = require('../../../../../lib/options')
 const { FormController } = require('../../../controllers')
-const { transformObjectToOption } = require('../../../../transformers')
 
 class MarketController extends FormController {
-  configure (req, res, next) {
-    const filterMarkets = filter(metadataRepo.omisMarketOptions, market => !market.disabled_on)
+  async configure (req, res, next) {
+    try {
+      const markets = await getOptions(req.session.token, 'omis-market')
 
-    req.form.options.fields.primary_market.options = filterMarkets.map(transformObjectToOption)
-    super.configure(req, res, next)
+      req.form.options.fields.primary_market.options = markets
+      super.configure(req, res, next)
+    } catch (error) {
+      next(error)
+    }
   }
 }
 

--- a/src/apps/omis/apps/create/controllers/sector.js
+++ b/src/apps/omis/apps/create/controllers/sector.js
@@ -1,13 +1,18 @@
 const { get } = require('lodash')
 
-const metadataRepo = require('../../../../../lib/metadata')
+const { getOptions } = require('../../../../../lib/options')
 const { FormController } = require('../../../controllers')
-const { transformObjectToOption } = require('../../../../transformers')
 
 class SectorController extends FormController {
-  configure (req, res, next) {
-    req.form.options.fields.sector.options = metadataRepo.sectorOptions.map(transformObjectToOption)
-    super.configure(req, res, next)
+  async configure (req, res, next) {
+    try {
+      const sectors = await getOptions(req.session.token, 'sector')
+
+      req.form.options.fields.sector.options = sectors
+      super.configure(req, res, next)
+    } catch (error) {
+      next(error)
+    }
   }
 
   saveValues (req, res, next) {

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,3 +1,5 @@
+const { sortBy } = require('lodash')
+
 const config = require('../../config')
 const authorisedRequest = require('../lib/authorised-request')
 const { filterDisabledOption } = require('../apps/filters')
@@ -11,7 +13,7 @@ async function getOptions (token, key, { createdOn, currentValue, includeDisable
     options = options.filter(filterDisabledOption({ currentValue, createdOn }))
   }
 
-  return options.map(transformObjectToOption)
+  return sortBy(options.map(transformObjectToOption), 'label')
 }
 
 module.exports = {

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -1,3 +1,5 @@
+const { sortBy } = require('lodash')
+
 const companiesHouseAndLtdCompanies = require('~/test/unit/data/search/companiesHouseAndLtdCompanies')
 const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company')
 const displayHouseCompany = require('~/test/unit/data/companies/display-companies-house')
@@ -76,7 +78,7 @@ describe('Company add controller', () => {
         render: function (template, options) {
           const allOptions = mergeLocals(res, options)
           expect(allOptions.ukOtherCompanyOptions).to.deep.equal(expectedUk)
-          expect(allOptions.foreignOtherCompanyOptions).to.deep.equal(expectedForeign)
+          expect(allOptions.foreignOtherCompanyOptions).to.deep.equal(sortBy(expectedForeign, 'label'))
         },
       }
 

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -211,8 +211,8 @@ describe('Companies form middleware', () => {
 
       it('should include the active country options for use in the form and the current option', () => {
         expect(this.resMock.locals.options.countries).to.deep.equal([
-          { value: '9999', label: 'United Kingdom' },
           { value: '8888', label: 'Test' },
+          { value: '9999', label: 'United Kingdom' },
         ])
       })
     })

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -265,8 +265,8 @@ describe('Event edit controller', () => {
       it('should get all active country type options when the event was created', () => {
         const options = getFormFieldOptions(this.res, 'address_country')
         expect(options).to.deep.equal([
-          { label: 'United Kingdom', value: '9999' },
           { label: 'Test', value: '8888' },
+          { label: 'United Kingdom', value: '9999' },
         ])
       })
 


### PR DESCRIPTION
During the create journey the list of sectors was not being filtered
for disabled values.

This change updates the controllers within the create journey to use
the new `getOptions` method to retrieve options from metadata
endpoints.

This method handle filtering out disabled items in the list.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
