### PR TITLE
Filter subsidiary suggestions to exclude Global HQ

### DIFF
--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -7,6 +7,13 @@ const {
   transformCompaniesHouseToListItem,
 } = require('../transformers')
 
+const globalHQId = '43281c5e-92a4-4794-867b-b4d5f801e6f3'
+const nonGLobalHQId = [
+  null,
+  '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+  'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+]
+
 async function getCompanyCollection (req, res, next) {
   try {
     res.locals.results = await search({
@@ -60,7 +67,6 @@ async function getLimitedCompaniesCollection (req, res, next) {
 
 async function getGlobalHQCompaniesCollection (req, res, next) {
   const searchTerm = res.locals.searchTerm = req.query.term
-  const globalHQId = '43281c5e-92a4-4794-867b-b4d5f801e6f3'
   const { id: companyId } = res.locals.company
 
   if (!searchTerm) {
@@ -109,6 +115,7 @@ async function getSubsidiaryCompaniesCollection (req, res, next) {
       page: req.query.page,
       requestBody: {
         ...req.body,
+        headquarter_type: nonGLobalHQId,
       },
     })
       .then(transformApiResponseToSearchCollection(

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -4,10 +4,14 @@ const config = require('~/config')
 const companiesHouseSearchResults = require('~/test/unit/data/companies/companies-house-search.json')
 const ghqCompanySearchResponse = require('~/test/unit/data/companies/ghq-company-search-response.json')
 const ghqCompanyTransformedResults = require('~/test/unit/data/companies/ghq-company-transformed-results.json')
+const subsidiaryCompanySearchResponse = require('~/test/unit/data/companies/subsidiary-company-search-response.json')
+const subsidiaryCompanyTransformedResults = require('~/test/unit/data/companies/subsidiary-company-transformed-results.json')
+
 const {
   getRequestBody,
   getCompanyCollection,
   getGlobalHQCompaniesCollection,
+  getSubsidiaryCompaniesCollection,
 } = require('~/src/apps/companies/middleware/collection')
 
 describe('Company collection middleware', () => {
@@ -203,6 +207,139 @@ describe('Company collection middleware', () => {
 
         it('should have expected error message', () => {
           expect(this.nextSpy.args[0][0].message).to.have.string(`Error: ${this.errorMsg}`)
+        })
+
+        it('results should be undefined', () => {
+          expect(this.resMock.locals.results).to.be.undefined
+        })
+      })
+    })
+  })
+
+  describe('#getSubsidiaryCompaniesCollection', () => {
+    beforeEach(async () => {
+      this.resMock.locals.company = { id: 'mock-parent-company-id' }
+    })
+
+    context('no searchTerm', () => {
+      beforeEach(async () => {
+        this.reqMock.query = {}
+        await getSubsidiaryCompaniesCollection(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy.calledOnce).to.be.true
+        expect(this.nextSpy).to.be.calledWithExactly()
+      })
+
+      it('results should be undefined', () => {
+        expect(this.resMock.locals.results).to.be.undefined
+      })
+    })
+
+    context('with searchTerm', () => {
+      beforeEach(() => {
+        this.reqMock.query.term = 'mock-search-term'
+      })
+
+      context('a couple of results', () => {
+        beforeEach(async () => {
+          nock(config.apiRoot)
+            .post('/v3/search/company?offset=0&limit=10', {
+              headquarter_type: [
+                null,
+                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+                'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+              ],
+              original_query: 'mock-search-term',
+              isAggregation: false,
+            })
+            .reply(200, subsidiaryCompanySearchResponse)
+
+          await getSubsidiaryCompaniesCollection(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        it('should return results', () => {
+          expect(this.resMock.locals).to.have.property('results')
+        })
+
+        it('should include a count of results', () => {
+          const results = this.resMock.locals.results
+          expect(results).to.have.property('count', 2)
+        })
+
+        it('should not include any pagination information', () => {
+          const results = this.resMock.locals.results
+          expect(results).to.have.property('pagination', null)
+        })
+
+        it('should include transformed result items', () => {
+          const results = this.resMock.locals.results
+          expect(results).to.have.property('items')
+          expect(results.items).to.deep.equal(subsidiaryCompanyTransformedResults.items)
+        })
+
+        it('should call next', () => {
+          expect(this.nextSpy).to.be.calledOnce
+          expect(this.nextSpy).to.be.calledWithExactly()
+        })
+      })
+
+      context('more than 10 results', () => {
+        beforeEach(async () => {
+          nock(config.apiRoot)
+            .post('/v3/search/company?offset=0&limit=10', {
+              headquarter_type: [
+                null,
+                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+                'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+              ],
+              original_query: 'mock-search-term',
+              isAggregation: false,
+            })
+            .reply(200, {
+              ...subsidiaryCompanySearchResponse,
+              count: 50,
+            })
+
+          await getSubsidiaryCompaniesCollection(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        it('should include pagination information', () => {
+          const results = this.resMock.locals.results
+          expect(results).to.have.property('pagination')
+          expect(results.pagination).to.have.property('currentPage', 1)
+          expect(results.pagination).to.have.property('prev')
+          expect(results.pagination).to.have.property('next')
+          expect(results.pagination.pages).to.have.length(5)
+        })
+      })
+
+      context('with error response', () => {
+        beforeEach(async () => {
+          this.errorMsg = 'oh no!'
+
+          nock(config.apiRoot)
+            .post('/v3/search/company?offset=0&limit=10', {
+              headquarter_type: [
+                null,
+                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+                'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+              ],
+              original_query: 'mock-search-term',
+              isAggregation: false,
+            })
+            .reply(500, this.errorMsg)
+
+          await getSubsidiaryCompaniesCollection(this.reqMock, this.resMock, this.nextSpy)
+        })
+
+        it('should call next', () => {
+          expect(this.nextSpy.calledOnce).to.be.true
+        })
+
+        it('should have expected error message', () => {
+          expect(this.nextSpy.firstCall.args[0].message).to.have.string(`500 - "${this.errorMsg}"`)
         })
 
         it('results should be undefined', () => {

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -14,6 +14,20 @@ const {
   getSubsidiaryCompaniesCollection,
 } = require('~/src/apps/companies/middleware/collection')
 
+const headquarterTypes = [{
+  id: '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+  name: 'ukhq',
+  disabled_on: null,
+}, {
+  id: 'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+  name: 'ehq',
+  disabled_on: null,
+}, {
+  id: '43281c5e-92a4-4794-867b-b4d5f801e6f3',
+  name: 'ghq',
+  disabled_on: null,
+}]
+
 describe('Company collection middleware', () => {
   beforeEach(() => {
     this.mockCompanyResults = {
@@ -174,6 +188,8 @@ describe('Company collection middleware', () => {
           this.reqMock.query.term = 'mock-search-term'
 
           nock(config.apiRoot)
+            .get('/metadata/headquarter-type/')
+            .reply(200, headquarterTypes)
             .post('/v3/search/company?offset=0&limit=10')
             .reply(200, ghqCompanySearchResponse)
 
@@ -195,6 +211,8 @@ describe('Company collection middleware', () => {
           this.errorMsg = 'oh no!'
 
           nock(config.apiRoot)
+            .get('/metadata/headquarter-type/')
+            .reply(200, headquarterTypes)
             .post('/v3/search/company?offset=0&limit=10')
             .replyWithError(this.errorMsg)
 
@@ -245,11 +263,13 @@ describe('Company collection middleware', () => {
       context('a couple of results', () => {
         beforeEach(async () => {
           nock(config.apiRoot)
+            .get('/metadata/headquarter-type/')
+            .reply(200, headquarterTypes)
             .post('/v3/search/company?offset=0&limit=10', {
               headquarter_type: [
-                null,
-                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
                 'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+                null,
               ],
               original_query: 'mock-search-term',
               isAggregation: false,
@@ -288,11 +308,13 @@ describe('Company collection middleware', () => {
       context('more than 10 results', () => {
         beforeEach(async () => {
           nock(config.apiRoot)
+            .get('/metadata/headquarter-type/')
+            .reply(200, headquarterTypes)
             .post('/v3/search/company?offset=0&limit=10', {
               headquarter_type: [
-                null,
-                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
                 'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+                null,
               ],
               original_query: 'mock-search-term',
               isAggregation: false,
@@ -320,11 +342,13 @@ describe('Company collection middleware', () => {
           this.errorMsg = 'oh no!'
 
           nock(config.apiRoot)
+            .get('/metadata/headquarter-type/')
+            .reply(200, headquarterTypes)
             .post('/v3/search/company?offset=0&limit=10', {
               headquarter_type: [
-                null,
-                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
                 'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+                '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+                null,
               ],
               original_query: 'mock-search-term',
               isAggregation: false,

--- a/test/unit/data/companies/subsidiary-company-search-response.json
+++ b/test/unit/data/companies/subsidiary-company-search-response.json
@@ -1,0 +1,178 @@
+{
+  "count": 2,
+  "results": [
+    {
+      "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd",
+      "account_manager": null,
+      "archived_by": null,
+      "business_type": {
+        "id": "98d14e94-5d95-e211-a939-e4115bead28a",
+        "name": "Company"
+      },
+      "classification": null,
+      "companies_house_data": null,
+      "contacts": [
+        {
+          "id": "7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b",
+          "first_name": "Mark",
+          "last_name": "Halomi",
+          "name": "Mark Halomi"
+        },
+        {
+          "id": "6791d583-7a52-418f-a0d3-d8d527f20d43",
+          "first_name": "Benjamina",
+          "last_name": "Clarksoon",
+          "name": "Benjamina Clarksoon"
+        }
+      ],
+      "employee_range": {
+        "id": "41afd8d0-5d95-e211-a939-e4115bead28a",
+        "name": "500+"
+      },
+      "export_experience_category": null,
+      "export_to_countries": [
+        {
+          "id": "82756b9a-5d95-e211-a939-e4115bead28a",
+          "name": "France"
+        },
+        {
+          "id": "83756b9a-5d95-e211-a939-e4115bead28a",
+          "name": "Germany"
+        }
+      ],
+      "future_interest_countries": [
+        {
+          "id": "37afd8d0-5d95-e211-a939-e4115bead28a",
+          "name": "Yemen"
+        }
+      ],
+      "global_headquarters": null,
+      "headquarter_type": null,
+      "one_list_account_owner": null,
+      "parent": null,
+      "registered_address_country": {
+        "id": "81756b9a-5d95-e211-a939-e4115bead28a",
+        "name": "United States"
+      },
+      "sector": {
+        "id": "355f977b-8ac3-e211-a646-e4115bead28a",
+        "name": "Retail",
+        "ancestors": [
+
+        ]
+      },
+      "trading_address_country": null,
+      "turnover_range": {
+        "id": "7a4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "\u00a333.5M+"
+      },
+      "uk_based": false,
+      "uk_region": null,
+      "trading_name": null,
+      "registered_address_town": "New York",
+      "archived": false,
+      "trading_address_2": null,
+      "trading_address_postcode": null,
+      "description": "This is a dummy company for testing",
+      "registered_address_county": null,
+      "registered_address_postcode": "765413",
+      "archived_on": null,
+      "trading_address_town": null,
+      "trading_address_county": null,
+      "website": null,
+      "registered_address_1": "12 First Street",
+      "registered_address_2": null,
+      "name": "Mars Exports Ltd",
+      "modified_on": "2017-11-16T11:00:00+00:00",
+      "archived_reason": null,
+      "reference_code": "",
+      "vat_number": "",
+      "trading_address_1": null,
+      "company_number": null,
+      "created_on": "2017-10-16T11:00:00+00:00"
+    },
+    {
+      "id": "731bdcc1-f685-4c8e-bd66-b356b2c16995",
+      "account_manager": null,
+      "archived_by": null,
+      "business_type": {
+        "id": "9ad14e94-5d95-e211-a939-e4115bead28a",
+        "name": "Partnership"
+      },
+      "classification": null,
+      "companies_house_data": null,
+      "contacts": [
+
+      ],
+      "employee_range": {
+        "id": "41afd8d0-5d95-e211-a939-e4115bead28a",
+        "name": "500+"
+      },
+      "export_experience_category": null,
+      "export_to_countries": [
+        {
+          "id": "35afd8d0-5d95-e211-a939-e4115bead28a",
+          "name": "Occupied Palestinian Territories"
+        },
+        {
+          "id": "36afd8d0-5d95-e211-a939-e4115bead28a",
+          "name": "Western Sahara"
+        }
+      ],
+      "future_interest_countries": [
+        {
+          "id": "37afd8d0-5d95-e211-a939-e4115bead28a",
+          "name": "Yemen"
+        }
+      ],
+      "global_headquarters": null,
+      "headquarter_type": null,
+      "one_list_account_owner": null,
+      "parent": null,
+      "registered_address_country": {
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+        "name": "United Kingdom"
+      },
+      "sector": {
+        "id": "355f977b-8ac3-e211-a646-e4115bead28a",
+        "name": "Retail",
+        "ancestors": [
+
+        ]
+      },
+      "trading_address_country": null,
+      "turnover_range": {
+        "id": "7a4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "\u00a333.5M+"
+      },
+      "uk_based": true,
+      "uk_region": {
+        "id": "824cd12a-6095-e211-a939-e4115bead28a",
+        "name": "North West"
+      },
+      "trading_name": null,
+      "registered_address_town": "Volcanus",
+      "archived": false,
+      "trading_address_2": null,
+      "trading_address_postcode": null,
+      "description": "This is a dummy company for testing",
+      "registered_address_county": null,
+      "registered_address_postcode": "NE28 5AQ",
+      "archived_on": null,
+      "trading_address_town": null,
+      "trading_address_county": null,
+      "website": null,
+      "registered_address_1": "12 Alpha Street",
+      "registered_address_2": null,
+      "name": "Mars Components Ltd",
+      "modified_on": "2017-10-16T11:00:00+00:00",
+      "archived_reason": null,
+      "reference_code": "",
+      "vat_number": "",
+      "trading_address_1": null,
+      "company_number": null,
+      "created_on": "2016-09-16T11:00:00+00:00"
+    }
+  ],
+  "page": 1
+}

--- a/test/unit/data/companies/subsidiary-company-transformed-results.json
+++ b/test/unit/data/companies/subsidiary-company-transformed-results.json
@@ -1,0 +1,62 @@
+{
+  "items": [
+    {
+      "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd",
+      "name": "Mars Exports Ltd",
+      "url": "\/companies\/mock-parent-company-id\/hierarchies\/subsidiaries\/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd\/add",
+      "meta": [
+        {
+          "label": "Sector",
+          "value": "Retail"
+        },
+        {
+          "label": "Country",
+          "type": "badge",
+          "value": "United States"
+        },
+        {
+          "label": "Primary address",
+          "value": "12 First Street, New York, 765413, United States"
+        }
+      ],
+      "subTitle": {
+        "type": "datetime",
+        "value": "2017-11-16T11:00:00+00:00",
+        "label": "Updated on"
+      },
+      "type": "company"
+    },
+    {
+      "id": "731bdcc1-f685-4c8e-bd66-b356b2c16995",
+      "name": "Mars Components Ltd",
+      "url": "\/companies\/mock-parent-company-id\/hierarchies\/subsidiaries\/731bdcc1-f685-4c8e-bd66-b356b2c16995\/add",
+      "meta": [
+        {
+          "label": "Sector",
+          "value": "Retail"
+        },
+        {
+          "label": "Country",
+          "type": "badge",
+          "value": "United Kingdom"
+        },
+        {
+          "label": "UK region",
+          "type": "badge",
+          "value": "North West"
+        },
+        {
+          "label": "Primary address",
+          "value": "12 Alpha Street, Volcanus, NE28 5AQ, United Kingdom"
+        }
+      ],
+      "subTitle": {
+        "type": "datetime",
+        "value": "2017-10-16T11:00:00+00:00",
+        "label": "Updated on"
+      },
+      "type": "company"
+    }
+  ],
+  "count": 2
+}


### PR DESCRIPTION
When a user adds a subsidiary the list of companies returned by search should exclude companies that are flagged as a global HQ.