### PR TITLE
Feature/stacked collections

### DIFF
--- a/assets/stylesheets/components/_entity.scss
+++ b/assets/stylesheets/components/_entity.scss
@@ -55,11 +55,16 @@
   padding: $default-spacing-unit;
   border: 2px solid $grey-2;
   display: block;
+  text-decoration: none;
 
   &:focus,
   &:hover {
     background-color: $grey-4;
     border-color: $link-hover-colour;
     color: $link-hover-colour;
+  }
+
+  .c-entity__title {
+    text-decoration: underline;
   }
 }

--- a/assets/stylesheets/components/_entity.scss
+++ b/assets/stylesheets/components/_entity.scss
@@ -11,39 +11,40 @@
       text-decoration: underline;
     }
   }
+}
 
-  @include media(tablet) {
-    max-width: 80%;
+.c-entity__subtitle {
+  @include core-font(14);
+  color: $grey-1;
+  margin: 0;
+}
+
+.c-entity__badges {
+  @include core-font(14);
+  margin: 20 - 14px 0;
+}
+
+.c-entity__content {
+  @include core-font(16);
+
+  * + & {
+    margin-top: $default-spacing-unit / 2;
   }
 }
 
 @include media(tablet) {
-  .c-entity__header,
-  .c-entity__content {
+  .c-entity__header {
     @include clearfix;
   }
 
-  .c-entity__title {
-    float: left;
+  .c-entity__title,
+  .c-entity__subtitle {
+    max-width: 80%;
   }
 
   .c-entity__badges {
     float: right;
   }
-}
-
-.c-entity__code,
-.c-entity__content,
-.c-entity__badges {
-  @include core-font(14);
-}
-
-.c-entity__badges {
-  margin: 20 - 14px 0;
-}
-
-.c-entity__code {
-  color: $grey-1;
 }
 
 // modifiers

--- a/src/apps/investment-projects/transformers/collection.js
+++ b/src/apps/investment-projects/transformers/collection.js
@@ -30,7 +30,7 @@ function transformInvestmentProjectToListItem ({
     id,
     name,
     type: 'investment-project',
-    code: project_code,
+    subTitle: project_code,
     meta: compact(metaItems),
   }
 }

--- a/src/templates/_macros/collection/collection.njk
+++ b/src/templates/_macros/collection/collection.njk
@@ -32,8 +32,7 @@
             <li class="c-entity-list__item">
               {{ Entity(item | assign({
                 highlightTerm: props.highlightTerm,
-                isBlockLink: hasBlockLinks,
-                contentMetaModifier: 'split'
+                isBlockLink: hasBlockLinks
               })) }}
             </li>
           {% endfor %}

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -8,6 +8,7 @@
  # @param {string} [props.id] - entity id, used to create a link to the entity if provided
  # @param {string} [props.url] - entity URL, defaults to props.urlPrefix + props.id
  # @param {string} [props.urlPrefix] - base URL for linking to an entity, by default it will pluralise props.type
+ # @param {string|object} [props.subTitle] - sub-title below the main link/title
  # @param {array}  [props.metaBadges{}] - an array of metadata item objects
  # @param {array}  [props.metaItems{}] - an array of metadata item objects
  # @param {string} [props.highlightTerm] - text to use to apply highlight filter
@@ -19,7 +20,6 @@
     {% set urlPrefix = props.urlPrefix or props.type | pluralise + '/' %}
     {% set url = props.url | default('/' + urlPrefix + props.id) %}
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
-    {% set contentMetaModifier = props.contentMetaModifier %}
     {% set metaItems = props.meta | reject(['type', 'badge']) %}
     {% set highlightedName = props.name | escape | highlight(props.highlightTerm) %}
     {% set containerElement = 'a' if props.isBlockLink else 'div' %}
@@ -28,19 +28,7 @@
       class="c-entity c-entity--{{ props.type }} {{ 'c-entity--block-link' if props.isBlockLink }}"
       {% if props.isBlockLink %}href="{{ url }}"{% endif %}
     >
-      {% if props.code %}
-        <div class="c-entity__code">{{ props.code | highlight(props.highlightTerm, true) }}</div>
-      {% endif %}
-
       <div class="c-entity__header">
-        <h3 class="c-entity__title">
-          {% if props.id and not props.isBlockLink %}
-            <a href="{{ url }}">{{ highlightedName }}</a>
-          {% else %}
-            {{ highlightedName }}
-          {% endif %}
-        </h3>
-
         {% if metaBadges | length %}
           <div class="c-entity__badges">
             {{
@@ -52,6 +40,18 @@
             }}
           </div>
         {% endif %}
+
+        <h3 class="c-entity__title">
+          {% if props.id and not props.isBlockLink %}
+            <a href="{{ url }}">{{ highlightedName }}</a>
+          {% else %}
+            {{ highlightedName }}
+          {% endif %}
+        </h3>
+
+        {% if props.subTitle %}
+          {{ SubTitle(props.subTitle) }}
+        {% endif %}
       </div>
 
       {% if metaItems | length %}
@@ -60,11 +60,32 @@
             MetaList({
               items: metaItems,
               highlightTerm: props.highlightTerm,
-              modifier: contentMetaModifier
+              modifier: props.contentMetaModifier
             })
           }}
         </div>
       {% endif %}
     </{{ containerElement }}>
   {% endif %}
+{% endmacro %}
+
+{% macro SubTitle (props) %}
+  <h4 class="c-entity__subtitle">
+    {% if props.value %}
+      {% if props.type === 'date' %}
+        {% set value = props.value | formatDate %}
+      {% elif props.type === 'dateMonthYear' %}
+        {% set value = props.value | formatDate('MMMM YYYY') %}
+      {% elif props.type === 'datetime' %}
+        {% set value = props.value | formatDateTime %}
+      {% elif props.type === 'fromNow' %}
+        {% set value = FromNow({ datetime: props.value }) %}
+      {% else %}
+        {% set value = props.value %}
+      {% endif %}
+      {{ props.label }} {{ value }}
+    {% else %}
+      {{ props }}
+    {% endif %}
+  </h4>
 {% endmacro %}

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -43,7 +43,7 @@
 
         <h3 class="c-entity__title">
           {% if props.id and not props.isBlockLink %}
-            <a href="{{ url }}">{{ highlightedName }}</a>
+            <a href="{{ url }}" class="c-entity__link">{{ highlightedName }}</a>
           {% else %}
             {{ highlightedName }}
           {% endif %}

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -127,8 +127,8 @@ Then(/^the result count should be reset$/, async function () {
 Then(/^I choose the first item in the collection$/, async function () {
   await Collection
     .section.firstCollectionItem
-    .waitForElementVisible('@header')
-    .click('@header')
+    .waitForElementVisible('@link')
+    .click('@link')
 })
 
 Then(/^I can view the collection$/, async function () {

--- a/test/acceptance/pages/Collection.js
+++ b/test/acceptance/pages/Collection.js
@@ -46,6 +46,7 @@ module.exports = {
       elements: {
         header: '.c-entity__title',
         updatedOn: getSelectorForMetaListItemValue('Updated on'),
+        link: '.c-entity--block-link, .c-entity__link',
       },
     },
     filters: {

--- a/test/unit/apps/investment-projects/transformers/collection.test.js
+++ b/test/unit/apps/investment-projects/transformers/collection.test.js
@@ -14,7 +14,7 @@ describe('Investment project transformers', () => {
       expect(firstItem.id).to.a('string')
       expect(firstItem.name).to.a('string')
       expect(firstItem.type).to.a('string')
-      expect(firstItem.code).to.a('string')
+      expect(firstItem.subTitle).to.a('string')
       expect(firstItem.meta).to.an('array').that.have.length(5)
 
       expect(firstItem.meta[0].label).to.be.a('string')


### PR DESCRIPTION
DH-1546 - Migrate collection display from split to stacked style

* Drops the use of the split modifier for collection metadata
* Introduces updated entity macro which removes code element and introduces subtitle
* Updates the investment collection to put the project code in the subtitle
* Adjusts font sizes in collections to make slightly clearer
* Correct an issue with underlines when using block link modifier

![companies](https://user-images.githubusercontent.com/56056/36664021-62dc2318-1adb-11e8-8e58-833b2a21a4ad.PNG)
![addcompany](https://user-images.githubusercontent.com/56056/36664022-62f11fe8-1adb-11e8-998f-3669273a146d.PNG)
![projects](https://user-images.githubusercontent.com/56056/36664023-63053000-1adb-11e8-893d-8fc90cc26418.PNG)
![interactions](https://user-images.githubusercontent.com/56056/36664024-631d978a-1adb-11e8-9b9e-9109f55d1fc7.PNG)
![events](https://user-images.githubusercontent.com/56056/36664025-63326c50-1adb-11e8-8136-a1e37f3b8a66.PNG)
![contacts](https://user-images.githubusercontent.com/56056/36664027-6346722c-1adb-11e8-8d77-db3cb7ed4752.PNG)

