### PR TITLE
DH-1645 Subsidiary search doesn't work

### DIFF
--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -103,15 +103,13 @@ async function getSubsidiaryCompaniesCollection (req, res, next) {
   }
 
   try {
-    res.locals.results = await search({
+    res.locals.results = await searchCompanies({
+      token: req.session.token,
       searchTerm,
-      searchEntity: 'company',
+      page: req.query.page,
       requestBody: {
         ...req.body,
       },
-      token: req.session.token,
-      page: req.query.page,
-      isAggregation: false,
     })
       .then(transformApiResponseToSearchCollection(
         { query: req.query },


### PR DESCRIPTION
Searching for a company in the subsidiary search panel returns all the companies in the database.

Fixed by applying the same fix made by ztolley in commit # 7e2fd72d9a831a8cc18675a0382e39e9d9b16186

[x] Bug fixed
