### PR TITLE
Replace use of deprecated Given, Then, When for cucumber

### DIFF
--- a/test/acceptance/features/audit/step_definitions/company.js
+++ b/test/acceptance/features/audit/step_definitions/company.js
@@ -1,61 +1,60 @@
 const faker = require('faker')
 const format = require('date-fns/format')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Given, Then, When } = require('cucumber')
 const { set } = require('lodash')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const Message = client.page.Message()
-  const Company = client.page.Company()
-  const Contact = client.page.Contact()
-  const AuditContact = client.page.AuditContact()
-  const AuditCompany = client.page.AuditCompany()
-  const AuditList = client.page.AuditList()
-  Given(/^I Amend (.*) records of an existing company record$/, async function (number) {
-    await Company
-      .navigate()
-      .findCompany('Venus')
-    await AuditList.section.lastContactInList
-      .getText('@header', (result) => set(this.state, 'companyName', result.value))
-      .click('@header')
-    await AuditCompany
-      .editCompanyRecords(faker.name.jobDescriptor(), faker.internet.url(), number)
-      .submitForm('form')
-    await Message
-      .verifyMessage('success')
-  })
+const Message = client.page.Message()
+const Company = client.page.Company()
+const Contact = client.page.Contact()
+const AuditContact = client.page.AuditContact()
+const AuditCompany = client.page.AuditCompany()
+const AuditList = client.page.AuditList()
 
-  When(/^I search for this company record$/, async function () {
-    await Company
-      .navigate()
-      .findCompany(this.state.companyName)
-    await Contact
-      .click('@firstCompanyFromList')
-    await AuditContact
-      .getText('@userName', (result) => set(this.state, 'username', result.value))
-  })
+Given(/^I Amend (.*) records of an existing company record$/, async function (number) {
+  await Company
+    .navigate()
+    .findCompany('Venus')
+  await AuditList.section.lastContactInList
+    .getText('@header', (result) => set(this.state, 'companyName', result.value))
+    .click('@header')
+  await AuditCompany
+    .editCompanyRecords(faker.name.jobDescriptor(), faker.internet.url(), number)
+    .submitForm('form')
+  await Message
+    .verifyMessage('success')
+})
 
-  Then(/^I see the name of the person who made the recent company record changes$/, async function () {
-    await AuditContact
-      .getText('@userName', (result) => set(this.state, 'username', result.value))
+When(/^I search for this company record$/, async function () {
+  await Company
+    .navigate()
+    .findCompany(this.state.companyName)
+  await Contact
+    .click('@firstCompanyFromList')
+  await AuditContact
+    .getText('@userName', (result) => set(this.state, 'username', result.value))
+})
 
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', this.state.username)
-  })
+Then(/^I see the name of the person who made the recent company record changes$/, async function () {
+  await AuditContact
+    .getText('@userName', (result) => set(this.state, 'username', result.value))
 
-  Then(/^I see the date time stamp when the recent company record changed$/, async function () {
-    const today = format(new Date(), 'D MMM YYYY')
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@header', today)
-  })
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@adviser', this.state.username)
+})
 
-  Then(/^I see the total number of changes occurred recently on this company record$/, async function () {
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@changeCount', '2 changes')
-  })
+Then(/^I see the date time stamp when the recent company record changed$/, async function () {
+  const today = format(new Date(), 'D MMM YYYY')
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@header', today)
+})
 
-  Then(/^I see the field names that were recently changed on this company record$/, async function () {
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@fields', 'Business description')
-  })
+Then(/^I see the total number of changes occurred recently on this company record$/, async function () {
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@changeCount', '2 changes')
+})
+
+Then(/^I see the field names that were recently changed on this company record$/, async function () {
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@fields', 'Business description')
 })

--- a/test/acceptance/features/audit/step_definitions/contact.js
+++ b/test/acceptance/features/audit/step_definitions/contact.js
@@ -1,117 +1,115 @@
 const format = require('date-fns/format')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Given, Then, When } = require('cucumber')
 const { merge, set } = require('lodash')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const Message = client.page.Message()
-  const Company = client.page.Company()
-  const Contact = client.page.Contact()
-  const ContactList = client.page.ContactList()
-  const AuditContact = client.page.AuditContact()
-  const AuditList = client.page.AuditList()
-  const InvestmentProject = client.page.InvestmentProject()
+const Message = client.page.Message()
+const Company = client.page.Company()
+const Contact = client.page.Contact()
+const ContactList = client.page.ContactList()
+const AuditContact = client.page.AuditContact()
+const AuditList = client.page.AuditList()
+const InvestmentProject = client.page.InvestmentProject()
 
-  Given(/^I archive an existing contact record$/, async function () {
-    await Company
-      .navigate()
-      .findCompany(this.fixtures.company.foreign.name)
-    await ContactList
-      .click('@contactsTab')
-    await AuditList.section.lastContactInList
-      .getText('@header', (result) => set(this.state, 'contactName', result.value))
-      .click('@header')
-    await InvestmentProject.section.projectDetails.section.archive
-      .click('@archiveButton')
-    await AuditContact
-      .click('@archiveReason')
-      .submitForm('form')
-    await Message
-      .verifyMessage('success')
-  })
+Given(/^I archive an existing contact record$/, async function () {
+  await Company
+    .navigate()
+    .findCompany(this.fixtures.company.foreign.name)
+  await ContactList
+    .click('@contactsTab')
+  await AuditList.section.lastContactInList
+    .getText('@header', (result) => set(this.state, 'contactName', result.value))
+    .click('@header')
+  await InvestmentProject.section.projectDetails.section.archive
+    .click('@archiveButton')
+  await AuditContact
+    .click('@archiveReason')
+    .submitForm('form')
+  await Message
+    .verifyMessage('success')
+})
 
-  When(/^the contact has ([0-9]) fields edited for audit$/, async function (count) {
-    await Contact
-      .getText('@firstCompanyFromList', (result) => set(this.state, 'contactName', result.value))
-      .click('@firstCompanyFromList')
+When(/^the contact has ([0-9]) fields edited for audit$/, async function (count) {
+  await Contact
+    .getText('@firstCompanyFromList', (result) => set(this.state, 'contactName', result.value))
+    .click('@firstCompanyFromList')
 
-    await AuditContact
-      .editContactDetails({}, count, (contact) => {
-        set(this.state, 'contact', merge({}, this.state.contact, contact))
-      })
-  })
+  await AuditContact
+    .editContactDetails({}, count, (contact) => {
+      set(this.state, 'contact', merge({}, this.state.contact, contact))
+    })
+})
 
-  When(/^I search for this Contact record$/, async function () {
-    await Company
-      .navigate()
-      .findCompany(this.state.contactName)
-    await ContactList
-      .click('@contactsTab')
-    await Contact
-      .click('@firstCompanyFromList')
-    await AuditContact
-      .getText('@userName', (result) => set(this.state, 'username', result.value))
-  })
+When(/^I search for this Contact record$/, async function () {
+  await Company
+    .navigate()
+    .findCompany(this.state.contactName)
+  await ContactList
+    .click('@contactsTab')
+  await Contact
+    .click('@firstCompanyFromList')
+  await AuditContact
+    .getText('@userName', (result) => set(this.state, 'username', result.value))
+})
 
-  When(/^I navigate to Audit History tab$/, async function () {
-    await AuditContact
-      .click('@auditHistoryTab')
-  })
+When(/^I navigate to Audit History tab$/, async function () {
+  await AuditContact
+    .click('@auditHistoryTab')
+})
 
-  When(/^I archive this contact record$/, async function () {
-    await InvestmentProject.section.projectDetails.section.archive
-      .click('@archiveButton')
-    await AuditContact
-      .click('@archiveReason')
-      .submitForm('form')
-    await Message
-      .verifyMessage('success')
-  })
+When(/^I archive this contact record$/, async function () {
+  await InvestmentProject.section.projectDetails.section.archive
+    .click('@archiveButton')
+  await AuditContact
+    .click('@archiveReason')
+    .submitForm('form')
+  await Message
+    .verifyMessage('success')
+})
 
-  When(/^I unarchive this contact record$/, async function () {
-    await AuditContact
-      .click('@unarchiveAnContactButton')
-    await Message
-      .verifyMessage('success')
-  })
+When(/^I unarchive this contact record$/, async function () {
+  await AuditContact
+    .click('@unarchiveAnContactButton')
+  await Message
+    .verifyMessage('success')
+})
 
-  Then(/^I see the name of the person who made the recent contact record changes$/, async function () {
-    await AuditContact
-      .getText('@userName', (result) => set(this.state, 'username', result.value))
+Then(/^I see the name of the person who made the recent contact record changes$/, async function () {
+  await AuditContact
+    .getText('@userName', (result) => set(this.state, 'username', result.value))
 
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', this.state.username)
-  })
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@adviser', this.state.username)
+})
 
-  Then(/^I see the date time stamp when the recent contact record changed$/, async function () {
-    const today = format(new Date(), 'D MMM YYYY')
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@header', today)
-  })
+Then(/^I see the date time stamp when the recent contact record changed$/, async function () {
+  const today = format(new Date(), 'D MMM YYYY')
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@header', today)
+})
 
-  Then(/^I see the total number of changes occurred recently on this contact record$/, async function () {
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@changeCount', '2 changes')
-  })
+Then(/^I see the total number of changes occurred recently on this contact record$/, async function () {
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@changeCount', '2 changes')
+})
 
-  Then(/^I see the field names that were recently changed$/, async function () {
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@fields', 'Phone number')
-  })
+Then(/^I see the field names that were recently changed$/, async function () {
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@fields', 'Phone number')
+})
 
-  Then(/^I see the details who archived the contact$/, async function () {
-    await AuditContact
-      .getText('@userName', (result) => set(this.state, 'username', result.value))
+Then(/^I see the details who archived the contact$/, async function () {
+  await AuditContact
+    .getText('@userName', (result) => set(this.state, 'username', result.value))
 
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', this.state.username)
-  })
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@adviser', this.state.username)
+})
 
-  Then(/^I see the details who unarchived the contact$/, async function () {
-    await AuditContact
-      .getText('@userName', (result) => set(this.state, 'username', result.value))
+Then(/^I see the details who unarchived the contact$/, async function () {
+  await AuditContact
+    .getText('@userName', (result) => set(this.state, 'username', result.value))
 
-    await AuditList.section.firstAuditInList
-      .assert.containsText('@adviser', this.state.username)
-  })
+  await AuditList.section.firstAuditInList
+    .assert.containsText('@adviser', this.state.username)
 })

--- a/test/acceptance/features/collection/step_definitions/collection.js
+++ b/test/acceptance/features/collection/step_definitions/collection.js
@@ -1,145 +1,143 @@
 const { get, set, camelCase } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 
 const { getButtonWithText } = require('../../../helpers/selectors')
 const { pluralise } = require('../../../../../config/nunjucks/filters')
 
