### PR TITLE
DHI-88 Display for SPI type interactions `Created on` value in the details view

### DIFF
--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -27,11 +27,49 @@ const INTERACTION_NAMES = {
 
 const SERVICE_DELIVERY_STATUS_COMPLETED = '47329c18-6095-e211-a939-e4115bead28a'
 
+const IST_ONLY_SERVICES = [
+  {
+    name: 'Investment - IST Aftercare (IST use only)',
+    id: 'bd3d1be3-f9f7-e511-888e-e4115bead28a',
+  }, {
+    name: 'IST Client Proposal (IST use only)',
+    id: 'd03cce05-f9f7-e511-888e-e4115bead28a',
+  }, {
+    name: 'IST Visit (IST use only)',
+    id: '42c71892-f9f7-e511-888e-e4115bead28a',
+  }, {
+    name: 'Investment Enquiry ? Assigned to HQ (IST use only)',
+    id: '38a67092-f485-4ea1-8a1a-402b949d2d13',
+  }, {
+    name: 'Investment Enquiry ? Assigned to IST-CMC (IST use only)',
+    id: '2591b204-8a31-4824-a93b-d7a03dca8cb5',
+  }, {
+    name: 'Investment Enquiry ? Assigned to IST-SAS (IST use only)',
+    id: 'c579b89b-d49d-4926-a6a4-0a1459cd25cb',
+  }, {
+    name: 'Investment Enquiry ? Confirmed prospect project status (IST use only)',
+    id: '4f142041-2b9d-4776-ace8-22612260eae6',
+  }, {
+    name: 'Investment Enquiry ? Requested more information from source (IST use only)',
+    id: '73ceedc1-c139-4bdf-9e47-17b1bae488da',
+  }, {
+    name: 'Investment Enquiry ? Transferred to DA (IST use only)',
+    id: '05c8175a-abf5-4cc6-af34-bcee8699fd4b',
+  }, {
+    name: 'Investment Enquiry ? Transferred to L&P (IST use only)',
+    id: 'c707f81d-ae66-490a-98f5-575438944c43',
+  }, {
+    name: 'Investment Enquiry ? Transferred to LEP (IST use only)',
+    id: '48e6bc3e-56c5-4bdc-a718-093614547d73',
+  },
+]
+
 module.exports = {
-  GLOBAL_NAV_ITEM,
-  DEFAULT_COLLECTION_QUERY,
   APP_PERMISSIONS,
+  DEFAULT_COLLECTION_QUERY,
+  GLOBAL_NAV_ITEM,
   INTERACTION_NAMES,
-  SERVICE_DELIVERY_STATUS_COMPLETED,
+  IST_ONLY_SERVICES,
   POLICY_FEEDBACK_PERMISSIONS,
+  SERVICE_DELIVERY_STATUS_COMPLETED,
 }

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -3,6 +3,7 @@ const interaction = {
   subject: 'Subject',
   notes: 'Notes',
   contact: 'Contact',
+  created_on: 'Created on',
   date: 'Date of interaction',
   dit_adviser: 'DIT adviser',
   service: 'Service',

--- a/src/apps/interactions/transformers.js
+++ b/src/apps/interactions/transformers.js
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
-const { get, assign, isNil, omit, pickBy, camelCase } = require('lodash')
+const { assign, camelCase, get, isNil, omit, pickBy, some } = require('lodash')
 const { format, isValid } = require('date-fns')
 
 const { transformDateObjectToDateString } = require('../transformers')
 const config = require('../../../config')
 const labels = require('./labels')
-const { INTERACTION_NAMES } = require('./constants')
+const { INTERACTION_NAMES, IST_ONLY_SERVICES } = require('./constants')
 
 const transformEntityLink = (entity, entityPath, noLinkText = null) => {
   return entity ? {
@@ -25,6 +25,15 @@ const transformDocumentsLink = (archived_documents_url_path) => {
   }
 
   return { name: 'There are no files or documents' }
+}
+
+const transformCreatedOnDate = (service, name) => {
+  if (some(IST_ONLY_SERVICES, { id: service.id })) {
+    return {
+      type: 'date',
+      name,
+    }
+  }
 }
 
 function transformInteractionResponseToForm ({
@@ -124,6 +133,7 @@ function transformInteractionResponseToViewRecord ({
   company,
   subject,
   notes,
+  created_on,
   date,
   dit_adviser,
   service,
@@ -160,6 +170,7 @@ function transformInteractionResponseToViewRecord ({
     } : null,
     subject,
     notes,
+    created_on: transformCreatedOnDate(service, created_on),
     date: {
       type: 'date',
       name: date,

--- a/test/unit/apps/interactions/transformers.test.js
+++ b/test/unit/apps/interactions/transformers.test.js
@@ -814,6 +814,123 @@ describe('Interaction transformers', () => {
       })
     })
 
+    context('when provided with an IST only specific service ', () => {
+      beforeEach(() => {
+        const istService = assign({}, mockInteraction, {
+          service: {
+            name: 'Investment - IST Aftercare (IST use only)',
+            id: 'bd3d1be3-f9f7-e511-888e-e4115bead28a',
+          },
+        })
+
+        this.transformed = transformInteractionResponseToViewRecord(istService)
+      })
+
+      it('should transform to display format', () => {
+        expect(this.transformed).to.deep.equal({
+          'Company': {
+            url: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a',
+            name: 'Samsung',
+          },
+          'Contact': {
+            url: '/contacts/b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+            name: 'Jackson Whitfield',
+          },
+          'Service provider': {
+            id: '222',
+            name: 'Team',
+          },
+          'Service': {
+            id: 'bd3d1be3-f9f7-e511-888e-e4115bead28a',
+            name: 'Investment - IST Aftercare (IST use only)',
+          },
+          'Created on': {
+            type: 'date',
+            name: '2017-05-31T13:06:45.049191',
+          },
+          'Communication channel': {
+            id: '72c226d7-5d95-e211-a939-e4115bead28a',
+            name: 'Telephone',
+          },
+          'Subject': 'Test interactions',
+          'Notes': 'lorem ipsum',
+          'Date of interaction': {
+            type: 'date',
+            name: '2017-05-31T00:00:00',
+          },
+          'DIT adviser': {
+            id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+            first_name: 'Test',
+            last_name: 'CMU 1',
+            name: 'Test CMU 1',
+          },
+          'Investment project': {
+            url: '/investment-projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
+            name: 'Test project',
+          },
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
+        })
+      })
+    })
+
+    context('when provided with a non IST specific service ', () => {
+      beforeEach(() => {
+        this.transformed = transformInteractionResponseToViewRecord(mockInteraction)
+      })
+
+      it('should transform to display format', () => {
+        expect(this.transformed).to.deep.equal({
+          'Company': {
+            url: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a',
+            name: 'Samsung',
+          },
+          'Contact': {
+            url: '/contacts/b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+            name: 'Jackson Whitfield',
+          },
+          'Service provider': {
+            id: '222',
+            name: 'Team',
+          },
+          'Service': {
+            id: '1231231231312',
+            name: 'Test service',
+          },
+          'Communication channel': {
+            id: '72c226d7-5d95-e211-a939-e4115bead28a',
+            name: 'Telephone',
+          },
+          'Subject': 'Test interactions',
+          'Notes': 'lorem ipsum',
+          'Date of interaction': {
+            type: 'date',
+            name: '2017-05-31T00:00:00',
+          },
+          'DIT adviser': {
+            id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+            first_name: 'Test',
+            last_name: 'CMU 1',
+            name: 'Test CMU 1',
+          },
+          'Investment project': {
+            url: '/investment-projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
+            name: 'Test project',
+          },
+          'Documents': {
+            hint: '(will open another website)',
+            hintId: 'external-link-label',
+            name: 'View files and documents',
+            url: 'http://base/documents/123',
+          },
+        })
+      })
+    })
+
     context('when there is not an archived documents URL path', () => {
       beforeEach(() => {
         const interaction = assign({}, mockInteraction, { archived_documents_url_path: '' })


### PR DESCRIPTION
DHI-88 Display for SPI type interactions `Created on` value in the details view

In order to prevent users from fudging the interaction creation dates, for IST specific interactions - SPIs - steakholders requested to display the system generated date amongst the manually created one

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
