### PR TITLE
Push new history before response returns

### DIFF
--- a/assets/javascripts/lib/xhr.js
+++ b/assets/javascripts/lib/xhr.js
@@ -32,7 +32,7 @@ const XHR = {
     if (params) {
       const url = `?${queryString.stringify(params)}`
       try {
-        history.push(url, { data: res.data })
+        history.replace(url, { data: res.data })
       } catch (err) {
         // state was too large for browser to handle. Do full page load.
         window.location.assign(url)
@@ -48,6 +48,11 @@ const XHR = {
 
     if (showLoader) {
       outlet.classList.add('u-loading')
+    }
+
+    if (params) {
+      const url = `?${queryString.stringify(params)}`
+      history.push(url)
     }
 
     return axios

--- a/test/unit/assets/javascripts/lib/xhr.test.js
+++ b/test/unit/assets/javascripts/lib/xhr.test.js
@@ -35,7 +35,7 @@ describe('XHR', () => {
       expect(history.location.search).to.equal('')
     })
     it('should perform page load if unable to pushState', () => {
-      sandbox.stub(history, 'push').throws('error')
+      sandbox.stub(history, 'replace').throws('error')
       sandbox.stub(window.location, 'assign')
       const res = { data: {} }
       const params = { a: 1, b: 2 }


### PR DESCRIPTION
Previously the URL and state are only updated once the response
is returned on the xhr call. This leads to a problem when the call
errors and you refresh the page and the selected filters and state
are lost.

This change adds a simple push to the browser history before the call
and this url is then updated on a successful xhr request.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
