### PR TITLE
Change add attendee search to use GET

### DIFF
--- a/src/apps/events/attendees/controllers/find.js
+++ b/src/apps/events/attendees/controllers/find.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash')
+const { get, isEmpty } = require('lodash')
 
 const { search } = require('../../../search/services')
 const { transformApiResponseToSearchCollection } = require('../../../search/transformers')
@@ -31,7 +31,11 @@ async function findAttendee (req, res, next) {
     }
 
     const query = req.query
-    const searchTerm = res.locals.searchTerm = get(req, 'body.term', '').trim()
+    const searchTerm = res.locals.searchTerm = (query.term || '').trim()
+
+    if (isEmpty(searchTerm)) {
+      return next()
+    }
 
     const contacts = await search({
       searchTerm,

--- a/src/apps/events/attendees/router.js
+++ b/src/apps/events/attendees/router.js
@@ -9,9 +9,7 @@ const {
 
 router.get('/', renderAttendees)
 
-router.route('/find-new')
-  .get(renderFindAttendee)
-  .post(findAttendee, renderFindAttendee)
+router.get('/find-new', findAttendee, renderFindAttendee)
 
 router.get('/create/:contactId', createAttendee)
 

--- a/src/apps/events/attendees/views/find.njk
+++ b/src/apps/events/attendees/views/find.njk
@@ -5,13 +5,10 @@
 
   {{
     EntitySearchForm({
-      inputName: "term",
       inputLabel: "Find the contact",
       inputPlaceholder: "Contact or company name to search for",
       searchTerm: searchTerm,
-      isLabelHidden: true,
-      method: 'post',
-      value: searchTerm
+      isLabelHidden: true
     })
   }}
 

--- a/test/unit/apps/events/attendees/controllers/find.test.js
+++ b/test/unit/apps/events/attendees/controllers/find.test.js
@@ -83,9 +83,7 @@ describe('Find new event attendees controller', () => {
 
       context('and a search term', () => {
         beforeEach(() => {
-          this.req.body = {
-            term: 'Fred ',
-          }
+          this.req.query.term = 'Fred '
         })
 
         context('with a couple of results', () => {
@@ -138,7 +136,10 @@ describe('Find new event attendees controller', () => {
 
           it('should include the original query in the result', () => {
             expect(this.res.locals.contacts).to.have.property('query')
-            expect(this.res.locals.contacts.query).to.deep.equal({ page: '1' })
+            expect(this.res.locals.contacts.query).to.deep.equal({
+              term: 'Fred ',
+              page: '1',
+            })
           })
 
           it('should include collection count information', () => {
@@ -164,6 +165,10 @@ describe('Find new event attendees controller', () => {
 
           it('should use the block link style for results', () => {
             expect(this.res.locals.contacts).to.have.property('listModifier', 'block-links')
+          })
+
+          it('should include the search term in the locals', () => {
+            expect(this.res.locals.searchTerm).to.equal('Fred')
           })
         })
 
@@ -191,7 +196,10 @@ describe('Find new event attendees controller', () => {
 
           it('should include the original query in the result', () => {
             expect(this.res.locals.contacts).to.have.property('query')
-            expect(this.res.locals.contacts.query).to.deep.equal({ page: '2' })
+            expect(this.res.locals.contacts.query).to.deep.equal({
+              page: '2',
+              term: 'Fred ',
+            })
           })
 
           it('should include collection count information', () => {


### PR DESCRIPTION
Previously the search form for add attendee was using a POST method but this meant that
the pagination links did not get the search term and as a result, they didn't work.

Changing the form to a GET means all parameters get appended to the
pagination links. 


