### PR TITLE
Acceptance tests/fixture step definition

### DIFF
--- a/test/acceptance/features/audit/contact.feature
+++ b/test/acceptance/features/audit/contact.feature
@@ -7,8 +7,8 @@ Feature: View Audit history of a contact
   @audit-contact--fields
   Scenario: View name of the person who made contact record changes
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form
@@ -26,8 +26,8 @@ Feature: View Audit history of a contact
   @audit-contact--count
   Scenario: View the number of changes occurred on a contact record
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     Then a primary contact is added
     When I submit the form
@@ -42,8 +42,8 @@ Feature: View Audit history of a contact
   @audit-contact--archived
   Scenario: View audit log for Archived contact
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     Then a primary contact is added
     When I submit the form
@@ -61,8 +61,8 @@ Feature: View Audit history of a contact
   @audit-contact--unarchived
   Scenario: View audit log for UnArchived contact
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form

--- a/test/acceptance/features/companies/account-management-save.feature
+++ b/test/acceptance/features/companies/account-management-save.feature
@@ -4,7 +4,7 @@ Feature: Save account management details for a company
   @companies-account-management-save--update
   Scenario: Save account management details
 
-    Given I navigate to company fixture Lambda plc
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
     Then the Account management details are displayed
       | key                       | value                   |
       | One List tier             | None                    |

--- a/test/acceptance/features/companies/contacts-collection.feature
+++ b/test/acceptance/features/companies/contacts-collection.feature
@@ -8,8 +8,8 @@ Feature: View collection of contacts for a company
   @companies-contact-collection--view
   Scenario: View companies contact collection
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     And I submit the form
@@ -29,8 +29,8 @@ Feature: View collection of contacts for a company
   @companies-contact-collection--filter
   Scenario: Filter companies contact list
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact with new company address is added
     When I submit the form
@@ -51,8 +51,8 @@ Feature: View collection of contacts for a company
   @companies-contact-collection--sort
   Scenario: Sort companies contact list
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form

--- a/test/acceptance/features/companies/documents.feature
+++ b/test/acceptance/features/companies/documents.feature
@@ -4,14 +4,14 @@ Feature: Company documents
   @companies-documents--document-link
   Scenario: Company has documents
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Documents local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Documents local nav link
     Then view should contain the Documents link
 
   @companies-documents--no-document-link
   Scenario: Company does not have documents
 
-    Given I navigate to company fixture Lambda plc
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
     When I click the Documents local nav link
     Then view should not contain the Documents link
 

--- a/test/acceptance/features/companies/export-save.feature
+++ b/test/acceptance/features/companies/export-save.feature
@@ -4,8 +4,8 @@ Feature: Company export save
   @companies-export-save--save
   Scenario: Save company export details
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Export local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Export local nav link
     Then the Exports details are displayed
       | key                          | value                             |
       | Export win category          | None                              |

--- a/test/acceptance/features/companies/interactions-collection.feature
+++ b/test/acceptance/features/companies/interactions-collection.feature
@@ -4,8 +4,8 @@ Feature: View collection of interactions for a company
   @companies-interactions-collection--view
   Scenario: View companies interaction collection
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And the results summary for a interaction collection is present
     And I can view the collection
 

--- a/test/acceptance/features/companies/local-nav.feature
+++ b/test/acceptance/features/companies/local-nav.feature
@@ -4,7 +4,7 @@ Feature: Companies local nav
   @companies-local-nav
   Scenario: Companies local nav as DIT staff
 
-    When I navigate to company fixture Venus Ltd
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
     Then there should be a local nav
       | text                      |
       | Details                   |
@@ -19,7 +19,7 @@ Feature: Companies local nav
   @companies-local-nav--lep @lep
   Scenario: Companies local nav as LEP
 
-    When I navigate to company fixture Venus Ltd
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
     Then there should be a local nav
       | text                      |
       | Details                   |
@@ -31,7 +31,7 @@ Feature: Companies local nav
   @companies-local-nav--da @da
   Scenario: Companies local nav as DA
 
-    When I navigate to company fixture Venus Ltd
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
     Then there should be a local nav
       | text                      |
       | Details                   |

