### PR TITLE
Fix component modifiers

### DIFF
--- a/assets/stylesheets/components/form/_form-fieldset.scss
+++ b/assets/stylesheets/components/form/_form-fieldset.scss
@@ -29,29 +29,3 @@
   margin-top: $default-spacing-unit;
   margin-bottom: 0;
 }
-
-// Modifiers
-fieldset.c-form-fieldset--subfield {
-  border-left: 0;
-  padding-left: $default-spacing-unit * 2;
-  position: relative;
-
-  &::before {
-    position: absolute;
-    left: $default-spacing-unit;
-    top: 0;
-    bottom: 0;
-    border-left: 5px solid $grey-2;
-    margin-left: -$default-spacing-unit;
-    content: "";
-  }
-
-  &.has-error {
-    border-left: 0;
-    padding-left: $default-spacing-unit * 2;
-
-    &::before {
-      border-left-color: $error-colour;
-    }
-  }
-}

--- a/assets/stylesheets/components/form/_form-group.scss
+++ b/assets/stylesheets/components/form/_form-group.scss
@@ -86,6 +86,26 @@ fieldset.c-form-group.has-error {
   }
 }
 
+fieldset.c-form-group.c-form-group--subfield {
+  border-left: 0;
+  padding-left: $default-spacing-unit * 2;
+  position: relative;
+
+  &::before {
+    position: absolute;
+    left: $default-spacing-unit;
+    top: 0;
+    bottom: 0;
+    border-left: 5px solid $grey-2;
+    margin-left: -$default-spacing-unit;
+    content: "";
+  }
+
+  &.has-error::before {
+    border-left-color: $error-colour;
+  }
+}
+
 .c-form-group--inline:not(fieldset) {
   @include media(tablet) {
     vertical-align: top;

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -204,7 +204,7 @@ const filters = {
   applyClassModifiers (className, modifier) {
     if (!isString(className) || !(isString(modifier) || isArray(modifier))) { return className }
 
-    const classModifier = flatten([modifier]).map(mod => `${className}--${mod}`).join(' ')
+    const classModifier = flatten([modifier]).filter(isNotEmpty).map(mod => `${className}--${mod}`).join(' ')
 
     return `${className} ${classModifier}`.trim()
   },

--- a/src/templates/_macros/form/entity-search-form.njk
+++ b/src/templates/_macros/form/entity-search-form.njk
@@ -23,10 +23,9 @@
   {% set inputPlaceholder = props.inputPlaceholder | default(props.inputLabel) -%}
   {% set isLabelHidden = props.isLabelHidden | default(true) %}
   {% set entityType = props.entityType | default('company') %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-entity-search--') if props.modifier %}
 
   {% call Form(props | assign({
-    class: 'c-entity-search ' + modifier,
+    class: 'c-entity-search' | applyClassModifiers(props.modifier),
     role: 'search',
     method: method,
     hideFormActions: true,

--- a/src/templates/_macros/form/fieldset.njk
+++ b/src/templates/_macros/form/fieldset.njk
@@ -12,14 +12,12 @@
  # @callback {function} caller - Inner contents
 #}
 {% macro Fieldset(props) %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-form-fieldset--') if props.modifier %}
   {% set children = caller() if caller else renderAsMacro(props.children) %}
 
   <fieldset
     class="
-      c-form-fieldset
+      {{ 'c-form-fieldset' | applyClassModifiers(props.modifier) }}
       {{ props.class if props.class }}
-      {{ modifier }}
       {{ 'js-ConditionalSubfield' if props.condition }}
     "
     {% if props.condition %}

--- a/src/templates/_macros/form/form-group.njk
+++ b/src/templates/_macros/form/form-group.njk
@@ -27,19 +27,15 @@
   {% set labelElement = 'legend' if isFieldset else 'label' %}
   {% set labelClassName = className + '__label' if className === 'c-form-group' else className + '__legend' %}
   {% set isLegend = 'legend' if isFieldset %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-form-group--') if props.modifier %}
-  {% set fieldsetModifier = props.modifier | concat('') | reverse | join(' c-form-fieldset--') if props.modifier %}
   {% set children = caller() if caller else renderAsMacro(props.children) %}
 
   {% if props.label and props.name -%}
     <{{ groupElement }}
       id="group-{{ props.fieldId }}"
       class="
-        {{ className }}
+        {{ className | applyClassModifiers(props.modifier) }}
         {{ 'has-error' if props.error and not isLabelHidden }}
         {{ 'js-ConditionalSubfield' if isConditional }}
-        {{ modifier }}
-        {{ fieldsetModifier }}
         {{ props.class if props.class }}
       "
       {% if isConditional %}

--- a/src/templates/_macros/form/input.njk
+++ b/src/templates/_macros/form/input.njk
@@ -12,15 +12,13 @@
  # @param {object} [props.data] - data attributes to add to control
  #}
 {% macro Input(props) %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-form-control--') if props.modifier %}
-
   <input
     name="{{ props.name }}"
     type="{{ props.type if props.type else 'text' }}"
     id="{{ props.fieldId }}"
     {% if props.placeholder %}placeholder="{{ props.placeholder }}"{% endif %}
     value="{{ props.value }}"
-    class="c-form-control {{ modifier }} {{ 'has-error' if props.error }} {{ props.class }}"
+    class="{{ 'c-form-control' | applyClassModifiers(props.modifier) }} {{ 'has-error' if props.error }} {{ props.class }}"
     {% if props.autofocus %}autofocus{% endif %}
     {% if props.hint %}aria-describedby="hint-{{ props.fieldId }}"{% endif %}
     {% for key, value in props.data %}

--- a/src/templates/_macros/form/multiple-choice-field.njk
+++ b/src/templates/_macros/form/multiple-choice-field.njk
@@ -54,11 +54,11 @@
  #}
 {% macro MultipleChoice(props) %}
   {% if props.type in ['checkbox', 'radio'] %}
-    {% set modifier = props.modifier | concat('') | reverse | join(' c-multiple-choice--') if props.modifier %}
+    {% set componentClassNames = 'c-multiple-choice' | applyClassModifiers(props.modifier) %}
     {% set options = props.options() if props.options | isFunction else props.options %}
 
     {% if props.type == 'radio' and props.initialOption %}
-      <div class="c-multiple-choice {{ modifier }}">
+      <div class="{{ componentClassNames }}">
         <input
           class="c-multiple-choice__input"
           type="{{ props.type }}"
@@ -84,7 +84,7 @@
         {% endif %}
       {% endif %}
 
-      <div class="c-multiple-choice {{ modifier }}">
+      <div class="{{ componentClassNames }}">
         <input
           class="c-multiple-choice__input"
           type="{{ props.type }}"

--- a/src/templates/_macros/form/select-box.njk
+++ b/src/templates/_macros/form/select-box.njk
@@ -13,14 +13,13 @@
  # @param {string} [props.persistsConditionalValue] - Whether the values should persist when collapsed
  #}
 {% macro SelectBox(props) %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-form-control--') if props.modifier %}
   {% set options = props.options() if props.options | isFunction else props.options %}
   {% set fieldValue = props.value.id or props.value %}
 
   <select
     id="{{ props.fieldId }}"
     name="{{ props.name }}"
-    class="c-form-control {{ modifier }} {{ 'has-error' if props.error }} {{ props.class }}"
+    class="{{ 'c-form-control' | applyClassModifiers(props.modifier) }} {{ 'has-error' if props.error }} {{ props.class }}"
     {% if props.persistsConditionalValue %}data-persist-values="true"{% endif %}
     {% if props.hint %}aria-describedby="hint-{{ props.fieldId }}"{% endif %}
     {% for key, value in props.data %}

--- a/src/templates/_macros/form/text-area.njk
+++ b/src/templates/_macros/form/text-area.njk
@@ -11,11 +11,9 @@
  # @param {object} [props.data] - data attributes to add to control
  #}
 {% macro TextArea(props) %}
-  {% set modifier = props.modifier | concat('') | reverse | join(' c-form-control--') if props.modifier %}
-
   <textarea
     name="{{ props.name }}"
-    class="c-form-control {{ modifier }} {{ 'has-error' if props.error }} {{ props.class }}"
+    class="{{ 'c-form-control' | applyClassModifiers(props.modifier) }} {{ 'has-error' if props.error }} {{ props.class }}"
     id="{{ props.fieldId }}"
     placeholder="{{ props.placeholder }}"
     {% if props.hint %}aria-describedby="hint-{{ props.fieldId }}"{% endif %}


### PR DESCRIPTION
Currently some modifiers can be applied with undefined values. It can lead to examples like this:

```scss
c-component-name c-component-name--undefined
```

This set of changes uses a filter to apply those modifiers rather than always manually building them out.

See the commit descriptions for a better breakdown of each change.