### PR TITLE
Button consistency

### DIFF
--- a/assets/javascripts/modules/archive-form.js
+++ b/assets/javascripts/modules/archive-form.js
@@ -59,7 +59,7 @@ const ArchiveForm = {
 
   createShowButton () {
     const showArchiveFormButton = this.document.createElement('a')
-    showArchiveFormButton.classList.add('button')
+    showArchiveFormButton.classList.add('button', 'button--secondary')
     showArchiveFormButton.href = '#'
     showArchiveFormButton.textContent = 'Archive'
     return showArchiveFormButton

--- a/src/apps/companies/macros.js
+++ b/src/apps/companies/macros.js
@@ -57,8 +57,8 @@ const accountManagementFormConfig = function ({
 }) {
   return {
     returnLink,
-    buttonText: 'Save',
-    returnText: 'Cancel',
+    buttonText: 'Save and return',
+    returnText: 'Return without saving',
     children: [
       {
         macroName: 'MultipleChoiceField',

--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -15,15 +15,15 @@
   {% endif %}
 
   {% if company.id %}
-    <p><a href="/companies/{{company.id}}/edit" class="button button--secondary">Edit</a></p>
+    <p><a href="/companies/{{company.id}}/edit" class="button button--secondary">Edit company details</a></p>
   {% else %}
-    <p><a href="/companies/add/{{company.company_number}}" class="button">Add</a></p>
+    <p><a href="/companies/add/{{company.company_number}}" class="button">Add company</a></p>
   {% endif %}
 
   <div class="section">
     <h2 class="heading-medium">Account management</h2>
     {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
-    <p><a href="/companies/{{company.id}}/account-management/edit" class="button button--secondary">Edit</a></p>
+    <p><a href="/companies/{{company.id}}/account-management/edit" class="button button--secondary">Edit account management</a></p>
   </div>
 
   {% if company.id and not company.archived %}

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -26,9 +26,9 @@
   {% endif %}
 
   {% call Form({
-    buttonText: 'Save' if company.id else 'Save and create',
-    returnLink: '/companies/' + company.id if company.id,
-    returnText: 'Return without saving' if company.id,
+    buttonText: 'Save and return' if company.id else 'Add company',
+    returnLink: '/companies/' + company.id if company.id else '/companies/add-step-1',
+    returnText: 'Return without saving' if company.id else 'Back',
     errors: {
       messages: errors
     },

--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -9,7 +9,8 @@
 
 {% block main_grid_right_column %}
   {% call Form({
-    buttonText: 'Update',
+    buttonText: 'Save and return',
+    returnText: 'Return without saving',
     returnLink: '/companies/' + company.id + '/exports',
     hiddenFields: {
       id: company.id

--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -6,7 +6,7 @@
   {% component 'key-value-table', items=exportDetails %}
 
   <p class="actions">
-    <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit</a>
+    <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
   </p>
 
   <div class="section">

--- a/src/apps/contacts/views/details.njk
+++ b/src/apps/contacts/views/details.njk
@@ -7,7 +7,7 @@
 
   {% if not contact.archived %}
     <p>
-      <a href="/contacts/{{id}}/edit" class="button">Edit contact details</a>
+      <a href="/contacts/{{id}}/edit" class="button button--secondary">Edit contact</a>
     </p>
 
     <h2 class="heading-medium">Archive contact</h2>

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -18,7 +18,9 @@
 
 {% block main_grid_right_column %}
   {% call Form({
-    buttonText: 'Save',
+    buttonText: 'Save and return' if contact.id else 'Add contact',
+    returnLink: '/contacts/' + contact.id if contact.id else '/companies/' + formData.company + '/contacts',
+    returnText: 'Return without saving' if contact.id else 'Cancel',
     errors: errors,
     hiddenFields: {
       company: formData.company,

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -51,10 +51,7 @@ async function renderEditPage (req, res, next) {
       .breadcrumb(eventName, `/events/${eventId}`)
       .breadcrumb(`${eventId ? 'Edit' : 'Add'} event`)
       .render('events/views/edit', {
-        eventForm: assign(eventForm, {
-          returnLink: `/events/${eventId}`,
-          returnText: 'Cancel',
-        }),
+        eventForm,
       })
   } catch (error) {
     next(error)

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -14,7 +14,9 @@ const eventFormConfig = ({
 }) => {
   return {
     method: 'post',
-    buttonText: 'Save',
+    buttonText: eventId ? 'Save and return' : 'Add event',
+    returnText: eventId ? 'Return without saving' : 'Cancel',
+    returnLink: eventId ? `/events/${eventId}` : '/events',
     hiddenFields: {
       id: eventId,
     },

--- a/src/apps/events/views/details.njk
+++ b/src/apps/events/views/details.njk
@@ -2,5 +2,5 @@
 
 {% block main_grid_right_column %}
   {% component 'key-value-table', variant='striped', items=eventViewRecord %}
-  <a class="button button--secondary" href="{{ event.id }}/edit">Edit Event</a>
+  <a class="button button--secondary" href="{{ event.id }}/edit">Edit event</a>
 {% endblock %}

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -19,13 +19,16 @@ function renderEditPage (req, res) {
     dit_team: get(req, 'session.user.dit_team.id'),
   }
   const mergedInteractionData = pickBy(merge({}, interactionDefaults, interactionData, res.locals.requestBody))
+  const interactionId = get(res.locals, 'interaction.id')
   const interactionForm =
     buildFormWithStateAndErrors(
       formConfigs[req.params.kind](
         assign({}, res.locals.options, res.locals.conditions, {
-          returnLink: res.locals.returnLink,
+          returnLink: interactionId ? `/interactions/${interactionId}` : res.locals.returnLink,
+          returnText: interactionId ? 'Return without saving' : 'Cancel',
+          buttonText: interactionId ? 'Save and return' : `Add ${lowerCase(req.params.kind)}`,
           hiddenFields: {
-            id: get(res.locals, 'interaction.id'),
+            id: interactionId,
             company: res.locals.company.id,
             investment_project: get(res.locals, 'investmentData.id'),
             kind: snakeCase(req.params.kind),

--- a/src/apps/interactions/macros/interaction-form.js
+++ b/src/apps/interactions/macros/interaction-form.js
@@ -14,6 +14,8 @@ const {
 
 module.exports = function ({
   returnLink,
+  returnText,
+  buttonText,
   contacts = [],
   advisers = [],
   services = [],
@@ -23,8 +25,8 @@ module.exports = function ({
 }) {
   return {
     returnLink,
-    buttonText: 'Save',
-    returnText: 'Cancel',
+    returnText,
+    buttonText,
     hiddenFields,
     children: [
       contact(contacts),

--- a/src/apps/interactions/macros/service-delivery-form.js
+++ b/src/apps/interactions/macros/service-delivery-form.js
@@ -13,6 +13,8 @@ const {
 
 module.exports = function ({
   returnLink,
+  returnText,
+  buttonText,
   contacts = [],
   advisers = [],
   services = [],
@@ -25,8 +27,8 @@ module.exports = function ({
 }) {
   return {
     returnLink,
-    buttonText: 'Save',
-    returnText: 'Cancel',
+    returnText,
+    buttonText,
     hiddenFields,
     children: [
       contact(contacts),

--- a/test/acceptance/pages/audit/Contact.js
+++ b/test/acceptance/pages/audit/Contact.js
@@ -6,7 +6,7 @@ const { getButtonWithText } = require('../../helpers/selectors')
 module.exports = {
   url: process.env.QA_HOST,
   elements: {
-    editContactDetailsButton: getButtonWithText('Edit contact details'),
+    editContactDetailsButton: getButtonWithText('Edit contact'),
     saveButton: getButtonWithText('Save'),
     auditHistoryTab: 'a[href*="/audit"]',
     telephone: '#field-telephone_number',

--- a/test/acceptance/pages/companies/Company.js
+++ b/test/acceptance/pages/companies/Company.js
@@ -17,7 +17,7 @@ module.exports = {
     searchForm: '.c-entity-search__button',
     addCompanyButton: getButtonWithText('Add company'),
     continueButton: getButtonWithText('Continue'),
-    saveAndCreateButton: getButtonWithText('Save and create'),
+    saveAndCreateButton: getButtonWithText('Add company'),
     ukPrivateOrPublicLimitedCompanyOption: 'label[for=field-business_type-1]',
     otherTypeOfUKOrganisationOption: 'label[for=field-business_type-2]',
     otherTypeOfUKOrganisationBusinessType: 'select[name="business_type_uk_other"]',
@@ -586,7 +586,7 @@ module.exports = {
       selector: 'form',
       elements: {
         exportWinCategory: '#field-export_experience_category',
-        saveButton: getButtonWithText('Update'),
+        saveButton: getButtonWithText('Save'),
       },
     },
   },

--- a/test/acceptance/pages/events/Event.js
+++ b/test/acceptance/pages/events/Event.js
@@ -46,7 +46,7 @@ module.exports = {
     relatedProgrammes: '#field-related_programmes',
     addAnotherProgramme: 'input[name="add_related_programme"]',
     editButton: getButtonWithText('Edit event'),
-    saveButton: getButtonWithText('Save'),
+    saveButton: getButtonWithText('Add event'),
   },
   commands: [
     {

--- a/test/acceptance/pages/events/Event.js
+++ b/test/acceptance/pages/events/Event.js
@@ -45,7 +45,7 @@ module.exports = {
     addAnotherSharedTeam: 'input[name="add_team"]',
     relatedProgrammes: '#field-related_programmes',
     addAnotherProgramme: 'input[name="add_related_programme"]',
-    editButton: getButtonWithText('Edit Event'),
+    editButton: getButtonWithText('Edit event'),
     saveButton: getButtonWithText('Save'),
   },
   commands: [

--- a/test/acceptance/pages/interactions/Interaction.js
+++ b/test/acceptance/pages/interactions/Interaction.js
@@ -24,7 +24,7 @@ module.exports = {
     aStandardInteraction: getRadioButtonWithText('A standard interaction'),
     aServiceThatYouHaveProvided: getRadioButtonWithText('A service that you have provided'),
     continueButton: getButtonWithText('Continue'),
-    saveButton: getButtonWithText('Save'),
+    saveButton: getButtonWithText('Add'),
     subject: '#field-subject',
     notes: '#field-notes',
     dateOfInteractionYear: '#field-date_year',


### PR DESCRIPTION
This change addresses a lot of inconsistency with form and edit actions across the main
parts of the application.

It ensures:

- secondary buttons are used for edit actions when linked to data tables
- primary action buttons use consistent text
- secondary action buttons are present and use consistent text

## Before

### Companies
![image](https://user-images.githubusercontent.com/3327997/36493168-e2c6f05c-1726-11e8-866d-fbe7d2b28c8f.png)

#### Create
![image](https://user-images.githubusercontent.com/3327997/36493223-02b60074-1727-11e8-88e8-c45d5bac9622.png)
#### Edit
![image](https://user-images.githubusercontent.com/3327997/36493190-f04cfdfc-1726-11e8-99d0-b3b33143fcdd.png)

### Contacts
![image](https://user-images.githubusercontent.com/3327997/36493546-c8849f0e-1727-11e8-9850-186e8dbd470e.png)

#### Create/edit
![image](https://user-images.githubusercontent.com/3327997/36493573-dc0d13ee-1727-11e8-8989-df9b2e394073.png)

### Events
![image](https://user-images.githubusercontent.com/3327997/36493782-5059f03c-1728-11e8-93c3-3cffb3e50683.png)

#### Create/edit
![image](https://user-images.githubusercontent.com/3327997/36493807-5cbbe510-1728-11e8-80c9-694f3c90c64c.png)

### Interactions
![image](https://user-images.githubusercontent.com/3327997/36493974-bd86cca2-1728-11e8-83e5-8ca74d89458a.png)

#### Create
![image](https://user-images.githubusercontent.com/3327997/36494000-ce38cfdc-1728-11e8-81d9-1754e3b96e0e.png)

#### Edit
![image](https://user-images.githubusercontent.com/3327997/36493990-c7f5bc34-1728-11e8-8599-334ee524ce92.png)

## After

### Companies
![image](https://user-images.githubusercontent.com/3327997/36493128-c826333e-1726-11e8-9995-5c8c3138f85d.png)

#### Create
![image](https://user-images.githubusercontent.com/3327997/36595548-76be5ccc-189a-11e8-9009-3663b2d2bd60.png)
#### Edit
![image](https://user-images.githubusercontent.com/3327997/36493401-71bcf6da-1727-11e8-95f7-5679b7eae607.png)

### Contacts
![image](https://user-images.githubusercontent.com/3327997/36493512-b4f47400-1727-11e8-8090-4191c4674402.png)

#### Create
![image](https://user-images.githubusercontent.com/3327997/36595494-4dbc5c52-189a-11e8-8f9e-3dea74261c04.png)

#### Edit
![image](https://user-images.githubusercontent.com/3327997/36493483-a363c15a-1727-11e8-8b81-706a1c70f4e4.png)

### Events
![image](https://user-images.githubusercontent.com/3327997/36493852-728e0878-1728-11e8-837e-bc131f48f3c6.png)

#### Create
![image](https://user-images.githubusercontent.com/3327997/36595568-893aa2f2-189a-11e8-82a7-85859fd65f38.png)
#### Edit
![image](https://user-images.githubusercontent.com/3327997/36493888-8415c590-1728-11e8-901c-2d1d59a85a76.png)

### Interactions
![image](https://user-images.githubusercontent.com/3327997/36493954-afa510bc-1728-11e8-99fd-995daba77bd7.png)

#### Create
![image](https://user-images.githubusercontent.com/3327997/36595450-20a2e902-189a-11e8-8a80-47f99ac4efd8.png)
![image](https://user-images.githubusercontent.com/3327997/36595464-2e31243a-189a-11e8-8396-111581615bd3.png)
#### Edit
![image](https://user-images.githubusercontent.com/3327997/36493931-a3556f8c-1728-11e8-9b0e-83d48583a85a.png)

