### PR TITLE
[DH-1607] Use business type provided by the API when adding a CH company

### DIFF
--- a/src/apps/companies/transformers/company-to-form.js
+++ b/src/apps/companies/transformers/company-to-form.js
@@ -1,13 +1,10 @@
 /* eslint-disable camelcase */
 const {
   assign,
-  find,
   get,
   isPlainObject,
   mapValues,
 } = require('lodash')
-
-const metadataRepository = require('../../../lib/metadata')
 
 // TODO: This is a temporary transformer to transform an API response into
 // a format needed for the form view
@@ -34,15 +31,6 @@ module.exports = function transformCompanyToForm (body) {
     }
     return get(body, `${key}.id`)
   })
-
-  // TODO we need to create an "other" business_type on DH to place any Companies House company_category that do not match DH business_type
-  if (body.company_category) {
-    const businessType = find(metadataRepository.businessTypeOptions, (type) => {
-      return type.name.toLowerCase() === body.company_category.toLowerCase()
-    })
-
-    formatted.business_type = get(businessType, 'id')
-  }
 
   formatted.headquarter_type = get(formatted, 'headquarter_type.id', 'not_headquarters')
 

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -151,7 +151,7 @@ describe('Companies form middleware', () => {
       it('should pre-populate the form with companies house values', () => {
         const formData = this.resMock.locals.formData
         expect(formData).to.have.property('name', 'Mercury Trading Ltd')
-        expect(formData).to.have.property('business_type', '33333')
+        expect(formData).to.have.property('business_type', '6f75408b-03e7-e611-bca1-e4115bead28a')
         expect(formData).to.have.property('company_number', '99919')
         expect(formData).to.have.property('registered_address_1', '64 Ermin Street')
         expect(formData).to.have.property('registered_address_town', 'Y Ffor')

--- a/test/unit/data/companies/companies-house.json
+++ b/test/unit/data/companies/companies-house.json
@@ -15,9 +15,12 @@
   "sic_code_4": "",
   "uri": "",
   "incorporation_date": "2000-12-14",
+  "business_type": {
+    "id": "6f75408b-03e7-e611-bca1-e4115bead28a",
+    "name": "Private limited company"
+  },
   "registered_address_country": {
-      "id": "80756b9a-5d95-e211-a939-e4115bead28a",
-      "disabled_on": null,
-      "name": "United Kingdom"
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+    "name": "United Kingdom"
   }
 }


### PR DESCRIPTION
Fixes problems adding companies limited by guarantee using their Companies House record.

This depends on https://github.com/uktrade/data-hub-leeloo/pull/884, so this shouldn't be merged until that's been merged and released.