### PR TITLE
Hide payment count when only 1 payment

### DIFF
--- a/src/apps/omis/apps/view/views/payment-receipt.njk
+++ b/src/apps/omis/apps/view/views/payment-receipt.njk
@@ -95,10 +95,17 @@
     </tfoot>
   </table>
 
-  <h2 class="heading-medium">Payment details ({{ payments.length }} {{ ' payment' | pluralise(payments.length) }})</h2>
+  <h2 class="heading-medium">
+      Payment details
+      {% if payments.length > 1 %}
+        ({{ payments.length }} payments)
+      {% endif %}
+    </h2>
 
   {% for payment in payments %}
-    <h3 class="heading-small">Payment {{ loop.index }}</h3>
+    {% if payments.length > 1 %}
+      <h3 class="heading-small">Payment {{ loop.index }}</h3>
+    {% endif %}
 
     {{ MetaList({
       items: [


### PR DESCRIPTION
During some research sessions users found it confusing when we
dispalyed the payment count and payment number as a heading when there
was only 1 payment.

This logic has been changed so that the payment count and payment
number heading will only appear when there is more than one payment.

## Before
![localhost_3001_omis_85c989cf-2a48-4251-8c87-dd8fdc50c69d_payment-receipt 1](https://user-images.githubusercontent.com/3327997/37146897-02b65488-22bd-11e8-8169-f29a1fb18ab9.png)

## After
![localhost_3001_omis_85c989cf-2a48-4251-8c87-dd8fdc50c69d_payment-receipt](https://user-images.githubusercontent.com/3327997/37146886-fce93d22-22bc-11e8-988f-4a4a1855656b.png)

