### PR TITLE
Event attendees - double-clicking adds the same attendee twice

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -16,6 +16,7 @@ const PrintDialog = require('./modules/print-dialog')
 const MirrorValue = require('./modules/mirror-value.js')
 const ClearInputs = require('./modules/clear-inputs.js')
 const PreventMultipleSubmits = require('./modules/prevent-multiple-submits.js')
+const PreventLinkDoubleClick = require('./modules/prevent-link-double-click.js')
 
 const CompanyAdd = require('./_deprecated/company-add')
 const CompanyEdit = require('./_deprecated/company-edit')
@@ -33,6 +34,7 @@ PrintDialog.init()
 MirrorValue.init()
 ClearInputs.init()
 PreventMultipleSubmits.init()
+PreventLinkDoubleClick.init()
 
 // Deprecated
 CompanyAdd.init()

--- a/assets/javascripts/modules/prevent-link-double-click.js
+++ b/assets/javascripts/modules/prevent-link-double-click.js
@@ -1,0 +1,39 @@
+const CONSTANTS = {
+  selectors: {
+    anchor: 'js-prevent-double-click',
+  },
+  events: {
+    click: 'click',
+  },
+}
+
+const PreventLinkDoubleClick = {
+  counter: 0,
+
+  init () {
+    if (document.querySelectorAll(`.${CONSTANTS.selectors.anchor}`).length) {
+      this.bindEvents()
+    }
+  },
+
+  preventDoubleClick (event) {
+    const target = event.target
+    const targetAnchor = target.closest(`.${CONSTANTS.selectors.anchor}`)
+
+    if (!targetAnchor) {
+      return
+    }
+
+    if (this.counter >= 1) {
+      event.preventDefault()
+    } else {
+      this.counter += 1
+    }
+  },
+
+  bindEvents () {
+    document.addEventListener(CONSTANTS.events.click, this.preventDoubleClick.bind(this))
+  },
+}
+
+module.exports = PreventLinkDoubleClick

--- a/src/apps/events/attendees/controllers/find.js
+++ b/src/apps/events/attendees/controllers/find.js
@@ -70,6 +70,7 @@ async function findAttendee (req, res, next) {
       highlightTerm: searchTerm,
       countLabel: 'contact',
       listModifier: 'block-links',
+      preventDoubleClick: true,
     }
 
     return next()

--- a/src/templates/_macros/entity/entity-list.njk
+++ b/src/templates/_macros/entity/entity-list.njk
@@ -9,7 +9,8 @@
       <li class="c-entity-list__item">
         {{ Entity(item | assign({
           highlightTerm: props.highlightTerm,
-          isBlockLink: hasBlockLinks
+          isBlockLink: hasBlockLinks,
+          preventDoubleClick: props.preventDoubleClick
         })) }}
       </li>
     {% endfor %}

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -30,6 +30,7 @@
       {{ 'c-entity--block-link' if props.isBlockLink }}
       {{ 'c-entity__link' if props.isBlockLink and not props.isLinkDisabled }}
       {{ 'disabled' if props.isLinkDisabled }}
+      js-prevent-double-click
       "
       {% if props.isBlockLink and not props.isLinkDisabled %}href="{{ url }}"{% endif %}
     >

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -30,7 +30,7 @@
       {{ 'c-entity--block-link' if props.isBlockLink }}
       {{ 'c-entity__link' if props.isBlockLink and not props.isLinkDisabled }}
       {{ 'disabled' if props.isLinkDisabled }}
-      js-prevent-double-click
+      {{ 'js-prevent-double-click' if props.preventDoubleClick }}
       "
       {% if props.isBlockLink and not props.isLinkDisabled %}href="{{ url }}"{% endif %}
     >

--- a/test/unit/macros/entity/entity.test.js
+++ b/test/unit/macros/entity/entity.test.js
@@ -24,7 +24,7 @@ describe('Entity macro', () => {
         name: 'Horse',
         type: 'animal',
       })
-      expect(component.className.trim()).to.equal('c-entity c-entity--animal\n      \n      \n      \n      js-prevent-double-click')
+      expect(component.className.trim()).to.equal('c-entity c-entity--animal')
       expect(component.querySelector('.c-entity__title a')).to.have.property('href', '/animals/12345')
     })
 

--- a/test/unit/macros/entity/entity.test.js
+++ b/test/unit/macros/entity/entity.test.js
@@ -24,7 +24,7 @@ describe('Entity macro', () => {
         name: 'Horse',
         type: 'animal',
       })
-      expect(component.className.trim()).to.equal('c-entity c-entity--animal')
+      expect(component.className.trim()).to.equal('c-entity c-entity--animal\n      \n      \n      \n      js-prevent-double-click')
       expect(component.querySelector('.c-entity__title a')).to.have.property('href', '/animals/12345')
     })
 


### PR DESCRIPTION
Some users still double click on links and this creates an unwanted behaviour, i.e. multiple entries.
I've done some discovery on what's the best way to approach this, and because in the node layer it creates multiple "threads" you can't really control the state of multiple requests unless you create an observer pattern in the authorised-request file.

Knowing that the authorised-request file is being used with almost all request, this pattern is not fit for purpose so I decided to solve it very simply in the client by preventing any double or multi click actions on a link with a predefined class, thus preserving the native browser behaviour.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
