### PR TITLE
DH-1447 Fix editing project with empty estimated date

### DIFF
--- a/src/apps/investment-projects/transformers/project.js
+++ b/src/apps/investment-projects/transformers/project.js
@@ -99,9 +99,10 @@ function transformFromApi (body) {
     return get(body, `${key}.id`)
   })
 
-  const date = new Date(body['estimated_land_date'])
-  if (date) {
-    formatted['estimated_land_date_year'] = date.getFullYear()
+  const estimatedLandDate = body.estimated_land_date
+  if (!isEmpty(estimatedLandDate)) {
+    const date = new Date(estimatedLandDate)
+    formatted['estimated_land_date_year'] = date.getFullYear().toString()
     formatted['estimated_land_date_month'] = format(date, 'MM')
   }
 

--- a/test/unit/apps/investment-projects/transformers/project.test.js
+++ b/test/unit/apps/investment-projects/transformers/project.test.js
@@ -5,6 +5,7 @@ const {
   transformBriefInvestmentSummary,
   transformInvestmentDataForView,
   transformToApi,
+  transformFromApi,
 } = require('~/src/apps/investment-projects/transformers/project')
 
 describe('Investment project transformers', () => {
@@ -779,6 +780,38 @@ describe('Investment project transformers', () => {
 
     it('should set the estimated land date value to null', () => {
       expect(this.result).to.have.property('estimated_land_date', null)
+    })
+  })
+
+  describe('#transformFromApi', () => {
+    context('when an estimated land date is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          estimated_land_date: '2017-12-15T14:25:38.989026Z',
+        })
+
+        this.result = transformFromApi(data)
+      })
+
+      it('should create a split date for month and year', () => {
+        expect(this.result).to.have.property('estimated_land_date_year', '2017')
+        expect(this.result).to.have.property('estimated_land_date_month', '12')
+      })
+    })
+
+    context('when an estimated land date is not provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          estimated_land_date: null,
+        })
+
+        this.result = transformFromApi(data)
+      })
+
+      it('should not create a split date for month and year', () => {
+        expect(this.result).to.not.have.property('estimated_land_date_year')
+        expect(this.result).to.not.have.property('estimated_land_date_month')
+      })
     })
   })
 })


### PR DESCRIPTION
The investment form populate function did not cater for an estimated land date being null, this ended up with a date being generated in 1970. The change tests for the presence of the date before parsing it.
