### PR TITLE
Tidy use of nock in unit tests

### DIFF
--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -7,7 +7,7 @@ describe('Adviser repository', () => {
   describe('getAdvisers', () => {
     context('when an adviser without a name is encountered', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, badAdviserData)
         this.advisers = await repos.getAdvisers(123)
@@ -26,15 +26,11 @@ describe('Adviser repository', () => {
 
         expect(this.advisers).to.deep.equal(expected)
       })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
     })
 
     context('when all advisers have names', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, adviserData)
         this.advisers = await repos.getAdvisers(123)
@@ -42,10 +38,6 @@ describe('Adviser repository', () => {
 
       it('will not filter out any advisers', () => {
         expect(this.advisers).to.deep.equal(adviserData)
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -48,7 +48,7 @@ describe('Company add controller', () => {
 
   describe('Get step 1', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/metadata/business-type/')
         .twice().reply(200, metaDataMock.businessTypeOptions)
     })

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -74,7 +74,7 @@ describe('Company edit controller', () => {
 
   describe('renderForm', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/metadata/business-type/')
         .twice().reply(200, metaDataMock.businessTypeOptions)
     })
@@ -123,10 +123,6 @@ describe('Company edit controller', () => {
 
       it('should not show the trading address fields', () => {
         expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
 
@@ -188,10 +184,6 @@ describe('Company edit controller', () => {
       it('should not show the trading address fields', () => {
         expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
       })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
     })
 
     context('when adding a UK sole trader', () => {
@@ -239,10 +231,6 @@ describe('Company edit controller', () => {
       it('should not show the trading address fields', () => {
         expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
       })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
     })
 
     context('when adding a foreign sole trader', () => {
@@ -289,10 +277,6 @@ describe('Company edit controller', () => {
 
       it('should not show the trading address fields', () => {
         expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
 
@@ -346,10 +330,6 @@ describe('Company edit controller', () => {
 
       it('should not show the trading address fields', () => {
         expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.true
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/companies/middleware/account-management.test.js
+++ b/test/unit/apps/companies/middleware/account-management.test.js
@@ -57,7 +57,7 @@ describe('Companies account management middleware', () => {
 
   describe('#populateAccountManagementForm', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, this.activeInactiveAdviserData)
 
@@ -75,10 +75,6 @@ describe('Companies account management middleware', () => {
     it('should set the active advisers', () => {
       const expectedAdvisers = filter(this.activeInactiveAdviserData.results, 'is_active')
       expect(this.resMock.locals.advisers).to.deep.equal(expectedAdvisers)
-    })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -23,7 +23,7 @@ describe('Company collection middleware', () => {
 
   describe('#getCompanyCollection', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .post(`/v3/search/company`)
         .reply(200, this.mockCompanyResults)
 
@@ -42,10 +42,6 @@ describe('Company collection middleware', () => {
       expect(actual).to.have.property('pagination')
       expect(actual.count).to.equal(3)
       expect(this.next).to.have.been.calledOnce
-    })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const { assign } = require('lodash')
 const moment = require('moment')
 

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -72,7 +72,7 @@ describe('Companies form middleware', () => {
   describe('#populateForm()', () => {
     beforeEach(() => {
       metadata.businessTypeOptions = metadataMock.businessTypeOptions
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/metadata/uk-region/')
         .reply(200, metadataMock.regionOptions)
         .get('/metadata/headquarter-type/')
@@ -241,7 +241,7 @@ describe('Companies form middleware', () => {
 
     context('when saving a new company works', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .post('/v3/company')
           .reply(200, companyRecord)
 
@@ -271,7 +271,7 @@ describe('Companies form middleware', () => {
 
     context('when saving a new company fails validation', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .post('/v3/company')
           .reply(500, {
             errors: 'error',
@@ -295,7 +295,7 @@ describe('Companies form middleware', () => {
 
     context('when saving an existing company works', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch(`/v3/company/${companyRecord.id}`)
           .reply(200, companyRecord)
 
@@ -326,7 +326,7 @@ describe('Companies form middleware', () => {
 
     context('when saving an existing company fails', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch(`/v3/company/${companyRecord.id}`)
           .reply(500, {
             errors: 'error',
@@ -351,7 +351,7 @@ describe('Companies form middleware', () => {
 
     context('when saving a uk company with just a registered address', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .post('/v3/company')
           .reply(200, companyRecord)
           .get('/metadata/country/')
@@ -380,7 +380,7 @@ describe('Companies form middleware', () => {
 
     context('when saving a uk company with a trading and registered address', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .post('/v3/company')
           .reply(200, companyRecord)
           .get('/metadata/country/')
@@ -412,7 +412,7 @@ describe('Companies form middleware', () => {
 
     context('when the user indicates the company is not a headquarters', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .post('/v3/company')
           .reply(200, companyRecord)
 

--- a/test/unit/apps/contacts/controllers/edit.test.js
+++ b/test/unit/apps/contacts/controllers/edit.test.js
@@ -1,5 +1,4 @@
 /* eslint handle-callback-err: 0 */
-const nock = require('nock')
 const moment = require('moment')
 
 const config = require('~/config')

--- a/test/unit/apps/contacts/controllers/edit.test.js
+++ b/test/unit/apps/contacts/controllers/edit.test.js
@@ -49,7 +49,7 @@ describe('Contact controller, edit', () => {
 
   describe('get', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/metadata/country/')
         .reply(200, [
           { id: '9999', name: 'United Kingdom', disabled_on: null },
@@ -354,7 +354,7 @@ describe('Contact controller, edit', () => {
       }
       req.body = body
 
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/metadata/country/')
         .reply(200, [
           { id: '9999', name: 'United Kingdom', disabled_on: null },

--- a/test/unit/apps/contacts/repos.test.js
+++ b/test/unit/apps/contacts/repos.test.js
@@ -10,7 +10,7 @@ const companyId = '23232323'
 describe('Investment repository', () => {
   describe('#getContactsForCompany', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/contact?company_id=${companyId}&limit=500`)
         .reply(200, contactsApiResult)
       this.contacts = await getContactsForCompany('token', companyId)
@@ -18,10 +18,6 @@ describe('Investment repository', () => {
 
     it('should return company contacts array', async () => {
       expect(this.contacts).to.deep.equal(contactsApiResult.results)
-    })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 })

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -99,7 +99,7 @@ describe('Event edit controller', () => {
 
   describe('#renderEditPage', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/adviser/')
         .query({ limit: 100000, offset: 0 })
         .reply(200, this.activeInactiveAdviserData)
@@ -140,10 +140,6 @@ describe('Event edit controller', () => {
         const actual = find(eventForm.children, { name: 'lead_team' }).value
 
         expect(actual).to.equal(currentUserTeam)
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
 
@@ -246,7 +242,6 @@ describe('Event edit controller', () => {
       it('should add a breadcrumb', () => {
         expect(this.res.breadcrumb.firstCall).to.be.calledWith('name', '/events/123')
         expect(this.res.breadcrumb.secondCall).to.be.calledWith('Edit event')
-        expect(this.nockScope.isDone()).to.be.true
       })
 
       it('should get all active event type options when the event was created', () => {
@@ -351,7 +346,6 @@ describe('Event edit controller', () => {
         }
 
         expect(actualErrors).to.deep.equal(expectedErrors)
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/events/controllers/list.test.js
+++ b/test/unit/apps/events/controllers/list.test.js
@@ -61,7 +61,7 @@ describe('Event list controller', () => {
       disabled_on: null,
     }]
 
-    this.nockScope = nock(config.apiRoot)
+    nock(config.apiRoot)
       .get(`/adviser/?limit=100000&offset=0`)
       .reply(200, { results: advisers })
   })
@@ -77,10 +77,6 @@ describe('Event list controller', () => {
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('sortForm'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('filtersFields'))
       expect(this.resMock.render).to.have.been.calledWith('events/views/list', sinon.match.hasOwn('selectedFilters'))
-    })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 
@@ -123,7 +119,6 @@ describe('Event list controller', () => {
 
     it('nock mocked scope has been called', async () => {
       await this.controller.renderEventList(this.reqMock, this.resMock, this.nextSpy)
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 })

--- a/test/unit/apps/events/repos.test.js
+++ b/test/unit/apps/events/repos.test.js
@@ -77,7 +77,7 @@ describe('Event repos', () => {
           }],
         }
 
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .post('/v3/search/event')
           .reply(200, this.eventCollection)
       })
@@ -134,10 +134,6 @@ describe('Event repos', () => {
             limit: 100000,
             isAggregation: false,
           })
-        })
-
-        it('nock mocked scope has been called', () => {
-          expect(this.nockScope.isDone()).to.be.true
         })
       })
     })

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -262,7 +262,7 @@ describe('Interaction details middleware', () => {
 
     context('when interaction', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, this.activeInactiveAdviserData)
           .get('/metadata/team/')
@@ -350,15 +350,11 @@ describe('Interaction details middleware', () => {
       it('should not set event options', () => {
         expect(this.res.locals.options.events).to.be.undefined
       })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
     })
 
     context('when service delivery', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, this.activeInactiveAdviserData)
           .get('/metadata/team/')
@@ -466,10 +462,6 @@ describe('Interaction details middleware', () => {
           label: 'name',
         }]
         expect(this.res.locals.options.events).to.deep.equal(expectedEvents)
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/investment-projects/middleware/collection.test.js
+++ b/test/unit/apps/investment-projects/middleware/collection.test.js
@@ -14,7 +14,7 @@ describe('Investment projects collection middleware', () => {
 
   describe('#getInvestmentProjectsCollection', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .post(`/v3/search/investment_project`)
         .reply(200, investmentCollectioData)
       this.req.query = {
@@ -32,10 +32,6 @@ describe('Investment projects collection middleware', () => {
       expect(actual).to.have.property('pagination')
       expect(actual.count).to.equal(3)
       expect(this.next).to.have.been.calledOnce
-    })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const { assign } = require('lodash')
 
 const config = require('~/config')

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -24,7 +24,7 @@ describe('Investment form middleware - client relationship management', () => {
         },
       })
 
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/adviser/?limit=100000&offset=0`)
         .reply(200, {
           count: 5,
@@ -149,10 +149,6 @@ describe('Investment form middleware - client relationship management', () => {
         ]
 
         expect(this.resMock.locals.form.options.accountManagers).to.deep.equal(expectedOptions)
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/investment-projects/middleware/forms/details.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/details.test.js
@@ -234,7 +234,7 @@ describe('investment details middleware', () => {
 
     context('when adding a new project', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, this.advisersData)
           .get('/metadata/investment-type/')
@@ -280,10 +280,6 @@ describe('investment details middleware', () => {
         ]
 
         expect(this.res.locals.form.options.referralSourceAdvisers).to.deep.equal(expectedOptions)
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
 
@@ -356,10 +352,6 @@ describe('investment details middleware', () => {
         ]
 
         expect(this.res.locals.form.options.referralSourceAdvisers).to.deep.equal(expectedOptions)
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/investment-projects/middleware/forms/details.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/details.test.js
@@ -1,6 +1,5 @@
 const uuid = require('uuid')
 const { assign } = require('lodash')
-const nock = require('nock')
 const moment = require('moment')
 
 const config = require('~/config')

--- a/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
@@ -19,7 +19,7 @@ describe('Investment form middleware - project magement', () => {
 
       this.controller = require('~/src/apps/investment-projects/middleware/forms/project-management')
 
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/adviser/?limit=100000&offset=0`)
         .reply(200, {
           count: 5,
@@ -101,10 +101,6 @@ describe('Investment form middleware - project magement', () => {
         ]
 
         expect(this.resMock.locals.form.options.projectAssuranceAdvisers).to.deep.equal(expectedOptions)
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/project-management.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const { assign } = require('lodash')
 
 const config = require('~/config')

--- a/test/unit/apps/investment-projects/middleware/forms/requirements.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/requirements.test.js
@@ -84,7 +84,7 @@ describe('Investment requirements form middleware', () => {
     beforeEach(() => {
       this.resMock.locals = assign({}, this.reqMock.locals, { investmentData })
 
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get('/metadata/uk-region/')
         .reply(200, metadataMock.regionOptions)
         .get('/metadata/country/')
@@ -98,10 +98,6 @@ describe('Investment requirements form middleware', () => {
     context('when called without posted data', () => {
       beforeEach(async () => {
         await populateForm(this.reqMock, this.resMock, this.nextStub)
-      })
-
-      it('should get options', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
 
       it('should build the form with the investment data', () => {
@@ -124,10 +120,6 @@ describe('Investment requirements form middleware', () => {
         })
 
         await populateForm(this.reqMock, this.resMock, this.nextStub)
-      })
-
-      it('should get the options', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
 
       it('should build the form with the posted data', () => {
@@ -161,7 +153,7 @@ describe('Investment requirements form middleware', () => {
   describe('#handleFormPost', () => {
     context('when called with multiple strategic drivers', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             strategic_drivers: [
               '844cd12a-6095-e211-a939-e4115bead28a',
@@ -187,10 +179,6 @@ describe('Investment requirements form middleware', () => {
         await handleFormPost(this.reqMock, this.resMock, this.nextStub)
       })
 
-      it('should call the API with transformed data', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
-
       it('should redirect the user to the details screen', () => {
         expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
       })
@@ -202,7 +190,7 @@ describe('Investment requirements form middleware', () => {
 
     context('when called with a single strategic driver', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             actual_uk_regions: [],
             competitor_countries: [],
@@ -225,10 +213,6 @@ describe('Investment requirements form middleware', () => {
         await handleFormPost(this.reqMock, this.resMock, this.nextStub)
       })
 
-      it('should call the API with transformed data', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
-
       it('should redirect the user to the details screen', () => {
         expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
       })
@@ -247,7 +231,7 @@ describe('Investment requirements form middleware', () => {
 
       context('when called with multiple competitor countries', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               client_considering_other_countries: 'true',
               competitor_countries: [
@@ -275,10 +259,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -290,7 +270,7 @@ describe('Investment requirements form middleware', () => {
 
       context('when called with a single competitor country', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               client_considering_other_countries: 'true',
               actual_uk_regions: [],
@@ -315,10 +295,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -338,7 +314,7 @@ describe('Investment requirements form middleware', () => {
 
       context('when called with multiple competitor countries', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               client_considering_other_countries: 'false',
               competitor_countries: [],
@@ -363,10 +339,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -378,7 +350,7 @@ describe('Investment requirements form middleware', () => {
 
       context('when called with a single competitor country', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               client_considering_other_countries: 'false',
               actual_uk_regions: [],
@@ -401,10 +373,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -417,7 +385,7 @@ describe('Investment requirements form middleware', () => {
 
     context('when called with multiple uk regions', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             uk_region_locations: [
               '844cd12a-6095-e211-a939-e4115bead28a',
@@ -443,10 +411,6 @@ describe('Investment requirements form middleware', () => {
         await handleFormPost(this.reqMock, this.resMock, this.nextStub)
       })
 
-      it('should call the API with transformed data', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
-
       it('should redirect the user to the details screen', () => {
         expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
       })
@@ -458,7 +422,7 @@ describe('Investment requirements form middleware', () => {
 
     context('when called with a single uk region', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             actual_uk_regions: [],
             strategic_drivers: [],
@@ -481,10 +445,6 @@ describe('Investment requirements form middleware', () => {
         await handleFormPost(this.reqMock, this.resMock, this.nextStub)
       })
 
-      it('should call the API with transformed data', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
-
       it('should redirect the user to the details screen', () => {
         expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
       })
@@ -497,7 +457,7 @@ describe('Investment requirements form middleware', () => {
     context('when uk location has been decided', () => {
       context('when called with multiple actual landed regions', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               site_decided: 'true',
               actual_uk_regions: [
@@ -525,10 +485,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -540,7 +496,7 @@ describe('Investment requirements form middleware', () => {
 
       context('when called with a single actual landed region', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               site_decided: 'true',
               strategic_drivers: [],
@@ -563,10 +519,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -580,7 +532,7 @@ describe('Investment requirements form middleware', () => {
     context('when uk location has not been decided', () => {
       context('when called with multiple actual landed regions', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               site_decided: 'false',
               actual_uk_regions: [],
@@ -605,10 +557,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -620,7 +568,7 @@ describe('Investment requirements form middleware', () => {
 
       context('when called with a single actual landed region', () => {
         beforeEach(async () => {
-          this.nockScope = nock(config.apiRoot)
+          nock(config.apiRoot)
             .patch('/v3/investment/1234', {
               site_decided: 'false',
               strategic_drivers: [],
@@ -643,10 +591,6 @@ describe('Investment requirements form middleware', () => {
           await handleFormPost(this.reqMock, this.resMock, this.nextStub)
         })
 
-        it('should call the API with transformed data', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
-
         it('should redirect the user to the details screen', () => {
           expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
         })
@@ -664,7 +608,7 @@ describe('Investment requirements form middleware', () => {
           { client_requirements: ['This field may not be blank.'] },
         ]
 
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             site_decided: 'true',
             strategic_drivers: [],
@@ -709,7 +653,7 @@ describe('Investment requirements form middleware', () => {
           { client_requirements: ['This field may not be blank.'] },
         ]
 
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             strategic_drivers: [],
             competitor_countries: [],
@@ -757,15 +701,11 @@ describe('Investment requirements form middleware', () => {
           delivery_partners: [],
         })
       })
-
-      it('should not try and save the record', () => {
-        expect(this.nockScope.isDone()).to.be.false
-      })
     })
 
     context('when called with multiple partners', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             uk_region_locations: [],
             client_requirements: 'some requirements',
@@ -791,10 +731,6 @@ describe('Investment requirements form middleware', () => {
         await handleFormPost(this.reqMock, this.resMock, this.nextStub)
       })
 
-      it('should call the API with transformed data', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
-
       it('should redirect the user to the details screen', () => {
         expect(this.resMock.redirect).to.be.calledWith('/investment-projects/1234/details')
       })
@@ -806,7 +742,7 @@ describe('Investment requirements form middleware', () => {
 
     context('when called with a single partner', () => {
       beforeEach(async () => {
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             actual_uk_regions: [],
             strategic_drivers: [],
@@ -827,10 +763,6 @@ describe('Investment requirements form middleware', () => {
         this.reqMock = assign({}, this.reqMock, { body })
 
         await handleFormPost(this.reqMock, this.resMock, this.nextStub)
-      })
-
-      it('should call the API with transformed data', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
 
       it('should redirect the user to the details screen', () => {

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -29,7 +29,7 @@ describe('Investment form middleware - team members', () => {
 
   describe('#populateForm', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/adviser/?limit=100000&offset=0`)
         .reply(200, {
           count: 5,
@@ -112,10 +112,6 @@ describe('Investment form middleware - team members', () => {
         expect(this.resMock.locals.form.buttonText).to.equal('Save')
         expect(this.resMock.locals.form.returnLink).to.equal(`/investment-projects/${investmentData.id}/team`)
       })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
     })
 
     context('when the investment project contains no team member data', () => {
@@ -157,10 +153,6 @@ describe('Investment form middleware - team members', () => {
         expect(this.resMock.locals.form.buttonText).to.equal('Save')
         expect(this.resMock.locals.form.returnLink).to.equal(`/investment-projects/${investmentData.id}/team`)
       })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
-      })
     })
   })
 
@@ -177,7 +169,7 @@ describe('Investment form middleware - team members', () => {
           },
         })
 
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .put(`/v3/investment/${investmentData.id}/team-member`, [{
             adviser: '1',
             role: 'manager',
@@ -188,10 +180,6 @@ describe('Investment form middleware - team members', () => {
           .reply(200, {})
 
         await teamMembersController.postTeamEdit(this.reqMock, this.resMock, this.nextStub)
-      })
-
-      it('should call the api with the correct parameters', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
 
       it('should redirect back to the details page', () => {
@@ -224,7 +212,7 @@ describe('Investment form middleware - team members', () => {
           },
         })
 
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, {
             count: 5,
@@ -296,7 +284,7 @@ describe('Investment form middleware - team members', () => {
           },
         })
 
-        this.nockScope = nock(config.apiRoot)
+        nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, {
             count: 5,

--- a/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/team-members.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const { assign } = require('lodash')
 const uuid = require('uuid')
 

--- a/test/unit/apps/investment-projects/middleware/forms/value.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/value.test.js
@@ -34,7 +34,7 @@ describe('Investment form middleware - investment value', () => {
       locals: {},
     }
 
-    this.nockScope = nock(config.apiRoot)
+    nock(config.apiRoot)
       .get(`/adviser/?limit=100000&offset=0`)
       .reply(200, adviserData)
       .get('/metadata/salary-range/')

--- a/test/unit/apps/investment-projects/repos.test.js
+++ b/test/unit/apps/investment-projects/repos.test.js
@@ -16,7 +16,7 @@ const investmentProjectAuditData = require('~/test/unit/data/investment/audit-lo
 describe('Investment repository', () => {
   describe('#getCompanyInvestmentProjects', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/investment?investor_company_id=${companyData.id}&limit=10&offset=0`)
         .reply(200, companyData)
       this.investmentProjects = await getCompanyInvestmentProjects('token', companyData.id)
@@ -25,15 +25,11 @@ describe('Investment repository', () => {
     it('should return a company object', () => {
       expect(this.investmentProjects).to.deep.equal(companyData)
     })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
-    })
   })
 
   describe('#getInvestment', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/investment/${investmentData.id}`)
         .reply(200, investmentData)
       this.investmentProject = await getInvestment('token', investmentData.id)
@@ -42,15 +38,11 @@ describe('Investment repository', () => {
     it('should return an investment object', () => {
       expect(this.investmentProject).to.deep.equal(investmentData)
     })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
-    })
   })
 
   describe('#createInvestmentProject', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .post(`/v3/investment`)
         .reply(200, { id: '12345' })
       this.investmentProject = await createInvestmentProject('token', { foo: 'bar' })
@@ -59,17 +51,13 @@ describe('Investment repository', () => {
     it('should return an investment requirements object', () => {
       expect(this.investmentProject).to.deep.equal({ id: '12345' })
     })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
-    })
   })
 
   describe('#updateInvestment', () => {
     const appendedData = { foo: 'bar' }
 
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .patch(`/v3/investment/${investmentData.id}`)
         .reply(200, investmentData)
       this.investmentProject = await updateInvestment('token', investmentData.id, appendedData)
@@ -78,15 +66,11 @@ describe('Investment repository', () => {
     it('should return an investment requirements object', async () => {
       expect(this.investmentProject).to.deep.equal(investmentData)
     })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
-    })
   })
 
   describe('#archiveInvestmentProject', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .post(`/v3/investment/${investmentData.id}/archive`, { reason: 'test' })
         .reply(200, investmentProjectAuditData)
       this.investmentProjectAuditData = await archiveInvestmentProject('token', investmentData.id, 'test')
@@ -95,15 +79,11 @@ describe('Investment repository', () => {
     it('should call archive url and post reason', () => {
       expect(this.investmentProjectAuditData).to.deep.equal(investmentProjectAuditData)
     })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
-    })
   })
 
   describe('#unarchiveInvestmentProject', async () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .post(`/v3/investment/${investmentData.id}/unarchive`)
         .reply(200, investmentProjectAuditData)
       this.investmentProjectAuditData = await unarchiveInvestmentProject('token', investmentData.id)
@@ -111,10 +91,6 @@ describe('Investment repository', () => {
 
     it('should call unarchive url', async () => {
       expect(this.investmentProjectAuditData).to.deep.equal(investmentProjectAuditData)
-    })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 })

--- a/test/unit/apps/oauth/controllers/oauth.test.js
+++ b/test/unit/apps/oauth/controllers/oauth.test.js
@@ -157,10 +157,6 @@ describe('OAuth controller', () => {
         it('token should match expected value', () => {
           expect(this.reqMock.session.token).to.equal(this.mockOauthAccessToken)
         })
-
-        it('nock mocked scope has been called', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
       })
 
       context('when there is an error query param', () => {
@@ -214,10 +210,6 @@ describe('OAuth controller', () => {
           expect(this.resMock.redirect.args[0][0]).to.equal('/')
           expect(this.reqMock.session.token).to.equal(mockOauthAccessToken)
         })
-
-        it('nock mocked scope has been called', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
       })
 
       context('redirect to returnTo', () => {
@@ -238,10 +230,6 @@ describe('OAuth controller', () => {
           expect(this.resMock.redirect.args[0][0]).to.equal(returnToUrl)
           expect(this.reqMock.session.token).to.equal(mockOauthAccessToken)
         })
-
-        it('nock mocked scope has been called', () => {
-          expect(this.nockScope.isDone()).to.be.true
-        })
       })
 
       context('redirect to returnTo', () => {
@@ -259,10 +247,6 @@ describe('OAuth controller', () => {
           expect(this.nextSpy).to.have.been.calledOnce
           expect(this.nextSpy.args[0][0].message).to.equal(`Error: ${returnedError}`)
           expect(this.reqMock.session.token).to.be.undefined
-        })
-
-        it('nock mocked scope has been called', () => {
-          expect(this.nockScope.isDone()).to.be.true
         })
       })
     })

--- a/test/unit/apps/omis/apps/list/middleware.test.js
+++ b/test/unit/apps/omis/apps/list/middleware.test.js
@@ -17,7 +17,7 @@ describe('OMIS list middleware', () => {
 
   describe('Results', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .post(`/v3/search/order`)
         .reply(200, orderCollectionData)
     })
@@ -39,10 +39,6 @@ describe('OMIS list middleware', () => {
         expect(actual).to.have.property('pagination')
         expect(actual.count).to.equal(3)
         expect(this.next).to.have.been.calledOnce
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/omis/apps/reconciliation/middleware.test.js
+++ b/test/unit/apps/omis/apps/reconciliation/middleware.test.js
@@ -17,7 +17,7 @@ describe('OMIS reconciliation middleware', () => {
 
   describe('Results', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .post(`/v3/search/order`)
         .reply(200, orderCollectionData)
     })
@@ -39,10 +39,6 @@ describe('OMIS reconciliation middleware', () => {
         expect(actual).to.have.property('pagination')
         expect(actual.count).to.equal(3)
         expect(this.next).to.have.been.calledOnce
-      })
-
-      it('nock mocked scope has been called', () => {
-        expect(this.nockScope.isDone()).to.be.true
       })
     })
   })

--- a/test/unit/apps/search/controllers.test.js
+++ b/test/unit/apps/search/controllers.test.js
@@ -45,7 +45,7 @@ describe('Search Controller #renderSearchResults', () => {
 
   context('for investment projects', () => {
     beforeEach(async () => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/search`)
         .query(Object.assign({}, searchQuery, { entity: 'investment_project' }))
         .reply(200, investmentResponse)
@@ -67,15 +67,11 @@ describe('Search Controller #renderSearchResults', () => {
     it('should transform investment projects data', () => {
       expect(this.renderFunction.getCall(0).args[1].results.items[0].type).to.equal('investment-project')
     })
-
-    it('nock mocked scope has been called', () => {
-      expect(this.nockScope.isDone()).to.be.true
-    })
   })
 
   context('for contacts', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/search`)
         .query(Object.assign({}, searchQuery, { entity: 'contact' }))
         .reply(200, contactResponse)
@@ -107,7 +103,7 @@ describe('Search Controller #renderSearchResults', () => {
 
   context('for companies', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/search`)
         .query(Object.assign({}, searchQuery, { entity: 'company' }))
         .reply(200, companyResponse)
@@ -139,7 +135,7 @@ describe('Search Controller #renderSearchResults', () => {
 
   context('investment projects', () => {
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/search`)
         .query(Object.assign({}, searchQuery, { entity: 'event' }))
         .reply(200, eventResponse)

--- a/test/unit/apps/search/services.test.js
+++ b/test/unit/apps/search/services.test.js
@@ -10,7 +10,7 @@ describe('Search service', () => {
     const mockResponse = { message: 'mock response' }
 
     beforeEach(() => {
-      this.nockScope = nock(config.apiRoot)
+      nock(config.apiRoot)
         .get(`/v3/search`)
         .query({
           term: searchTerm,
@@ -33,7 +33,6 @@ describe('Search service', () => {
       })
 
       expect(actual).to.deep.equal(expectedResponse)
-      expect(this.nockScope.isDone()).to.be.true
     })
   })
 })

--- a/test/unit/lib/options.test.js
+++ b/test/unit/lib/options.test.js
@@ -15,7 +15,7 @@ const regionOptions = [
 
 describe('#options', () => {
   beforeEach(() => {
-    this.nockScope = nock(config.apiRoot)
+    nock(config.apiRoot)
       .get('/metadata/uk-region/')
       .reply(200, regionOptions)
   })

--- a/test/unit/lib/options.test.js
+++ b/test/unit/lib/options.test.js
@@ -1,4 +1,3 @@
-const nock = require('nock')
 const moment = require('moment')
 
 const config = require('~/config')


### PR DESCRIPTION
This changes reduces some of the use cases of nock in unit tests:

- `nock` is available globally so does not need to be included in test files
- testing of nock scope being done doesn't feel necessary as we are already testing for the result being mocked. If they're not called with the mocked response our tests will already fail.
