### PR TITLE
DH-1491 Do not sort all options

### DIFF
--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -29,8 +29,8 @@ async function getCompanyFormOptions (token, createdOn) {
     headquarters: await getHeadquarterOptions(token),
     regions: await getOptions(token, 'uk-region', { createdOn }),
     sectors: await getOptions(token, 'sector', { createdOn }),
-    employees: await getOptions(token, 'employee-range', { createdOn }),
-    turnovers: await getOptions(token, 'turnover', { createdOn }),
+    employees: await getOptions(token, 'employee-range', { createdOn, sorted: false }),
+    turnovers: await getOptions(token, 'turnover', { createdOn, sorted: false }),
     countries: await getOptions(token, 'country', { createdOn }),
   }
 }

--- a/src/apps/investment-projects/middleware/forms/value.js
+++ b/src/apps/investment-projects/middleware/forms/value.js
@@ -17,7 +17,7 @@ async function populateForm (req, res, next) {
     }),
     options: {
       averageSalaryRange: await getOptions(token, 'salary-range', { createdOn }),
-      fdiValue: await getOptions(token, 'fdi-value', { createdOn }),
+      fdiValue: await getOptions(token, 'fdi-value', { createdOn, sorted: false }),
     },
   }
 

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -5,7 +5,7 @@ const authorisedRequest = require('../lib/authorised-request')
 const { filterDisabledOption } = require('../apps/filters')
 const { transformObjectToOption } = require('../apps/transformers')
 
-async function getOptions (token, key, { createdOn, currentValue, includeDisabled = false } = {}) {
+async function getOptions (token, key, { createdOn, currentValue, includeDisabled = false, sorted = true } = {}) {
   const url = `${config.apiRoot}/metadata/${key}/`
   let options = await authorisedRequest(token, url)
 
@@ -13,7 +13,9 @@ async function getOptions (token, key, { createdOn, currentValue, includeDisable
     options = options.filter(filterDisabledOption({ currentValue, createdOn }))
   }
 
-  return sortBy(options.map(transformObjectToOption), 'label')
+  const mappedOptions = options.map(transformObjectToOption)
+
+  return sorted ? sortBy(mappedOptions, 'label') : mappedOptions
 }
 
 module.exports = {

--- a/test/unit/lib/options.test.js
+++ b/test/unit/lib/options.test.js
@@ -9,8 +9,8 @@ const { getOptions } = require('~/src/lib/options')
 
 const regionOptions = [
   { id: '1', name: 'r1', disabled_on: null },
-  { id: '2', name: 'r2', disabled_on: yesterday },
   { id: '3', name: 'r3', disabled_on: null },
+  { id: '2', name: 'r2', disabled_on: yesterday },
 ]
 
 describe('#options', () => {
@@ -71,6 +71,20 @@ describe('#options', () => {
         { label: 'r1', value: '1' },
         { label: 'r2', value: '2' },
         { label: 'r3', value: '3' },
+      ])
+    })
+  })
+
+  context('when the options are to not be sorted', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', { includeDisabled: true, sorted: false })
+    })
+
+    it('should not sort the options', () => {
+      expect(this.options).to.deep.equal([
+        { label: 'r1', value: '1' },
+        { label: 'r3', value: '3' },
+        { label: 'r2', value: '2' },
       ])
     })
   })


### PR DESCRIPTION
DH-1491

# Issue

Fields in the company edit and investment project value edit forms contain fields with multiple options. These options are being sorted by the new option library.

# Fix

Not all options should be sorted so a parameter is being passed into the function to prevent sorting. Options will be sorted by default.

# Before

<img width="345" alt="screen shot 2018-01-31 at 14 46 27" src="https://user-images.githubusercontent.com/1150417/35629098-aaababd2-0695-11e8-80b3-297367bea336.png">

<img width="717" alt="screen shot 2018-01-31 at 14 47 06" src="https://user-images.githubusercontent.com/1150417/35629101-ad045262-0695-11e8-9469-4d59944bfea8.png">


# After

<img width="412" alt="screen shot 2018-01-31 at 14 45 42" src="https://user-images.githubusercontent.com/1150417/35629110-b7e98620-0695-11e8-92de-5535fb91dcb7.png">

<img width="720" alt="screen shot 2018-01-31 at 14 45 18" src="https://user-images.githubusercontent.com/1150417/35629112-b9d53e20-0695-11e8-8afa-4b0e06fe2cdf.png">

