### PR TITLE
OMIS bug fixes

### DIFF
--- a/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
+++ b/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
@@ -75,7 +75,7 @@ class EditPaymentReconciliationController extends EditController {
     const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
 
     // convert pounds to pence
-    data.amount = numeral(data.amount).value() * 100
+    data.amount = parseInt(numeral(data.amount).value() * 100)
 
     try {
       // TODO: Support adding of multiple payments

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -65,7 +65,7 @@ class EditController extends FormController {
       }
 
       const parsedDate = dateFns.parse(newValue)
-      if (dateFields.includes(key) && dateFns.isValid(parsedDate)) {
+      if (dateFields.includes(key) && newValue && dateFns.isValid(parsedDate)) {
         return dateFns.format(parsedDate, longDateFormat)
       }
 

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -10,7 +10,7 @@
   {% block form %}
     {% call MultiStepForm(options | assign({
       buttonText: options.buttonText or 'Continue',
-      returnLink: options.backLink,
+      returnLink: options.backLink or backLink,
       errors: errors
     })) %}
 

--- a/test/unit/apps/omis/controllers/edit.test.js
+++ b/test/unit/apps/omis/controllers/edit.test.js
@@ -356,6 +356,24 @@ describe('OMIS EditController', () => {
       })
     })
 
+    context('when a field marked as a date field is null', () => {
+      it('should not format field as a date', (done) => {
+        const resMock = {
+          locals: {
+            order: {
+              delivery_date: null,
+            },
+          },
+        }
+        const nextMock = (e, values) => {
+          expect(values).to.deep.equal({})
+          done()
+        }
+
+        this.controller.getValues(this.reqMock, resMock, nextMock)
+      })
+    })
+
     context('when a field not marked as a date field contains a date', () => {
       it('should return the value', (done) => {
         const resMock = {


### PR DESCRIPTION
This change combines two small bug fixes for the OMIS journeys:

- ensures the correct back link is displayed during the create journey
- ensures null isn't formatted into a date
- fix rounding errors in payment reconciliation