### PR TITLE
Display contact job title on work order

### DIFF
--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -2,6 +2,9 @@
 
 {% set contactName %}
   <a href="/contacts/{{ values.contact.id }}">{{ values.contact.name }}</a>
+  {%- if values.contact.job_title -%}
+    , {{ values.contact.job_title }}
+  {%- endif -%}
 {% endset %}
 
 {% set contactEmail %}


### PR DESCRIPTION
This replicates the behaviour we have during the creation summary.

This creates consistency between the two and also allows us to better
check against the two values during acceptance tests.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