-defineSupportCode(({ When, Then }) => {
-  const Collection = client.page.Collection()
+const Collection = client.page.Collection()
 
-  When(/^I navigate to the (.+) collection page$/, async function (collectionType) {
-    const url = this.urls[camelCase(collectionType)].collection
+When(/^I navigate to the (.+) collection page$/, async function (collectionType) {
+  const url = this.urls[camelCase(collectionType)].collection
 
-    await client
-      .url(url)
+  await client
+    .url(url)
 
-    await Collection
-      .captureResultCount((count) => {
-        set(this.state, 'collection.resultCount', count)
-      })
-  })
-
-  When(/^I click the "(.+)" link$/, async (linkTextContent) => {
-    const { selector: addLink } = getButtonWithText(linkTextContent)
-
-    await Collection
-      .api.useXpath()
-      .waitForElementVisible(addLink)
-      .assert.containsText(addLink, linkTextContent)
-      .click(addLink)
-      .useCss()
-  })
-
-  When(/^I clear all filters$/, async function () {
-    await Collection.section.collectionHeader
-      .click('@removeAllFiltersLink')
-      .wait() // wait for xhr
-  })
-
-  Then(/^I capture the modified on date for the first item$/, async function () {
-    await Collection
-      .section.firstCollectionItem
-      .waitForElementPresent('@updatedOn')
-      .getText('@updatedOn', (updatedOn) => {
-        set(this.state, 'collection.updated', updatedOn.value)
-      })
-  })
-
-  Then(/^the results summary for a (.+) collection is present$/, async function (collectionType) {
-    await Collection.captureResultCount((count) => {
+  await Collection
+    .captureResultCount((count) => {
       set(this.state, 'collection.resultCount', count)
     })
+})
 
-    const resultCount = get(this.state, 'collection.resultCount')
-    const collectionTypeTitle = pluralise(collectionType, resultCount)
+When(/^I click the "(.+)" link$/, async (linkTextContent) => {
+  const { selector: addLink } = getButtonWithText(linkTextContent)
 
-    await Collection
-      .section.collectionHeader
-      .assert.visible('@intro')
-      .assert.containsText('@intro', `${resultCount} ${collectionTypeTitle}`)
-  })
+  await Collection
+    .api.useXpath()
+    .waitForElementVisible(addLink)
+    .assert.containsText(addLink, linkTextContent)
+    .click(addLink)
+    .useCss()
+})
 
-  Then(/^there is an (.+) button in the collection header$/, async function (buttonText) {
-    const button = Collection
-      .getButtonSelectorWithText(buttonText)
+When(/^I clear all filters$/, async function () {
+  await Collection.section.collectionHeader
+    .click('@removeAllFiltersLink')
+    .wait() // wait for xhr
+})
 
-    await Collection
-      .section.collectionHeader
-      .api.useXpath()
-      .assert.visible(button.selector)
-      .useCss()
-  })
-
-  Then(/^I can view the (.+) in the collection$/, async function (entityType, dataTable) {
-    const entityHeading = get(this.state, `${camelCase(entityType)}.heading`)
-
-    await Collection
-      .section.firstCollectionItem
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', entityHeading)
-
-    for (const row of dataTable.hashes()) {
-      const metaListValueElement = Collection.getSelectorForMetaListItemValue(row.text)
-      const expectedMetaListValue = get(this.state, row.expected)
-
-      // If we have a value in state that we expecting then test for its contents
-      // meaning we can specify metaItems that only appear when specific entries have been made to a form. e.g Uk region
-      if (expectedMetaListValue) {
-        await Collection
-          .section.firstCollectionItem
-          .api.useXpath()
-          .assert.containsText(metaListValueElement.selector, expectedMetaListValue)
-          .useCss()
-      }
-    }
-  })
-
-  Then(/^the (.+) has badges$/, async function (entityType, dataTable) {
-    for (const row of dataTable.hashes()) {
-      const badgeValueElement = Collection.getSelectorForBadgeWithText(row.text)
-      const expectedBadgeValue = get(this.state, row.expected)
-
-      // If we have a value in state that we expecting then test for its contents
-      // meaning we can specify badges that only appear when specific entries have been made to a form. e.g Uk region
-      if (expectedBadgeValue) {
-        await Collection
-          .section.firstCollectionItem
-          .api.useXpath()
-          .assert.visible(badgeValueElement.selector)
-          .assert.containsText(badgeValueElement.selector, expectedBadgeValue)
-          .useCss()
-      }
-    }
-  })
-
-  Then(/^there are no filters selected$/, async function () {
-    await Collection
-      .api.elements('css selector', '.c-collection__filter-tag', (result) => {
-        client.expect(result.value.length).to.equal(0)
-      })
-  })
-
-  Then(/^the result count should be reset$/, async function () {
-    await Collection
-      .section.collectionHeader
-      .waitForElementVisible('@resultCount')
-      .getText('@resultCount', (result) => {
-        const expected = get(this.state, 'collection.resultCount')
-        client.expect(result.value).to.equal(expected)
-      })
-  })
-
-  Then(/^I choose the first item in the collection$/, async function () {
-    await Collection
-      .section.firstCollectionItem
-      .waitForElementVisible('@header')
-      .click('@header')
-  })
-
-  Then(/^I can view the collection$/, async function () {
-    await Collection.api.elements('css selector', '.c-entity-list__item', (result) => {
-      client.expect(result.value.length).to.be.greaterThan(0)
+Then(/^I capture the modified on date for the first item$/, async function () {
+  await Collection
+    .section.firstCollectionItem
+    .waitForElementPresent('@updatedOn')
+    .getText('@updatedOn', (updatedOn) => {
+      set(this.state, 'collection.updated', updatedOn.value)
     })
+})
+
+Then(/^the results summary for a (.+) collection is present$/, async function (collectionType) {
+  await Collection.captureResultCount((count) => {
+    set(this.state, 'collection.resultCount', count)
+  })
+
+  const resultCount = get(this.state, 'collection.resultCount')
+  const collectionTypeTitle = pluralise(collectionType, resultCount)
+
+  await Collection
+    .section.collectionHeader
+    .assert.visible('@intro')
+    .assert.containsText('@intro', `${resultCount} ${collectionTypeTitle}`)
+})
+
+Then(/^there is an (.+) button in the collection header$/, async function (buttonText) {
+  const button = Collection
+    .getButtonSelectorWithText(buttonText)
+
+  await Collection
+    .section.collectionHeader
+    .api.useXpath()
+    .assert.visible(button.selector)
+    .useCss()
+})
+
+Then(/^I can view the (.+) in the collection$/, async function (entityType, dataTable) {
+  const entityHeading = get(this.state, `${camelCase(entityType)}.heading`)
+
+  await Collection
+    .section.firstCollectionItem
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', entityHeading)
+
+  for (const row of dataTable.hashes()) {
+    const metaListValueElement = Collection.getSelectorForMetaListItemValue(row.text)
+    const expectedMetaListValue = get(this.state, row.expected)
+
+    // If we have a value in state that we expecting then test for its contents
+    // meaning we can specify metaItems that only appear when specific entries have been made to a form. e.g Uk region
+    if (expectedMetaListValue) {
+      await Collection
+        .section.firstCollectionItem
+        .api.useXpath()
+        .assert.containsText(metaListValueElement.selector, expectedMetaListValue)
+        .useCss()
+    }
+  }
+})
+
+Then(/^the (.+) has badges$/, async function (entityType, dataTable) {
+  for (const row of dataTable.hashes()) {
+    const badgeValueElement = Collection.getSelectorForBadgeWithText(row.text)
+    const expectedBadgeValue = get(this.state, row.expected)
+
+    // If we have a value in state that we expecting then test for its contents
+    // meaning we can specify badges that only appear when specific entries have been made to a form. e.g Uk region
+    if (expectedBadgeValue) {
+      await Collection
+        .section.firstCollectionItem
+        .api.useXpath()
+        .assert.visible(badgeValueElement.selector)
+        .assert.containsText(badgeValueElement.selector, expectedBadgeValue)
+        .useCss()
+    }
+  }
+})
+
+Then(/^there are no filters selected$/, async function () {
+  await Collection
+    .api.elements('css selector', '.c-collection__filter-tag', (result) => {
+      client.expect(result.value.length).to.equal(0)
+    })
+})
+
+Then(/^the result count should be reset$/, async function () {
+  await Collection
+    .section.collectionHeader
+    .waitForElementVisible('@resultCount')
+    .getText('@resultCount', (result) => {
+      const expected = get(this.state, 'collection.resultCount')
+      client.expect(result.value).to.equal(expected)
+    })
+})
+
+Then(/^I choose the first item in the collection$/, async function () {
+  await Collection
+    .section.firstCollectionItem
+    .waitForElementVisible('@header')
+    .click('@header')
+})
+
+Then(/^I can view the collection$/, async function () {
+  await Collection.api.elements('css selector', '.c-entity-list__item', (result) => {
+    client.expect(result.value.length).to.be.greaterThan(0)
   })
 })

--- a/test/acceptance/features/companies/step_definitions/collection.js
+++ b/test/acceptance/features/companies/step_definitions/collection.js
@@ -1,150 +1,148 @@
 const moment = require('moment')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const { get, set } = require('lodash')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const CompanyList = client.page.CompanyList()
+const CompanyList = client.page.CompanyList()
 
-  When(/^I click on the first company collection link$/, async function () {
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementVisible('@header')
-      .click('@header')
-  })
+When(/^I click on the first company collection link$/, async function () {
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementVisible('@header')
+    .click('@header')
+})
 
-  When(/^I filter the companies list by company/, async function () {
-    await CompanyList.section.filters
-      .waitForElementPresent('@company')
-      .setValue('@company', this.state.company.uniqueSearchTerm)
-      .sendKeys('@company', [ client.Keys.ENTER ])
-      .wait() // wait for xhr
-  })
+When(/^I filter the companies list by company/, async function () {
+  await CompanyList.section.filters
+    .waitForElementPresent('@company')
+    .setValue('@company', this.state.company.uniqueSearchTerm)
+    .sendKeys('@company', [ client.Keys.ENTER ])
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the companies list by sector$/, async function () {
-    await CompanyList.section.filters
-      .waitForElementPresent('@sector')
-      .clickMultipleChoiceOption('sector', this.state.company.sector)
-      .wait() // wait for xhr
-  })
+When(/^I filter the companies list by sector$/, async function () {
+  await CompanyList.section.filters
+    .waitForElementPresent('@sector')
+    .clickMultipleChoiceOption('sector', this.state.company.sector)
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the companies list by country$/, async function () {
-    await CompanyList.section.filters
-      .waitForElementPresent('@country')
-      .clickMultipleChoiceOption('country', this.state.company.country)
-      .wait() // wait for xhr
-  })
+When(/^I filter the companies list by country$/, async function () {
+  await CompanyList.section.filters
+    .waitForElementPresent('@country')
+    .clickMultipleChoiceOption('country', this.state.company.country)
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the companies list by UK region/, async function () {
-    await CompanyList.section.filters
-      .waitForElementPresent('@ukRegion')
-      .clickMultipleChoiceOption('uk_region', this.state.company.ukRegion)
-      .wait() // wait for xhr
-  })
+When(/^I filter the companies list by UK region/, async function () {
+  await CompanyList.section.filters
+    .waitForElementPresent('@ukRegion')
+    .clickMultipleChoiceOption('uk_region', this.state.company.ukRegion)
+    .wait() // wait for xhr
+})
 
-  When(/^the companies are sorted by (Company name: A-Z|Recently updated)$/, async function (sortOption) {
-    await CompanyList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the companies are sorted by (Company name: A-Z|Recently updated)$/, async function (sortOption) {
+  await CompanyList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementPresent('@header')
-      .getText('@header', (result) => {
-        set(this.state, 'collection.firstItem.field', result.value)
-      })
-  })
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementPresent('@header')
+    .getText('@header', (result) => {
+      set(this.state, 'collection.firstItem.field', result.value)
+    })
+})
 
-  When(/^the companies are sorted by (Company name: Z-A|Least recently updated)$/, async function (sortOption) {
-    await CompanyList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the companies are sorted by (Company name: Z-A|Least recently updated)$/, async function (sortOption) {
+  await CompanyList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementPresent('@header')
-      .getText('@header', (result) => {
-        set(this.state, 'collection.lastItem.field', result.value)
-      })
-  })
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementPresent('@header')
+    .getText('@header', (result) => {
+      set(this.state, 'collection.lastItem.field', result.value)
+    })
+})
 
-  Then(/^the companies should be filtered by company name/, async function () {
-    const expected = get(this.state, `company.heading`)
+Then(/^the companies should be filtered by company name/, async function () {
+  const expected = get(this.state, `company.heading`)
 
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementVisible('@header')
-      .assert.containsText('@header', expected)
-  })
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementVisible('@header')
+    .assert.containsText('@header', expected)
+})
 
-  Then(/^the companies should be filtered by company sector$/, async function () {
-    const expected = get(this.state, `company.sector`)
+Then(/^the companies should be filtered by company sector$/, async function () {
+  const expected = get(this.state, `company.sector`)
 
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementVisible('@companySector')
-      .assert.containsText('@companySector', expected)
-  })
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementVisible('@companySector')
+    .assert.containsText('@companySector', expected)
+})
 
-  Then(/^the companies should be filtered to show badge company country$/, async function () {
-    const expectedBadgeText = get(this.state, 'company.country')
+Then(/^the companies should be filtered to show badge company country$/, async function () {
+  const expectedBadgeText = get(this.state, 'company.country')
 
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementVisible('@countryBadge')
-      .assert.containsText('@countryBadge', expectedBadgeText)
-  })
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementVisible('@countryBadge')
+    .assert.containsText('@countryBadge', expectedBadgeText)
+})
 
-  Then(/^the companies should be filtered to show badge company UK region/, async function () {
-    const expectedBadgeText = get(this.state, 'company.ukRegion')
+Then(/^the companies should be filtered to show badge company UK region/, async function () {
+  const expectedBadgeText = get(this.state, 'company.ukRegion')
 
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementVisible('@ukRegionBadge')
-      .assert.containsText('@ukRegionBadge', expectedBadgeText)
-  })
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementVisible('@ukRegionBadge')
+    .assert.containsText('@ukRegionBadge', expectedBadgeText)
+})
 
-  // TODO potentially abstract this out to collections
-  Then(/^the companies should be sorted by (Least recently|Recently) updated$/, async function (sortType) {
-    const updateValues = {
-      firstItem: null,
-      secondItem: null,
-    }
-    const formatDateString = (string) => {
-      return moment(string, 'DD MMM YYYY, h:mma')
-    }
+// TODO potentially abstract this out to collections
+Then(/^the companies should be sorted by (Least recently|Recently) updated$/, async function (sortType) {
+  const updateValues = {
+    firstItem: null,
+    secondItem: null,
+  }
+  const formatDateString = (string) => {
+    return moment(string, 'DD MMM YYYY, h:mma')
+  }
 
-    await CompanyList
-      .section.firstCompanyInList
-      .waitForElementPresent('@header')
-      .getText('@updated', (text) => {
-        set(updateValues, 'firstItem', formatDateString(text.value))
-      })
+  await CompanyList
+    .section.firstCompanyInList
+    .waitForElementPresent('@header')
+    .getText('@updated', (text) => {
+      set(updateValues, 'firstItem', formatDateString(text.value))
+    })
 
-    await CompanyList
-      .section.secondCompanyInList
-      .waitForElementPresent('@header')
-      .getText('@updated', (text) => {
-        set(updateValues, 'secondItem', formatDateString(text.value))
-      })
+  await CompanyList
+    .section.secondCompanyInList
+    .waitForElementPresent('@header')
+    .getText('@updated', (text) => {
+      set(updateValues, 'secondItem', formatDateString(text.value))
+    })
 
-    if (sortType === 'Recently') {
-      client.expect(updateValues.firstItem.isSameOrAfter(updateValues.secondItem)).to.be.true
-    }
+  if (sortType === 'Recently') {
+    client.expect(updateValues.firstItem.isSameOrAfter(updateValues.secondItem)).to.be.true
+  }
 
-    if (sortType === 'Least recently') {
-      client.expect(updateValues.firstItem.isSameOrBefore(updateValues.secondItem)).to.be.true
-    }
-  })
+  if (sortType === 'Least recently') {
+    client.expect(updateValues.firstItem.isSameOrBefore(updateValues.secondItem)).to.be.true
+  }
+})
 
-  Then(/^the companies should have been correctly sorted for text fields$/, async function () {
-    const firstItemField = get(this.state, 'collection.firstItem.field')
-    const lastItemField = get(this.state, 'collection.lastItem.field')
+Then(/^the companies should have been correctly sorted for text fields$/, async function () {
+  const firstItemField = get(this.state, 'collection.firstItem.field')
+  const lastItemField = get(this.state, 'collection.lastItem.field')
 
-    return client.expect(firstItemField < lastItemField).to.be.true
-  })
+  return client.expect(firstItemField < lastItemField).to.be.true
 })

--- a/test/acceptance/features/companies/step_definitions/company.js
+++ b/test/acceptance/features/companies/step_definitions/company.js
@@ -1,80 +1,78 @@
 const { get, set } = require('lodash')
 
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const { getUid } = require('../../../helpers/uuid')
 
 const companySearchPage = `${process.env.QA_HOST}/search/companies` // TODO move these urls out into a url world object
 const dashboardPage = `${process.env.QA_HOST}/`
 
-defineSupportCode(({ When, Then }) => {
-  const Company = client.page.Company()
-  const Search = client.page.Search()
+const Company = client.page.Company()
+const Search = client.page.Search()
 
-  When(/^a "UK private or public limited company" is created$/, async function () {
-    await client
-      .url(companySearchPage)
+When(/^a "UK private or public limited company" is created$/, async function () {
+  await client
+    .url(companySearchPage)
 
-    await Company
-      .createUkPrivateOrPublicLimitedCompany(
-        get(this.fixtures, 'company.companiesHouse'),
-        {},
-        (company) => set(this.state, 'company', company),
-      )
-      .wait() // wait for backend to sync
-  })
+  await Company
+    .createUkPrivateOrPublicLimitedCompany(
+      get(this.fixtures, 'company.companiesHouse'),
+      {},
+      (company) => set(this.state, 'company', company),
+    )
+    .wait() // wait for backend to sync
+})
 
-  When(/^a "UK non-private or non-public limited company" is created$/, async function () {
-    await client
-      .url(companySearchPage)
+When(/^a "UK non-private or non-public limited company" is created$/, async function () {
+  await client
+    .url(companySearchPage)
 
-    await Company
-      .createUkNonPrivateOrNonPublicLimitedCompany({}, (company) => {
-        set(this.state, 'company', company)
-      })
-      .wait() // wait for backend to sync
-  })
+  await Company
+    .createUkNonPrivateOrNonPublicLimitedCompany({}, (company) => {
+      set(this.state, 'company', company)
+    })
+    .wait() // wait for backend to sync
+})
 
-  When(/^a "Foreign company" is created$/, async function () {
-    await client
-      .url(companySearchPage)
+When(/^a "Foreign company" is created$/, async function () {
+  await client
+    .url(companySearchPage)
 
-    await Company
-      .createForeignCompany({}, (company) => set(this.state, 'company', company))
-      .wait() // wait for backend to sync
-  })
+  await Company
+    .createForeignCompany({}, (company) => set(this.state, 'company', company))
+    .wait() // wait for backend to sync
+})
 
-  When(/^a "UK branch of a foreign company" is created$/, async function () {
-    await client
-      .url(companySearchPage)
+When(/^a "UK branch of a foreign company" is created$/, async function () {
+  await client
+    .url(companySearchPage)
 
-    await Company
-      .createUkBranchOfForeignCompany({}, (company) => set(this.state, 'company', company))
-      .wait() // wait for backend to sync
-  })
+  await Company
+    .createUkBranchOfForeignCompany({}, (company) => set(this.state, 'company', company))
+    .wait() // wait for backend to sync
+})
 
-  Then(/^the company is in the search results$/, async function () {
-    const companyName = get(this.state, 'company.name', get(this.state, 'company.tradingName'))
+Then(/^the company is in the search results$/, async function () {
+  const companyName = get(this.state, 'company.name', get(this.state, 'company.tradingName'))
 
-    await client
-      .url(dashboardPage)
+  await client
+    .url(dashboardPage)
 
-    await Company
-      .findCompany(getUid(companyName))
-      .assert.containsText('@collectionResultsCompanyName', companyName)
-  })
+  await Company
+    .findCompany(getUid(companyName))
+    .assert.containsText('@collectionResultsCompanyName', companyName)
+})
 
-  Then(/^the company trading name is in the search results$/, async function () {
-    const companyName = get(this.state, 'company.tradingName')
+Then(/^the company trading name is in the search results$/, async function () {
+  const companyName = get(this.state, 'company.tradingName')
 
-    await client
-      .url(dashboardPage)
+  await client
+    .url(dashboardPage)
 
-    await Search
-      .navigate()
-      .search(companyName)
-      .section.firstCompanySearchResult
-      .waitForElementPresent('@tradingName')
-      .assert.containsText('@tradingName', companyName)
-  })
+  await Search
+    .navigate()
+    .search(companyName)
+    .section.firstCompanySearchResult
+    .waitForElementPresent('@tradingName')
+    .assert.containsText('@tradingName', companyName)
 })

--- a/test/acceptance/features/companies/step_definitions/details.js
+++ b/test/acceptance/features/companies/step_definitions/details.js
@@ -1,14 +1,12 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then } = require('cucumber')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const Company = client.page.Company()
+const Company = client.page.Company()
 
-  Then(/^the company details UK region is displayed$/, async function () {
-    const { ukRegion } = this.state.company
+Then(/^the company details UK region is displayed$/, async function () {
+  const { ukRegion } = this.state.company
 
-    await Company
-      .section.companyDetails
-      .assert.containsText('@ukRegion', ukRegion)
-  })
+  await Company
+    .section.companyDetails
+    .assert.containsText('@ukRegion', ukRegion)
 })

--- a/test/acceptance/features/companies/step_definitions/save.js
+++ b/test/acceptance/features/companies/step_definitions/save.js
@@ -1,23 +1,21 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { When } = require('cucumber')
 const { set, get, assign } = require('lodash')
 
-defineSupportCode(({ When }) => {
-  const Company = client.page.Company()
+const Company = client.page.Company()
 
-  When(/^the Account management details are updated$/, async function () {
-    await Company
-      .updateAccountManagement((accountManagement) => {
-        const company = get(this.state, 'company')
-        set(this.state, 'company', assign({}, company, accountManagement))
-      })
-  })
+When(/^the Account management details are updated$/, async function () {
+  await Company
+    .updateAccountManagement((accountManagement) => {
+      const company = get(this.state, 'company')
+      set(this.state, 'company', assign({}, company, accountManagement))
+    })
+})
 
-  When(/^the Exports details are updated$/, async function () {
-    await Company
-      .updateExports((exports) => {
-        const company = get(this.state, 'company')
-        set(this.state, 'company', assign({}, company, exports))
-      })
-  })
+When(/^the Exports details are updated$/, async function () {
+  await Company
+    .updateExports((exports) => {
+      const company = get(this.state, 'company')
+      set(this.state, 'company', assign({}, company, exports))
+    })
 })

--- a/test/acceptance/features/contacts/step_definitions/collection.js
+++ b/test/acceptance/features/contacts/step_definitions/collection.js
@@ -1,322 +1,320 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const { get, set, camelCase } = require('lodash')
 const { compareDesc } = require('date-fns')
 
 const { getUid } = require('../../../helpers/uuid')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const Contact = client.page.Contact()
-  const ContactList = client.page.ContactList()
+const Contact = client.page.Contact()
+const ContactList = client.page.ContactList()
 
-  When(/^I click on the first contact collection link$/, async function () {
-    await Contact
-      .click('@firstCompanyFromList')
-  })
+When(/^I click on the first contact collection link$/, async function () {
+  await Contact
+    .click('@firstCompanyFromList')
+})
 
-  When(/^I filter the contacts list by contact/, async function () {
-    await ContactList.section.filters
-      .waitForElementPresent('@contact')
-      .setValue('@contact', getUid(this.state.contact.lastName))
-      .sendKeys('@contact', [ client.Keys.ENTER ])
-      .wait() // wait for xhr
-  })
+When(/^I filter the contacts list by contact/, async function () {
+  await ContactList.section.filters
+    .waitForElementPresent('@contact')
+    .setValue('@contact', getUid(this.state.contact.lastName))
+    .sendKeys('@contact', [ client.Keys.ENTER ])
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the contacts list by company/, async function () {
-    await ContactList.section.filters
-      .waitForElementPresent('@company')
-      .setValue('@company', this.state.company.name)
-      .sendKeys('@company', [ client.Keys.ENTER ])
-      .wait() // wait for xhr
-  })
+When(/^I filter the contacts list by company/, async function () {
+  await ContactList.section.filters
+    .waitForElementPresent('@company')
+    .setValue('@company', this.state.company.name)
+    .sendKeys('@company', [ client.Keys.ENTER ])
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the contacts list by sector$/, async function () {
-    await ContactList.section.filters
-      .waitForElementPresent('@sector')
-      .clickMultipleChoiceOption('company_sector', this.state.company.sector)
-      .wait() // wait for xhr
-  })
+When(/^I filter the contacts list by sector$/, async function () {
+  await ContactList.section.filters
+    .waitForElementPresent('@sector')
+    .clickMultipleChoiceOption('company_sector', this.state.company.sector)
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the contacts list by country$/, async function () {
-    await ContactList.section.filters
-      .waitForElementPresent('@country')
-      .clickMultipleChoiceOption('address_country', this.state.company.country)
-      .wait() // wait for xhr
-  })
+When(/^I filter the contacts list by country$/, async function () {
+  await ContactList.section.filters
+    .waitForElementPresent('@country')
+    .clickMultipleChoiceOption('address_country', this.state.company.country)
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the contacts list by UK region/, async function () {
-    await ContactList.section.filters
-      .waitForElementPresent('@ukRegion')
-      .clickMultipleChoiceOption('company_uk_region', this.state.company.ukRegion)
-      .wait() // wait for xhr
-  })
+When(/^I filter the contacts list by UK region/, async function () {
+  await ContactList.section.filters
+    .waitForElementPresent('@ukRegion')
+    .clickMultipleChoiceOption('company_uk_region', this.state.company.ukRegion)
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the contacts list by inactive status/, async function () {
-    await ContactList.section.filters
-      .waitForElementPresent('@inactive')
-      .click('@inactive')
-      .wait() // wait for xhr
-  })
+When(/^I filter the contacts list by inactive status/, async function () {
+  await ContactList.section.filters
+    .waitForElementPresent('@inactive')
+    .click('@inactive')
+    .wait() // wait for xhr
+})
 
-  When(/^I filter the contacts list by active status/, async function () {
-    await ContactList.section.filters
-      .waitForElementPresent('@active')
-      .click('@active')
-      .wait() // wait for xhr
-  })
+When(/^I filter the contacts list by active status/, async function () {
+  await ContactList.section.filters
+    .waitForElementPresent('@active')
+    .click('@active')
+    .wait() // wait for xhr
+})
 
-  When(/^the contacts are sorted by (Newest)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Newest)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@header', (result) => {
-        set(this.state, 'collection.firstItem.field', result.value)
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@header', (result) => {
+      set(this.state, 'collection.firstItem.field', result.value)
+    })
+})
 
-  When(/^the contacts are sorted by (Oldest)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Oldest)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@header', (result) => {
-        set(this.state, 'collection.lastItem.field', result.value)
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@header', (result) => {
+      set(this.state, 'collection.lastItem.field', result.value)
+    })
+})
 
-  When(/^the contacts are sorted by (Recently updated)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Recently updated)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@updated', (result) => {
-        set(this.state, 'collection.firstItem.field', result.value)
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@updated', (result) => {
+      set(this.state, 'collection.firstItem.field', result.value)
+    })
+})
 
-  When(/^the contacts are sorted by (Least recently updated)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Least recently updated)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@updated', (result) => {
-        set(this.state, 'collection.lastItem.field', result.value)
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@updated', (result) => {
+      set(this.state, 'collection.lastItem.field', result.value)
+    })
+})
 
-  When(/^the contacts are sorted by (First name: A-Z)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (First name: A-Z)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@header', (result) => {
-        const name = result.value.split(' ')[0]
-        set(this.state, 'collection.firstItem.field', name.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@header', (result) => {
+      const name = result.value.split(' ')[0]
+      set(this.state, 'collection.firstItem.field', name.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (First name: Z-A)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (First name: Z-A)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@header', (result) => {
-        const name = result.value.split(' ')[0]
-        set(this.state, 'collection.lastItem.field', name.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@header', (result) => {
+      const name = result.value.split(' ')[0]
+      set(this.state, 'collection.lastItem.field', name.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Last name: A-Z)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Last name: A-Z)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@header', (result) => {
-        const name = result.value.split(' ')[0]
-        set(this.state, 'collection.firstItem.field', name.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@header', (result) => {
+      const name = result.value.split(' ')[0]
+      set(this.state, 'collection.firstItem.field', name.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Last name: Z-A)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Last name: Z-A)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@header', (result) => {
-        const name = result.value.split(' ')[0]
-        set(this.state, 'collection.lastItem.field', name.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@header', (result) => {
+      const name = result.value.split(' ')[0]
+      set(this.state, 'collection.lastItem.field', name.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Country: A-Z)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Country: A-Z)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@countryBadge', (result) => {
-        set(this.state, 'collection.firstItem.field', result.value.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@countryBadge', (result) => {
+      set(this.state, 'collection.firstItem.field', result.value.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Country: Z-A)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Country: Z-A)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@countryBadge', (result) => {
-        set(this.state, 'collection.lastItem.field', result.value.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@countryBadge', (result) => {
+      set(this.state, 'collection.lastItem.field', result.value.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Company: A-Z)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Company: A-Z)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@companyName', (result) => {
-        set(this.state, 'collection.firstItem.field', result.value.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@companyName', (result) => {
+      set(this.state, 'collection.firstItem.field', result.value.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Company: Z-A)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Company: Z-A)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@companyName', (result) => {
-        set(this.state, 'collection.lastItem.field', result.value.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@companyName', (result) => {
+      set(this.state, 'collection.lastItem.field', result.value.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Sector: A-Z)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Sector: A-Z)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@companySector', (result) => {
-        set(this.state, 'collection.firstItem.field', result.value.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@companySector', (result) => {
+      set(this.state, 'collection.firstItem.field', result.value.toLowerCase())
+    })
+})
 
-  When(/^the contacts are sorted by (Sector: Z-A)$/, async function (sortOption) {
-    await ContactList
-      .section.collectionHeader
-      .waitForElementVisible('@sortBy')
-      .clickListOption('sortby', sortOption)
-      .wait() // wait for xhr
+When(/^the contacts are sorted by (Sector: Z-A)$/, async function (sortOption) {
+  await ContactList
+    .section.collectionHeader
+    .waitForElementVisible('@sortBy')
+    .clickListOption('sortby', sortOption)
+    .wait() // wait for xhr
 
-    await ContactList
-      .section.firstContactInList
-      .getText('@companySector', (result) => {
-        set(this.state, 'collection.lastItem.field', result.value.toLowerCase())
-      })
-  })
+  await ContactList
+    .section.firstContactInList
+    .getText('@companySector', (result) => {
+      set(this.state, 'collection.lastItem.field', result.value.toLowerCase())
+    })
+})
 
-  Then(/^the contacts should be filtered by ([A-Za-z]+) ([A-Za-z]+)$/, async function (entityType, field) {
-    const entityTypeField = camelCase(`${entityType} ${field}`)
+Then(/^the contacts should be filtered by ([A-Za-z]+) ([A-Za-z]+)$/, async function (entityType, field) {
+  const entityTypeField = camelCase(`${entityType} ${field}`)
 
-    let selector
-    let expected
+  let selector
+  let expected
 
-    if (entityTypeField === 'contactName') {
-      selector = '@header'
-      expected = `${get(this.state, 'contact.firstName')} ${get(this.state, 'contact.lastName')}`
-    } else {
-      selector = `@${entityTypeField}`
-      expected = get(this.state, `${entityType}.${field}`)
-    }
+  if (entityTypeField === 'contactName') {
+    selector = '@header'
+    expected = `${get(this.state, 'contact.firstName')} ${get(this.state, 'contact.lastName')}`
+  } else {
+    selector = `@${entityTypeField}`
+    expected = get(this.state, `${entityType}.${field}`)
+  }
 
-    await ContactList
-      .section.firstContactInList
-      .waitForElementVisible(selector)
-      .assert.containsText(selector, expected)
-  })
+  await ContactList
+    .section.firstContactInList
+    .waitForElementVisible(selector)
+    .assert.containsText(selector, expected)
+})
 
-  Then(/^the contacts should be filtered to show badge ([A-Za-z]+) ([A-Za-z]+)$/, async function (entityType, field) {
-    const expectedBadgeText = get(this.state, `${entityType}.${field}`)
+Then(/^the contacts should be filtered to show badge ([A-Za-z]+) ([A-Za-z]+)$/, async function (entityType, field) {
+  const expectedBadgeText = get(this.state, `${entityType}.${field}`)
 
-    await ContactList
-      .section.firstContactInList
-      .waitForElementVisible('@countryBadge')
-      .assert.containsText('@countryBadge', expectedBadgeText)
-  })
+  await ContactList
+    .section.firstContactInList
+    .waitForElementVisible('@countryBadge')
+    .assert.containsText('@countryBadge', expectedBadgeText)
+})
 
-  Then(/^the contacts should have been correctly sorted for date fields$/, async function () {
-    const firstItemField = get(this.state, `collection.firstItem.field`)
-    const lastItemField = get(this.state, `collection.lastItem.field`)
+Then(/^the contacts should have been correctly sorted for date fields$/, async function () {
+  const firstItemField = get(this.state, `collection.firstItem.field`)
+  const lastItemField = get(this.state, `collection.lastItem.field`)
 
-    client.expect(compareDesc(firstItemField, lastItemField)).to.be.within(0, 1)
-  })
+  client.expect(compareDesc(firstItemField, lastItemField)).to.be.within(0, 1)
+})
 
-  // TODO make this work in the same way as the "companies should be sorted by (Least recently|Recently) updated" step does
-  // TODO or move it into collections
-  Then(/^the contacts should have been correctly sorted by creation date$/, async function () {
-    const firstItemField = get(this.state, 'collection.firstItem.field')
-    const lastItemField = get(this.state, 'collection.lastItem.field')
-    const expectedFirstItemField = get(this.state, 'contact.heading')
-    const expectedLastItemField = this.fixtures.contact.georginaClark.name
+// TODO make this work in the same way as the "companies should be sorted by (Least recently|Recently) updated" step does
+// TODO or move it into collections
+Then(/^the contacts should have been correctly sorted by creation date$/, async function () {
+  const firstItemField = get(this.state, 'collection.firstItem.field')
+  const lastItemField = get(this.state, 'collection.lastItem.field')
+  const expectedFirstItemField = get(this.state, 'contact.heading')
+  const expectedLastItemField = this.fixtures.contact.georginaClark.name
 
-    client.expect(firstItemField).to.equal(expectedFirstItemField)
-    client.expect(lastItemField).to.equal(expectedLastItemField)
-  })
+  client.expect(firstItemField).to.equal(expectedFirstItemField)
+  client.expect(lastItemField).to.equal(expectedLastItemField)
+})
 
-  Then(/^the contacts should have been correctly sorted for text fields$/, async function () {
-    const firstItemField = get(this.state, 'collection.firstItem.field')
-    const lastItemField = get(this.state, 'collection.lastItem.field')
+Then(/^the contacts should have been correctly sorted for text fields$/, async function () {
+  const firstItemField = get(this.state, 'collection.firstItem.field')
+  const lastItemField = get(this.state, 'collection.lastItem.field')
 
-    return client.expect(firstItemField < lastItemField).to.be.true
-  })
+  return client.expect(firstItemField < lastItemField).to.be.true
 })

--- a/test/acceptance/features/contacts/step_definitions/save.js
+++ b/test/acceptance/features/contacts/step_definitions/save.js
@@ -1,86 +1,84 @@
 const { set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const { getAddress } = require('../../../helpers/address')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const Company = client.page.Company()
-  const Contact = client.page.Contact()
-  const Dashboard = client.page.Dashboard()
+const Company = client.page.Company()
+const Contact = client.page.Contact()
+const Dashboard = client.page.Dashboard()
 
-  When(/^a primary contact is added$/, async function () {
-    await Contact
-      .createNewContact({}, true, (contact) => {
-        set(this.state, 'contact', contact)
-        set(this.state, 'contact.type', 'Primary')
-        set(this.state, 'contact.address', getAddress(this.state.company))
-      })
-  })
+When(/^a primary contact is added$/, async function () {
+  await Contact
+    .createNewContact({}, true, (contact) => {
+      set(this.state, 'contact', contact)
+      set(this.state, 'contact.type', 'Primary')
+      set(this.state, 'contact.address', getAddress(this.state.company))
+    })
+})
 
-  When(/^a primary contact with new company address is added$/, async function () {
-    await Contact
-      .createNewPrimaryContactWithNewCompanyAddress({}, (contact) => {
-        set(this.state, 'contact', contact)
-      })
-  })
+When(/^a primary contact with new company address is added$/, async function () {
+  await Contact
+    .createNewPrimaryContactWithNewCompanyAddress({}, (contact) => {
+      set(this.state, 'contact', contact)
+    })
+})
 
-  When(/^a non-primary contact is added$/, async function () {
-    await Contact
-      .createNewContact({}, false, (contact) => {
-        set(this.state, 'contact', contact)
-        set(this.state, 'contact.address', getAddress(this.state.company))
-      })
-  })
+When(/^a non-primary contact is added$/, async function () {
+  await Contact
+    .createNewContact({}, false, (contact) => {
+      set(this.state, 'contact', contact)
+      set(this.state, 'contact.address', getAddress(this.state.company))
+    })
+})
 
-  When(/^the contact is clicked/, async function () {
-    await Company
-      .section.firstContactsTabContact
-      .click('@header')
-  })
+When(/^the contact is clicked/, async function () {
+  await Company
+    .section.firstContactsTabContact
+    .click('@header')
+})
 
-  Then(/^there are contact fields$/, async function () { // TODO this can be DRY'd up to use a generic datatable to assert what the form contains
-    await Contact
-      .waitForElementVisible('@firstName')
-      .assert.visible('@firstName')
-      .assert.visible('@lastName')
-      .assert.visible('@jobTitle')
-      .assert.visible('@primaryContactYes')
-      .assert.visible('@primaryContactNo')
-      .assert.visible('@telephoneCountryCode')
-      .assert.visible('@telephoneNumber')
-      .assert.visible('@emailAddress')
-      .assert.visible('@acceptsEmailMarketingFromDit')
-      .assert.visible('@sameAddressAsCompanyYes')
-      .assert.visible('@sameAddressAsCompanyNo')
-      .assert.visible('@alternativePhoneNumber')
-      .assert.visible('@alternativeEmail')
-      .assert.visible('@notes')
-  })
+Then(/^there are contact fields$/, async function () { // TODO this can be DRY'd up to use a generic datatable to assert what the form contains
+  await Contact
+    .waitForElementVisible('@firstName')
+    .assert.visible('@firstName')
+    .assert.visible('@lastName')
+    .assert.visible('@jobTitle')
+    .assert.visible('@primaryContactYes')
+    .assert.visible('@primaryContactNo')
+    .assert.visible('@telephoneCountryCode')
+    .assert.visible('@telephoneNumber')
+    .assert.visible('@emailAddress')
+    .assert.visible('@acceptsEmailMarketingFromDit')
+    .assert.visible('@sameAddressAsCompanyYes')
+    .assert.visible('@sameAddressAsCompanyNo')
+    .assert.visible('@alternativePhoneNumber')
+    .assert.visible('@alternativeEmail')
+    .assert.visible('@notes')
+})
 
-  Then(/^the contact fields have error messages$/, async function () {
-    await Contact
-      .assert.visible('@firstNameError')
-      .assert.visible('@lastNameError')
-      .assert.visible('@primaryContactError')
-      .assert.visible('@telephoneCountryCodeError')
-      .assert.visible('@telephoneNumber')
-      .assert.visible('@emailAddressError')
-  })
+Then(/^the contact fields have error messages$/, async function () {
+  await Contact
+    .assert.visible('@firstNameError')
+    .assert.visible('@lastNameError')
+    .assert.visible('@primaryContactError')
+    .assert.visible('@telephoneCountryCodeError')
+    .assert.visible('@telephoneNumber')
+    .assert.visible('@emailAddressError')
+})
 
-  Then(/^the contact is displayed on the company contact tab$/, async function () {
-    const contactName = `${this.state.contact.firstName} ${this.state.contact.lastName}`
+Then(/^the contact is displayed on the company contact tab$/, async function () {
+  const contactName = `${this.state.contact.firstName} ${this.state.contact.lastName}`
 
-    await Company
-      .section.firstContactsTabContact
-      .assert.visible('@header')
-      .assert.containsText('@header', contactName)
-  })
+  await Company
+    .section.firstContactsTabContact
+    .assert.visible('@header')
+    .assert.containsText('@header', contactName)
+})
 
-  Then(/^the contact is displayed on the dashboard$/, async function () {
-    const contactName = `${this.state.contact.firstName} ${this.state.contact.lastName}`
-    const dashboardContactEntry = `${contactName} from ${this.state.company.name}`
+Then(/^the contact is displayed on the dashboard$/, async function () {
+  const contactName = `${this.state.contact.firstName} ${this.state.contact.lastName}`
+  const dashboardContactEntry = `${contactName} from ${this.state.company.name}`
 
-    await Dashboard
-      .assert.containsText('@firstMyLatestContact', dashboardContactEntry)
-  })
+  await Dashboard
+    .assert.containsText('@firstMyLatestContact', dashboardContactEntry)
 })

--- a/test/acceptance/features/dashboard/step_definitions/dashboard.js
+++ b/test/acceptance/features/dashboard/step_definitions/dashboard.js
@@ -1,43 +1,41 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 
-defineSupportCode(({ When, Then }) => {
-  const Dashboard = client.page.Dashboard()
+const Dashboard = client.page.Dashboard()
 
-  When(/^I navigate to the dashboard$/, async () => {
+When(/^I navigate to the dashboard$/, async () => {
+  await Dashboard
+    .navigate()
+    .waitForElementPresent('@term')
+})
+
+Then(/^there should be a global nav$/, async (dataTable) => {
+  await Dashboard.section.globalHeader
+    .waitForElementPresent('@serviceName')
+
+  const expectedGlobalNav = dataTable.hashes()
+
+  await Dashboard.api.elements('css selector', '.c-global-nav__link', (result) => {
+    client.expect(result.value.length).to.equal(expectedGlobalNav.length)
+  })
+
+  for (const row of expectedGlobalNav) {
+    const globalNavItemSelector = Dashboard.getGlobalNavItemSelector(row.text)
     await Dashboard
-      .navigate()
-      .waitForElementPresent('@term')
-  })
+      .api.useXpath()
+      .waitForElementPresent(globalNavItemSelector.selector)
+      .assert.visible(globalNavItemSelector.selector)
+      .useCss()
+  }
+})
 
-  Then(/^there should be a global nav$/, async (dataTable) => {
-    await Dashboard.section.globalHeader
-      .waitForElementPresent('@serviceName')
+Then(/^I navigate to the support page$/, async () => {
+  await Dashboard.section.globalHeader
+    .assert.visible('@support')
+    .click('@support')
 
-    const expectedGlobalNav = dataTable.hashes()
-
-    await Dashboard.api.elements('css selector', '.c-global-nav__link', (result) => {
-      client.expect(result.value.length).to.equal(expectedGlobalNav.length)
-    })
-
-    for (const row of expectedGlobalNav) {
-      const globalNavItemSelector = Dashboard.getGlobalNavItemSelector(row.text)
-      await Dashboard
-        .api.useXpath()
-        .waitForElementPresent(globalNavItemSelector.selector)
-        .assert.visible(globalNavItemSelector.selector)
-        .useCss()
-    }
-  })
-
-  Then(/^I navigate to the support page$/, async () => {
-    await Dashboard.section.globalHeader
-      .assert.visible('@support')
-      .click('@support')
-
-    await Dashboard
-      .waitForElementVisible('@pageHeading')
-      .assert.visible('@pageHeading')
-      .assert.containsText('@pageHeading', 'Report a problem or leave feedback')
-  })
+  await Dashboard
+    .waitForElementVisible('@pageHeading')
+    .assert.visible('@pageHeading')
+    .assert.containsText('@pageHeading', 'Report a problem or leave feedback')
 })

--- a/test/acceptance/features/details/step_definitions/details.js
+++ b/test/acceptance/features/details/step_definitions/details.js
@@ -1,5 +1,5 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then } = require('cucumber')
 const { get, includes } = require('lodash')
 
 const { getDetailsTableRowValue } = require('../../../helpers/selectors')
@@ -20,102 +20,100 @@ function getExpectedValue (row, state) {
   return row.value
 }
 
-defineSupportCode(({ Then }) => {
-  const Details = client.page.Details()
+const Details = client.page.Details()
 
-  Then(/^details heading should contain what I entered for "(.+)" field$/, async function (fieldName) {
-    await Details
-      .waitForElementPresent('@heading')
-      .assert.containsText('@heading', this.state[fieldName])
+Then(/^details heading should contain what I entered for "(.+)" field$/, async function (fieldName) {
+  await Details
+    .waitForElementPresent('@heading')
+    .assert.containsText('@heading', this.state[fieldName])
+})
+
+Then(/^details heading should contain "(.+)"$/, async (value) => {
+  await Details
+    .waitForElementPresent('@heading')
+    .assert.containsText('@heading', value)
+})
+
+Then(/^details view data for "(.+)" should contain what I entered for "(.+)" field$/, async function (detailsItemName, fieldName) {
+  const detail = await Details.getDetailFor(detailsItemName)
+
+  await Details
+    .api.useXpath()
+    .waitForElementPresent(detail.selector)
+    .assert.containsText(detail.selector, this.state[fieldName])
+    .useCss()
+})
+
+Then(/^details view data for "(.+)" should contain "(.+)"$/, async (detailsItemName, value) => {
+  const detail = await Details.getDetailFor(detailsItemName)
+
+  await Details
+    .api.useXpath()
+    .waitForElementPresent(detail.selector)
+    .assert.containsText(detail.selector, value)
+    .useCss()
+})
+
+Then(/^there should be a local nav$/, async (dataTable) => {
+  const expectedLocalNav = dataTable.hashes()
+
+  await Details.api.elements('css selector', '.c-local-nav__link', (result) => {
+    client.expect(result.value.length).to.equal(expectedLocalNav.length)
   })
 
-  Then(/^details heading should contain "(.+)"$/, async (value) => {
-    await Details
-      .waitForElementPresent('@heading')
-      .assert.containsText('@heading', value)
-  })
-
-  Then(/^details view data for "(.+)" should contain what I entered for "(.+)" field$/, async function (detailsItemName, fieldName) {
-    const detail = await Details.getDetailFor(detailsItemName)
-
+  for (const row of expectedLocalNav) {
+    const localNavItemSelector = Details.getLocalNavItemSelector(row.text)
     await Details
       .api.useXpath()
-      .waitForElementPresent(detail.selector)
-      .assert.containsText(detail.selector, this.state[fieldName])
+      .waitForElementPresent(localNavItemSelector.selector)
+      .assert.visible(localNavItemSelector.selector)
       .useCss()
+  }
+})
+
+Then(/^there should not be a local nav$/, async () => {
+  await Details
+    .assert.elementNotPresent('@localNav')
+})
+
+Then(/^view should (not\s?)?contain the Documents link$/, async (noDocumentsLink) => {
+  const tag = noDocumentsLink ? '@noDocumentsMessage' : '@documentsLink'
+
+  await Details
+    .waitForElementPresent(tag)
+    .assert.visible(tag)
+})
+
+Then(/^the (.+) details are displayed$/, async function (detailsTableTitle, dataTable) {
+  const expectedDetails = dataTable.hashes()
+  const detailsTableSelector = Details.getSelectorForDetailsTableWithTitle(detailsTableTitle)
+
+  await Details.api.elements('xpath', `${detailsTableSelector.selector}//th`, (result) => {
+    client.expect(result.value.length).to.equal(expectedDetails.length)
   })
 
-  Then(/^details view data for "(.+)" should contain "(.+)"$/, async (detailsItemName, value) => {
-    const detail = await Details.getDetailFor(detailsItemName)
+  for (const row of expectedDetails) {
+    if (row.key === 'Business type') {
+      // todo: case issues
+      continue
+    }
+    if (row.key === 'Sector') {
+      // todo: https://uktrade.atlassian.net/browse/DH-1086
+      continue
+    }
 
+    const rowValueSelector = getDetailsTableRowValue(row.key)
+    const detailsTableRowValueXPathSelector = detailsTableSelector.selector + rowValueSelector.selector
+    const expectedValue = getExpectedValue(row, this.state)
     await Details
       .api.useXpath()
-      .waitForElementPresent(detail.selector)
-      .assert.containsText(detail.selector, value)
+      .waitForElementPresent(detailsTableRowValueXPathSelector)
+      .getText(detailsTableRowValueXPathSelector, (actual) => {
+        if (row.formatter) {
+          return client.expect(formatters[row.formatter](expectedValue, actual.value), row.key).to.be.true
+        }
+        client.expect(actual.value, row.key).to.equal(expectedValue)
+      })
       .useCss()
-  })
-
-  Then(/^there should be a local nav$/, async (dataTable) => {
-    const expectedLocalNav = dataTable.hashes()
-
-    await Details.api.elements('css selector', '.c-local-nav__link', (result) => {
-      client.expect(result.value.length).to.equal(expectedLocalNav.length)
-    })
-
-    for (const row of expectedLocalNav) {
-      const localNavItemSelector = Details.getLocalNavItemSelector(row.text)
-      await Details
-        .api.useXpath()
-        .waitForElementPresent(localNavItemSelector.selector)
-        .assert.visible(localNavItemSelector.selector)
-        .useCss()
-    }
-  })
-
-  Then(/^there should not be a local nav$/, async () => {
-    await Details
-      .assert.elementNotPresent('@localNav')
-  })
-
-  Then(/^view should (not\s?)?contain the Documents link$/, async (noDocumentsLink) => {
-    const tag = noDocumentsLink ? '@noDocumentsMessage' : '@documentsLink'
-
-    await Details
-      .waitForElementPresent(tag)
-      .assert.visible(tag)
-  })
-
-  Then(/^the (.+) details are displayed$/, async function (detailsTableTitle, dataTable) {
-    const expectedDetails = dataTable.hashes()
-    const detailsTableSelector = Details.getSelectorForDetailsTableWithTitle(detailsTableTitle)
-
-    await Details.api.elements('xpath', `${detailsTableSelector.selector}//th`, (result) => {
-      client.expect(result.value.length).to.equal(expectedDetails.length)
-    })
-
-    for (const row of expectedDetails) {
-      if (row.key === 'Business type') {
-        // todo: case issues
-        continue
-      }
-      if (row.key === 'Sector') {
-        // todo: https://uktrade.atlassian.net/browse/DH-1086
-        continue
-      }
-
-      const rowValueSelector = getDetailsTableRowValue(row.key)
-      const detailsTableRowValueXPathSelector = detailsTableSelector.selector + rowValueSelector.selector
-      const expectedValue = getExpectedValue(row, this.state)
-      await Details
-        .api.useXpath()
-        .waitForElementPresent(detailsTableRowValueXPathSelector)
-        .getText(detailsTableRowValueXPathSelector, (actual) => {
-          if (row.formatter) {
-            return client.expect(formatters[row.formatter](expectedValue, actual.value), row.key).to.be.true
-          }
-          client.expect(actual.value, row.key).to.equal(expectedValue)
-        })
-        .useCss()
-    }
-  })
+  }
 })

--- a/test/acceptance/features/events/step_definitions/collections.js
+++ b/test/acceptance/features/events/step_definitions/collections.js
@@ -1,202 +1,200 @@
 const { compareAsc, compareDesc } = require('date-fns')
 const { get, set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 
 const { getDateFor } = require('../../../helpers/date')
 
-defineSupportCode(({ Then, When }) => {
-  const EventList = client.page.EventList()
-  const Event = client.page.Event()
+const EventList = client.page.EventList()
+const Event = client.page.Event()
 
-  When(/^I populate the create event form$/, async function () {
-    await Event
-      .populateCreateEventForm({}, true, (event) => {
-        set(this.state, 'event', event)
-        set(this.state, 'event.heading', get(this.state, 'event.name'))
-      })
-  })
-
-  When(/^I populate the create event form with United Kingdom and a region$/, async function () {
-    await Event
-      .populateCreateEventForm({ address_country: 'United Kingdom' }, true, (event) => {
-        set(this.state, 'event', event)
-        set(this.state, 'event.heading', event.name)
-      })
-  })
-
-  When(/^I populate the create event form with United Kingdom and without a region$/, async function () {
-    await Event
-      .populateCreateEventForm({ address_country: 'United Kingdom' }, false, (event) => {
-        set(this.state, 'event', event)
-        set(this.state, 'event.heading', event.name)
-      })
-  })
-
-  Then(/^I can view the event$/, async function () {
-    const startDate = getDateFor({
-      year: get(this.state, 'event.start_date_year'),
-      month: get(this.state, 'event.start_date_month'),
-      day: get(this.state, 'event.start_date_day'),
+When(/^I populate the create event form$/, async function () {
+  await Event
+    .populateCreateEventForm({}, true, (event) => {
+      set(this.state, 'event', event)
+      set(this.state, 'event.heading', get(this.state, 'event.name'))
     })
-    const endDate = getDateFor({
-      year: get(this.state, 'event.end_date_year'),
-      month: get(this.state, 'event.end_date_month'),
-      day: get(this.state, 'event.end_date_day'),
+})
+
+When(/^I populate the create event form with United Kingdom and a region$/, async function () {
+  await Event
+    .populateCreateEventForm({ address_country: 'United Kingdom' }, true, (event) => {
+      set(this.state, 'event', event)
+      set(this.state, 'event.heading', event.name)
+    })
+})
+
+When(/^I populate the create event form with United Kingdom and without a region$/, async function () {
+  await Event
+    .populateCreateEventForm({ address_country: 'United Kingdom' }, false, (event) => {
+      set(this.state, 'event', event)
+      set(this.state, 'event.heading', event.name)
+    })
+})
+
+Then(/^I can view the event$/, async function () {
+  const startDate = getDateFor({
+    year: get(this.state, 'event.start_date_year'),
+    month: get(this.state, 'event.start_date_month'),
+    day: get(this.state, 'event.start_date_day'),
+  })
+  const endDate = getDateFor({
+    year: get(this.state, 'event.end_date_year'),
+    month: get(this.state, 'event.end_date_month'),
+    day: get(this.state, 'event.end_date_day'),
+  })
+
+  await EventList.section.firstEventInList
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', this.state.event.name)
+    .assert.containsText('@eventType', this.state.event.event_type)
+    .assert.containsText('@country', this.state.event.address_country)
+    .assert.containsText('@eventStart', startDate)
+    .assert.containsText('@eventEnd', endDate)
+    .assert.containsText('@organiser', this.state.event.organiser)
+    .assert.containsText('@leadTeam', this.state.event.lead_team)
+})
+
+Then(/^I filter the events list by name$/, async function () {
+  await EventList.section.filters
+    .waitForElementPresent('@nameInput')
+    .setValue('@nameInput', this.state.event.name)
+    .sendKeys('@nameInput', [ client.Keys.ENTER ])
+    .wait() // wait for xhr
+
+  await EventList.section.firstEventInList
+    .waitForElementVisible('@header')
+    .assert.containsText('@header', this.state.event.name)
+})
+
+Then(/^I filter the events list by organiser$/, async function () {
+  await EventList.section.filters
+    .waitForElementPresent('@organiser')
+    .clickMultipleChoiceOption('organiser', this.state.event.organiser)
+    .wait() // wait for xhr
+})
+
+Then(/^I filter the events list by country/, async function () {
+  await EventList.section.filters
+    .waitForElementPresent('@country')
+    .clickMultipleChoiceOption('address_country', this.state.event.address_country)
+    .wait() // wait for xhr
+})
+
+Then(/^I filter the events list by event type/, async function () {
+  await EventList.section.filters
+    .waitForElementPresent('@eventType')
+    .clickMultipleChoiceOption('event_type', this.state.event.event_type)
+    .wait() // wait for xhr
+})
+
+Then(/^I filter the events list by start date/, async function () {
+  const event = this.state.event
+  const startDate = getDateFor({
+    year: event.start_date_year,
+    month: event.start_date_month,
+    day: event.start_date_day,
+  })
+
+  await EventList.section.filters
+    .waitForElementPresent('@startDateAfter')
+    .setValue('@startDateAfter', startDate)
+    .sendKeys('@startDateAfter', [ client.Keys.ENTER ])
+    .wait() // wait for xhr
+})
+
+Then(/^I sort the events list name A-Z$/, async function () {
+  await EventList
+    .click('select[name="sortby"] option[value="name:asc"]')
+    .wait()// wait for xhr
+
+  await EventList.section.firstEventInList
+    .waitForElementVisible('@header')
+    .getText('@header', (text) => {
+      set(this.state, 'list.firstItem.heading', text.value)
     })
 
-    await EventList.section.firstEventInList
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', this.state.event.name)
-      .assert.containsText('@eventType', this.state.event.event_type)
-      .assert.containsText('@country', this.state.event.address_country)
-      .assert.containsText('@eventStart', startDate)
-      .assert.containsText('@eventEnd', endDate)
-      .assert.containsText('@organiser', this.state.event.organiser)
-      .assert.containsText('@leadTeam', this.state.event.lead_team)
-  })
+  await EventList.section.secondEventInList
+    .waitForElementVisible('@header')
+    .getText('@header', (text) => {
+      set(this.state, 'list.secondItem.heading', text.value)
+    })
+})
 
-  Then(/^I filter the events list by name$/, async function () {
-    await EventList.section.filters
-      .waitForElementPresent('@nameInput')
-      .setValue('@nameInput', this.state.event.name)
-      .sendKeys('@nameInput', [ client.Keys.ENTER ])
-      .wait() // wait for xhr
+Then(/^I see the list in A-Z alphabetical order$/, async function () {
+  client.expect(
+    this.state.list.firstItem.heading.toLowerCase() < this.state.list.secondItem.heading.toLowerCase()
+  ).to.be.true
+})
 
-    await EventList.section.firstEventInList
-      .waitForElementVisible('@header')
-      .assert.containsText('@header', this.state.event.name)
-  })
+Then(/^I sort the events list name Z-A$/, async function () {
+  await EventList
+    .click('select[name="sortby"] option[value="name:desc"]')
+    .wait() // wait for xhr
 
-  Then(/^I filter the events list by organiser$/, async function () {
-    await EventList.section.filters
-      .waitForElementPresent('@organiser')
-      .clickMultipleChoiceOption('organiser', this.state.event.organiser)
-      .wait() // wait for xhr
-  })
-
-  Then(/^I filter the events list by country/, async function () {
-    await EventList.section.filters
-      .waitForElementPresent('@country')
-      .clickMultipleChoiceOption('address_country', this.state.event.address_country)
-      .wait() // wait for xhr
-  })
-
-  Then(/^I filter the events list by event type/, async function () {
-    await EventList.section.filters
-      .waitForElementPresent('@eventType')
-      .clickMultipleChoiceOption('event_type', this.state.event.event_type)
-      .wait() // wait for xhr
-  })
-
-  Then(/^I filter the events list by start date/, async function () {
-    const event = this.state.event
-    const startDate = getDateFor({
-      year: event.start_date_year,
-      month: event.start_date_month,
-      day: event.start_date_day,
+  await EventList.section.firstEventInList
+    .waitForElementVisible('@header')
+    .getText('@header', (text) => {
+      set(this.state, 'list.firstItem.heading', text.value)
     })
 
-    await EventList.section.filters
-      .waitForElementPresent('@startDateAfter')
-      .setValue('@startDateAfter', startDate)
-      .sendKeys('@startDateAfter', [ client.Keys.ENTER ])
-      .wait() // wait for xhr
-  })
+  await EventList.section.secondEventInList
+    .waitForElementVisible('@header')
+    .getText('@header', (text) => {
+      set(this.state, 'list.secondItem.heading', text.value)
+    })
+})
 
-  Then(/^I sort the events list name A-Z$/, async function () {
-    await EventList
-      .click('select[name="sortby"] option[value="name:asc"]')
-      .wait()// wait for xhr
+Then(/^I see the list in Z-A alphabetical order$/, async function () {
+  client.expect(
+    this.state.list.firstItem.heading.toLowerCase() > this.state.list.secondItem.heading.toLowerCase()
+  ).to.be.true
+})
 
-    await EventList.section.firstEventInList
-      .waitForElementVisible('@header')
-      .getText('@header', (text) => {
-        set(this.state, 'list.firstItem.heading', text.value)
-      })
+Then(/^I sort the events list by recently updated$/, async function () {
+  await EventList
+    .click('select[name="sortby"] option[value="modified_on:desc"]')
+    .wait() // wait for xhr
 
-    await EventList.section.secondEventInList
-      .waitForElementVisible('@header')
-      .getText('@header', (text) => {
-        set(this.state, 'list.secondItem.heading', text.value)
-      })
-  })
+  await EventList.section.firstEventInList
+    .waitForElementVisible('@updated')
+    .getText('@updated', (dateString) => {
+      set(this.state, 'firstItem.updated ', dateString.value)
+    })
 
-  Then(/^I see the list in A-Z alphabetical order$/, async function () {
-    client.expect(
-      this.state.list.firstItem.heading.toLowerCase() < this.state.list.secondItem.heading.toLowerCase()
-    ).to.be.true
-  })
+  await EventList.section.secondEventInList
+    .waitForElementVisible('@updated')
+    .getText('@updated', (dateString) => {
+      set(this.state, 'list.secondItem.updated', dateString.value)
+    })
+})
 
-  Then(/^I sort the events list name Z-A$/, async function () {
-    await EventList
-      .click('select[name="sortby"] option[value="name:desc"]')
-      .wait() // wait for xhr
+Then(/^I see the list in descending recently updated order$/, async function () {
+  client.expect(
+    compareDesc(this.state.list.firstItem.updated, this.state.list.secondItem.updated)
+  ).to.be.within(0, 1)
+})
 
-    await EventList.section.firstEventInList
-      .waitForElementVisible('@header')
-      .getText('@header', (text) => {
-        set(this.state, 'list.firstItem.heading', text.value)
-      })
+Then(/^I sort the events list by least recently updated$/, async function () {
+  await EventList
+    .click('select[name="sortby"] option[value="modified_on:asc"]')
+    .wait() // wait for xhr
 
-    await EventList.section.secondEventInList
-      .waitForElementVisible('@header')
-      .getText('@header', (text) => {
-        set(this.state, 'list.secondItem.heading', text.value)
-      })
-  })
+  await EventList.section.firstEventInList
+    .waitForElementVisible('@updated')
+    .getText('@updated', (dateString) => {
+      set(this.state, 'list.firstItem.updated', dateString.value)
+    })
 
-  Then(/^I see the list in Z-A alphabetical order$/, async function () {
-    client.expect(
-      this.state.list.firstItem.heading.toLowerCase() > this.state.list.secondItem.heading.toLowerCase()
-    ).to.be.true
-  })
+  await EventList.section.secondEventInList
+    .waitForElementVisible('@updated')
+    .getText('@updated', (dateString) => {
+      set(this.state, 'list.secondItem.updated', dateString.value)
+    })
+})
 
-  Then(/^I sort the events list by recently updated$/, async function () {
-    await EventList
-      .click('select[name="sortby"] option[value="modified_on:desc"]')
-      .wait() // wait for xhr
-
-    await EventList.section.firstEventInList
-      .waitForElementVisible('@updated')
-      .getText('@updated', (dateString) => {
-        set(this.state, 'firstItem.updated ', dateString.value)
-      })
-
-    await EventList.section.secondEventInList
-      .waitForElementVisible('@updated')
-      .getText('@updated', (dateString) => {
-        set(this.state, 'list.secondItem.updated', dateString.value)
-      })
-  })
-
-  Then(/^I see the list in descending recently updated order$/, async function () {
-    client.expect(
-      compareDesc(this.state.list.firstItem.updated, this.state.list.secondItem.updated)
-    ).to.be.within(0, 1)
-  })
-
-  Then(/^I sort the events list by least recently updated$/, async function () {
-    await EventList
-      .click('select[name="sortby"] option[value="modified_on:asc"]')
-      .wait() // wait for xhr
-
-    await EventList.section.firstEventInList
-      .waitForElementVisible('@updated')
-      .getText('@updated', (dateString) => {
-        set(this.state, 'list.firstItem.updated', dateString.value)
-      })
-
-    await EventList.section.secondEventInList
-      .waitForElementVisible('@updated')
-      .getText('@updated', (dateString) => {
-        set(this.state, 'list.secondItem.updated', dateString.value)
-      })
-  })
-
-  Then(/^I see the list in ascending recently updated order$/, async function () {
-    client.expect(
-      compareAsc(this.state.list.firstItem.updated, this.state.list.secondItem.updated)
-    ).to.be.within(0, 1)
-  })
+Then(/^I see the list in ascending recently updated order$/, async function () {
+  client.expect(
+    compareAsc(this.state.list.firstItem.updated, this.state.list.secondItem.updated)
+  ).to.be.within(0, 1)
 })

--- a/test/acceptance/features/events/step_definitions/create.js
+++ b/test/acceptance/features/events/step_definitions/create.js
@@ -1,238 +1,236 @@
 const { set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Given, Then, When } = require('cucumber')
 
-defineSupportCode(function ({ Given, Then, When }) {
-  const Event = client.page.Event()
+const Event = client.page.Event()
 
-  Given(/^I create an event$/, async function () {
-    await Event
-      .navigate()
-      .populateCreateEventForm({}, true, (event) => {
-        set(this.state, 'event', event)
-      })
-      .wait() // wait for backend to sync
-  })
+Given(/^I create an event$/, async function () {
+  await Event
+    .navigate()
+    .populateCreateEventForm({}, true, (event) => {
+      set(this.state, 'event', event)
+    })
+    .wait() // wait for backend to sync
+})
 
-  When(/^I choose the (.+) country option$/, async (country) => {
-    await Event
-      .setValue('@addressCountry', '')
-      .clickListOption('address_country', country)
-  })
+When(/^I choose the (.+) country option$/, async (country) => {
+  await Event
+    .setValue('@addressCountry', '')
+    .clickListOption('address_country', country)
+})
 
-  Then(/^I verify the event name field is displayed$/, async () => {
-    await Event
-      .assert.visible('@eventName')
-  })
+Then(/^I verify the event name field is displayed$/, async () => {
+  await Event
+    .assert.visible('@eventName')
+})
 
-  Then(/^I verify the event type field is displayed$/, async () => {
-    await Event
-      .assert.visible('@eventType')
-  })
+Then(/^I verify the event type field is displayed$/, async () => {
+  await Event
+    .assert.visible('@eventType')
+})
 
-  Then(/^I verify the event additional reference code field is displayed$/, async () => {
-    await Event
-      .assert.visible('@additionalRefCode')
-  })
+Then(/^I verify the event additional reference code field is displayed$/, async () => {
+  await Event
+    .assert.visible('@additionalRefCode')
+})
 
-  Then(/^I verify the event start date fields are displayed$/, async () => {
-    await Event
-      .assert.visible('@startDateYear')
-    await Event
-      .assert.visible('@startDateMonth')
-    await Event
-      .assert.visible('@startDateDay')
-  })
+Then(/^I verify the event start date fields are displayed$/, async () => {
+  await Event
+    .assert.visible('@startDateYear')
+  await Event
+    .assert.visible('@startDateMonth')
+  await Event
+    .assert.visible('@startDateDay')
+})
 
-  Then(/^I verify the event end date fields are displayed$/, async () => {
-    await Event
-      .assert.visible('@endDateYear')
-    await Event
-      .assert.visible('@endDateMonth')
-    await Event
-      .assert.visible('@endDateDay')
-  })
+Then(/^I verify the event end date fields are displayed$/, async () => {
+  await Event
+    .assert.visible('@endDateYear')
+  await Event
+    .assert.visible('@endDateMonth')
+  await Event
+    .assert.visible('@endDateDay')
+})
 
-  Then(/^I verify the event location type field is displayed$/, async () => {
-    await Event
-      .assert.visible('@locationType')
-  })
+Then(/^I verify the event location type field is displayed$/, async () => {
+  await Event
+    .assert.visible('@locationType')
+})
 
-  Then(/^I verify the event address line1 field is displayed$/, async () => {
-    await Event
-      .assert.visible('@addressLine1')
-  })
+Then(/^I verify the event address line1 field is displayed$/, async () => {
+  await Event
+    .assert.visible('@addressLine1')
+})
 
-  Then(/^I verify the event address line2 field is displayed$/, async () => {
-    await Event
-      .assert.visible('@addressLine2')
-  })
+Then(/^I verify the event address line2 field is displayed$/, async () => {
+  await Event
+    .assert.visible('@addressLine2')
+})
 
-  Then(/^I verify the event address town field is displayed$/, async () => {
-    await Event
-      .assert.visible('@addressTown')
-  })
+Then(/^I verify the event address town field is displayed$/, async () => {
+  await Event
+    .assert.visible('@addressTown')
+})
 
-  Then(/^I verify the event address county field is displayed$/, async () => {
-    await Event
-      .assert.visible('@addressCounty')
-  })
+Then(/^I verify the event address county field is displayed$/, async () => {
+  await Event
+    .assert.visible('@addressCounty')
+})
 
-  Then(/^I verify the event address postcode field is displayed$/, async () => {
-    await Event
-      .assert.visible('@addressPostcode')
-  })
+Then(/^I verify the event address postcode field is displayed$/, async () => {
+  await Event
+    .assert.visible('@addressPostcode')
+})
 
-  Then(/^I verify the event address country field is displayed$/, async () => {
-    await Event
-      .assert.visible('@addressCountry')
-  })
+Then(/^I verify the event address country field is displayed$/, async () => {
+  await Event
+    .assert.visible('@addressCountry')
+})
 
-  Then(/^I verify the event UK region field is displayed$/, async () => {
-    await Event
-      .assert.visible('@ukRegion')
-  })
+Then(/^I verify the event UK region field is displayed$/, async () => {
+  await Event
+    .assert.visible('@ukRegion')
+})
 
-  Then(/^I verify the event UK region field is not displayed$/, async () => {
-    await Event
-      .assert.hidden('@ukRegion')
-  })
+Then(/^I verify the event UK region field is not displayed$/, async () => {
+  await Event
+    .assert.hidden('@ukRegion')
+})
 
-  Then(/^I verify the event notes field is displayed$/, async () => {
-    await Event
-      .assert.visible('@notes')
-  })
+Then(/^I verify the event notes field is displayed$/, async () => {
+  await Event
+    .assert.visible('@notes')
+})
 
-  Then(/^I verify the event Team hosting field is displayed$/, async () => {
-    await Event
-      .assert.visible('@leadTeam')
-  })
+Then(/^I verify the event Team hosting field is displayed$/, async () => {
+  await Event
+    .assert.visible('@leadTeam')
+})
 
-  Then(/^I verify the event services field is displayed$/, async () => {
-    await Event
-      .assert.visible('@service')
-  })
+Then(/^I verify the event services field is displayed$/, async () => {
+  await Event
+    .assert.visible('@service')
+})
 
-  Then(/^I verify the event organiser field is displayed$/, async () => {
-    await Event
-      .assert.visible('@organiser')
-  })
+Then(/^I verify the event organiser field is displayed$/, async () => {
+  await Event
+    .assert.visible('@organiser')
+})
 
-  Then(/^I verify the event is shared or not field is displayed$/, async () => {
-    await Event
-      .assert.visible('@sharedYes')
-      .assert.visible('@sharedNo')
-  })
+Then(/^I verify the event is shared or not field is displayed$/, async () => {
+  await Event
+    .assert.visible('@sharedYes')
+    .assert.visible('@sharedNo')
+})
 
-  When(/^I choose the Yes option$/, async () => {
-    await Event
-      .setValue('@sharedYes', '')
-      .click('@sharedYes')
-  })
+When(/^I choose the Yes option$/, async () => {
+  await Event
+    .setValue('@sharedYes', '')
+    .click('@sharedYes')
+})
 
-  When(/^I choose the No option$/, async () => {
-    await Event
-      .setValue('@sharedNo', '')
-      .click('@sharedNo')
-  })
+When(/^I choose the No option$/, async () => {
+  await Event
+    .setValue('@sharedNo', '')
+    .click('@sharedNo')
+})
 
-  Then(/^I verify the shared teams field is displayed$/, async () => {
-    await Event
-      .assert.visible('@teams')
-  })
+Then(/^I verify the shared teams field is displayed$/, async () => {
+  await Event
+    .assert.visible('@teams')
+})
 
-  Then(/^I verify the shared teams field is not displayed$/, async () => {
-    await Event
-      .assert.hidden('@teams')
-  })
+Then(/^I verify the shared teams field is not displayed$/, async () => {
+  await Event
+    .assert.hidden('@teams')
+})
 
-  When(/^I select shared team ([0-9])$/, async (optionNumber) => {
-    await Event
-      .setValue('@teams', '')
-      .selectListOption('teams', optionNumber)
-  })
+When(/^I select shared team ([0-9])$/, async (optionNumber) => {
+  await Event
+    .setValue('@teams', '')
+    .selectListOption('teams', optionNumber)
+})
 
-  When(/^I add it to the shared teams list$/, async () => {
-    await Event
-      .click('@addAnotherSharedTeam')
-  })
+When(/^I add it to the shared teams list$/, async () => {
+  await Event
+    .click('@addAnotherSharedTeam')
+})
 
-  Then(/^I verify there should be ([0-9]) shared teams lists$/, async (expected) => {
-    await Event
-      .assertVisibleTeamsList(expected)
-  })
+Then(/^I verify there should be ([0-9]) shared teams lists$/, async (expected) => {
+  await Event
+    .assertVisibleTeamsList(expected)
+})
 
-  Then(/^I verify there is the option to add another shared team$/, async () => {
-    await Event
-      .assert.visible('@addAnotherSharedTeam')
-  })
+Then(/^I verify there is the option to add another shared team$/, async () => {
+  await Event
+    .assert.visible('@addAnotherSharedTeam')
+})
 
-  Then(/^I verify the event related programmes field is displayed$/, async () => {
-    await Event
-      .assert.visible('@relatedProgrammes')
-  })
+Then(/^I verify the event related programmes field is displayed$/, async () => {
+  await Event
+    .assert.visible('@relatedProgrammes')
+})
 
-  When(/^I select programme ([0-9])$/, async (optionNumber) => {
-    await Event
-      .setValue('@teams', '')
-      .selectListOption('related_programmes', optionNumber)
-  })
+When(/^I select programme ([0-9])$/, async (optionNumber) => {
+  await Event
+    .setValue('@teams', '')
+    .selectListOption('related_programmes', optionNumber)
+})
 
-  When(/^I add it to the programmes list$/, async () => {
-    await Event
-      .click('@addAnotherProgramme')
-  })
+When(/^I add it to the programmes list$/, async () => {
+  await Event
+    .click('@addAnotherProgramme')
+})
 
-  Then(/^I verify there should be ([0-9]) programmes lists$/, async (expected) => {
-    await Event
-      .assertVisibleRelatedProgrammesList(expected)
-  })
+Then(/^I verify there should be ([0-9]) programmes lists$/, async (expected) => {
+  await Event
+    .assertVisibleRelatedProgrammesList(expected)
+})
 
-  Then(/^I verify there is the option to add another programme/, async () => {
-    await Event
-      .assert.visible('@addAnotherProgramme')
-  })
+Then(/^I verify there is the option to add another programme/, async () => {
+  await Event
+    .assert.visible('@addAnotherProgramme')
+})
 
-  Then(/^I verify the event save button is displayed$/, async () => {
-    await Event
-      .assert.visible('@saveButton')
-  })
+Then(/^I verify the event save button is displayed$/, async () => {
+  await Event
+    .assert.visible('@saveButton')
+})
 
-  Then(/^I verify the event name has an error message$/, async () => {
-    await Event
-      .assert.visible('@eventNameError')
-  })
+Then(/^I verify the event name has an error message$/, async () => {
+  await Event
+    .assert.visible('@eventNameError')
+})
 
-  Then(/^I click the save button$/, async () => {
-    await Event
-      .waitForElementPresent('@saveButton')
-      .click('@saveButton')
-      .wait() // wait for backend to sync
-  })
+Then(/^I click the save button$/, async () => {
+  await Event
+    .waitForElementPresent('@saveButton')
+    .click('@saveButton')
+    .wait() // wait for backend to sync
+})
 
-  Then(/^the event fields have error messages$/, async () => {
-    await Event
-      .assert.visible('@nameError')
-      .assert.visible('@typeError')
-      .assert.visible('@startDateError')
-      .assert.visible('@endDateError')
-      .assert.visible('@addressLine1Error')
-      .assert.visible('@addressTownError')
-      .assert.visible('@addressCountryError')
-      .assert.visible('@serviceError')
-  })
+Then(/^the event fields have error messages$/, async () => {
+  await Event
+    .assert.visible('@nameError')
+    .assert.visible('@typeError')
+    .assert.visible('@startDateError')
+    .assert.visible('@endDateError')
+    .assert.visible('@addressLine1Error')
+    .assert.visible('@addressTownError')
+    .assert.visible('@addressCountryError')
+    .assert.visible('@serviceError')
+})
 
-  Then(/^I verify the event UK region has an error message$/, async () => {
-    await Event
-      .assert.visible('@ukRegionError')
-  })
+Then(/^I verify the event UK region has an error message$/, async () => {
+  await Event
+    .assert.visible('@ukRegionError')
+})
 
-  Then(/^I see the event is displayed correctly with all field values$/, async () => {
-    await Event
-      .assert.containsText('@eventNameFromDetails', '')
-      .assert.containsText('@eventTypeFromDetails', '')
-      .assert.containsText('@addressLine1FromDetails', '')
-      .assert.containsText('@addressTownFromDetails', '')
-      .assert.containsText('@addressCountryFromDetails', '')
-  })
+Then(/^I see the event is displayed correctly with all field values$/, async () => {
+  await Event
+    .assert.containsText('@eventNameFromDetails', '')
+    .assert.containsText('@eventTypeFromDetails', '')
+    .assert.containsText('@addressLine1FromDetails', '')
+    .assert.containsText('@addressTownFromDetails', '')
+    .assert.containsText('@addressCountryFromDetails', '')
 })

--- a/test/acceptance/features/events/step_definitions/edit.js
+++ b/test/acceptance/features/events/step_definitions/edit.js
@@ -2,50 +2,48 @@
 const { assign, set } = require('lodash')
 
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { When } = require('cucumber')
 const { format } = require('date-fns')
 
-defineSupportCode(({ When }) => {
-  const Form = client.page.Form()
-  const Event = client.page.Event()
-  const EventList = client.page.EventList()
+const Form = client.page.Form()
+const Event = client.page.Event()
+const EventList = client.page.EventList()
 
-  // TODO feels like this can be DRY'd up (see location)
-  When(/^I navigate to event details page$/, async () => {
-    await EventList
-      .navigate()
-      .section.firstEventInList
-      .waitForElementPresent('@header')
-      .click('@header')
+// TODO feels like this can be DRY'd up (see location)
+When(/^I navigate to event details page$/, async () => {
+  await EventList
+    .navigate()
+    .section.firstEventInList
+    .waitForElementPresent('@header')
+    .click('@header')
+})
+
+When(/^I click on edit event button$/, async () => {
+  await Event
+    .click('@editButton')
+})
+
+When(/^I change start date to decrease year by one$/, async function () {
+  const currentDate = new Date()
+  const form = {}
+
+  await Form.getState((result) => {
+    set(form, 'state', result.value)
   })
 
-  When(/^I click on edit event button$/, async () => {
-    await Event
-      .click('@editButton')
-  })
+  await Event
+    .api.perform(() => {
+      const start_date_year = form.state.start_date_year || format(currentDate, 'YYYY')
 
-  When(/^I change start date to decrease year by one$/, async function () {
-    const currentDate = new Date()
-    const form = {}
-
-    await Form.getState((result) => {
-      set(form, 'state', result.value)
-    })
-
-    await Event
-      .api.perform(() => {
-        const start_date_year = form.state.start_date_year || format(currentDate, 'YYYY')
-
-        this.state = assign({}, this.state, {
-          start_date_year: parseInt(start_date_year, 10) - 1,
-          start_date_month: form.state.start_date_month || format(currentDate, 'MM'),
-          start_date_day: form.state.start_date_day || format(currentDate, 'DD'),
-        })
-
-        return Event
-          .replaceValue('@startDateYear', this.state.start_date_year)
-          .replaceValue('@startDateMonth', this.state.start_date_month)
-          .replaceValue('@startDateDay', this.state.start_date_day)
+      this.state = assign({}, this.state, {
+        start_date_year: parseInt(start_date_year, 10) - 1,
+        start_date_month: form.state.start_date_month || format(currentDate, 'MM'),
+        start_date_day: form.state.start_date_day || format(currentDate, 'DD'),
       })
-  })
+
+      return Event
+        .replaceValue('@startDateYear', this.state.start_date_year)
+        .replaceValue('@startDateMonth', this.state.start_date_month)
+        .replaceValue('@startDateDay', this.state.start_date_day)
+    })
 })

--- a/test/acceptance/features/form/step_definitions/form.js
+++ b/test/acceptance/features/form/step_definitions/form.js
@@ -1,5 +1,5 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const faker = require('faker')
 const { snakeCase } = require('lodash')
 
@@ -36,53 +36,51 @@ const getSelectorsForElement = (type, name) => {
   }
 }
 
-defineSupportCode(({ When, Then }) => {
-  const Form = client.page.Form()
+const Form = client.page.Form()
 
-  When(/^I change form text field "(.+)" to (.+)$/, async function (fieldName, fieldValue) {
-    const fieldSelector = `[name="${fieldName}"]`
+When(/^I change form text field "(.+)" to (.+)$/, async function (fieldName, fieldValue) {
+  const fieldSelector = `[name="${fieldName}"]`
 
-    this.state[fieldName] = getValue(fieldValue)
+  this.state[fieldName] = getValue(fieldValue)
 
-    await Form
-      .replaceValue(fieldSelector, this.state[fieldName])
-  })
+  await Form
+    .replaceValue(fieldSelector, this.state[fieldName])
+})
 
-  When(/^I change form dropdown "(.+)" to (.+)$/, async function (fieldName, fieldValue) {
-    this.state[fieldName] = getValue(fieldValue)
+When(/^I change form dropdown "(.+)" to (.+)$/, async function (fieldName, fieldValue) {
+  this.state[fieldName] = getValue(fieldValue)
 
-    await Form
-      .clickListOption(fieldName, this.state[fieldName])
-  })
+  await Form
+    .clickListOption(fieldName, this.state[fieldName])
+})
 
-  When(/^I select "(.+)" for boolean option "(.+)"$/, async (label, fieldName) => {
-    const fieldSelector = `//label[contains(., "${label}") and contains(@for, "field-${fieldName}")]`
+When(/^I select "(.+)" for boolean option "(.+)"$/, async (label, fieldName) => {
+  const fieldSelector = `//label[contains(., "${label}") and contains(@for, "field-${fieldName}")]`
 
-    await Form
-      .api.useXpath()
-      .click(fieldSelector)
-      .useCss()
-  })
+  await Form
+    .api.useXpath()
+    .click(fieldSelector)
+    .useCss()
+})
 
-  When(/^I submit (.+) form$/, async (selector) => {
-    selector = selector === 'the' ? 'form' : selector
+When(/^I submit (.+) form$/, async (selector) => {
+  selector = selector === 'the' ? 'form' : selector
 
-    await Form
-      .submitForm(selector)
-  })
+  await Form
+    .submitForm(selector)
+})
 
-  Then(/^I see form error summary$/, async () => {
-    await Form
-      .assert.visible('@errorSummary')
-  })
+Then(/^I see form error summary$/, async () => {
+  await Form
+    .assert.visible('@errorSummary')
+})
 
-  Then(/^there are form fields$/, async function (dataTable) {
-    for (const row of dataTable.hashes()) {
-      const selectors = getSelectorsForElement(row.type, row.name)
-      await client
-        .waitForElementPresent(selectors.element)
-        .assert.visible(selectors.label)
-        .assert.visible(selectors.element)
-    }
-  })
+Then(/^there are form fields$/, async function (dataTable) {
+  for (const row of dataTable.hashes()) {
+    const selectors = getSelectorsForElement(row.type, row.name)
+    await client
+      .waitForElementPresent(selectors.element)
+      .assert.visible(selectors.label)
+      .assert.visible(selectors.element)
+  }
 })

--- a/test/acceptance/features/interactions/step_definitions/collection.js
+++ b/test/acceptance/features/interactions/step_definitions/collection.js
@@ -1,24 +1,22 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const { get } = require('lodash')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const InteractionList = client.page.InteractionList()
+const InteractionList = client.page.InteractionList()
 
-  When(/^I filter the interactions list by service provider$/, async function () {
-    await InteractionList.section.filters
-      .waitForElementPresent('@serviceProvider')
-      .clickMultipleChoiceOption('dit_team', this.state.interaction.serviceProvider)
-      .wait() // wait for xhr
-  })
+When(/^I filter the interactions list by service provider$/, async function () {
+  await InteractionList.section.filters
+    .waitForElementPresent('@serviceProvider')
+    .clickMultipleChoiceOption('dit_team', this.state.interaction.serviceProvider)
+    .wait() // wait for xhr
+})
 
-  Then(/^the interactions should be filtered by service provider$/, async function () {
-    const selector = '@serviceProvider'
-    const expected = get(this.state, `interaction.serviceProvider`)
+Then(/^the interactions should be filtered by service provider$/, async function () {
+  const selector = '@serviceProvider'
+  const expected = get(this.state, `interaction.serviceProvider`)
 
-    await InteractionList
-      .section.firstInteractionInList
-      .waitForElementVisible(selector)
-      .assert.containsText(selector, expected)
-  })
+  await InteractionList
+    .section.firstInteractionInList
+    .waitForElementVisible(selector)
+    .assert.containsText(selector, expected)
 })

--- a/test/acceptance/features/interactions/step_definitions/details.js
+++ b/test/acceptance/features/interactions/step_definitions/details.js
@@ -1,18 +1,16 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then } = require('cucumber')
 
-defineSupportCode(({ Then }) => {
-  const Interaction = client.page.Interaction()
+const Interaction = client.page.Interaction()
 
-  Then(/^the interaction details Documents link is displayed$/, async function () {
-    await Interaction
-      .section.details
-      .assert.visible('@documentsLink')
-  })
+Then(/^the interaction details Documents link is displayed$/, async function () {
+  await Interaction
+    .section.details
+    .assert.visible('@documentsLink')
+})
 
-  Then(/^the interaction details Documents link is not displayed$/, async function () {
-    await Interaction
-      .section.details
-      .assert.elementNotPresent('@documentsLink')
-  })
+Then(/^the interaction details Documents link is not displayed$/, async function () {
+  await Interaction
+    .section.details
+    .assert.elementNotPresent('@documentsLink')
 })

--- a/test/acceptance/features/interactions/step_definitions/save.js
+++ b/test/acceptance/features/interactions/step_definitions/save.js
@@ -1,170 +1,168 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Given, Then, When } = require('cucumber')
 const { get, set, camelCase } = require('lodash')
 
 const { getDateFor } = require('../../../helpers/date')
 
-defineSupportCode(({ Given, When, Then }) => {
-  const Interaction = client.page.Interaction()
-  const InteractionList = client.page.InteractionList()
+const Interaction = client.page.Interaction()
+const InteractionList = client.page.InteractionList()
 
-  Given(/^a company investment project is created for interactions$/, async function () {
-  })
+Given(/^a company investment project is created for interactions$/, async function () {
+})
 
-  When(/^an interaction is added$/, async function () {
-    await Interaction
-      .createInteraction({}, (interaction) => {
-        set(this.state, 'interaction', interaction)
-        set(this.state, 'interaction.date', getDateFor({
-          year: get(this.state, 'interaction.dateOfInteractionYear'),
-          month: get(this.state, 'interaction.dateOfInteractionMonth'),
-          day: get(this.state, 'interaction.dateOfInteractionDay'),
-        }))
-        set(this.state, 'interaction.type', 'Interaction')
-      })
-      .wait() // wait for backend to sync
-  })
+When(/^an interaction is added$/, async function () {
+  await Interaction
+    .createInteraction({}, (interaction) => {
+      set(this.state, 'interaction', interaction)
+      set(this.state, 'interaction.date', getDateFor({
+        year: get(this.state, 'interaction.dateOfInteractionYear'),
+        month: get(this.state, 'interaction.dateOfInteractionMonth'),
+        day: get(this.state, 'interaction.dateOfInteractionDay'),
+      }))
+      set(this.state, 'interaction.type', 'Interaction')
+    })
+    .wait() // wait for backend to sync
+})
 
-  When(/^a service delivery is added$/, async function () {
-    await Interaction
-      .createServiceDelivery({}, (serviceDelivery) => {
-        set(this.state, 'serviceDelivery', serviceDelivery)
-        set(this.state, 'serviceDelivery.date', getDateFor({
-          year: get(this.state, 'serviceDelivery.dateOfInteractionYear'),
-          month: get(this.state, 'serviceDelivery.dateOfInteractionMonth'),
-          day: get(this.state, 'serviceDelivery.dateOfInteractionDay'),
-        }))
-        set(this.state, 'serviceDelivery.type', 'Service delivery')
-      })
-      .wait() // wait for backend to sync
-  })
+When(/^a service delivery is added$/, async function () {
+  await Interaction
+    .createServiceDelivery({}, (serviceDelivery) => {
+      set(this.state, 'serviceDelivery', serviceDelivery)
+      set(this.state, 'serviceDelivery.date', getDateFor({
+        year: get(this.state, 'serviceDelivery.dateOfInteractionYear'),
+        month: get(this.state, 'serviceDelivery.dateOfInteractionMonth'),
+        day: get(this.state, 'serviceDelivery.dateOfInteractionDay'),
+      }))
+      set(this.state, 'serviceDelivery.type', 'Service delivery')
+    })
+    .wait() // wait for backend to sync
+})
 
-  When(/^selecting interaction$/, async function () {
-    await Interaction
-      .waitForElementVisible('@continueButton')
-      .click('@aStandardInteraction')
-      .click('@continueButton')
-  })
+When(/^selecting interaction$/, async function () {
+  await Interaction
+    .waitForElementVisible('@continueButton')
+    .click('@aStandardInteraction')
+    .click('@continueButton')
+})
 
-  When(/^selecting service delivery$/, async function () {
-    await Interaction
-      .waitForElementVisible('@continueButton')
-      .click('@aServiceThatYouHaveProvided')
-      .click('@continueButton')
-  })
+When(/^selecting service delivery$/, async function () {
+  await Interaction
+    .waitForElementVisible('@continueButton')
+    .click('@aServiceThatYouHaveProvided')
+    .click('@continueButton')
+})
 
-  When(/^the interaction events Yes option is chosen$/, async function () {
-    await Interaction
-      .setValue('@eventYes', '')
-      .click('@eventYes')
-  })
+When(/^the interaction events Yes option is chosen$/, async function () {
+  await Interaction
+    .setValue('@eventYes', '')
+    .click('@eventYes')
+})
 
-  When(/^the interaction events No option is chosen$/, async function () {
-    await Interaction
-      .setValue('@eventNo', '')
-      .click('@eventNo')
-  })
+When(/^the interaction events No option is chosen$/, async function () {
+  await Interaction
+    .setValue('@eventNo', '')
+    .click('@eventNo')
+})
 
-  Then(/^there are interaction fields$/, async function () {
-    await Interaction
-      .waitForElementVisible('@contact')
-      .assert.visible('@contact')
-      .assert.visible('@serviceProvider')
-      .assert.visible('@service')
-      .assert.visible('@subject')
-      .assert.visible('@notes')
-      .assert.visible('@dateOfInteractionYear')
-      .assert.visible('@dateOfInteractionMonth')
-      .assert.visible('@dateOfInteractionDay')
-      .assert.visible('@ditAdviser')
-      .assert.visible('@communicationChannel')
-      .assert.elementNotPresent('@eventYes')
-      .assert.elementNotPresent('@eventNo')
-      .assert.elementNotPresent('@event')
-  })
+Then(/^there are interaction fields$/, async function () {
+  await Interaction
+    .waitForElementVisible('@contact')
+    .assert.visible('@contact')
+    .assert.visible('@serviceProvider')
+    .assert.visible('@service')
+    .assert.visible('@subject')
+    .assert.visible('@notes')
+    .assert.visible('@dateOfInteractionYear')
+    .assert.visible('@dateOfInteractionMonth')
+    .assert.visible('@dateOfInteractionDay')
+    .assert.visible('@ditAdviser')
+    .assert.visible('@communicationChannel')
+    .assert.elementNotPresent('@eventYes')
+    .assert.elementNotPresent('@eventNo')
+    .assert.elementNotPresent('@event')
+})
 
-  Then(/^there are service delivery fields$/, async function () {
-    await Interaction
-      .waitForElementVisible('@contact')
-      .assert.visible('@contact')
-      .assert.visible('@serviceProvider')
-      .assert.visible('@service')
-      .assert.visible('@subject')
-      .assert.visible('@notes')
-      .assert.visible('@dateOfInteractionYear')
-      .assert.visible('@dateOfInteractionMonth')
-      .assert.visible('@dateOfInteractionDay')
-      .assert.visible('@ditAdviser')
-      .assert.elementNotPresent('@communicationChannel')
-      .assert.visible('@eventYes')
-      .assert.visible('@eventNo')
-      .assert.elementPresent('@event')
-  })
+Then(/^there are service delivery fields$/, async function () {
+  await Interaction
+    .waitForElementVisible('@contact')
+    .assert.visible('@contact')
+    .assert.visible('@serviceProvider')
+    .assert.visible('@service')
+    .assert.visible('@subject')
+    .assert.visible('@notes')
+    .assert.visible('@dateOfInteractionYear')
+    .assert.visible('@dateOfInteractionMonth')
+    .assert.visible('@dateOfInteractionDay')
+    .assert.visible('@ditAdviser')
+    .assert.elementNotPresent('@communicationChannel')
+    .assert.visible('@eventYes')
+    .assert.visible('@eventNo')
+    .assert.elementPresent('@event')
+})
 
-  Then(/^interaction fields are pre-populated$/, async function () {
-    const assertIsSet = (result) => client.expect(result.value.length).to.be.greaterThan(0)
-    // TODO test user does not have a DIT team
-    // await Interaction.getValue('@serviceProvider', assertIsSet)
-    await Interaction.getValue('@dateOfInteractionYear', assertIsSet)
-    await Interaction.getValue('@dateOfInteractionMonth', assertIsSet)
-    await Interaction.getValue('@dateOfInteractionDay', assertIsSet)
-    await Interaction.getValue('@ditAdviser', assertIsSet)
-  })
+Then(/^interaction fields are pre-populated$/, async function () {
+  const assertIsSet = (result) => client.expect(result.value.length).to.be.greaterThan(0)
+  // TODO test user does not have a DIT team
+  // await Interaction.getValue('@serviceProvider', assertIsSet)
+  await Interaction.getValue('@dateOfInteractionYear', assertIsSet)
+  await Interaction.getValue('@dateOfInteractionMonth', assertIsSet)
+  await Interaction.getValue('@dateOfInteractionDay', assertIsSet)
+  await Interaction.getValue('@ditAdviser', assertIsSet)
+})
 
-  Then(/^the interaction events is displayed$/, async function () {
-    await Interaction
-      .assert.visible('@event')
-  })
+Then(/^the interaction events is displayed$/, async function () {
+  await Interaction
+    .assert.visible('@event')
+})
 
-  Then(/^the interaction events is not displayed$/, async function () {
-    await Interaction
-      .assert.hidden('@event')
-  })
+Then(/^the interaction events is not displayed$/, async function () {
+  await Interaction
+    .assert.hidden('@event')
+})
 
-  /**
-   * The filtering available for Interactions and Service Delivery is particularly hard to pin down a specific
-   * Interaction or Service Delivery. This is by design. The filtering here combined with random dates for creation
-   * of an Interaction or Service Delivery should mean we always find what we are looking for in the first
-   * result of the Collection.
-   */
-  Then(/^I filter the collections to view the (.+) I have just created$/, async function (typeOfInteraction) {
-    const filtersSection = InteractionList.section.filters
-    const filterTagsSection = InteractionList.section.filterTags
-    const interactionType = camelCase(typeOfInteraction)
-    const waitForTimeout = 15000
-    const date = getDateFor({
-      year: get(this.state, `${interactionType}.dateOfInteractionYear`),
-      month: get(this.state, `${interactionType}.dateOfInteractionMonth`),
-      day: get(this.state, `${interactionType}.dateOfInteractionDay`),
-    }, 'YYYY-M-D')
+/**
+ * The filtering available for Interactions and Service Delivery is particularly hard to pin down a specific
+ * Interaction or Service Delivery. This is by design. The filtering here combined with random dates for creation
+ * of an Interaction or Service Delivery should mean we always find what we are looking for in the first
+ * result of the Collection.
+ */
+Then(/^I filter the collections to view the (.+) I have just created$/, async function (typeOfInteraction) {
+  const filtersSection = InteractionList.section.filters
+  const filterTagsSection = InteractionList.section.filterTags
+  const interactionType = camelCase(typeOfInteraction)
+  const waitForTimeout = 15000
+  const date = getDateFor({
+    year: get(this.state, `${interactionType}.dateOfInteractionYear`),
+    month: get(this.state, `${interactionType}.dateOfInteractionMonth`),
+    day: get(this.state, `${interactionType}.dateOfInteractionDay`),
+  }, 'YYYY-M-D')
 
+  await filtersSection
+    .waitForElementPresent(`@${interactionType}`)
+    .click(`@${interactionType}`)
+
+  await filterTagsSection
+    .waitForElementPresent('@kind', waitForTimeout)
+
+  await filtersSection
+    .setValue('@dateFrom', date)
+    .sendKeys('@dateFrom', [ client.Keys.ENTER ])
+
+  await filterTagsSection
+    .waitForElementPresent('@dateFrom', waitForTimeout)
+
+  await filtersSection
+    .setValue('@dateTo', date)
+    .sendKeys('@dateTo', [ client.Keys.ENTER ])
+
+  await filterTagsSection
+    .waitForElementPresent('@dateTo', waitForTimeout)
+
+  if (interactionType === 'interaction') {
     await filtersSection
-      .waitForElementPresent(`@${interactionType}`)
-      .click(`@${interactionType}`)
+      .clickMultipleChoiceOption('communication_channel', get(this.state, 'interaction.communicationChannel'))
 
     await filterTagsSection
-      .waitForElementPresent('@kind', waitForTimeout)
-
-    await filtersSection
-      .setValue('@dateFrom', date)
-      .sendKeys('@dateFrom', [ client.Keys.ENTER ])
-
-    await filterTagsSection
-      .waitForElementPresent('@dateFrom', waitForTimeout)
-
-    await filtersSection
-      .setValue('@dateTo', date)
-      .sendKeys('@dateTo', [ client.Keys.ENTER ])
-
-    await filterTagsSection
-      .waitForElementPresent('@dateTo', waitForTimeout)
-
-    if (interactionType === 'interaction') {
-      await filtersSection
-        .clickMultipleChoiceOption('communication_channel', get(this.state, 'interaction.communicationChannel'))
-
-      await filterTagsSection
-        .waitForElementPresent('@communicationChannel', waitForTimeout)
-    }
-  })
+      .waitForElementPresent('@communicationChannel', waitForTimeout)
+  }
 })

--- a/test/acceptance/features/investment-projects/step_definitions/create.js
+++ b/test/acceptance/features/investment-projects/step_definitions/create.js
@@ -1,123 +1,121 @@
 const { get, set, lowerCase, assign, find } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { When } = require('cucumber')
 
 const { getDateFor } = require('../../../helpers/date')
 
-defineSupportCode(({ Given, Then, When }) => {
-  const InvestmentProject = client.page.InvestmentProject()
-  const Location = client.page.Location()
+const InvestmentProject = client.page.InvestmentProject()
+const Location = client.page.Location()
 
-  When(/^I select (.+) as the Investment project type$/, async function (investmentType) {
-    if (lowerCase(investmentType) === 'fdi') {
-      await InvestmentProject
-        .selectFdiTypeOfInvestmentProject({
-          type: 'FDI',
-        }, (investmentProject) => {
-          set(this.state, 'investmentProject', assign({}, get(this.state, 'investmentProject'), investmentProject))
-        })
-    } else {
-      await InvestmentProject
-        .selectNonFdiTypeOfInvestmentProject()
-
-      set(this.state, 'investmentProject.type', 'Non-FDI')
-    }
-  })
-
-  When(/^I choose (.+) for "Will this company be the source of foreign equity investment\?"$/, async function (choice) {
-    if (lowerCase(choice) === 'yes') {
-      set(this.state, 'investmentProject.equitySource.name', get(this.state, 'company.name'))
-    }
-
+When(/^I select (.+) as the Investment project type$/, async function (investmentType) {
+  if (lowerCase(investmentType) === 'fdi') {
     await InvestmentProject
-      .setEquitySource(choice)
-  })
-
-  When(/^I populate the create Investment Project form$/, async function () {
-    await InvestmentProject
-      .section.projectForm
-      .assert.visible('@name')
-      .assert.visible('@description')
-      .assert.visible('@anonymousDescription')
-      .assert.visible('@primarySector')
-      .assert.visible('@businessActivity')
-      .assert.visible('@otherBusinessActivity')
-      .assert.visible('@clientRelationshipManagerYes')
-      .assert.visible('@clientRelationshipManagerNo')
-      .assert.visible('@referralSourceYes')
-      .assert.visible('@referralSourceNo')
-      .assert.visible('@estimatedLandDateYear')
-      .assert.visible('@estimatedLandDateMonth')
-      .assert.visible('@actualLandDateYear')
-      .assert.visible('@actualLandDateMonth')
-      .assert.visible('@actualLandDateDay')
-      .assert.visible('@investorType')
-      .assert.visible('@levelOfInvolvement')
-      .assert.visible('@specificInvestmentProgramme')
-      .assert.visible('@clientContact')
-      .assert.visible('@saveButton')
-
-    await InvestmentProject
-      .populateForm((investmentProject) => {
+      .selectFdiTypeOfInvestmentProject({
+        type: 'FDI',
+      }, (investmentProject) => {
         set(this.state, 'investmentProject', assign({}, get(this.state, 'investmentProject'), investmentProject))
-        set(this.state, 'investmentProject.heading', investmentProject.name)
-        set(this.state, 'investmentProject.estimatedLandDate', getDateFor({
-          year: this.state.investmentProject.estimatedLandDateYear,
-          month: this.state.investmentProject.estimatedLandDateMonth,
-          day: 1,
-        }, 'MMMM YYYY'))
-
-        set(this.state, 'investmentProject.actualLandDate', getDateFor({
-          year: this.state.investmentProject.actualLandDateYear,
-          month: this.state.investmentProject.actualLandDateMonth,
-          day: this.state.investmentProject.actualLandDateDay,
-        }))
-
-        const { businessActivity, otherBusinessActivity } = this.state.investmentProject
-        set(this.state, 'investmentProject.businessActivities', `${businessActivity}, ${otherBusinessActivity}`)
       })
-  })
-
-  When(/^I navigate to the Investment Projects source of equity investment$/, async function () {
-    const equitySource = get(this.state, 'investmentProject.equitySource.name')
-    const projectSummarySection = InvestmentProject.section.projectDetails.section.summary
-
-    await projectSummarySection
-      .assert.containsText('@header', 'Investment project summary')
-      .assert.containsText('@clientLink', equitySource)
-      .waitForElementPresent('@header')
-
+  } else {
     await InvestmentProject
-      .storeProjectDetails((projectDetails) => {
-        set(this.state, 'investmentProject', assign({}, projectDetails, get(this.state, 'investmentProject')))
-      })
+      .selectNonFdiTypeOfInvestmentProject()
 
-    await projectSummarySection
-      .click('@clientLink')
+    set(this.state, 'investmentProject.type', 'Non-FDI')
+  }
+})
 
-    await InvestmentProject
-      .section.localHeader
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', equitySource)
+When(/^I choose (.+) for "Will this company be the source of foreign equity investment\?"$/, async function (choice) {
+  if (lowerCase(choice) === 'yes') {
+    set(this.state, 'investmentProject.equitySource.name', get(this.state, 'company.name'))
+  }
 
-    await Location
-      .section.localNav
-      .waitForElementPresent('@investment')
-      .click('@investment')
-  })
+  await InvestmentProject
+    .setEquitySource(choice)
+})
 
-  When(/^I search for the foreign source of equity (.+)$/, async function (companyName) {
-    const sourceOfForeignEquity = find(this.fixtures.company, ['name', companyName])
+When(/^I populate the create Investment Project form$/, async function () {
+  await InvestmentProject
+    .section.projectForm
+    .assert.visible('@name')
+    .assert.visible('@description')
+    .assert.visible('@anonymousDescription')
+    .assert.visible('@primarySector')
+    .assert.visible('@businessActivity')
+    .assert.visible('@otherBusinessActivity')
+    .assert.visible('@clientRelationshipManagerYes')
+    .assert.visible('@clientRelationshipManagerNo')
+    .assert.visible('@referralSourceYes')
+    .assert.visible('@referralSourceNo')
+    .assert.visible('@estimatedLandDateYear')
+    .assert.visible('@estimatedLandDateMonth')
+    .assert.visible('@actualLandDateYear')
+    .assert.visible('@actualLandDateMonth')
+    .assert.visible('@actualLandDateDay')
+    .assert.visible('@investorType')
+    .assert.visible('@levelOfInvolvement')
+    .assert.visible('@specificInvestmentProgramme')
+    .assert.visible('@clientContact')
+    .assert.visible('@saveButton')
 
-    await InvestmentProject
-      .searchForEquitySourceCompany(sourceOfForeignEquity.name)
+  await InvestmentProject
+    .populateForm((investmentProject) => {
+      set(this.state, 'investmentProject', assign({}, get(this.state, 'investmentProject'), investmentProject))
+      set(this.state, 'investmentProject.heading', investmentProject.name)
+      set(this.state, 'investmentProject.estimatedLandDate', getDateFor({
+        year: this.state.investmentProject.estimatedLandDateYear,
+        month: this.state.investmentProject.estimatedLandDateMonth,
+        day: 1,
+      }, 'MMMM YYYY'))
 
-    set(this.state, 'investmentProject.equitySource', {
-      name: sourceOfForeignEquity.name,
-      heading: sourceOfForeignEquity.name,
-      address: `${sourceOfForeignEquity.address1}, ${sourceOfForeignEquity.town}, ${sourceOfForeignEquity.postcode}`,
-      country: sourceOfForeignEquity.country,
+      set(this.state, 'investmentProject.actualLandDate', getDateFor({
+        year: this.state.investmentProject.actualLandDateYear,
+        month: this.state.investmentProject.actualLandDateMonth,
+        day: this.state.investmentProject.actualLandDateDay,
+      }))
+
+      const { businessActivity, otherBusinessActivity } = this.state.investmentProject
+      set(this.state, 'investmentProject.businessActivities', `${businessActivity}, ${otherBusinessActivity}`)
     })
-    set(this.state, 'equitySource.heading', sourceOfForeignEquity.name)
+})
+
+When(/^I navigate to the Investment Projects source of equity investment$/, async function () {
+  const equitySource = get(this.state, 'investmentProject.equitySource.name')
+  const projectSummarySection = InvestmentProject.section.projectDetails.section.summary
+
+  await projectSummarySection
+    .assert.containsText('@header', 'Investment project summary')
+    .assert.containsText('@clientLink', equitySource)
+    .waitForElementPresent('@header')
+
+  await InvestmentProject
+    .storeProjectDetails((projectDetails) => {
+      set(this.state, 'investmentProject', assign({}, projectDetails, get(this.state, 'investmentProject')))
+    })
+
+  await projectSummarySection
+    .click('@clientLink')
+
+  await InvestmentProject
+    .section.localHeader
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', equitySource)
+
+  await Location
+    .section.localNav
+    .waitForElementPresent('@investment')
+    .click('@investment')
+})
+
+When(/^I search for the foreign source of equity (.+)$/, async function (companyName) {
+  const sourceOfForeignEquity = find(this.fixtures.company, ['name', companyName])
+
+  await InvestmentProject
+    .searchForEquitySourceCompany(sourceOfForeignEquity.name)
+
+  set(this.state, 'investmentProject.equitySource', {
+    name: sourceOfForeignEquity.name,
+    heading: sourceOfForeignEquity.name,
+    address: `${sourceOfForeignEquity.address1}, ${sourceOfForeignEquity.town}, ${sourceOfForeignEquity.postcode}`,
+    country: sourceOfForeignEquity.country,
   })
+  set(this.state, 'equitySource.heading', sourceOfForeignEquity.name)
 })

--- a/test/acceptance/features/investment-projects/step_definitions/value.js
+++ b/test/acceptance/features/investment-projects/step_definitions/value.js
@@ -1,5 +1,5 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { When } = require('cucumber')
 const {
   set,
   get,
@@ -9,15 +9,13 @@ const {
   camelCase,
 } = require('lodash')
 
-defineSupportCode(({ When }) => {
-  const InvestmentValue = client.page.InvestmentValue()
+const InvestmentValue = client.page.InvestmentValue()
 
-  When(/^I populate the create investment project value form$/, async function (dataTable) {
-    const details = fromPairs(map(dataTable.hashes(), hash => [camelCase(hash.key), hash.value]))
-    await InvestmentValue
-      .add(details, (value) => {
-        const investmentProject = get(this.state, 'investmentProject')
-        set(this.state, 'investmentProject', assign({}, investmentProject, { value }))
-      })
-  })
+When(/^I populate the create investment project value form$/, async function (dataTable) {
+  const details = fromPairs(map(dataTable.hashes(), hash => [camelCase(hash.key), hash.value]))
+  await InvestmentValue
+    .add(details, (value) => {
+      const investmentProject = get(this.state, 'investmentProject')
+      set(this.state, 'investmentProject', assign({}, investmentProject, { value }))
+    })
 })

--- a/test/acceptance/features/location/step_definitions/location.js
+++ b/test/acceptance/features/location/step_definitions/location.js
@@ -1,6 +1,6 @@
 const { find, assign, set, get, camelCase, includes } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Given, Then, When } = require('cucumber')
 
 const formatters = require('../../../helpers/formatters')
 
@@ -19,128 +19,126 @@ function getExpectedValue (row, state) {
   return row.value
 }
 
-defineSupportCode(({ Given, When, Then }) => {
-  const Location = client.page.Location()
-  const Search = client.page.Search()
+const Location = client.page.Location()
+const Search = client.page.Search()
 
-  Given(/^I navigate to (.+) fixture (.+)$/, async function (entityType, fixtureName) {
-    const entityTypeFieldName = camelCase(entityType)
-    const fixtureDetails = find(this.fixtures[entityTypeFieldName], ['name', fixtureName])
-    set(this.state, entityTypeFieldName, assign({}, get(this.state, entityTypeFieldName), fixtureDetails))
+Given(/^I navigate to (.+) fixture (.+)$/, async function (entityType, fixtureName) {
+  const entityTypeFieldName = camelCase(entityType)
+  const fixtureDetails = find(this.fixtures[entityTypeFieldName], ['name', fixtureName])
+  set(this.state, entityTypeFieldName, assign({}, get(this.state, entityTypeFieldName), fixtureDetails))
 
-    await Search
-      .navigate()
-      .search(fixtureName)
+  await Search
+    .navigate()
+    .search(fixtureName)
 
-    await Search
-      .section.tabs
-      .waitForElementPresent(`@${entityTypeFieldName}`)
-      .click(`@${entityTypeFieldName}`)
+  await Search
+    .section.tabs
+    .waitForElementPresent(`@${entityTypeFieldName}`)
+    .click(`@${entityTypeFieldName}`)
 
-    await Search
-      .section.firstSearchResult
-      .waitForElementPresent('@header')
-      .click('@header')
+  await Search
+    .section.firstSearchResult
+    .waitForElementPresent('@header')
+    .click('@header')
 
-    await Location
-      .section.localHeader
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', fixtureName)
-  })
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', fixtureName)
+})
 
-  Given(/^I navigate directly to ([^\s]+)$/, async function (path) {
-    await client.url(process.env.QA_HOST + path)
-  })
+Given(/^I navigate directly to ([^\s]+)$/, async function (path) {
+  await client.url(process.env.QA_HOST + path)
+})
 
-  Given(/^I navigate directly to ([^\s]+) of (.+) fixture (.+)$/, async function (path, entityType, fixtureName) {
-    const entityTypeFieldName = camelCase(entityType)
-    const fixtureDetails = find(this.fixtures[entityTypeFieldName], ['name', fixtureName])
-    const collection = this.urls[entityTypeFieldName].collection
-    const url = `${collection}/${fixtureDetails.pk}${path}`
+Given(/^I navigate directly to ([^\s]+) of (.+) fixture (.+)$/, async function (path, entityType, fixtureName) {
+  const entityTypeFieldName = camelCase(entityType)
+  const fixtureDetails = find(this.fixtures[entityTypeFieldName], ['name', fixtureName])
+  const collection = this.urls[entityTypeFieldName].collection
+  const url = `${collection}/${fixtureDetails.pk}${path}`
 
-    await client.url(url)
-  })
+  await client.url(url)
+})
 
-  When(/^I click the (.+) global nav link/, async (globalNavLinkText) => {
-    const globalNavLinkSelector = Location.section.globalNav.getGlobalNavLinkSelector(globalNavLinkText)
+When(/^I click the (.+) global nav link/, async (globalNavLinkText) => {
+  const globalNavLinkSelector = Location.section.globalNav.getGlobalNavLinkSelector(globalNavLinkText)
 
-    await Location
-      .navigate()
-      .section.globalNav
+  await Location
+    .navigate()
+    .section.globalNav
+    .api.useXpath()
+    .waitForElementVisible(globalNavLinkSelector.selector)
+    .click(globalNavLinkSelector.selector)
+    .useCss()
+})
+
+When(/^I click the (.+) local nav link$/, async (localNavLinkText) => {
+  const localNavLinkSelector = Location.section.localNav.getLocalNavLinkSelector(localNavLinkText)
+
+  await Location.section.localNav
+    .api.useXpath()
+    .waitForElementVisible(localNavLinkSelector.selector)
+    .click(localNavLinkSelector.selector)
+    .useCss()
+})
+
+When(/^I click the local header link$/, async () => {
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@headerLink')
+    .click('@headerLink')
+})
+
+Then(/^I am taken to the "(.+)" page$/, async (text) => {
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', text)
+})
+
+Then(/^I confirm I am on the (.+) page$/, async (text) => {
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', text)
+})
+
+Then(/^I wait and then refresh the page$/, async () => {
+  await client
+    .wait()
+    .refresh()
+})
+
+Then(/^the (.+) local header is displayed$/, async function (entityType, dataTable) {
+  const expectedHeading = get(this.state, `${camelCase(entityType)}.name`)
+  const expectedHeaderMetas = dataTable.hashes()
+
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', expectedHeading)
+
+  for (const row of expectedHeaderMetas) {
+    const headerMetaValueSelector = Location.section.localHeader.getHeaderMetaValueSelector(row.key).selector
+    const expectedValue = getExpectedValue(row, this.state)
+    await Location.section.localHeader
       .api.useXpath()
-      .waitForElementVisible(globalNavLinkSelector.selector)
-      .click(globalNavLinkSelector.selector)
+      .waitForElementPresent(headerMetaValueSelector)
+      .getText(headerMetaValueSelector, (actual) => {
+        if (row.formatter) {
+          return client.expect(formatters[row.formatter](expectedValue, actual.value), row.key).to.be.true
+        }
+        client.expect(actual.value, row.key).to.equal(expectedValue)
+      })
       .useCss()
-  })
+  }
+})
 
-  When(/^I click the (.+) local nav link$/, async (localNavLinkText) => {
-    const localNavLinkSelector = Location.section.localNav.getLocalNavLinkSelector(localNavLinkText)
+Then(/^I see the ([0-9]+) error page$/, async function (statusCode) {
+  const headingSelector = Location.getHeading('//h3', statusCode).selector
 
-    await Location.section.localNav
-      .api.useXpath()
-      .waitForElementVisible(localNavLinkSelector.selector)
-      .click(localNavLinkSelector.selector)
-      .useCss()
-  })
-
-  When(/^I click the local header link$/, async () => {
-    await Location
-      .section.localHeader
-      .waitForElementPresent('@headerLink')
-      .click('@headerLink')
-  })
-
-  Then(/^I am taken to the "(.+)" page$/, async (text) => {
-    await Location
-      .section.localHeader
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', text)
-  })
-
-  Then(/^I confirm I am on the (.+) page$/, async (text) => {
-    await Location
-      .section.localHeader
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', text)
-  })
-
-  Then(/^I wait and then refresh the page$/, async () => {
-    await client
-      .wait()
-      .refresh()
-  })
-
-  Then(/^the (.+) local header is displayed$/, async function (entityType, dataTable) {
-    const expectedHeading = get(this.state, `${camelCase(entityType)}.name`)
-    const expectedHeaderMetas = dataTable.hashes()
-
-    await Location
-      .section.localHeader
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', expectedHeading)
-
-    for (const row of expectedHeaderMetas) {
-      const headerMetaValueSelector = Location.section.localHeader.getHeaderMetaValueSelector(row.key).selector
-      const expectedValue = getExpectedValue(row, this.state)
-      await Location.section.localHeader
-        .api.useXpath()
-        .waitForElementPresent(headerMetaValueSelector)
-        .getText(headerMetaValueSelector, (actual) => {
-          if (row.formatter) {
-            return client.expect(formatters[row.formatter](expectedValue, actual.value), row.key).to.be.true
-          }
-          client.expect(actual.value, row.key).to.equal(expectedValue)
-        })
-        .useCss()
-    }
-  })
-
-  Then(/^I see the ([0-9]+) error page$/, async function (statusCode) {
-    const headingSelector = Location.getHeading('//h3', statusCode).selector
-
-    await Location
-      .api.useXpath()
-      .assert.visible(headingSelector)
-      .useCss()
-  })
+  await Location
+    .api.useXpath()
+    .assert.visible(headingSelector)
+    .useCss()
 })

--- a/test/acceptance/features/messages/step_definitions/message.js
+++ b/test/acceptance/features/messages/step_definitions/message.js
@@ -1,11 +1,9 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then } = require('cucumber')
 
-defineSupportCode(({ Then }) => {
-  const Message = client.page.Message()
+const Message = client.page.Message()
 
-  Then(/^I see the (success|error) message$/, async (messageType) => {
-    await Message
-      .verifyMessage(messageType)
-  })
+Then(/^I see the (success|error) message$/, async (messageType) => {
+  await Message
+    .verifyMessage(messageType)
 })

--- a/test/acceptance/features/search/step_definitions/search.js
+++ b/test/acceptance/features/search/step_definitions/search.js
@@ -1,98 +1,96 @@
 /* eslint-disable camelcase */
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const { getDateFor } = require('../../../helpers/date')
 
-defineSupportCode(function ({ Then, When }) {
-  const Search = client.page.Search()
-  const Dashboard = client.page.Dashboard()
+const Search = client.page.Search()
+const Dashboard = client.page.Dashboard()
 
-  When(/^I search for the created (.+)/, async function (entityType) {
-    await Dashboard
-      .navigate()
+When(/^I search for the created (.+)/, async function (entityType) {
+  await Dashboard
+    .navigate()
 
-    await Search
-      .search(this.state[entityType].uniqueSearchTerm)
-  })
+  await Search
+    .search(this.state[entityType].uniqueSearchTerm)
+})
 
-  When(/^the (.+) search tab is clicked/, async (tabText) => {
-    const searchTabSelector = Search.section.tabs.getSearchResultsTabSelector(tabText)
+When(/^the (.+) search tab is clicked/, async (tabText) => {
+  const searchTabSelector = Search.section.tabs.getSearchResultsTabSelector(tabText)
 
-    await Search.section.tabs
-      .api.useXpath()
-      .waitForElementVisible(searchTabSelector.selector)
-      .click(searchTabSelector.selector)
-      .useCss()
-  })
+  await Search.section.tabs
+    .api.useXpath()
+    .waitForElementVisible(searchTabSelector.selector)
+    .click(searchTabSelector.selector)
+    .useCss()
+})
 
-  When(/^the first search result is clicked/, async () => {
-    await Search
-      .section.firstSearchResult
-      .waitForElementVisible('@header')
-      .click('@header')
-  })
+When(/^the first search result is clicked/, async () => {
+  await Search
+    .section.firstSearchResult
+    .waitForElementVisible('@header')
+    .click('@header')
+})
 
-  Then(/^I verify the search tabs are displayed$/, async (expectedSearchTabs) => {
-    for (const expectedSearchTab of expectedSearchTabs.hashes()) {
-      const searchTabSelector = Search.section.tabs.getSearchResultsTabSelector(expectedSearchTab.text)
-
-      await Search.section.tabs
-        .api.useXpath()
-        .waitForElementPresent(searchTabSelector.selector)
-        .assert.visible(searchTabSelector.selector)
-        .useCss()
-    }
-  })
-
-  Then(/^the (.+) search tab has ([0-9]+) results/, async (tabText, resultsCount) => {
-    const searchTabSelector = Search.section.tabs.getSearchResultsTabSelector(tabText)
+Then(/^I verify the search tabs are displayed$/, async (expectedSearchTabs) => {
+  for (const expectedSearchTab of expectedSearchTabs.hashes()) {
+    const searchTabSelector = Search.section.tabs.getSearchResultsTabSelector(expectedSearchTab.text)
 
     await Search.section.tabs
       .api.useXpath()
       .waitForElementPresent(searchTabSelector.selector)
-      .assert.cssClassPresent(searchTabSelector.selector, 'is-active')
+      .assert.visible(searchTabSelector.selector)
       .useCss()
+  }
+})
 
-    await Search
-      .assert.visible('@resultsCount')
-      .assert.containsText('@resultsCount', resultsCount)
-  })
+Then(/^the (.+) search tab has ([0-9]+) results/, async (tabText, resultsCount) => {
+  const searchTabSelector = Search.section.tabs.getSearchResultsTabSelector(tabText)
 
-  Then(/^I can view the event in the search results/, async function () {
-    const {
-      start_date_year,
-      start_date_month,
-      start_date_day,
-      end_date_year,
-      end_date_month,
-      end_date_day,
-    } = this.state.event
+  await Search.section.tabs
+    .api.useXpath()
+    .waitForElementPresent(searchTabSelector.selector)
+    .assert.cssClassPresent(searchTabSelector.selector, 'is-active')
+    .useCss()
 
-    const expectedStartDate = getDateFor({ year: start_date_year, month: start_date_month, day: start_date_day })
-    const expectedEndDate = getDateFor({ year: end_date_year, month: end_date_month, day: end_date_day })
+  await Search
+    .assert.visible('@resultsCount')
+    .assert.containsText('@resultsCount', resultsCount)
+})
 
-    await Search.section.firstEventSearchResult
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', this.state.event.name)
-      .assert.containsText('@eventType', this.state.event.event_type)
-      .assert.containsText('@country', this.state.event.address_country)
-      .assert.containsText('@eventStart', expectedStartDate)
-      .assert.containsText('@eventEnd', expectedEndDate)
-      .assert.containsText('@organiser', this.state.event.organiser)
-      .assert.containsText('@leadTeam', this.state.event.lead_team)
-  })
+Then(/^I can view the event in the search results/, async function () {
+  const {
+    start_date_year,
+    start_date_month,
+    start_date_day,
+    end_date_year,
+    end_date_month,
+    end_date_day,
+  } = this.state.event
 
-  Then(/^I can view the company in the search results/, async function () {
-    const {
-      name,
-      sector,
-      primaryAddress,
-    } = this.state.company
+  const expectedStartDate = getDateFor({ year: start_date_year, month: start_date_month, day: start_date_day })
+  const expectedEndDate = getDateFor({ year: end_date_year, month: end_date_month, day: end_date_day })
 
-    await Search.section.firstCompanySearchResult
-      .waitForElementPresent('@header')
-      .assert.containsText('@header', name)
-      .assert.containsText('@sector', sector)
-      .assert.containsText('@registeredAddress', primaryAddress)
-  })
+  await Search.section.firstEventSearchResult
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', this.state.event.name)
+    .assert.containsText('@eventType', this.state.event.event_type)
+    .assert.containsText('@country', this.state.event.address_country)
+    .assert.containsText('@eventStart', expectedStartDate)
+    .assert.containsText('@eventEnd', expectedEndDate)
+    .assert.containsText('@organiser', this.state.event.organiser)
+    .assert.containsText('@leadTeam', this.state.event.lead_team)
+})
+
+Then(/^I can view the company in the search results/, async function () {
+  const {
+    name,
+    sector,
+    primaryAddress,
+  } = this.state.company
+
+  await Search.section.firstCompanySearchResult
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', name)
+    .assert.containsText('@sector', sector)
+    .assert.containsText('@registeredAddress', primaryAddress)
 })

--- a/test/acceptance/features/setup/hooks.js
+++ b/test/acceptance/features/setup/hooks.js
@@ -1,7 +1,5 @@
-const { defineSupportCode } = require('cucumber')
+const { Before } = require('cucumber')
 
-defineSupportCode(({ Before }) => {
-  Before(function () {
-    this.resetState()
-  })
+Before(function () {
+  this.resetState()
 })

--- a/test/acceptance/features/setup/world.js
+++ b/test/acceptance/features/setup/world.js
@@ -1,6 +1,6 @@
 const fixtures = require('./fixtures')
 const urls = require('./urls')
-const { defineSupportCode } = require('cucumber')
+const { setWorldConstructor } = require('cucumber')
 
 /**
  * setup state object to be used across UAT tests
@@ -15,6 +15,4 @@ function World () {
   this.resetState()
 }
 
-defineSupportCode(({ setWorldConstructor }) => {
-  setWorldConstructor(World)
-})
+setWorldConstructor(World)

--- a/test/acceptance/features/support/step_definitions/support.js
+++ b/test/acceptance/features/support/step_definitions/support.js
@@ -1,34 +1,32 @@
 const { client } = require('nightwatch-cucumber')
-const { defineSupportCode } = require('cucumber')
+const { Then, When } = require('cucumber')
 const { get, set } = require('lodash')
 
-defineSupportCode(({ When, Then }) => {
-  const Support = client.page.Support()
+const Support = client.page.Support()
 
-  When(/^the support Send button is clicked$/, async function () {
-    await Support.section.form
-      .click('@sendButton')
-  })
+When(/^the support Send button is clicked$/, async function () {
+  await Support.section.form
+    .click('@sendButton')
+})
 
-  Then(/^the support fields have error messages$/, async function () {
-    await Support.section.form
-      .assert.visible('@titleError')
-      .assert.visible('@chooseOneOfTheseError')
-      .assert.visible('@emailError')
-  })
+Then(/^the support fields have error messages$/, async function () {
+  await Support.section.form
+    .assert.visible('@titleError')
+    .assert.visible('@chooseOneOfTheseError')
+    .assert.visible('@emailError')
+})
 
-  Then(/^a new support request is created$/, async function () {
-    await Support
-      .createSupportTicket({}, (supportRequest) => {
-        set(this.state, 'supportRequest', supportRequest)
-      })
-  })
+Then(/^a new support request is created$/, async function () {
+  await Support
+    .createSupportTicket({}, (supportRequest) => {
+      set(this.state, 'supportRequest', supportRequest)
+    })
+})
 
-  Then(/^the success message contains the ticket ID/, async function () {
-    const ticketId = get(this.state, 'ticket.id')
-    const expectedText = `Created new report, reference number ${ticketId}`
+Then(/^the success message contains the ticket ID/, async function () {
+  const ticketId = get(this.state, 'ticket.id')
+  const expectedText = `Created new report, reference number ${ticketId}`
 
-    await Support
-      .assert.containsText('@flashMessage', expectedText)
-  })
+  await Support
+    .assert.containsText('@flashMessage', expectedText)
 })

--- a/test/acceptance/global.cucumber.js
+++ b/test/acceptance/global.cucumber.js
@@ -1,5 +1,3 @@
-const { defineSupportCode } = require('cucumber')
+const { setDefaultTimeout } = require('cucumber')
 
-defineSupportCode(({ setDefaultTimeout }) => {
-  setDefaultTimeout(300000)
-})
+setDefaultTimeout(300000)


### PR DESCRIPTION
Nightwatch cucumber has deprecated support for defineSupportCode and
methods should be imported individually from cucumber.

This change replaces the use of defineSupportCode with individual
imports.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
