### PR TITLE
DH-1627 Clear filters functionality doesn't apply for typeahead filter

### DIFF
--- a/assets/javascripts/modules/clear-inputs.js
+++ b/assets/javascripts/modules/clear-inputs.js
@@ -41,6 +41,10 @@ const ClearInputs = {
     if (targetForm) {
       const formControls = getFormControls(targetForm)
       clearValues(formControls)
+
+      Array.from(targetForm.querySelectorAll('.js-ClearInputs--removable-field'))
+        .forEach(input => input.parentNode.removeChild(input))
+
       targetForm.submit()
     }
   },

--- a/assets/javascripts/modules/print-dialog.js
+++ b/assets/javascripts/modules/print-dialog.js
@@ -8,7 +8,7 @@ const PrintDialog = {
   contentLoaded () {
     const printLinks = document.querySelectorAll(this.selector)
 
-    printLinks.forEach((link) => {
+    Array.from(printLinks).forEach((link) => {
       link.addEventListener('click', this.handleClick.bind(this))
     })
   },

--- a/assets/javascripts/vue/typeahead.vue
+++ b/assets/javascripts/vue/typeahead.vue
@@ -37,7 +37,7 @@
         </div>
       </template>
     </multiselect>
-    <input type="hidden" :name="name" v-for="(option, index) in selectedOptions" :key="index" :value="option.value">
+    <input type="hidden" class="js-ClearInputs--removable-field" :name="name" v-for="(option, index) in selectedOptions" :key="index" :value="option.value">
   </div>
 </template>
 


### PR DESCRIPTION
Because typeahed filters have a different behaviour than normal filters we had to find a way of clearing them before the submit to the server.
We were able to clear the filter using normal vue behaviour but this was creating a race condition with the global filters submit,
therefore decided for this approach, by removing the filter field from the clear-filters submit.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
