### PR TITLE
DH-1486 Display Grant offered field on service delivery details

### DIFF
--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -21,6 +21,7 @@ const serviceDelivery = {
   dit_adviser: 'DIT adviser',
   service: 'Service',
   service_delivery_status: 'Service status',
+  grant_amount_offered: 'Grant offered',
   dit_team: 'Service provider',
   communication_channel: 'Communication channel',
   is_event: 'Is this an event?',

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -123,6 +123,7 @@ function transformInteractionResponseToViewRecord ({
   dit_adviser,
   service,
   service_delivery_status,
+  grant_amount_offered,
   dit_team,
   contact,
   investment_project,
@@ -138,6 +139,10 @@ function transformInteractionResponseToViewRecord ({
     dit_team,
     service,
     service_delivery_status,
+    grant_amount_offered: grant_amount_offered ? {
+      type: 'currency',
+      name: grant_amount_offered,
+    } : null,
     subject,
     notes,
     date: {

--- a/src/apps/investment-projects/transformers/project.js
+++ b/src/apps/investment-projects/transformers/project.js
@@ -3,7 +3,7 @@ const { assign, castArray, get, isEmpty, isPlainObject, mapValues } = require('l
 const format = require('date-fns/format')
 const moment = require('moment')
 
-const { formatCurrency, getInvestmentTypeDetails } = require('./shared')
+const { getInvestmentTypeDetails } = require('./shared')
 const { transformDateObjectToDateString } = require('../../transformers')
 
 function transformToApi (body) {
@@ -173,7 +173,10 @@ function transformBriefInvestmentSummary (data) {
     uk_region_locations: regionLocations.map(region => region.name).join(', '),
     competitor_countries: competitorCountries.map(country => country.name).join(', '),
     estimated_land_date: !isEmpty(data.estimated_land_date) ? moment(data.estimated_land_date, 'YYYY-MM-DD').format('MMMM YYYY') : null,
-    total_investment: formatCurrency(data.total_investment),
+    total_investment: data.total_investment ? {
+      type: 'currency',
+      name: data.total_investment,
+    } : null,
   }
 }
 

--- a/src/apps/investment-projects/transformers/shared.js
+++ b/src/apps/investment-projects/transformers/shared.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { compact, get, isNull } = require('lodash')
+const { compact, get } = require('lodash')
 
 function getInvestmentTypeDetails (investment_type, fdi_type) {
   const types = [
@@ -9,17 +9,6 @@ function getInvestmentTypeDetails (investment_type, fdi_type) {
   return compact(types).join(', ')
 }
 
-function formatCurrency (number) {
-  if (isNull(number)) { return null }
-
-  return new Intl.NumberFormat('en-GB', {
-    style: 'currency',
-    currency: 'GBP',
-    minimumFractionDigits: 0,
-  }).format(number)
-}
-
 module.exports = {
-  formatCurrency,
   getInvestmentTypeDetails,
 }

--- a/src/apps/investment-projects/transformers/value.js
+++ b/src/apps/investment-projects/transformers/value.js
@@ -1,14 +1,19 @@
 /* eslint-disable camelcase */
 const { get, isPlainObject, isNull } = require('lodash')
 
-function formatCurrency (number) {
-  if (isNull(number)) { return null }
+function transformInvestmentAmount (clientCannotProvideInvestment, investmentAmount) {
+  if (clientCannotProvideInvestment) {
+    return 'Client cannot provide this information'
+  }
 
-  return new Intl.NumberFormat('en-GB', {
-    style: 'currency',
-    currency: 'GBP',
-    minimumFractionDigits: 0,
-  }).format(number)
+  if (!investmentAmount) {
+    return null
+  }
+
+  return {
+    type: 'currency',
+    name: investmentAmount,
+  }
 }
 
 function transformInvestmentValueForView ({
@@ -40,12 +45,8 @@ function transformInvestmentValueForView ({
   })
 
   return {
-    total_investment: client_cannot_provide_total_investment
-      ? 'Client cannot provide this information'
-      : formatCurrency(total_investment),
-    foreign_equity_investment: client_cannot_provide_foreign_investment
-      ? 'Client cannot provide this information'
-      : formatCurrency(foreign_equity_investment),
+    total_investment: transformInvestmentAmount(client_cannot_provide_total_investment, total_investment),
+    foreign_equity_investment: transformInvestmentAmount(client_cannot_provide_foreign_investment, foreign_equity_investment),
     number_new_jobs: number_new_jobs && `${number_new_jobs} new jobs`,
     number_safeguarded_jobs: number_safeguarded_jobs && `${number_safeguarded_jobs} safeguarded jobs`,
     government_assistance: formatBoolean(government_assistance, {

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -43,6 +43,8 @@
             {% elif data | isPlainObject %}
               {% if data.type == "date" %}
                 {{ data.name | formatDate }}
+              {% elif data.type == "currency" %}
+                {{ data.name | formatCurrency }}
               {% else %}
                 {{ data.name }}
               {% endif %}

--- a/test/acceptance/features/interactions/details.feature
+++ b/test/acceptance/features/interactions/details.feature
@@ -12,6 +12,7 @@ Feature: Interactions details
       | Service provider         | interaction.serviceProvider   |
       | Service                  | interaction.service           |
       | Service status           | interaction.tapStatus         |
+      | Grant offered            | interaction.grantOffered      |
       | Subject                  | interaction.subject           |
       | Notes                    | interaction.notes             |
       | Date of service delivery | interaction.date              |

--- a/test/acceptance/features/interactions/details.feature
+++ b/test/acceptance/features/interactions/details.feature
@@ -11,7 +11,7 @@ Feature: Interactions details
       | Contact                  | interaction.contact           |
       | Service provider         | interaction.serviceProvider   |
       | Service                  | interaction.service           |
-      | Service status           | interaction.tapStatus         |
+      | Service status           | interaction.serviceStatus     |
       | Grant offered            | interaction.grantOffered      |
       | Subject                  | interaction.subject           |
       | Notes                    | interaction.notes             |

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -31,7 +31,7 @@ Feature: Investment projects evaluations details
     Then the Project value (Test D) details are displayed
       | key                               | value                                          | formatter                               |
       | Primary sector                    | investmentProject.primarySector                |                                         |
-      | Total investment                  | £100,000                                       |                                         |
+      | Total investment                  | £100,000.00                                    |                                         |
       | New jobs                          | 100 new jobs                                   |                                         |
       | Average salary of new jobs        | investmentProject.value.averageSalary          |                                         |
       | R&D budget                        | Has R&D budget                                 |                                         |
@@ -46,7 +46,7 @@ Feature: Investment projects evaluations details
       | Foreign investor                  | Lambda plc                                     |
       | Foreign country                   | France                                         |
       | UK company                        | Not Known                                      |
-      | Foreign equity investment         | £200,000                                       |
+      | Foreign equity investment         | £200,000.00                                    |
       | Investor retains 10% voting power | No                                             |
       | New jobs                          | 100 new jobs                                   |
       | Safeguarded jobs                  | 200 safeguarded jobs                           |

--- a/test/acceptance/features/investment-projects/value-add.feature
+++ b/test/acceptance/features/investment-projects/value-add.feature
@@ -22,17 +22,17 @@ Feature: Add value to investment project
       | Export revenue radio              | Yes                                            |
     Then I see the success message
     And the Value details are displayed
-      | key                        | value                                           |
-      | Total investment           | £100,000                                        |
-      | Foreign equity investment  | £200,000                                        |
-      | Government assistance      | Has government assistance                       |
-      | New jobs                   | 100 new jobs                                    |
-      | Average salary of new jobs | investmentProject.value.averageSalary           |
-      | Safeguarded jobs           | 200 safeguarded jobs                            |
-      | R&D budget                 | Has R&D budget                                  |
-      | Non-FDI R&D project        | Find project                                    |
-      | New-to-world tech          | Has new-to-world tech, business model or IP     |
-      | Export revenue             | Yes, will create significant export revenue     |
+      | key                        | value                                            |
+      | Total investment           | £100,000.00                                      |
+      | Foreign equity investment  | £200,000.00                                      |
+      | Government assistance      | Has government assistance                        |
+      | New jobs                   | 100 new jobs                                     |
+      | Average salary of new jobs | investmentProject.value.averageSalary            |
+      | Safeguarded jobs           | 200 safeguarded jobs                             |
+      | R&D budget                 | Has R&D budget                                   |
+      | Non-FDI R&D project        | Find project                                     |
+      | New-to-world tech          | Has new-to-world tech, business model or IP      |
+      | Export revenue             | Yes, will create significant export revenue      |
 
 
   @investment-projects-value-add--all-no

--- a/test/acceptance/features/setup/fixtures.js
+++ b/test/acceptance/features/setup/fixtures.js
@@ -97,6 +97,7 @@ module.exports = {
       serviceProvider: 'Marketing - Marketing Team',
       service: 'Tradeshow Access Programme (TAP)',
       tapStatus: 'Offered',
+      grantOffered: '£2,500.00',
       subject: 'TAP grant',
       name: 'TAP grant',
       notes: 'This is a dummy service delivery for testing',

--- a/test/acceptance/features/setup/fixtures.js
+++ b/test/acceptance/features/setup/fixtures.js
@@ -90,7 +90,7 @@ module.exports = {
       pk: '0dcb3748-c097-4f20-b84f-0114bbb1a8e0',
       subject: 'Provided funding information',
     },
-    tapStatus: {
+    tapGrant: {
       pk: 'aa350238-5d84-4bed-be68-b08dea7ea6d5',
       company: 'Venus Ltd',
       contact: 'Dean Cox',

--- a/test/acceptance/features/setup/fixtures.js
+++ b/test/acceptance/features/setup/fixtures.js
@@ -96,7 +96,7 @@ module.exports = {
       contact: 'Dean Cox',
       serviceProvider: 'Marketing - Marketing Team',
       service: 'Tradeshow Access Programme (TAP)',
-      tapStatus: 'Offered',
+      serviceStatus: 'Offered',
       grantOffered: '£2,500.00',
       subject: 'TAP grant',
       name: 'TAP grant',

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -1,6 +1,6 @@
 const { client } = require('nightwatch-cucumber')
 const { Then } = require('cucumber')
-const { get, includes } = require('lodash')
+const { get, includes, startsWith } = require('lodash')
 
 const { getDetailsTableRowValue } = require('../../helpers/selectors')
 const formatters = require('../../helpers/formatters')
@@ -8,7 +8,7 @@ const formatters = require('../../helpers/formatters')
 const Details = client.page.Details()
 
 function getExpectedValue (row, state) {
-  if (includes(row.value, '.') && !includes(row.value, ' ')) {
+  if (includes(row.value, '.') && !includes(row.value, ' ') && !startsWith(row.value, '£')) {
     const expectedText = get(state, row.value)
 
     if (row.key === 'Client contacts') {

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -482,6 +482,7 @@ describe('Interaction transformers', () => {
             name: 'Offered',
             id: '45329c18-6095-e211-a939-e4115bead28a',
           },
+          grant_amount_offered: '1000.00',
         })
 
         delete serviceDelivery.communication_channel
@@ -510,6 +511,10 @@ describe('Interaction transformers', () => {
           'Service status': {
             id: '45329c18-6095-e211-a939-e4115bead28a',
             name: 'Offered',
+          },
+          'Grant offered': {
+            name: '1000.00',
+            type: 'currency',
           },
           'Subject': 'Test interactions',
           'Notes': 'lorem ipsum',
@@ -547,6 +552,7 @@ describe('Interaction transformers', () => {
           event: null,
           kind: 'service_delivery',
           service_delivery_status: null,
+          grant_amount_offered: null,
         })
 
         delete serviceDelivery.communication_channel

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -47,7 +47,10 @@ describe('Investment evaluation controller', () => {
   it('should return evaluation details with correct investment data', (done) => {
     const expectedValue = {
       'Primary sector': 'Aerospace : Manufacturing and Assembly : Space Technology',
-      'Total investment': '£100,000',
+      'Total investment': {
+        type: 'currency',
+        name: '100000',
+      },
       'New jobs': '10 new jobs',
       'Average salary of new jobs': undefined,
       'R&D budget': 'Has R&D budget',
@@ -65,7 +68,10 @@ describe('Investment evaluation controller', () => {
       },
       'Foreign country': 'Korea (South)',
       'UK company': null,
-      'Foreign equity investment': '£50,000',
+      'Foreign equity investment': {
+        type: 'currency',
+        name: '50000',
+      },
       'Investor retains 10% voting power': 'No',
       'New jobs': '10 new jobs',
       'Safeguarded jobs': '5 safeguarded jobs',
@@ -103,7 +109,10 @@ describe('Investment evaluation controller', () => {
   it('should return evaluation details with correct investment data with UK company', (done) => {
     const expectedValue = {
       'Primary sector': 'Automotive : Motorsport',
-      'Total investment': '£40,000,000,000',
+      'Total investment': {
+        type: 'currency',
+        name: '40000000000',
+      },
       'New jobs': '456 new jobs',
       'Average salary of new jobs': '£25,000 – £29,000',
       'R&D budget': 'Has R&D budget',
@@ -124,7 +133,10 @@ describe('Investment evaluation controller', () => {
         name: 'AITCH (Bananas are us) LIMITED',
         url: '/companies/f91c0685-e2ac-41e7-8500-cdd0ad747a97',
       },
-      'Foreign equity investment': '£400,000',
+      'Foreign equity investment': {
+        type: 'currency',
+        name: '400000',
+      },
       'Investor retains 10% voting power': 'Yes',
       'New jobs': '456 new jobs',
       'Safeguarded jobs': '10 safeguarded jobs',

--- a/test/unit/apps/investment-projects/transformers/project.test.js
+++ b/test/unit/apps/investment-projects/transformers/project.test.js
@@ -279,7 +279,10 @@ describe('Investment project transformers', () => {
       })
 
       it('should include the total investment value', () => {
-        expect(this.result).to.have.property('total_investment', '£100.24')
+        expect(this.result.total_investment).to.deep.equal({
+          type: 'currency',
+          name: '100.24',
+        })
       })
     })
 
@@ -293,7 +296,7 @@ describe('Investment project transformers', () => {
       })
 
       it('should set total investment to null', () => {
-        expect(this.result).to.have.property('total_investment', null)
+        expect(this.result.total_investment).to.be.null
       })
     })
   })

--- a/test/unit/apps/investment-projects/transformers/value.test.js
+++ b/test/unit/apps/investment-projects/transformers/value.test.js
@@ -92,8 +92,87 @@ describe('Investment project transformers', () => {
 
       it('should correctly format the value view', () => {
         const expectedInvestmentValue = {
-          total_investment: '£100,000',
-          foreign_equity_investment: '£200,000',
+          total_investment: {
+            type: 'currency',
+            name: 100000,
+          },
+          foreign_equity_investment: {
+            type: 'currency',
+            name: 200000,
+          },
+          number_new_jobs: '100 new jobs',
+          number_safeguarded_jobs: '200 safeguarded jobs',
+          government_assistance: 'Has government assistance',
+          r_and_d_budget: 'Has R&D budget',
+          average_salary: '£30,000 – £34,000',
+          new_tech_to_uk: 'Has new-to-world tech, business model or IP',
+          export_revenue: 'Yes, will create significant export revenue',
+          sector_name: 'Renewable Energy : Wind : Renewable energy: Wind: Onshore',
+          account_tier: 'New hotel (Non-FDI)',
+          business_activities: 'Yes',
+          associated_non_fdi_r_and_d_project: {
+            name: 'Freds',
+            actions: [
+              {
+                label: 'Edit project',
+                url: '/investment-projects/1/edit-associated?term=DHP-00000460',
+              },
+              {
+                label: 'Remove association',
+                url: '/investment-projects/1/remove-associated',
+              },
+            ],
+          },
+        }
+
+        expect(this.actualInvestmentValue).to.deep.equal(expectedInvestmentValue)
+      })
+    })
+
+    context('when all fields are set but the client has not supplied investment information', () => {
+      beforeEach(() => {
+        this.actualInvestmentValue = transformInvestmentValueForView({
+          client_cannot_provide_total_investment: false,
+          total_investment: null,
+          client_cannot_provide_foreign_investment: false,
+          foreign_equity_investment: null,
+          number_new_jobs: 100,
+          number_safeguarded_jobs: 200,
+          government_assistance: true,
+          r_and_d_budget: true,
+          average_salary: {
+            name: '£30,000 – £34,000',
+          },
+          new_tech_to_uk: true,
+          export_revenue: true,
+          sector: {
+            name: 'Renewable Energy : Wind : Renewable energy: Wind: Onshore',
+          },
+          investor_company: {
+            name: 'Venus Ltd',
+            classification: {
+              name: 'New hotel (Non-FDI)',
+            },
+          },
+          business_activities: [
+            {
+              name: 'European headquarters',
+            },
+          ],
+          non_fdi_r_and_d_budget: true,
+          id: 1,
+          associated_non_fdi_r_and_d_project: {
+            name: 'Freds',
+            id: 'ac035522-ad0b-4eeb-87f4-0ce964e4b999',
+            project_code: 'DHP-00000460',
+          },
+        })
+      })
+
+      it('should correctly format the value view', () => {
+        const expectedInvestmentValue = {
+          total_investment: null,
+          foreign_equity_investment: null,
           number_new_jobs: '100 new jobs',
           number_safeguarded_jobs: '200 safeguarded jobs',
           government_assistance: 'Has government assistance',


### PR DESCRIPTION
DH-1486

This makes changes to the following:
- consolidates `formatCurrency` as it was being defined in multiple locations
- introduces `Grant offered` to the service delivery details screen

![screen shot 2018-02-13 at 12 57 25](https://user-images.githubusercontent.com/1150417/36151005-85ac6fec-10bd-11e8-9002-648e68bbe971.png)
