### PR TITLE
DH-1499 Hide net receipt field for Offered status

### DIFF
--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -11,7 +11,6 @@ const { getDitCompany } = require('../../companies/repos')
 const { transformObjectToOption, transformContactToOption } = require('../../transformers')
 const { getOptions } = require('../../../lib/options')
 
-const SERVICE_DELIVERY_STATUS_OFFERED = '45329c18-6095-e211-a939-e4115bead28a'
 const SERVICE_DELIVERY_STATUS_COMPLETED = '47329c18-6095-e211-a939-e4115bead28a'
 
 async function postDetails (req, res, next) {
@@ -99,7 +98,6 @@ async function getInteractionOptions (req, res, next) {
       return tapService.value
     })
     const successfulServiceStatuses = [
-      SERVICE_DELIVERY_STATUS_OFFERED,
       SERVICE_DELIVERY_STATUS_COMPLETED,
     ]
     res.locals.conditions = {

--- a/test/acceptance/features/interactions/add.feature
+++ b/test/acceptance/features/interactions/add.feature
@@ -62,7 +62,7 @@ Feature: Add a new interaction in Data hub
     When a service delivery is added
       | key             | value                                    |
       | Service         | Trade - Tradeshow Access Programme (TAP) |
-      | Service status  | Offered                                  |
+      | Service status  | Completed                                |
       | Grant offered   | 100000                                   |
       | Net receipt     | 50000                                    |
     Then I see the success message
@@ -205,11 +205,9 @@ Feature: Add a new interaction in Data hub
     Then there are service delivery fields
     When I change form dropdown "service" to Tradeshow Access Programme (TAP)
     Then the service fields are visible
-    When I change form dropdown "service_delivery_status" to Offered
+    When I change form dropdown "service_delivery_status" to Completed
     Then the net receipt field is visible
     When I change form dropdown "service_delivery_status" to Current
     Then the net receipt field is hidden
-    When I change form dropdown "service_delivery_status" to Completed
-    Then the net receipt field is visible
     When I change form dropdown "service" to Trade - Enquiry
     Then the service fields are hidden

--- a/test/acceptance/features/interactions/add.feature
+++ b/test/acceptance/features/interactions/add.feature
@@ -51,7 +51,7 @@ Feature: Add a new interaction in Data hub
       | Documents                | There are no files or documents   |
 
   @interaction-add--companies-service-delivery-tap-service-optional-complete-submit
-  Scenario: Companies service delivery is saved
+  Scenario: Companies service delivery is saved and TAP service optional fields are specified
 
     Given I navigate to company fixture Venus Ltd
     When I click the Interactions local nav link
@@ -83,7 +83,7 @@ Feature: Add a new interaction in Data hub
       | Documents                | There are no files or documents   |
 
   @interaction-add--companies-service-delivery-tap-service-optional-empty-submit
-  Scenario: Companies service delivery is saved
+  Scenario: Companies service delivery is saved and TAP service optional fields are not specified
 
     Given I navigate to company fixture Venus Ltd
     When I click the Interactions local nav link

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -370,7 +370,6 @@ describe('Interaction details middleware', () => {
 
       it('should set successful service status conditions', () => {
         const expectedSuccessfulServiceStatusConditions = [
-          '45329c18-6095-e211-a939-e4115bead28a',
           '47329c18-6095-e211-a939-e4115bead28a',
         ]
 


### PR DESCRIPTION
DH-1499

This change will only show the `Net receipt` field when `Completed` is selected for `Status`. Previously the `Net receipt` field was also being shown for `Offered` status.
