### PR TITLE
Hide "Add Investment project" button for archived companies

### DIFF
--- a/src/apps/companies/controllers/investments.js
+++ b/src/apps/companies/controllers/investments.js
@@ -5,7 +5,7 @@ const { transformApiResponseToCollection } = require('../../transformers')
 async function renderInvestments (req, res, next) {
   const token = req.session.token
   const page = req.query.page || 1
-  const { id, name } = res.locals.company
+  const { id, name, archived } = res.locals.company
 
   try {
     const results = await getCompanyInvestmentProjects(token, id, page)
@@ -14,15 +14,17 @@ async function renderInvestments (req, res, next) {
         transformInvestmentProjectToListItem,
       ))
 
+    const actionButtons = archived ? undefined : [{
+      label: 'Add investment project',
+      url: `/investment-projects/create/${req.params.companyId}`,
+    }]
+
     res
       .breadcrumb(name, `/companies/${id}`)
       .breadcrumb('Investment')
       .render('companies/views/investments', {
         results,
-        actionButtons: [{
-          label: 'Add investment project',
-          url: `/investment-projects/create/${req.params.companyId}`,
-        }],
+        actionButtons,
       })
   } catch (error) {
     next(error)

--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -43,19 +43,25 @@ Feature: View collection of companies
     When a "UK non-private or non-public limited company" is created
     Then I see the success message
     When I navigate to the `companies.list` page
+    When I clear all filters
+    Then there are no filters selected
     Given I store the result count in state
     And I filter the companies list by company
     Then the companies should be filtered by company name
+    And the result count should be 1
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
     When I filter the companies list by active status
-    Then the result count should be reset
+    Then the result count should be 1 less than the total
     When I clear all filters
     Then there are no filters selected
+    And the result count should be reset
     When I filter the companies list by inactive status
-    Then the result count should be less
+    Then the result count should be 1
     When I clear all filters
+    Then there are no filters selected
+    And the result count should be reset
     When I filter the companies list by country
     Then the companies should be filtered to show badge company country
     When I clear all filters

--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -43,7 +43,7 @@ Feature: View collection of companies
     When a "UK non-private or non-public limited company" is created
     Then I see the success message
     When I navigate to the `companies.list` page
-    And I store the result count in state
+    Given I store the result count in state
     And I filter the companies list by company
     Then the companies should be filtered by company name
     When I clear all filters

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -53,34 +53,36 @@ Feature: View collection of contacts
     Then I see the success message
     Then I wait and then refresh the page
     When I navigate to the `contacts.list` page
-    And I store the result count in state
+    When I clear all filters
+    Then there are no filters selected
+    Given I store the result count in state
     And I filter the contacts list by contact
     Then the contacts should be filtered by contact name
+    And the result count should be 1
     When I clear all filters
     Then there are no filters selected
+    And the result count should be reset
     When I filter the contacts list by active status
-    Then the result count should be reset
+    And the result count should be reset
     When I clear all filters
     Then there are no filters selected
+    And the result count should be reset
     When I filter the contacts list by inactive status
-    Then the result count should be less
+    Then the result count should be 0
     When I clear all filters
+    Then there are no filters selected
+    And the result count should be reset
     When I filter the contacts list by company
     Then the contacts should be filtered by company name
+    And the result count should be less than the total
     When I clear all filters
     Then there are no filters selected
-    When I filter the contacts list by active status
-    Then the result count should be reset
-    When I clear all filters
-    Then there are no filters selected
-    When I filter the contacts list by active status
-    Then the result count should be reset
+    And the result count should be reset
     When I filter the contacts list by country
     Then the contacts should be filtered to show badge company country
     When I clear all filters
     Then there are no filters selected
-    When I filter the contacts list by active status
-    Then the result count should be reset
+    And the result count should be reset
     When I filter the contacts list by country
     And I filter the contacts list by UK region
     Then the contacts should be filtered to show badge company country

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -117,3 +117,9 @@ Feature: Create a new Investment project
       | New or existing investor      | investmentProject.investorType                |
       | Level of involvement          | investmentProject.levelOfInvolvement          |
       | Specific investment programme | investmentProject.specificInvestmentProgramme |
+
+  @investment-projects-create--archived-company
+  Scenario: Add a Non Foreign Direct Investment (Non-FDI) Investment project
+
+    When I navigate to the `companies.investments` page using `company` `Archived Ltd` fixture
+    And I should not see the "Add investment project" button

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -59,6 +59,13 @@ When(/^I select a value for `(.+)` on the `(.+)` page$/, async function (element
   }
 })
 
