### PR TITLE
DH-1648 Filter Persistance Fix for Contacts and Companies

### DIFF
--- a/src/apps/companies/controllers/list.js
+++ b/src/apps/companies/controllers/list.js
@@ -29,7 +29,7 @@ async function renderCompanyList (req, res, next) {
 
     res.render('_layouts/collection', {
       sortForm,
-      filtersFields,
+      filtersFields: filtersFieldsWithSelectedOptions,
       selectedFilters,
       title: 'Companies',
       countLabel: 'company',

--- a/src/apps/contacts/controllers/list.js
+++ b/src/apps/contacts/controllers/list.js
@@ -30,8 +30,8 @@ async function renderContactList (req, res, next) {
 
     res.render('_layouts/collection', {
       sortForm,
-      filtersFields,
       selectedFilters,
+      filtersFields: filtersFieldsWithSelectedOptions,
       title: 'Contacts',
       countLabel: 'contact',
       highlightTerm: get(selectedFilters, 'name.valueLabel'),


### PR DESCRIPTION
When filtering with text inputs, on `contacts` and `companies` the filtered value
would not persist after collection view reload. this is because we weren't
passing the selected options to the `render` method.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
