### PR TITLE
Move saving of OMIS data to saveValues method

### DIFF
--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -1,4 +1,4 @@
-const { filter, flatten, get, pick } = require('lodash')
+const { filter, flatten, get } = require('lodash')
 
 const { EditController } = require('../../../controllers')
 const { Order } = require('../../../models')
@@ -23,8 +23,8 @@ class EditAssigneeTimeController extends EditController {
     next()
   }
 
-  async successHandler (req, res, next) {
-    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
+  async saveValues (req, res, next) {
+    const data = req.form.values
     const timeValues = flatten([data.assignee_time])
     const assignees = timeValues.map((value, index) => {
       return {
@@ -37,15 +37,7 @@ class EditAssigneeTimeController extends EditController {
 
     try {
       await Order.saveAssignees(req.session.token, res.locals.order.id, filter(assignees))
-      const nextUrl = req.form.options.next || `/omis/${res.locals.order.id}`
-
-      req.journeyModel.reset()
-      req.journeyModel.destroy()
-      req.sessionModel.reset()
-      req.sessionModel.destroy()
-
-      req.flash('success', 'Order updated')
-      res.redirect(nextUrl)
+      next()
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -1,4 +1,4 @@
-const { get, pick, sortBy } = require('lodash')
+const { get, sortBy } = require('lodash')
 
 const { EditController } = require('../../../controllers')
 const { getAdvisers } = require('../../../../adviser/repos')
@@ -28,8 +28,8 @@ class EditAssigneesController extends EditController {
     }
   }
 
-  async successHandler (req, res, next) {
-    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
+  async saveValues (req, res, next) {
+    const data = req.form.values
     const assignees = data.assignees.map((id) => {
       return {
         adviser: { id },
@@ -40,7 +40,6 @@ class EditAssigneesController extends EditController {
       const orderId = get(res.locals, 'order.id')
       const canEditOrder = get(res.locals, 'order.canEditOrder')
       const token = get(req.session, 'token')
-      const nextUrl = get(req, 'form.options.next') || `/omis/${orderId}`
 
       if (canEditOrder) {
         await Order.forceSaveAssignees(token, orderId, assignees)
@@ -48,13 +47,7 @@ class EditAssigneesController extends EditController {
         await Order.saveAssignees(token, orderId, assignees)
       }
 
-      req.journeyModel.reset()
-      req.journeyModel.destroy()
-      req.sessionModel.reset()
-      req.sessionModel.destroy()
-
-      req.flash('success', 'Order updated')
-      res.redirect(nextUrl)
+      next()
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/apps/edit/controllers/cancel-order.js
+++ b/src/apps/omis/apps/edit/controllers/cancel-order.js
@@ -1,4 +1,4 @@
-const { get, filter, merge, pick } = require('lodash')
+const { get, filter, merge } = require('lodash')
 
 const { EditController } = require('../../../controllers')
 const { transformObjectToOption } = require('../../../../transformers')
@@ -32,22 +32,14 @@ class CancelOrderController extends EditController {
     super.configure(req, res, next)
   }
 
-  async successHandler (req, res, next) {
+  async saveValues (req, res, next) {
     const token = req.session.token
     const orderId = get(res.locals, 'order.id')
-    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
+    const data = req.form.values
 
     try {
       await Order.cancel(token, orderId, data)
-      const nextUrl = req.form.options.next || `/omis/${orderId}`
-
-      req.journeyModel.reset()
-      req.journeyModel.destroy()
-      req.sessionModel.reset()
-      req.sessionModel.destroy()
-
-      req.flash('success', 'Order cancelled')
-      res.redirect(nextUrl)
+      next()
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/apps/edit/controllers/edit-handler.js
+++ b/src/apps/omis/apps/edit/controllers/edit-handler.js
@@ -25,6 +25,7 @@ function editHandler (req, res, next) {
     template: '_layouts/form-wizard-step',
     controller: EditController,
     translate: i18n.translate.bind(i18n),
+    successMessage: 'Order updated',
   }
   const overrides = {
     fields: reduce(step.fields, (result, field) => {

--- a/src/apps/omis/apps/edit/controllers/subscribers.js
+++ b/src/apps/omis/apps/edit/controllers/subscribers.js
@@ -1,4 +1,4 @@
-const { get, sortBy, pick } = require('lodash')
+const { get, sortBy } = require('lodash')
 
 const { EditController } = require('../../../controllers')
 const { getAdvisers } = require('../../../../adviser/repos')
@@ -26,21 +26,13 @@ class EditSubscribersController extends EditController {
     }
   }
 
-  async successHandler (req, res, next) {
-    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
+  async saveValues (req, res, next) {
+    const data = req.form.values
     const subscribers = data.subscribers.map(transformIdToObject)
 
     try {
       await Order.saveSubscribers(req.session.token, res.locals.order.id, subscribers)
-      const nextUrl = req.form.options.next || `/omis/${res.locals.order.id}`
-
-      req.journeyModel.reset()
-      req.journeyModel.destroy()
-      req.sessionModel.reset()
-      req.sessionModel.destroy()
-
-      req.flash('success', 'Order updated')
-      res.redirect(nextUrl)
+      next()
     } catch (error) {
       next(error)
     }

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -97,6 +97,7 @@ const steps = merge({}, createSteps, {
     ],
     templatePath: 'omis/apps/edit/views',
     template: 'complete-order.njk',
+    successMessage: 'Order completed',
     controller: CompleteOrderController,
   },
   '/cancel-order': {
@@ -104,6 +105,7 @@ const steps = merge({}, createSteps, {
     fields: [
       'cancellation_reason',
     ],
+    successMessage: 'Order cancelled',
     controller: CancelOrderController,
   },
 })

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -17,23 +17,24 @@ const FormController = require('./form')
 const { Order } = require('../models')
 
 class EditController extends FormController {
-  async successHandler (req, res, next) {
-    const data = pick(req.sessionModel.toJSON(), Object.keys(req.form.options.fields))
-
+  async saveValues (req, res, next) {
     try {
-      const order = await Order.update(req.session.token, res.locals.order.id, data)
-      const nextUrl = req.form.options.next || `/omis/${order.id}`
+      await Order.update(req.session.token, res.locals.order.id, req.form.values)
 
-      req.journeyModel.reset()
-      req.journeyModel.destroy()
-      req.sessionModel.reset()
-      req.sessionModel.destroy()
-
-      req.flash('success', 'Order updated')
-      res.redirect(nextUrl)
+      next()
     } catch (error) {
       next(error)
     }
+  }
+
+  successHandler (req, res) {
+    req.journeyModel.reset()
+    req.journeyModel.destroy()
+    req.sessionModel.reset()
+    req.sessionModel.destroy()
+
+    req.flash('success', req.form.options.successMessage)
+    res.redirect(this.getNextStep(req, res))
   }
 
   getValues (req, res, next) {

--- a/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
+++ b/test/unit/apps/omis/apps/edit/controllers/assignees.test.js
@@ -155,45 +155,20 @@ describe('OMIS edit subscribers controller', () => {
     })
   })
 
-  describe('successHandler()', () => {
+  describe('saveValues()', () => {
     beforeEach(() => {
-      this.resetSpy = sandbox.spy()
-      this.destroySpy = sandbox.spy()
-      this.flashSpy = sandbox.spy()
-      this.redirectSpy = sandbox.spy()
-
       this.reqMock = Object.assign({}, globalReq, {
         form: {
-          options: {
-            fields: {
-              assignees: {},
-              fizz: {},
-            },
+          values: {
+            assignees: [
+              '33736be0-3e6b-4d4e-9fa8-32f23d0ba55e',
+              '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
+            ],
           },
         },
         session: {
           token: tokenMock,
         },
-        sessionModel: {
-          toJSON: () => {
-            return {
-              'csrf-secret': 'secret-key',
-              errors: {},
-              assignees: [
-                '33736be0-3e6b-4d4e-9fa8-32f23d0ba55e',
-                '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
-              ],
-              fizz: 'buzz',
-            }
-          },
-          reset: this.resetSpy,
-          destroy: this.destroySpy,
-        },
-        journeyModel: {
-          reset: this.resetSpy,
-          destroy: this.destroySpy,
-        },
-        flash: this.flashSpy,
       })
 
       this.resMock = Object.assign({}, globalRes, {
@@ -206,15 +181,16 @@ describe('OMIS edit subscribers controller', () => {
       })
     })
 
-    context('when an async call rejects', () => {
+    context('when save fails', () => {
       beforeEach(async () => {
         this.error = new Error('Async error')
         this.saveAssigneesStub.rejects(this.error)
 
-        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+        await this.controller.saveValues(this.reqMock, this.resMock, this.nextSpy)
       })
 
       it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledOnce
         expect(this.nextSpy).to.have.been.calledWith(this.error)
       })
     })
@@ -223,12 +199,14 @@ describe('OMIS edit subscribers controller', () => {
       beforeEach(async () => {
         this.resMock.locals.order.canEditOrder = true
 
-        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+        await this.controller.saveValues(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should force save assignees', () => {
+      it('should not call save assignees method', () => {
         expect(this.saveAssigneesStub).not.to.have.been.called
+      })
 
+      it('should call force save assignees method', () => {
         expect(this.forceSaveAssigneesStub).to.have.been.calledOnce
         expect(this.forceSaveAssigneesStub).to.have.been.calledWith(tokenMock, orderMock.id, [{
           adviser: {
@@ -240,32 +218,20 @@ describe('OMIS edit subscribers controller', () => {
           },
         }])
       })
-
-      it('should reset the models', () => {
-        expect(this.resetSpy).to.have.been.calledTwice
-        expect(this.destroySpy).to.have.been.calledTwice
-      })
-
-      it('should set a flash message', () => {
-        expect(this.flashSpy).to.have.been.calledOnce
-      })
-
-      it('should redirect back to the order', () => {
-        expect(this.redirectSpy).to.have.been.calledOnce
-        expect(this.redirectSpy).to.have.been.calledWith(`/omis/${orderMock.id}`)
-      })
     })
 
     context('when order is editable', () => {
       beforeEach(async () => {
         this.resMock.locals.order.canEditOrder = false
 
-        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
+        await this.controller.saveValues(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should not force save assignees', () => {
+      it('should not call force save method', () => {
         expect(this.forceSaveAssigneesStub).not.to.have.been.called
+      })
 
+      it('should call save assignees method', () => {
         expect(this.saveAssigneesStub).to.have.been.calledOnce
         expect(this.saveAssigneesStub).to.have.been.calledWith(tokenMock, orderMock.id, [{
           adviser: {
@@ -276,17 +242,6 @@ describe('OMIS edit subscribers controller', () => {
             id: '3cfad090-8f7e-4a8b-beb0-14c909d6f052',
           },
         }])
-      })
-    })
-
-    context('when next is set', () => {
-      it('should redirect back to returnUrl', async () => {
-        this.reqMock.form.options.next = '/custom-return-url'
-
-        await this.controller.successHandler(this.reqMock, this.resMock, this.nextSpy)
-
-        expect(this.redirectSpy).to.have.been.calledOnce
-        expect(this.redirectSpy).to.have.been.calledWith('/custom-return-url')
       })
     })
   })


### PR DESCRIPTION
This change splits out what the current successHandler method is
responsible for. It was previously handling saving of the data to the
API and redirecting on success.

Looking again at the lifecycle it makes more sense that the saving of
data is taken care of in the saveValues method then the next method
is called to move to the successHandler.

This means the successHandler is then only responsible for clearing of
the session data and redirecting to the next URL. It means repetition
in those code when a custom method for saving is required can be
removed.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
