### PR TITLE
Lock down form fields for One List companies

### DIFF
--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -260,23 +260,55 @@
       }) }}
     {% endif %}
 
-    {{ MultipleChoiceField({
-      type: 'radio',
-      name: 'headquarter_type',
-      label: 'Headquarter type',
-      options: options.headquarters,
-      value: formData.headquarter_type,
-      error: errors.headquarter_type
-    }) }}
+    {% if isOnOneList %}
+      <fieldset id="group-field-headquarter_type" class="c-form-group">
+        <legend class="c-form-group__label">
+          <span class="c-form-group__label-text">Headquarter type</span>
+        </legend>
 
-    {{ MultipleChoiceField({
-      name: 'sector',
-      label: 'Sector',
-      initialOption: '-- Select sector --',
-      options: options.sectors,
-      value: formData.sector,
-      error: errors.sector
-    }) }}
+        <p>{{companyDetails['Headquarter type']}}</p>
+
+        {% call HiddenContent({ summary: 'Need to edit the headquarter type?' }) %}
+          {% call Message({ type: 'muted' }) %}
+            If you need to change the headquarter type for a company on the One List, please email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+          {% endcall %}
+        {% endcall %}
+      </fieldset>
+    {% else %}
+      {{ MultipleChoiceField({
+        type: 'radio',
+        name: 'headquarter_type',
+        label: 'Headquarter type',
+        options: options.headquarters,
+        value: formData.headquarter_type,
+        error: errors.headquarter_type
+      }) }}
+    {% endif %}
+
+    {% if isOnOneList %}
+      <fieldset id="group-field-sector" class="c-form-group">
+        <legend class="c-form-group__label">
+          <span class="c-form-group__label-text">Sector</span>
+        </legend>
+
+        <p>{{companyDetails['Sector']}}</p>
+
+        {% call HiddenContent({ summary: 'Need to edit the sector?' }) %}
+          {% call Message({ type: 'muted' }) %}
+            If you need to change the sector for a company on the One List, please email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+          {% endcall %}
+        {% endcall %}
+      </fieldset>
+    {% else %}
+      {{ MultipleChoiceField({
+        name: 'sector',
+        label: 'Sector',
+        initialOption: '-- Select sector --',
+        options: options.sectors,
+        value: formData.sector,
+        error: errors.sector
+      }) }}
+    {% endif %}
 
     {{ TextField({
       name: 'website',

--- a/test/acceptance/features/companies/edit.feature
+++ b/test/acceptance/features/companies/edit.feature
@@ -31,4 +31,12 @@ Feature: Company details
     Then I see the success message
     And details view data for "Headquarter type" should contain "Global HQ"
 
+  @companies-edit--one-list
+  Scenario: Update one list company
+
+    When I navigate to the `companies.fixture` page using `company` `One List Corp` fixture
+    When I click the Global headquarters summary edit button
+    Then I cannot see the field "headquarter_type"
+    And I cannot see the field "sector"
+
   # TODO add more editing and viewing in details work

--- a/test/acceptance/features/step_definitions/form.js
+++ b/test/acceptance/features/step_definitions/form.js
@@ -91,3 +91,10 @@ Then(/^there are form fields$/, async function (dataTable) {
       .assert.visible(selectors.element)
   }
 })
+
+Then(/^I can(not)? see the field "(.+)"$/, async function (negate, fieldName) {
+  const fieldSelector = `[name="${fieldName}"]`
+  const expectation = negate ? 'elementNotPresent' : 'elementPresent'
+
+  await client.assert[expectation](fieldSelector)
+})

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -50,6 +50,21 @@ module.exports = {
       description: 'This is a dummy company for testing',
       referenceCode: 'ORG-10096257',
     },
+    oneList: {
+      id: '375094ac-f79a-43e5-9c88-059a7caa17f0',
+      name: 'One List Corp',
+      address1: '12 St George\'s Road',
+      town: 'Paris',
+      postcode: '75001',
+      country: 'France',
+      primaryAddress: '12 St George\'s Road, Paris, 75001, France',
+      businessType: 'Company',
+      headquarterType: 'Global HQ',
+      sector: 'Retail',
+      description: 'This is a dummy company for testing the One List',
+      employeeRange: '500+',
+      turnoverRange: '£33.5M+',
+    },
   },
   contact: {
     georginaClark: {

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -70,6 +70,15 @@ describe('Company edit controller', () => {
         company: companyMock,
       },
     }
+    this.getCalledRenderLocals = () => {
+      return this.resMock.render.firstCall.args[1]
+    }
+    this.getCalledRenderView = () => {
+      return this.resMock.render.firstCall.args[0]
+    }
+    this.getCalledBreadcrumb = (call = 0) => {
+      return this.resMock.breadcrumb.getCall(call)
+    }
   })
 
   describe('renderForm', () => {
@@ -98,31 +107,43 @@ describe('Company edit controller', () => {
       })
 
       it('should render the edit page', () => {
-        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+        expect(this.getCalledRenderView()).to.equal('companies/views/edit')
       })
 
       it('should set the add breadcrumb', () => {
-        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Add')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add')
       })
 
       it('should set heading', () => {
-        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Add UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Add UK company')
       })
 
       it('should set isForeign', () => {
-        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+        expect(this.getCalledRenderLocals().isForeign).to.be.false
+      })
+
+      it('should set isOnOneList', () => {
+        expect(this.getCalledRenderLocals().isOnOneList).to.be.false
+      })
+
+      it('should not include company details', () => {
+        expect(this.getCalledRenderLocals().companyDetails).to.deep.equal({})
+      })
+
+      it('should include a link to the One List support email', () => {
+        expect(this.getCalledRenderLocals().oneListEmail).to.equal(config.oneList.email)
       })
 
       it('should set businessTypeLabel', () => {
-        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('UK branch of foreign company (BR)')
+        expect(this.getCalledRenderLocals().businessTypeLabel).to.equal('UK branch of foreign company (BR)')
       })
 
       it('should show the company number field', () => {
-        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.true
+        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.true
       })
 
       it('should not show the trading address fields', () => {
-        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+        expect(this.getCalledRenderLocals().showTradingAddress).to.be.false
       })
     })
 
@@ -150,39 +171,51 @@ describe('Company edit controller', () => {
       })
 
       it('should render the edit page', () => {
-        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+        expect(this.getCalledRenderView()).to.equal('companies/views/edit')
       })
 
       it('should set the company breadcrumb text', () => {
-        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Existing UK branch of foreign company')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Existing UK branch of foreign company')
       })
 
       it('should set the company breadcrumb link', () => {
-        expect(this.resMock.breadcrumb.getCall(0).args[1]).to.equal('/companies/1')
+        expect(this.getCalledBreadcrumb().args[1]).to.equal('/companies/1')
       })
 
       it('should set the edit breadcrumb', () => {
-        expect(this.resMock.breadcrumb.getCall(1).args[0]).to.equal('Edit')
+        expect(this.getCalledBreadcrumb(1).args[0]).to.equal('Edit')
       })
 
       it('should set heading', () => {
-        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Edit UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Edit UK company')
       })
 
       it('should set isForeign', () => {
-        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+        expect(this.getCalledRenderLocals().isForeign).to.be.false
+      })
+
+      it('should set isOnOneList', () => {
+        expect(this.getCalledRenderLocals().isOnOneList).to.be.false
+      })
+
+      it('should include company details', () => {
+        expect(this.getCalledRenderLocals().companyDetails).to.not.be.null
+      })
+
+      it('should include a link to the One List support email', () => {
+        expect(this.getCalledRenderLocals().oneListEmail).to.equal(config.oneList.email)
       })
 
       it('should set businessTypeLabel', () => {
-        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('UK branch of foreign company (BR)')
+        expect(this.getCalledRenderLocals().businessTypeLabel).to.equal('UK branch of foreign company (BR)')
       })
 
       it('should show the company number field', () => {
-        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.true
+        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.true
       })
 
       it('should not show the trading address fields', () => {
-        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+        expect(this.getCalledRenderLocals().showTradingAddress).to.be.false
       })
     })
 
