### PR TITLE
Use generic link step defintion

### DIFF
--- a/test/acceptance/features/audit/company.feature
+++ b/test/acceptance/features/audit/company.feature
@@ -9,7 +9,7 @@ Feature: View Audit history of a Company
 
     Given I Amend 1 records of an existing company record
     When I search for this company record
-    And I click the Audit History tab
+    And I click the "Audit history" link
     Then I see the name of the person who made the recent company record changes
 
   @audit-company--timestamp
@@ -17,7 +17,7 @@ Feature: View Audit history of a Company
 
     Given I Amend 1 records of an existing company record
     When I search for this company record
-    And I click the Audit History tab
+    And I click the "Audit history" link
     Then I see the date time stamp when the recent company record changed
 
   @audit-company--field-names
@@ -25,5 +25,5 @@ Feature: View Audit history of a Company
 
     Given I Amend 1 records of an existing company record
     When I search for this company record
-    And I click the Audit History tab
+    And I click the "Audit history" link
     Then I see the field names that were recently changed on this company record

--- a/test/acceptance/features/audit/contact.feature
+++ b/test/acceptance/features/audit/contact.feature
@@ -18,7 +18,7 @@ Feature: View Audit history of a contact
     And the contact has 1 fields edited for audit
     Then I see the success message
     When I search for this Contact record
-    And I click the Audit History tab
+    And I click the "Audit history" link
     Then I see the name of the person who made the recent contact record changes
     And I see the date time stamp when the recent contact record changed
     And I see the field names that were recently changed
@@ -36,7 +36,7 @@ Feature: View Audit history of a contact
     And the contact has 2 fields edited for audit
     Then I see the success message
     When I search for this Contact record
-    And I click the Audit History tab
+    And I click the "Audit history" link
     Then I see the total number of changes occurred recently on this contact record
 
   @audit-contact--archived
@@ -55,7 +55,7 @@ Feature: View Audit history of a contact
     And I search for the created contact
     And the Contacts search tab is clicked
     And I click on the first contact collection link
-    And I click the Audit History tab
+    And I click the "Audit history" link
     Then I see the details who archived the contact
 
   @audit-contact--unarchived
@@ -76,5 +76,5 @@ Feature: View Audit history of a contact
     And I search for the created contact
     And the Contacts search tab is clicked
     And I click on the first contact collection link
-    And I click the Audit History tab
+    And I click the "Audit history" link
     Then I see the details who unarchived the contact

--- a/test/acceptance/features/audit/step_definitions/contact.js
+++ b/test/acceptance/features/audit/step_definitions/contact.js
@@ -54,11 +54,6 @@ When(/^I search for this Contact record$/, async function () {
     .getText('@userName', (result) => set(this.state, 'username', result.value))
 })
 
