### PR TITLE
Improve meta lists

### DIFF
--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -84,18 +84,16 @@
   }
 
   @include media(tablet) {
-    .c-meta-list__item {
-      max-width: 50%;
-    }
-
     .c-meta-list__item:nth-child(odd) {
       float: left;
       clear: both;
+      max-width: 50%;
     }
 
     .c-meta-list__item:nth-child(even) {
       float: right;
       text-align: right;
+      max-width: 50%;
     }
   }
 }

--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -1,15 +1,9 @@
 @import "../settings";
 @import "../tools";
 
-.c-meta-list {
-  display: table;
-}
-
 .c-meta-list__item {
-  display: inline-block;
-
   & + & {
-    margin-left: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit / 4;
   }
 }
 
@@ -20,7 +14,6 @@
 
 .c-meta-list__item-value {
   color: $text-colour;
-  display: inline-block;
   word-break: break-all;
 
   &:link,
@@ -40,13 +33,31 @@
 // Modifiers
 
 .c-meta-list--inline {
+  display: inline-block;
+  margin-top: -($default-spacing-unit / 2);
+
   .c-meta-list__item-label {
     display: inline-block;
   }
 
   .c-meta-list__item {
-    margin-top: $baseline-grid-unit;
-    margin-right: $default-spacing-unit;
+    display: inline-block;
+    margin-right: $default-spacing-unit * 2;
+    margin-top: $default-spacing-unit / 2;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+.c-meta-list--condensed {
+  &.c-meta-list--inline .c-meta-list__item {
+    margin-right: $default-spacing-unit / 4;
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }
 
@@ -54,18 +65,7 @@
   display: block;
 
   & + & {
-    margin-left: 0;
     margin-top: $default-spacing-unit / 2;
-  }
-
-  @include media(tablet) {
-    display: inline-block;
-    vertical-align: top;
-
-    & + & {
-      margin-left: $default-spacing-unit * 2;
-      margin-top: 0;
-    }
   }
 
   .c-meta-list__item-label {
@@ -75,36 +75,28 @@
 
 .c-meta-list--split {
   @include clearfix;
+  margin-top: -($default-spacing-unit / 4);
   width: 100%;
 
   .c-meta-list__item {
     display: block;
-    margin-left: 0;
+    margin-top: $default-spacing-unit / 4;
   }
 
   @include media(tablet) {
+    .c-meta-list__item {
+      max-width: 50%;
+    }
+
     .c-meta-list__item:nth-child(odd) {
       float: left;
       clear: both;
-      max-width: 50%;
     }
 
     .c-meta-list__item:nth-child(even) {
       float: right;
-      margin-right: 0;
+      text-align: right;
     }
   }
 }
 
-.c-meta-list--stacked {
-  display: block;
-
-  .c-meta-list__item {
-    display: block;
-  }
-
-  .c-meta-list__item + .c-meta-list__item {
-    margin-left: 0;
-    margin-top: $default-spacing-unit / 2;
-  }
-}

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -137,6 +137,24 @@ function renderHiddenText (req, res) {
     .render('components/views/hidden-text')
 }
 
+function renderMetaList (req, res) {
+  return res
+    .breadcrumb('Meta list')
+    .render('components/views/meta-list', {
+      meta: [
+        {
+          label: 'Status',
+          value: 'Ongoing',
+          url: '/investment-projects/5d341b34-1fc8-4638-b4b1-a0922ebf401e/status',
+          urlLabel: 'change',
+        },
+        { label: 'Project code', value: 'DHP-00000009' },
+        { label: 'Valuation', value: 'Not yet valued' },
+        { label: 'Created on', value: '5 Jan 2016, 3:00pm' },
+      ],
+    })
+}
+
 module.exports = {
   renderEntityList,
   renderIndex,
@@ -148,4 +166,5 @@ module.exports = {
   renderCollection,
   renderKeyValueTables,
   renderHiddenText,
+  renderMetaList,
 }

--- a/src/apps/components/router.js
+++ b/src/apps/components/router.js
@@ -11,6 +11,7 @@ const {
   renderCollection,
   renderKeyValueTables,
   renderHiddenText,
+  renderMetaList,
 } = require('./controllers')
 
 const { renderFormElements } = require('./form/controllers')
@@ -30,6 +31,7 @@ router
   .get('/progress', renderProgress)
   .get('/keyvaluetables', renderKeyValueTables)
   .get('/hidden-text', renderHiddenText)
+  .get('/meta-list', renderMetaList)
   .all('/form', renderFormElements)
 
 module.exports = router

--- a/src/apps/components/views/entity-list.njk
+++ b/src/apps/components/views/entity-list.njk
@@ -4,12 +4,25 @@
 
 {% block body_main_content %}
   {% call Example('`entity-list` of `Entity` items') %}
-    <ul class="c-entity-list">
-      {% for project in investmentProjects.items %}
-        <li class="c-entity-list__item">
-          {{ Entity(project) }}
-        </li>
-      {% endfor %}
-    </ul>
+    {{
+      Collection(investmentProjects | assign({
+        highlightTerm: searchTerm,
+        countLabel: 'Investments',
+        query: QUERY
+      }))
+    }}
+  {% endcall %}
+
+  <hr/>
+
+  {% call Example('`entity-list` of `Entity` items with `block-links` modifer') %}
+    {{
+      Collection(investmentProjects | assign({
+        highlightTerm: searchTerm,
+        countLabel: 'Investments',
+        listModifier: 'block-links',
+        query: QUERY
+      }))
+    }}
   {% endcall %}
 {% endblock %}

--- a/src/apps/components/views/index.njk
+++ b/src/apps/components/views/index.njk
@@ -13,6 +13,9 @@
       <a href="components/entity-list">Entity list</a>
     </li>
     <li>
+      <a href="components/meta-list">Meta list</a>
+    </li>
+    <li>
       <a href="components/breadcrumbs">Breadcrumbs</a>
     </li>
     <li>

--- a/src/apps/components/views/meta-list.njk
+++ b/src/apps/components/views/meta-list.njk
@@ -1,0 +1,46 @@
+{% extends "./_layout.njk" %}
+
+{% block body_main_content %}
+  {% call Example('`meta-list`') %}
+    {{ MetaList({
+      items: meta
+    }) }}
+  {% endcall %}
+
+  {% call Example('`meta-list` with `stacked` item modifier') %}
+    {{ MetaList({
+      items: meta,
+      itemModifier: 'stacked'
+    }) }}
+  {% endcall %}
+
+  {% call Example('`meta-list` with `inline` modifier') %}
+    {{ MetaList({
+      items: meta,
+      modifier: 'inline'
+    }) }}
+  {% endcall %}
+
+  {% call Example('`meta-list` with `inline` modifier and `stacked` item modifier') %}
+    {{ MetaList({
+      items: meta,
+      modifier: 'inline',
+      itemModifier: 'stacked'
+    }) }}
+  {% endcall %}
+
+  {% call Example('`meta-list` with `split` modifier') %}
+    {{ MetaList({
+      items: meta,
+      modifier: 'split'
+    }) }}
+  {% endcall %}
+
+  {% call Example('`meta-list` with `split` modifier and `stacked` item modifier') %}
+    {{ MetaList({
+      items: meta,
+      modifier: 'split',
+      itemModifier: 'stacked'
+    }) }}
+  {% endcall %}
+{% endblock %}

--- a/src/apps/investment-projects/views/_layout.njk
+++ b/src/apps/investment-projects/views/_layout.njk
@@ -13,6 +13,7 @@
 
   {{ MetaList({
     items: investmentStatus.meta,
+    modifier: 'inline',
     itemModifier: 'stacked'
   }) }}
 

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -66,6 +66,7 @@
         { label: 'Market (country)', value: order.primary_market },
         { label: 'UK region', value: order.uk_region }
       ],
+      modifier: 'inline',
       itemModifier: 'stacked'
     }) }}
 
@@ -75,6 +76,7 @@
         { label: 'Updated on', value: order.modified_on, type: 'datetime' },
         { label: 'Status', value: statusText | safe }
       ],
