### PR TITLE
Favour dot notation when possible in JavaScript

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
       }
     ],
     "object-curly-spacing": ["error", "always"],
+    "dot-notation": "error",
     "mocha/no-exclusive-tests": "error"
   }
 }

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -155,12 +155,12 @@ function transformEventResponseToViewRecord ({
     'Service': service,
   })
 
-  viewRecord['Documents'] = {
+  viewRecord.Documents = {
     name: 'There are no files or documents',
   }
 
   if (archived_documents_url_path) {
-    viewRecord['Documents'] = {
+    viewRecord.Documents = {
       url: config.archivedDocumentsBaseUrl + archived_documents_url_path,
       name: 'View files and documents',
       hint: '(will open another website)',

--- a/src/apps/investment-projects/controllers/create/equity-source.js
+++ b/src/apps/investment-projects/controllers/create/equity-source.js
@@ -61,8 +61,8 @@ async function getHandler (req, res, next) {
 }
 
 function postHandler (req, res, next) {
-  const isEquitySource = req.body['is_equity_source']
-  const clientCompanyId = req.body['company_id']
+  const isEquitySource = req.body.is_equity_source
+  const clientCompanyId = req.body.company_id
 
   if (isEquitySource === 'true') {
     return res.redirect(`/investment-projects/create/project/${clientCompanyId}`)

--- a/src/apps/investment-projects/transformers/project.js
+++ b/src/apps/investment-projects/transformers/project.js
@@ -55,17 +55,17 @@ function transformToApi (body) {
     return { id: value }
   })
 
-  if (body['estimated_land_date_year'] || body['estimated_land_date_month']) {
-    formatted['estimated_land_date'] = [
-      body['estimated_land_date_year'],
-      body['estimated_land_date_month'],
+  if (body.estimated_land_date_year || body.estimated_land_date_month) {
+    formatted.estimated_land_date = [
+      body.estimated_land_date_year,
+      body.estimated_land_date_month,
       '01',
     ].join('-')
   } else {
-    formatted['estimated_land_date'] = null
+    formatted.estimated_land_date = null
   }
 
-  formatted['actual_land_date'] = transformDateObjectToDateString('actual_land_date')(body)
+  formatted.actual_land_date = transformDateObjectToDateString('actual_land_date')(body)
 
   return assign({}, body, formatted)
 }
@@ -102,8 +102,8 @@ function transformFromApi (body) {
   const estimatedLandDate = body.estimated_land_date
   if (!isEmpty(estimatedLandDate)) {
     const date = new Date(estimatedLandDate)
-    formatted['estimated_land_date_year'] = date.getFullYear().toString()
-    formatted['estimated_land_date_month'] = format(date, 'MM')
+    formatted.estimated_land_date_year = date.getFullYear().toString()
+    formatted.estimated_land_date_month = format(date, 'MM')
   }
 
   return assign({}, body, formatted)

--- a/test/unit/apps/companies/transformers/company-to-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-view.test.js
@@ -49,15 +49,15 @@ describe('transformCompanyToView', () => {
     })
 
     it('should supply the headquarters', () => {
-      expect(this.viewRecord['Headquarters']).to.equal('European headquarters (EHQ)')
+      expect(this.viewRecord.Headquarters).to.equal('European headquarters (EHQ)')
     })
 
     it('should supply sector', () => {
-      expect(this.viewRecord['Sector']).to.equal('Aerospace')
+      expect(this.viewRecord.Sector).to.equal('Aerospace')
     })
 
     it('should convert website to link', () => {
-      expect(this.viewRecord['Website']).to.deep.equal({
+      expect(this.viewRecord.Website).to.deep.equal({
         name: 'http://www.test.com',
         url: 'http://www.test.com',
       })
@@ -103,7 +103,7 @@ describe('transformCompanyToView', () => {
     })
 
     it('should supply sector', () => {
-      expect(this.viewRecord['Sector']).to.equal('Aerospace')
+      expect(this.viewRecord.Sector).to.equal('Aerospace')
     })
   })
 
@@ -157,11 +157,11 @@ describe('transformCompanyToView', () => {
     })
 
     it('should supply the country', () => {
-      expect(this.viewRecord['Country']).to.equal('France')
+      expect(this.viewRecord.Country).to.equal('France')
     })
 
     it('should supply sector', () => {
-      expect(this.viewRecord['Sector']).to.equal('Aerospace')
+      expect(this.viewRecord.Sector).to.equal('Aerospace')
     })
   })
 })


### PR DESCRIPTION
The dot notation is the preferred over square-bracket notation because
it is easier to read, less verbose, and works better with aggressive
JavaScript minimizers.

Also includes an autofix to existing uses of square-bracket notation.