### PR TITLE
Remove vat status step from quote errors

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -134,6 +134,8 @@ async function setQuotePreview (req, res, next) {
       }
     })
 
+    delete quoteErrors['/vat-status']
+
     res.locals.missingLeadAssignee = error.error.hasOwnProperty('assignee_lead')
     res.locals.incompleteFields = pickBy(quoteErrors)
   }

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -74,12 +74,12 @@
       {% if quote.content %}
         {% call Example(tabTitle = '') %}
           <div class="l-markdown">
-  {# Ugly indentation is so that markdown spacing is handled correctly #}
-  {% markdown %}{{ quote.content | safe }}{% endmarkdown %}
+{# Ugly indentation is so that markdown spacing is handled correctly #}
+{% markdown %}{{ quote.content | safe }}{% endmarkdown %}
 
             {% call HiddenContent({ summary: 'View full terms and conditions' }) %}
-  {# Ugly indentation is so that markdown spacing is handled correctly #}
-  {% markdown %}{{ quote.terms_and_conditions | safe }}{% endmarkdown %}
+{# Ugly indentation is so that markdown spacing is handled correctly #}
+{% markdown %}{{ quote.terms_and_conditions | safe }}{% endmarkdown %}
             {% endcall %}
           </div>
         {% endcall %}
@@ -114,7 +114,7 @@
       </ul>
     {% endif %}
 
-    {{ Form(quoteForm) }}
-
   {% endif %}
+
+  {{ Form(quoteForm) }}
 {% endblock %}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -80,6 +80,18 @@ describe('OMIS View middleware', () => {
             'description',
           ],
         },
+        '/four': {
+          heading: 'Step four',
+          fields: [
+            'description',
+          ],
+        },
+        '/vat-status': {
+          heading: 'VAT status step',
+          fields: [
+            'description',
+          ],
+        },
         '@noCallThru': true,
       },
     })
@@ -487,10 +499,31 @@ describe('OMIS View middleware', () => {
           this.previewQuoteStub.rejects(error)
         })
 
-        it('should set errors on locals', async () => {
+        it('should include incomplete fields object', async () => {
           await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
 
           expect(this.resMock.locals).to.have.property('incompleteFields')
+        })
+
+        it('should contain the correct error step', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.resMock.locals.incompleteFields).to.have.ordered.keys([
+            '/one',
+            '/three',
+            '/four',
+          ])
+        })
+
+        it('should not contain the vat status step', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
+          expect(this.resMock.locals.incompleteFields).not.to.have.property('/vat-status')
+        })
+
+        it('should contain correct object structure', async () => {
+          await this.middleware.setQuotePreview(this.reqMock, this.resMock, this.nextSpy)
+
           expect(this.resMock.locals.incompleteFields).to.deep.equal({
             '/one': {
               heading: 'Step one',
@@ -500,6 +533,12 @@ describe('OMIS View middleware', () => {
             },
             '/three': {
               heading: 'Step three',
+              errors: [
+                'description',
+              ],
+            },
+            '/four': {
+              heading: 'Step four',
               errors: [
                 'description',
               ],


### PR DESCRIPTION
The vat status step is a nested step used when changing the billing
address country and also contains the `vat_status` field.

Adding this step caused it to be caught by the quote middleware and
it to show the same error twice with a link to 2 different steps.

As the vat status step is hidden within a journey we want to remove
it from this quote logic.

This change also contains updates to the test to catch this change.

## Before
![localhost_3001_omis_3efdc8de-2405-40be-9d8c-d50661a8b117_quote 1](https://user-images.githubusercontent.com/3327997/37149864-7cb86e88-22c7-11e8-9fb5-a56135df36f1.png)

## After
![localhost_3001_omis_3efdc8de-2405-40be-9d8c-d50661a8b117_quote](https://user-images.githubusercontent.com/3327997/37150488-c229708c-22c9-11e8-9fb2-1b3eca1b6081.png)


