### PR TITLE
DH-1522 Add knowledgebase link to support page

### DIFF
--- a/src/apps/support/views/feedback.njk
+++ b/src/apps/support/views/feedback.njk
@@ -1,5 +1,6 @@
 {% extends "_layouts/datahub-base.njk" %}
 
 {% block body_main_content %}
+  Take a look at our <a href="https://uktrade.zendesk.com/hc">help centre</a> for help, guidance and updates.
   {{ Form(feedbackForm) }}
 {% endblock %}


### PR DESCRIPTION
This adds a link to the Zendesk knowledgebase to the support page. We'll be using that for help and in future for release notes