### PR TITLE
Require verification before completing order

### DIFF
--- a/assets/stylesheets/components/form/_form-group.scss
+++ b/assets/stylesheets/components/form/_form-group.scss
@@ -18,10 +18,10 @@
 .c-form-group__label {
   display: table;
   line-height: 1.1;
-  margin-bottom: 10px;
 
-  * + * {
-    margin-top: $default-spacing-unit / 2;
+  > * {
+    display: inline-block;
+    margin-bottom: $baseline-grid-unit * 2.5;
   }
 }
 

--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -202,6 +202,16 @@ const editFields = merge({}, globalFields, {
     options: [],
     validate: ['required'],
   },
+  verify_work_sent: {
+    fieldType: 'MultipleChoiceField',
+    label: 'fields.verify_work_sent.label',
+    type: 'checkbox',
+    options: [{
+      value: 'true',
+      label: 'I have completed the work and sent this to the contact',
+    }],
+    validate: ['required'],
+  },
 })
 
 module.exports = editFields

--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -121,6 +121,7 @@ const steps = merge({}, createSteps, {
     heading: 'Complete order',
     fields: [
       'assignee_actual_time',
+      'verify_work_sent',
     ],
     templatePath: 'omis/apps/edit/views',
     template: 'complete-order.njk',

--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -53,6 +53,7 @@
       name: 'verify_work_sent',
       label: translate(options.fields.verify_work_sent.label),
       isLabelHidden: true,
+      forceErrorMessage: true,
       value: values['verify_work_sent'],
       error: errors['verify_work_sent'].message
     })) }}

--- a/src/apps/omis/apps/edit/views/complete-order.njk
+++ b/src/apps/omis/apps/edit/views/complete-order.njk
@@ -3,9 +3,7 @@
 {% block fields %}
   {% if assignees.length %}
 
-    <p>Send completed work described in the quote directly to the client by email.</p>
-
-    <p>Complete the order after all work and reports have been delivered to the client.</p>
+    <p>Complete the order after all work has been sent to the contact.</p>
 
     {% set key = 'assignee_actual_time' %}
     {% set defaultProps = options.fields[key] %}
@@ -50,6 +48,14 @@
 
       <p>This information won’t be shared with the client, and won’t change how much the client has to pay for the work.</p>
     {% endcall %}
+
+    {{ MultipleChoiceField(options.fields.verify_work_sent | assignCopy({
+      name: 'verify_work_sent',
+      label: translate(options.fields.verify_work_sent.label),
+      isLabelHidden: true,
+      value: values['verify_work_sent'],
+      error: errors['verify_work_sent'].message
+    })) }}
 
   {% endif %}
 {% endblock %}

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -105,6 +105,9 @@
     },
     "cancellation_reason": {
       "label": "Reason for cancelling"
+    },
+    "verify_work_sent": {
+      "label": "Work has been sent to the contact"
     }
   },
   "errors": {
@@ -130,7 +133,10 @@
     "duration": "must be a whole number, for example 5",
     "greaterthanamount": "must be equal to or larger than the invoice amount",
     "euvatnumber": "must be a valid EU VAT number starting with the country code, for example IT12345678901 for Italy where \"IT\" is the country code",
-    "default": "is required"
+    "default": "is required",
+    "verify_work_sent": {
+      "required": "must be verified"
+    }
   },
   "status": {
     "draft": "Draft",

--- a/src/templates/_macros/form/form-group.njk
+++ b/src/templates/_macros/form/form-group.njk
@@ -10,6 +10,7 @@
  # @param {string, array} [props.modifier] - Group modifier
  # @param {boolean} [props.optional] - Marks field as optional
  # @param {boolean} [props.isLabelHidden=false] - Whether input label should be hidden
+ # @param {boolean} [props.forceErrorMessage=false] - Whether error message and border should be shown even when label is hidden
  # @param {string} [props.condition.name] - Name of the field that controls this form group if it is a subfield
  # @param {string} [props.condition.value] - Value of the field that controls this form group if it is a subfield
  # @param {string} [props.innerHTML] - Optional inner HTML content
@@ -22,6 +23,7 @@
   {% set groupElement = props.element or 'div' %}
   {% set isFieldset = groupElement == 'fieldset' %}
   {% set isLabelHidden = props.isLabelHidden | default(false) %}
+  {% set forceErrorMessage = props.forceErrorMessage | default(false) %}
   {% set isConditional = props.condition %}
   {% set className = props.groupClassName | default('c-form-group') %}
   {% set labelElement = 'legend' if isFieldset else 'label' %}
@@ -34,7 +36,7 @@
       id="group-{{ props.fieldId }}"
       class="
         {{ className | applyClassModifiers(props.modifier) }}
-        {{ 'has-error' if props.error and not isLabelHidden }}
+        {{ 'has-error' if props.error and (not isLabelHidden or forceErrorMessage) }}
         {{ 'js-ConditionalSubfield' if isConditional }}
         {{ props.class if props.class }}
       "
@@ -46,7 +48,7 @@
       <{{ labelElement }}
         class="
           {{ labelClassName }}
-          {{ 'u-visually-hidden' if isLabelHidden }}
+          {{ 'u-visually-hidden' if isLabelHidden and not (props.error and forceErrorMessage) }}
         "
         {% if labelElement == 'label' %}for="{{ props.fieldId }}"{% endif %}
       >


### PR DESCRIPTION
One of the current requirements is that the work must be sent to the
contact before an order is completed.

Previously this was a message but whilst the system doesn't support
the uploading and sending of the documents a change is added to
require the person completing the order to verify that the work
has been sent to the contact.

## What it looks like

![localhost_3001_omis_066d6a1d-2d7a-46e2-b521-d27187b1905c_edit_complete-order 2](https://user-images.githubusercontent.com/3327997/37652458-7a2960b2-2c33-11e8-9be9-904aba41ece4.png)

![localhost_3001_omis_066d6a1d-2d7a-46e2-b521-d27187b1905c_edit_complete-order 3](https://user-images.githubusercontent.com/3327997/37709422-0f624788-2d02-11e8-93a1-4f1e041ae07a.png)
