### PR TITLE
Direct navigation in acceptance tests

### DIFF
--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -7,8 +7,7 @@ Feature: View collection of contacts
   @contacts-collection--view
   Scenario: View contact collection
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Venus Ltd` fixture
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form
@@ -47,8 +46,7 @@ Feature: View collection of contacts
   @contacts-collection--filter
   Scenario: Filter contact list
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Venus Ltd` fixture
     And I click the "Add contact" link
     And a primary contact is added
     When I submit the form

--- a/test/acceptance/features/contacts/interactions-collection.feature
+++ b/test/acceptance/features/contacts/interactions-collection.feature
@@ -4,8 +4,7 @@ Feature: View collection of interactions for a contact
   @contacts-interactions-collection--view
   Scenario: View contacts interaction collection
 
-    When I navigate to the `contacts.Fixture` page using `contact` `Dean Cox` fixture
-    When I click the Interactions local nav link
+    When I navigate to the `contacts.Interactions` page using `contact` `Dean Cox` fixture
     And the results summary for a interaction collection is present
     And I can view the collection
 

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -7,8 +7,7 @@ Feature: Create New Contact
   @contacts-save--primary
   Scenario: Add a new primary contact
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     Then there are contact fields
     When a primary contact is added
@@ -33,8 +32,7 @@ Feature: Create New Contact
   @contacts-save--primary-new-company-address
   Scenario: Add a new primary contact with new company address
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     Then there are contact fields
     When a primary contact with new company address is added
@@ -58,8 +56,7 @@ Feature: Create New Contact
   @contacts-save--non-primary
   Scenario: Add a new non-primary contact
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     Then there are contact fields
     When a non-primary contact is added
@@ -83,8 +80,7 @@ Feature: Create New Contact
   @contacts-save--primary-dashboard
   Scenario: New primary contact is visible on the dashboard
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     Then there are contact fields
     When a primary contact is added
@@ -98,8 +94,7 @@ Feature: Create New Contact
   @contacts-save--mandatory-fields
   Scenario: Contact fields are mandatory
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Contacts local nav link
+    When I navigate to the `companies.Contacts` page using `company` `Lambda plc` fixture
     And I click the "Add contact" link
     Then there are contact fields
     When I submit the form

--- a/test/acceptance/features/interactions/add.feature
+++ b/test/acceptance/features/interactions/add.feature
@@ -4,8 +4,7 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-interaction-submit
   Scenario: Companies interaction is saved
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select interaction
     Then there are interaction fields
@@ -29,8 +28,7 @@ Feature: Add a new interaction in Data hub
 #  @interaction-add--companies-policy-feedback-submit
 #  Scenario: Companies policy feedback is saved
 #
-#    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-#    And I click the Interactions local nav link
+#    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
 #    And I click the "Add interaction" link
 #    And I select policy feedback
 #    Then there are policy feedback fields
@@ -54,8 +52,7 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-service-delivery-submit
   Scenario: Companies service delivery is saved
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -79,8 +76,7 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-service-delivery-tap-service-optional-complete-submit
   Scenario: Companies service delivery is saved and TAP service optional fields are specified
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -111,8 +107,7 @@ Feature: Add a new interaction in Data hub
   @interaction-add--companies-service-delivery-tap-service-optional-empty-submit
   Scenario: Companies service delivery is saved and TAP service optional fields are not specified
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -137,8 +132,7 @@ Feature: Add a new interaction in Data hub
   @interaction-add--contacts-interaction-submit
   Scenario: Interaction fields from contacts
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select interaction
     Then there are interaction fields
@@ -162,8 +156,7 @@ Feature: Add a new interaction in Data hub
 #  @interaction-add--contacts-policy-feedback-submit
 #  Scenario: Policy feedback fields from contacts
 #
-#    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-#    And I click the Interactions local nav link
+#    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
 #    And I click the "Add interaction" link
 #    And I select policy feedback
 #    Then there are interaction fields
@@ -187,8 +180,7 @@ Feature: Add a new interaction in Data hub
   @interaction-add--contacts-service-delivery-submit
   Scenario: Service delivery fields from contacts
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -212,8 +204,7 @@ Feature: Add a new interaction in Data hub
   @interaction-add--investment-projects-interaction-submit
   Scenario: Interaction fields from investment projects
 
-    When I navigate to the `investments.Fixture` page using `investment project` `New rollercoaster` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `investments.Interactions` page using `investment project` `New rollercoaster` fixture
     And I click the "Add interaction" link
     Then there are interaction fields
     And interaction fields are pre-populated
@@ -237,8 +228,7 @@ Feature: Add a new interaction in Data hub
   @interactions-add--events-toggle
   Scenario: Toggle service delivery event association
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields
@@ -251,8 +241,7 @@ Feature: Add a new interaction in Data hub
   @interactions-add--service-toggle
   Scenario: Toggle service delivery service fields
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select service delivery
     Then there are service delivery fields