--- a/test/acceptance/features/companies/omis-collection.feature
+++ b/test/acceptance/features/companies/omis-collection.feature
@@ -4,15 +4,15 @@ Feature: View collection of orders for a company
   @companies-omis-collection--view
   Scenario: View companies OMIS collection
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Orders (OMIS) local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Orders (OMIS) local nav link
     And the results summary for a order collection is present
 
   @companies-omis-collection--view--da
   Scenario: View companies OMIS collection as DA
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Orders (OMIS) local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Orders (OMIS) local nav link
     And the results summary for a order collection is present
 
   @companies-omis-collection--filter # TODO

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -7,8 +7,8 @@ Feature: View collection of contacts
   @contacts-collection--view
   Scenario: View contact collection
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form
@@ -47,8 +47,8 @@ Feature: View collection of contacts
   @contacts-collection--filter
   Scenario: Filter contact list
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form

--- a/test/acceptance/features/contacts/documents.feature
+++ b/test/acceptance/features/contacts/documents.feature
@@ -4,14 +4,14 @@ Feature: Contact details
   @contact-documents--link
   Scenario: Contact has Documents link
 
-    When I navigate to contact fixture Johnny Cakeman
+    When I navigate to the `contacts.Fixture` page using `contact` `Johnny Cakeman` fixture
     And I click the Documents local nav link
     Then view should contain the Documents link
 
   @contact-documents--no-documents-link
   Scenario: Contact does not have Documents link
 
-    When I navigate to contact fixture Georgina Clark
+    When I navigate to the `contacts.Fixture` page using `contact` `Georgina Clark` fixture
     And I click the Documents local nav link
     Then view should not contain the Documents link
 

--- a/test/acceptance/features/contacts/interactions-collection.feature
+++ b/test/acceptance/features/contacts/interactions-collection.feature
@@ -4,7 +4,7 @@ Feature: View collection of interactions for a contact
   @contacts-interactions-collection--view
   Scenario: View contacts interaction collection
 
-    Given I navigate to contact fixture Dean Cox
+    When I navigate to the `contacts.Fixture` page using `contact` `Dean Cox` fixture
     When I click the Interactions local nav link
     And the results summary for a interaction collection is present
     And I can view the collection

--- a/test/acceptance/features/contacts/local-nav.feature
+++ b/test/acceptance/features/contacts/local-nav.feature
@@ -4,7 +4,7 @@ Feature: Contact local nav
   @contact-local-nav
   Scenario: Contact local nav as DIT staff
 
-    When I navigate to contact fixture Johnny Cakeman
+    When I navigate to the `contacts.Fixture` page using `contact` `Johnny Cakeman` fixture
     Then there should be a local nav
       | text                        |
       | Details                     |
@@ -15,7 +15,7 @@ Feature: Contact local nav
   @contact-local-nav--lep @lep
   Scenario: Contact local nav as LEP
 
-    When I navigate to contact fixture Johnny Cakeman
+    When I navigate to the `contacts.Fixture` page using `contact` `Johnny Cakeman` fixture
     Then there should be a local nav
       | text                        |
       | Details                     |
@@ -24,7 +24,7 @@ Feature: Contact local nav
   @contact-local-nav--da @da
   Scenario: Contact local nav as DA
 
-    When I navigate to contact fixture Johnny Cakeman
+    When I navigate to the `contacts.Fixture` page using `contact` `Johnny Cakeman` fixture
     Then there should be a local nav
       | text                        |
       | Details                     |

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -7,8 +7,8 @@ Feature: Create New Contact
   @contacts-save--primary
   Scenario: Add a new primary contact
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     Then there are contact fields
     When a primary contact is added
@@ -33,8 +33,8 @@ Feature: Create New Contact
   @contacts-save--primary-new-company-address
   Scenario: Add a new primary contact with new company address
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     Then there are contact fields
     When a primary contact with new company address is added
@@ -58,8 +58,8 @@ Feature: Create New Contact
   @contacts-save--non-primary
   Scenario: Add a new non-primary contact
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     Then there are contact fields
     When a non-primary contact is added
@@ -83,8 +83,8 @@ Feature: Create New Contact
   @contacts-save--primary-dashboard
   Scenario: New primary contact is visible on the dashboard
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     Then there are contact fields
     When a primary contact is added
@@ -98,8 +98,8 @@ Feature: Create New Contact
   @contacts-save--mandatory-fields
   Scenario: Contact fields are mandatory
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Contacts local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Contacts local nav link
     And I click the "Add contact" link
     Then there are contact fields
     When I submit the form

--- a/test/acceptance/features/events/details.feature
+++ b/test/acceptance/features/events/details.feature
@@ -4,13 +4,13 @@ Feature: Event details
   @events-details--documents-link
   Scenario: Event has Documents link
 
