### PR TITLE
Create journey acceptance tests

### DIFF
--- a/test/acceptance/features/omis/create.feature
+++ b/test/acceptance/features/omis/create.feature
@@ -1,0 +1,45 @@
+@omis @omis--create
+Feature: Create new order using company ID
+
+  Background: Create initial draft
+    When I navigate to the `omis.create.start` page using `company` `Venus Ltd` fixture
+    And I select a value for `contactField` on the `omis.create.contact` page
+    And I submit the form
+    And I select a value for `marketField` on the `omis.create.market` page
+    And I submit the form
+    And I choose the company’s primary sector
+    And I submit the form
+    Then I should see the correct text on the `omis.create.summary` page
+      | elementPath     | expectedText                     |
+      | contact.contact | omis.create.contact.contactField |
+      | market.market   | omis.create.market.marketField   |
+      | sector.sector   | omis.create.sector.sectorField   |
+
+  Scenario: Edit steps from summary
+    When I click `editContactLink` on the `omis.create.summary` page
+    Then I am on the `omis.create.contact` page
+    When I select a value for `contactField` on the `omis.create.contact` page
+    And I submit the form
+    Then I am on the `omis.create.summary` page
+    And I should see the correct text on the `omis.create.summary` page
+      | elementPath     | expectedText                     |
+      | contact.contact | omis.create.contact.contactField |
+
+    When I click `editMarketLink` on the `omis.create.summary` page
+    Then I am on the `omis.create.market` page
+    When I select a value for `marketField` on the `omis.create.market` page
+    And I submit the form
+    Then I am on the `omis.create.summary` page
+    And I should see the correct text on the `omis.create.summary` page
+      | elementPath     | expectedText                     |
+      | market.market   | omis.create.market.marketField   |
+
+    When I click `editSectorLink` on the `omis.create.summary` page
+    Then I am on the `omis.create.sector` page
+    When I click `useCustomSectorOption` on the `omis.create.sector` page
+    And I select a value for `sectorField` on the `omis.create.sector` page
+    And I submit the form
+    Then I am on the `omis.create.summary` page
+    And I should see the correct text on the `omis.create.summary` page
+      | elementPath     | expectedText                     |
+      | sector.sector   | omis.create.sector.sectorField   |

--- a/test/acceptance/features/omis/create.feature
+++ b/test/acceptance/features/omis/create.feature
@@ -15,6 +15,16 @@ Feature: Create new order using company ID
       | market.market   | omis.create.market.marketField   |
       | sector.sector   | omis.create.sector.sectorField   |
 
+  Scenario: Save draft order
+    When I submit the form
+    Then I am on the `omis.order` page
+    And I should see the correct text on the `omis.order` page
+      | elementPath            | expectedText                     |
+      | contact.name           | omis.create.contact.contactField |
+      | internal.sector        | omis.create.sector.sectorField   |
+      | header.status          | Draft                            |
+      | header.metadata.market | omis.create.market.marketField   |
+
   Scenario: Edit steps from summary
     When I click `editContactLink` on the `omis.create.summary` page
     Then I am on the `omis.create.contact` page

--- a/test/acceptance/features/omis/step_definitions/create.js
+++ b/test/acceptance/features/omis/step_definitions/create.js
@@ -1,0 +1,13 @@
+const { set } = require('lodash')
+const { client } = require('nightwatch-cucumber')
+const { Then } = require('cucumber')
+
+Then('I choose the company’s primary sector', async function () {
+  const SectorPage = client.page.omis.create.sector()
+
+  await SectorPage
+    .getText('@companySector', (result) => {
+      set(this.state, 'omis.create.sector.sectorField', result.value)
+    })
+    .click('@useCompanySectorOption')
+})

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -1,6 +1,6 @@
 const { assign, camelCase, find, get, set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { When } = require('cucumber')
+const { When, Then } = require('cucumber')
 
 const fixtures = require('../../fixtures')
 
@@ -55,5 +55,19 @@ When(/^I select a value for `(.+)` on the `(.+)` page$/, async function (element
       })
   } catch (error) {
     throw new Error(`The page object '${pageName}' does not exist`)
+  }
+})
+
+Then(/^I am on the `(.+)` page$/, async function (pageName) {
+  try {
+    const page = get(client.page, pageName)()
+
+    if (page.props.urlMatch) {
+      await client.assert.urlMatch(page.props.urlMatch)
+    } else {
+      await client.assert.urlContains(page.url)
+    }
+  } catch (error) {
+    throw new Error(error)
   }
 })

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -35,3 +35,12 @@ When('I click the {string} link', async function (linkText) {
     .click(`//a[text()='${linkText}']`)
     .useCss()
 })
