### PR TITLE
Create difference between things that can be cancelled

### DIFF
--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -251,7 +251,7 @@ function setQuoteForm (req, res, next) {
 
   if (get(quote, 'created_on') && !get(quote, 'cancelled_on')) {
     form.action = `/omis/${orderId}/quote/cancel`
-    form.buttonText = 'Cancel quote'
+    form.buttonText = 'Withdraw quote'
     form.buttonModifiers = 'button--destructive'
     res.locals.destructive = true
 

--- a/src/apps/omis/apps/view/views/quote.njk
+++ b/src/apps/omis/apps/view/views/quote.njk
@@ -90,7 +90,7 @@
           type: 'error',
           element: 'div'
         }) %}
-          <p>The client will no longer be able to accept the quote once it has been cancelled.</p>
+          <p>The client will no longer be able to accept the quote once it has been withdrawn.</p>
           <p>They will be notified by email.</p>
         {% endcall %}
       {% endif %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -43,7 +43,7 @@
   {% if order.status === 'quote_awaiting_acceptance' %}
     {% call Message({ type: 'info', element: 'div' }) %}
       <p>You cannot edit the order once a quote has been sent.</p>
-      <p><a href="quote">Cancel the quote</a> to edit the order.</p>
+      <p><a href="quote">Withdraw the quote</a> to edit the order.</p>
     {% endcall %}
   {% endif %}
 

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -1073,7 +1073,7 @@ describe('OMIS View middleware', () => {
         const nextSpy = () => {
           try {
             expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
-            expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Cancel quote')
+            expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Withdraw quote')
             expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button--destructive')
 
             done()
@@ -1102,7 +1102,7 @@ describe('OMIS View middleware', () => {
             const nextSpy = () => {
               try {
                 expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
-                expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Cancel quote')
+                expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Withdraw quote')
                 expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button--destructive')
 
                 done()


### PR DESCRIPTION
We use the term cancel for both the quote and the order. This has
caused confusion with a lot of users.

This change changes the term _cancel quote_ to _withdraw quote_ so that
it is distinguishable from cancellation the order which has an
irreversible effect.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