@@ -205,31 +238,43 @@ describe('Company edit controller', () => {
       })
 
       it('should render the edit page', () => {
-        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+        expect(this.getCalledRenderView()).to.equal('companies/views/edit')
       })
 
       it('should set the add breadcrumb', () => {
-        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Add')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add')
       })
 
       it('should set heading', () => {
-        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Add UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Add UK company')
       })
 
       it('should set isForeign', () => {
-        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+        expect(this.getCalledRenderLocals().isForeign).to.be.false
+      })
+
+      it('should set isOnOneList', () => {
+        expect(this.getCalledRenderLocals().isOnOneList).to.be.false
+      })
+
+      it('should not include company details', () => {
+        expect(this.getCalledRenderLocals().companyDetails).to.deep.equal({})
+      })
+
+      it('should include a link to the One List support email', () => {
+        expect(this.getCalledRenderLocals().oneListEmail).to.equal(config.oneList.email)
       })
 
       it('should set businessTypeLabel', () => {
-        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('Sole Trader')
+        expect(this.getCalledRenderLocals().businessTypeLabel).to.equal('Sole Trader')
       })
 
       it('should not show the company number field', () => {
-        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.false
+        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.false
       })
 
       it('should not show the trading address fields', () => {
-        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+        expect(this.getCalledRenderLocals().showTradingAddress).to.be.false
       })
     })
 
