### PR TITLE
DH-1637L INVESTMENTS: Display the project status badge on project search results card

### DIFF
--- a/src/apps/investment-projects/transformers/collection.js
+++ b/src/apps/investment-projects/transformers/collection.js
@@ -9,6 +9,7 @@ function transformInvestmentProjectToListItem ({
   project_code,
   stage,
   investment_type,
+  status,
   investor_company,
   estimated_land_date,
   sector,
@@ -16,6 +17,7 @@ function transformInvestmentProjectToListItem ({
   const metaItems = [
     { key: 'stage', value: stage, type: 'badge' },
     { key: 'investment_type', value: investment_type, type: 'badge', badgeModifier: 'secondary' },
+    { key: 'status', value: status, type: 'badge', badgeModifier: 'secondary' },
     { key: 'investor_company', value: investor_company },
     { key: 'sector', value: sector },
     { key: 'estimated_land_date', value: estimated_land_date, type: 'dateMonthYear', isInert: true },


### PR DESCRIPTION
As a DataHub user, I want to know the status of an investment project displayed on the search results card so that I can easily identify the status of the project without having to go into the project.

**GIVEN** that the user can log on to Datahub
**WHEN** they search for investment projects, 
**THEN** they should get the list of projects matching their search criteria.
**GIVEN** that the investment search results are displayed
**WHEN** the results are presented,
**THEN** they should show the status of the project in a form of a badge. (See screen shot) 

![screenshot](https://user-images.githubusercontent.com/151028/38555485-2dd3207c-3cbe-11e8-931b-2f8434347bb8.PNG)

- [x] Added status badge to investment card