### PR TITLE
fix error where sometimes the results are equal

### DIFF
--- a/test/acceptance/features/companies/step_definitions/collection.js
+++ b/test/acceptance/features/companies/step_definitions/collection.js
@@ -133,11 +133,11 @@ defineSupportCode(({ Given, Then, When }) => {
       })
 
     if (sortType === 'Recently') {
-      client.expect(updateValues.firstItem.isAfter(updateValues.secondItem)).to.be.true
+      client.expect(updateValues.firstItem.isSameOrAfter(updateValues.secondItem)).to.be.true
     }
 
     if (sortType === 'Least recently') {
-      client.expect(updateValues.firstItem.isBefore(updateValues.secondItem)).to.be.true
+      client.expect(updateValues.firstItem.isSameOrBefore(updateValues.secondItem)).to.be.true
     }
   })
 


### PR DESCRIPTION
When checking the sorting in collection of Least/ recently updated results sometimes we see errors when Items are equal. This fix addresses these errors.

An example of the failure can be seen 
- [cucumber report](https://17945-83823675-gh.circle-artifacts.com/3/root/data-hub-frontend/cucumber/report.html)
- [circleci datahub fe job](https://circleci.com/gh/uktrade/data-hub-frontend/17945#artifacts/containers/3)

![screen shot 2018-01-26 at 15 33 56](https://user-images.githubusercontent.com/2305016/35447049-85e28f7c-02ae-11e8-9164-c9ac462289ea.png)

