### PR TITLE
Place reason for hours worked in hidden content

### DIFF
--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -7,14 +7,6 @@
 
     <p>Complete the order after all work and reports have been delivered to the client.</p>
 
-    <h2 class="heading-medium">Recording actual hours worked on the order</h2>
-
-    <p>This information will not be used to analyse individual performance.</p>
-
-    <p>The actual hours worked can be different to those in the original estimate.</p>
-
-    <p>This information won’t be shared with the client, and won’t change how much the client has to pay for the work.</p>
-
     {% set key = 'assignee_actual_time' %}
     {% set defaultProps = options.fields[key] %}
 
@@ -23,7 +15,7 @@
         <tr>
           <th></th>
           <th class="c-answers-summary__content">Original estimate</th>
-          <th class="c-answers-summary__control">Hours spent</th>
+          <th class="c-answers-summary__control">Actual hours worked</th>
         </tr>
       </thead>
       <tbody>
@@ -50,6 +42,14 @@
         {% endfor %}
       </tbody>
     </table>
+
+    {% call HiddenContent({ summary: 'Why do I need to provide hours worked?' }) %}
+      <p>This information will not be used to analyse individual performance.</p>
+
+      <p>The actual hours worked can be different to those in the original estimate.</p>
+
+      <p>This information won’t be shared with the client, and won’t change how much the client has to pay for the work.</p>
+    {% endcall %}
 
   {% endif %}
 {% endblock %}

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -52,7 +52,7 @@
       "label": "Estimated hours"
     },
     "assignee_actual_time": {
-      "label": "Hours spent"
+      "label": "Actual hours worked"
     },
     "vat_status": {
       "label": "VAT category",


### PR DESCRIPTION
Placing the reason why we require this piece of information as
normal text meant it was often overlooked.

This change uses the hidden content and a clearer piece of text
for users that are asking themselves the question as to why this
piece of information is required.

## Before
![localhost_3001_omis_066d6a1d-2d7a-46e2-b521-d27187b1905c_edit_complete-order](https://user-images.githubusercontent.com/3327997/37570571-550aef1c-2ae9-11e8-865e-2c42049b67d5.png)

## After 
![localhost_3001_omis_066d6a1d-2d7a-46e2-b521-d27187b1905c_edit_complete-order 1](https://user-images.githubusercontent.com/3327997/37570587-76836aca-2ae9-11e8-8d19-9d756c81ad8d.png)

