### PR TITLE
DH-1586 changed the Adviser filter on the Events results page

### DIFF
--- a/src/apps/events/macros/event-filters-fields.js
+++ b/src/apps/events/macros/event-filters-fields.js
@@ -1,9 +1,8 @@
 const { assign, flatten } = require('lodash')
 const { globalFields } = require('../../macros')
 const { collectionFilterLabels } = require('../labels')
-const { transformObjectToOption } = require('../../transformers')
-
 const currentYear = (new Date()).getFullYear()
+const { transformObjectToOption } = require('../../transformers')
 
 const eventFiltersFields = ({ advisers }) => {
   return [
@@ -11,6 +10,12 @@ const eventFiltersFields = ({ advisers }) => {
       macroName: 'TextField',
       name: 'name',
       hint: 'At least three characters',
+    },
+    {
+      macroName: 'Typeahead',
+      name: 'organiser',
+      entity: 'adviser',
+      options: advisers.map(transformObjectToOption),
     },
     assign({}, globalFields.eventTypes, {
       name: 'event_type',
@@ -27,14 +32,6 @@ const eventFiltersFields = ({ advisers }) => {
       type: 'checkbox',
       modifier: 'option-select',
     }),
-    {
-      macroName: 'MultipleChoiceField',
-      name: 'organiser',
-      label: 'Organiser',
-      type: 'checkbox',
-      modifier: 'option-select',
-      options: advisers.map(transformObjectToOption),
-    },
     {
       macroName: 'TextField',
       name: 'start_date_after',

--- a/src/apps/events/middleware/collection.js
+++ b/src/apps/events/middleware/collection.js
@@ -27,8 +27,8 @@ async function getEventsCollection (req, res, next) {
 function getRequestBody (req, res, next) {
   const selectedFiltersQuery = pick(req.query, [
     'name',
-    'event_type',
     'organiser',
+    'event_type',
     'address_country',
     'uk_region',
     'start_date_after',

--- a/test/acceptance/features/events/collection.feature
+++ b/test/acceptance/features/events/collection.feature
@@ -64,8 +64,6 @@ Feature: View a list of events
     When I click the Events global nav link
     And I filter the events list by name
     Then I can view the event
-    And I filter the events list by organiser
-    Then I can view the event
     And I filter the events list by event type
     Then I can view the event
     And I filter the events list by country


### PR DESCRIPTION
The typeahead vue filter is essential to the Events results page because it solves a performance issue related to the vast amount of advisers, in this case event organisers, generating too many dom elements for the page to handle.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