--- a/test/acceptance/features/interactions/collection.feature
+++ b/test/acceptance/features/interactions/collection.feature
@@ -7,8 +7,7 @@ Feature: View collection of interactions
   @interactions-collection--view-interaction
   Scenario: View interaction in interactions and services collection
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select interaction
     When an interaction is added
@@ -31,8 +30,7 @@ Feature: View collection of interactions
 #  @interactions-collection--view-policy-feedback
 #  Scenario: View policy feedback in interactions and services collection
 #
-#    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-#    And I click the Interactions local nav link
+#    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
 #    And I click the "Add interaction" link
 #    And I select policy feedback
 #    When a policy feedback is added
@@ -55,8 +53,7 @@ Feature: View collection of interactions
   @interactions-collection--view-service-delivery
   Scenario: View service delivery in interactions and services collection
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select service delivery
     And a service delivery is added
@@ -79,8 +76,7 @@ Feature: View collection of interactions
   @interactions-collection--filter
   Scenario: filter interaction list
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `companies.Interactions` page using `company` `Venus Ltd` fixture
     And I click the "Add interaction" link
     And I select interaction
     And an interaction is added

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -7,8 +7,7 @@ Feature: View a list of Investment Projects
   @investment-projects-collection--view
   Scenario: View Investment Projects list
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -6,16 +6,14 @@ Feature: Create a new Investment project
   @investment-projects-create--verify-add
   Scenario: Verify Add Investment project option
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
 
   @investment-projects-create--fdi
   Scenario: Add a Foreign Direct Investment (FDI) Investment project
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -46,8 +44,7 @@ Feature: Create a new Investment project
   @investment-projects-create--fdi-different-source-of-equity
   Scenario: Add a Foreign Direct Investment (FDI) Investment project with a separate company as the source of foreign equity
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -86,8 +83,7 @@ Feature: Create a new Investment project
   @investment-projects-create--non-fdi
   Scenario: Add a Non Foreign Direct Investment (Non-FDI) Investment project
 
-    When I navigate to the `companies.Fixture` page using `company` `Venus Ltd` fixture
-    And I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Venus Ltd` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select Non FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -4,8 +4,7 @@ Feature: Investment projects evaluations details
   @investment-projects-evaluations-details--value-yes
   Scenario: View investment project evaluations after user selects all yes for value details
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type
@@ -60,8 +59,7 @@ Feature: Investment projects evaluations details
   @investment-projects-evaluations-details--value-no
   Scenario: View investment project evaluations after user selects all no for value details
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    And I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
     When I select FDI as the Investment project type

--- a/test/acceptance/features/investment-projects/interactions-collection.feature
+++ b/test/acceptance/features/investment-projects/interactions-collection.feature
@@ -4,24 +4,21 @@ Feature: View collection of interactions for an investment project
   @investment-projects-interactions-collection--view
   Scenario: View investment projects interaction collection
 
-    When I navigate to the `investments.Fixture` page using `investment project` `New hotel (FDI)` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `investments.Interactions` page using `investment project` `New hotel (FDI)` fixture
     And the results summary for a interaction collection is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--lep @lep
   Scenario: View investment projects interaction collection
 
-    When I navigate to the `investments.Fixture` page using `investment project` `New zoo (LEP)` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `investments.Interactions` page using `investment project` `New zoo (LEP)` fixture
     And the results summary for a interaction collection is present
     And I can view the collection
 
   @investment-projects-interactions-collection--view--da @da
   Scenario: View investment projects interaction collection
 
-    When I navigate to the `investments.Fixture` page using `investment project` `New golf course (DA)` fixture
-    And I click the Interactions local nav link
+    When I navigate to the `investments.Interactions` page using `investment project` `New golf course (DA)` fixture
     And the results summary for a interaction collection is present
     And I can view the collection
 

--- a/test/acceptance/features/investment-projects/value-add.feature
+++ b/test/acceptance/features/investment-projects/value-add.feature
@@ -70,8 +70,7 @@ Feature: Add value to investment project
   @investment-projects-value-add--blank
   Scenario: Save a blank value form in the prospect stage
 
-    When I navigate to the `companies.Fixture` page using `company` `Lambda plc` fixture
-    Then I click the Investment local nav link
+    When I navigate to the `companies.Investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     And I select FDI as the Investment project type
     And I choose Yes for "Will this company be the source of foreign equity investment?"

--- a/test/acceptance/pages/companies/Investments.js
+++ b/test/acceptance/pages/companies/Investments.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { company } = require('../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(company, { name: companyName })
+    const companyId = fixture ? fixture.id : company.ukLtd.id
+
+    return `${process.env.QA_HOST}/companies/${companyId}/investments`
+  },
+  elements: {},
+}


### PR DESCRIPTION
This continues to use page objects to navigate directly to a nested page within an
entity rather than using the local nav to get to pages within things like companies
or contacts.