### PR TITLE
DH-1467 Fix/oauth stateid mismatch part 02

### DIFF
--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -1,11 +1,11 @@
 const request = require('request-promise')
 const queryString = require('query-string')
 const uuid = require('uuid')
-
-const { get, set } = require('lodash')
+const { get, set, isUndefined } = require('lodash')
 
 const config = require('./../../../config')
 const logger = require('./../../../config/logger') // @TODO remove this once we've diagnosed the cause of the mismatches
+const { reloadSession } = require('./../../lib/session-helper')
 
 function getAccessToken (code) {
   const options = {
@@ -27,10 +27,21 @@ function getAccessToken (code) {
 async function callbackOAuth (req, res, next) {
   const errorQueryParam = get(req.query, 'error')
   const stateQueryParam = get(req.query, 'state')
-  const sessionOAuthState = get(req.session, 'oauth.state')
+  let sessionOAuthState = get(req.session, 'oauth.state')
 
   if (errorQueryParam) {
     return renderHelpPage(req, res, next)
+  }
+
+  logger.error('session:', req.session) // @TODO remove this once we've diagnosed the cause of the mismatches
+
+  if (isUndefined(sessionOAuthState)) { // an instance is not in sync with the Redis session store
+    try {
+      await reloadSession(req)
+      sessionOAuthState = get(req.session, 'oauth.state')
+    } catch (error) {
+      return next(error)
+    }
   }
 
   if (sessionOAuthState !== stateQueryParam) {

--- a/src/lib/session-helper.js
+++ b/src/lib/session-helper.js
@@ -1,0 +1,23 @@
+const logger = require('./../../config/logger')
+
+/**
+ * Promise wrapper around expressjs session reload callback method
+ * @param session
+ * @returns {Promise}
+ */
+function reloadSession ({ session }) {
+  return new Promise((resolve, reject) => {
+    session.reload((error) => {
+      if (error) {
+        return reject(error)
+      }
+
+      logger.error('Session reloaded')
+      resolve()
+    })
+  })
+}
+
+module.exports = {
+  reloadSession,
+}


### PR DESCRIPTION
# What we know so far
This work has been split out into its own PR as I cannot reproduce the problem seen in production in staging.

The session between instances on staging updates as expected and the `reloadSession` is never called. Even when the SSO journey starts on 1 instance and redirects to a different instance.

So the next step will be to look at why staging and production are behaving differently. This will stay as `WIP` until we have worked out if it is needed in the codebase or not.

## Potentially Redis setup
After speaking with webops it turns out that there may be other reasons that this is occurring and also why it may not be reproducible in staging. Details (if interested) can be seen in `Jira > DH-1467`


## Suspected problem
~~A user comes into datahub and goes through SSO~~
~~- they are on instance `a`~~
~~- in the `redirectOAuth` method `stateId` is saved to the session~~
~~- then SSO redirects back to the application but this time to instance `b`~~
~~- the session on instance `b` is not in sync with redis so the `stateId` is not present in its session~~
~~- the error [in sentry](https://sentry.ci.uktrade.io/dit/front-end/issues/3045/?referrer=slack) then occurs~~

~~After reverse engineering the journey it appears that everything is ok apart from we don't~~ 
~~sync instances. So part 2 of this investigation adds `reloadSession` which will reload a~~ 
~~session from `redis` using the ID in our session cookie.~~

### Of note
all the logging will be going once this fix is confirmed
