### PR TITLE
Add protection to cancelled by for OMIS orders

### DIFF
--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -49,8 +49,16 @@
 
   {% if order.status === 'cancelled' %}
     {% call Message({ type: 'info', element: 'div' }) %}
-      <p>Order cancelled on {{ order.cancelled_on | formatDateTime }} by {{ order.cancelled_by.name }}.</p>
-      <p>It was cancelled because {{ order.cancellation_reason.name | lower }}.</p>
+      <p>
+        Order cancelled on {{ order.cancelled_on | formatDateTime }}
+        {%- if order.cancelled_b.name %}
+          by {{ order.cancelled_by.name }}
+        {% endif -%}
+        .
+      </p>
+      {% if order.cancellation_reason.name %}
+        <p>It was cancelled because {{ order.cancellation_reason.name | lower }}.</p>
+      {% endif %}
     {% endcall %}
   {% endif %}
 


### PR DESCRIPTION
This adds a small if block around the cancelled by text to ensure it
has some value before displaying this text.

This is to cover legacy orders and cases where there is no name so
the sentence will end with _by_.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
