### PR TITLE
Ensure correct prop value is passed to select box macro

### DIFF
--- a/src/templates/_macros/form/multiple-choice-field.njk
+++ b/src/templates/_macros/form/multiple-choice-field.njk
@@ -30,7 +30,7 @@
     {% if props.type in ['checkbox', 'radio'] %}
       {{ MultipleChoice(props) }}
     {% else %}
-      {{ SelectBox(props | assign({ class: inputClass })) }}
+      {{ SelectBox(props | assign({ class: props.inputClass })) }}
     {% endif %}
 
     {{ children }}

--- a/src/templates/_macros/form/multiple-choice-field.njk
+++ b/src/templates/_macros/form/multiple-choice-field.njk
@@ -30,7 +30,7 @@
     {% if props.type in ['checkbox', 'radio'] %}
       {{ MultipleChoice(props) }}
     {% else %}
-      {{ SelectBox(props | assign({ class: props.inputClass })) }}
+      {{ SelectBox(props | assignCopy({ class: props.inputClass })) }}
     {% endif %}
 
     {{ children }}


### PR DESCRIPTION
The top-level multiple choice macro supports a prop to add a class
to the lower field.

This was being referenced on its own and not as a property on the
props object so the value was never picked up.

This change makes sure the lower macro receives the correct value.