### PR TITLE
DH-1600: HIERARCHIES: Change help text when linking records

### DIFF
--- a/src/apps/companies/views/add-global-hq.njk
+++ b/src/apps/companies/views/add-global-hq.njk
@@ -23,7 +23,7 @@
 
   {{ Message({
     type: 'muted',
-    text: 'If you can’t find the company you’re looking for, try a different search term, check the company’s website or any email correspondence that contains company registration details'
+    text: 'If you can’t find the company you’re looking for, it may not be a Global HQ. You should check if it is a Global HQ by clicking ‘Companies’ at the top of the page and searching for it there.'
   }) }}
 
   {{ Pagination(companies.pagination) }}


### PR DESCRIPTION
As a Data Hub user I need to easily find Global HQs when trying to link hierarchies
So that I can understand company hierarchies and find the right people to speak to

**GIVEN** that the user can log in to DH
**WHEN** they navigate to a non-Global HQ record
**THEN** a 'Link Global HQ' field is displayed in the company summary

**GIVEN** that the 'Link Global HQ' field is dispayed
**WHEN** they user clicks on 'Link Global HQ'
**THEN** a company search page is displayed with new help text:

> If you can’t find the company you’re looking for, it may not be a Global HQ. You should check if it is a Global HQ by clicking ‘Companies’ at the top of the page and searching for it there.

![Updated text](https://user-images.githubusercontent.com/151028/38932287-a9b2ca1c-430d-11e8-8a99-56cd13107bdc.PNG)

- [x] Updated help text on 'link global hq' page.