### PR TITLE
Update XHR to only update results section

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -14,6 +14,7 @@ const XhrLink = require('./modules/xhr-link')
 const AddItems = require('./modules/add-items')
 const PrintDialog = require('./modules/print-dialog')
 const MirrorValue = require('./modules/mirror-value.js')
+const ClearInputs = require('./modules/clear-inputs.js')
 
 const CompanyAdd = require('./_deprecated/company-add')
 const CompanyEdit = require('./_deprecated/company-edit')
@@ -29,6 +30,7 @@ XhrLink.init()
 AddItems.init()
 PrintDialog.init()
 MirrorValue.init()
+ClearInputs.init()
 
 // Deprecated
 CompanyAdd.init()

--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -13,6 +13,7 @@ const AutoSubmit = require('./modules/auto-submit')
 const XhrLink = require('./modules/xhr-link')
 const AddItems = require('./modules/add-items')
 const PrintDialog = require('./modules/print-dialog')
+const MirrorValue = require('./modules/mirror-value.js')
 
 const CompanyAdd = require('./_deprecated/company-add')
 const CompanyEdit = require('./_deprecated/company-edit')
@@ -27,6 +28,7 @@ AutoSubmit.init()
 XhrLink.init()
 AddItems.init()
 PrintDialog.init()
+MirrorValue.init()
 
 // Deprecated
 CompanyAdd.init()

--- a/assets/javascripts/modules/clear-inputs.js
+++ b/assets/javascripts/modules/clear-inputs.js
@@ -1,0 +1,49 @@
+function getFormControls (form) {
+  const formInputs = form.querySelectorAll('input, select, checkbox, textarea')
+
+  return Array.from(formInputs)
+    .filter((element) => {
+      return element.tagName !== 'INPUT' || element.type !== 'hidden'
+    })
+}
+
+function clearValues (formInputs) {
+  formInputs.forEach((field) => {
+    if (['select', 'radio', 'checkbox'].indexOf(field.type) > -1) {
+      field.checked = false
+    } else {
+      field.value = ''
+    }
+  })
+}
+
+const ClearInputs = {
+  selector: '.js-ClearInputs',
+
+  init (wrapper = document) {
+    this.wrapper = wrapper
+    wrapper.addEventListener('click', this.handleClick.bind(this))
+  },
+
+  handleClick (event) {
+    const target = event.target
+    const url = target.getAttribute('href')
+    const hasClass = target.classList.contains(this.selector.substring(1))
+    const shouldClear = target.tagName === 'A' && hasClass
+
+    if (!shouldClear || !url || url.match(/^http:\/\//)) { return }
+
+    event.preventDefault()
+
+    const targetSelector = target.getAttribute('data-target-selector')
+    const targetForm = this.wrapper.querySelector(targetSelector)
+
+    if (targetForm) {
+      const formControls = getFormControls(targetForm)
+      clearValues(formControls)
+      targetForm.submit()
+    }
+  },
+}
+
+module.exports = ClearInputs

--- a/assets/javascripts/modules/mirror-value.js
+++ b/assets/javascripts/modules/mirror-value.js
@@ -1,0 +1,21 @@
+/*
+ * Mirror Value
+ *
+ * Listens for a change on one form element and mirrors the value to another
+ */
+const MirrorValue = {
+  init (wrapper = document) {
+    const sourceField = wrapper.querySelector('.js-MirrorValue')
+
+    if (sourceField) {
+      const targetSelector = sourceField.getAttribute('data-target-selector')
+      const targetField = wrapper.querySelector(targetSelector)
+
+      sourceField.addEventListener('change', (event) => {
+        targetField.value = event.target.value
+      })
+    }
+  },
+}
+
+module.exports = MirrorValue

--- a/src/apps/companies/macros.js
+++ b/src/apps/companies/macros.js
@@ -42,6 +42,10 @@ const companySortForm = {
       label: 'Sort by',
       name: 'sortby',
       modifier: ['small', 'inline', 'light'],
+      inputClass: 'js-MirrorValue',
+      inputData: {
+        'target-selector': '.c-collection-filters input[name="sortby"]',
+      },
       options: [
         { value: 'modified_on:desc', label: 'Recently updated' },
         { value: 'modified_on:asc', label: 'Least recently updated' },

--- a/src/apps/companies/views/contacts.njk
+++ b/src/apps/companies/views/contacts.njk
@@ -12,13 +12,16 @@
       filtersFields: filtersFields,
       action: CURRENT_PATH
   }) }}
-
-  {{ Collection(contactResults | assign({
-      countLabel: 'contact',
-      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
-      selectedFilters: selectedFilters,
-      query: QUERY,
-      action: CURRENT_PATH,
-      summaryActionsHTML: addProjectButton
-  })) }}
+  {% block xhr_content %}
+    <article id="xhr-outlet">
+      {{ Collection(contactResults | assign({
+          countLabel: 'contact',
+          sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
+          selectedFilters: selectedFilters,
+          query: QUERY,
+          action: CURRENT_PATH,
+          summaryActionsHTML: addProjectButton
+      })) }}
+    </article>
+  {% endblock %}
 {% endblock %}

