### PR TITLE
Avoid duplicate attendees

### DIFF
--- a/assets/stylesheets/components/_entity.scss
+++ b/assets/stylesheets/components/_entity.scss
@@ -68,6 +68,18 @@
     color: $link-hover-colour;
   }
 
+  &.disabled {
+    background-color: $grey-4;
+    border-color: $grey-4;
+
+    &:focus,
+    &:hover {
+      background-color: $grey-4;
+      border-color: $grey-4;
+      color: $black;
+    }
+  }
+
   .c-entity__badges {
     color: $black;
   }

--- a/src/apps/events/attendees/controllers/create.js
+++ b/src/apps/events/attendees/controllers/create.js
@@ -2,6 +2,7 @@ const { get } = require('lodash')
 
 const { saveInteraction } = require('../../../interactions/repos')
 const { getContact } = require('../../../contacts/repos')
+const { fetchEventAttendees } = require('../repos')
 
 async function createAttendee (req, res, next) {
   try {
@@ -11,6 +12,12 @@ async function createAttendee (req, res, next) {
 
     if (!event || !contactId) {
       throw new Error('Missing eventId or contactId')
+    }
+
+    const attendees = await fetchEventAttendees({ token, contactId, eventId: event.id })
+    if (attendees.count > 0) {
+      req.flash('failure', 'Event attendee not added - This contact has already been added as an event attendee')
+      return res.redirect(`/events/${event.id}/attendees`)
     }
 
     const contact = await getContact(token, contactId)

--- a/src/apps/events/attendees/controllers/list.js
+++ b/src/apps/events/attendees/controllers/list.js
@@ -33,7 +33,7 @@ async function renderAttendees (req, res, next) {
         ],
       })
 
-      const attendees = await fetchEventAttendees(token, event.id, page, sortby)
+      const attendees = await fetchEventAttendees({ token, eventId: event.id, page, sortby })
         .then(transformApiResponseToCollection(
           { query },
           transformServiceDeliveryToAttendeeListItem

--- a/src/apps/events/attendees/repos.js
+++ b/src/apps/events/attendees/repos.js
@@ -1,8 +1,11 @@
 const config = require('../../../../config')
 const authorisedRequest = require('../../../lib/authorised-request')
 
-async function fetchEventAttendees (token, eventId, page = 1, sortby) {
-  const limit = 10
+async function fetchEventAttendees ({ token, eventId, page = 1, sortby, limit = 10 }) {
+  if (!eventId) {
+    return null
+  }
+
   const offset = limit * (page - 1)
 
   const eventAttendees = await authorisedRequest(token, {

--- a/src/apps/events/attendees/repos.js
+++ b/src/apps/events/attendees/repos.js
@@ -1,7 +1,9 @@
+const { isNil, pickBy } = require('lodash')
+
 const config = require('../../../../config')
 const authorisedRequest = require('../../../lib/authorised-request')
 
-async function fetchEventAttendees ({ token, eventId, page = 1, sortby, limit = 10 }) {
+async function fetchEventAttendees ({ token, eventId, page = 1, sortby, limit = 10, contactId }) {
   if (!eventId) {
     return null
   }
@@ -10,12 +12,13 @@ async function fetchEventAttendees ({ token, eventId, page = 1, sortby, limit = 
 
   const eventAttendees = await authorisedRequest(token, {
     url: `${config.apiRoot}/v3/interaction`,
-    qs: {
+    qs: pickBy({
       limit,
       offset,
       sortby,
       event_id: eventId,
-    },
+      contact_id: contactId,
+    }, value => !isNil(value)),
   })
 
   return eventAttendees

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -23,11 +23,15 @@
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
     {% set metaItems = props.meta | reject(['type', 'badge']) %}
     {% set highlightedName = props.name | highlight(props.highlightTerm) %}
-    {% set containerElement = 'a' if props.isBlockLink else 'div' %}
+    {% set containerElement = 'a' if props.isBlockLink and not props.isLinkDisabled else 'div' %}
 
     <{{ containerElement }}
-      class="c-entity c-entity--{{ props.type }} {{ 'c-entity__link c-entity--block-link' if props.isBlockLink }}"
-      {% if props.isBlockLink %}href="{{ url }}"{% endif %}
+      class="c-entity c-entity--{{ props.type }}
+      {{ 'c-entity--block-link' if props.isBlockLink }}
+      {{ 'c-entity__link' if props.isBlockLink and not props.isLinkDisabled }}
+      {{ 'disabled' if props.isLinkDisabled }}
+      "
+      {% if props.isBlockLink and not props.isLinkDisabled %}href="{{ url }}"{% endif %}
     >
       <div class="c-entity__header">
         {% if metaBadges | length %}


### PR DESCRIPTION
This ticket tackles the issue in 2 ways but is separate from the issue of users double clicking.

![capture](https://user-images.githubusercontent.com/56056/42691153-c2a37ac4-869e-11e8-9434-7aab7f234651.PNG)

When a user searches for contacts to add as event attendees, if a result has already been added, its style is modified to use the highlight background colour, a badge to indicate it has already been added and nothing happens if they try and click the result.

In addition, when a call is made to the 'create attendee' controller, it checks the attendee list for the event to see if it contains the contact passed to it. If that contact has previously been added then the user is shown an error.