@@ -252,31 +297,43 @@ describe('Company edit controller', () => {
       })
 
       it('should render the edit page', () => {
-        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+        expect(this.getCalledRenderView()).to.equal('companies/views/edit')
       })
 
       it('should set the add breadcrumb', () => {
-        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Add')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add')
       })
 
       it('should set heading', () => {
-        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Add foreign company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Add foreign company')
       })
 
       it('should set isForeign', () => {
-        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.true
+        expect(this.getCalledRenderLocals().isForeign).to.be.true
+      })
+
+      it('should set isOnOneList', () => {
+        expect(this.getCalledRenderLocals().isOnOneList).to.be.false
+      })
+
+      it('should not include company details', () => {
+        expect(this.getCalledRenderLocals().companyDetails).to.deep.equal({})
+      })
+
+      it('should include a link to the One List support email', () => {
+        expect(this.getCalledRenderLocals().oneListEmail).to.equal(config.oneList.email)
       })
 
       it('should set businessTypeLabel', () => {
-        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('Sole Trader')
+        expect(this.getCalledRenderLocals().businessTypeLabel).to.equal('Sole Trader')
       })
 
       it('should not show the company number field', () => {
-        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.false
+        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.false
       })
 
       it('should not show the trading address fields', () => {
-        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.false
+        expect(this.getCalledRenderLocals().showTradingAddress).to.be.false
       })
     })
 
@@ -305,31 +362,86 @@ describe('Company edit controller', () => {
       })
 
       it('should render the edit page', () => {
-        expect(this.resMock.render.getCall(0).args[0]).to.equal('companies/views/edit')
+        expect(this.getCalledRenderView()).to.equal('companies/views/edit')
       })
 
       it('should set the add breadcrumb', () => {
-        expect(this.resMock.breadcrumb.getCall(0).args[0]).to.equal('Existing government department')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Existing government department')
       })
 
       it('should set heading', () => {
-        expect(this.resMock.render.getCall(0).args[1].heading).to.equal('Edit UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Edit UK company')
       })
 
       it('should set isForeign', () => {
-        expect(this.resMock.render.getCall(0).args[1].isForeign).to.be.false
+        expect(this.getCalledRenderLocals().isForeign).to.be.false
+      })
+
+      it('should set isOnOneList', () => {
+        expect(this.getCalledRenderLocals().isOnOneList).to.be.false
+      })
+
+      it('should include company details', () => {
+        expect(this.getCalledRenderLocals().companyDetails).to.not.be.null
       })
 
       it('should set businessTypeLabel', () => {
-        expect(this.resMock.render.getCall(0).args[1].businessTypeLabel).to.equal('Government department')
+        expect(this.getCalledRenderLocals().businessTypeLabel).to.equal('Government department')
+      })
+
+      it('should include a link to the One List support email', () => {
+        expect(this.getCalledRenderLocals().oneListEmail).to.equal(config.oneList.email)
       })
 
       it('should not show the company number field', () => {
-        expect(this.resMock.render.getCall(0).args[1].showCompanyNumber).to.be.false
+        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.false
       })
 
       it('should not show the trading address fields', () => {
-        expect(this.resMock.render.getCall(0).args[1].showTradingAddress).to.be.true
+        expect(this.getCalledRenderLocals().showTradingAddress).to.be.true
+      })
+    })
+
+    context('when editing a company on the One List', () => {
+      beforeEach(async () => {
+        const resMock = assign(this.resMock, {
+          locals: {
+            company: {
+              id: 1,
+              name: 'One List Company',
+              classification: {
+                id: '4321',
+                name: 'The classification',
+              },
+            },
+          },
+        })
+
+        await this.controller.renderForm(this.reqMock, resMock, this.nextSpy)
+      })
+
+      it('should render the edit page', () => {
+        expect(this.getCalledRenderView()).to.equal('companies/views/edit')
+      })
+
+      it('should set the add breadcrumb', () => {
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('One List Company')
+      })
+
+      it('should set heading', () => {
+        expect(this.getCalledRenderLocals().heading).to.equal('Edit foreign company')
+      })
+
+      it('should set isOnOneList', () => {
+        expect(this.getCalledRenderLocals().isOnOneList).to.be.true
+      })
+
+      it('should include company details', () => {
+        expect(this.getCalledRenderLocals().companyDetails).to.not.be.null
+      })
+
+      it('should include a link to the One List support email', () => {
+        expect(this.getCalledRenderLocals().oneListEmail).to.equal(config.oneList.email)
       })
     })
   })


### PR DESCRIPTION
This locks down the fields `sector` and `headquarter_type` for companies on the One List.
Changing those fields in that case should only be allowed by specific people and only via the admin area.

<img width="809" alt="screen shot 2018-06-01 at 10 15 46" src="https://user-images.githubusercontent.com/178865/40833075-cc13782e-6584-11e8-9bf0-4d372f9c54cf.png">
