### PR TITLE
Change wording in One List section

### DIFF
--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -27,12 +27,14 @@
   {% endif %}
 
   <div class="section">
-    <h2 class="heading-medium">Global account management</h2>
+    <h2 class="heading-medium">Global Account Manager – One List</h2>
     {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
 
     {% call HiddenContent({ summary: 'Need to edit the account management information?' }) %}
       {% call Message({ type: 'muted' }) %}
-        If you need to change the One List tier or account manager for this company, please <a href="{{ feedbackLink }}">contact the support team</a>.
+        If you need to change the One List tier or One List account manager for this company, please <a href="{{ feedbackLink }}">contact the support team</a>.
+        <br><br>
+        Read more about the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">One List</a>.
       {% endcall %}
     {% endcall %}
   </div>

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -24,7 +24,7 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global account management details are displayed
+    And the Global Account Manager – One List details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
       | Account manager           | None                       |
@@ -48,7 +48,7 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global account management details are displayed
+    And the Global Account Manager – One List details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
       | Account manager           | None                       |
@@ -72,7 +72,7 @@ Feature: Create a new company
       | Number of employees       | company.employeeRange            |
       | Annual turnover           | company.turnoverRange            |
       | Country                   | company.registeredAddressCountry |
-    And the Global account management details are displayed
+    And the Global Account Manager – One List details are displayed
       | key                       | value                            |
       | One List tier             | None                             |
       | Account manager           | None                             |
@@ -96,7 +96,7 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global account management details are displayed
+    And the Global Account Manager – One List details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
       | Account manager           | None                       |


### PR DESCRIPTION
The previous header and help text didn't specify that this section
is only intended for One List purposes.
This also adds a link to a page explaining what the One List is.

*Before*
![screen shot 2018-05-24 at 11 16 01](https://user-images.githubusercontent.com/178865/40479706-37c5a426-5f44-11e8-86cb-ea22a75a49ca.png)

*After*
![screen shot 2018-05-24 at 11 14 32](https://user-images.githubusercontent.com/178865/40479713-3dda8728-5f44-11e8-94f7-d5784b02a38e.png)
