### PR TITLE
Use direct navigation for document tests

### DIFF
--- a/test/acceptance/features/companies/documents.feature
+++ b/test/acceptance/features/companies/documents.feature
@@ -3,26 +3,20 @@ Feature: Company documents
 
   @companies-documents--document-link
   Scenario: Company has documents
-
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Documents local nav link
+    When I navigate to the `companies.Documents` page using `company` `Venus Ltd` fixture
     Then view should contain the Documents link
 
   @companies-documents--no-document-link
   Scenario: Company does not have documents
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    When I click the Documents local nav link
+    When I navigate to the `companies.Documents` page using `company` `Lambda plc` fixture
     Then view should not contain the Documents link
 
   @companies-documents--lep @lep
   Scenario: Navigate to documents as LEP
-
     When I navigate to the `companies.Documents` page using `company` `Lambda plc` fixture
     Then I see the 403 error page
 
   @companies-documents--da @da
   Scenario: Navigate to documents as DA
-
     When I navigate to the `companies.Documents` page using `company` `Lambda plc` fixture
     Then I see the 403 error page

--- a/test/acceptance/features/contacts/documents.feature
+++ b/test/acceptance/features/contacts/documents.feature
@@ -3,26 +3,20 @@ Feature: Contact details
 
   @contact-documents--link
   Scenario: Contact has Documents link
-
-    When I navigate to the `contacts.Fixture` page using `contact` `Johnny Cakeman` fixture
-    And I click the Documents local nav link
+    When I navigate to the `contacts.Documents` page using `contact` `Johnny Cakeman` fixture
     Then view should contain the Documents link
 
   @contact-documents--no-documents-link
   Scenario: Contact does not have Documents link
-
-    When I navigate to the `contacts.Fixture` page using `contact` `Georgina Clark` fixture
-    And I click the Documents local nav link
+    When I navigate to the `contacts.Documents` page using `contact` `Georgina Clark` fixture
     Then view should not contain the Documents link
 
   @contact-documents--lep @lep
   Scenario: Navigate to documents as LEP
-
     When I navigate to the `contacts.Documents` page using `contact` `Johnny Cakeman` fixture
     Then I see the 403 error page
 
   @contact-documents--da @da
   Scenario: Navigate to documents as DA
-
     When I navigate to the `contacts.Documents` page using `contact` `Johnny Cakeman` fixture
     Then I see the 403 error page

--- a/test/acceptance/features/interactions/documents.feature
+++ b/test/acceptance/features/interactions/documents.feature
@@ -3,14 +3,12 @@ Feature: Interaction details
 
   @interactions-documents--documents-link
   Scenario: Interaction has Documents link
-
     When I navigate to the `interactions.Fixture` page using `interaction` `Attended gamma event` fixture
     Then there should not be a local nav
     And details view data for "Documents" should contain "View files and documents (will open another website)"
 
   @interactions-documents--no-documents-link
   Scenario: Interaction does not have Documents link
-
     When I navigate to the `interactions.Fixture` page using `interaction` `Provided funding information` fixture
     Then there should not be a local nav
     And details view data for "Documents" should contain "There are no files or documents"

--- a/test/acceptance/features/investment-projects/documents.feature
+++ b/test/acceptance/features/investment-projects/documents.feature
@@ -3,26 +3,20 @@ Feature: Investment project documents
 
   @investment-projects-documents--document-link
   Scenario: Investment project has documents
-
-    When I navigate to the `investments.Fixture` page using `investment project` `New hotel (commitment to invest)` fixture
-    And I click the Documents local nav link
+    When I navigate to the `investments.Documents` page using `investment project` `New hotel (commitment to invest)` fixture
     Then view should contain the Documents link
 
   @investment-projects-documents--no-document-link
   Scenario: Investment project does not have documents
-
-    When I navigate to the `investments.Fixture` page using `investment project` `New rollercoaster` fixture
-    And I click the Documents local nav link
+    When I navigate to the `investments.Documents` page using `investment project` `New rollercoaster` fixture
     Then view should not contain the Documents link
 
   @investment-projects-documents--lep @lep
   Scenario: Navigate to documents as LEP
-
     When I navigate to the `investments.Documents` page using `investment project` `New zoo (LEP)` fixture
     Then I see the 403 error page
 
   @investment-projects-documents--da @da
   Scenario: Navigate to documents as DA
-
     When I navigate to the `investments.Documents` page using `investment project` `New golf course (DA)` fixture
     Then I see the 403 error page


### PR DESCRIPTION
We currently navigate to a fixture and click the local nav item
to navigate to the documents page.

These checks are checking the state of that page so we can skip the
double page load and navigate directly to that page instead.

This nicely helps to reduce the time tests are taking too 😄 

| Test name | Before  | After   |
| --------- | ------- | ------- |
| DIT staff | 10m 34s | 10m 16s |
| DA staff  | 4m 9s   | 3m 12s  |
| LEP staff | 3m 20s  | 2m 25s  |



