### PR TITLE
Fix bug redirecting to wrong page after setting subsidiary

### DIFF
--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -117,7 +117,7 @@ async function getSubsidiaryCompaniesCollection (req, res, next) {
         (item) => {
           return {
             ...item,
-            url: `/companies/${item.id}/hierarchies/subsidiaries/${companyId}/add`,
+            url: `/companies/${companyId}/hierarchies/subsidiaries/${item.id}/add`,
           }
         }
       ))

--- a/src/apps/companies/middleware/hierarchies.js
+++ b/src/apps/companies/middleware/hierarchies.js
@@ -64,28 +64,8 @@ async function addSubsidiary (req, res, next) {
   return res.redirect(`/companies/${companyId}/subsidiaries`)
 }
 
-async function removeSubsidiary (req, res, next) {
-  const token = req.session.token
-  const parentCompanyId = req.params.parentCompanyId
-  const body = { global_headquarters: null }
-
-  try {
-    const response = await updateCompany(token, parentCompanyId, body)
-
-    req.flash('success', 'You’ve removed the link to the Subsidiary')
-    return res.redirect(`/companies/${response.id}/details`)
-  } catch (error) {
-    if (error.statusCode === 400) {
-      req.flash('error', transformErrorMessage(error.error))
-      return res.redirect(`/companies/${parentCompanyId}/details`)
-    }
-    next(error)
-  }
-}
-
 module.exports = {
   setGlobalHQ,
   removeGlobalHQ,
   addSubsidiary,
-  removeSubsidiary,
 }

--- a/src/apps/companies/middleware/hierarchies.js
+++ b/src/apps/companies/middleware/hierarchies.js
@@ -45,24 +45,23 @@ async function removeGlobalHQ (req, res, next) {
   }
 }
 
-async function setSubsidiary (req, res, next) {
+async function addSubsidiary (req, res, next) {
   const token = req.session.token
-  const companyId = req.params.companyId
-  const parentCompanyId = req.params.parentCompanyId
+  const { companyId, subsidiaryCompanyId } = req.params
   const body = { global_headquarters: companyId }
 
   try {
-    const response = await updateCompany(token, parentCompanyId, body)
-
+    await updateCompany(token, subsidiaryCompanyId, body)
     req.flash('success', 'You’ve linked the Subsidiary')
-    return res.redirect(`/companies/${response.id}/details`)
   } catch (error) {
-    if (error.statusCode === 400) {
-      req.flash('error', transformErrorMessage(error.error))
-      return res.redirect(`/companies/${parentCompanyId}/details`)
+    if (error.statusCode !== 400) {
+      return next(error)
     }
-    next(error)
+
+    req.flash('error', transformErrorMessage(error.error))
   }
+
+  return res.redirect(`/companies/${companyId}/subsidiaries`)
 }
 
 async function removeSubsidiary (req, res, next) {
@@ -87,6 +86,6 @@ async function removeSubsidiary (req, res, next) {
 module.exports = {
   setGlobalHQ,
   removeGlobalHQ,
-  setSubsidiary,
+  addSubsidiary,
   removeSubsidiary,
 }

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -48,7 +48,7 @@ const { setCompanyContactRequestBody, getCompanyContactCollection } = require('.
 const { populateForm, handleFormPost, setIsEditMode } = require('./middleware/form')
 const { getCompany, getCompaniesHouseRecord } = require('./middleware/params')
 const { setInteractionsReturnUrl, setInteractionsEntityName } = require('./middleware/interactions')
-const { setGlobalHQ, removeGlobalHQ, setSubsidiary, removeSubsidiary } = require('./middleware/hierarchies')
+const { setGlobalHQ, removeGlobalHQ, addSubsidiary, removeSubsidiary } = require('./middleware/hierarchies')
 const setCompaniesLocalNav = require('./middleware/local-navigation')
 
 const interactionsRouter = require('../interactions/router.sub-app')
@@ -98,7 +98,7 @@ router.get('/:companyId/hierarchies/ghq/:globalHqId/add', setGlobalHQ)
 router.get('/:companyId/hierarchies/ghq/remove', removeGlobalHQ)
 
 router.get('/:companyId/hierarchies/subsidiaries/search', getSubsidiaryCompaniesCollection, renderLinkSubsidiary)
-router.get('/:parentCompanyId/hierarchies/subsidiaries/:companyId/add', setSubsidiary)
+router.get('/:companyId/hierarchies/subsidiaries/:subsidiaryCompanyId/add', addSubsidiary)
 router.get('/:parentCompanyId/hierarchies/subsidiaries/remove', removeSubsidiary)
 
 router.get('/:companyId/contacts',

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -48,7 +48,7 @@ const { setCompanyContactRequestBody, getCompanyContactCollection } = require('.
 const { populateForm, handleFormPost, setIsEditMode } = require('./middleware/form')
 const { getCompany, getCompaniesHouseRecord } = require('./middleware/params')
 const { setInteractionsReturnUrl, setInteractionsEntityName } = require('./middleware/interactions')
-const { setGlobalHQ, removeGlobalHQ, addSubsidiary, removeSubsidiary } = require('./middleware/hierarchies')
+const { setGlobalHQ, removeGlobalHQ, addSubsidiary } = require('./middleware/hierarchies')
 const setCompaniesLocalNav = require('./middleware/local-navigation')
 
 const interactionsRouter = require('../interactions/router.sub-app')
@@ -99,7 +99,6 @@ router.get('/:companyId/hierarchies/ghq/remove', removeGlobalHQ)
 
 router.get('/:companyId/hierarchies/subsidiaries/search', getSubsidiaryCompaniesCollection, renderLinkSubsidiary)
 router.get('/:companyId/hierarchies/subsidiaries/:subsidiaryCompanyId/add', addSubsidiary)
-router.get('/:parentCompanyId/hierarchies/subsidiaries/remove', removeSubsidiary)
 
 router.get('/:companyId/contacts',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),


### PR DESCRIPTION
A bug in the previous version meant that when a subsidiary was added to a parent company the browser would be redirected to the subsidiary details page.

This bug fix corrects this so now when you add a subsidiary you are taken back to the subsidiaries list on the parent company.

Also refactored tests and added missing tests for adding a subsidiary.