### PR TITLE
Update copy in One List section and link for support

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -70,6 +70,9 @@ const config = {
     user: process.env.BASIC_AUTH_USER,
     password: process.env.BASIC_AUTH_PASSWORD,
   },
+  oneList: {
+    email: process.env.ONE_LIST_EMAIL || 'one.list@example.com',
+  },
 }
 
 module.exports = config

--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -1,3 +1,4 @@
+const config = require('../../../../config')
 const {
   transformCompanyToView,
   transformCompaniesHouseToView,
@@ -13,6 +14,7 @@ function renderDetails (req, res) {
       companyDetails: transformCompanyToView(company),
       accountManagementDetails: transformCompanyToOneListView(company),
       chDetails: company.companies_house_data ? transformCompaniesHouseToView(company.companies_house_data) : null,
+      oneListEmail: config.oneList.email,
     })
 }
 

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -69,7 +69,7 @@ const hqLabels = {
 
 const accountManagementDisplayLabels = {
   one_list_tier: 'One List tier',
-  one_list_account_owner: 'Account manager',
+  one_list_account_owner: 'Global account manager',
 }
 
 const exportDetailsLabels = {

--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -30,9 +30,11 @@
     <h2 class="heading-medium">Global Account Manager – One List</h2>
     {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
 
-    {% call HiddenContent({ summary: 'Need to edit the account management information?' }) %}
+    {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
       {% call Message({ type: 'muted' }) %}
-        If you need to change the One List tier or One List account manager for this company, please <a href="{{ feedbackLink }}">contact the support team</a>.
+        If you need to change the One List tier or Global account manager for this company,
+        please click <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">here</a>
+        or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
       {% endcall %}
     {% endcall %}
   </div>

--- a/test/acceptance/features/companies/account-management-save.feature
+++ b/test/acceptance/features/companies/account-management-save.feature
@@ -9,9 +9,9 @@ Feature: Save account management details for a company
     Then the Account management details are displayed
       | key                       | value                   |
       | One List tier             | None                    |
-      | Account manager           | None                    |
+      | Global account manager    | None                    |
     When the Account management details are updated
     Then the Account management details are displayed
       | key                       | value                       |
       | One List tier             | None                        |
-      | Account manager           | company.oneListAccountOwner |
+      | Global account manager    | company.oneListAccountOwner |

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -27,7 +27,7 @@ Feature: Create a new company
     And the Global Account Manager – One List details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | Account manager           | None                       |
+      | Global account manager    | None                       |
 
   @companies-save--uk-non-private-or-non-public-ltd-company
   Scenario: Create a UK non-private or non-public limited company
@@ -51,7 +51,7 @@ Feature: Create a new company
     And the Global Account Manager – One List details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | Account manager           | None                       |
+      | Global account manager    | None                       |
 
   @companies-save--foreign
   Scenario: Create a foreign company
@@ -75,7 +75,7 @@ Feature: Create a new company
     And the Global Account Manager – One List details are displayed
       | key                       | value                            |
       | One List tier             | None                             |
-      | Account manager           | None                             |
+      | Global account manager    | None                             |
 
   @companies-save--foreign-uk-branch
   Scenario: Create a UK branch of a foreign company
@@ -99,4 +99,4 @@ Feature: Create a new company
     And the Global Account Manager – One List details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | Account manager           | None                       |
+      | Global account manager    | None                       |

--- a/test/unit/apps/companies/controllers/details.test.js
+++ b/test/unit/apps/companies/controllers/details.test.js
@@ -1,4 +1,5 @@
 const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
+const config = require('~/config')
 const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
 const { renderDetails } = require('~/src/apps/companies/controllers/details')
 
@@ -46,6 +47,11 @@ describe('Companies details controller', () => {
         const options = this.res.render.firstCall.args[1]
         expect(options.accountManagementDetails).to.not.be.null
       })
+
+      it('should include a link to the One List support email', () => {
+        const options = this.res.render.firstCall.args[1]
+        expect(options.oneListEmail).to.equal(config.oneList.email)
+      })
     })
 
     context('when the company has no companies house data', () => {
@@ -72,6 +78,11 @@ describe('Companies details controller', () => {
       it('should include one list information', () => {
         const options = this.res.render.firstCall.args[1]
         expect(options.accountManagementDetails).to.not.be.null
+      })
+
+      it('should include a link to the One List support email', () => {
+        const options = this.res.render.firstCall.args[1]
+        expect(options.oneListEmail).to.equal(config.oneList.email)
       })
     })
   })

--- a/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
@@ -16,7 +16,7 @@ describe('transformCompanyToOneListView', () => {
 
     it('indicate there is no one list account management information', () => {
       expect(this.viewRecord).to.deep.equal({
-        'Account manager': 'None',
+        'Global account manager': 'None',
         'One List tier': 'None',
       })
     })
@@ -40,7 +40,7 @@ describe('transformCompanyToOneListView', () => {
 
     it('indicate there is no one list account management information', () => {
       expect(this.viewRecord).to.deep.equal({
-        'Account manager': 'The owner',
+        'Global account manager': 'The owner',
         'One List tier': 'The classification',
       })
     })


### PR DESCRIPTION
This changes the copy in the One List section so that users can email the one list email address directly instead of going through the support team if they need changes.

*Before*

![screen shot 2018-05-29 at 15 45 33](https://user-images.githubusercontent.com/178865/40666514-d3cc5d26-6357-11e8-889c-c37859e79232.png)

*After*

![screen shot 2018-05-29 at 15 50 18](https://user-images.githubusercontent.com/178865/40666587-036f153c-6358-11e8-9d7a-b69a89605a12.png)


