### PR TITLE
Bugfix/test stability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,6 @@ aliases:
   - &docker_postgres
     image: *postgres_version
     name: postgres
-    restart: always
     environment:
       POSTGRES_DB: datahub
 

--- a/test/acceptance/commands/getRadioOption.js
+++ b/test/acceptance/commands/getRadioOption.js
@@ -1,21 +1,35 @@
 /**
- * Get a random option from a radio button list
- * @param selector
+ * Get a random or defined option from a radio button list
+ * @param props.name - Fieldname
+ * @param prop.option - The text for the option to pick
  * @param callback
  */
-exports.command = function getRadioOption (name, callback) {
+exports.command = function getRadioOption ({ name, option }, callback) {
   const selector = `input[name="${name}"] + label span`
 
   return this.elements('css selector', selector, (result) => {
     if (result.value.length) {
-      const random = Math.floor(Math.random() * result.value.length)
+      if (!option) {
+        const random = Math.floor(Math.random() * result.value.length)
 
-      this.elementIdAttribute(result.value[random].ELEMENT, 'textContent', function (textContent) {
-        if (typeof callback === 'function') {
-          const id = `field-${name}-${random + 1}`
-          callback.call(this, { labelSelector: `label[for=${id}]`, text: textContent.value.trim() })
-        }
-      })
+        this.elementIdAttribute(result.value[random].ELEMENT, 'textContent', function ({ value: textContent }) {
+          if (typeof callback === 'function') {
+            const id = `field-${name}-${random + 1}`
+            callback.call(this, { labelSelector: `label[for=${id}]`, text: textContent.trim() })
+          }
+        })
+
+        return
+      }
+
+      for (let pos = 0; pos < result.value.length; pos += 1) {
+        this.elementIdAttribute(result.value[pos].ELEMENT, 'textContent', function ({ value: textContent }) {
+          if (textContent === option && typeof callback === 'function') {
+            const id = `field-${name}-${pos + 1}`
+            callback.call(this, { labelSelector: `label[for=${id}]`, text: textContent.trim() })
+          }
+        })
+      }
     } else {
       this.log(`check the contents of the selector: ${selector}`)
     }

--- a/test/acceptance/global.nightwatch.js
+++ b/test/acceptance/global.nightwatch.js
@@ -1,6 +1,6 @@
 module.exports = {
-  waitForConditionPollInterval: 2000,
-  waitForConditionTimeout: 12000,
-  pauseDuration: 7500,
-  retryAssertionTimeout: 5000,
+  waitForConditionPollInterval: 1000,
+  waitForConditionTimeout: 6000,
+  pauseDuration: 5000,
+  retryAssertionTimeout: 2500,
 }

--- a/test/acceptance/pages/companies/company.js
+++ b/test/acceptance/pages/companies/company.js
@@ -102,19 +102,19 @@ module.exports = {
                 })
               })
               .perform((done) => {
-                this.getRadioOption('headquarter_type', (result) => {
+                this.getRadioOption({ name: 'headquarter_type', option: 'Not a headquarters' }, (result) => {
                   companyRadioButtons.headquarterType = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('employee_range', (result) => {
+                this.getRadioOption({ name: 'employee_range' }, (result) => {
                   companyRadioButtons.employeeRange = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('turnover_range', (result) => {
+                this.getRadioOption({ name: 'turnover_range' }, (result) => {
                   companyRadioButtons.turnoverRange = result
                   done()
                 })
@@ -208,19 +208,19 @@ module.exports = {
                 })
               })
               .perform((done) => {
-                this.getRadioOption('headquarter_type', (result) => {
+                this.getRadioOption({ name: 'headquarter_type', option: 'Not a headquarters' }, (result) => {
                   companyStep2RadioOptions.headquarterType = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('employee_range', (result) => {
+                this.getRadioOption({ name: 'employee_range' }, (result) => {
                   companyStep2RadioOptions.employeeRange = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('turnover_range', (result) => {
+                this.getRadioOption({ name: 'turnover_range' }, (result) => {
                   companyStep2RadioOptions.turnoverRange = result
                   done()
                 })
@@ -316,19 +316,19 @@ module.exports = {
                 })
               })
               .perform((done) => {
-                this.getRadioOption('headquarter_type', (result) => {
+                this.getRadioOption({ name: 'headquarter_type', option: 'Not a headquarters' }, (result) => {
                   companyRadioButtons.headquarterType = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('employee_range', (result) => {
+                this.getRadioOption({ name: 'employee_range' }, (result) => {
                   companyRadioButtons.employeeRange = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('turnover_range', (result) => {
+                this.getRadioOption({ name: 'turnover_range' }, (result) => {
                   companyRadioButtons.turnoverRange = result
                   done()
                 })
@@ -413,19 +413,19 @@ module.exports = {
                 })
               })
               .perform((done) => {
-                this.getRadioOption('headquarter_type', (result) => {
+                this.getRadioOption({ name: 'headquarter_type', option: 'Not a headquarters' }, (result) => {
                   companyStep2RadioOptions.headquarterType = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('employee_range', (result) => {
+                this.getRadioOption({ name: 'employee_range' }, (result) => {
                   companyStep2RadioOptions.employeeRange = result
                   done()
                 })
               })
               .perform((done) => {
-                this.getRadioOption('turnover_range', (result) => {
+                this.getRadioOption({ name: 'turnover_range' }, (result) => {
                   companyStep2RadioOptions.turnoverRange = result
                   done()
                 })

--- a/test/acceptance/pages/investments/value.js
+++ b/test/acceptance/pages/investments/value.js
@@ -39,7 +39,7 @@ module.exports = {
 
         return this
           .api.perform((done) => {
-            this.getRadioOption('average_salary', (result) => {
+            this.getRadioOption({ name: 'average_salary' }, (result) => {
               this.api.useCss().click(result.labelSelector)
               randomlySetRadioOptions.averageSalary = result
               done()

--- a/test/acceptance/pages/support.js
+++ b/test/acceptance/pages/support.js
@@ -22,7 +22,7 @@ module.exports = {
         return this.section.form
           .waitForElementPresent('@sendButton')
           .api.perform((done) => {
-            this.getRadioOption('feedback_type', (result) => {
+            this.getRadioOption({ name: 'feedback_type' }, (result) => {
               supportRequestRadioOptions.employeeRange = result
               done()
             })


### PR DESCRIPTION
Previously the tests would create a company with a random headquarters type but this made
tests fail if a company was created as an HQ as the title for the company page changed.

This change allows the getOptions function in tests accept an option to select and tells the test to pick the 'not a headquarters' option