### PR TITLE
Fix/oauth state mismatch

### DIFF
--- a/src/lib/session-helper.js
+++ b/src/lib/session-helper.js
@@ -1,0 +1,20 @@
+/**
+ * promise wrapper around express session save method
+ * @param req
+ * @returns {Promise}
+ */
+function saveSession (session) {
+  return new Promise((resolve, reject) => {
+    session.save((error) => {
+      if (error) {
+        return reject(error)
+      }
+
+      resolve()
+    })
+  })
+}
+
+module.exports = {
+  saveSession,
+}

--- a/test/unit/apps/oauth/controllers.test.js
+++ b/test/unit/apps/oauth/controllers.test.js
@@ -5,9 +5,13 @@ describe('OAuth controller', () => {
   beforeEach(() => {
     this.mockUuid = sandbox.stub().returns(this.mockUUIDvalue)
     this.mockConfig = {}
+    this.saveSessionStub = sandbox.stub()
     this.controller = proxyquire.noCallThru().load('~/src/apps/oauth/controllers', {
       './../../../config': this.mockConfig,
       'uuid': this.mockUuid,
+      './../../lib/session-helper': {
+        saveSession: this.saveSessionStub,
+      },
     })
     this.mockOauthAccessToken = 'mockAccessToken'
     this.mockAuthCode = 'mock-auth-code'
@@ -56,24 +60,63 @@ describe('OAuth controller', () => {
         })
 
         set(this.mockConfig, 'oauth', this.mockOauthConfig)
-        this.controller.redirectOAuth(this.reqMock, this.resMock, this.nextSpy)
       })
 
-      it('should redirect', () => {
-        expect(this.resMock.redirect).to.have.been.calledOnce
+      context('with a successful session save', () => {
+        beforeEach(async () => {
+          this.saveSessionStub.resolves()
+          await this.controller.redirectOAuth(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        it('should call saveSessionStub', () => {
+          expect(this.saveSessionStub).to.have.been.calledOnce
+        })
+
+        it('should call saveSessionStub with expected argument', () => {
+          expect(this.saveSessionStub).to.be.calledWith(this.reqMock)
+        })
+
+        it('should redirect', () => {
+          expect(this.resMock.redirect).to.have.been.calledOnce
+        })
+
+        it('should redirect to the correct Oauth url', () => {
+          expect(this.resMock.redirect).to.be.calledWith(`${this.mockOauthConfig.url}?${this.expectedOauthRedirectUrl}`)
+        })
+
+        it('session should hold correct UUID', () => {
+          expect(this.reqMock.session.oauth.state).to.equal(this.mockUUIDvalue)
+        })
       })
 
-      it('should redirect to the correct Oauth url', () => {
-        expect(this.resMock.redirect).to.be.calledWith(`${this.mockOauthConfig.url}?${this.expectedOauthRedirectUrl}`)
-      })
+      context('with a rejected session save', () => {
+        beforeEach(async () => {
+          this.returnedError = 'oh no!'
+          this.saveSessionStub.rejects(this.returnedError)
+          await this.controller.redirectOAuth(this.reqMock, this.resMock, this.nextSpy)
+        })
 
-      it('session should hold correct UUID', () => {
-        expect(this.reqMock.session.oauth.state).to.equal(this.mockUUIDvalue)
+        it('should call saveSessionStub', () => {
+          expect(this.saveSessionStub).to.have.been.calledOnce
+        })
+
+        it('should call saveSessionStub with expected argument', () => {
+          expect(this.saveSessionStub).to.be.calledWith(this.reqMock)
+        })
+
+        it('should handle error as expected', () => {
+          expect(this.nextSpy).to.have.been.calledOnce
+          expect(this.nextSpy.args[0][0].name).to.equal(this.returnedError)
+        })
+
+        it('token should be undefined', () => {
+          expect(this.reqMock.session.token).to.be.undefined
+        })
       })
     })
 
     context('with oauth.devToken', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         this.mockDevToken = 'robo-cat-developer'
         this.mockOauthConfig.devToken = this.mockDevToken
         this.expectedOauthRedirectUrl = queryString.stringify({
@@ -86,7 +129,7 @@ describe('OAuth controller', () => {
         })
 
         set(this.mockConfig, 'oauth', this.mockOauthConfig)
-        this.controller.redirectOAuth(this.reqMock, this.resMock, this.nextSpy)
+        await this.controller.redirectOAuth(this.reqMock, this.resMock, this.nextSpy)
       })
 
       it('should redirect', () => {

--- a/test/unit/apps/oauth/controllers.test.js
+++ b/test/unit/apps/oauth/controllers.test.js
@@ -73,7 +73,7 @@ describe('OAuth controller', () => {
         })
 
         it('should call saveSessionStub with expected argument', () => {
-          expect(this.saveSessionStub).to.be.calledWith(this.reqMock)
+          expect(this.saveSessionStub).to.be.calledWith(this.reqMock.session)
         })
 
         it('should redirect', () => {
@@ -101,7 +101,7 @@ describe('OAuth controller', () => {
         })
 
         it('should call saveSessionStub with expected argument', () => {
-          expect(this.saveSessionStub).to.be.calledWith(this.reqMock)
+          expect(this.saveSessionStub).to.be.calledWith(this.reqMock.session)
         })
 
         it('should handle error as expected', () => {

--- a/test/unit/lib/session-helper.test.js
+++ b/test/unit/lib/session-helper.test.js
@@ -1,0 +1,53 @@
+const { assign } = require('lodash')
+
+const sessionHelper = require('~/src/lib/session-helper')
+
+describe('#saveSession', () => {
+  beforeEach(() => {
+    this.saveSession = sandbox.spy(sessionHelper, 'saveSession')
+    this.reqMock = assign({}, globalReq, {
+      session: {
+        save: sandbox.stub(),
+      },
+    })
+  })
+
+  context('session save success', () => {
+    beforeEach(async () => {
+      this.reqMock.session.save.yields()
+      await this.saveSession(this.reqMock.session)
+    })
+
+    it('should call saveSession', () => {
+      expect(this.saveSession).to.have.been.calledOnce
+    })
+
+    it('should call session save method', () => {
+      expect(this.reqMock.session.save).to.have.been.calledOnce
+    })
+  })
+
+  context('session save error', () => {
+    beforeEach(async () => {
+      this.returnedError = 'huston we have a problem!'
+      this.reqMock.session.save.yields(this.returnedError)
+      try {
+        await this.saveSession(this.reqMock.session)
+      } catch (error) {
+        this.error = error
+      }
+    })
+
+    it('should call saveSession', () => {
+      expect(this.saveSession).to.have.been.calledOnce
+    })
+
+    it('should call session save method', () => {
+      expect(this.reqMock.session.save).to.have.been.calledOnce
+    })
+
+    it('should handle error as expected', () => {
+      expect(this.error).to.equal(this.returnedError)
+    })
+  })
+})


### PR DESCRIPTION
This PR will supersede https://github.com/uktrade/data-hub-frontend/pull/1229
The approach here is one of saving the session to the session store before moving on through the SSO journey.

Thanks to @web-bert for his thoughts on this.