### PR TITLE
DH-1467 Fix Oauth stateId mismatch

### DIFF
--- a/src/middleware/session-store.js
+++ b/src/middleware/session-store.js
@@ -5,9 +5,9 @@ const config = require('../../config')
 
 const sessionStore = session({
   store: redisStore,
-  proxy: !config.isDev,
+  proxy: config.isProd,
   cookie: {
-    secure: !config.isDev,
+    secure: config.isProd,
     maxAge: config.session.ttl,
   },
   rolling: true,

--- a/src/middleware/session-store.js
+++ b/src/middleware/session-store.js
@@ -14,6 +14,7 @@ const sessionStore = session({
   secret: config.session.secret,
   resave: true,
   saveUninitialized: false,
+  unset: 'destroy',
 })
 
 module.exports = sessionStore

--- a/src/middleware/session-store.js
+++ b/src/middleware/session-store.js
@@ -11,7 +11,6 @@ const sessionStore = session({
     maxAge: config.session.ttl,
   },
   rolling: true,
-  key: 'datahub.sid',
   secret: config.session.secret,
   resave: true,
   saveUninitialized: true,

--- a/src/middleware/session-store.js
+++ b/src/middleware/session-store.js
@@ -13,7 +13,7 @@ const sessionStore = session({
   rolling: true,
   secret: config.session.secret,
   resave: true,
-  saveUninitialized: true,
+  saveUninitialized: false,
 })
 
 module.exports = sessionStore


### PR DESCRIPTION
This is `Part 1` of an investigation into the Oauth StateId mismatch errors we are getting. 
There are a few things which have been updated in the session middleware in this PR, specifically changing 
`saveUninitialized` to `false` due to the comments in the [saveUninitialized](https://github.com/expressjs/session#saveuninitialized) section. I feel this may go some way to helping with the `undefined` property we get with `req.session.oauth.state`

>Forces a session that is "uninitialized" to be saved to the store. A session is uninitialized when it is new but not modified. Choosing false is useful for implementing login sessions, reducing server storage usage, or complying with laws that require permission before setting a cookie. Choosing false will also help with race conditions where a client makes multiple parallel requests without a session.

`Part 2:` see whats going on with production Redis