### PR TITLE
DH-1640 companies hierarchies filters

### DIFF
--- a/src/apps/companies/macros.js
+++ b/src/apps/companies/macros.js
@@ -1,25 +1,18 @@
 const { assign, flatten } = require('lodash')
 
 const { globalFields } = require('../macros')
-const { accountManagementDisplayLabels, hqLabels } = require('./labels')
+const { accountManagementDisplayLabels } = require('./labels')
 const { transformObjectToOption } = require('../transformers')
 const FILTER_CONSTANTS = require('../../lib/filter-constants')
 const PRIMARY_SECTOR_NAME = FILTER_CONSTANTS.COMPANIES.SECTOR.PRIMARY.NAME
 
 const companyFiltersFields = function ({ sectorOptions }) {
   return [
-    {
-      macroName: 'MultipleChoiceField',
+    Object.assign({}, globalFields.headquarter_type, {
       name: 'headquarter_type',
       type: 'checkbox',
-      label: 'HQ Type',
-      options: [
-        { value: '43281c5e-92a4-4794-867b-b4d5f801e6f3', label: hqLabels.ghq },
-        { value: 'eb59eaeb-eeb8-4f54-9506-a5e08773046b', label: hqLabels.ehq },
-        { value: '3e6debb4-1596-40c5-aa25-f00da0e05af9', label: hqLabels.ukhq },
-      ],
       modifier: 'option-select',
-    },
+    }),
     {
       macroName: 'TextField',
       label: 'Company name',

--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -1,6 +1,5 @@
 const { pick, pickBy, assign } = require('lodash')
 
-const removeArray = require('../../../lib/remove-array')
 const { search, searchLimitedCompanies, searchCompanies } = require('../../search/services')
 const { transformApiResponseToSearchCollection } = require('../../search/transformers')
 const {
@@ -132,13 +131,13 @@ async function getSubsidiaryCompaniesCollection (req, res, next) {
 }
 
 function getRequestBody (req, res, next) {
-  const selectedFiltersQuery = removeArray(pick(req.query, [
+  const selectedFiltersQuery = pick(req.query, [
     'name',
     'sector_descends',
     'country',
     'uk_region',
     'headquarter_type',
-  ]), 'headquarter_type')
+  ])
 
   const selectedSortBy = req.query.sortby ? {
     sortby: req.query.sortby,

--- a/src/apps/macros.js
+++ b/src/apps/macros.js
@@ -1,5 +1,5 @@
 const metadata = require('../lib/metadata')
-const { transformObjectToOption, transformStringToOption } = require('./transformers')
+const { transformObjectToOption, transformStringToOption, transformHQCodeToLabelledOption } = require('./transformers')
 
 const foreignOtherCompanyOptions = [
   'Charity',
@@ -29,6 +29,16 @@ const globalFields = {
     initialOption: '-- Select region --',
     options () {
       return metadata.regionOptions.map(transformObjectToOption)
+    },
+  },
+
+  headquarter_type: {
+    macroName: 'MultipleChoiceField',
+    name: 'headquarter_type',
+    type: 'checkbox',
+    label: 'Type',
+    options () {
+      return metadata.headquarterOptions.map(transformHQCodeToLabelledOption)
     },
   },
 

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -11,11 +11,32 @@ const {
 const { isValid, format, parse } = require('date-fns')
 
 const { buildPagination } = require('../lib/pagination')
+const { hqLabels } = require('./companies/labels')
 
 function transformObjectToOption ({ id, name }) {
   return {
     value: id,
     label: name,
+  }
+}
+
+function transformHQCodeToLabelledOption ({ id, name }) {
+  switch (name) {
+    case 'ehq':
+      return {
+        value: id,
+        label: hqLabels.ehq,
+      }
+    case 'ghq':
+      return {
+        value: id,
+        label: hqLabels.ghq,
+      }
+    case 'ukhq':
+      return {
+        value: id,
+        label: hqLabels.ukhq,
+      }
   }
 }
 
@@ -109,6 +130,7 @@ function transformApiResponseToCollection (options = {}, ...itemTransformers) {
 
 module.exports = {
   buildMetaDataObj,
+  transformHQCodeToLabelledOption,
   transformObjectToOption,
   transformStringToOption,
   transformContactToOption,


### PR DESCRIPTION
**Defect**: the selection of more than one filter option returns result = all the companies record.

select Global HQ = global HQ record
select Global HQ + European HQ = All companies record

**Expected result**
Select two of the 3 options = xxx Companies + xxx companies record.

- [x] Filter bug fixed by refactoring `getRequestBody` (see below)
- [x] Refactored macro to follow the same pattern as the other filter macros
- [x] Refactored macro to use database values instead of hardcoded values

```javascript
function getRequestBody (req, res, next) {
  const selectedFiltersQuery = removeArray(pick(req.query, [
    'name',
    'sector',
    'country',
    'uk_region',
    'headquarter_type',
  ]), 'headquarter_type')
```

to

```javascript
function getRequestBody (req, res, next) {
  const selectedFiltersQuery = pick(req.query, [
    'name',
    'sector',
    'country',
    'uk_region',
    'headquarter_type',
  ])
```

