### PR TITLE
Prevent getPageTitle error not rendering the layout

### DIFF
--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -11,7 +11,7 @@
   {% extends "./dit-base.njk" %}
 {% endif %}
 
-{% set pageTitle = [getPageTitle(), 'DIT Data Hub'] | flatten | join(' - ') %}
+{% set pageTitle = [getPageTitle() if getPageTitle, 'DIT Data Hub'] | removeNilAndEmpty | flatten | join(' - ') %}
 
 {% block head %}
   {{ super() }}
@@ -52,7 +52,7 @@
   {{ super() }}
 
   {% block local_header %}
-    {% set pageTitle = getPageTitle() %}
+    {% set pageTitle = getPageTitle() if getPageTitle %}
     {% set heading = heading or pageTitle[0] %}
     {{ LocalHeader({ heading: heading, modifier: 'light-banner' }) }}
   {% endblock %}

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block local_header %}
-  {% set pageTitle = getPageTitle() %}
+  {% set pageTitle = getPageTitle() if getPageTitle %}
   {% set heading = heading or pageTitle[0] %}
   {{ LocalHeader({ heading: heading }) }}
 {% endblock %}


### PR DESCRIPTION
A helper function is used to get the page title for the current page.

This template is also used for the error is triggered and the error
page is rendered before the locals middleware has been called and had
time to set this helper function.

This change as some protection around calling this function so that it
will fail gracefully rather than render only this error.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
