### PR TITLE
Tweak block entity item style

### DIFF
--- a/assets/stylesheets/components/_entity.scss
+++ b/assets/stylesheets/components/_entity.scss
@@ -52,7 +52,7 @@
 .c-entity--block-link {
   margin-top: -$default-spacing-unit;
   margin-bottom: -$default-spacing-unit;
-  padding: $default-spacing-unit;
+  padding: ($baseline-grid-unit * 3) $default-spacing-unit;
   border: 2px solid $grey-2;
   display: block;
   text-decoration: none;
@@ -64,7 +64,7 @@
     color: $link-hover-colour;
   }
 
-  .c-entity__title {
-    text-decoration: underline;
+  .c-entity__badges {
+    color: $black;
   }
 }


### PR DESCRIPTION
This removes the underline on the block style link. The underline
suggests only the heading is clickable whereas in this variation
we are making the whole block area clickable.

It also reduces the padding on the top and bottom to cater for line
height so that visually the text is more aligned.

## Before
![image](https://user-images.githubusercontent.com/3327997/37606371-3f3033c4-2b8d-11e8-9100-975a5591b233.png)

## After
![image](https://user-images.githubusercontent.com/3327997/37606352-30d232fa-2b8d-11e8-9ab8-51602f3c634f.png)