-    When I navigate to event fixture One-day exhibition
+    When I navigate to the `events.Fixture` page using `event` `One-day exhibition` fixture
     Then there should not be a local nav
     And details view data for "Documents" should contain "View files and documents (will open another website)"
 
   @events-details--no-documents-link
   Scenario: Event does not have Documents link
 
-    When I navigate to event fixture Grand exhibition
+    When I navigate to the `events.Fixture` page using `event` `Grand exhibition` fixture
     Then there should not be a local nav
     And details view data for "Documents" should contain "There are no files or documents"

--- a/test/acceptance/features/interactions/add.feature
+++ b/test/acceptance/features/interactions/add.feature
@@ -4,8 +4,8 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-interaction-submit
   Scenario: Companies interaction is saved
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select interaction
     Then there are interaction fields
@@ -29,8 +29,8 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-service-delivery-submit
   Scenario: Companies service delivery is saved
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -54,8 +54,8 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-service-delivery-tap-service-optional-complete-submit
   Scenario: Companies service delivery is saved and TAP service optional fields are specified
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -86,8 +86,8 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-service-delivery-tap-service-optional-empty-submit
   Scenario: Companies service delivery is saved and TAP service optional fields are not specified
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -112,8 +112,8 @@ Feature: Add a new interaction in Data hub
   @interaction-add--contacts-interaction-submit
   Scenario: Interaction fields from contacts
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select interaction
     Then there are interaction fields
@@ -137,8 +137,8 @@ Feature: Add a new interaction in Data hub
   @interaction-add--contacts-service-delivery-submit
   Scenario: Service delivery fields from contacts
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -162,8 +162,8 @@ Feature: Add a new interaction in Data hub
   @interaction-add--investment-projects-interaction-submit
   Scenario: Interaction fields from investment projects
 
-    Given I navigate to investment project fixture New rollercoaster
-    When I click the Interactions local nav link
+    When I navigate to the `investments.Fixture` page using `investment project` `New rollercoaster` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     Then there are interaction fields
     And interaction fields are pre-populated
@@ -187,8 +187,8 @@ Feature: Add a new interaction in Data hub
   @interactions-add--events-toggle
   Scenario: Toggle service delivery event association
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -201,8 +201,8 @@ Feature: Add a new interaction in Data hub
   @interactions-add--service-toggle
   Scenario: Toggle service delivery service fields
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields

--- a/test/acceptance/features/interactions/collection.feature
+++ b/test/acceptance/features/interactions/collection.feature
@@ -7,8 +7,8 @@ Feature: View collection of interactions
   @interactions-collection--view-interaction
   Scenario: View interaction in interactions and services collection
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select interaction
     When an interaction is added
@@ -31,8 +31,8 @@ Feature: View collection of interactions
   @interactions-collection--view-service-delivery
   Scenario: View service delivery in interactions and services collection
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select service delivery
     And a service delivery is added
@@ -55,8 +55,8 @@ Feature: View collection of interactions
   @interactions-collection--filter
   Scenario: filter interaction list
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Interactions local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Interactions local nav link
     And I click the "Add interaction" link
     And I select interaction
     And an interaction is added

--- a/test/acceptance/features/interactions/documents.feature
+++ b/test/acceptance/features/interactions/documents.feature
@@ -4,13 +4,13 @@ Feature: Interaction details
   @interactions-documents--documents-link
   Scenario: Interaction has Documents link
 
-    When I navigate to interaction fixture Attended gamma event
+    When I navigate to the `interactions.Fixture` page using `interaction` `Attended gamma event` fixture
     Then there should not be a local nav
     And details view data for "Documents" should contain "View files and documents (will open another website)"
 
   @interactions-documents--no-documents-link
   Scenario: Interaction does not have Documents link
 
-    When I navigate to interaction fixture Provided funding information
+    When I navigate to the `interactions.Fixture` page using `interaction` `Provided funding information` fixture
     Then there should not be a local nav
     And details view data for "Documents" should contain "There are no files or documents"

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -7,8 +7,8 @@ Feature: View a list of Investment Projects
   @investment-projects-collection--view
   Scenario: View Investment Projects list
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Investment local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -6,7 +6,7 @@ Feature: Create a new Investment project
   @investment-projects-create--verify-add
   Scenario: Verify Add Investment project option
 
