### PR TITLE
Fix spacing a different screen widths

### DIFF
--- a/assets/stylesheets/trumps/_layout.scss
+++ b/assets/stylesheets/trumps/_layout.scss
@@ -1,16 +1,7 @@
 @import "../tools/mixins/layout";
 
 .l-container {
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: $default-spacing-unit;
-  padding-right: $default-spacing-unit;
-  max-width: $site-width;
-
-  @include media($min-width: $site-width) {
-    padding-left: 0;
-    padding-right: 0;
-  }
+  @include site-width-container;
 }
 
 .column-two-quarters,


### PR DESCRIPTION
This changes the `l-container` class to use the `site-width-container`
mixin that is provided and provives the spacing based on screen
width for other parts of the layout, like the header.

## Before
![localhost_3001_companies_0fb3379c-341c-4da4-b825-bf8d47b26baa_details](https://user-images.githubusercontent.com/3327997/36845458-bc2ea39e-1d4e-11e8-8e62-443948c19886.png)

## After
![localhost_3001_companies_0fb3379c-341c-4da4-b825-bf8d47b26baa_details 1](https://user-images.githubusercontent.com/3327997/36845436-a6850b8c-1d4e-11e8-8891-2faba05d3f2d.png)

