### PR TITLE
Fix rounding errors during OMIS reconciliation

### DIFF
--- a/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
+++ b/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
@@ -73,9 +73,9 @@ class EditPaymentReconciliationController extends EditController {
 
   async saveValues (req, res, next) {
     const data = req.form.values
+    const penceAmount = Math.round(numeral(data.amount).value() * 100)
 
-    // convert pounds to pence
-    data.amount = Math.round(numeral(data.amount).value() * 100)
+    data.amount = penceAmount
 
     try {
       // TODO: Support adding of multiple payments

--- a/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
+++ b/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
@@ -75,7 +75,7 @@ class EditPaymentReconciliationController extends EditController {
     const data = req.form.values
 
     // convert pounds to pence
-    data.amount = parseInt(numeral(data.amount).value() * 100)
+    data.amount = Math.round(numeral(data.amount).value() * 100)
 
     try {
       // TODO: Support adding of multiple payments


### PR DESCRIPTION
It appears the previous fix hadn't caught all possibilities.

It was using `parseInt` which would round down rather than to the
nearest whole number.

This caused the API to return a possible value mismatch on the
total cost of the order.

Using `Math.round` ensures it will round to the closest integer and
avoid the API returning a mismatch in values.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