-When(/^I click the Audit History tab$/, async function () {
-  await AuditContact
-    .click('@auditHistoryTab')
-})
-
 When(/^I archive this contact record$/, async function () {
   await InvestmentProject.section.projectDetails.section.archive
     .click('@archiveButton')

--- a/test/acceptance/features/events/edit.feature
+++ b/test/acceptance/features/events/edit.feature
@@ -11,7 +11,7 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     When I change form text field "name" to random words
     And I submit the form
     Then details heading should contain what I entered for "name" field
@@ -21,11 +21,11 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "event_type" to "Seminar"
     And I submit the form
     Then details view data for "Type of event" should contain "Seminar"
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "event_type" to Exhibition
     And I submit the form
     Then details view data for "Type of event" should contain "Exhibition"
@@ -35,7 +35,7 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     When I change start date to decrease year by one
     And I submit the form
     Then details view data for "Event start date" should contain what I entered for "start_date_year" field
@@ -45,11 +45,11 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "location_type" to "HQ"
     And I submit the form
     Then details view data for "Event location type" should contain "HQ"
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "location_type" to "Post"
     And I submit the form
     Then details view data for "Event location type" should contain "Post"
@@ -59,7 +59,7 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form text field "address_1" to a random street address
     And I submit the form
     Then details view data for "Address" should contain what I entered for "address_1" field
@@ -69,7 +69,7 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form text field "notes" to a random paragraph
     And I submit the form
     Then details view data for "Notes" should contain what I entered for "notes" field
@@ -79,11 +79,11 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "lead_team" to "CBBC Leeds"
     And I submit the form
     Then details view data for "Lead team" should contain "CBBC Leeds"
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "lead_team" to "CBBC London"
     And I submit the form
     Then details view data for "Lead team" should contain "CBBC London"
@@ -93,12 +93,12 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     And I select "Yes" for boolean option "event_shared"
     And I change form dropdown "teams" to "BPI"
     And I submit the form
     Then details view data for "Other teams" should contain "BPI"
-    And I click on edit event button
+    And I click the "Edit event" link
     When I select "Yes" for boolean option "event_shared"
     And I change form dropdown "teams" to "Intellect"
     And I submit the form
@@ -109,11 +109,11 @@ Feature: Edit an Event in Data hub
 
     When I navigate to the `events.List` page
     And I choose the first item in the collection
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "related_programmes" to "Grown in Britain"
     And I submit the form
     Then details view data for "Related programmes" should contain "Grown in Britain"
-    And I click on edit event button
+    And I click the "Edit event" link
     And I change form dropdown "related_programmes" to "GREAT Branded"
     And I submit the form
     Then details view data for "Related programmes" should contain "GREAT Branded"

--- a/test/acceptance/features/events/step_definitions/edit.js
+++ b/test/acceptance/features/events/step_definitions/edit.js
@@ -8,11 +8,6 @@ const { format } = require('date-fns')
 const Form = client.page.Form()
 const Event = client.page.events.Event()
 
-When(/^I click on edit event button$/, async () => {
-  await Event
-    .click('@editButton')
-})
-
 When(/^I change start date to decrease year by one$/, async function () {
   const currentDate = new Date()
   const form = {}

--- a/test/acceptance/features/investment-projects/value-add.feature
+++ b/test/acceptance/features/investment-projects/value-add.feature
@@ -77,5 +77,5 @@ Feature: Add value to investment project
     And I choose Yes for "Will this company be the source of foreign equity investment?"
     And I populate the create Investment Project form
     When I click the "Add value" link
-    And I click the "Save" link
+    And I submit the form
     Then I see the success message

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -24,3 +24,10 @@ When(/^I (?:navigate|go|open|visit).*? `(.+)` page using `(.+)` `(.+)` fixture$/
 
   await Page.navigate(Page.url(fixtureName))
 })
+
+When('I click the {string} link', async function (linkText) {
+  await client
+    .useXpath()
+    .click(`//a[text()='${linkText}']`)
+    .useCss()
+})

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -3,7 +3,6 @@ const { client } = require('nightwatch-cucumber')
 const { Then, When } = require('cucumber')
 const moment = require('moment')
 
-const { getButtonWithText } = require('../../helpers/selectors')
 const { pluralise } = require('../../../../config/nunjucks/filters')
 const { mediumDateTimeFormat } = require('../../../../config')
 
@@ -14,17 +13,6 @@ When('I store the result count in state', async function () {
     .captureResultCount((count) => {
       set(this.state, 'collection.resultCount', count)
     })
-})
-
-When(/^I click the "(.+)" link$/, async (linkTextContent) => {
-  const { selector: addLink } = getButtonWithText(linkTextContent)
-
-  await Collection
-    .api.useXpath()
-    .waitForElementVisible(addLink)
-    .assert.containsText(addLink, linkTextContent)
-    .click(addLink)
-    .useCss()
 })
 
 When(/^I clear all filters$/, async function () {

--- a/test/acceptance/pages/audit/Contact.js
+++ b/test/acceptance/pages/audit/Contact.js
@@ -8,7 +8,6 @@ module.exports = {
   elements: {
     editContactDetailsButton: getButtonWithText('Edit contact'),
     saveButton: getButtonWithText('Save'),
-    auditHistoryTab: 'a[href*="/audit"]',
     telephone: '#field-telephone_number',
     telephoneCountryCode: '#field-telephone_countrycode',
     archiveReason: 'label[for=field-archived_reason-1]',

--- a/test/acceptance/pages/events/Event.js
+++ b/test/acceptance/pages/events/Event.js
@@ -45,7 +45,6 @@ module.exports = {
     addAnotherSharedTeam: 'input[name="add_team"]',
     relatedProgrammes: '#field-related_programmes',
     addAnotherProgramme: 'input[name="add_related_programme"]',
-    editButton: getButtonWithText('Edit event'),
     saveButton: getButtonWithText('Add event'),
   },
   commands: [


### PR DESCRIPTION
This tries to tidy up some of the uses of specific step definitions for clicking links
with the more generic step definition.

This is continuing to remove some of the duplication around acceptance tests in
favour of more shared step definitions.