### PR TITLE
Bug/contact active filter

### DIFF
--- a/assets/javascripts/lib/xhr.js
+++ b/assets/javascripts/lib/xhr.js
@@ -56,7 +56,7 @@ const XHR = {
     }
 
     return axios
-      .get(`${url}?${queryString.stringify(params)}`, {
+      .get(`${url}?${queryString.stringify(params, { arrayFormat: 'repeat' })}`, {
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
       })
       .then(res => this.updateOutlet(res, params))

--- a/src/apps/contacts/middleware/collection.js
+++ b/src/apps/contacts/middleware/collection.js
@@ -1,4 +1,4 @@
-const { pick, mapValues, isArray, pickBy, get } = require('lodash')
+const { pick, pickBy } = require('lodash')
 
 const { search } = require('../../search/services')
 const { transformApiResponseToSearchCollection } = require('../../search/transformers')
@@ -34,10 +34,6 @@ function getRequestBody (req, res, next) {
     'address_country',
     'company_uk_region',
   ]), 'archived')
-
-  mapValues(get(selectedFiltersQuery, 'archived'), (value) => {
-    return isArray(value) ? null : value
-  })
 
   const selectedSortBy = req.query.sortby
     ? { sortby: req.query.sortby }

--- a/src/apps/contacts/middleware/collection.js
+++ b/src/apps/contacts/middleware/collection.js
@@ -39,7 +39,11 @@ function getRequestBody (req, res, next) {
     ? { sortby: req.query.sortby }
     : null
 
-  req.body = Object.assign({}, req.body, selectedSortBy, pickBy(selectedFiltersQuery))
+  req.body = {
+    ...req.body,
+    ...selectedSortBy,
+    ...pickBy(selectedFiltersQuery),
+  }
 
   next()
 }

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -60,6 +60,11 @@ Feature: View collection of contacts
     Then there are no filters selected
     When I filter the contacts list by active status
     Then the result count should be reset
+    When I clear all filters
+    Then there are no filters selected
+    When I filter the contacts list by inactive status
+    Then the result count should be less
+    When I clear all filters
     When I filter the contacts list by company
     Then the contacts should be filtered by company name
     When I clear all filters

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -11,7 +11,7 @@ const Collection = client.page.collection()
 When('I store the result count in state', async function () {
   await Collection
     .captureResultCount((count) => {
-      set(this.state, 'collection.resultCount', count)
+      set(this.state, 'collection.resultCount', parseInt(count))
     })
 })
 
@@ -23,7 +23,7 @@ When(/^I clear all filters$/, async function () {
 
 Then(/^the results summary for (?:a|an).*? (.+) collection is present$/, async function (collectionType) {
   await Collection.captureResultCount((count) => {
-    set(this.state, 'collection.resultCount', count)
+    set(this.state, 'collection.resultCount', parseInt(count))
   })
 
   const resultCount = get(this.state, 'collection.resultCount')
@@ -101,7 +101,17 @@ Then(/^the result count should be reset$/, async function () {
     .waitForElementVisible('@resultCount')
     .getText('@resultCount', (result) => {
       const expected = get(this.state, 'collection.resultCount')
-      client.expect(result.value).to.equal(expected)
+      client.expect(parseInt(result.value)).to.equal(expected)
+    })
+})
+
+Then(/^the result count should be less$/, async function () {
+  await Collection
+    .section.collectionHeader
+    .waitForElementVisible('@resultCount')
+    .getText('@resultCount', (result) => {
+      const expected = get(this.state, 'collection.resultCount')
+      client.expect(parseInt(result.value)).to.be.below(expected)
     })
 })
 

--- a/test/unit/apps/contacts/middleware/collection.test.js
+++ b/test/unit/apps/contacts/middleware/collection.test.js
@@ -1,0 +1,107 @@
+describe('Contact collection middleware', () => {
+  beforeEach(() => {
+    this.middleware = require('~/src/apps/contacts/middleware/collection')
+    this.req = {
+      body: '',
+      query: {
+        name: 'contact name',
+        company_name: 'company name',
+        company_sector_descends: [
+          '9b38cecc-5f95-e211-a939-e4115bead28a',
+        ],
+        address_country: [
+          'af959812-6095-e211-a939-e4115bead28a',
+        ],
+        company_uk_region: [
+          '934cd12a-6095-e211-a939-e4115bead28a',
+        ],
+      },
+    }
+    this.res = {}
+    this.nextSpy = sinon.spy()
+  })
+
+  describe('#getRequestBody', () => {
+    context('when supplied with default parameters', () => {
+      beforeEach(() => {
+        this.req = {
+          ...this.req,
+          query: {
+            ...this.req.query,
+            archived: 'false',
+          },
+        }
+
+        this.middleware.getRequestBody(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set the request body', () => {
+        expect(this.req.body).to.deep.equal({
+          address_country: [
+            'af959812-6095-e211-a939-e4115bead28a',
+          ],
+          archived: 'false',
+          company_name: 'company name',
+          company_sector_descends: [
+            '9b38cecc-5f95-e211-a939-e4115bead28a',
+          ],
+          company_uk_region: [
+            '934cd12a-6095-e211-a939-e4115bead28a',
+          ],
+          name: 'contact name',
+        })
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.be.calledOnce
+      })
+    })
+
+    context('when archived is set twice as true and false', () => {
+      beforeEach(() => {
+        this.req = {
+          ...this.req,
+          query: {
+            ...this.req.query,
+            archived: [
+              'true',
+              'false',
+            ],
+          },
+        }
+
+        this.middleware.getRequestBody(this.req, this.res, this.nextSpy)
+      })
+
+      it('should not set archived on the request body', () => {
+        expect(this.req.body.archived).to.be.undefined
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.be.calledOnce
+      })
+    })
+
+    context('when sort is set', () => {
+      beforeEach(() => {
+        this.req = {
+          ...this.req,
+          query: {
+            ...this.req.query,
+            sortby: 'modified_on:desc',
+          },
+        }
+
+        this.middleware.getRequestBody(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set sort on the request body', () => {
+        expect(this.req.body.sortby).to.equal('modified_on:desc')
+      })
+
+      it('should call next', () => {
+        expect(this.nextSpy).to.be.calledOnce
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/POfOIgX8/136-fix-active-inactive-filter-on-contacts-page

# Problem
Active/inactive filters were not working correctly because the query string parameter was being passed as an array element. Arrays are set to `null`.

# Solution
Specify the `arrayFormat` to be `repeat` so that if just one filter is selected then it is not understood as an array in the middleware.

In addition I have:
* Added unit tests around `getRequestBody` middleware
* Refactored code
* Updated acceptance tests