### PR TITLE
Acceptance test filter race condition

### DIFF
--- a/test/acceptance/features/companies/collection.feature
+++ b/test/acceptance/features/companies/collection.feature
@@ -52,21 +52,25 @@ Feature: View collection of companies
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the companies list by active status
     Then the result count should be 1 less than the total
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the companies list by inactive status
     Then the result count should be 1
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the companies list by country
     Then the companies should be filtered to show badge company country
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the companies list by country
     And I filter the companies list by UK region
     Then the companies should be filtered to show badge company country

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -63,7 +63,7 @@ Feature: View collection of contacts
     Then there are no filters selected
     And the result count should be reset
     When I filter the contacts list by active status
-    And the result count should be reset
+    Then the result count should be 0 less than the total
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset

--- a/test/acceptance/features/contacts/collection.feature
+++ b/test/acceptance/features/contacts/collection.feature
@@ -62,27 +62,32 @@ Feature: View collection of contacts
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the contacts list by active status
     Then the result count should be 0 less than the total
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the contacts list by inactive status
     Then the result count should be 0
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the contacts list by company
     Then the contacts should be filtered by company name
     And the result count should be less than the total
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the contacts list by country
     Then the contacts should be filtered to show badge company country
     When I clear all filters
     Then there are no filters selected
     And the result count should be reset
+    Given I store the result count in state
     When I filter the contacts list by country
     And I filter the contacts list by UK region
     Then the contacts should be filtered to show badge company country


### PR DESCRIPTION
There is a race condition when the tests are running in parallel. This is because the result count is captured at the beginning of the test. When another parallel test creates a company, the value stored in state is stale.