### PR TITLE
Don't apply spacing for hidden siblings

### DIFF
--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -66,7 +66,7 @@
     margin-top: 0;
   }
 
-  * + * {
+  *:not([type="hidden"]) + * {
     margin-bottom: 0;
     margin-top: $default-spacing-unit;
   }


### PR DESCRIPTION
The sibling selector was being used to apply spacing within the
answers summary component but this caused unwanted spacing to appear
if an element was preceded by a hidden element.

This extra check prevents that from occuring.

## Before
![image](https://user-images.githubusercontent.com/3327997/36681371-4f6cadea-1b10-11e8-82ce-220ce90ae036.png)

## After
![image](https://user-images.githubusercontent.com/3327997/36681332-34904248-1b10-11e8-908c-d9729bfa6b09.png)

