### PR TITLE
DH-1439 changed the global submit type button selector to a more spec…

### DIFF
--- a/assets/javascripts/modules/prevent-multiple-submits.js
+++ b/assets/javascripts/modules/prevent-multiple-submits.js
@@ -1,6 +1,6 @@
 const CONSTANTS = {
   selectors: {
-    button: 'button[type="submit"]',
+    button: 'js-prevent-multiple-submits',
     form: 'form',
   },
   types: {
@@ -19,16 +19,16 @@ const PreventMultipleSubmits = {
   counter: 0,
 
   init () {
-    if (document.querySelectorAll(CONSTANTS.selectors.button).length) {
+    if (document.querySelectorAll(`.${CONSTANTS.selectors.button}`).length) {
       this.bindEvents()
     }
   },
 
   handleFormSubmit (event) {
-    const targetForm = event.target.closest(CONSTANTS.selectors.form)
+    const target = event.target
+    const targetForm = target.closest(CONSTANTS.selectors.form)
     if (!targetForm ||
-      event.target.type !== CONSTANTS.types.submit ||
-      targetForm.classList.contains('js-AutoSubmit')) { return }
+      !target.classList.contains(CONSTANTS.selectors.button)) { return }
 
     if (this.counter >= 1) {
       event.target.setAttribute(CONSTANTS.attributes.disabled, true)

--- a/src/templates/_macros/form/form.njk
+++ b/src/templates/_macros/form/form.njk
@@ -59,7 +59,7 @@
     {% if not hideFormActions %}
       <div class="c-form-actions {{ props.actionsClass }}">
         {% if not props.hidePrimaryFormAction %}
-          <button class="button {{ buttonModifiers }}" type="submit" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
+          <button class="button js-prevent-multiple-submits {{ buttonModifiers }}" {{ 'disabled="disabled"' if props.disableFormAction }}>{{ buttonText }}</button>
         {% endif %}
         {% if props.returnLink %}
           <a href="{{ props.returnLink }}">{{ returnText }}</a>


### PR DESCRIPTION
changed the global submit type button selector to a more specific classname selector.

@teneightfive  pointed out that there are other functionalities in the app that break when used in conjunction with the module that prevents multiple submits. So we decided to change the global selector to `.js-prevent-multiple-submits` instead, and add it to where it's required in the future.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
