### PR TITLE
Event attendees

### DIFF
--- a/src/apps/events/constants.js
+++ b/src/apps/events/constants.js
@@ -13,8 +13,19 @@ const GLOBAL_NAV_ITEM = {
 
 const APP_PERMISSIONS = [ GLOBAL_NAV_ITEM ]
 
+const LOCAL_NAV = [
+  {
+    path: 'details',
+    label: 'Details',
+    permissions: [
+      'event.read_event',
+    ],
+  },
+]
+
 module.exports = {
   GLOBAL_NAV_ITEM,
   DEFAULT_COLLECTION_QUERY,
   APP_PERMISSIONS,
+  LOCAL_NAV,
 }

--- a/src/apps/events/constants.js
+++ b/src/apps/events/constants.js
@@ -21,6 +21,13 @@ const LOCAL_NAV = [
       'event.read_event',
     ],
   },
+  {
+    path: 'attendees',
+    label: 'Attendees',
+    permissions: [
+      'event.read_event',
+    ],
+  },
 ]
 
 module.exports = {

--- a/src/apps/events/controllers/attendees.js
+++ b/src/apps/events/controllers/attendees.js
@@ -1,0 +1,36 @@
+const { get } = require('lodash')
+
+const { transformApiResponseToCollection } = require('../../transformers')
+const { fetchEventAttendees } = require('../repos')
+const { transformServiceDeliveryToAttendeeListItem } = require('../../interactions/transformers')
+
+async function renderAttendees (req, res, next) {
+  try {
+    const eventId = req.params.eventId
+    const name = get(res.locals, 'event.name')
+    const query = req.query
+    const page = query.page || 1
+    const token = req.session.token
+
+    const attendees = await fetchEventAttendees(token, eventId, page)
+      .then(transformApiResponseToCollection(
+        { query },
+        transformServiceDeliveryToAttendeeListItem
+      ))
+
+    res
+      .breadcrumb(name)
+      .render('events/views/attendees', {
+        attendees: {
+          ...attendees,
+          countLabel: 'attendee',
+        },
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderAttendees,
+}

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -47,10 +47,28 @@ async function getActiveEvents (token, createdOn) {
   return eventsResponse.results
 }
 
+async function fetchEventAttendees (token, eventId, page = 1) {
+  const limit = 10
+  const offset = limit * (page - 1)
+
+  const eventAttendees = await authorisedRequest(token, {
+    url: `${config.apiRoot}/v3/interaction`,
+    qs: {
+      limit,
+      offset,
+      event_id: eventId,
+      sortby: 'contact__last_name,contact__first_name',
+    },
+  })
+
+  return eventAttendees
+}
+
 module.exports = {
   saveEvent,
   fetchEvent,
   getEvents,
   getAllEvents,
   getActiveEvents,
+  fetchEventAttendees,
 }

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -8,6 +8,7 @@ const { renderEditPage } = require('./controllers/edit')
 const { postDetails, getEventDetails } = require('./middleware/details')
 const { getRequestBody, getEventsCollection } = require('./middleware/collection')
 const { renderEventList } = require('./controllers/list')
+const { renderAttendees } = require('./controllers/attendees')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
@@ -32,5 +33,6 @@ router.route('/:eventId/edit')
 
 router.get('/:eventId', redirectToFirstNavItem)
 router.get('/:eventId/details', renderDetailsPage)
+router.get('/:eventId/attendees', renderAttendees)
 
 module.exports = router

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,8 +1,8 @@
 const router = require('express').Router()
 
-const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS } = require('./constants')
+const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, LOCAL_NAV } = require('./constants')
 
-const { setDefaultQuery, handleRoutePermissions } = require('../middleware')
+const { setDefaultQuery, handleRoutePermissions, setLocalNav, redirectToFirstNavItem } = require('../middleware')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderEditPage } = require('./controllers/edit')
 const { postDetails, getEventDetails } = require('./middleware/details')
@@ -11,7 +11,13 @@ const { renderEventList } = require('./controllers/list')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
-router.param('id', getEventDetails)
+router.route('/create')
+  .post(postDetails, renderEditPage)
+  .get(renderEditPage)
+
+router.param('eventId', getEventDetails)
+
+router.use('/:eventId', handleRoutePermissions(LOCAL_NAV), setLocalNav(LOCAL_NAV))
 
 router.get('/',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
@@ -20,10 +26,11 @@ router.get('/',
   renderEventList,
 )
 
-router.route(['/create', '/:id/edit'])
+router.route('/:eventId/edit')
   .post(postDetails, renderEditPage)
   .get(renderEditPage)
 
-router.get('/:id', renderDetailsPage)
+router.get('/:eventId', redirectToFirstNavItem)
+router.get('/:eventId/details', renderDetailsPage)
 
 module.exports = router

--- a/src/apps/events/views/_layout.njk
+++ b/src/apps/events/views/_layout.njk
@@ -1,0 +1,5 @@
+{% extends "_layouts/two-column.njk" %}
+
+{% block main_grid_left_column %}
+  {{ LocalNav({ items: localNavItems }) }}
+{% endblock %}

--- a/src/apps/events/views/attendees.njk
+++ b/src/apps/events/views/attendees.njk
@@ -1,0 +1,6 @@
+{% extends "./_layout.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Event Attendees</h2>
+  {{ CollectionContent(attendees) }}
+{% endblock %}

--- a/src/apps/events/views/details.njk
+++ b/src/apps/events/views/details.njk
@@ -1,6 +1,6 @@
-{% extends "_layouts/two-column.njk" %}
+{% extends "./_layout.njk" %}
 
 {% block main_grid_right_column %}
   {% component 'key-value-table', variant='striped', items=eventViewRecord %}
-  <a class="button button--secondary" href="{{ event.id }}/edit">Edit event</a>
+  <a class="button button--secondary" href="/events/{{ event.id }}/edit">Edit event</a>
 {% endblock %}

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -56,7 +56,15 @@ const filters = {
   sector_descends: 'Sector',
 }
 
+const attendeeLabels = {
+  company: 'Company',
+  job_title: 'Job title',
+  attended_date: 'Date attended',
+  service_delivery: 'Service delivery',
+}
+
 module.exports = {
+  attendeeLabels,
   interaction,
   serviceDelivery,
   policyFeedback,

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -1,10 +1,11 @@
 /* eslint-disable camelcase */
-const { get, assign, isNil, omit, pickBy, camelCase } = require('lodash')
+const { assign, camelCase, compact, get, isNil, omit, pickBy } = require('lodash')
 const { format, isValid } = require('date-fns')
 
 const { transformDateObjectToDateString } = require('../transformers')
 const config = require('../../../config')
 const labels = require('./labels')
+
 const { INTERACTION_NAMES } = require('./constants')
 
 const transformEntityLink = (entity, entityPath, noLinkText = null) => {
@@ -198,10 +199,42 @@ function transformInteractionListItemToHaveUrlPrefix (urlPrefix) {
   }
 }
 
+function transformServiceDeliveryToAttendeeListItem ({ contact, company, date, id }) {
+  if (!contact || !company) { return }
+
+  const { attendeeLabels } = labels
+
+  const {
+    id: contactId,
+    name,
+    job_title,
+  } = contact
+
+  const metaItems = [
+    { key: 'company', value: company.name, url: `/companies/${company.id}` },
+    { key: 'job_title', value: job_title },
+    { key: 'attended_date', value: date, type: 'date' },
+    { key: 'service_delivery', value: 'View service delivery', url: `/interactions/${id}` },
+  ]
+    .filter(({ value }) => value)
+    .map(({ key, value, type, url }) => ({
+      ...pickBy({ value, type, url }),
+      label: attendeeLabels[key],
+    }))
+
+  return {
+    id: contactId,
+    type: 'contact',
+    name,
+    meta: compact(metaItems),
+  }
+}
+
 module.exports = {
   transformInteractionResponseToForm,
   transformInteractionToListItem,
   transformInteractionFormBodyToApiRequest,
   transformInteractionResponseToViewRecord,
   transformInteractionListItemToHaveUrlPrefix,
+  transformServiceDeliveryToAttendeeListItem,
 }

--- a/test/acceptance/features/events/attendeed.feature
+++ b/test/acceptance/features/events/attendeed.feature
@@ -1,0 +1,8 @@
+@event-attendees
+Feature: Event attendees
+
+@event-attendees--collection-list
+Scenario: Event lists attendees
+  When I navigate to the `events.attendees` page using `event` `Grand exhibition` fixture
+  And the results summary for an attendee collection is present
+  And I can view the collection

--- a/test/acceptance/features/events/details.feature
+++ b/test/acceptance/features/events/details.feature
@@ -3,14 +3,16 @@ Feature: Event details
 
   @events-details--documents-link
   Scenario: Event has Documents link
-
     When I navigate to the `events.fixture` page using `event` `One-day exhibition` fixture
-    Then there should not be a local nav
+    Then there should be a local nav
+      | text             |
+      | Details          |
     And details view data for "Documents" should contain "View files and documents (will open another website)"
 
   @events-details--no-documents-link
   Scenario: Event does not have Documents link
-
     When I navigate to the `events.fixture` page using `event` `Grand exhibition` fixture
-    Then there should not be a local nav
+    Then there should be a local nav
+      | text             |
+      | Details          |
     And details view data for "Documents" should contain "There are no files or documents"

--- a/test/acceptance/features/events/details.feature
+++ b/test/acceptance/features/events/details.feature
@@ -4,15 +4,9 @@ Feature: Event details
   @events-details--documents-link
   Scenario: Event has Documents link
     When I navigate to the `events.fixture` page using `event` `One-day exhibition` fixture
-    Then there should be a local nav
-      | text             |
-      | Details          |
     And details view data for "Documents" should contain "View files and documents (will open another website)"
 
   @events-details--no-documents-link
   Scenario: Event does not have Documents link
     When I navigate to the `events.fixture` page using `event` `Grand exhibition` fixture
-    Then there should be a local nav
-      | text             |
-      | Details          |
     And details view data for "Documents" should contain "There are no files or documents"

--- a/test/acceptance/features/events/navigation.feature
+++ b/test/acceptance/features/events/navigation.feature
@@ -1,0 +1,10 @@
+
+Feature: Event Navigation
+
+  @events-navigation
+  Scenario: Event navigation for details and attendees
+    When I navigate to the `events.fixture` page using `event` `One-day exhibition` fixture
+    Then there should be a local nav
+      | text             |
+      | Details          |
+      | Attendees        |

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -21,7 +21,7 @@ When(/^I clear all filters$/, async function () {
     .wait() // wait for xhr
 })
 
-Then(/^the results summary for a (.+) collection is present$/, async function (collectionType) {
+Then(/^the results summary for (?:a|an).*? (.+) collection is present$/, async function (collectionType) {
   await Collection.captureResultCount((count) => {
     set(this.state, 'collection.resultCount', count)
   })

--- a/test/acceptance/pages/events/attendees.js
+++ b/test/acceptance/pages/events/attendees.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { event } = require('../../fixtures')
+
+module.exports = {
+  url: function eventAttendeesUrl (eventName) {
+    const fixture = find(event, { name: eventName })
+    const eventId = fixture ? fixture.id : event.oneDayExhibition.id
+
+    return `${process.env.QA_HOST}/events/${eventId}/attendees`
+  },
+  elements: {},
+}

--- a/test/unit/apps/events/controllers/atendees.test.js
+++ b/test/unit/apps/events/controllers/atendees.test.js
@@ -1,0 +1,132 @@
+const config = require('~/config')
+const attendeesData = require('~/test/unit/data/interactions/attendees.json')
+
+const { renderAttendees } = require('~/src/apps/events/controllers/attendees')
+
+describe('event attendees', () => {
+  beforeEach(() => {
+    this.req = {
+      params: {
+        eventId: '1234',
+      },
+      query: {},
+      session: {
+        token: '4321',
+      },
+    }
+
+    this.res = {
+      breadcrumb: sinon.stub().returnsThis(),
+      render: sinon.spy(),
+      locals: {
+        event: {
+          name: 'Dance',
+        },
+      },
+    }
+
+    this.nextSpy = sinon.spy()
+  })
+
+  context('when there are no attendees', () => {
+  })
+
+  context('when there is an attendee', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v3/interaction?limit=10&offset=0&event_id=1234&sortby=contact__last_name%2Ccontact__first_name`)
+        .reply(200, attendeesData)
+
+      await renderAttendees(this.req, this.res, this.nextSpy)
+      this.properties = this.res.render.firstCall.args[1]
+    })
+
+    it('should render the attendees layout', () => {
+      const template = this.res.render.firstCall.args[0]
+      expect(template).to.equal('events/views/attendees')
+    })
+
+    it('should fetch attendees from the API', () => {
+      expect(nock.isDone()).to.be.true
+    })
+
+    it('should transform the results to a collection', () => {
+      expect(this.properties).to.have.property('attendees')
+      expect(this.properties.attendees).to.have.property('items').an('array')
+      expect(this.properties.attendees).to.have.property('count', 1)
+      expect(this.properties.attendees).to.have.property('pagination', null)
+      expect(this.properties.attendees).to.have.property('countLabel', 'attendee')
+    })
+
+    it('should include transformed items in the returned collection', () => {
+      const item = this.properties.attendees.items[0]
+      expect(item).to.have.property('id')
+      expect(item).to.have.property('type')
+      expect(item).to.have.property('name')
+      expect(item).to.have.property('meta')
+    })
+
+    it('calls next', () => {
+      expect(this.nextSpy).to.not.be.called
+    })
+  })
+
+  context('when there are many attendees', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v3/interaction?limit=10&offset=0&event_id=1234&sortby=contact__last_name%2Ccontact__first_name`)
+        .reply(200, {
+          ...attendeesData,
+          count: 200,
+        })
+
+      await renderAttendees(this.req, this.res, this.nextSpy)
+      this.properties = this.res.render.firstCall.args[1]
+    })
+
+    it('should include pagination information', () => {
+      expect(this.properties.attendees.pagination).to.not.be.null
+    })
+  })
+
+  context('when a specific page is requested', () => {
+    beforeEach(async () => {
+      this.req.query.page = 2
+
+      nock(config.apiRoot)
+        .get(`/v3/interaction?limit=10&offset=10&event_id=1234&sortby=contact__last_name%2Ccontact__first_name`)
+        .reply(200, {
+          ...attendeesData,
+          count: 200,
+        })
+
+      await renderAttendees(this.req, this.res, this.nextSpy)
+      this.properties = this.res.render.firstCall.args[1]
+    })
+
+    it('should fetch attendees from the API', () => {
+      expect(nock.isDone()).to.be.true
+    })
+  })
+
+  context('when there is an error fetching attendees', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v3/interaction?limit=10&offset=0&event_id=1234&sortby=contact__last_name%2Ccontact__first_name`)
+        .reply(500, 'Error message')
+
+      await renderAttendees(this.req, this.res, this.nextSpy)
+    })
+
+    it('should not call render', () => {
+      expect(this.res.render).to.not.be.called
+    })
+
+    it('should call next', () => {
+      expect(this.nextSpy).to.be.calledOnce
+      expect(this.nextSpy).to.be.calledWith(sinon.match({
+        message: '500 - "Error message"',
+      }))
+    })
+  })
+})

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -9,6 +9,7 @@ const {
   transformInteractionFormBodyToApiRequest,
   transformInteractionResponseToViewRecord,
   transformInteractionListItemToHaveUrlPrefix,
+  transformServiceDeliveryToAttendeeListItem,
 } = proxyquire('~/src/apps/interactions/transformers', {
   '../../../config': {
     archivedDocumentsBaseUrl,
@@ -945,6 +946,114 @@ describe('Interaction transformers', () => {
         const expectedInteraction = assign({}, mockInteraction)
 
         expect(actualInteraction).to.deep.equal(expectedInteraction)
+      })
+    })
+  })
+
+  describe('#transformEventToAttendeeListItem', () => {
+    beforeEach(() => {
+      this.serviceDelivery = {
+        id: '1234',
+        date: '2017-05-31T00:00:00',
+      }
+    })
+
+    context('when the contact is missing', () => {
+      beforeEach(() => {
+        this.serviceDelivery.company = {
+          id: '2222',
+          name: 'Test company',
+        }
+
+        this.result = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
+      })
+
+      it('should return undefined', () => {
+        expect(this.result).to.be.undefined
+      })
+    })
+
+    context('when the company is missing', () => {
+      beforeEach(() => {
+        this.serviceDelivery.contact = {
+          id: '3333',
+          name: 'Test contact',
+        }
+
+        this.result = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
+      })
+
+      it('should return undefined', () => {
+        expect(this.result).to.be.undefined
+      })
+    })
+
+    context('when a valid company is provided', () => {
+      beforeEach(() => {
+        this.serviceDelivery.company = {
+          id: '2222',
+          name: 'Test company',
+        }
+      })
+
+      context('when a valid contact is provided without a job title', () => {
+        beforeEach(() => {
+          this.serviceDelivery.contact = {
+            id: '3333',
+            name: 'Test contact',
+          }
+
+          this.transformedAttendee = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
+        })
+
+        it('should return a transformed attendee with the contact name and link', () => {
+          expect(this.transformedAttendee).to.have.property('id', '3333')
+          expect(this.transformedAttendee).to.have.property('type', 'contact')
+          expect(this.transformedAttendee).to.have.property('name', 'Test contact')
+        })
+
+        it('should return a transformed attendee with the company name and link', () => {
+          expect(this.transformedAttendee.meta).to.include.deep({
+            label: 'Company',
+            value: 'Test company',
+            url: `/companies/2222`,
+          })
+        })
+
+        it('should return a transformed attendee with the attendance date', () => {
+          expect(this.transformedAttendee.meta).to.include.deep({
+            label: 'Date attended',
+            value: '2017-05-31T00:00:00',
+            type: 'date',
+          })
+        })
+
+        it('should return a transformed attendee with a link to the associated service delivery', () => {
+          expect(this.transformedAttendee.meta).to.include.deep({
+            label: 'Service delivery',
+            value: 'View service delivery',
+            url: '/interactions/1234',
+          })
+        })
+      })
+
+      context('when a valid contact is provided with a job title', () => {
+        beforeEach(() => {
+          this.serviceDelivery.contact = {
+            id: '3333',
+            name: 'Test contact',
+            job_title: 'Director',
+          }
+
+          this.transformedAttendee = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
+        })
+
+        it('should return a transformed attendee with their job title', () => {
+          expect(this.transformedAttendee.meta).to.include.deep({
+            label: 'Job title',
+            value: 'Director',
+          })
+        })
       })
     })
   })

--- a/test/unit/data/interactions/attendees.json
+++ b/test/unit/data/interactions/attendees.json
@@ -1,0 +1,66 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "id": "ec4a46ef-6e50-4a5c-bba0-e311f0471312",
+          "company": {
+              "name": "Venus Ltd",
+              "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          },
+          "contact": {
+              "name": "Johnny Cakeman",
+              "first_name": "Johnny",
+              "last_name": "Cakeman",
+              "job_title": null,
+              "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef"
+          },
+          "created_on": "2017-06-05T00:00:00Z",
+          "created_by": {
+              "first_name": "Puck",
+              "last_name": "Head",
+              "name": "Puck Head",
+              "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+          },
+          "event": {
+              "name": "Grand exhibition",
+              "id": "bda12a57-433c-4a0c-a7ce-5ebd080e09e8"
+          },
+          "is_event": true,
+          "kind": "service_delivery",
+          "modified_by": {
+              "first_name": "Puck",
+              "last_name": "Head",
+              "name": "Puck Head",
+              "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+          },
+          "modified_on": "2017-06-05T00:00:00Z",
+          "date": "2017-09-05",
+          "dit_adviser": {
+              "first_name": "Puck",
+              "last_name": "Head",
+              "name": "Puck Head",
+              "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+          },
+          "dit_team": {
+              "name": "CBBC North EAST",
+              "id": "602b971d-5df6-e511-888e-e4115bead28a"
+          },
+          "communication_channel": null,
+          "grant_amount_offered": null,
+          "investment_project": null,
+          "net_company_receipt": null,
+          "service": {
+              "name": "Events - UK Based",
+              "id": "9584b82b-3499-e211-a939-e4115bead28a"
+          },
+          "service_delivery_status": null,
+          "subject": "Attended gamma event",
+          "notes": "This is a dummy service delivery for testing",
+          "archived_documents_url_path": "/documents/123",
+          "policy_area": null,
+          "policy_issue_type": null
+      }
+  ]
+}


### PR DESCRIPTION
The event screen needs an attendees list to show a list of people who attended that event.

To get a list of attendees the frontend fetches a list of service deliveries that are associated with an event, these signify a contact attended an event.

The attendee list contains the contact, their company and the date they attended the event. A link is provided to navigate to the service delivery to find more information.

![event_details](https://user-images.githubusercontent.com/56056/41165860-9ceab01e-6b36-11e8-95c5-02cd71140dab.PNG)
![event_attendees](https://user-images.githubusercontent.com/56056/41165862-9d0bfa94-6b36-11e8-9a47-cc4cb633fb16.PNG)

