### PR TITLE
MI-1437 - Hide policy interactions

### DIFF
--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -14,7 +14,7 @@ module.exports = function ({ currentAdviserId, channels = [], teams = [] }) {
       options: [
         { value: 'interaction', label: 'Interaction' },
         { value: 'service_delivery', label: 'Service delivery' },
-        { value: 'policy_feedback', label: 'Policy feedback' },
+        // { value: 'policy_feedback', label: 'Policy feedback' },
       ],
       modifier: 'option-select',
     },

--- a/src/apps/interactions/macros/kind-form.js
+++ b/src/apps/interactions/macros/kind-form.js
@@ -19,11 +19,13 @@ module.exports = function ({
           value: 'service_delivery',
           label: 'A service that you have provided',
           hint: 'For example, account management, a significant assist or an event',
-        }, {
+        },
+        /*, {
           value: 'policy_feedback',
           label: 'Policy feedback',
           hint: 'For example, when a company wants to give UK government policy feedback',
-        }],
+        } */
+        ],
       },
     ],
   }

--- a/test/acceptance/features/interactions/add.feature
+++ b/test/acceptance/features/interactions/add.feature
@@ -26,30 +26,30 @@ Feature: Add a new interaction in Data hub
       | Communication channel    | interaction.communicationChannel         |
       | Documents                | There are no files or documents          |
 
-  @interaction-add--companies-policy-feedback-submit
-  Scenario: Companies policy feedback is saved
-
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
-    And I click the "Add interaction" link
-    And I select policy feedback
-    Then there are policy feedback fields
-    And policy feedback fields are pre-populated
-    When a policy feedback is added
-      | key                      | value                                    |
-    Then I see the success message
-    And the details are displayed
-      | key                      | value                                    |
-      | Company                  | Venus Ltd                                |
-      | Contact                  | interaction.contact                      |
-      | Service provider         | interaction.serviceProvider              |
-      | Service                  | interaction.service                      |
-      | Subject                  | interaction.subject                      |
-      | Notes                    | interaction.notes                        |
-      | Date of interaction      | interaction.date                         |
-      | DIT adviser              | interaction.ditAdviser                   |
-      | Communication channel    | interaction.communicationChannel         |
-      | Documents                | There are no files or documents          |
+#  @interaction-add--companies-policy-feedback-submit
+#  Scenario: Companies policy feedback is saved
+#
+#    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+#    And I click the Interactions local nav link
+#    And I click the "Add interaction" link
+#    And I select policy feedback
+#    Then there are policy feedback fields
+#    And policy feedback fields are pre-populated
+#    When a policy feedback is added
+#      | key                      | value                                    |
+#    Then I see the success message
+#    And the details are displayed
+#      | key                      | value                                    |
+#      | Company                  | Venus Ltd                                |
+#      | Contact                  | interaction.contact                      |
+#      | Service provider         | interaction.serviceProvider              |
+#      | Service                  | interaction.service                      |
+#      | Subject                  | interaction.subject                      |
+#      | Notes                    | interaction.notes                        |
+#      | Date of interaction      | interaction.date                         |
+#      | DIT adviser              | interaction.ditAdviser                   |
+#      | Communication channel    | interaction.communicationChannel         |
+#      | Documents                | There are no files or documents          |
 
   @interaction-add--companies-service-delivery-submit
   Scenario: Companies service delivery is saved
@@ -159,30 +159,30 @@ Feature: Add a new interaction in Data hub
       | Communication channel    | interaction.communicationChannel         |
       | Documents                | There are no files or documents          |
 
