### PR TITLE
DH-1622 The reset button on interactions collection throws an error

### DIFF
--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -1,4 +1,4 @@
-const { assign, pick, merge, omit } = require('lodash')
+const { assign, merge, pick, pickBy, omit } = require('lodash')
 
 const { collectionSortForm } = require('../macros')
 const { search } = require('../../search/services')
@@ -45,7 +45,7 @@ function getInteractionsRequestBody (req, res, next) {
     searchBody.company = req.params.companyId
   }
 
-  req.body = assign({}, req.body, searchBody)
+  req.body = assign({}, req.body, pickBy(searchBody))
 
   next()
 }

--- a/test/unit/apps/interactions/middleware/collection.test.js
+++ b/test/unit/apps/interactions/middleware/collection.test.js
@@ -129,6 +129,27 @@ describe('interaction collection middleware', () => {
         expect(this.req.body).to.not.have.property('fruit')
       })
     })
+
+    context('when called clear filters', () => {
+      beforeEach(() => {
+        this.req.query = assign({}, this.req.query, {
+          sortby: 'date:desc',
+          date_after: '',
+          date_before: '',
+        })
+
+        this.middleware.getInteractionsRequestBody(this.req, this.res, this.next)
+      })
+
+      it('should put the default criteria in the request body', () => {
+        expect(this.req.body.sortby).to.equal(this.req.query.sortby)
+      })
+
+      it('should not include empty parameters', () => {
+        expect(this.req.body).to.not.have.property('date_after')
+        expect(this.req.body).to.not.have.property('date_before')
+      })
+    })
   })
 
   describe('#getInteractionSortForm', () => {


### PR DESCRIPTION
On Interactions page, after adding some filters, when reseting,
it posts all input as deselected, default or empty. But on the middleware, wen sending the data
to remove the filters, it breaks because it's not being sanitised for empty values. This is a fix to clean out empty
filters.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
