### PR TITLE
DH-1564 Make OAuth more robust

### DIFF
--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -44,6 +44,11 @@ async function callbackOAuth (req, res, next) {
   if (get(req.session, 'token')) {
     return res.redirect('/')
   }
+
+  // No state query param
+  if (isUndefined(stateQueryParam)) {
+    return next({ statusCode: 403 })
+  }
   if (errorQueryParam) {
     return renderHelpPage(req, res, next)
   }

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -74,7 +74,7 @@ async function callbackOAuth (req, res, next) {
 }
 
 async function redirectOAuth (req, res, next) {
-  const stateId = uuid()
+  const stateId = get(req.session, 'oauth.state', uuid())
   const urlParams = {
     response_type: 'code',
     client_id: config.oauth.clientId,

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -48,10 +48,13 @@ async function callbackOAuth (req, res, next) {
   if (isUndefined(stateQueryParam)) {
     return next({ statusCode: 403 })
   }
+
+  // Error query param present
   if (errorQueryParam) {
     return renderHelpPage(req, res, next)
   }
 
+  // Session state does not match query param state
   if (sessionOAuthState !== stateQueryParam) {
     return next(Error('There has been an OAuth stateId mismatch sessionOAuthState'))
   }

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -40,6 +40,10 @@ async function callbackOAuth (req, res, next) {
   const stateQueryParam = get(req.query, 'state')
   const sessionOAuthState = get(req.session, 'oauth.state')
 
+  // Already been through OAuth
+  if (get(req.session, 'token')) {
+    return res.redirect('/')
+  }
   if (errorQueryParam) {
     return renderHelpPage(req, res, next)
   }

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -2,7 +2,7 @@ const request = require('request-promise')
 const queryString = require('query-string')
 const uuid = require('uuid')
 
-const { get, set } = require('lodash')
+const { get, set, isUndefined } = require('lodash')
 
 const { saveSession } = require('./../../lib/session-helper')
 const config = require('./../../../config')
@@ -23,6 +23,16 @@ function getAccessToken (code) {
   }
 
   return request(options)
+}
+
+function handleMissingState (req, res, next) {
+  const sessionOAuthState = get(req.session, 'oauth.state')
+
+  if (isUndefined(sessionOAuthState)) {
+    return res.redirect('/oauth')
+  }
+
+  next()
 }
 
 async function callbackOAuth (req, res, next) {
@@ -105,4 +115,5 @@ module.exports = {
   redirectOAuth,
   renderHelpPage,
   signOutOAuth,
+  handleMissingState,
 }

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -6,7 +6,6 @@ const { get, set, isUndefined } = require('lodash')
 
 const { saveSession } = require('./../../lib/session-helper')
 const config = require('./../../../config')
-const logger = require('./../../../config/logger') // @TODO remove this once we've diagnosed the cause of the mismatches
 
 function getAccessToken (code) {
   const options = {
@@ -54,13 +53,6 @@ async function callbackOAuth (req, res, next) {
   }
 
   if (sessionOAuthState !== stateQueryParam) {
-    // @TODO remove this once we've diagnosed the cause of the mismatches
-    logger.error('OAuth mismatch')
-    logger.error(`sessionOAuthState: ${sessionOAuthState}`)
-    logger.error(`stateQueryParam: ${stateQueryParam}`)
-    logger.error(`Host: ${req.hostname}`)
-    logger.error(`Original URL: ${req.originalUrl}`)
-    // END @TODO
     return next(Error('There has been an OAuth stateId mismatch sessionOAuthState'))
   }
 
@@ -82,8 +74,6 @@ async function redirectOAuth (req, res, next) {
     state: stateId,
     idp: 'cirrus',
   }
-
-  logger.error(`Host redirected from: ${req.hostname}`) // @TODO remove this once we've diagnosed the cause of the mismatches
 
   // As you are here you have not byPassed SSO and if the oAuthDevToken is present then pass it to the code parameter
   // that is sent to the SSO provider. When using the mock-sso app, the oAuthDevToken is simply passed through the

--- a/src/apps/oauth/router.js
+++ b/src/apps/oauth/router.js
@@ -1,8 +1,8 @@
 const router = require('express').Router()
-const { callbackOAuth, redirectOAuth, signOutOAuth } = require('./controllers')
+const { callbackOAuth, redirectOAuth, signOutOAuth, handleMissingState } = require('./controllers')
 
 router.get('/', redirectOAuth)
-router.get('/callback', callbackOAuth)
+router.get('/callback', handleMissingState, callbackOAuth)
 router.get('/sign-out', signOutOAuth)
 
 module.exports = router

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,5 +1,5 @@
 module.exports = function auth (req, res, next) {
-  const passThrough = req.session.token || /^\/(support|healthcheck|oauth|oauth\/callback)\b/.test(req.url)
+  const passThrough = req.session.token || /^\/(support|healthcheck|oauth)\b/.test(req.url)
 
   if (passThrough) {
     return next()

--- a/src/middleware/session-store.js
+++ b/src/middleware/session-store.js
@@ -15,6 +15,7 @@ const sessionStore = session({
   resave: true,
   saveUninitialized: false,
   unset: 'destroy',
+  key: 'datahub.sid',
 })
 
 module.exports = sessionStore

--- a/test/unit/apps/oauth/controllers.test.js
+++ b/test/unit/apps/oauth/controllers.test.js
@@ -270,6 +270,25 @@ describe('OAuth controller', () => {
       })
     })
 
+    context('without the state query param in the url', () => {
+      context('and user has no token', () => {
+        beforeEach(async () => {
+          set(this.reqMock, 'session.token', undefined)
+          set(this.reqMock, 'query.state', undefined)
+          await this.controller.callbackOAuth(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        it('should handle error as expected', () => {
+          expect(this.nextSpy).to.have.been.calledOnce
+          expect(this.nextSpy.args[0][0].statusCode).to.equal(403)
+        })
+
+        it('token should be undefined', () => {
+          expect(this.reqMock.session.token).to.be.undefined
+        })
+      })
+    })
+
     describe('#getAccessToken', () => {
       beforeEach(() => {
         this.reqMock.query = {

--- a/test/unit/apps/oauth/controllers.test.js
+++ b/test/unit/apps/oauth/controllers.test.js
@@ -176,6 +176,28 @@ describe('OAuth controller', () => {
 
   describe('#callbackOAuth', () => {
     context('with the state query param in the url', () => {
+      context('and user has a token', () => {
+        beforeEach(async () => {
+          this.mockOauthAccessToken = 'example-already-oauth-token'
+          set(this.reqMock, 'query.state', this.mockStateId)
+          set(this.reqMock, 'session.token', this.mockOauthAccessToken)
+
+          await this.controller.callbackOAuth(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        it('should redirect', () => {
+          expect(this.resMock.redirect).to.have.been.calledOnce
+        })
+
+        it('should redirect to expected location', () => {
+          expect(this.resMock.redirect).to.have.been.calledWith('/')
+        })
+
+        it('token should match expected value', () => {
+          expect(this.reqMock.session.token).to.equal(this.mockOauthAccessToken)
+        })
+      })
+
       context('and a state mismatch', () => {
         beforeEach(() => {
           set(this.reqMock, 'query.state', this.mockStateId)

--- a/test/unit/apps/oauth/controllers.test.js
+++ b/test/unit/apps/oauth/controllers.test.js
@@ -146,6 +146,34 @@ describe('OAuth controller', () => {
     })
   })
 
+  describe('#handleMissingState', () => {
+    context('with state in the session', () => {
+      beforeEach(() => {
+        set(this.reqMock, 'session.oauth.state', 'example-session-state')
+        this.controller.handleMissingState(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
+    })
+
+    context('without state in the session', () => {
+      beforeEach(() => {
+        set(this.reqMock, 'session.oauth.state', undefined)
+        this.controller.handleMissingState(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should redirect', () => {
+        expect(this.resMock.redirect).to.have.been.calledOnce
+      })
+
+      it('should redirect to expected location', () => {
+        expect(this.resMock.redirect).to.have.been.calledWith('/oauth')
+      })
+    })
+  })
+
   describe('#callbackOAuth', () => {
     context('with the state query param in the url', () => {
       context('and a state mismatch', () => {

--- a/test/unit/apps/oauth/controllers.test.js
+++ b/test/unit/apps/oauth/controllers.test.js
@@ -89,6 +89,42 @@ describe('OAuth controller', () => {
         })
       })
 
+      context('with a state already in the session', () => {
+        beforeEach(async () => {
+          const urlParts = queryString.parse(this.expectedOauthRedirectUrl)
+          this.mockSessionStoredUUIDvalue = 'mock-uuid-1234-3465745'
+          this.expectedOauthRedirectUrl = queryString.stringify({
+            ...urlParts,
+            ...{ state: this.mockSessionStoredUUIDvalue },
+          })
+
+          set(this.reqMock, 'session.oauth.state', this.mockSessionStoredUUIDvalue)
+
+          this.saveSessionStub.resolves()
+          await this.controller.redirectOAuth(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        it('should call saveSessionStub', () => {
+          expect(this.saveSessionStub).to.have.been.calledOnce
+        })
+
+        it('should call saveSessionStub with expected argument', () => {
+          expect(this.saveSessionStub).to.be.calledWith(this.reqMock.session)
+        })
+
+        it('should redirect', () => {
+          expect(this.resMock.redirect).to.have.been.calledOnce
+        })
+
+        it('should redirect to the correct Oauth url', () => {
+          expect(this.resMock.redirect).to.be.calledWith(`${this.mockOauthConfig.url}?${this.expectedOauthRedirectUrl}`)
+        })
+
+        it('session should hold correct UUID', () => {
+          expect(this.reqMock.session.oauth.state).to.equal(this.mockSessionStoredUUIDvalue)
+        })
+      })
+
       context('with a rejected session save', () => {
         beforeEach(async () => {
           this.returnedError = 'oh no!'


### PR DESCRIPTION
This work tackles a number of issues with Oauth. Specifically the `OAuth stateId mismatch sessionOAuthState`

It also guards against:
- Visits to `/oauth/callback/` without a `session.token`
- Visits to `/oauth/callback/` without a `session.oauth.state`
- Visits to `/oauth/callback/` without a `state` query param

This work now means that if there is a `state` already in `session.oauth.state` then it will use that, rather than overriding it.

It removes logging as this is making a mess of the file and isn't really informing us of anything new.

I have also added more tests to all this work.

FYI @web-bert