### PR TITLE
Filter the services in add event to limit to those for events

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -22,7 +22,7 @@ async function getEditOptions (token, createdOn, currentAdviser) {
     locationTypes: await getOptions(token, 'location-type', { createdOn }),
     countries: await getOptions(token, 'country', { createdOn }),
     teams: await getOptions(token, 'team', { createdOn }),
-    services: await getOptions(token, 'service', { createdOn }),
+    services: await getOptions(token, 'service', { createdOn, context: 'event' }),
     programmes: await getOptions(token, 'programme', { createdOn }),
     ukRegions: await getOptions(token, 'uk-region', { createdOn }),
   }

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -111,7 +111,7 @@ describe('Event edit controller', () => {
         .reply(200, metadataMock.countryOptions)
         .get('/metadata/team/')
         .reply(200, metadataMock.teamOptions)
-        .get('/metadata/service/')
+        .get('/metadata/service/?contexts__has_any=event')
         .reply(200, metadataMock.serviceOptions)
         .get('/metadata/programme/')
         .reply(200, metadataMock.programmeOptions)


### PR DESCRIPTION
Changes the event create and edit form to only list services that have been allocated the event context