### PR TITLE
Fix fragility when testing collection header

### DIFF
--- a/test/acceptance/features/collection/page-objects/Collection.js
+++ b/test/acceptance/features/collection/page-objects/Collection.js
@@ -1,5 +1,3 @@
-const { lowerCase } = require('lodash')
-
 const {
   getSelectorForElementWithText,
   getButtonWithText,
@@ -17,15 +15,6 @@ const getSelectorForMetaListItemValue = (text) => {
 module.exports = {
   commands: [
     {
-      getSelectorForResultsCountHeader (collectionType) {
-        return getSelectorForElementWithText(
-          lowerCase(collectionType),
-          {
-            el: '//div',
-            className: 'c-collection__header-intro',
-          }
-        )
-      },
       getSelectorForMetaListItemValue,
       getSelectorForBadgeWithText (text) {
         return getListItemMetaElementWithText(text)
@@ -46,6 +35,7 @@ module.exports = {
     collectionHeader: {
       selector: '.c-collection__header',
       elements: {
+        intro: '.c-collection__header-intro',
         paginationSummary: '.c-collection__pagination-summary',
         resultCount: '.c-collection__result-count',
         removeAllFiltersLink: '.c-collection__filter-remove-all',

--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -12,7 +12,7 @@ Feature: View collection of companies
     Then I see the success message
     When I navigate to the Company collection page
     Then I confirm I am on the Companies page
-    And the results count header for companies is present
+    And the results summary for a company collection is present
     And there is an Add company button in the collection header
     And I can view the Company in the collection
       | text               | expected                  |
@@ -28,14 +28,14 @@ Feature: View collection of companies
 
     When I navigate to the Company collection page
     Then I confirm I am on the Companies page
-    And the results count header for companies is present
+    And the results summary for a company collection is present
 
   @companies-collection--view--da @da
   Scenario: View companies collection as DA
 
     When I navigate to the Company collection page
     Then I confirm I am on the Companies page
-    And the results count header for companies is present
+    And the results summary for a company collection is present
 
   @companies-collection--filter
   Scenario: Filter companies list

--- a/test/acceptance/features/companies/contacts-collection.feature
+++ b/test/acceptance/features/companies/contacts-collection.feature
@@ -17,7 +17,7 @@ Feature: View collection of contacts for a company
     Then I wait and then refresh the page
     And I confirm I am on the Lambda plc page
     Then I capture the modified on date for the first item
-    And the results count header for contacts is present
+    And the results summary for a contact collection is present
     And I can view the Contact in the collection
       | text         | expected           |
       | Sector       | company.sector     |
@@ -39,7 +39,7 @@ Feature: View collection of contacts for a company
     Then I see the success message
     Then I wait and then refresh the page
     Then I confirm I am on the Lambda plc page
-    And the results count header for contacts is present
+    And the results summary for a contact collection is present
     When I clear all filters
     Then there are no filters selected
     And I filter the contacts list by contact
@@ -61,7 +61,7 @@ Feature: View collection of contacts for a company
     Then I see the success message
     Then I wait and then refresh the page
     Then I confirm I am on the Lambda plc page
-    And the results count header for contacts is present
+    And the results summary for a contact collection is present
     When the contacts are sorted by Newest
     When the contacts are sorted by Oldest
     Then the contacts should have been correctly sorted by creation date

--- a/test/acceptance/features/companies/interactions-collection.feature
+++ b/test/acceptance/features/companies/interactions-collection.feature
@@ -6,7 +6,7 @@ Feature: View collection of interactions for a company
 
     Given I navigate to company fixture Venus Ltd
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    And the results summary for a interaction collection is present
     And I can view the collection
 
   @companies-interactions-collection--filter # TODO

--- a/test/acceptance/features/companies/omis-collection.feature
+++ b/test/acceptance/features/companies/omis-collection.feature
@@ -6,14 +6,14 @@ Feature: View collection of orders for a company
 
     Given I navigate to company fixture Lambda plc
     When I click the Orders (OMIS) local nav link
-    Then the results count header for orders is present
+    And the results summary for a order collection is present
 
   @companies-omis-collection--view--da
   Scenario: View companies OMIS collection as DA
 
     Given I navigate to company fixture Lambda plc
     When I click the Orders (OMIS) local nav link
-    Then the results count header for orders is present
+    And the results summary for a order collection is present
 
   @companies-omis-collection--filter # TODO
 

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -17,7 +17,7 @@ Feature: View collection of contacts
     Then I capture the modified on date for the first item
     When I navigate to the Contact collection page
     Then I confirm I am on the Contacts page
-    And the results count header for contacts is present
+    And the results summary for a contact collection is present
     And I can view the Contact in the collection
       | text         | expected           |
       | Job title    | contact.jobTitle   |
@@ -35,14 +35,14 @@ Feature: View collection of contacts
 
     When I navigate to the Contact collection page
     Then I confirm I am on the Contacts page
-    And the results count header for contacts is present
+    And the results summary for a contact collection is present
 
   @contacts-collection--view--da @da
   Scenario: View contact collection as DA
 
     When I navigate to the Contact collection page
     Then I confirm I am on the Contacts page
-    And the results count header for contacts is present
+    And the results summary for a contact collection is present
 
   @contacts-collection--filter
   Scenario: Filter contact list

--- a/test/acceptance/features/contacts/interactions-collection.feature
+++ b/test/acceptance/features/contacts/interactions-collection.feature
@@ -6,7 +6,7 @@ Feature: View collection of interactions for a contact
 
     Given I navigate to contact fixture Dean Cox
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    And the results summary for a interaction collection is present
     And I can view the collection
 
   @contacts-interactions-collection--filter # TODO

--- a/test/acceptance/features/interactions/collection.feature
+++ b/test/acceptance/features/interactions/collection.feature
@@ -15,7 +15,7 @@ Feature: View collection of interactions
     Then I see the success message
     When I navigate to the Interactions and service collection page
     Then I confirm I am on the Interactions page
-    And the results count header for interactions is present
+    And the results summary for a interaction collection is present
     Then I filter the collections to view the Interaction I have just created
     And I can view the Interaction in the collection
       | text    | expected               |
@@ -38,7 +38,7 @@ Feature: View collection of interactions
     Then I see the success message
     When I navigate to the Interactions and service collection page
     Then I confirm I am on the Interactions page
-    And the results count header for interactions is present
+    And the results summary for a interaction collection is present
     Then I filter the collections to view the Service Delivery I have just created
     And I can view the Service delivery in the collection
       | text    | expected                   |
@@ -61,7 +61,7 @@ Feature: View collection of interactions
     Then I see the success message
     When I navigate to the Interactions and service collection page
     Then I confirm I am on the Interactions page
-    And the results count header for interactions is present
+    And the results summary for a interaction collection is present
     Then I filter the interactions list by service provider
     Then the interactions should be filtered by service provider
 

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -51,11 +51,11 @@ Feature: View a list of Investment Projects
 
     When I navigate to the Investment project collection page
     Then I confirm I am on the Investment projects page
-    And the results count header for projects is present
+    And the results summary for a project collection is present
 
   @investment-projects-collection--view--da @da
   Scenario: View Investment Projects list as DA
 
     When I navigate to the Investment project collection page
     Then I confirm I am on the Investment projects page
-    And the results count header for projects is present
+    And the results summary for a project collection is present

--- a/test/acceptance/features/investment-projects/interactions-collection.feature
+++ b/test/acceptance/features/investment-projects/interactions-collection.feature
@@ -6,7 +6,7 @@ Feature: View collection of interactions for an investment project
 
     Given I navigate to investment project fixture New hotel (FDI)
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    And the results summary for a interaction collection is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--lep @lep
@@ -14,7 +14,7 @@ Feature: View collection of interactions for an investment project
 
     Given I navigate to investment project fixture New zoo (LEP)
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    And the results summary for a interaction collection is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--da @da
@@ -22,7 +22,7 @@ Feature: View collection of interactions for an investment project
 
     Given I navigate to investment project fixture New golf course (DA)
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    And the results summary for a interaction collection is present
     And I can view the collection
 
   @investment-projects-interactions-collection--filter # TODO


### PR DESCRIPTION
Previously when testing the collection header the tests assumed that there would be 0 or > 1 results. If the result actually had 1 result the heading wouldn't match the test text. This is because the heading uses the pluralise function to decide if it should say 'company' or 'companies'.

This fix addresses these issues:
* Makes locating the collection intro non-dependant on its plural nature
* Renames the step for checking the collection heading to accurately reflect it's purpose
* Separates locating a collection title from asserting the title contains the correct text
