### PR TITLE
Stop user adding attendees to incomplete event

### DIFF
--- a/src/apps/events/attendees/views/list.njk
+++ b/src/apps/events/attendees/views/list.njk
@@ -2,9 +2,17 @@
 
 {% block main_grid_right_column %}
   <h2 class="heading-medium">Event Attendees</h2>
-  {% block xhr_content %}
-    <article id="xhr-outlet">
-      {{ CollectionContent(attendees) }}
-    </article>
-  {% endblock %}
+  {% if incompleteEvent %}
+    <p class="c-message c-message--info">
+      You cannot add an event attendee on this page because the event
+      record is incomplete. You can create a service delivery interaction
+      from the company record to add an event attendee.
+    </p>
+  {% else %}
+    {% block xhr_content %}
+      <article id="xhr-outlet">
+        {{ CollectionContent(attendees) }}
+      </article>
+    {% endblock %}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Some events do not have a lead team or service which are required when creating a service delivery.

If the event is incomplete, block the user from adding an attendee.

