### PR TITLE
Replace prime symbols with apostrophe in OMIS content

### DIFF
--- a/src/apps/omis/apps/create/views/sector.njk
+++ b/src/apps/omis/apps/create/views/sector.njk
@@ -2,7 +2,7 @@
 
 {% block fields %}
   {% call Message({ type: 'muted' }) %}
-    {{ company.name }}'s primary sector is <strong>{{ company.sector.name }}</strong>
+    {{ company.name }}’s primary sector is <strong>{{ company.sector.name }}</strong>
   {% endcall %}
 
   {{ super() }}

--- a/src/apps/omis/apps/edit/views/invoice-details.njk
+++ b/src/apps/omis/apps/edit/views/invoice-details.njk
@@ -34,7 +34,7 @@
       {% else %}
         {{ registeredAddress | join('<br>') | safe }}
         {% call Message({ type: 'muted' }) %}
-          The company's registered address is currently being used for the invoice.
+          The company’s registered address is currently being used for the invoice.
           <br>
           <a href="billing-address?returnUrl={{ CURRENT_PATH }}">Add a different billing address</a>
         {% endcall %}

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -19,7 +19,7 @@
       "label": "Description of the work or activity"
     },
     "use_sector_from_company": {
-      "label": "Do you want to use the company's primary sector (shown above) for this order?"
+      "label": "Do you want to use the company’s primary sector (shown above) for this order?"
     },
     "sector": {
       "label": "Sector"
@@ -113,8 +113,8 @@
       "assignee_time": "Allocate hours to at least one adviser in the market",
       "assignee_lead": "Set a lead adviser",
       "vat_status": "Choose a VAT category",
-      "vat_number": "Enter the EU company's VAT number",
-      "vat_verified": "Verify the EU company's VAT number"
+      "vat_number": "Enter the EU company’s VAT number",
+      "vat_verified": "Verify the EU company’s VAT number"
     }
   },
   "validation": {


### PR DESCRIPTION
Previously within some content the prime symbol was being used
instead of an apostrophe. This change replaces the use of these
with the correct use of apostrophe.

[Article which explains their use](https://webdesignledger.com/common-typography-mistakes-apostrophes-versus-quotation-marks/)

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
