### PR TITLE
DH-1646: HQ filters in incorrect order on company collections page

### DIFF
--- a/src/apps/macros.js
+++ b/src/apps/macros.js
@@ -1,3 +1,4 @@
+const { sortBy } = require('lodash')
 const metadata = require('../lib/metadata')
 const { transformObjectToOption, transformStringToOption, transformHQCodeToLabelledOption } = require('./transformers')
 
@@ -38,7 +39,7 @@ const globalFields = {
     type: 'checkbox',
     label: 'Type',
     options () {
-      return metadata.headquarterOptions.map(transformHQCodeToLabelledOption)
+      return sortBy(metadata.headquarterOptions.map(transformHQCodeToLabelledOption), ['order', 'label', 'value'])
     },
   },
 


### PR DESCRIPTION
**Expected**: Global is top as in

> Global HQ
> European HQ
> UK HQ

**Actual**: As they're coming straight from the db they render in alphabetical order, so European is top:

> European HQ
> Global HQ
> UK HQ

[x] Added Lodash to macros.js 
[x] Used the Lodash `sortby` function to sort headquarter types by the upcoming `order` field.

**Note:** The `sortby` function is used in a way that will allow it to fallback to name or ID to sort. This means that this fix can go live even if https://github.com/uktrade/data-hub-leeloo/pull/898 has not been merged into master yet. When the `order` field exists in the data, then it will automatically start to sort by that field.
