### PR TITLE
Increase dockerize leeloo timout to 5 mins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ aliases:
   - &wait_for_backend
     run:
       name: Wait for backend
-      command: dockerize -wait ${API_ROOT}/admin/ -timeout 240s
+      command: dockerize -wait ${API_ROOT}/admin/ -timeout 300s
 
   # Wait for mock-sso to report OK
   - &wait_for_mock_sso


### PR DESCRIPTION
We are seeing a few timeouts on ES when leeloo is being spun up for
CirclCi. This work increases the timeout to 5 mins to give it a little
more breathing space.

Its worth keeping an eye on this as when more migrations to the BE in
Postgres are added the time it will take for leeloo to spin up on
CircleCi will increase.