-    Given I navigate to company fixture Lambda plc
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
     And I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
@@ -14,8 +14,8 @@ Feature: Create a new Investment project
   @investment-projects-create--fdi
   Scenario: Add a Foreign Direct Investment (FDI) Investment project
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Investment local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -46,8 +46,8 @@ Feature: Create a new Investment project
   @investment-projects-create--fdi-different-source-of-equity
   Scenario: Add a Foreign Direct Investment (FDI) Investment project with a separate company as the source of foreign equity
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Investment local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -86,8 +86,8 @@ Feature: Create a new Investment project
   @investment-projects-create--non-fdi
   Scenario: Add a Non Foreign Direct Investment (Non-FDI) Investment project
 
-    Given I navigate to company fixture Venus Ltd
-    When I click the Investment local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+    And I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select Non FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/documents.feature
+++ b/test/acceptance/features/investment-projects/documents.feature
@@ -4,15 +4,15 @@ Feature: Investment project documents
   @investment-projects-documents--document-link
   Scenario: Investment project has documents
 
-    Given I navigate to investment project fixture New hotel (commitment to invest)
-    When I click the Documents local nav link
+    When I navigate to the `investments.Fixture` page using `investment project` `New hotel (commitment to invest)` fixture
+    And I click the Documents local nav link
     Then view should contain the Documents link
 
   @investment-projects-documents--no-document-link
   Scenario: Investment project does not have documents
 
-    Given I navigate to investment project fixture New rollercoaster
-    When I click the Documents local nav link
+    When I navigate to the `investments.Fixture` page using `investment project` `New rollercoaster` fixture
+    And I click the Documents local nav link
     Then view should not contain the Documents link
 
   @investment-projects-documents--lep @lep

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -4,8 +4,8 @@ Feature: Investment projects evaluations details
   @investment-projects-evaluations-details--value-yes
   Scenario: View investment project evaluations after user selects all yes for value details
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Investment local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -60,8 +60,8 @@ Feature: Investment projects evaluations details
   @investment-projects-evaluations-details--value-no
   Scenario: View investment project evaluations after user selects all no for value details
 
-    Given I navigate to company fixture Lambda plc
-    When I click the Investment local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    And I click the Investment local nav link
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/interactions-collection.feature
+++ b/test/acceptance/features/investment-projects/interactions-collection.feature
@@ -4,24 +4,24 @@ Feature: View collection of interactions for an investment project
   @investment-projects-interactions-collection--view
   Scenario: View investment projects interaction collection
 
-    Given I navigate to investment project fixture New hotel (FDI)
-    When I click the Interactions local nav link
+    When I navigate to the `investments.Fixture` page using `investment project` `New hotel (FDI)` fixture
+    And I click the Interactions local nav link
     And the results summary for a interaction collection is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--lep @lep
   Scenario: View investment projects interaction collection
 
-    Given I navigate to investment project fixture New zoo (LEP)
-    When I click the Interactions local nav link
+    When I navigate to the `investments.Fixture` page using `investment project` `New zoo (LEP)` fixture
+    And I click the Interactions local nav link
     And the results summary for a interaction collection is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--da @da
   Scenario: View investment projects interaction collection
 
-    Given I navigate to investment project fixture New golf course (DA)
-    When I click the Interactions local nav link
+    When I navigate to the `investments.Fixture` page using `investment project` `New golf course (DA)` fixture
+    And I click the Interactions local nav link
     And the results summary for a interaction collection is present
     And I can view the collection
 

--- a/test/acceptance/features/investment-projects/local-nav.feature
+++ b/test/acceptance/features/investment-projects/local-nav.feature
@@ -4,7 +4,7 @@ Feature: Investment projects local nav
   @investment-projects-local-nav
   Scenario: Investment projects local nav as DIT staff
 
-    When I navigate to investment project fixture New hotel (commitment to invest)
+    When I navigate to the `investments.Fixture` page using `investment project` `New hotel (commitment to invest)` fixture
     Then there should be a local nav
       | text                      |
       | Project details           |
@@ -17,7 +17,7 @@ Feature: Investment projects local nav
   @investment-projects-local-nav--lep @lep
   Scenario: Investment projects local nav as LEP
 
-    When I navigate to investment project fixture New zoo (LEP)
+    When I navigate to the `investments.Fixture` page using `investment project` `New zoo (LEP)` fixture
     Then there should be a local nav
       | text                      |
       | Project details           |
