### PR TITLE
Use correct date for payment receipt

### DIFF
--- a/src/apps/omis/apps/view/views/payment-receipt.njk
+++ b/src/apps/omis/apps/view/views/payment-receipt.njk
@@ -27,7 +27,7 @@
         items: [
           { label: 'For the attention of', value: billingAddress | safe },
           { label: 'Purchase order (PO) number', value: invoice.po_number },
-          { label: 'Receipt date', value: invoice.created_on, type: 'datetime' }
+          { label: 'Receipt date', value: order.paid_on, type: 'date' }
         ],
         modifier: 'stacked',
         itemModifier: 'stacked'


### PR DESCRIPTION
The payment receipt was previously displaying the invoice date rather
than the date that the order was paid.

This change uses the `paid_on` value from the order rather than the
date from the invoice.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
