### PR TITLE
Ensure values are escape correctly

### DIFF
--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -14,12 +14,12 @@
     {{ values.company.name | escape }}
     <br>
     {{ [
-      values.company.registered_address_1 | escape,
-      values.company.registered_address_2 | escape,
-      values.company.registered_address_county | escape,
-      values.company.registered_address_town | escape,
-      values.company.registered_address_postcode | escape
-    ] | removeNilAndEmpty | join(", ") }}
+      values.company.registered_address_1,
+      values.company.registered_address_2,
+      values.company.registered_address_county,
+      values.company.registered_address_town,
+      values.company.registered_address_postcode
+    ] | removeNilAndEmpty | join(", ") | escape }}
   {% endset %}
 
   {% call MultiStepForm({


### PR DESCRIPTION
In the order creation summary some of the values were being
double escaped. This meant the display would seem wrong.

What was happening is that values output using the curly brackets within
a nunjucs set block were being escaped. They were also being
individually escaped causing strange display in the view.

## Before
![image](https://user-images.githubusercontent.com/3327997/36485267-aff99c46-1713-11e8-87c0-5189bf9a11cd.png)

## After

![image](https://user-images.githubusercontent.com/3327997/36485254-a4a88bae-1713-11e8-8e9f-435b1d8d7530.png)


<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
