### PR TITLE
Bugfix/dh 1563 search term highlighting

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -8,6 +8,7 @@ const queryString = require('query-string')
 const {
   assign,
   concat,
+  escape,
   isArray,
   isFunction,
   isPlainObject,
@@ -104,7 +105,7 @@ const filters = {
         ? new RegExp(`\\b(${cleanedSearchTerm})\\b`, 'gi')
         : new RegExp(`(${cleanedSearchTerm})`, 'gi')
 
-      const result = searchResultText.replace(searchPattern, '<span class="u-highlight">$1</span>')
+      const result = escape(searchResultText).replace(searchPattern, '<span class="u-highlight">$1</span>')
       return new nunjucks.runtime.SafeString(result)
     } catch (error) {
       return searchResultText

--- a/test/unit/config/nunjucks/filters.test.js
+++ b/test/unit/config/nunjucks/filters.test.js
@@ -133,6 +133,17 @@ describe('nunjucks filters', () => {
         expect(this.highlightedString.val).to.equal('<span class="u-highlight">Here is an example phrase</span>')
       })
     })
+
+    context('when search result contains hazardous characters', () => {
+      beforeEach(() => {
+        this.mockString = 'Here is <>an example phrase'
+        this.highlightedString = filters.highlight(this.mockString, 'example')
+      })
+
+      it('should escape the characters and transform them into character entity references', () => {
+        expect(this.highlightedString.val).to.equal('Here is &lt;&gt;an <span class="u-highlight">example</span> phrase')
+      })
+    })
   })
 
   describe('#removeNilAndEmpty', () => {


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/DH-1563

Because the regex isn't escaping all characters, we added an `escape` filter on top of of the search results string to prevent the app from crashing. 