### PR TITLE
DH-1549 : Add adviser filter to interaction collection 

### DIFF
--- a/assets/javascripts/vue/typeahead.vue
+++ b/assets/javascripts/vue/typeahead.vue
@@ -6,7 +6,7 @@
     <multiselect
       label="label"
       open-direction="bottom"
-      placeholder="Type to search"
+      placeholder="Starts with"
       track-by="value"
       v-model="selectedOptions"
       :clear-on-select="true"
@@ -20,9 +20,8 @@
       :show-no-results="false"
       :showLabels="false"
       :searchable="true"
-      @search-change="asyncFind"
       :id="id"
-      :value="term">
+      @search-change="asyncFind">
       <template slot="clear" slot-scope="props">
         <div class="multiselect__clear" v-if="selectedOptions.length" @mousedown.prevent.stop="clearAll(props.search)"></div>
       </template>
@@ -38,6 +37,7 @@
         </div>
       </template>
     </multiselect>
+    <input type="hidden" :name="name" v-for="(option, index) in selectedOptions" :key="index" :value="option.value">
   </div>
 </template>
 
@@ -84,9 +84,6 @@
         type: Boolean,
         default: true,
       },
-      term: {
-        type: String,
-      }
     },
     data () {
       return {
@@ -105,6 +102,7 @@
         if (!form) { return }
 
         const query = pickBy(getFormData(form))
+        delete query[this.id]
         query[this.name] = newOptions.map(option => option.value)
 
         XHR.request(form.action, query)

--- a/assets/stylesheets/components/form/_form-group.scss
+++ b/assets/stylesheets/components/form/_form-group.scss
@@ -164,6 +164,16 @@ fieldset.c-form-group.c-form-group--subfield {
   padding: $default-spacing-unit / 2;
 }
 
+.c-form-group--filter.c-form-group--hide-label {
+  padding-top: ($default-spacing-unit / 2) - 3;
+}
+
+.c-form-group--hide-label {
+  .c-form-group__label {
+    display: none;
+  }
+}
+
 .c-form-group--option-select {
   legend.c-form-group__label {
     float: left;

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -319,12 +319,12 @@
 
   {% call Example('Typeahead') %}
     <form class="js-vue-wrapper">
-      <typeahead
-        entity="adviser"
-        name="adviser"
-        label="Adviser"
-        value="{{ advisers | dump }}">
-      </typeahead>
+      {{ Typeahead({
+        entity: 'adviser',
+        name: 'adviser',
+        label: 'Adviser',
+        selectedOptions: advisers
+      }) }}
     </form>
 
     <hr>

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -1,7 +1,7 @@
 const { get } = require('lodash')
 
 const { collectionFilterFields } = require('../macros')
-const { buildSelectedFiltersSummary } = require('../../builders')
+const { buildSelectedFiltersSummary, buildFieldsWithSelectedEntities } = require('../../builders')
 const { getOptions } = require('../../../lib/options')
 
 async function renderInteractionList (req, res, next) {
@@ -16,11 +16,13 @@ async function renderInteractionList (req, res, next) {
       channels,
       currentAdviserId,
     })
-    const selectedFilters = buildSelectedFiltersSummary(filtersFields, req.query)
+
+    const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, req.query)
+    const selectedFilters = await buildSelectedFiltersSummary(filtersFieldsWithSelectedOptions, req.query)
 
     res.render('collection', {
-      filtersFields,
       selectedFilters,
+      filtersFields: filtersFieldsWithSelectedOptions,
       title: 'Interactions',
       countLabel: 'interaction',
     })

--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -22,10 +22,15 @@ module.exports = function ({ currentAdviserId, channels = [], teams = [] }) {
       macroName: 'MultipleChoiceField',
       name: 'dit_adviser',
       type: 'checkbox',
-      modifier: 'option-select',
+      modifier: ['option-select', 'hide-label'],
       options: [
         { value: currentAdviserId, label: 'My interactions' },
       ],
+    },
+    {
+      macroName: 'Typeahead',
+      name: 'dit_adviser',
+      entity: 'adviser',
     },
     assign({}, communicationChannel(channels), {
       type: 'checkbox',

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -1,11 +1,15 @@
-const { sortBy } = require('lodash')
+const { castArray, sortBy } = require('lodash')
 
 const config = require('../../config')
 const authorisedRequest = require('../lib/authorised-request')
 const { filterDisabledOption } = require('../apps/filters')
 const { transformObjectToOption } = require('../apps/transformers')
 
-async function getOptions (token, key, { createdOn, currentValue, includeDisabled = false, sorted = true, term } = {}) {
+async function getOptions (token, key, { createdOn, currentValue, includeDisabled = false, sorted = true, term, id } = {}) {
+  if (id) {
+    return getOptionsForId(token, key, id)
+  }
+
   const url = `${config.apiRoot}/metadata/${key}/`
   let options = await authorisedRequest(token, url)
 
@@ -23,6 +27,22 @@ async function getOptions (token, key, { createdOn, currentValue, includeDisable
   const mappedOptions = options.map(transformObjectToOption)
 
   return sorted ? sortBy(mappedOptions, 'label') : mappedOptions
+}
+
+async function getOptionsForId (token, key, id) {
+  const ids = castArray(id)
+  const options = []
+
+  for (let index = 0; index < ids.length; index += 1) {
+    const url = key === 'adviser' ? `${config.apiRoot}/adviser/${ids[index]}/` : `${config.apiRoot}/v3/${key}/${ids[index]}`
+    const data = await authorisedRequest(token, url)
+    options.push({
+      value: data.id,
+      label: data.name,
+    })
+  }
+
+  return options
 }
 
 module.exports = {

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -1,4 +1,4 @@
-{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset %}
+{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset, Typeahead %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Message, MessageList, Breadcrumbs, Pagination, GlobalNav, LocalNav, Progress, FromNow, AnswersSummary, HiddenContent %}

--- a/src/templates/_macros/collection/collection-filters.njk
+++ b/src/templates/_macros/collection/collection-filters.njk
@@ -1,4 +1,4 @@
-{% from '../form.njk' import Form, MultipleChoiceField, TextField %}
+{% from '../form.njk' import Form, MultipleChoiceField, TextField, Typeahead %}
 
 {##
  # Render collection filters form
@@ -10,7 +10,7 @@
   {% if props.filtersFields | removeNilAndEmpty | length %}
     {% call Form({
       method: 'get',
-      class: 'c-collection-filters js-AutoSubmit',
+      class: 'c-collection-filters js-AutoSubmit js-vue-wrapper',
       action: props.action,
       buttonText: 'Refresh results',
       actionsClass: 'u-js-hidden',

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -12,6 +12,7 @@
 {% from "./form/select-box.njk" import SelectBox with context %}
 {% from "./form/text-area.njk" import TextArea with context %}
 {% from "./form/text-field.njk" import TextField %}
+{% from "./form/typeahead.njk" import Typeahead %}
 
 {% set AddAnother = AddAnother %}
 {% set DateFieldset = DateFieldset %}
@@ -27,3 +28,4 @@
 {% set SelectBox = SelectBox %}
 {% set TextArea = TextArea %}
 {% set TextField = TextField %}
+{% set Typeahead = Typeahead %}

--- a/src/templates/_macros/form/typeahead.njk
+++ b/src/templates/_macros/form/typeahead.njk
@@ -1,0 +1,8 @@
+{% macro Typeahead(props) %}
+  <typeahead
+    entity="{{ props.entity }}"
+    name="{{ props.name }}"
+    label="{{ props.label }}"
+    value="{{ props.selectedOptions | dump }}"
+  ></typeahead>
+{% endmacro %}

--- a/test/vue/typeahead.test.js
+++ b/test/vue/typeahead.test.js
@@ -101,6 +101,11 @@ describe('Typeahead', () => {
       it('should show the adviser name in the tag', () => {
         expect(component.find('.multiselect__tag').text()).to.equal('Fred Jones')
       })
+
+      it('should render the selected options as hidden fields', () => {
+        const element = component.find('input[type="hidden"][name="adviser"]').element
+        expect(element.value).to.equal('1234')
+      })
     })
   })
 
@@ -213,6 +218,7 @@ describe('Typeahead', () => {
         name: 'adviser',
         entity: 'adviser',
         autoSubmit: true,
+        id: 'xyz',
       }
     })
 
@@ -229,6 +235,7 @@ describe('Typeahead', () => {
             <form id="form" action="/search">
               <h1>Form</h1>
               <input name="country" value="9999">
+              <input name="xyz" value="zzz">
             </form>
             <div id="xhr-target">Some stuff</div>
           </div>`


### PR DESCRIPTION
This pull request integrates the `typeahead` vue control into the nunjucks templating system and form generation code and then makes use of it to add an instance to the interaction filter form to allow the user to filter by the adviser.

In addition a few minor fixes have been made to the `typeahead` control and introduced a modifier to hide form control labels.

![inter](https://user-images.githubusercontent.com/56056/37422764-e3a5fc00-27b3-11e8-8809-e91b0140c814.gif)

See the control in action: https://datahub-beta2-pr-1337.herokuapp.com/interactions?sortby=date%3Adesc