### PR TITLE
Swap Gemnasium for SNYK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/uktrade/data-hub-frontend.svg)](https://greenkeeper.io/)
 [![CircleCI](https://circleci.com/gh/uktrade/data-hub-frontend.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-frontend)
-[![Dependency Status](https://gemnasium.com/badges/github.com/uktrade/data-hub-frontend.svg)](https://gemnasium.com/github.com/uktrade/data-hub-frontend)
+[![Known Vulnerabilities](https://snyk.io/test/github/uktrade/data-hub-frontend/badge.svg)](https://snyk.io/test/github/uktrade/data-hub-frontend) 
 
 An express application that fetches data from a back end JSON based api and renders it to the screen.
 This front end layer is primarily turning requests from the browser into back end API calls and then


### PR DESCRIPTION
Gemnasium is no longer available and SNYK it now being used to track potential security issues related to out of date dependencies.

