### PR TITLE
Improve authorised request

### DIFF
--- a/src/lib/controller-utils.js
+++ b/src/lib/controller-utils.js
@@ -14,52 +14,6 @@ function transformErrors (sourceErrors) {
 
   return errors
 }
-// V2 source errors come in a fairly useless format, which we have to fix here
-function transformV2Errors (sourceErrors) {
-  if (!sourceErrors) {
-    return null
-  }
-
-  const errors = {}
-  const req = ' is required'
-  const typeMatcher = new RegExp(/.*type': '(.*)'}}.*/)
-
-  sourceErrors.forEach((err) => {
-    // deal with errors which do not contain a source for the error
-    if (typeof err.detail === 'string') {
-      if (err.source.pointer === '/data/attributes/subject') {
-        errors.subject = 'Subject' + req
-      }
-
-      if (err.source.pointer === '/data/attributes/notes') {
-        errors.notes = 'Notes are required'
-      }
-      // this error only occurs if the service delivery exists and there are no other errors
-      if (err.detail === 'This combination of service and service provider does not exist.') {
-        errors.Alert = 'This combination of service and service provider does not exist.'
-      }
-
-      // most errors come in this form: {"errors":[{"detail":"{'data': {'type': 'UKRegion'}} has no key id",
-      if (err.detail.startsWith('{\'data')) {
-        let type = typeMatcher.exec(err.detail)
-        if (type.length > 1) {
-          if (type[1] === 'Country') {
-            errors.country_of_interest = type[1] + req
-          } else if (type[1] === 'ServiceDeliveryStatus') {
-            errors.status = 'Status ' + req
-          } else if (type[1] === 'Team') {
-            errors.dit_team = 'Service provider ' + req
-          } else if (type[1] === 'UKRegion') {
-            errors.uk_region = 'UK Region ' + req
-          } else {
-            errors[type[1].toLowerCase()] = type[1] + req
-          }
-        }
-      }
-    }
-  })
-  return errors
-}
 
 function convertAutosuggestCollection (form, targetFieldName) {
   const lowerTargetFieldName = targetFieldName.toLocaleLowerCase()
@@ -126,7 +80,6 @@ function getDataLabels (data, labels) {
 module.exports = {
   getDataLabels,
   transformErrors,
-  transformV2Errors,
   convertAutosuggestCollection,
   flattenIdFields,
   isBlank,

--- a/test/unit/lib/controller-utils.test.js
+++ b/test/unit/lib/controller-utils.test.js
@@ -1,6 +1,5 @@
 const {
   isBlank,
-  transformV2Errors,
   isValidGuid,
   getDataLabels,
 } = require('~/src/lib/controller-utils')
@@ -25,108 +24,6 @@ describe('isBlank', () => {
   })
   it('should know when it is sent a valid object', () => {
     expect(isBlank({ x: 1 })).to.be.false
-  })
-})
-
-describe('transformV2Errors: Formatting V2 service delivery endpoint errors', () => {
-  it('Should warn if the Service Delivery triple does not exist', () => {
-    const source = [
-      {
-        'detail': 'This combination of service and service provider does not exist.',
-        'source': {
-          'pointer': '/data/relationships/service',
-        },
-      },
-    ]
-    const actual = transformV2Errors(source)
-    expect(actual.Alert).to.exist
-    expect(actual.Alert).to.equal('This combination of service and service provider does not exist.')
-  })
-  it('Should return multiple errors when presented with an array of errors', () => {
-    const source = [
-      {
-        'detail': 'Required',
-        'source': {
-          'pointer': '/data/attributes/subject',
-        },
-      },
-      {
-        'detail': 'Required',
-        'source': {
-          'pointer': '/data/attributes/notes',
-        },
-      },
-      {
-        'detail': "{'data': {'type': 'ServiceDeliveryStatus'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/status',
-        },
-      },
-      {
-        'detail': "{'data': {'type': 'Contact'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/contact',
-        },
-      },
-      {
-        'detail': "{'data': {'type': 'Service'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/service',
-        },
-      },
-      {
-        'detail': "{'data': {'type': 'Team'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/dit_team',
-        },
-      },
-      {
-        'detail': "{'data': {'type': 'Sector'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/sector',
-        },
-      },
-      {
-        'detail': "{'data': {'type': 'UKRegion'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/uk_region',
-        },
-      },
-      {
-        'detail': "{'data': {'type': 'Country'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/country_of_interest',
-        },
-      },
-    ]
-    const transformedErrors = transformV2Errors(source)
-    const expectedErrors = {
-      subject: 'Subject is required',
-      notes: 'Notes are required',
-      status: 'Status  is required',
-      contact: 'Contact is required',
-      service: 'Service is required',
-      dit_team: 'Service provider  is required',
-      sector: 'Sector is required',
-      uk_region: 'UK Region  is required',
-      country_of_interest: 'Country is required',
-    }
-
-    expect(transformedErrors).to.deep.equal(expectedErrors)
-  })
-  it('Should match keys not specially defined', () => {
-    const source = [
-      {
-        'detail': "{'data': {'type': 'Foo'}} has no key id",
-        'source': {
-          'pointer': '/data/relationships/foo',
-        },
-      },
-    ]
-    const transformedErrors = transformV2Errors(source)
-    const expectedErrors = { foo: 'Foo is required' }
-
-    expect(transformedErrors).to.deep.equal(expectedErrors)
   })
 })
 


### PR DESCRIPTION
Previously the authorised request function would send things such as `qs=undefined` or `term=''`. This strips out empty params, body and headers

Also removes the error transformer for V2 calls as we no longer make those calls.