### PR TITLE
Use direction navigation in company tests

### DIFF
--- a/test/acceptance/features/companies/contacts-collection.feature
+++ b/test/acceptance/features/companies/contacts-collection.feature
@@ -7,9 +7,7 @@ Feature: View collection of contacts for a company
 
   @companies-contact-collection--view
   Scenario: View companies contact collection
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     And a primary contact is added
     And I submit the form
@@ -28,9 +26,7 @@ Feature: View collection of contacts for a company
 
   @companies-contact-collection--filter
   Scenario: Filter companies contact list
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     And a primary contact with new company address is added
     When I submit the form
@@ -50,9 +46,7 @@ Feature: View collection of contacts for a company
 
   @companies-contact-collection--sort
   Scenario: Sort companies contact list
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form

--- a/test/acceptance/features/companies/exports.feature
+++ b/test/acceptance/features/companies/exports.feature
@@ -3,9 +3,7 @@ Feature: Company export save
 
   @companies-export-save--save
   Scenario: Save company export details
-
     When I navigate to the `companies.Exports` page using `company` `Lambda plc` fixture
-    And I click the "Export" link
     Then the Exports details are displayed
       | key                          | value                             |
       | Export win category          | None                              |

--- a/test/acceptance/features/companies/interactions-collection.feature
+++ b/test/acceptance/features/companies/interactions-collection.feature
@@ -3,9 +3,7 @@ Feature: View collection of interactions for a company
 
   @companies-interactions-collection--view
   Scenario: View companies interaction collection
-
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And the results summary for a interaction collection is present
     And I can view the collection
 
@@ -15,12 +13,10 @@ Feature: View collection of interactions for a company
 
   @companies-interactions-collection--lep @lep
   Scenario: Navigate to interactions as LEP
-
     When I navigate to the `companies.Interactions` page using `company` `Lambda plc` fixture
     Then I see the 403 error page
 
   @companies-interactions-collection--da @da
   Scenario: Navigate to interactions as DA
-
     When I navigate to the `companies.Interactions` page using `company` `Lambda plc` fixture
     Then I see the 403 error page

--- a/test/acceptance/features/companies/omis-collection.feature
+++ b/test/acceptance/features/companies/omis-collection.feature
@@ -3,16 +3,12 @@ Feature: View collection of orders for a company
 
   @companies-omis-collection--view
   Scenario: View companies OMIS collection
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Orders (OMIS) local nav link
+    When I navigate to the `companies.Orders` page using `company` `Lambda plc` fixture
     And the results summary for a order collection is present
 
   @companies-omis-collection--view--da
   Scenario: View companies OMIS collection as DA
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Orders (OMIS) local nav link
+    When I navigate to the `companies.Orders` page using `company` `Lambda plc` fixture
     And the results summary for a order collection is present
 
   @companies-omis-collection--filter # TODO
@@ -21,6 +17,5 @@ Feature: View collection of orders for a company
 
   @companies-omis-collection--lep @lep
   Scenario: Navigate to OMIS as LEP
-
     When I navigate to the `companies.Orders` page using `company` `Lambda plc` fixture
     Then I see the 403 error page

--- a/test/acceptance/pages/companies/Contacts.js
+++ b/test/acceptance/pages/companies/Contacts.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { company } = require('../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(company, { name: companyName })
+    const companyId = fixture ? fixture.id : company.ukLtd.id
+
+    return `${process.env.QA_HOST}/companies/${companyId}/contacts`
+  },
+  elements: {},
+}


### PR DESCRIPTION
With the new idea of page objects we can navigate directly to a
particular sub-page within an entity.

This means we don't have to navigate to the details page and click
a nav item which adds extra time to the tests to do all the page
loads and page interactions.

This removes those extra steps within the company tests.

| Test name | Before  | After   |
| --------- | ------- | ------- |
| DIT Staff | 7m 48s | 7m 45s |
| DA Staff  | 53s | 49s |
| LEP Staff | 56s | 52s |
