### PR TITLE
DH-1632 Filters don't work on IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "postcss-cli": "^5.0.0",
     "postcss-loader": "^2.0.9",
     "proxyquire": "^2.0.0",
-    "query-string": "^6.0.0",
+    "query-string": "^5.1.1",
     "raven": "^2.3.0",
     "redis": "^2.8.0",
     "reqres": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8847,12 +8847,13 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.0.0.tgz#8b8f39447b73e8290d6f5e3581779218e9171142"
+query-string@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
   dependencies:
     decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -10245,10 +10246,6 @@ stream-to-observable@^0.2.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-argv@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Previous if a user used IE 11 or below and selected a filter it threw an error
in the console. Investigation showed that when query-string moved from 5 to 6, the
breaking change is that it is not supported by IE any longer. Reverting the dependency fixes the issue.

![before](https://user-images.githubusercontent.com/56056/37852830-059d1f26-2edc-11e8-91db-64874d2b8966.gif)
Before

--------------------------------

![fixed](https://user-images.githubusercontent.com/56056/37852837-0d26b2de-2edc-11e8-923a-3c1c2db571ab.gif)
After
