### PR TITLE
Shown known details for attendees without contact

### DIFF
--- a/src/apps/events/attendees/transformers.js
+++ b/src/apps/events/attendees/transformers.js
@@ -1,20 +1,12 @@
 /* eslint-disable camelcase */
-const { compact, pickBy } = require('lodash')
+const { compact, get, pickBy } = require('lodash')
 
 const { attendeeLabels } = require('./labels')
 
 function transformServiceDeliveryToAttendeeListItem ({ contact, company, date, id }) {
-  if (!contact || !company) { return }
-
-  const {
-    id: contactId,
-    name,
-    job_title,
-  } = contact
-
   const metaItems = [
-    { key: 'company', value: company.name, url: `/companies/${company.id}` },
-    { key: 'job_title', value: job_title },
+    { key: 'company', value: get(company, 'name'), url: `/companies/${get(company, 'id')}` },
+    { key: 'job_title', value: contact ? contact.job_title : 'Not available' },
     { key: 'attended_date', value: date, type: 'date' },
     { key: 'service_delivery', value: 'View or edit service delivery', url: `/interactions/${id}` },
   ]
@@ -24,12 +16,21 @@ function transformServiceDeliveryToAttendeeListItem ({ contact, company, date, i
       label: attendeeLabels[key],
     }))
 
-  return {
-    id: contactId,
-    type: 'contact',
-    name,
-    meta: compact(metaItems),
-  }
+  const listItem = contact
+    ? {
+      id: contact.id,
+      type: 'contact',
+      name: contact.name,
+      meta: compact(metaItems),
+    }
+    : {
+      id,
+      type: 'interaction',
+      name: 'No contact assigned',
+      meta: compact(metaItems),
+    }
+
+  return listItem
 }
 
 module.exports = { transformServiceDeliveryToAttendeeListItem }

--- a/test/unit/apps/events/attendees/transformers.test.js
+++ b/test/unit/apps/events/attendees/transformers.test.js
@@ -18,8 +18,17 @@ describe('#transformEventToAttendeeListItem', () => {
       this.result = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
     })
 
-    it('should return undefined', () => {
-      expect(this.result).to.be.undefined
+    it('should indicate no contact selected', () => {
+      expect(this.result.name).to.equal('No contact assigned')
+    })
+
+    it('should link to the service delivery instead of the contact', () => {
+      expect(this.result.id).to.equal('1234')
+      expect(this.result.type).to.equal('interaction')
+    })
+
+    it('should indicate job title not available', () => {
+      expect(this.result.meta[1].value).to.equal('Not available')
     })
   })
 
@@ -28,13 +37,15 @@ describe('#transformEventToAttendeeListItem', () => {
       this.serviceDelivery.contact = {
         id: '3333',
         name: 'Test contact',
+        job_title: 'Director',
       }
 
       this.result = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
     })
 
-    it('should return undefined', () => {
-      expect(this.result).to.be.undefined
+    it('not include a company in the meta data.', () => {
+      const companyItem = this.result.meta.find(item => item.label === 'Company')
+      expect(companyItem).to.be.undefined
     })
   })
 


### PR DESCRIPTION
For some reason, some event attendance has been recorded without a contact, only the company. This
change modifies the attendee transformers to inform the user and change the title link to link
to the attendance so they can update it.

The transformation for company has also been made more robust, though the database scheme
always requires a company.

![capture](https://user-images.githubusercontent.com/56056/42530781-f64c31bc-8479-11e8-87d7-880114419cb5.PNG)

