### PR TITLE
[DH-1492] Fix handling of blank fields in the investment value form

### DIFF
--- a/src/apps/investment-projects/controllers/edit.js
+++ b/src/apps/investment-projects/controllers/edit.js
@@ -22,14 +22,8 @@ function editDetailsPost (req, res, next) {
   return res.redirect(`/investment-projects/${res.locals.resultId}/details`)
 }
 
-function editValuePost (req, res) {
-  if (res.locals.form.errors) {
-    return res
-      .breadcrumb('Edit value')
-      .render('investment-projects/views/value-edit')
-  }
-  req.flash('success', 'Investment value updated')
-  return res.redirect(`/investment-projects/${res.locals.projectId}/details`)
+function renderValueForm (req, res) {
+  return res.render('investment-projects/views/value-edit')
 }
 
 module.exports = {
@@ -37,5 +31,5 @@ module.exports = {
   editValueGet,
   renderRequirementsForm,
   editDetailsPost,
-  editValuePost,
+  renderValueForm,
 }

--- a/src/apps/investment-projects/middleware/forms/value.js
+++ b/src/apps/investment-projects/middleware/forms/value.js
@@ -42,16 +42,6 @@ async function handleFormPost (req, res, next) {
       res.locals.errors = {
         messages: err.error,
       }
-
-      if (!req.body.client_cannot_provide_total_investment) {
-        delete res.locals.errors.messages.total_investment
-        res.locals.errors.messages.client_cannot_provide_total_investment = ['This field is required']
-      }
-      if (!req.body.client_cannot_provide_foreign_investment) {
-        delete res.locals.errors.messages.foreign_equity_investment
-        res.locals.errors.messages.client_cannot_provide_foreign_investment = ['This field is required']
-      }
-
       next()
     } else {
       next(err)

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -124,7 +124,7 @@ router
 router
   .route('/:investmentId/edit-value')
   .get(valueFormMiddleware.populateForm, edit.editValueGet)
-  .post(valueFormMiddleware.populateForm, valueFormMiddleware.handleFormPost, edit.editValuePost)
+  .post(valueFormMiddleware.populateForm, valueFormMiddleware.handleFormPost, edit.renderValueForm)
 
 router
   .route('/:investmentId/edit-requirements')

--- a/src/apps/investment-projects/transformers/value.js
+++ b/src/apps/investment-projects/transformers/value.js
@@ -76,16 +76,22 @@ function transformInvestmentValueForView ({
 }
 
 function transformInvestmentValueFormBodyToApiRequest (props) {
-  const newProps = {
-    average_salary: {
-      id: props.average_salary,
-    },
-    total_investment: props.client_cannot_provide_total_investment === 'true' ? null : props.total_investment,
-    foreign_equity_investment: props.client_cannot_provide_foreign_investment === 'true' ? null : props.foreign_equity_investment,
-  }
+  const totalInvestment = props.client_cannot_provide_total_investment === 'true'
+    ? null
+    : props.total_investment || null
+
+  const foreignEquityInvestment = props.client_cannot_provide_foreign_investment === 'true'
+    ? null
+    : props.foreign_equity_investment || null
+
   return {
     ...props,
-    ...newProps,
+    ...{
+      total_investment: totalInvestment,
+      foreign_equity_investment: foreignEquityInvestment,
+      number_new_jobs: props.number_new_jobs || null,
+      number_safeguarded_jobs: props.number_safeguarded_jobs || null,
+    },
   }
 }
 

--- a/src/apps/investment-projects/transformers/value.js
+++ b/src/apps/investment-projects/transformers/value.js
@@ -75,6 +75,20 @@ function transformInvestmentValueForView ({
   }
 }
 
+function transformInvestmentValueFormBodyToApiRequest (props) {
+  const newProps = {
+    average_salary: {
+      id: props.average_salary,
+    },
+    total_investment: props.client_cannot_provide_total_investment === 'true' ? null : props.total_investment,
+    foreign_equity_investment: props.client_cannot_provide_foreign_investment === 'true' ? null : props.foreign_equity_investment,
+  }
+  return {
+    ...props,
+    ...newProps,
+  }
+}
+
 function transformAssociatedProject ({
   id,
   associated_non_fdi_r_and_d_project,
@@ -100,4 +114,7 @@ function transformAssociatedProject ({
   }
 }
 
-module.exports = { transformInvestmentValueForView }
+module.exports = {
+  transformInvestmentValueForView,
+  transformInvestmentValueFormBodyToApiRequest,
+}

--- a/src/apps/investment-projects/views/value-edit.njk
+++ b/src/apps/investment-projects/views/value-edit.njk
@@ -6,7 +6,7 @@
 
   {% call Form({
     buttonText: 'Save',
-    errors: form.errors
+    errors: errors
   }) %}
 
     {{ MultipleChoiceField({
@@ -15,7 +15,7 @@
         modifier: 'inline',
         label: form.labels.client_cannot_provide_total_investment,
         value: form.state.client_cannot_provide_total_investment,
-        error: form.errors.messages.client_cannot_provide_total_investment,
+        error: errors.messages.client_cannot_provide_total_investment,
         options: [
           { label: 'Yes', value: 'false' },
           { label: 'No', value: 'true' }
@@ -27,7 +27,7 @@
       name: 'total_investment',
       label: form.labels.total_investment,
       value: form.state.total_investment,
-      error: form.errors.messages.total_investment,
+      error: errors.messages.total_investment,
       modifier: 'subfield',
       condition: {
         name: 'client_cannot_provide_total_investment',
@@ -41,7 +41,7 @@
         modifier: 'inline',
         label: form.labels.client_cannot_provide_foreign_investment,
         value: form.state.client_cannot_provide_foreign_investment,
-        error: form.errors.messages.client_cannot_provide_foreign_investment,
+        error: errors.messages.client_cannot_provide_foreign_investment,
         options: [
           { label: 'Yes', value: 'false' },
           { label: 'No', value: 'true' }
@@ -53,7 +53,7 @@
       name: 'foreign_equity_investment',
       label: form.labels.foreign_equity_investment,
       value: form.state.foreign_equity_investment,
-      error: form.errors.messages.foreign_equity_investment,
+      error: errors.messages.foreign_equity_investment,
       modifier: 'subfield',
       condition: {
         name: 'client_cannot_provide_foreign_investment',
@@ -65,7 +65,7 @@
       name: 'number_new_jobs',
       label: form.labels.number_new_jobs,
       value: form.state.number_new_jobs,
-      error: form.errors.messages.number_new_jobs
+      error: errors.messages.number_new_jobs
     }) }}
 
     {{ MultipleChoiceField({
@@ -73,7 +73,7 @@
       type: 'radio',
       label: form.labels.average_salary,
       value: form.state.average_salary,
-      error: form.errors.messages.average_salary,
+      error: errors.messages.average_salary,
       options: form.options.averageSalaryRange
     }) }}
 
@@ -81,7 +81,7 @@
       name: 'number_safeguarded_jobs',
       label: form.labels.number_safeguarded_jobs,
       value: form.state.number_safeguarded_jobs,
-      error: form.errors.messages.number_safeguarded_jobs
+      error: errors.messages.number_safeguarded_jobs
     }) }}
 
     {% if investmentData.investment_type.name == 'FDI' %}
@@ -89,7 +89,7 @@
         name: 'fdi_value',
         label: form.labels.fdi_value,
         value: form.state.fdi_value,
-        error: form.errors.messages.fdi_value,
+        error: errors.messages.fdi_value,
         initialOption: '-- Select a project value --',
         options: form.options.fdiValue
       }) }}
@@ -101,7 +101,7 @@
       modifier: 'inline',
       label: form.labels.government_assistance,
       value: form.state.government_assistance,
-      error: form.errors.messages.government_assistance,
+      error: errors.messages.government_assistance,
       options: [
         { label: 'Yes', value: 'true' },
         { label: 'No', value: 'false' }
@@ -114,7 +114,7 @@
       modifier: 'inline',
       label: form.labels.r_and_d_budget,
       value: form.state.r_and_d_budget,
-      error: form.errors.messages.r_and_d_budget,
+      error: errors.messages.r_and_d_budget,
       options: [
         { label: 'Yes', value: 'true' },
         { label: 'No', value: 'false' }
@@ -127,7 +127,7 @@
       modifier: 'inline',
       label: form.labels.non_fdi_r_and_d_budget,
       value: form.state.non_fdi_r_and_d_budget,
-      error: form.errors.messages.non_fdi_r_and_d_budget,
+      error: errors.messages.non_fdi_r_and_d_budget,
       options: [
         { label: 'Yes', value: 'true' },
         { label: 'No', value: 'false' }
@@ -140,7 +140,7 @@
       modifier: 'inline',
       label: form.labels.new_tech_to_uk,
       value: form.state.new_tech_to_uk,
-      error: form.errors.messages.new_tech_to_uk,
+      error: errors.messages.new_tech_to_uk,
       options: [
         { label: 'Yes', value: 'true' },
         { label: 'No', value: 'false' }
@@ -153,7 +153,7 @@
       modifier: 'inline',
       label: form.labels.export_revenue,
       value: form.state.export_revenue,
-      error: form.errors.messages.export_revenue,
+      error: errors.messages.export_revenue,
       options: [
         { label: 'Yes', value: 'true' },
         { label: 'No', value: 'false' }

--- a/test/acceptance/features/investment-projects/value-add.feature
+++ b/test/acceptance/features/investment-projects/value-add.feature
@@ -65,3 +65,17 @@ Feature: Add value to investment project
       | Non-FDI R&D project        | Not linked to a non-FDI R&D project             |
       | New-to-world tech          | No new-to-world tech, business model or IP      |
       | Export revenue             | No, will not create significant export revenue  |
+
+
+  @investment-projects-value-add--blank
+  Scenario: Save a blank value form in the prospect stage
+
+    Given I navigate to company fixture Lambda plc
+    And I click the Investment local nav link
+    And I click the "Add investment project" link
+    And I select FDI as the Investment project type
+    And I choose Yes for "Will this company be the source of foreign equity investment?"
+    And I populate the create Investment Project form
+    When I click the "Add value" link
+    And I click the "Save" link
+    Then I see the success message

--- a/test/unit/apps/investment-projects/middleware/forms/value.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/value.test.js
@@ -200,9 +200,7 @@ describe('Investment form middleware - investment value', () => {
             client_cannot_provide_foreign_investment: 'false',
             foreign_equity_investment: '5000',
             number_new_jobs: '10',
-            average_salary: {
-              id: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
-            },
+            average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
             number_safeguarded_jobs: '100',
             fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
             government_assistance: 'false',
@@ -248,13 +246,11 @@ describe('Investment form middleware - investment value', () => {
         nock(config.apiRoot)
           .patch('/v3/investment/1234', {
             client_cannot_provide_total_investment: 'false',
-            total_investment: '',
+            total_investment: null,
             client_cannot_provide_foreign_investment: 'false',
             foreign_equity_investment: '5000',
             number_new_jobs: '10',
-            average_salary: {
-              id: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
-            },
+            average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
             number_safeguarded_jobs: '100',
             fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
             government_assistance: 'false',

--- a/test/unit/apps/investment-projects/transformers/value.test.js
+++ b/test/unit/apps/investment-projects/transformers/value.test.js
@@ -2,7 +2,10 @@ const { assign } = require('lodash')
 
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
 
-const { transformInvestmentValueForView } = require('~/src/apps/investment-projects/transformers/value')
+const {
+  transformInvestmentValueForView,
+  transformInvestmentValueFormBodyToApiRequest,
+} = require('~/src/apps/investment-projects/transformers/value')
 
 describe('Investment project transformers', () => {
   describe('#transformInvestmentValueForView', () => {
@@ -260,6 +263,125 @@ describe('Investment project transformers', () => {
         expect(this.transformedInvestmentValues.r_and_d_budget).to.equal('No R&D budget')
         expect(this.transformedInvestmentValues.new_tech_to_uk).to.equal('No new-to-world tech, business model or IP')
         expect(this.transformedInvestmentValues.export_revenue).to.equal('No, will not create significant export revenue')
+      })
+    })
+  })
+  describe('#transformInvestmentValueFormBodyToApiRequest', () => {
+    context('when all fields have been filled in', () => {
+      beforeEach(() => {
+        this.formData = {
+          client_cannot_provide_total_investment: 'false',
+          total_investment: '10000',
+          client_cannot_provide_foreign_investment: 'false',
+          foreign_equity_investment: '5000',
+          number_new_jobs: '10',
+          average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+          number_safeguarded_jobs: '100',
+          fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
+          government_assistance: 'false',
+          r_and_d_budget: 'false',
+          non_fdi_r_and_d_budget: 'false',
+          new_tech_to_uk: 'false',
+          export_revenue: 'false',
+        }
+      })
+      it('transforms and returns the entire object', () => {
+        const transformedData = transformInvestmentValueFormBodyToApiRequest(this.formData)
+        expect(transformedData).to.deep.equal({
+          client_cannot_provide_total_investment: 'false',
+          total_investment: '10000',
+          client_cannot_provide_foreign_investment: 'false',
+          foreign_equity_investment: '5000',
+          number_new_jobs: '10',
+          average_salary: {
+            'id': '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+          },
+          number_safeguarded_jobs: '100',
+          fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
+          government_assistance: 'false',
+          r_and_d_budget: 'false',
+          non_fdi_r_and_d_budget: 'false',
+          new_tech_to_uk: 'false',
+          export_revenue: 'false',
+        })
+      })
+    })
+    context('when the client cannot provide the total investment value', () => {
+      beforeEach(() => {
+        this.formData = {
+          client_cannot_provide_total_investment: 'true',
+          total_investment: '10000',
+          client_cannot_provide_foreign_investment: 'false',
+          foreign_equity_investment: '5000',
+          number_new_jobs: '10',
+          average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+          number_safeguarded_jobs: '100',
+          fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
+          government_assistance: 'false',
+          r_and_d_budget: 'false',
+          non_fdi_r_and_d_budget: 'false',
+          new_tech_to_uk: 'false',
+          export_revenue: 'false',
+        }
+      })
+      it('sets the total investment value to null', () => {
+        const transformedData = transformInvestmentValueFormBodyToApiRequest(this.formData)
+        expect(transformedData).to.deep.equal({
+          client_cannot_provide_total_investment: 'true',
+          total_investment: null,
+          client_cannot_provide_foreign_investment: 'false',
+          foreign_equity_investment: '5000',
+          number_new_jobs: '10',
+          average_salary: {
+            'id': '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+          },
+          number_safeguarded_jobs: '100',
+          fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
+          government_assistance: 'false',
+          r_and_d_budget: 'false',
+          non_fdi_r_and_d_budget: 'false',
+          new_tech_to_uk: 'false',
+          export_revenue: 'false',
+        })
+      })
+    })
+    context('when the client cannot provide the foreign equity investment value', () => {
+      beforeEach(() => {
+        this.formData = {
+          client_cannot_provide_total_investment: 'false',
+          total_investment: '10000',
+          client_cannot_provide_foreign_investment: 'true',
+          foreign_equity_investment: '5000',
+          number_new_jobs: '10',
+          average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+          number_safeguarded_jobs: '100',
+          fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
+          government_assistance: 'false',
+          r_and_d_budget: 'false',
+          non_fdi_r_and_d_budget: 'false',
+          new_tech_to_uk: 'false',
+          export_revenue: 'false',
+        }
+      })
+      it('sets the foreign total investment value to null', () => {
+        const transformedData = transformInvestmentValueFormBodyToApiRequest(this.formData)
+        expect(transformedData).to.deep.equal({
+          client_cannot_provide_total_investment: 'false',
+          total_investment: '10000',
+          client_cannot_provide_foreign_investment: 'true',
+          foreign_equity_investment: null,
+          number_new_jobs: '10',
+          average_salary: {
+            'id': '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+          },
+          number_safeguarded_jobs: '100',
+          fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
+          government_assistance: 'false',
+          r_and_d_budget: 'false',
+          non_fdi_r_and_d_budget: 'false',
+          new_tech_to_uk: 'false',
+          export_revenue: 'false',
+        })
       })
     })
   })

--- a/test/unit/apps/investment-projects/transformers/value.test.js
+++ b/test/unit/apps/investment-projects/transformers/value.test.js
@@ -266,10 +266,11 @@ describe('Investment project transformers', () => {
       })
     })
   })
+
   describe('#transformInvestmentValueFormBodyToApiRequest', () => {
     context('when all fields have been filled in', () => {
       beforeEach(() => {
-        this.formData = {
+        const formData = {
           client_cannot_provide_total_investment: 'false',
           total_investment: '10000',
           client_cannot_provide_foreign_investment: 'false',
@@ -284,18 +285,17 @@ describe('Investment project transformers', () => {
           new_tech_to_uk: 'false',
           export_revenue: 'false',
         }
+        this.transformedData = transformInvestmentValueFormBodyToApiRequest(formData)
       })
+
       it('transforms and returns the entire object', () => {
-        const transformedData = transformInvestmentValueFormBodyToApiRequest(this.formData)
-        expect(transformedData).to.deep.equal({
+        expect(this.transformedData).to.deep.equal({
           client_cannot_provide_total_investment: 'false',
           total_investment: '10000',
           client_cannot_provide_foreign_investment: 'false',
           foreign_equity_investment: '5000',
           number_new_jobs: '10',
-          average_salary: {
-            'id': '2943bf3d-32dd-43be-8ad4-969b006dee7b',
-          },
+          average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
           number_safeguarded_jobs: '100',
           fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
           government_assistance: 'false',
@@ -306,9 +306,10 @@ describe('Investment project transformers', () => {
         })
       })
     })
+
     context('when the client cannot provide the total investment value', () => {
       beforeEach(() => {
-        this.formData = {
+        const formData = {
           client_cannot_provide_total_investment: 'true',
           total_investment: '10000',
           client_cannot_provide_foreign_investment: 'false',
@@ -323,18 +324,17 @@ describe('Investment project transformers', () => {
           new_tech_to_uk: 'false',
           export_revenue: 'false',
         }
+        this.transformedData = transformInvestmentValueFormBodyToApiRequest(formData)
       })
+
       it('sets the total investment value to null', () => {
-        const transformedData = transformInvestmentValueFormBodyToApiRequest(this.formData)
-        expect(transformedData).to.deep.equal({
+        expect(this.transformedData).to.deep.equal({
           client_cannot_provide_total_investment: 'true',
           total_investment: null,
           client_cannot_provide_foreign_investment: 'false',
           foreign_equity_investment: '5000',
           number_new_jobs: '10',
-          average_salary: {
-            'id': '2943bf3d-32dd-43be-8ad4-969b006dee7b',
-          },
+          average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
           number_safeguarded_jobs: '100',
           fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
           government_assistance: 'false',
@@ -345,9 +345,10 @@ describe('Investment project transformers', () => {
         })
       })
     })
+
     context('when the client cannot provide the foreign equity investment value', () => {
       beforeEach(() => {
-        this.formData = {
+        const formData = {
           client_cannot_provide_total_investment: 'false',
           total_investment: '10000',
           client_cannot_provide_foreign_investment: 'true',
@@ -362,18 +363,17 @@ describe('Investment project transformers', () => {
           new_tech_to_uk: 'false',
           export_revenue: 'false',
         }
+        this.transformedData = transformInvestmentValueFormBodyToApiRequest(formData)
       })
+
       it('sets the foreign total investment value to null', () => {
-        const transformedData = transformInvestmentValueFormBodyToApiRequest(this.formData)
-        expect(transformedData).to.deep.equal({
+        expect(this.transformedData).to.deep.equal({
           client_cannot_provide_total_investment: 'false',
           total_investment: '10000',
           client_cannot_provide_foreign_investment: 'true',
           foreign_equity_investment: null,
           number_new_jobs: '10',
-          average_salary: {
-            'id': '2943bf3d-32dd-43be-8ad4-969b006dee7b',
-          },
+          average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
           number_safeguarded_jobs: '100',
           fdi_value: '38e36c77-61ad-4186-a7a8-ac6a1a1104c6',
           government_assistance: 'false',
@@ -381,6 +381,29 @@ describe('Investment project transformers', () => {
           non_fdi_r_and_d_budget: 'false',
           new_tech_to_uk: 'false',
           export_revenue: 'false',
+        })
+      })
+    })
+
+    context('when no fields are filled in', () => {
+      beforeEach(() => {
+        const formData = {
+          total_investment: '',
+          foreign_equity_investment: '',
+          number_new_jobs: '',
+          number_safeguarded_jobs: '',
+          fdi_value: '',
+        }
+        this.transformedData = transformInvestmentValueFormBodyToApiRequest(formData)
+      })
+
+      it('sets numerical fields to null', () => {
+        expect(this.transformedData).to.deep.equal({
+          total_investment: null,
+          foreign_equity_investment: null,
+          number_new_jobs: null,
+          number_safeguarded_jobs: null,
+          fdi_value: '',
         })
       })
     })


### PR DESCRIPTION
This:
* refactors the investment value form code slightly so that it's more similar to the recently refactored requirements form
* corrects handling of the numeric fields and average salary when they are left blank
* improves test coverage of the form

Saving a blank value form is meant to work in the prospect stage, because investment projects use a save and carry on later model.

The errors were mostly happening due to empty strings and empty objects being sent for numerical fields and foreign keys, which the API doesn't allow. Incorrect handling of blank numerical fields seems to be a recurring problem, so it's begging for a more general solution. This fixes this specific form, though.

## Before

![value-form-before](https://user-images.githubusercontent.com/12693549/36600907-8b1556a6-18ab-11e8-8bc3-cfe349d9658e.png)

## After

![value-form-after](https://user-images.githubusercontent.com/12693549/36600909-8d2c9bb6-18ab-11e8-825c-2779b10edd0a.png)

![image](https://user-images.githubusercontent.com/12693549/36601746-ce5ab986-18ad-11e8-86f5-cb3b8b4e6ddc.png)