### PR TITLE
Allow contact details to be edited after a quote has been sent

### DIFF
--- a/src/apps/omis/apps/create/views/client-details.njk
+++ b/src/apps/omis/apps/create/views/client-details.njk
@@ -21,4 +21,11 @@
       If the contact you are looking for is not listed you can <a href="/contacts/create?company={{ company.id }}">add a new contact</a>.
     {% endcall %}
   {% endcall %}
+
+  {% if order.canEditContactDetails %}
+    {% call Message({ type: 'info', element: 'div' }) %}
+      <p>Changing the contact will change who notifications are sent to.</p>
+      <p>It will not change the contact details on the quote.</p>
+    {% endcall %}
+  {% endif %}
 {% endblock %}

--- a/src/apps/omis/apps/edit/controllers/client-details.js
+++ b/src/apps/omis/apps/edit/controllers/client-details.js
@@ -13,6 +13,10 @@ class EditClientDetailsController extends EditController {
       contacts.push(...sortBy(companyContacts, 'label'))
     }
 
+    if (req.form.options.disableFormAction) {
+      req.form.options.disableFormAction = !get(res.locals, 'order.canEditContactDetails')
+    }
+
     req.form.options.fields.contact.options = contacts
     super.configure(req, res, next)
   }

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -54,7 +54,7 @@
   {{ AnswersSummary({
     heading: 'Client contact details',
     actions: [{
-      url: 'edit/client-details' if order.canEditOrder
+      url: 'edit/client-details' if order.canEditOrder or order.canEditContactDetails
     }],
     items: [{
       label: 'Name',

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -16,11 +16,13 @@ async function setCompany (req, res, next, companyId) {
 async function setOrder (req, res, next, orderId) {
   try {
     const order = await Order.getById(req.session.token, orderId)
+    const activeOrder = !(['cancelled', 'complete'].includes(order.status))
 
     res.locals.order = assign({}, order, {
       canEditOrder: order.status === 'draft',
-      canEditAdvisers: !['cancelled', 'complete'].includes(order.status),
-      canEditInvoiceDetails: !['cancelled', 'complete'].includes(order.status),
+      canEditAdvisers: activeOrder,
+      canEditInvoiceDetails: activeOrder,
+      canEditContactDetails: activeOrder,
     })
 
     const currencyFields = [

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -112,6 +112,7 @@ describe('OMIS middleware', () => {
           canEditOrder: true,
           canEditAdvisers: true,
           canEditInvoiceDetails: true,
+          canEditContactDetails: true,
         })
         expect(this.resMock.locals).to.have.property('order')
         expect(this.resMock.locals.order).to.deep.equal(order)
@@ -140,6 +141,10 @@ describe('OMIS middleware', () => {
         it('should be able to edit advisers', () => {
           expect(this.resMock.locals.order.canEditAdvisers).to.equal(true)
         })
+
+        it('should not be able to edit contact details', () => {
+          expect(this.resMock.locals.order.canEditContactDetails).to.equal(true)
+        })
       })
 
       context('when order is in quote awaiting acceptance', () => {
@@ -162,6 +167,10 @@ describe('OMIS middleware', () => {
 
         it('should be able to edit invoice details', () => {
           expect(this.resMock.locals.order.canEditInvoiceDetails).to.equal(true)
+        })
+
+        it('should be able to edit contact details', () => {
+          expect(this.resMock.locals.order.canEditContactDetails).to.equal(true)
         })
       })
 
@@ -186,6 +195,10 @@ describe('OMIS middleware', () => {
         it('should not be able to edit invoice details', () => {
           expect(this.resMock.locals.order.canEditInvoiceDetails).to.equal(false)
         })
+
+        it('should not be able to edit contact details', () => {
+          expect(this.resMock.locals.order.canEditContactDetails).to.equal(false)
+        })
       })
 
       context('when order is cancelled', () => {
@@ -208,6 +221,10 @@ describe('OMIS middleware', () => {
 
         it('should not be able to edit invoice details', () => {
           expect(this.resMock.locals.order.canEditInvoiceDetails).to.equal(false)
+        })
+
+        it('should not be able to edit contact details', () => {
+          expect(this.resMock.locals.order.canEditContactDetails).to.equal(false)
         })
       })
     })


### PR DESCRIPTION
This change allows the contact details to be changed during later
stages of the OMIS order.

It uses the same method as used for subscribers, assignees and
invoice details.

## What it looks like

![localhost_3001_omis_b171225e-bade-4c11-8996-de9d30c8f9e0_edit_client-details 1](https://user-images.githubusercontent.com/3327997/35970084-e4000f46-0cc0-11e8-9903-8796a99c67a8.png)
