### PR TITLE
DH-1467 Fix oauth stateid mismatch part 2

### DIFF
--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -1,4 +1,3 @@
-const request = require('request-promise')
 const queryString = require('query-string')
 const uuid = require('uuid')
 
@@ -6,23 +5,7 @@ const { get, set } = require('lodash')
 
 const config = require('./../../../config')
 const logger = require('./../../../config/logger') // @TODO remove this once we've diagnosed the cause of the mismatches
-
-function getAccessToken (oauthCode) {
-  const options = {
-    method: 'POST',
-    url: config.oauth.tokenFetchUrl,
-    formData: {
-      code: oauthCode,
-      grant_type: 'authorization_code',
-      client_id: config.oauth.clientId,
-      client_secret: config.oauth.clientSecret,
-      redirect_uri: config.oauth.redirectUri,
-    },
-    json: true,
-  }
-
-  return request(options)
-}
+const { getAccessToken } = require('./services')
 
 async function callbackOAuth (req, res, next) {
   const errorQueryParam = get(req.query, 'error')

--- a/src/apps/oauth/services.js
+++ b/src/apps/oauth/services.js
@@ -1,0 +1,24 @@
+const request = require('request-promise')
+
+const config = require('./../../../config')
+
+function getAccessToken (oauthCode) {
+  const options = {
+    method: 'POST',
+    url: config.oauth.tokenFetchUrl,
+    formData: {
+      code: oauthCode,
+      grant_type: 'authorization_code',
+      client_id: config.oauth.clientId,
+      client_secret: config.oauth.clientSecret,
+      redirect_uri: config.oauth.redirectUri,
+    },
+    json: true,
+  }
+
+  return request(options)
+}
+
+module.exports = {
+  getAccessToken,
+}

--- a/src/lib/session-helper.js
+++ b/src/lib/session-helper.js
@@ -1,0 +1,23 @@
+const logger = require('./../../config/logger')
+
+/**
+ * Promise wrapper around expressjs session reload callback method
+ * @param session
+ * @returns {Promise}
+ */
+function reloadSession ({ session }) {
+  return new Promise((resolve, reject) => {
+    session.reload((error) => {
+      if (error) {
+        return reject(error)
+      }
+
+      logger.error('Session reloaded')
+      resolve()
+    })
+  })
+}
+
+module.exports = {
+  reloadSession,
+}

--- a/test/unit/apps/oauth/controllers.test.js
+++ b/test/unit/apps/oauth/controllers.test.js
@@ -1,6 +1,8 @@
 const queryString = require('query-string')
 const { assign, set } = require('lodash')
 
+const sessionHelper = require('~/src/lib/session-helper')
+
 describe('OAuth controller', () => {
   beforeEach(() => {
     this.mockUuid = sandbox.stub().returns(this.mockUUIDvalue)
@@ -8,12 +10,16 @@ describe('OAuth controller', () => {
     this.services = proxyquire.noCallThru().load('~/src/apps/oauth/services', {
       './../../../config': this.mockConfig,
     })
+    this.reloadSessionStub = sandbox.stub(sessionHelper, 'reloadSession')
     this.getAccessTokenSpy = sandbox.spy(this.services, 'getAccessToken')
     this.controller = proxyquire('~/src/apps/oauth/controllers', {
       './../../../config': this.mockConfig,
       'uuid': this.mockUuid,
       './services': {
         getAccessToken: this.getAccessTokenSpy,
+      },
+      './../../lib/session-helper': {
+        reloadSession: this.reloadSessionStub,
       },
     })
     this.mockOauthAccessToken = 'mockAccessToken'
@@ -110,6 +116,73 @@ describe('OAuth controller', () => {
 
   describe('#callbackOAuth', () => {
     context('with the state query param in the url', () => {
+      context('an "undefined" oauth state in the session', () => {
+        beforeEach(() => {
+          set(this.reqMock, 'query', {
+            state: this.mockStateId,
+            code: this.mockAuthCode,
+          })
+          set(this.reqMock, 'session.oauth.state', undefined)
+
+          nock(this.mockFetchUrl.host)
+            .post(this.mockFetchUrl.path)
+            .reply(200, { access_token: this.mockOauthAccessToken })
+        })
+
+        context('reload session resolves', () => {
+          beforeEach(async () => {
+            this.reloadSessionStub.resolves().callsFake(() => {
+              set(this.reqMock, 'session.oauth.state', this.mockStateId)
+            })
+
+            await this.controller.callbackOAuth(this.reqMock, this.resMock, this.nextSpy)
+          })
+
+          it('should call reloadSession', () => {
+            expect(this.reloadSessionStub).to.have.been.calledOnce
+          })
+
+          it('should call getAccessToken', () => {
+            expect(this.getAccessTokenSpy).to.have.been.calledOnce
+          })
+
+          it('should call getAccessToken with arguments', () => {
+            expect(this.getAccessTokenSpy).to.have.been.calledWith(this.mockAuthCode)
+          })
+
+          it('should complete the callbackOAuth call', () => {
+            expect(this.resMock.redirect).to.have.been.calledOnce
+            expect(this.resMock.redirect).to.have.been.calledWith('/')
+          })
+
+          it('token should match expected value', () => {
+            expect(this.reqMock.session.token).to.equal(this.mockOauthAccessToken)
+          })
+        })
+
+        context('reload session rejects', () => {
+          beforeEach(async () => {
+            this.returnedError = 'oh no!'
+            this.reloadSessionStub.rejects(this.returnedError)
+
+            await this.controller.callbackOAuth(this.reqMock, this.resMock, this.nextSpy)
+          })
+
+          it('should call reloadSession', () => {
+            expect(this.reloadSessionStub).to.have.been.calledOnce
+          })
+
+          it('should handle error as expected', () => {
+            expect(this.nextSpy).to.have.been.calledOnce
+            expect(this.nextSpy.args[0][0].name).to.equal(this.returnedError)
+          })
+
+          it('token should be undefined', () => {
+            expect(this.reqMock.session.token).to.be.undefined
+          })
+        })
+      })
+
       context('and a state mismatch', () => {
         beforeEach(() => {
           set(this.reqMock, 'query.state', this.mockStateId)


### PR DESCRIPTION
## Suspected problem
A user comes into datahub and goes through SSO
- they are on instance `a`
- in the `redirectOAuth` method `stateId` is saved to the session
- then SSO redirects back to the application but this time to instance `b`
- the session on instance `b` is not in sync with redis so the `stateId` is not present in its session
- the error [in sentry](https://sentry.ci.uktrade.io/dit/front-end/issues/3045/?referrer=slack) then occurs

After reverse engineering the journey it appears that everything is ok apart from we don't sync instances. So part 2 of this investigation adds `reloadSession` which will reload a session from `redis` using the ID in our session cookie. 

Due to complications in testing this PR also has work that splits out the rather fat controller into teh relvant files, it also updates the tests to reflect the work and the splitting out.

### Of note
all the logging will be going ocne this fix is confirmed
