### PR TITLE
Fix collection filter tag spacing

### DIFF
--- a/assets/stylesheets/components/_collection.scss
+++ b/assets/stylesheets/components/_collection.scss
@@ -47,6 +47,7 @@
   color: $text-colour;
   display: inline-block;
   position: relative;
+  margin-right: $default-spacing-unit / 2;
   margin-top: $default-spacing-unit / 2;
   padding: 0 ($default-spacing-unit / 2);
   background: $grey-4;


### PR DESCRIPTION
Since we've started minifying the HTML the spacing between filter
tags in the collection has gone.

This sets the same spacing that is applied to the top/bottom.

## Before
![image](https://user-images.githubusercontent.com/3327997/36897007-c2179bbc-1e0c-11e8-8a08-bd1f72d928bc.png)

## After
![image](https://user-images.githubusercontent.com/3327997/36896988-b420eb08-1e0c-11e8-8c98-d526889b7720.png)

