### PR TITLE
Call breadcrumb method in form wizard render function

### DIFF
--- a/src/apps/omis/controllers/form.js
+++ b/src/apps/omis/controllers/form.js
@@ -2,14 +2,14 @@ const { get, filter, flatten, forEach, last, mapValues } = require('lodash')
 const { Controller } = require('hmpo-form-wizard')
 
 class FormController extends Controller {
-  configure (req, res, next) {
+  render (req, res, next) {
     const heading = req.form.options.heading
 
     if (heading) {
       res.breadcrumb(heading)
     }
 
-    next()
+    super.render(req, res, next)
   }
 
   getErrors (req, res) {

--- a/test/unit/apps/omis/controllers/form.test.js
+++ b/test/unit/apps/omis/controllers/form.test.js
@@ -9,7 +9,7 @@ describe('OMIS FormController', () => {
     this.controller = new Controller({ route: '/' })
   })
 
-  describe('configure()', () => {
+  describe('render()', () => {
     beforeEach(() => {
       this.breadcrumbSpy = sandbox.spy()
       this.reqMock = Object.assign({}, globalReq, {
@@ -24,7 +24,7 @@ describe('OMIS FormController', () => {
 
     context('when a step heading doesn\'t exists', () => {
       it('should not set a breadcrumb item', () => {
-        this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+        this.controller.render(this.reqMock, this.resMock, this.nextSpy)
 
         expect(this.breadcrumbSpy).not.to.have.been.called
         expect(this.nextSpy).to.have.been.calledWith()
@@ -34,7 +34,7 @@ describe('OMIS FormController', () => {
     context('when a step heading exists', () => {
       it('should set append a breadcrumb item', () => {
         this.reqMock.form.options.heading = 'Step heading'
-        this.controller.configure(this.reqMock, this.resMock, this.nextSpy)
+        this.controller.render(this.reqMock, this.resMock, this.nextSpy)
 
         expect(this.breadcrumbSpy).to.have.been.calledWith('Step heading')
         expect(this.nextSpy).to.have.been.calledWith()


### PR DESCRIPTION
The breadcrumb method was being called in the configure method which
is one of the first methods. If the heading form option was changed
dynamically within a set it would not pick up this change.

This change method ensures it is called later within the lifecycle just
before the template render is called so changes to the value are
still rendered correctly.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