-  @interaction-add--contacts-policy-feedback-submit
-  Scenario: Policy feedback fields from contacts
-
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
-    And I click the "Add interaction" link
-    And I select policy feedback
-    Then there are interaction fields
-    And interaction fields are pre-populated
-    When a policy feedback is added
-      | key                      | value                                    |
-    Then I see the success message
-    And the details are displayed
-      | key                      | value                                    |
-      | Company                  | Venus Ltd                                |
-      | Contact                  | interaction.contact                      |
-      | Service provider         | interaction.serviceProvider              |
-      | Service                  | interaction.service                      |
-      | Subject                  | interaction.subject                      |
-      | Notes                    | interaction.notes                        |
-      | Date of interaction      | interaction.date                         |
-      | DIT adviser              | interaction.ditAdviser                   |
-      | Communication channel    | interaction.communicationChannel         |
-      | Documents                | There are no files or documents          |
+#  @interaction-add--contacts-policy-feedback-submit
+#  Scenario: Policy feedback fields from contacts
+#
+#    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+#    And I click the Interactions local nav link
+#    And I click the "Add interaction" link
+#    And I select policy feedback
+#    Then there are interaction fields
+#    And interaction fields are pre-populated
+#    When a policy feedback is added
+#      | key                      | value                                    |
+#    Then I see the success message
+#    And the details are displayed
+#      | key                      | value                                    |
+#      | Company                  | Venus Ltd                                |
+#      | Contact                  | interaction.contact                      |
+#      | Service provider         | interaction.serviceProvider              |
+#      | Service                  | interaction.service                      |
+#      | Subject                  | interaction.subject                      |
+#      | Notes                    | interaction.notes                        |
+#      | Date of interaction      | interaction.date                         |
+#      | DIT adviser              | interaction.ditAdviser                   |
+#      | Communication channel    | interaction.communicationChannel         |
+#      | Documents                | There are no files or documents          |
 
   @interaction-add--contacts-service-delivery-submit
   Scenario: Service delivery fields from contacts

--- a/test/acceptance/features/interactions/collection.feature
+++ b/test/acceptance/features/interactions/collection.feature
@@ -28,29 +28,29 @@ Feature: View collection of interactions
       | text    | expected               |
       | Type    | interaction.type       |
 
-  @interactions-collection--view-policy-feedback
-  Scenario: View policy feedback in interactions and services collection
-
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
-    And I click the "Add interaction" link
-    And I select policy feedback
-    When a policy feedback is added
-      | key      | value                 |
-    Then I see the success message
-    When I navigate to the `interactions.List` page
-    Then I confirm I am on the Interactions page
-    And the results summary for a interaction collection is present
-    Then I filter the collections to view the policy feedback I have just created
-    And I can view the interaction in the collection
-      | text    | expected               |
-      | Contact | contact.heading        |
-      | Company | company.name           |
-      | Date    | interaction.date       |
-      | Adviser | interaction.ditAdviser |
-    And the Interaction has badges
-      | text    | expected               |
-      | Type    | interaction.type       |
+#  @interactions-collection--view-policy-feedback
+#  Scenario: View policy feedback in interactions and services collection
+#
+#    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
+#    And I click the Interactions local nav link
+#    And I click the "Add interaction" link
+#    And I select policy feedback
+#    When a policy feedback is added
+#      | key      | value                 |
+#    Then I see the success message
+#    When I navigate to the `interactions.List` page
+#    Then I confirm I am on the Interactions page
+#    And the results summary for a interaction collection is present
+#    Then I filter the collections to view the policy feedback I have just created
+#    And I can view the interaction in the collection
+#      | text    | expected               |
+#      | Contact | contact.heading        |
+#      | Company | company.name           |
+#      | Date    | interaction.date       |
+#      | Adviser | interaction.ditAdviser |
+#    And the Interaction has badges
+#      | text    | expected               |
+#      | Type    | interaction.type       |
 
   @interactions-collection--view-service-delivery
   Scenario: View service delivery in interactions and services collection


### PR DESCRIPTION
Comment out the feature tests
Comment out the radio option when adding a new interaction
Comment out the filter on the interactions page

There needs to be a decision on when to launch this feature, so hiding for now