+
+When(/^I click `(.+)` on the `(.+)` page$/, async function (elementName, pageName) {
+  try {
+    const page = get(client.page, pageName)()
+    await page.click(`@${elementName}`)
+  } catch (error) {
+    throw new Error(`The page object '${pageName}' does not exist`)
+  }
+})

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -44,3 +44,16 @@ When(/^I click `(.+)` on the `(.+)` page$/, async function (elementName, pageNam
     throw new Error(`The page object '${pageName}' does not exist`)
   }
 })
+
+When(/^I select a value for `(.+)` on the `(.+)` page$/, async function (elementName, pageName) {
+  try {
+    const page = get(client.page, pageName)()
+    await page
+      .getListOption(`@${elementName}`, (item) => {
+        page.setValue(`@${elementName}`, item)
+        set(this.state, `${pageName}[${elementName}]`, item)
+      })
+  } catch (error) {
+    throw new Error(`The page object '${pageName}' does not exist`)
+  }
+})

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -71,3 +71,23 @@ Then(/^I am on the `(.+)` page$/, async function (pageName) {
     throw new Error(error)
   }
 })
+
+Then(/^I should see the correct text on the `(.+)` page$/, async function (pageName, data) {
+  try {
+    for (const row of data.hashes()) {
+      const elementPath = row.elementPath.split('.')
+      const elementName = elementPath.pop()
+      const section = elementPath.join('.section.')
+      const expectedText = get(this.state, row.expectedText) || row.expectedText
+      let page = get(client.page, `${pageName}`)()
+
+      if (section) {
+        page = get(page, `section.${section}`)
+      }
+
+      await page.assert.containsText(`@${elementName}`, expectedText)
+    }
+  } catch (error) {
+    throw new Error(error)
+  }
+})

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -129,4 +129,10 @@ module.exports = {
       name: 'New zoo (LEP)',
     },
   },
+  order: {
+    // TODO: Populate with UUIDs when fixtures have been added to the API
+    draft: {
+      id: '',
+    },
+  },
 }

--- a/test/acceptance/pages/omis/create/company.js
+++ b/test/acceptance/pages/omis/create/company.js
@@ -1,0 +1,4 @@
+module.exports = {
+  url: `${process.env.QA_HOST}/omis/create/company`,
+  elements: {},
+}

--- a/test/acceptance/pages/omis/create/contact.js
+++ b/test/acceptance/pages/omis/create/contact.js
@@ -1,0 +1,6 @@
+module.exports = {
+  url: `${process.env.QA_HOST}/omis/create/contact`,
+  elements: {
+    contactField: '[name="contact"]',
+  },
+}

--- a/test/acceptance/pages/omis/create/market.js
+++ b/test/acceptance/pages/omis/create/market.js
@@ -1,0 +1,6 @@
+module.exports = {
+  url: `${process.env.QA_HOST}/omis/create/market`,
+  elements: {
+    marketField: '[name="primary_market"]',
+  },
+}

