### PR TITLE
Do all audit checks in one scenario

### DIFF
--- a/test/acceptance/features/audit/company.feature
+++ b/test/acceptance/features/audit/company.feature
@@ -4,26 +4,10 @@ Feature: View Audit history of a Company
   I would like to track changes to a Company record over time
   So that I can cross-check the validity and accuracy of a given company record
 
-  @audit-company--name
   Scenario: View name of the person who made company record changes
-
     Given I Amend 1 records of an existing company record
     When I search for this company record
     And I click the "Audit history" link
     Then I see the name of the person who made the recent company record changes
-
-  @audit-company--timestamp
-  Scenario: View time stamp when the company record changes
-
-    Given I Amend 1 records of an existing company record
-    When I search for this company record
-    And I click the "Audit history" link
-    Then I see the date time stamp when the recent company record changed
-
-  @audit-company--field-names
-  Scenario: View changed field names of a company record
-
-    Given I Amend 1 records of an existing company record
-    When I search for this company record
-    And I click the "Audit history" link
-    Then I see the field names that were recently changed on this company record
+    And I see the date time stamp when the recent company record changed
+    And I see the field names that were recently changed on this company record

--- a/test/acceptance/features/audit/contact.feature
+++ b/test/acceptance/features/audit/contact.feature
@@ -4,77 +4,21 @@ Feature: View Audit history of a contact
   I would like to track changes to a contact record over time
   So that I can cross-check the validity and accuracy of a given contact record
 
-  @audit-contact--fields
   Scenario: View name of the person who made contact record changes
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form
     Then I see the success message
     Then I wait and then refresh the page
     When I click the Contacts local nav link
-    And the contact has 1 fields edited for audit
+    And the contact has 2 fields edited for audit
     Then I see the success message
     When I search for this Contact record
     And I click the "Audit history" link
     Then I see the name of the person who made the recent contact record changes
     And I see the date time stamp when the recent contact record changed
     And I see the field names that were recently changed
-
-  @audit-contact--count
-  Scenario: View the number of changes occurred on a contact record
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
-    And I click the "Add contact" link
-    Then a primary contact is added
-    When I submit the form
-    Then I see the success message
-    When I click the Contacts local nav link
-    And the contact has 2 fields edited for audit
-    Then I see the success message
-    When I search for this Contact record
-    And I click the "Audit history" link
-    Then I see the total number of changes occurred recently on this contact record
-
-  @audit-contact--archived
-  Scenario: View audit log for Archived contact
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
-    And I click the "Add contact" link
-    Then a primary contact is added
-    When I submit the form
-    Then I see the success message
-    When I search for the created contact
-    And the Contacts search tab is clicked
-    And I click on the first contact collection link
-    And I archive this contact record
-    And I search for the created contact
-    And the Contacts search tab is clicked
-    And I click on the first contact collection link
-    And I click the "Audit history" link
-    Then I see the details who archived the contact
-
-  @audit-contact--unarchived
-  Scenario: View audit log for UnArchived contact
-
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
-    And I click the "Add contact" link
-    And a primary contact is added
-    When I submit the form
-    Then I see the success message
-    Then I wait and then refresh the page
-    And I search for the created contact
-    And the Contacts search tab is clicked
-    And I click on the first contact collection link
-    And I archive this contact record
-    And I unarchive this contact record
-    And I search for the created contact
-    And the Contacts search tab is clicked
-    And I click on the first contact collection link
-    And I click the "Audit history" link
-    Then I see the details who unarchived the contact
+    And I see the total number of changes occurred recently on this contact record
+    And I see the details who archived the contact
+    And I see the details who unarchived the contact


### PR DESCRIPTION
Currently we run a different scenario to check that an audit
item contains the correct data.

This feels quite intensive as for some scenarios it includes searching
for a company record, navigating to the contacts screen, adding a new
contact, navigating to that contact, navigating to the audit tab
and then checking the contents of the last audit item.

We can save lots of requests by only doing the checks once.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
