### PR TITLE
Use form submission to save forms

### DIFF
--- a/test/acceptance/features/events/collection.feature
+++ b/test/acceptance/features/events/collection.feature
@@ -17,7 +17,7 @@ Feature: View a list of events
     When I navigate to the `events.List` page
     And I click the "Add event" link
     And I populate the create event form
-    And I click the save button
+    And I submit the form
     Then I see the success message
     When I navigate to the `events.List` page
     Then I can view the Event in the collection
@@ -38,7 +38,7 @@ Feature: View a list of events
     When I navigate to the `events.List` page
     And I click the "Add event" link
     And I populate the create event form with United Kingdom and a region
-    And I click the save button
+    And I submit the form
     Then I see the success message
     When I navigate to the `events.List` page
     Then I can view the Event in the collection
@@ -59,7 +59,7 @@ Feature: View a list of events
     When I click the Events global nav link
     And I click the "Add event" link
     And I populate the create event form
-    And I click the save button
+    And I submit the form
     Then I see the success message
     When I click the Events global nav link
     And I filter the events list by name
@@ -79,12 +79,12 @@ Feature: View a list of events
     When I click the Events global nav link
     And I click the "Add event" link
     And I populate the create event form
-    And I click the save button
+    And I submit the form
     Then I see the success message
     When I click the Events global nav link
     And I click the "Add event" link
     And I populate the create event form
-    When I click the save button
+    And I submit the form
     Then I see the success message
     When I click the Events global nav link
     When I sort the events list name A-Z

--- a/test/acceptance/features/events/save.feature
+++ b/test/acceptance/features/events/save.feature
@@ -8,7 +8,7 @@ Feature: Save a new Event in Data hub
   Scenario: Verify event is submitted
 
     Given I create an event
-    And I click the save button
+    And I submit the form
     Then I see the success message
 
   @events-save--mandatory-fields
@@ -16,7 +16,7 @@ Feature: Save a new Event in Data hub
 
     When I click the Events global nav link
     And I click the "Add event" link
-    And I click the save button
+    And I submit the form
     Then the event fields have error messages
     And I see form error summary
 
@@ -26,7 +26,7 @@ Feature: Save a new Event in Data hub
     When I click the Events global nav link
     And I click the "Add event" link
     And I populate the create event form with United Kingdom and without a region
-    And I click the save button
+    And I submit the form
     And I verify the event UK region has an error message
     Then I see form error summary
 

--- a/test/acceptance/features/events/step_definitions/create.js
+++ b/test/acceptance/features/events/step_definitions/create.js
@@ -202,13 +202,6 @@ Then(/^I verify the event name has an error message$/, async () => {
     .assert.visible('@eventNameError')
 })
 
-Then(/^I click the save button$/, async () => {
-  await Event
-    .waitForElementPresent('@saveButton')
-    .click('@saveButton')
-    .wait() // wait for backend to sync
-})
-
 Then(/^the event fields have error messages$/, async () => {
   await Event
     .assert.visible('@nameError')

--- a/test/acceptance/features/search/search.feature
+++ b/test/acceptance/features/search/search.feature
@@ -10,7 +10,7 @@ Feature: Search
     When I click the Events global nav link
     And I click the "Add event" link
     And I populate the create event form
-    And I click the save button
+    And I submit the form
     Then I see the success message
     When I search for the created event
     Then I verify the search tabs are displayed


### PR DESCRIPTION
This replaces the use of a specific step definition to click the save
button with the more commonly used form submission step definition.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
