### PR TITLE
Move field processing to process() instead of saveValues()

### DIFF
--- a/src/apps/omis/controllers/form.js
+++ b/src/apps/omis/controllers/form.js
@@ -38,26 +38,19 @@ class FormController extends Controller {
         req.form.values[key].splice(index, 1)
       }
 
-      return this.saveValues(req, res, () => {
+      return super.saveValues(req, res, () => {
         res.redirect(req.baseUrl + req.path)
       })
     }
 
+    const fields = req.form.options.fields
+    forEach(fields, (options, key) => {
+      if (options.repeatable) {
+        req.form.values[key] = filter(flatten([req.form.values[key]]))
+      }
+    })
+
     next()
-  }
-
-  saveValues (req, res, next) {
-    if (!req.body['add-item'] && !req.body['remove-item']) {
-      const fields = req.form.options.fields
-
-      forEach(fields, (options, key) => {
-        if (options.repeatable) {
-          req.form.values[key] = filter(flatten([req.form.values[key]]))
-        }
-      })
-    }
-
-    super.saveValues(req, res, next)
   }
 
   errorHandler (err, req, res, next) {

--- a/test/unit/apps/omis/controllers/form.test.js
+++ b/test/unit/apps/omis/controllers/form.test.js
@@ -135,20 +135,6 @@ describe('OMIS FormController', () => {
     })
 
     context('when form submission is a save', () => {
-      it('should call next()', () => {
-        const saveValuesSpy = sandbox.spy()
-        FormController.prototype.saveValues = saveValuesSpy
-
-        this.controller.process(this.reqMock, this.resMock, this.nextSpy)
-
-        expect(this.nextSpy).to.have.been.calledOnce
-        expect(saveValuesSpy).not.to.have.been.called
-      })
-    })
-  })
-
-  describe('saveValues()', () => {
-    context('when form submission is a save', () => {
       beforeEach(() => {
         this.saveValuesSpy = sandbox.spy()
         this.reqMock = Object.assign({}, globalReq, {
@@ -168,19 +154,31 @@ describe('OMIS FormController', () => {
         FormController.prototype.saveValues = this.saveValuesSpy
       })
 
+      it('should not call parent saveValues()', () => {
+        this.controller.process(this.reqMock, this.resMock, this.nextSpy)
+
+        expect(this.saveValuesSpy).not.to.have.been.called
+      })
+
+      it('should call next()', () => {
+        this.controller.process(this.reqMock, this.resMock, this.nextSpy)
+
+        expect(this.nextSpy).to.have.been.calledOnce
+        expect(this.nextSpy).to.have.been.calledWith()
+      })
+
       context('when a repeatable field is not an array', () => {
         beforeEach(() => {
           this.reqMock.form.values.repeatableField = ''
         })
 
         it('should convert it to an array', () => {
-          this.controller.saveValues(this.reqMock, globalRes, this.nextSpy)
+          this.controller.process(this.reqMock, globalRes, this.nextSpy)
 
           expect(this.reqMock.form.values).to.deep.equal({
             nonRepeatableField: 'foo',
             repeatableField: [],
           })
-          expect(this.saveValuesSpy).to.have.been.calledOnce
         })
       })
 
@@ -190,13 +188,12 @@ describe('OMIS FormController', () => {
         })
 
         it('should filter falseys out', () => {
-          this.controller.saveValues(this.reqMock, globalRes, this.nextSpy)
+          this.controller.process(this.reqMock, globalRes, this.nextSpy)
 
           expect(this.reqMock.form.values).to.deep.equal({
             nonRepeatableField: 'foo',
             repeatableField: ['foo', 'bar'],
           })
-          expect(this.saveValuesSpy).to.have.been.calledOnce
         })
       })
     })


### PR DESCRIPTION
In the parent OMIS Form Controller there was some logic within the
`saveValues` method which converted repeatable fields into an array
when they were returned as a string.

With the recent changes to the Edit Controller this method was being
overridden and this was no longer happening.

Thinking about what was being done in this method it makes more sense
to handle this processing in the `process()` lifecycle method
rather than in the `saveValues()` method.

See the [form wizard lifecycle](https://github.com/UKHomeOffice/passports-form-wizard#post-lifecycle) for an understanding of which order these pre-defined methods
are called.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
