### PR TITLE
switch to use content hash for webpack css production assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,7 +132,7 @@ webpackConfigs.prod = merge.smart(common, {
       sourceMap: true,
       dead_code: true,
     }),
-    new ExtractTextPlugin('css/[name].[chunkhash:8].css'),
+    new ExtractTextPlugin('css/[name].[contenthash:8].css'),
   ],
 })
 


### PR DESCRIPTION
Our `css` assets via the [extract-text-webpack-plugin](https://webpack.js.org/plugins/extract-text-webpack-plugin/) are not being hashed on content. This work changes the file name to contain a hash dependant on the `css` files contents via `contenthash`.

