### PR TITLE
Redirect to redirect property in OMIS controller error handler

### DIFF
--- a/src/apps/omis/controllers/form.js
+++ b/src/apps/omis/controllers/form.js
@@ -1,5 +1,7 @@
-const { get, filter, flatten, forEach, last, mapValues } = require('lodash')
+const { get, filter, flatten, forEach, mapValues } = require('lodash')
 const { Controller } = require('hmpo-form-wizard')
+
+const logger = require('../../../../config/logger')
 
 class FormController extends Controller {
   render (req, res, next) {
@@ -54,13 +56,9 @@ class FormController extends Controller {
   }
 
   errorHandler (err, req, res, next) {
-    if (get(err, 'code') === 'MISSING_PREREQ') {
-      const lastStep = last(req.journeyModel.get('history'))
-
-      if (!lastStep) {
-        return res.redirect(req.baseUrl)
-      }
-      return res.redirect(lastStep.path)
+    if (err.redirect) {
+      logger.error(err)
+      return res.redirect(err.redirect)
     }
 
     if (get(err, 'code') === 'SESSION_TIMEOUT') {


### PR DESCRIPTION
If the error that is sent to the form controller contains a redirect
property the error handler should redirect there rather than calling
the parent error handler.

This change also negates the need to specifically handle the
`MISSING_PREREQ` error as [within the form wizard library](https://github.com/UKHomeOffice/passports-form-wizard/blob/a4d6ed05eceaa89674b6bb4e126864f45173d5b4/lib/controller/mixins/check-progress.js#L52-L57) this URL is already
decided and sent with the error object.

An example of how to handle this error within your app can be seen within
the [form wizard example app](https://github.com/UKHomeOffice/passports-form-wizard/blob/7f4fda662fc9aa70a646a8a4cae127c755d90e73/example/app.js#L80-L83).

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
