### PR TITLE
DH-1606 Removed archived contacts from new interaction view

### DIFF
--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -86,7 +86,7 @@ async function getInteractionOptions (req, res, next) {
     res.locals.options = {
       services,
       advisers: activeAdvisers.map(transformObjectToOption),
-      contacts: contacts.map(transformContactToOption),
+      contacts: filter(contacts, contact => !contact.archived).map(transformContactToOption),
       statuses: await getOptions(token, 'service-delivery-status', { createdOn, sorted: false }),
       teams: await getOptions(token, 'team', { createdOn }),
       channels: await getOptions(token, 'communication-channel', { createdOn }),

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -293,9 +293,6 @@ describe('Interaction details middleware', () => {
         }, {
           label: 'John Smith, Director',
           value: '12651151-2149-465e-871b-ac45bc568a63',
-        }, {
-          label: 'Jane Smith, Director',
-          value: '12651151-2149-465e-871b-ac45bc568a64',
         }]
 
         expect(this.res.locals.options.contacts).to.deep.equal(expectedContacts)
@@ -415,9 +412,6 @@ describe('Interaction details middleware', () => {
         }, {
           label: 'John Smith, Director',
           value: '12651151-2149-465e-871b-ac45bc568a63',
-        }, {
-          label: 'Jane Smith, Director',
-          value: '12651151-2149-465e-871b-ac45bc568a64',
         }]
 
         expect(this.res.locals.options.contacts).to.deep.equal(expectedContacts)


### PR DESCRIPTION
Because having archived (i.e. inactive) contacts on interactions view doesn't make sense,
we added a fix to filter them out

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
