### PR TITLE
Split responsibility of saving and handling success for create

### DIFF
--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -1,4 +1,4 @@
-const { assign, find, get, unset } = require('lodash')
+const { assign, find, get, isEmpty, unset } = require('lodash')
 
 const metadataRepo = require('../../../../../lib/metadata')
 const { FormController } = require('../../../controllers')
@@ -19,7 +19,7 @@ class ConfirmController extends FormController {
     })
   }
 
-  async successHandler (req, res, next) {
+  async saveValues (req, res, next) {
     const data = req.sessionModel.toJSON()
 
     // clean un-needed properties
@@ -28,16 +28,26 @@ class ConfirmController extends FormController {
 
     try {
       const order = await Order.save(req.session.token, data)
+      req.sessionModel.set('order-id', order.id)
 
-      req.journeyModel.reset()
-      req.journeyModel.destroy()
-      req.sessionModel.reset()
-      req.sessionModel.destroy()
-
-      res.redirect(`/omis/${order.id}`)
+      next()
     } catch (error) {
       next(error)
     }
+  }
+
+  successHandler (req, res) {
+    const orderId = req.sessionModel.get('order-id')
+
+    req.journeyModel.reset()
+    req.journeyModel.destroy()
+    req.sessionModel.reset()
+    req.sessionModel.destroy()
+
+    if (!isEmpty(req.form.options.successMessage)) {
+      req.flash('success', req.form.options.successMessage)
+    }
+    res.redirect(`/omis/${orderId}`)
   }
 }
 

--- a/test/unit/apps/omis/controllers/edit.test.js
+++ b/test/unit/apps/omis/controllers/edit.test.js
@@ -81,14 +81,11 @@ describe('OMIS EditController', () => {
       this.destroySpy = sandbox.spy()
       this.flashSpy = sandbox.spy()
       this.redirectSpy = sandbox.spy()
-      this.successMessageMock = 'Successfully handled'
       this.nextMock = '/next-step/'
 
       this.reqMock = {
         form: {
-          options: {
-            successMessage: this.successMessageMock,
-          },
+          options: {},
         },
         sessionModel: {
           reset: this.resetSpy,
@@ -102,15 +99,12 @@ describe('OMIS EditController', () => {
       }
       this.resMock = {
         redirect: this.redirectSpy,
-        locals: {
-          order: { id: updateMockData.id },
-        },
       }
 
       sandbox.stub(FormController.prototype, 'getNextStep').returns(this.nextMock)
     })
 
-    context('when a success message exists', () => {
+    context('when a success message doesn\'t exist', () => {
       beforeEach(() => {
         this.controller.successHandler(this.reqMock, this.resMock)
       })
@@ -120,9 +114,8 @@ describe('OMIS EditController', () => {
         expect(this.destroySpy).to.have.been.calledTwice
       })
 
-      it('should set a flash message', () => {
-        expect(this.flashSpy).to.have.been.calledOnce
-        expect(this.flashSpy).to.have.been.calledWith('success', this.successMessageMock)
+      it('should not set a flash message', () => {
+        expect(this.flashSpy).not.to.have.been.called
       })
 
       it('should get the next value', () => {
@@ -136,14 +129,15 @@ describe('OMIS EditController', () => {
       })
     })
 
-    context('when a success message doesn\'t exist', () => {
+    context('when a success message exists', () => {
       beforeEach(() => {
-        this.reqMock.form.options.successMessage = null
+        this.reqMock.form.options.successMessage = 'Successfully handled'
         this.controller.successHandler(this.reqMock, this.resMock)
       })
 
-      it('should not set a flash message', () => {
-        expect(this.flashSpy).not.to.have.been.called
+      it('should set a flash message', () => {
+        expect(this.flashSpy).to.have.been.calledOnce
+        expect(this.flashSpy).to.have.been.calledWith('success', 'Successfully handled')
       })
     })
   })


### PR DESCRIPTION
The edit controllers split the logic between saving the values
to the API and what to do on success of the form controller.

This change introduces that separation to the create journey too.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
