### PR TITLE
DH-1588 Sort investment projects results by most recently created

### DIFF
--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -100,6 +100,7 @@ const investmentSortForm = {
         'target-selector': '.c-collection-filters input[name="sortby"]',
       },
       options: [
+        { value: 'created_on:desc', label: 'Most recently created' },
         { value: 'estimated_land_date:asc', label: 'Earliest land date' },
         { value: 'estimated_land_date:desc', label: 'Latest land date' },
         { value: 'name:asc', label: 'Project name' },


### PR DESCRIPTION
Added the option to sort investment projects results by their `Most recently created`

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
