### PR TITLE
Only show contact message when order is not in draft

### DIFF
--- a/src/apps/omis/apps/create/views/contact.njk
+++ b/src/apps/omis/apps/create/views/contact.njk
@@ -22,7 +22,7 @@
     {% endcall %}
   {% endcall %}
 
-  {% if order.canEditContactDetails %}
+  {% if order.canEditContactDetails and order.status !== 'draft' %}
     {% call Message({ type: 'info', element: 'div' }) %}
       <p>Changing the contact will change who notifications are sent to.</p>
       <p>It will not change the contact details on the quote.</p>


### PR DESCRIPTION
This change makes sure the message about editing a contact only applies
when the order is not in draft.

During draft mode changing the contact will change the name on the quote
so this message isn't accurate.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
