### PR TITLE
DH-1631: Change save contact to redirect to detail

### DIFF
--- a/src/apps/contacts/controllers/edit.js
+++ b/src/apps/contacts/controllers/edit.js
@@ -65,38 +65,36 @@ async function editDetails (req, res, next) {
  * @param {Object} res
  * @param {Object} next
  */
-function postDetails (req, res, next) {
-  return new Promise(async (resolve, reject) => {
-    // Try and save the form data, if it fails
-    // then attach the errors to the response and re-render edit
-    try {
-      const newContact = await contactFormService.saveContactForm(req.session.token, req.body)
+async function postDetails (req, res, next) {
+  // Try and save the form data, if it fails
+  // then attach the errors to the response and re-render edit
+  try {
+    const newContact = await contactFormService.saveContactForm(req.session.token, req.body)
 
-      if (req.body.id) {
-        req.flash('success', 'Contact record updated')
-      } else {
-        req.flash('success', 'Added new contact')
-      }
-
-      res.redirect(`/contacts/${newContact.id}/details`)
-    } catch (errors) {
-      if (errors.error) {
-        if (errors.error.errors) {
-          res.locals.errors = {
-            messages: errors.error.errors,
-          }
-        } else {
-          res.locals.errors = {
-            messages: errors.error,
-          }
-        }
-
-        next()
-      } else {
-        next(errors)
-      }
+    if (req.body.id) {
+      req.flash('success', 'Contact record updated')
+    } else {
+      req.flash('success', 'Added new contact')
     }
-  })
+
+    res.redirect(`/contacts/${newContact.id}/details`)
+  } catch (errors) {
+    if (errors.error) {
+      if (errors.error.errors) {
+        res.locals.errors = {
+          messages: errors.error.errors,
+        }
+      } else {
+        res.locals.errors = {
+          messages: errors.error,
+        }
+      }
+
+      return next()
+    }
+
+    next(errors)
+  }
 }
 
 module.exports = {

--- a/src/apps/contacts/controllers/edit.js
+++ b/src/apps/contacts/controllers/edit.js
@@ -70,14 +70,15 @@ function postDetails (req, res, next) {
     // Try and save the form data, if it fails
     // then attach the errors to the response and re-render edit
     try {
-      await contactFormService.saveContactForm(req.session.token, req.body)
+      const newContact = await contactFormService.saveContactForm(req.session.token, req.body)
+
       if (req.body.id) {
         req.flash('success', 'Contact record updated')
-        res.redirect(`/contacts/${req.body.id}`)
       } else {
         req.flash('success', 'Added new contact')
-        res.redirect(`/companies/${req.body.company}/contacts`)
       }
+
+      res.redirect(`/contacts/${newContact.id}/details`)
     } catch (errors) {
       if (errors.error) {
         if (errors.error.errors) {
@@ -89,7 +90,8 @@ function postDetails (req, res, next) {
             messages: errors.error,
           }
         }
-        editDetails(req, res, next)
+
+        next()
       } else {
         next(errors)
       }

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -26,7 +26,7 @@ router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getRequestBody, getCo
 router
   .route('/create')
   .get(editDetails)
-  .post(postDetails)
+  .post(postDetails, editDetails)
 
 router.use('/:contactId', handleRoutePermissions(LOCAL_NAV), getCommon, setLocalNav(LOCAL_NAV))
 
@@ -36,7 +36,7 @@ router.get('/:contactId/details', getDetails)
 router
   .route('/:contactId/edit')
   .get(editDetails)
-  .post(postDetails)
+  .post(postDetails, editDetails)
 
 router.post('/:id/archive', archiveContact)
 router.get('/:id/unarchive', unarchiveContact)

--- a/test/acceptance/features/audit/contact.feature
+++ b/test/acceptance/features/audit/contact.feature
@@ -10,11 +10,8 @@ Feature: View Audit history of a contact
     And a primary contact is added
     When I submit the form
     Then I see the success message
-    Then I wait and then refresh the page
-    When I click the Contacts local nav link
     And the contact has 2 fields edited for audit
     Then I see the success message
-    When I search for this Contact record
     And I click the "Audit history" link
     Then I see the name of the person who made the recent contact record changes
     And I see the date time stamp when the recent contact record changed

--- a/test/acceptance/features/audit/step_definitions/contact.js
+++ b/test/acceptance/features/audit/step_definitions/contact.js
@@ -32,10 +32,6 @@ Given(/^I archive an existing contact record$/, async function () {
 })
 
 When(/^the contact has ([0-9]) fields edited for audit$/, async function (count) {
-  await Contact
-    .getText('@firstCompanyFromList', (result) => set(this.state, 'contactName', result.value))
-    .click('@firstCompanyFromList')
-
   await AuditContact
     .editContactDetails({}, count, (contact) => {
       set(this.state, 'contact', merge({}, this.state.contact, contact))

--- a/test/acceptance/features/companies/contacts-collection.feature
+++ b/test/acceptance/features/companies/contacts-collection.feature
@@ -8,13 +8,12 @@ Feature: View collection of contacts for a company
   @companies-contact-collection--view
   Scenario: View companies contact collection
     When I navigate to the `companies.contacts` page using `company` `Lambda plc` fixture
+    And the results summary for a contact collection is present
     And I click the "Add contact" link
     And a primary contact is added
     And I submit the form
     Then I see the success message
-    Then I wait and then refresh the page
-    And I confirm I am on the Lambda plc page
-    And the results summary for a contact collection is present
+    Then I navigate to the `companies.contacts` page using `company` `Lambda plc` fixture
     And I can view the Contact in the collection
       | text         | expected           |
       | Sector       | company.sector     |
@@ -31,7 +30,7 @@ Feature: View collection of contacts for a company
     And a primary contact with new company address is added
     When I submit the form
     Then I see the success message
-    Then I wait and then refresh the page
+    Then I navigate to the `companies.contacts` page using `company` `Lambda plc` fixture
     Then I confirm I am on the Lambda plc page
     And the results summary for a contact collection is present
     When I clear all filters
@@ -51,7 +50,7 @@ Feature: View collection of contacts for a company
     And a primary contact is added
     When I submit the form
     Then I see the success message
-    Then I wait and then refresh the page
+    When I navigate to the `companies.contacts` page using `company` `Lambda plc` fixture
     Then I confirm I am on the Lambda plc page
     And the results summary for a contact collection is present
     When the contacts are sorted by Newest

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -13,10 +13,6 @@ Feature: Create New Contact
     When a primary contact is added
     And I submit the form
     Then I see the success message
-    And I wait and then refresh the page
-    When I click the Contacts local nav link
-    Then the contact is displayed on the company contact tab
-    When the contact is clicked
     Then the Contact details details are displayed
       | key                   | value                                |
       | Job title             | contact.jobTitle                     |
@@ -38,9 +34,6 @@ Feature: Create New Contact
     When a primary contact with new company address is added
     And I submit the form
     Then I see the success message
-    When I click the Contacts local nav link
-    Then the contact is displayed on the company contact tab
-    When the contact is clicked
     Then the Contact details details are displayed
       | key                   | value                                |
       | Job title             | contact.jobTitle                     |
@@ -62,9 +55,6 @@ Feature: Create New Contact
     When a non-primary contact is added
     And I submit the form
     Then I see the success message
-    When I click the Contacts local nav link
-    Then the contact is displayed on the company contact tab
-    When the contact is clicked
     Then the Contact details details are displayed
       | key                   | value                                |
       | Job title             | contact.jobTitle                     |

--- a/test/unit/apps/contacts/controllers/edit.test.js
+++ b/test/unit/apps/contacts/controllers/edit.test.js
@@ -369,22 +369,24 @@ describe('Contact controller, edit', () => {
 
       contactEditController.postDetails(req, res, next)
     })
-    it('should redirect the user to the company contact list if added a new contact', function (done) {
+    it('should redirect the user to the contact details', function (done) {
       delete body.id
       res.redirect = function (url) {
-        expect(url).to.equal(`/companies/${company.id}/contacts`)
+        expect(url).to.equal(`/contacts/${company.id}/details`)
         done()
       }
       contactEditController.postDetails(req, res, next)
     })
     it('should redirect the user to the contact detail screen if editing an existing contact', function (done) {
       res.redirect = function (url) {
-        expect(url).to.equal('/contacts/1234')
+        expect(url).to.equal('/contacts/1234/details')
         done()
       }
       contactEditController.postDetails(req, res, next)
     })
-    it('should re-render the edit page with the original form data on validation errors', function (done) {
+    it('should re-render the edit page with the original form data on validation errors', async function () {
+      const next = sandbox.stub()
+
       saveContactFormStub = sinon.stub().rejects({
         error: { name: ['test'] },
       })
@@ -405,16 +407,10 @@ describe('Contact controller, edit', () => {
         },
       })
 
-      res.render = function (template) {
-        try {
-          expect(template).to.equal('contacts/views/edit')
-          expect(res.locals).to.have.property('errors')
-          done()
-        } catch (e) {
-          done(e)
-        }
-      }
-      contactEditController.postDetails(req, res, next)
+      await contactEditController.postDetails(req, res, next)
+
+      expect(res.locals).to.have.property('errors')
+      expect(next).to.be.called
     })
     it('should show errors when the save fails for a non-validation related reason', function (done) {
       saveContactFormStub = sinon.stub().rejects(Error('some error'))


### PR DESCRIPTION
Previously the save contact flow would take the user to the contact list, but as the contact can take a few seconds to save and appear in the elastic search index, the new contact did not show up, so the updated flow makes the contact act like other forms and go to the details screen after saving