+      modifier: 'inline',
       itemModifier: 'stacked'
     }) }}
 

--- a/src/templates/_macros/collection/collection.njk
+++ b/src/templates/_macros/collection/collection.njk
@@ -30,7 +30,11 @@
         <ol class="c-entity-list {{ listModifier }}">
           {% for item in props.items %}
             <li class="c-entity-list__item">
-              {{ Entity(item | assign({ highlightTerm: props.highlightTerm, isBlockLink: hasBlockLinks })) }}
+              {{ Entity(item | assign({
+                highlightTerm: props.highlightTerm,
+                isBlockLink: hasBlockLinks,
+                contentMetaModifier: 'split'
+              })) }}
             </li>
           {% endfor %}
         </ol>

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -19,7 +19,7 @@
     {% set urlPrefix = props.urlPrefix or props.type | pluralise + '/' %}
     {% set url = props.url | default('/' + urlPrefix + props.id) %}
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
-    {% set contentMetaModifier = props.contentMetaModifier| default(['inline', 'split']) %}
+    {% set contentMetaModifier = props.contentMetaModifier %}
     {% set metaItems = props.meta | reject(['type', 'badge']) %}
     {% set highlightedName = props.name | escape | highlight(props.highlightTerm) %}
     {% set containerElement = 'a' if props.isBlockLink else 'div' %}
