### PR TITLE
DH-1439 User can unintentionally create duplicate records

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -15,6 +15,7 @@ const AddItems = require('./modules/add-items')
 const PrintDialog = require('./modules/print-dialog')
 const MirrorValue = require('./modules/mirror-value.js')
 const ClearInputs = require('./modules/clear-inputs.js')
+const PreventMultipleSubmits = require('./modules/prevent-multiple-submits.js')
 
 const CompanyAdd = require('./_deprecated/company-add')
 const CompanyEdit = require('./_deprecated/company-edit')
@@ -31,6 +32,7 @@ AddItems.init()
 PrintDialog.init()
 MirrorValue.init()
 ClearInputs.init()
+PreventMultipleSubmits.init()
 
 // Deprecated
 CompanyAdd.init()

--- a/assets/javascripts/modules/prevent-multiple-submits.js
+++ b/assets/javascripts/modules/prevent-multiple-submits.js
@@ -1,0 +1,47 @@
+const CONSTANTS = {
+  selectors: {
+    button: 'button[type="submit"]',
+    form: 'form',
+  },
+  types: {
+    submit: 'submit',
+  },
+  attributes: {
+    disabled: 'disabled',
+  },
+  events: {
+    click: 'click',
+  },
+}
+
+const PreventMultipleSubmits = {
+  isSubmitting: false,
+  counter: 0,
+
+  init () {
+    if (document.querySelectorAll(CONSTANTS.selectors.button).length) {
+      this.bindEvents()
+    }
+  },
+
+  handleFormSubmit (event) {
+    const targetForm = event.target.closest(CONSTANTS.selectors.form)
+    if (!targetForm ||
+      event.target.type !== CONSTANTS.types.submit ||
+      targetForm.classList.contains('js-AutoSubmit')) { return }
+
+    if (this.counter >= 1) {
+      event.target.setAttribute(CONSTANTS.attributes.disabled, true)
+      event.preventDefault()
+    } else {
+      this.counter += 1
+      targetForm.submit()
+    }
+  },
+
+  bindEvents () {
+    document.addEventListener(CONSTANTS.events.click, this.handleFormSubmit.bind(this))
+  },
+}
+
+module.exports = PreventMultipleSubmits

--- a/src/apps/companies/views/interactions.njk
+++ b/src/apps/companies/views/interactions.njk
@@ -12,14 +12,18 @@
       An interaction could be a meeting, call, email or another activity where you have been in touch with a company.
     </p>
 
-    {{
-      Collection(results | assignCopy({
-        countLabel: 'interaction',
-        summaryActionsHTML: addButton,
-        sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
-        query: QUERY
-      }))
-    }}
+    {% block xhr_content %}
+      <article id="xhr-outlet">
+        {{
+          Collection(results | assignCopy({
+            countLabel: 'interaction',
+            summaryActionsHTML: addButton,
+            sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
+            query: QUERY
+          }))
+        }}
+      </article>
+    {% endblock %}
   {% else %}
     {% call Message({ type: 'info' }) %}
       You currently have no contacts for this company. To add an interaction you must first <a href="/contacts/create?company={{company.id}}">add a contact</a>.

--- a/src/apps/contacts/views/interactions.njk
+++ b/src/apps/contacts/views/interactions.njk
@@ -9,12 +9,18 @@
   <p>
     An interaction could be a meeting, call, email or another activity where you have been in touch with a contact.
   </p>
-  {{
-    Collection(results | assignCopy({
-      countLabel: 'interaction',
-      summaryActionsHTML: addButton,
-      sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
-      query: QUERY
-    }))
-  }}
+
+  {% block xhr_content %}
+    <article id="xhr-outlet">
+      {{
+        Collection(results | assignCopy({
+          countLabel: 'interaction',
+          summaryActionsHTML: addButton,
+          sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
+          query: QUERY
+        }))
+      }}
+    </article>
+  {% endblock %}
+
 {% endblock %}

--- a/src/templates/_macros/form/form.njk
+++ b/src/templates/_macros/form/form.njk
@@ -59,7 +59,7 @@
     {% if not hideFormActions %}
       <div class="c-form-actions {{ props.actionsClass }}">
         {% if not props.hidePrimaryFormAction %}
-          <button class="button {{ buttonModifiers }}" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
+          <button class="button {{ buttonModifiers }}" type="submit" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
         {% endif %}
         {% if props.returnLink %}
           <a href="{{ props.returnLink }}">{{ returnText }}</a>


### PR DESCRIPTION
Some people still use double click to submit forms or even access links, in order to prevent that behaviour, which also creates unwanted multiple entries in our database, we can simply disable the submit button after the user interacts with it.

this also fixes the sorting issue on the interactions page