--- a/test/acceptance/pages/omis/create/sector.js
+++ b/test/acceptance/pages/omis/create/sector.js
@@ -1,0 +1,9 @@
+module.exports = {
+  url: `${process.env.QA_HOST}/omis/create/sector`,
+  elements: {
+    companySector: '.c-message--muted strong',
+    useCompanySectorOption: 'label[for="field-use_sector_from_company-1"]',
+    useCustomSectorOption: 'label[for="field-use_sector_from_company-2"]',
+    sectorField: '[name="sector"]',
+  },
+}

--- a/test/acceptance/pages/omis/create/start.js
+++ b/test/acceptance/pages/omis/create/start.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { company: companyFixtures } = require('../../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(companyFixtures, { name: companyName })
+    const urlSuffix = fixture ? `?company=${fixture.id}&skip-company=true` : ''
+
+    return `${process.env.QA_HOST}/omis/create${urlSuffix}`
+  },
+  elements: {},
+}

--- a/test/acceptance/pages/omis/create/summary.js
+++ b/test/acceptance/pages/omis/create/summary.js
@@ -1,0 +1,35 @@
+module.exports = {
+  url: `${process.env.QA_HOST}/omis/create/confirm`,
+  elements: {
+    editCompanyLink: 'a[href="company/edit"]',
+    editContactLink: 'a[href="contact/edit"]',
+    editMarketLink: 'a[href="market/edit"]',
+    editSectorLink: 'a[href="sector/edit"]',
+  },
+  sections: {
+    company: {
+      selector: '.c-answers-summary:first-of-type',
+      elements: {
+        company: 'td.c-answers-summary__content',
+      },
+    },
+    contact: {
+      selector: '.c-answers-summary:nth-of-type(2)',
+      elements: {
+        contact: 'td.c-answers-summary__content',
+      },
+    },
+    market: {
+      selector: '.c-answers-summary:nth-of-type(3)',
+      elements: {
+        market: 'td.c-answers-summary__content',
+      },
+    },
+    sector: {
+      selector: '.c-answers-summary:nth-of-type(4)',
+      elements: {
+        sector: 'td.c-answers-summary__content',
+      },
+    },
+  },
+}

--- a/test/acceptance/pages/omis/order.js
+++ b/test/acceptance/pages/omis/order.js
@@ -1,0 +1,45 @@
+const { order: orderFixtures } = require('../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (order) {
+    const fixture = orderFixtures[order]
+    const orderId = fixture ? fixture.id : orderFixtures.draft.id
+
+    return `${process.env.QA_HOST}/omis/${orderId}`
+  },
+  props: {
+    urlMatch: new RegExp(/omis\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/work-order/),
+  },
+  elements: {},
+  sections: {
+    header: {
+      selector: '.c-local-header',
+      elements: {
+        heading: '.c-local-header__heading',
+        status: '.c-meta-list:nth-of-type(2) .c-meta-list__item:nth-of-type(3) .c-meta-list__item-value',
+      },
+      sections: {
+        metadata: {
+          selector: '.c-meta-list:first-of-type',
+          elements: {
+            company: '.c-meta-list__item:nth-of-type(1) .c-meta-list__item-value',
+            market: '.c-meta-list__item:nth-of-type(2) .c-meta-list__item-value',
+            ukRegion: '.c-meta-list__item:nth-of-type(3) .c-meta-list__item-value',
+          },
+        },
+      },
+    },
+    contact: {
+      selector: '.c-answers-summary:first-of-type',
+      elements: {
+        name: 'tr:nth-of-type(1) td.c-answers-summary__content',
+      },
+    },
+    internal: {
+      selector: '.c-answers-summary:nth-of-type(5)',
+      elements: {
+        sector: 'tr:nth-of-type(2) td.c-answers-summary__content',
+      },
+    },
+  },
+}


### PR DESCRIPTION
This change adds acceptance tests around the OMIS order creation journey.

It starts with adding the journey from a particular company which skips the company search.

It also adds some more shared step definitions which can be used across the rest of the tests
once this change has been merged.

See the commit logs for more detailed descriptions of each change.