@@ -29,7 +29,7 @@ Feature: Investment projects local nav
   @investment-projects-local-nav--da @da
   Scenario: Investment projects local nav as DA
 
-    When I navigate to investment project fixture New golf course (DA)
+    When I navigate to the `investments.Fixture` page using `investment project` `New golf course (DA)` fixture
     Then there should be a local nav
       | text                      |
       | Project details           |

--- a/test/acceptance/features/investment-projects/value-add.feature
+++ b/test/acceptance/features/investment-projects/value-add.feature
@@ -4,8 +4,8 @@ Feature: Add value to investment project
   @investment-projects-value-add--all-yes
   Scenario: Select Yes for all answers
 
-    Given I navigate to investment project fixture New hotel (commitment to invest)
-    When I click the "Add value" link
+    When I navigate to the `investments.Fixture` page using `investment project` `New hotel (commitment to invest)` fixture
+    And I click the "Add value" link
     Then I am taken to the "New hotel (commitment to invest)" page
     When I populate the create investment project value form
       | key                               | value                                          |
@@ -38,8 +38,8 @@ Feature: Add value to investment project
   @investment-projects-value-add--all-no
   Scenario: Select No for all answers
 
-    Given I navigate to investment project fixture New hotel (commitment to invest)
-    When I click the "Edit value" link
+    When I navigate to the `investments.Fixture` page using `investment project` `New hotel (commitment to invest)` fixture
+    And I click the "Edit value" link
     Then I am taken to the "New hotel (commitment to invest)" page
     When I populate the create investment project value form
       | key                               | value                                          |
@@ -70,8 +70,8 @@ Feature: Add value to investment project
   @investment-projects-value-add--blank
   Scenario: Save a blank value form in the prospect stage
 
