### PR TITLE
Reinstate sort contact list test

### DIFF
--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -83,31 +83,29 @@ Feature: View collection of contacts
     And I click the local header link
     Then the company details UK region is displayed
 
+   @contacts-collection--sort
+   Scenario: Sort contact list
 
-# TODO: This test is causing PR's to fail, it should be looked at when we have time to fix it.
-#   @contacts-collection--sort
-#   Scenario: Sort contact list
-
-#     When a "Foreign company" is created
-#     And the company is in the search results
-#     When the first search result is clicked
-#     When I click the Contacts local nav link
-#     And I click the "Add contact" link
-#     And a primary contact is added
-#     When I submit the form
-#     Then I see the success message
-#     Then I wait and then refresh the page
-#     When I navigate to the `contacts.list` page
-#     When the contacts are sorted by Newest
-#     When the contacts are sorted by Oldest
-#     Then the contacts should have been correctly sorted by creation date
-#     And the results are sorted by Recently updated
-#     Then the results should be sorted by Recently updated
-#     And the results are sorted by Least recently updated
-#     Then the results should be sorted by Least recently updated
-# #    When the contacts are sorted by Last name: A-Z
-# #    Then the contacts should have been correctly sorted for text fields TODO: potential bug being investigated (contacts dont appear to sort correctly)
-#     When the contacts are sorted by Country: A-Z
-#     Then I see the list in A-Z alphabetical order
-#     When the contacts are sorted by Company: A-Z
-#     Then I see the list in A-Z alphabetical order
+     When a "Foreign company" is created
+     And the company is in the search results
+     When the first search result is clicked
+     When I click the Contacts local nav link
+     And I click the "Add contact" link
+     And a primary contact is added
+     When I submit the form
+     Then I see the success message
+     Then I wait and then refresh the page
+     When I navigate to the `contacts.list` page
+     When the contacts are sorted by Newest
+     When the contacts are sorted by Oldest
+     Then the contacts should have been correctly sorted by creation date
+     And the results are sorted by Recently updated
+     Then the results should be sorted by Recently updated
+     And the results are sorted by Least recently updated
+     Then the results should be sorted by Least recently updated
+  #    When the contacts are sorted by Last name: A-Z
+  #    Then the contacts should have been correctly sorted for text fields TODO: potential bug being investigated (contacts dont appear to sort correctly)
+     When the contacts are sorted by Country: A-Z
+     Then I see the list in A-Z alphabetical order
+     When the contacts are sorted by Company: A-Z
+     Then I see the list in A-Z alphabetical order


### PR DESCRIPTION
Reinstating the acceptance test for sorting the contact list. It is understood that this was disabled because it was breaking and could not be fixed. It appears to be working now.

If this breaks again then I am happy to take responsibility for fixing it.