### PR TITLE
Update event team label to make required

### DIFF
--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -93,7 +93,7 @@ const eventFormConfig = ({
       assign({}, globalFields.teams, {
         name: 'lead_team',
         label: 'Team hosting the event',
-        optional: true,
+        optional: false,
         options: teams,
       }),
       assign({}, globalFields.serviceDeliveryServices, {


### PR DESCRIPTION
Changed the form definition for events to mark the team field as required.