### PR TITLE
clear the yarn cache in heroku post build

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "circle:acceptance:dit-staff": "npm run circle:acceptance --  --skiptags ignore,da,lep",
     "circle:acceptance:da-staff": "npm run circle:acceptance --  --tag da --skiptags ignore",
     "circle:acceptance:lep-staff": "npm run circle:acceptance --  --tag lep --skiptags ignore",
-    "heroku-postbuild": "npm rebuild && npm run build",
+    "heroku-postbuild": "yarn cache clean && npm rebuild && npm run build",
     "lint-staged": "lint-staged"
   },
   "pre-commit": "lint-staged",


### PR DESCRIPTION
This work removes the yarn cache on PaaS to avoid the `No space on device` errors