### PR TITLE
Removed duplicate params in XHR

### DIFF
--- a/assets/javascripts/lib/xhr.js
+++ b/assets/javascripts/lib/xhr.js
@@ -1,6 +1,8 @@
 const axios = require('axios')
 const createHistory = require('history').createBrowserHistory
 const queryString = require('query-string')
+const uniqWith = require('lodash/uniqWith')
+const isEqual = require('lodash/isEqual')
 
 const history = createHistory()
 
@@ -46,20 +48,22 @@ const XHR = {
     const outlet = this.getOutlet()
     if (!outlet) { return }
 
+    const uniqueParams = uniqWith(params, isEqual)
+
     if (showLoader) {
       outlet.classList.add('u-loading')
     }
 
     if (params) {
-      const url = `?${queryString.stringify(params)}`
-      history.push(url)
+      const historyUrl = `?${queryString.stringify(uniqueParams)}`
+      history.push(historyUrl)
     }
 
     return axios
-      .get(`${url}?${queryString.stringify(params)}`, {
+      .get(`${url}?${queryString.stringify(uniqueParams)}`, {
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
       })
-      .then(res => this.updateOutlet(res, params))
+      .then(res => this.updateOutlet(res, uniqueParams))
   },
 }
 


### PR DESCRIPTION
With the addition of the adviser lookup control, it will be possible to submit an identical key-value pair if the user picks their own name from the adviser typeahead control.

This simple change ensures that the key-value pairs are unique when generating the URL to search and when updating the user URL.

Note: that we need to find a better way to test this component to allow unit tests for things like this to be added but I want to do that separate so we can also consider how it would work with Jest.