### PR TITLE
Update OMIS reconciliation collection to newer styles

### DIFF
--- a/src/apps/omis/apps/reconciliation/macros.js
+++ b/src/apps/omis/apps/reconciliation/macros.js
@@ -1,4 +1,4 @@
-const { assign, filter, includes } = require('lodash')
+const { assign, filter, flatten, includes } = require('lodash')
 
 const { ORDER_STATES } = require('../../constants')
 const { collectionSortForm } = require('../list/macros')
@@ -8,7 +8,8 @@ const filtersFields = [
     macroName: 'MultipleChoiceField',
     label: 'Order status',
     name: 'status',
-    type: 'radio',
+    type: 'checkbox',
+    modifier: 'option-select',
     options: filter(ORDER_STATES, o => {
       return !includes(['draft', 'quote_awaiting_acceptance'], o.value)
     }),
@@ -17,13 +18,11 @@ const filtersFields = [
     macroName: 'TextField',
     label: 'Order reference',
     name: 'reference',
-    hint: 'At least three characters',
   },
   {
     macroName: 'TextField',
     label: 'Company name',
     name: 'company_name',
-    hint: 'At least three characters',
   },
   {
     macroName: 'TextField',
@@ -37,7 +36,7 @@ const filtersFields = [
   },
 ].map(filter => {
   return assign({}, filter, {
-    modifier: ['smaller', 'light'],
+    modifier: flatten([filter.modifier, 'smaller', 'light', 'filter']),
   })
 })
 

--- a/src/apps/omis/apps/reconciliation/views/list-reconciliation.njk
+++ b/src/apps/omis/apps/reconciliation/views/list-reconciliation.njk
@@ -1,16 +1,6 @@
-{% extends "_layouts/two-column.njk" %}
+{% extends "collection.njk" %}
 
-{% block main_grid_left_column %}
-  {{
-    CollectionFilters({
-      query: QUERY,
-      filtersFields: filtersFields,
-      action: CURRENT_PATH
-    })
-  }}
-{% endblock %}
-
-{% block main_grid_right_column %}
+{% block collection_results %}
   {% call Collection(results | assign({
     countLabel: 'order',
     sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
@@ -23,8 +13,16 @@
           <th>Reference</th>
           <th>Payment due date</th>
           <th>Company name</th>
-          <th align="right">Amount (ex. VAT)</th>
-          <th align="right">Amount (inc. VAT)</th>
+          <th align="right">
+            Amount
+            <br>
+            (ex.&nbsp;VAT)
+          </th>
+          <th align="right">
+            Amount
+            <br>
+            (inc.&nbsp;VAT)
+          </th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
During the recent changes to the collection pages this view was not
updated. This change brings this collection inline with the other
collections across the application.

## Before

![localhost_3001_omis_reconciliation_sortby payment_due_date 3aasc status quote_accepted 1](https://user-images.githubusercontent.com/3327997/35485799-68ed8264-045c-11e8-9738-5fad5e5d6305.png)

## After

![localhost_3001_omis_reconciliation_sortby payment_due_date 3aasc status quote_accepted](https://user-images.githubusercontent.com/3327997/35485794-53ddf4c6-045c-11e8-8d97-74bd6153ba96.png)