-    Given I navigate to company fixture Lambda plc
-    And I click the Investment local nav link
+    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
+    Then I click the Investment local nav link
     And I click the "Add investment project" link
     And I select FDI as the Investment project type
     And I choose Yes for "Will this company be the source of foreign equity investment?"

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -1,6 +1,8 @@
-const { get } = require('lodash')
+const { assign, camelCase, find, get, set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
 const { When } = require('cucumber')
+
+const fixtures = require('../../features/setup/fixtures')
 
 When(/^I (?:navigate|go|open|visit).*? `(.+)` page$/, async function (pageName) {
   try {
@@ -9,4 +11,16 @@ When(/^I (?:navigate|go|open|visit).*? `(.+)` page$/, async function (pageName) 
   } catch (error) {
     throw new Error(`The page object '${pageName}' does not exist`)
   }
+})
+
+When(/^I (?:navigate|go|open|visit).*? `(.+)` page using `(.+)` `(.+)` fixture$/, async function (pageName, entity, fixtureName) {
+  const Page = get(client.page, pageName)()
+
+  const fixture = find(fixtures[entity], { name: fixtureName })
+
+  // TODO: Need to find a way to remove needing to store the item in state
+  const entityTypeFieldName = camelCase(entity)
+  set(this.state, entityTypeFieldName, assign({}, get(this.state, entityTypeFieldName), fixture))
+
+  await Page.navigate(Page.url(fixtureName))
 })

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -125,9 +125,8 @@ Then(/^I choose the first item in the collection$/, async function () {
 })
 
 Then(/^I can view the collection$/, async function () {
-  await Collection.api.elements('css selector', '.c-entity-list__item', (result) => {
-    client.expect(result.value.length).to.be.greaterThan(0)
-  })
+  await Collection
+    .assert.visible('@collection')
 })
 
 Then(/^I see the list in A-Z alphabetical order$/, async function () {

--- a/test/acceptance/features/step_definitions/location.js
+++ b/test/acceptance/features/step_definitions/location.js
@@ -1,4 +1,4 @@
-const { find, assign, set, get, camelCase, includes } = require('lodash')
+const { find, get, camelCase, includes } = require('lodash')
 const { client } = require('nightwatch-cucumber')
 const { Given, Then, When } = require('cucumber')
 
@@ -20,32 +20,6 @@ function getExpectedValue (row, state) {
 }
 
 const Location = client.page.Location()
-const Search = client.page.Search()
-
-Given(/^I navigate to (.+) fixture (.+)$/, async function (entityType, fixtureName) {
-  const entityTypeFieldName = camelCase(entityType)
-  const fixtureDetails = find(this.fixtures[entityTypeFieldName], ['name', fixtureName])
-  set(this.state, entityTypeFieldName, assign({}, get(this.state, entityTypeFieldName), fixtureDetails))
-
-  await Search
-    .navigate()
-    .search(fixtureName)
-
-  await Search
-    .section.tabs
-    .waitForElementPresent(`@${entityTypeFieldName}`)
-    .click(`@${entityTypeFieldName}`)
-
-  await Search
-    .section.firstSearchResult
-    .waitForElementPresent('@header')
-    .click('@header')
-
-  await Location
-    .section.localHeader
-    .waitForElementPresent('@header')
-    .assert.containsText('@header', fixtureName)
-})
 
 Given(/^I navigate directly to ([^\s]+) of (.+) fixture (.+)$/, async function (path, entityType, fixtureName) {
   const entityTypeFieldName = camelCase(entityType)

--- a/test/acceptance/pages/Collection.js
+++ b/test/acceptance/pages/Collection.js
@@ -13,6 +13,9 @@ const getSelectorForMetaListItemValue = (text) => {
 }
 
 module.exports = {
+  elements: {
+    collection: '.c-collection',
+  },
   commands: [
     {
       getSelectorForMetaListItemValue,

--- a/test/acceptance/pages/companies/Fixture.js
+++ b/test/acceptance/pages/companies/Fixture.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { company } = require('../../features/setup/fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(company, { name: companyName })
+    const companyId = fixture ? fixture.pk : company.ukLtd.pk
+
+    return `${process.env.QA_HOST}/companies/${companyId}`
+  },
+  elements: {},
+}

--- a/test/acceptance/pages/contacts/Fixture.js
+++ b/test/acceptance/pages/contacts/Fixture.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { contact } = require('../../features/setup/fixtures')
+
+module.exports = {
+  url: function contactFixtureUrl (contactName) {
+    const fixture = find(contact, { name: contactName })
+    const contactId = fixture ? fixture.pk : contact.georginaClark.pk
+
+    return `${process.env.QA_HOST}/contacts/${contactId}`
+  },
+  elements: {},
+}

--- a/test/acceptance/pages/events/Fixture.js
+++ b/test/acceptance/pages/events/Fixture.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { event } = require('../../features/setup/fixtures')
+
+module.exports = {
+  url: function eventFixtureUrl (eventName) {
+    const fixture = find(event, { name: eventName })
+    const eventId = fixture ? fixture.pk : event.oneDayExhibition.pk
+
+    return `${process.env.QA_HOST}/events/${eventId}`
+  },
+  elements: {},
+}

--- a/test/acceptance/pages/interactions/Fixture.js
+++ b/test/acceptance/pages/interactions/Fixture.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { interaction } = require('../../features/setup/fixtures')
+
+module.exports = {
+  url: function interactionFixtureUrl (interactionName) {
+    const fixture = find(interaction, { subject: interactionName })
+    const interactionId = fixture ? fixture.pk : interaction.attendedGammaEvent.pk
+
+    return `${process.env.QA_HOST}/interactions/${interactionId}`
+  },
+  elements: {},
+}

--- a/test/acceptance/pages/investments/Fixture.js
+++ b/test/acceptance/pages/investments/Fixture.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { investmentProject } = require('../../features/setup/fixtures')
+
+module.exports = {
+  url: function projectFixtureUrl (projectName) {
+    const fixture = find(investmentProject, { name: projectName })
+    const projectId = fixture ? fixture.pk : investmentProject.newHotelCommitmentToInvest.pk
+
+    return `${process.env.QA_HOST}/investment-projects/${projectId}`
+  },
+  elements: {},
+}


### PR DESCRIPTION
The idea behind this change is to move to more of a page object structure with acceptance tests.

Currently navigating to fixtures involves visiting the homepage and searching for a name then clicking the first result. This creates a number of extra requests and adds time to a growing set of acceptance tests.

Search can still be tested separately but we should be able to navigate straight to a fixture if we know it's ID.

I'm not convinced on the new name for the page objects but the current page objects for each entity contain a lot of code for other pages. We would need to split out functionality used for nested pages like _contacts_ within _companies_ from the `Company.js` page object first. The main `Company.js` page object can then contain the code from the `Fixture.js` page object which allows you to navigate directly to a fixture using the page objects `.url()` method.

These changes are the start of moving to more flexible, shared step definitions and having some of the heavy lifting of interacting with the page done in page objects.