### PR TITLE
Fix bug picking services for invstment interactions

### DIFF
--- a/src/apps/interactions/services/interaction-options.js
+++ b/src/apps/interactions/services/interaction-options.js
@@ -56,7 +56,7 @@ async function getServiceOptions (req, res, createdOn) {
 }
 
 function getContextForInteraction (req, res) {
-  if (get(req, 'params.investmentId') || get(res.locals, 'interaction.investment_project.id')) {
+  if (get(res, 'locals.investmentData.id') || get(res.locals, 'interaction.investment_project.id')) {
     return 'investment_project_interaction'
   }
 

--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -362,7 +362,7 @@ describe('Interaction edit controller (Interactions)', () => {
         .reply(200, { results: this.contactsData })
         .get('/metadata/team/')
         .reply(200, this.metadataMock.teamOptions)
-        .get('/metadata/service/?contexts__has_any=interaction')
+        .get('/metadata/service/?contexts__has_any=investment_project_interaction')
         .reply(200, this.metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
@@ -559,7 +559,7 @@ describe('Interaction edit controller (Interactions)', () => {
         .reply(200, { results: this.contactsData })
         .get('/metadata/team/')
         .reply(200, this.metadataMock.teamOptions)
-        .get('/metadata/service/?contexts__has_any=interaction')
+        .get('/metadata/service/?contexts__has_any=investment_project_interaction')
         .reply(200, this.metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
@@ -588,9 +588,6 @@ describe('Interaction edit controller (Interactions)', () => {
         company: {
           id: '1',
           name: 'Fred ltd.',
-        },
-        investmentData: {
-          id: '3',
         },
         interaction: interactionData,
         form: {

--- a/test/unit/apps/interactions/controllers/edit.service.test.js
+++ b/test/unit/apps/interactions/controllers/edit.service.test.js
@@ -514,9 +514,6 @@ describe('Interaction edit controller (Service delivery)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        investmentData: {
-          id: '3',
-        },
         interaction: serviceDeliveryData,
         form: {
           errors: {


### PR DESCRIPTION
The previous code assumed that when an interaction was to be added to an investment project the router would pass the investmentId parameter, but for some reason when using sub-routes the parameters from the parent route are marked undefined.

This change uses the investment data loaded by previous middleware or the investment project id in the interaction to judge if it's an investment interaction or not.

Also fixed the tests that missed this.