@@ -46,7 +46,8 @@
             {{
               MetaList({
                 items: metaBadges,
-                highlightTerm: props.highlightTerm
+                highlightTerm: props.highlightTerm,
+                modifier: ['inline', 'condensed']
               })
             }}
           </div>

--- a/src/templates/_macros/entity/meta-item.njk
+++ b/src/templates/_macros/entity/meta-item.njk
@@ -15,6 +15,7 @@
  # @param {string} [props.isLabelHidden=false] - whether the label should be visually hidden
  # @param {string} [props.badgeModifier] - modifier for badge
  # @param {string} [props.highlightTerm] - text to use to apply highlight filter
+ # @param {string|array} [props.modifier] - Modifier for the outer class (e.g. 'stacked')
  #}
 {% macro MetaItem (props) %}
   {% set badgeModifier = props.badgeModifier | concat('') | reverse | join(' c-badge--') if props.badgeModifier %}
@@ -35,7 +36,6 @@
     {% endif %}
 
     {% set value = metaItemValue | escape | highlight(props.highlightTerm, true) %}
-
     <div class="{{ 'c-meta-list__item' | applyClassModifiers(props.modifier) }}">
       {% if props.label %}
         <span class="c-meta-list__item-label {{ 'u-visually-hidden' if isLabelHidden or props.type === 'badge' }}">

--- a/src/templates/_macros/entity/meta-list.njk
+++ b/src/templates/_macros/entity/meta-list.njk
@@ -5,14 +5,13 @@
  # @param {object} props
  # @param {array}  props.items - meta items
  # @param {string, array} [props.modifier] - meta container modifier (e.g. inline)
+ # @param {string, array} [props.itemModifier] - meta item modifier (e.g. stacked)
  #}
 {% macro MetaList (props) %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-meta-list--') if props.modifier %}
-
   {% if props.items | length %}
-    <div class="c-meta-list {{ modifier }}">
+    <div class="{{ 'c-meta-list' | applyClassModifiers(props.modifier) }}">
       {% for metaItem in props.items %}
-        {{ MetaItem(metaItem | assign({ highlightTerm: props.highlightTerm, modifier: metaItem.modifier or props.itemModifier })) }}
+        {{ MetaItem(metaItem | assignCopy({ highlightTerm: props.highlightTerm, modifier: metaItem.modifier or props.itemModifier })) }}
       {% endfor %}
     </div>
   {% endif %}

--- a/test/unit/macros/entity/entity.test.js
+++ b/test/unit/macros/entity/entity.test.js
@@ -67,19 +67,6 @@ describe('Entity macro', () => {
       expect(component.querySelector('.c-entity__title a')).to.have.property('href', '/horses/12345')
     })
 
-    it('should use a default modifier of inline split it no modifier specified', () => {
-      const component = entitiesMacros.renderToDom('Entity', {
-        id: '12345',
-        name: 'Horse',
-        type: 'animal',
-        meta: [
-          { label: 'Colour', value: 'brown', type: 'badge' },
-          { label: 'DOB', value: '2015-11-10', type: 'date', name: 'date_of_birth' },
-        ],
-      })
-      expect(component.querySelector('.c-meta-list.c-meta-list--split.c-meta-list--inline')).to.exist
-    })
-
     it('should use a content meta modifier if specified', () => {
       const component = entitiesMacros.renderToDom('Entity', {
         id: '12345',


### PR DESCRIPTION
The behaviour for meta lists was somewhat unpredictable and the use of multiple modifiers in search results was simply wrong and made things more complex and harder to debug.

As part of improving the layout for search results, the metadata lists first need to be cleaned up

This PR :
* Adds examples of meta lists and entity lists to the component library
* Cleans up the sass for metadata to be simpler and more predictable
* Removes the use of defaulting to multiple modifiers for meta lists
* Makes it explicit what modifiers to use in collection lists and investment details

[View meta list component](https://datahub-beta2-pr-1287.herokuapp.com/components/meta-list)
