### PR TITLE
DH-1463 Add actual land date collection filters

### DIFF
--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -131,6 +131,8 @@ const labels = {
       total_investment: 'Investment value',
       estimated_land_date_before: 'Estimated land date before',
       estimated_land_date_after: 'Estimated land date after',
+      actual_land_date_before: 'Actual land date before',
+      actual_land_date_after: 'Actual land date after',
       status: 'Status',
       uk_region_location: 'UK Region',
       investor_company_country: 'Country of origin',

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -41,6 +41,18 @@ const investmentFiltersFields = [
     placeholder: 'e.g. 2019-05-09',
   },
   {
+    macroName: 'TextField',
+    name: 'actual_land_date_before',
+    hint: 'YYYY-MM-DD',
+    placeholder: 'e.g. 2018-07-18',
+  },
+  {
+    macroName: 'TextField',
+    name: 'actual_land_date_after',
+    hint: 'YYYY-MM-DD',
+    placeholder: 'e.g. 2019-05-09',
+  },
+  {
     macroName: 'MultipleChoiceField',
     name: 'status',
     type: 'checkbox',

--- a/src/apps/investment-projects/middleware/collection.js
+++ b/src/apps/investment-projects/middleware/collection.js
@@ -34,6 +34,8 @@ function getRequestBody (req, res, next) {
     'investor_company',
     'estimated_land_date_before',
     'estimated_land_date_after',
+    'actual_land_date_before',
+    'actual_land_date_after',
     'client_relationship_manager',
     'status',
     'uk_region_location',


### PR DESCRIPTION
DH-1463

Change adds fields to filter investment project collection by `actual_land_date`.

<img width="306" alt="screen shot 2018-01-24 at 15 29 35" src="https://user-images.githubusercontent.com/1150417/35340734-da6bb8aa-011b-11e8-9b70-1274ba550c5e.png">