--- a/src/apps/contacts/macros.js
+++ b/src/apps/contacts/macros.js
@@ -13,6 +13,10 @@ const sortFormBase = {
       label: 'Sort by',
       name: 'sortby',
       modifier: ['small', 'inline', 'light'],
+      inputClass: 'js-MirrorValue',
+      inputData: {
+        'target-selector': '.c-collection-filters input[name="sortby"]',
+      },
     },
   ],
 }

--- a/src/apps/events/macros/event-sort-form.js
+++ b/src/apps/events/macros/event-sort-form.js
@@ -9,6 +9,10 @@ const eventSortForm = {
       label: 'Sort by',
       name: 'sortby',
       modifier: ['small', 'inline', 'light'],
+      inputClass: 'js-MirrorValue',
+      inputData: {
+        'target-selector': '.c-collection-filters input[name="sortby"]',
+      },
       options: [
         { value: 'name:asc', label: 'Event name: A-Z' },
         { value: 'modified_on:desc', label: 'Recently updated' },

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -95,6 +95,10 @@ const investmentSortForm = {
       label: 'Sort by',
       name: 'sortby',
       modifier: ['small', 'inline', 'light'],
+      inputClass: 'js-MirrorValue',
+      inputData: {
+        'target-selector': '.c-collection-filters input[name="sortby"]',
+      },
       options: [
         { value: 'estimated_land_date:asc', label: 'Earliest land date' },
         { value: 'estimated_land_date:desc', label: 'Latest land date' },

--- a/src/apps/omis/apps/list/macros.js
+++ b/src/apps/omis/apps/list/macros.js
@@ -65,6 +65,10 @@ const collectionSortForm = {
       label: 'Sort by',
       name: 'sortby',
       modifier: ['small', 'inline', 'light'],
+      inputClass: 'js-MirrorValue',
+      inputData: {
+        'target-selector': '.c-collection-filters input[name="sortby"]',
+      },
       options: [
         { value: 'created_on:desc', label: 'Newest' },
         { value: 'created_on:asc', label: 'Oldest' },

--- a/src/templates/_layouts/dit-base.njk
+++ b/src/templates/_layouts/dit-base.njk
@@ -116,7 +116,7 @@
               {% endif %}
             {% endblock %}
           {% endblock %}
-          <div class="main-content__inner l-container" id="xhr-outlet">
+          <div class="main-content__inner l-container">
             {% block body_main_content %}{% endblock %}
           </div>
         </main>

--- a/src/templates/_layouts/xhr.njk
+++ b/src/templates/_layouts/xhr.njk
@@ -1,3 +1,1 @@
-<div class="main-content__inner l-container" id="xhr-outlet">
-  {% block body_main_content %}{% endblock %}
-</div>
+{% block xhr_content %}{% endblock %}

--- a/src/templates/_macros/collection/collection-header.njk
+++ b/src/templates/_macros/collection/collection-header.njk
@@ -34,7 +34,8 @@
           {% if props.selectedFilters | length %}
             <a
               href="?{{ buildQuery({}, { custom: true, sortby: props.sortForm.children[0].value }) }}"
-              class="c-collection__filter-remove-all js-xhr"
+              class="c-collection__filter-remove-all js-xhr js-ClearInputs"
+              data-target-selector=".c-collection-filters"
               aria-label="Reset filter results"
             >
               Remove all filters

--- a/src/templates/collection.njk
+++ b/src/templates/collection.njk
@@ -12,16 +12,18 @@
       {% endblock %}
     </div>
 
-    <article class="column-two-thirds">
-      {% block collection_results %}
-        {{ Collection(results | assign({
-          countLabel: countLabel,
-          sortForm: assign({}, sortForm, { action: CURRENT_PATH }),
-          selectedFilters: selectedFilters,
-          highlightTerm: highlightTerm,
-          query: QUERY
-        })) }}
-      {% endblock %}
-    </article>
+    {% block xhr_content %}
+      <article class="column-two-thirds" id="xhr-outlet">
+        {% block collection_results %}
+          {{ Collection(results | assign({
+            countLabel: countLabel,
+            sortForm: assign({}, sortForm, { action: CURRENT_PATH }),
+            selectedFilters: selectedFilters,
+            highlightTerm: highlightTerm,
+            query: QUERY
+          })) }}
+        {% endblock %}
+      </article>
+    {% endblock %}
   </div>
 {% endblock %}


### PR DESCRIPTION
This change modifies the behaviour of the XHR module used to update collections when a filter is applied. The change causes only the results section to be refreshed instead of the entire content area. This change results in faster screen updates and less network traffic on collections with long filter lists.

The previous behaviour was required because the region filter was optional, but this has now been changed.

This change introduces a new module to synchronise the value between two fields, this allows the sort value to be kept in sync between the sort form and the filter form.

A second module was introduced to clear field values in a form, this is required as the filters now need to manually reset as the filter section does not get redrawn