### PR TITLE
Instantly see new subsidiary links

### DIFF
--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -4,31 +4,40 @@ const { getCompanySubsidiaries } = require('../repos')
 const { companyDetailsLabels } = require('../labels')
 
 async function renderSubsidiaries (req, res, next) {
-  const token = req.session.token
-  const query = req.query
-  const page = query.page || '1'
+  try {
+    const token = req.session.token
+    const query = req.query
+    const page = query.page || '1'
 
-  const {
-    id: companyId,
-    name: companyName,
-  } = res.locals.company
+    const {
+      id: companyId,
+      name: companyName,
+    } = res.locals.company
 
-  const companies = await getCompanySubsidiaries(token, companyId, page)
-    .then(transformApiResponseToSearchCollection(
-      { query },
-      transformCompanyToSubsidiaryListItem,
-    ))
+    const actionButtons = [{
+      label: companyDetailsLabels.link_a_subsidiary,
+      url: `/companies/${companyId}/subsidiaries/link`,
+    }]
 
-  res
-    .breadcrumb(companyName, `/companies/${companyId}`)
-    .breadcrumb(companyDetailsLabels.subsidiaries)
-    .render('companies/views/subsidiaries.njk', {
-      companies,
-      actionButtons: [{
-        label: companyDetailsLabels.link_a_subsidiary,
-        url: `/companies/${companyId}/subsidiaries/link`,
-      }],
-    })
+    const subsidiaryCollection = await getCompanySubsidiaries(token, companyId, page)
+      .then(transformApiResponseToSearchCollection(
+        { query },
+        transformCompanyToSubsidiaryListItem,
+      ))
+
+    const subsidiaries = {
+      ...subsidiaryCollection,
+      actionButtons,
+      countLabel: 'subsidiary',
+    }
+
+    return res
+      .breadcrumb(companyName, `/companies/${companyId}`)
+      .breadcrumb(companyDetailsLabels.subsidiaries)
+      .render('companies/views/subsidiaries.njk', { subsidiaries })
+  } catch (error) {
+    next(error)
+  }
 }
 
 module.exports = {

--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -1,6 +1,6 @@
-const { search } = require('../../search/services')
 const { transformApiResponseToSearchCollection } = require('../../search/transformers')
 const { transformCompanyToSubsidiaryListItem } = require('../transformers')
+const { getCompanySubsidiaries } = require('../repos')
 const { companyDetailsLabels } = require('../labels')
 
 async function renderSubsidiaries (req, res, next) {
@@ -13,13 +13,7 @@ async function renderSubsidiaries (req, res, next) {
     name: companyName,
   } = res.locals.company
 
-  const companies = await search({
-    token,
-    page,
-    searchEntity: 'company',
-    requestBody: { global_headquarters: companyId },
-    isAggregation: false,
-  })
+  const companies = await getCompanySubsidiaries(token, companyId, page)
     .then(transformApiResponseToSearchCollection(
       { query },
       transformCompanyToSubsidiaryListItem,

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -1,7 +1,6 @@
 /* eslint camelcase: 0, prefer-promise-reject-errors: 0 */
 const config = require('../../../config')
 const authorisedRequest = require('../../lib/authorised-request')
-const { search } = require('../search/services')
 
 // Get a company and then pad out the interactions with related data
 function getDitCompany (token, id) {
@@ -93,12 +92,16 @@ function getCompanyTimeline (token, companyId, page = 1) {
 }
 
 function getCompanySubsidiaries (token, companyId, page = 1) {
-  return search({
-    token,
-    page,
-    searchEntity: 'company',
-    requestBody: { global_headquarters: companyId },
-    isAggregation: false,
+  const limit = 10
+  const offset = limit * (page - 1)
+  return authorisedRequest(token, {
+    url: `${config.apiRoot}/v3/company`,
+    qs: {
+      limit,
+      offset,
+      sortby: 'name',
+      global_headquarters_id: companyId,
+    },
   })
 }
 

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0, prefer-promise-reject-errors: 0 */
 const config = require('../../../config')
 const authorisedRequest = require('../../lib/authorised-request')
+const { search } = require('../search/services')
 
 // Get a company and then pad out the interactions with related data
 function getDitCompany (token, id) {
@@ -91,6 +92,16 @@ function getCompanyTimeline (token, companyId, page = 1) {
   })
 }
 
+function getCompanySubsidiaries (token, companyId, page = 1) {
+  return search({
+    token,
+    page,
+    searchEntity: 'company',
+    requestBody: { global_headquarters: companyId },
+    isAggregation: false,
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
@@ -100,4 +111,5 @@ module.exports = {
   updateCompany,
   getCompanyAuditLog,
   getCompanyTimeline,
+  getCompanySubsidiaries,
 }

--- a/src/apps/companies/views/subsidiaries.njk
+++ b/src/apps/companies/views/subsidiaries.njk
@@ -1,12 +1,5 @@
 {% extends "./_layout-view.njk" %}
 
 {% block main_grid_right_column %}
-  {{
-    CollectionContent(companies | assign({
-      highlightTerm: searchTerm,
-      countLabel: 'subsidiary',
-      query: QUERY,
-      actionButtons: actionButtons
-    }))
-  }}
+  {{ CollectionContent(subsidiaries) }}
 {% endblock %}

--- a/test/unit/apps/companies/controllers/subsidiaries.test.js
+++ b/test/unit/apps/companies/controllers/subsidiaries.test.js
@@ -1,0 +1,168 @@
+const config = require('~/config')
+const subsidiariesController = require('~/src/apps/companies/controllers/subsidiaries')
+
+const companyData = require('~/test/unit/data/companies/companies-house-company.json')
+const subsidiaryData = require('~/test/unit/data/companies/subsidiaries.json')
+
+describe('company subsidiaries controller', () => {
+  beforeEach(() => {
+    this.breadcrumbStub = sinon.stub().returnsThis()
+    this.renderSpy = sinon.spy()
+    this.nextSpy = sinon.spy()
+
+    this.reqMock = {
+      query: {},
+      session: {
+        token: '1234',
+      },
+      params: {
+        compantId: '72fda78f-bdc3-44dc-9c22-c8ac82f7bda4',
+      },
+    }
+
+    this.resMock = {
+      breadcrumb: this.breadcrumbStub,
+      render: this.renderSpy,
+      locals: {
+        company: companyData,
+      },
+    }
+  })
+
+  context('when there are subsidiaries to list', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get('/v3/company?limit=10&offset=0&sortby=name&global_headquarters_id=72fda78f-bdc3-44dc-9c22-c8ac82f7bda4')
+        .reply(200, subsidiaryData)
+
+      await subsidiariesController.renderSubsidiaries(this.reqMock, this.resMock, this.nextSpy)
+      this.subsidiaries = this.resMock.render.firstCall.args[1].subsidiaries
+    })
+
+    it('should call the backend to get companies with this company as hq', () => {
+      expect(nock.isDone()).to.be.true
+    })
+
+    it('should return the subsidiaries as a collection', () => {
+      expect(this.subsidiaries).to.have.property('items')
+      expect(this.subsidiaries).to.have.property('count', 1)
+    })
+
+    it('should return no pagination data', () => {
+      expect(this.subsidiaries).to.have.property('pagination', null)
+    })
+
+    it('should transform each subsidiary for display', () => {
+      const subsidiary = this.subsidiaries.items[0]
+
+      expect(subsidiary).to.deep.equal({
+        id: '0f5216e0-849f-11e6-ae22-56b6b6499611',
+        name: 'Venus Ltd',
+        url: '/companies/0f5216e0-849f-11e6-ae22-56b6b6499611',
+        meta: [
+          { label: 'Sector', value: 'Retail' },
+          { label: 'Country', type: 'badge', value: 'United Kingdom' },
+          { label: 'UK region', type: 'badge', value: 'North West' },
+          { label: 'Primary address', value: '66 Marcham Road, Bordley, BD23 8RZ, United Kingdom' },
+          { label: '', value: 'Remove subsidiary', url: '/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/hierarchies/ghq/remove' },
+        ],
+        subTitle: {
+          type: 'datetime',
+          value: '2018-05-29T13:15:47.200952Z',
+          label: 'Updated on',
+        },
+        type: 'company',
+      })
+    })
+
+    it('should include a button to link a new subsidiary', () => {
+      expect(this.subsidiaries.actionButtons).to.deep.equal([{
+        label: 'Link a subsidiary',
+        url: '/companies/72fda78f-bdc3-44dc-9c22-c8ac82f7bda4/subsidiaries/link',
+      }])
+    })
+
+    it('should include a count label', () => {
+      expect(this.subsidiaries).to.have.property('countLabel', 'subsidiary')
+    })
+  })
+
+  context('when there are no subsidiaries', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get('/v3/company?limit=10&offset=0&sortby=name&global_headquarters_id=72fda78f-bdc3-44dc-9c22-c8ac82f7bda4')
+        .reply(200, {
+          count: 0,
+          next: null,
+          previous: null,
+          results: [],
+        })
+
+      await subsidiariesController.renderSubsidiaries(this.reqMock, this.resMock, this.nextSpy)
+      this.subsidiaries = this.resMock.render.firstCall.args[1].subsidiaries
+    })
+
+    it('should return the subsidiaries as a collection', () => {
+      expect(this.subsidiaries).to.have.property('items')
+      expect(this.subsidiaries).to.have.property('count', 0)
+    })
+
+    it('should return no pagination data', () => {
+      expect(this.subsidiaries).to.have.property('pagination', null)
+    })
+
+    it('should include a button to link a new subsidiary', () => {
+      expect(this.subsidiaries.actionButtons).to.deep.equal([{
+        label: 'Link a subsidiary',
+        url: '/companies/72fda78f-bdc3-44dc-9c22-c8ac82f7bda4/subsidiaries/link',
+      }])
+    })
+
+    it('should include a count label', () => {
+      expect(this.subsidiaries).to.have.property('countLabel', 'subsidiary')
+    })
+  })
+
+  context('when requesting page 2 of a large collection', () => {
+    beforeEach(async () => {
+      this.reqMock.query.page = 2
+      nock(config.apiRoot)
+        .get('/v3/company?limit=10&offset=10&sortby=name&global_headquarters_id=72fda78f-bdc3-44dc-9c22-c8ac82f7bda4')
+        .reply(200, {
+          ...subsidiaryData,
+          count: 50,
+        })
+
+      await subsidiariesController.renderSubsidiaries(this.reqMock, this.resMock, this.nextSpy)
+      this.subsidiaries = this.resMock.render.firstCall.args[1].subsidiaries
+    })
+
+    it('should call the backend to get companies with this company as hq', () => {
+      expect(nock.isDone()).to.be.true
+    })
+
+    it('should return the subsidiaries as a collection', () => {
+      expect(this.subsidiaries).to.have.property('items')
+      expect(this.subsidiaries).to.have.property('count', 50)
+    })
+
+    it('should return pagination data', () => {
+      const pagination = this.subsidiaries.pagination
+
+      expect(pagination).to.have.property('currentPage', 2)
+      expect(pagination).to.have.property('totalPages', 5)
+      expect(pagination.pages).to.have.length(5)
+    })
+
+    it('should include a button to link a new subsidiary', () => {
+      expect(this.subsidiaries.actionButtons).to.deep.equal([{
+        label: 'Link a subsidiary',
+        url: '/companies/72fda78f-bdc3-44dc-9c22-c8ac82f7bda4/subsidiaries/link',
+      }])
+    })
+
+    it('should include a count label', () => {
+      expect(this.subsidiaries).to.have.property('countLabel', 'subsidiary')
+    })
+  })
+})

--- a/test/unit/data/companies/subsidiaries.json
+++ b/test/unit/data/companies/subsidiaries.json
@@ -1,0 +1,111 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+          "reference_code": "ORG-10096257",
+          "name": "Venus Ltd",
+          "trading_name": null,
+          "uk_based": true,
+          "company_number": null,
+          "vat_number": "",
+          "registered_address_1": "66 Marcham Road",
+          "registered_address_2": null,
+          "registered_address_town": "Bordley",
+          "registered_address_county": null,
+          "registered_address_postcode": "BD23 8RZ",
+          "registered_address_country": {
+              "name": "United Kingdom",
+              "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+          },
+          "created_on": "2016-06-15T10:00:00Z",
+          "modified_on": "2018-05-29T13:15:47.200952Z",
+          "archived": false,
+          "archived_documents_url_path": "/documents/123",
+          "archived_on": null,
+          "archived_reason": null,
+          "archived_by": null,
+          "description": "This is a dummy company for testing",
+          "website": null,
+          "trading_address_1": null,
+          "trading_address_2": null,
+          "trading_address_town": null,
+          "trading_address_county": null,
+          "trading_address_postcode": null,
+          "trading_address_country": null,
+          "account_manager": null,
+          "business_type": {
+              "name": "Company",
+              "id": "98d14e94-5d95-e211-a939-e4115bead28a"
+          },
+          "classification": null,
+          "companies_house_data": null,
+          "contacts": [
+              {
+                  "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef",
+                  "title": null,
+                  "first_name": "Johnny",
+                  "last_name": "Cakeman",
+                  "name": "Johnny Cakeman",
+                  "job_title": null,
+                  "company": {
+                      "name": "Venus Ltd",
+                      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+                  },
+                  "adviser": null,
+                  "primary": false,
+                  "telephone_countrycode": "44",
+                  "telephone_number": "67890123432",
+                  "email": "johnny@cakeman.com",
+                  "address_same_as_company": false,
+                  "address_1": "82 Ramsgate Rd",
+                  "address_2": null,
+                  "address_town": "Willington",
+                  "address_county": null,
+                  "address_country": {
+                      "name": "United Kingdom",
+                      "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+                  },
+                  "address_postcode": "NE28 5JB",
+                  "telephone_alternative": null,
+                  "email_alternative": null,
+                  "notes": "This is a dummy contact for testing",
+                  "contactable_by_dit": false,
+                  "contactable_by_uk_dit_partners": false,
+                  "contactable_by_overseas_dit_partners": false,
+                  "accepts_dit_email_marketing": false,
+                  "contactable_by_email": false,
+                  "contactable_by_phone": true,
+                  "archived": false,
+                  "archived_documents_url_path": "/documents/123",
+                  "archived_on": null,
+                  "archived_reason": null,
+                  "archived_by": null,
+                  "created_on": "2017-02-28T15:00:00Z",
+                  "modified_on": "2017-06-05T00:00:00Z"
+              }
+          ],
+          "employee_range": null,
+          "export_to_countries": [],
+          "future_interest_countries": [],
+          "headquarter_type": null,
+          "one_list_account_owner": null,
+          "global_headquarters": {
+              "name": "Mercury Ltd",
+              "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+          },
+          "sector": {
+              "name": "Retail",
+              "id": "355f977b-8ac3-e211-a646-e4115bead28a"
+          },
+          "turnover_range": null,
+          "uk_region": {
+              "name": "North West",
+              "id": "824cd12a-6095-e211-a939-e4115bead28a"
+          },
+          "export_experience_category": null
+      }
+  ]
+}


### PR DESCRIPTION
Changes how subsidiaries are fetched so it uses the v3 API instead of the search API, that way the data is instantly available.

This fixes the issue of adding a subsidiary and not seeing it in the list when you press save.
![subsidiaries](https://user-images.githubusercontent.com/56056/40666195-0d276bfc-6357-11e8-9607-a53b3d7eb6d9.gif)
