### PR TITLE
DH-1473 add application version to meta tag

### DIFF
--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -3,6 +3,7 @@ const { get } = require('lodash')
 const GLOBAL_NAV_ITEMS = require('../apps/global-nav-items')
 const logger = require('../../config/logger')
 const config = require('../../config')
+const { version } = require('../../package.json')
 const { filterNonPermittedItem } = require('../apps/filters')
 
 let webpackManifest = {}
@@ -19,6 +20,7 @@ module.exports = function locals (req, res, next) {
   const userPermissions = get(res, 'locals.user.permissions')
 
   res.locals = Object.assign({}, res.locals, {
+    APP_VERSION: version,
     BASE_URL: baseUrl,
     CANONICAL_URL: baseUrl + req.path,
     ORIGINAL_URL: baseUrl + req.originalUrl,

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -5,6 +5,7 @@
     {% block head %}
       <meta http-equiv="content-type" content="text/html; charset=UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
+      <meta name="version" content="{{ APP_VERSION }}">
       <meta http-equiv="x-ua-compatible" content="ie=edge">
       <title>{% block head_title_content %}{{ pageTitle | default(titleDefault) }}{% endblock %}</title>
       {% if description -%}


### PR DESCRIPTION
Add the application version to a meta tag so its easy to work out which version of the frontend you are currently looking at
