### PR TITLE
Improve logic of view quote link

### DIFF
--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -23,7 +23,7 @@
     <p class="c-local-header__action">
       {% if order.status == 'draft' %}
         <a href="quote" class="button">Preview quote</a>
-      {% else %}
+      {% elif order.status not in ['cancelled']  %}
         <a href="quote">View quote</a>
       {% endif %}
     </p>


### PR DESCRIPTION
This change ensures that the view quote link isn't displayed in the
header area if the order has been cancelled and the quote hasn't
been sent.

This would lead to linking to a page that doesn't technically exist.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
