### PR TITLE
DH-1427 DH-1428 - Remove preset date filters in investment collection

### DIFF
--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -1,7 +1,5 @@
 const { concat } = require('lodash')
 
-const currentYear = (new Date()).getFullYear()
-
 const GLOBAL_NAV_ITEM = {
   path: '/investment-projects',
   label: 'Investment projects',
@@ -47,8 +45,6 @@ const LOCAL_NAV = [
 ]
 
 const DEFAULT_COLLECTION_QUERY = {
-  estimated_land_date_after: `${currentYear}-04-05`,
-  estimated_land_date_before: `${currentYear + 1}-04-06`,
   sortby: 'estimated_land_date:asc',
 }
 

--- a/test/acceptance/features/collection/step_definitions/collection.js
+++ b/test/acceptance/features/collection/step_definitions/collection.js
@@ -3,6 +3,7 @@ const { client } = require('nightwatch-cucumber')
 const { defineSupportCode } = require('cucumber')
 
 const { getButtonWithText } = require('../../../helpers/selectors')
+const { pluralise } = require('../../../../../config/nunjucks/filters')
 
 defineSupportCode(({ When, Then }) => {
   const Collection = client.page.Collection()
@@ -46,19 +47,22 @@ defineSupportCode(({ When, Then }) => {
   })
 
   Then(/^the results count header for (.+) is present$/, async function (collectionType) {
-    const resultsCountHeaderSelector = Collection
-      .getSelectorForResultsCountHeader(collectionType)
-
     await Collection
       .captureResultCount((count) => {
         set(this.state, 'collection.resultCount', count)
       })
 
+    const count = get(this.state, 'collection.resultCount')
+    const collectionTypeTitle = pluralise(collectionType, count)
+
+    const resultsCountHeaderSelector = Collection
+      .getSelectorForResultsCountHeader(collectionTypeTitle)
+
     await Collection
       .api.useXpath()
       .assert.visible(resultsCountHeaderSelector.selector)
-      .assert.containsText(resultsCountHeaderSelector.selector, collectionType)
-      .assert.containsText(resultsCountHeaderSelector.selector, get(this.state, 'collection.resultCount'))
+      .assert.containsText(resultsCountHeaderSelector.selector, collectionTypeTitle)
+      .assert.containsText(resultsCountHeaderSelector.selector, count)
       .useCss()
   })
 

--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -12,7 +12,7 @@ Feature: View collection of companies
     Then I see the success message
     When I navigate to the Company collection page
     Then I confirm I am on the Companies page
-    And the results count header for companies is present
+    And the results count header for company is present
     And there is an Add company button in the collection header
     And I can view the Company in the collection
       | text               | expected                  |
@@ -28,14 +28,14 @@ Feature: View collection of companies
 
     When I navigate to the Company collection page
     Then I confirm I am on the Companies page
-    And the results count header for companies is present
+    And the results count header for company is present
 
   @companies-collection--view--da @da
   Scenario: View companies collection as DA
 
     When I navigate to the Company collection page
     Then I confirm I am on the Companies page
-    And the results count header for companies is present
+    And the results count header for company is present
 
   @companies-collection--filter
   Scenario: Filter companies list

--- a/test/acceptance/features/companies/contacts-collection.feature
+++ b/test/acceptance/features/companies/contacts-collection.feature
@@ -17,7 +17,7 @@ Feature: View collection of contacts for a company
     Then I wait and then refresh the page
     And I confirm I am on the Lambda plc page
     Then I capture the modified on date for the first item
-    And the results count header for contacts is present
+    And the results count header for contact is present
     And I can view the Contact in the collection
       | text         | expected           |
       | Sector       | company.sector     |
@@ -39,7 +39,7 @@ Feature: View collection of contacts for a company
     Then I see the success message
     Then I wait and then refresh the page
     Then I confirm I am on the Lambda plc page
-    And the results count header for contacts is present
+    And the results count header for contact is present
     When I clear all filters
     Then there are no filters selected
     And I filter the contacts list by contact
@@ -73,7 +73,7 @@ Feature: View collection of contacts for a company
     Then I see the success message
     Then I wait and then refresh the page
     Then I confirm I am on the Lambda plc page
-    And the results count header for contacts is present
+    And the results count header for contact is present
     When the contacts are sorted by Newest
     When the contacts are sorted by Oldest
     Then the contacts should have been correctly sorted by creation date

--- a/test/acceptance/features/companies/interactions-collection.feature
+++ b/test/acceptance/features/companies/interactions-collection.feature
@@ -6,7 +6,7 @@ Feature: View collection of interactions for a company
 
     Given I navigate to company fixture Venus Ltd
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    Then the results count header for interaction is present
     And I can view the collection
 
   @companies-interactions-collection--filter # TODO

--- a/test/acceptance/features/companies/omis-collection.feature
+++ b/test/acceptance/features/companies/omis-collection.feature
@@ -13,7 +13,7 @@ Feature: View collection of orders for a company
 
     Given I navigate to company fixture Lambda plc
     When I click the Orders (OMIS) local nav link
-    Then the results count header for orde is present
+    Then the results count header for order is present
 
   @companies-omis-collection--filter # TODO
 

--- a/test/acceptance/features/companies/omis-collection.feature
+++ b/test/acceptance/features/companies/omis-collection.feature
@@ -6,14 +6,14 @@ Feature: View collection of orders for a company
 
     Given I navigate to company fixture Lambda plc
     When I click the Orders (OMIS) local nav link
-    Then the results count header for orders is present
+    Then the results count header for order is present
 
   @companies-omis-collection--view--da
   Scenario: View companies OMIS collection as DA
 
     Given I navigate to company fixture Lambda plc
     When I click the Orders (OMIS) local nav link
-    Then the results count header for orders is present
+    Then the results count header for orde is present
 
   @companies-omis-collection--filter # TODO
 

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -17,7 +17,7 @@ Feature: View collection of contacts
     Then I capture the modified on date for the first item
     When I navigate to the Contact collection page
     Then I confirm I am on the Contacts page
-    And the results count header for contacts is present
+    And the results count header for contact is present
     And I can view the Contact in the collection
       | text         | expected           |
       | Job title    | contact.jobTitle   |
@@ -35,14 +35,14 @@ Feature: View collection of contacts
 
     When I navigate to the Contact collection page
     Then I confirm I am on the Contacts page
-    And the results count header for contacts is present
+    And the results count header for contact is present
 
   @contacts-collection--view--da @da
   Scenario: View contact collection as DA
 
     When I navigate to the Contact collection page
     Then I confirm I am on the Contacts page
-    And the results count header for contacts is present
+    And the results count header for contact is present
 
   @contacts-collection--filter
   Scenario: Filter contact list

--- a/test/acceptance/features/contacts/interactions-collection.feature
+++ b/test/acceptance/features/contacts/interactions-collection.feature
@@ -6,7 +6,7 @@ Feature: View collection of interactions for a contact
 
     Given I navigate to contact fixture Dean Cox
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    Then the results count header for interaction is present
     And I can view the collection
 
   @contacts-interactions-collection--filter # TODO

--- a/test/acceptance/features/interactions/collection.feature
+++ b/test/acceptance/features/interactions/collection.feature
@@ -15,7 +15,7 @@ Feature: View collection of interactions
     Then I see the success message
     When I navigate to the Interactions and service collection page
     Then I confirm I am on the Interactions page
-    And the results count header for interactions is present
+    And the results count header for interaction is present
     Then I filter the collections to view the Interaction I have just created
     And I can view the Interaction in the collection
       | text    | expected               |
@@ -38,7 +38,7 @@ Feature: View collection of interactions
     Then I see the success message
     When I navigate to the Interactions and service collection page
     Then I confirm I am on the Interactions page
-    And the results count header for interactions is present
+    And the results count header for interaction is present
     Then I filter the collections to view the Service Delivery I have just created
     And I can view the Service delivery in the collection
       | text    | expected                   |
@@ -61,7 +61,7 @@ Feature: View collection of interactions
     Then I see the success message
     When I navigate to the Interactions and service collection page
     Then I confirm I am on the Interactions page
-    And the results count header for interactions is present
+    And the results count header for interaction is present
     Then I filter the interactions list by service provider
     Then the interactions should be filtered by service provider
 

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -51,11 +51,11 @@ Feature: View a list of Investment Projects
 
     When I navigate to the Investment project collection page
     Then I confirm I am on the Investment projects page
-    And the results count header for projects is present
+    And the results count header for project is present
 
   @investment-projects-collection--view--da @da
   Scenario: View Investment Projects list as DA
 
     When I navigate to the Investment project collection page
     Then I confirm I am on the Investment projects page
-    And the results count header for projects is present
+    And the results count header for project is present

--- a/test/acceptance/features/investment-projects/interactions-collection.feature
+++ b/test/acceptance/features/investment-projects/interactions-collection.feature
@@ -6,7 +6,7 @@ Feature: View collection of interactions for an investment project
 
     Given I navigate to investment project fixture New hotel (FDI)
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    Then the results count header for interaction is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--lep @lep
@@ -14,7 +14,7 @@ Feature: View collection of interactions for an investment project
 
     Given I navigate to investment project fixture New zoo (LEP)
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    Then the results count header for interaction is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--da @da
@@ -22,7 +22,7 @@ Feature: View collection of interactions for an investment project
 
     Given I navigate to investment project fixture New golf course (DA)
     When I click the Interactions local nav link
-    Then the results count header for interactions is present
+    Then the results count header for interaction is present
     And I can view the collection
 
   @investment-projects-interactions-collection--filter # TODO


### PR DESCRIPTION
The default date filters for investment collection caused no results to be shown, so the user has asked for the default to be removed.

ANY TEST COMMENTS GO ON 1196