### PR TITLE
DH-1642: Fix issue searching for HQ when adding

### DIFF
--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -1,7 +1,7 @@
 const { pick, pickBy, assign } = require('lodash')
 
 const removeArray = require('../../../lib/remove-array')
-const { search, searchLimitedCompanies } = require('../../search/services')
+const { search, searchLimitedCompanies, searchCompanies } = require('../../search/services')
 const { transformApiResponseToSearchCollection } = require('../../search/transformers')
 const {
   transformCompanyToListItem,
@@ -69,16 +69,14 @@ async function getGlobalHQCompaniesCollection (req, res, next) {
   }
 
   try {
-    res.locals.results = await search({
+    res.locals.results = await searchCompanies({
+      token: req.session.token,
       searchTerm,
-      searchEntity: 'company',
+      page: req.query.page,
       requestBody: {
         ...req.body,
         headquarter_type: globalHQId,
       },
-      token: req.session.token,
-      page: req.query.page,
-      isAggregation: false,
     })
       .then(transformApiResponseToSearchCollection(
         { query: req.query },

--- a/src/apps/search/services.js
+++ b/src/apps/search/services.js
@@ -32,16 +32,17 @@ function search ({ token, searchTerm = '', searchEntity, requestBody, isAggregat
 }
 
 // TODO the search endpoints need aligning see Jira DH-293 for details
-function searchCompanies ({ token, searchTerm, isUkBased, page = 1, limit = 10 }) {
+function searchCompanies ({ token, searchTerm, isUkBased, page = 1, limit = 10, requestBody = {} }) {
   const queryParams = {
     offset: (page * limit) - limit,
     limit,
   }
-  const body = {
+  const body = assign({}, requestBody, {
     original_query: searchTerm,
     uk_based: isUkBased,
     isAggregation: false,
-  }
+  })
+
   const options = {
     url: `${config.apiRoot}/v3/search/company?${queryString.stringify(queryParams)}`,
     method: 'POST',

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -170,7 +170,7 @@ describe('Company collection middleware', () => {
           this.reqMock.query.term = 'mock-search-term'
 
           nock(config.apiRoot)
-            .post('/v3/search/company')
+            .post('/v3/search/company?limit=10&offset=0')
             .reply(200, ghqCompanySearchResponse)
 
           await getGlobalHQCompaniesCollection(this.reqMock, this.resMock, this.nextSpy)
@@ -191,7 +191,7 @@ describe('Company collection middleware', () => {
           this.errorMsg = 'oh no!'
 
           nock(config.apiRoot)
-            .post('/v3/search/company')
+            .post('/v3/search/company?limit=10&offset=0')
             .replyWithError(this.errorMsg)
 
           await getGlobalHQCompaniesCollection(this.reqMock, this.resMock, this.nextSpy)


### PR DESCRIPTION
When a user was searching for a HQ to add
the search call used global search the search
parameter is not supported for the global
company search endpoint.

Switched the search to use the searchCompanies
endpoint the same as investment project
and added support for filters to allow filtering by
HQ.