### PR TITLE
Change playback of client email address when sending quote

### DIFF
--- a/assets/stylesheets/components/_messages.scss
+++ b/assets/stylesheets/components/_messages.scss
@@ -28,7 +28,7 @@
     margin-top: $default-spacing-unit;
   }
 
-  > *:not([type="hidden"]) + * {
+  > *:not(span):not([type="hidden"]) + * {
     margin-top: $default-spacing-unit;
     margin-bottom: 0;
   }

--- a/assets/stylesheets/trumps/_utility.scss
+++ b/assets/stylesheets/trumps/_utility.scss
@@ -46,6 +46,10 @@
   max-width: 50%;
 }
 
+.u-block {
+  display: block;
+}
+
 .u-loading {
   &::before {
     animation: growRight 3s;

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -188,11 +188,12 @@ async function setPayments (req, res, next) {
 
 async function generateQuote (req, res, next) {
   const orderId = get(res.locals, 'order.id')
+  const clientEmail = get(res.locals, 'order.contact.email') || 'client'
 
   try {
     await Order.createQuote(req.session.token, orderId)
 
-    req.flash('success', 'Quote has been sent to client.')
+    req.flash('success', `Quote sent ${clientEmail}`)
     res.redirect(`/omis/${orderId}`)
   } catch (error) {
     const errorCode = error.statusCode

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -238,9 +238,8 @@ function setQuoteForm (req, res, next) {
   const quote = res.locals.quote
   const orderId = get(res.locals, 'order.id')
   const orderStatus = get(res.locals, 'order.status')
-  const sendDestination = get(res.locals, 'order.contact.email') || 'client'
   const form = {
-    buttonText: `Send quote to ${sendDestination}`,
+    buttonText: `Send quote to client`,
     returnText: 'Return to order',
     returnLink: `/omis/${orderId}`,
   }

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -42,7 +42,7 @@ router.get('/payment-receipt', setInvoice, setPayments, renderPaymentReceipt)
 router
   .route('/quote')
   .get(setContact, setQuotePreview, setQuote, setQuoteForm, renderQuote)
-  .post(generateQuote)
+  .post(setContact, generateQuote)
 
 router.post('/quote/cancel', cancelQuote)
 

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -103,15 +103,16 @@
         text: 'Quotes should be reviewed by a manager before being sent.'
       }) }}
 
-      <h2 class="heading-medium">What happens next</h2>
-
-      <ul class="list-disc">
-        <li>
-          An email with a link to this quote will be sent to
-          {{ order.contact.email | default('the client') }}
-          for acceptance
-        </li>
-      </ul>
+      {% if order.contact.email %}
+        {% call Message({ type: 'muted', element: 'div' }) %}
+          <span class="font-xsmall">
+            An email with a link to this quote will be sent to:
+          </span>
+          <span class="u-block font-medium">
+            {{ order.contact.email }}
+          </span>
+        {% endcall %}
+      {% endif %}
     {% endif %}
 
   {% endif %}


### PR DESCRIPTION
This change amends how we display what email address the quote
email will be sent to for the client.

We previously used a _What happens next_ heading and some text within
a list but this was often missed during research. We also displayed
the email address within the action button but in some cases of a long
email address this would break the layout of the page and also loses
the consistency in form actions.

This change uses a pattern tested on GOV.UK Pay to replay the email in
a larger typography before the user submits the form.

It also uses a consistent language for the button rather than changing
the value.

## Before

### Quote preview
![image](https://user-images.githubusercontent.com/3327997/37417570-87465f78-27a8-11e8-870f-1a881e0dbbbe.png)

### Success notification
![image](https://user-images.githubusercontent.com/3327997/37419018-720b8d6a-27ab-11e8-8a86-9ecf7f70595a.png)

## After

### Quote preview
![image](https://user-images.githubusercontent.com/3327997/37417590-93971fc4-27a8-11e8-9f7b-b830af08e6bc.png)

### Success notification
![image](https://user-images.githubusercontent.com/3327997/37418946-48e9fc14-27ab-11e8-93ae-759939a1d6af.png)

## GOV.UK Pay example

![image](https://user-images.githubusercontent.com/3327997/37417640-b2db641c-27a8-11e8-80ae-770ddd2f1505.png)
