### PR TITLE
Disable the One List form

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -69,7 +69,7 @@ const hqLabels = {
 
 const accountManagementDisplayLabels = {
   one_list_tier: 'One List tier',
-  one_list_account_owner: 'One List account manager',
+  one_list_account_owner: 'Account manager',
 }
 
 const exportDetailsLabels = {

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -28,7 +28,6 @@ const {
   renderExportEdit,
   handleEditFormPost,
 } = require('./controllers/exports')
-const { renderAccountManagementEditPage } = require('./controllers/account-management')
 
 const { setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
 const {
@@ -49,7 +48,6 @@ const { setCompanyContactRequestBody, getCompanyContactCollection } = require('.
 const { populateForm, handleFormPost, setIsEditMode } = require('./middleware/form')
 const { getCompany, getCompaniesHouseRecord } = require('./middleware/params')
 const { setInteractionsReturnUrl, setInteractionsEntityName } = require('./middleware/interactions')
-const { populateAccountManagementForm, postAccountManagementDetails } = require('./middleware/account-management')
 const { setGlobalHQ, removeGlobalHQ, setSubsidiary, removeSubsidiary } = require('./middleware/hierarchies')
 const setCompaniesLocalNav = require('./middleware/local-navigation')
 
@@ -86,11 +84,6 @@ router
   .route('/:companyId/edit')
   .get(setIsEditMode, populateForm, renderForm)
   .post(handleFormPost, setIsEditMode, populateForm, renderForm)
-
-router
-  .route('/:companyId/account-management/edit')
-  .get(populateAccountManagementForm, renderAccountManagementEditPage)
-  .post(populateAccountManagementForm, postAccountManagementDetails, renderAccountManagementEditPage)
 
 router.post('/:companyId/archive', archiveCompany)
 router.get('/:companyId/unarchive', unarchiveCompany)

--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -27,9 +27,14 @@
   {% endif %}
 
   <div class="section">
-    <h2 class="heading-medium">Account management</h2>
+    <h2 class="heading-medium">Global account management</h2>
     {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
-    <p><a href="/companies/{{company.id}}/account-management/edit" class="button button--secondary">Edit account management</a></p>
+
+    {% call HiddenContent({ summary: 'Need to edit the account management information?' }) %}
+      {% call Message({ type: 'muted' }) %}
+        If you need to change the One List tier or account manager for this company, please <a href="{{ feedbackLink }}">contact the support team</a>.
+      {% endcall %}
+    {% endcall %}
   </div>
 
   {% if company.id and not company.archived %}

--- a/test/acceptance/features/companies/account-management-save.feature
+++ b/test/acceptance/features/companies/account-management-save.feature
@@ -1,4 +1,5 @@
-@companies-account-management-save
+# disabled as the one list fields are temporarly locked down until we decide what to do with them
+@companies-account-management-save @ignore
 Feature: Save account management details for a company
 
   @companies-account-management-save--update
@@ -8,9 +9,9 @@ Feature: Save account management details for a company
     Then the Account management details are displayed
       | key                       | value                   |
       | One List tier             | None                    |
-      | One List account manager  | None                    |
+      | Account manager           | None                    |
     When the Account management details are updated
     Then the Account management details are displayed
       | key                       | value                       |
       | One List tier             | None                        |
-      | One List account manager  | company.oneListAccountOwner |
+      | Account manager           | company.oneListAccountOwner |

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -24,10 +24,10 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Account management details are displayed
+    And the Global account management details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | One List account manager  | None                       |
+      | Account manager           | None                       |
 
   @companies-save--uk-non-private-or-non-public-ltd-company
   Scenario: Create a UK non-private or non-public limited company
@@ -48,10 +48,10 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Account management details are displayed
+    And the Global account management details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | One List account manager  | None                       |
+      | Account manager           | None                       |
 
   @companies-save--foreign
   Scenario: Create a foreign company
@@ -72,10 +72,10 @@ Feature: Create a new company
       | Number of employees       | company.employeeRange            |
       | Annual turnover           | company.turnoverRange            |
       | Country                   | company.registeredAddressCountry |
-    And the Account management details are displayed
+    And the Global account management details are displayed
       | key                       | value                            |
       | One List tier             | None                             |
-      | One List account manager  | None                             |
+      | Account manager           | None                             |
 
   @companies-save--foreign-uk-branch
   Scenario: Create a UK branch of a foreign company
@@ -96,7 +96,7 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Account management details are displayed
+    And the Global account management details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | One List account manager  | None                       |
+      | Account manager           | None                       |

--- a/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
@@ -16,7 +16,7 @@ describe('transformCompanyToOneListView', () => {
 
     it('indicate there is no one list account management information', () => {
       expect(this.viewRecord).to.deep.equal({
-        'One List account manager': 'None',
+        'Account manager': 'None',
         'One List tier': 'None',
       })
     })
@@ -40,7 +40,7 @@ describe('transformCompanyToOneListView', () => {
 
     it('indicate there is no one list account management information', () => {
       expect(this.viewRecord).to.deep.equal({
-        'One List account manager': 'The owner',
+        'Account manager': 'The owner',
         'One List tier': 'The classification',
       })
     })


### PR DESCRIPTION
*Before*: you could edit the One List Manager assigned to a company

<img width="949" alt="screen shot 2018-05-17 at 17 29 06" src="https://user-images.githubusercontent.com/178865/40190893-e0e1b182-59f7-11e8-8c67-765b8b983ee9.png">


*After*: you cannot edit the One List Manager any more. If you want to, you have to contact the support team instead.

<img width="954" alt="screen shot 2018-05-17 at 17 28 05" src="https://user-images.githubusercontent.com/178865/40190900-e553dd58-59f7-11e8-9a4b-4e83e3f18108.png">


This is just a temporary solution before we figure out what the needs really are and how we can meet them so I'm not deleting all the related logic and modules just yet.
