### PR TITLE
Add service as filter in Interactions

### DIFF
--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -55,6 +55,7 @@ const filters = {
   date_before: 'To',
   dit_team: 'Service provider',
   sector_descends: 'Sector',
+  service: 'Service',
 }
 
 module.exports = {

--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -1,4 +1,4 @@
-const { assign, flatten } = require('lodash')
+const { flatten } = require('lodash')
 
 const labels = require('../labels')
 const { provider } = require('./fields')
@@ -8,7 +8,13 @@ const { POLICY_FEEDBACK_PERMISSIONS } = require('../constants')
 
 const currentYear = (new Date()).getFullYear()
 
-module.exports = function ({ currentAdviserId, channels = [], teams = [], sectorOptions, permissions }) {
+module.exports = function ({
+  currentAdviserId,
+  permissions,
+  sectorOptions,
+  serviceOptions,
+  teamOptions,
+}) {
   return [
     {
       macroName: 'MultipleChoiceField',
@@ -50,10 +56,18 @@ module.exports = function ({ currentAdviserId, channels = [], teams = [], sector
       hint: 'YYYY-MM-DD',
       placeholder: `e.g. ${currentYear}-07-21`,
     },
-    assign({}, provider(teams), {
+    {
+      ...provider(teamOptions),
       type: 'checkbox',
       modifier: 'option-select',
-    }),
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      type: 'checkbox',
+      name: 'service',
+      modifier: 'option-select',
+      options: serviceOptions,
+    },
     {
       macroName: 'MultipleChoiceField',
       type: 'checkbox',
@@ -62,9 +76,10 @@ module.exports = function ({ currentAdviserId, channels = [], teams = [], sector
       options: sectorOptions,
     },
   ].map(filter => {
-    return assign(filter, {
+    return {
+      ...filter,
       label: labels.filters[filter.name],
       modifier: flatten([filter.modifier, 'smaller', 'light', 'filter']),
-    })
+    }
   })
 }

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -36,6 +36,7 @@ function getInteractionsRequestBody (req, res, next) {
     'date_before',
     'sortby',
     'dit_team',
+    'service',
   ])
 
   if (req.params.contactId) {

--- a/src/apps/interactions/transformers/interaction-to-list-item.js
+++ b/src/apps/interactions/transformers/interaction-to-list-item.js
@@ -11,6 +11,7 @@ function transformInteractionToListItem ({
   date,
   dit_adviser,
   dit_team,
+  service,
 }) {
   return {
     id,
@@ -42,6 +43,10 @@ function transformInteractionToListItem ({
       {
         label: 'Service provider',
         value: dit_team,
+      },
+      {
+        label: 'Service',
+        value: service,
       },
     ],
   }

--- a/test/unit/apps/interactions/controllers/list.test.js
+++ b/test/unit/apps/interactions/controllers/list.test.js
@@ -25,10 +25,10 @@ describe('interaction list', () => {
         { id: 'te2', name: 'te2', disabled_on: null },
         { id: 'te', name: 'te3', disabled_on: null },
       ],
-      channelOptions: [
-        { id: 'c1', name: 'c1', disabled_on: null },
-        { id: 'c2', name: 'c2', disabled_on: null },
-        { id: 'c3', name: 'c3', disabled_on: null },
+      service: [
+        { id: 's1', name: 's1', disabled_on: null },
+        { id: 's2', name: 's2', disabled_on: null },
+        { id: 's3', name: 's3', disabled_on: null },
       ],
       sectorOptions: [
         { id: 's1', name: 's1', disabled_on: null },
@@ -38,8 +38,8 @@ describe('interaction list', () => {
     }
 
     nock(config.apiRoot)
-      .get('/metadata/communication-channel/')
-      .reply(200, this.metadataMock.channelOptions)
+      .get('/metadata/service/')
+      .reply(200, this.metadataMock.sectorOptions)
       .get('/metadata/team/')
       .reply(200, this.metadataMock.teamOptions)
       .get('/metadata/sector/?level__lte=0')

--- a/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
@@ -56,6 +56,13 @@ describe('#transformInteractionToListItem', () => {
               name: 'Team',
             },
           },
+          {
+            label: 'Service',
+            value: {
+              id: '1231231231312',
+              name: 'Test service',
+            },
+          },
         ],
       })
     })
@@ -143,6 +150,13 @@ describe('#transformInteractionToListItem', () => {
               name: 'Team',
             },
           },
+          {
+            label: 'Service',
+            value: {
+              id: '1231231231312',
+              name: 'Test service',
+            },
+          },
         ],
       })
     })
@@ -202,6 +216,13 @@ describe('#transformInteractionToListItem', () => {
             value: {
               id: '222',
               name: 'Team',
+            },
+          },
+          {
+            label: 'Service',
+            value: {
+              id: '1231231231312',
+              name: 'Test service',
             },
           },
         ],


### PR DESCRIPTION
Adds 'Service' as a filter option in the interactions list. Also adds the service in the result card
