### PR TITLE
Ensure values are escaped in entity and meta item

### DIFF
--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -21,7 +21,7 @@
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
     {% set contentMetaModifier = props.contentMetaModifier| default(['inline', 'split']) %}
     {% set metaItems = props.meta | reject(['type', 'badge']) %}
-    {% set highlightedName = props.name | highlight(props.highlightTerm) %}
+    {% set highlightedName = props.name | escape | highlight(props.highlightTerm) %}
     {% set containerElement = 'a' if props.isBlockLink else 'div' %}
 
     <{{ containerElement }}

--- a/src/templates/_macros/entity/meta-item.njk
+++ b/src/templates/_macros/entity/meta-item.njk
@@ -34,7 +34,7 @@
       {% set metaItemValue = props.value.name | default(props.value) %}
     {% endif %}
 
-    {% set value = metaItemValue | highlight(props.highlightTerm, true) %}
+    {% set value = metaItemValue | escape | highlight(props.highlightTerm, true) %}
 
     <div class="{{ 'c-meta-list__item' | applyClassModifiers(props.modifier) }}">
       {% if props.label %}


### PR DESCRIPTION
Due to the use of the `highlight` filter the output for the heading
within an entity and meta item will not be escaped.

Seeing as this value can come from user input we should ensure that
the initial value at least is always escaped before the highlight
filter is applied.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