+Then(/^I should not see the "([^"]*)?" (link|button)$/, async function (linkText, type) {
+  await client
+    .useXpath()
+    .assert.elementNotPresent(`//a[text()='${linkText}']`)
+    .useCss()
+})
+
 Then(/^I am on the `(.+)` page$/, async function (pageName) {
   try {
     const page = get(client.page, pageName)()

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -105,13 +105,32 @@ Then(/^the result count should be reset$/, async function () {
     })
 })
 
-Then(/^the result count should be less$/, async function () {
+Then(/^the result count should be ([0-9])$/, async function (expected) {
   await Collection
     .section.collectionHeader
     .waitForElementVisible('@resultCount')
     .getText('@resultCount', (result) => {
-      const expected = get(this.state, 'collection.resultCount')
-      client.expect(parseInt(result.value)).to.be.below(expected)
+      client.expect(result.value).to.equal(expected)
+    })
+})
+
+Then(/^the result count should be ([0-9]) less than the total$/, async function (valueToSubtract) {
+  await Collection
+    .section.collectionHeader
+    .waitForElementVisible('@resultCount')
+    .getText('@resultCount', (result) => {
+      const total = get(this.state, 'collection.resultCount')
+      client.expect(parseInt(result.value)).to.equal(total - parseInt(valueToSubtract))
+    })
+})
+
+Then(/^the result count should be less than the total$/, async function () {
+  await Collection
+    .section.collectionHeader
+    .waitForElementVisible('@resultCount')
+    .getText('@resultCount', (result) => {
+      const total = get(this.state, 'collection.resultCount')
+      client.expect(parseInt(result.value)).to.be.below(total)
     })
 })
 

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -1,6 +1,6 @@
 const { get, set, camelCase } = require('lodash')
 const { client } = require('nightwatch-cucumber')
-const { Then, When } = require('cucumber')
+const { Given, When, Then } = require('cucumber')
 const moment = require('moment')
 
 const { pluralise } = require('../../../../config/nunjucks/filters')
@@ -8,7 +8,7 @@ const { mediumDateTimeFormat } = require('../../../../config')
 
 const Collection = client.page.collection()
 
-When('I store the result count in state', async function () {
+Given('I store the result count in state', async function () {
   await Collection
     .captureResultCount((count) => {
       set(this.state, 'collection.resultCount', parseInt(count))

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -65,6 +65,21 @@ module.exports = {
       employeeRange: '500+',
       turnoverRange: '£33.5M+',
     },
+    archived: {
+      id: '346f78a5-1d23-4213-b4c2-bf48246a13c3',
+      name: 'Archived Ltd',
+      address1: '16 Getabergsvagen',
+      town: 'Geta',
+      postcode: '22340',
+      country: 'Aland Islands',
+      primaryAddress: '16 Getabergsvagen, Geta, 22340, Aland Islands',
+      businessType: 'Company',
+      headquarterType: 'Global HQ',
+      sector: 'Retail',
+      description: 'This is a dummy company for testing archived features',
+      employeeRange: '500+',
+      turnoverRange: '£33.5M+',
+    },
   },
   contact: {
     georginaClark: {


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Add Investment project` button should not be show if a company has been archived. If the button is visible then data is being added where it should not be.

### Solution

Hide the `Add investment project` button for archived companies

<img width="888" alt="screen shot 2018-07-06 at 15 12 06" src="https://user-images.githubusercontent.com/1150417/42383413-1064b3b0-812f-11e8-8f69-0e8b0a28d698.png">
