### PR TITLE
Reuse getCollection for companies

### DIFF
--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -1,7 +1,7 @@
 const { assign } = require('lodash')
 
 const { getOptions } = require('../../../lib/options')
-const { search, searchLimitedCompanies, searchCompanies } = require('../../search/services')
+const { searchLimitedCompanies, searchCompanies } = require('../../search/services')
 const { transformApiResponseToSearchCollection } = require('../../../modules/search/transformers')
 const {
   transformCompanyToListItem,
@@ -24,27 +24,6 @@ async function getNonGlobalHQs (token) {
 async function getGlobalHQ (token) {
   const headerquarterTypes = await getOptions(token, 'headquarter-type')
   return headerquarterTypes.find(hqType => hqType.label === 'ghq')
-}
-
-async function getCompanyCollection (req, res, next) {
-  try {
-    res.locals.results = await search({
-      searchEntity: 'company',
-      requestBody: req.body,
-      token: req.session.token,
-      page: req.query.page,
-      isAggregation: false,
-    })
-      .then(transformApiResponseToSearchCollection(
-        { query: req.query },
-        ENTITIES,
-        transformCompanyToListItem,
-      ))
-
-    next()
-  } catch (error) {
-    next(error)
-  }
 }
 
 async function getLimitedCompaniesCollection (req, res, next) {
@@ -158,7 +137,6 @@ async function getSubsidiaryCompaniesCollection (req, res, next) {
 }
 
 module.exports = {
-  getCompanyCollection,
   getLimitedCompaniesCollection,
   getGlobalHQCompaniesCollection,
   getSubsidiaryCompaniesCollection,

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -1,8 +1,10 @@
 const router = require('express').Router()
 
+const { ENTITIES } = require('../search/constants')
 const { LOCAL_NAV, DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
 
 const { getRequestBody } = require('../../middleware/collection')
+const { getCollection } = require('../../modules/search/middleware/collection')
 
 const {
   renderAddStepOne,
@@ -40,7 +42,6 @@ const {
 } = require('../interactions/middleware/collection')
 
 const {
-  getCompanyCollection,
   getLimitedCompaniesCollection,
   getGlobalHQCompaniesCollection,
   getSubsidiaryCompaniesCollection,
@@ -53,6 +54,8 @@ const { setInteractionsReturnUrl, setInteractionsEntityName } = require('./middl
 const { setGlobalHQ, removeGlobalHQ, addSubsidiary } = require('./middleware/hierarchies')
 const setCompaniesLocalNav = require('./middleware/local-navigation')
 
+const { transformCompanyToListItem } = require('./transformers')
+
 const interactionsRouter = require('../interactions/router.sub-app')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
@@ -60,7 +63,12 @@ router.use(handleRoutePermissions(APP_PERMISSIONS))
 router.param('companyId', getCompany)
 router.param('companyNumber', getCompaniesHouseRecord)
 
-router.get('/', setDefaultQuery(DEFAULT_COLLECTION_QUERY), getRequestBody(QUERY_FIELDS), getCompanyCollection, renderCompanyList)
+router.get('/',
+  setDefaultQuery(DEFAULT_COLLECTION_QUERY),
+  getRequestBody(QUERY_FIELDS),
+  getCollection('company', ENTITIES, transformCompanyToListItem),
+  renderCompanyList,
+)
 
 router
   .route('/add-step-1')

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -8,7 +8,6 @@ const subsidiaryCompanySearchResponse = require('~/test/unit/data/companies/subs
 const subsidiaryCompanyTransformedResults = require('~/test/unit/data/companies/subsidiary-company-transformed-results.json')
 
 const {
-  getCompanyCollection,
   getGlobalHQCompaniesCollection,
   getSubsidiaryCompaniesCollection,
 } = require('~/src/apps/companies/middleware/collection')
@@ -29,14 +28,6 @@ const headquarterTypes = [{
 
 describe('Company collection middleware', () => {
   beforeEach(() => {
-    this.mockCompanyResults = {
-      count: 3,
-      results: [
-        { id: '111', name: 'A' },
-        { id: '222', name: 'B' },
-        { id: '333', name: 'C' },
-      ],
-    }
     this.nextSpy = sinon.spy()
     this.reqMock = {
       ...globalReq,
@@ -45,30 +36,6 @@ describe('Company collection middleware', () => {
     this.resMock = {
       locals: {},
     }
-  })
-
-  describe('#getCompanyCollection', () => {
-    beforeEach(async () => {
-      nock(config.apiRoot)
-        .post(`/v3/search/company`)
-        .reply(200, this.mockCompanyResults)
-
-      this.reqMock.query = {
-        stage: 'i1',
-        sector: 's1',
-        sortby: 'name:asc',
-      }
-      await getCompanyCollection(this.reqMock, this.resMock, this.nextSpy)
-    })
-
-    it('should set results property on locals with pagination', () => {
-      const actual = this.resMock.locals.results
-      expect(actual).to.have.property('count')
-      expect(actual).to.have.property('items').to.have.length(3)
-      expect(actual).to.have.property('pagination')
-      expect(actual.count).to.equal(3)
-      expect(this.nextSpy).to.have.been.calledOnce
-    })
   })
 
   describe('#getLimitedCompaniesCollection', () => {

--- a/test/unit/modules/search/middleware/collection.test.js
+++ b/test/unit/modules/search/middleware/collection.test.js
@@ -1,0 +1,55 @@
+const config = require('~/config')
+
+describe('Collection middleware', () => {
+  beforeEach(() => {
+    this.middleware = require('~/src/modules/search/middleware/collection')
+    this.reqMock = {
+      session: {
+        token: '1234',
+      },
+    }
+    this.resMock = {
+      locals: {},
+    }
+    this.nextSpy = sinon.spy()
+    this.mockEntityResults = {
+      count: 3,
+      results: [
+        { id: '111', name: 'A' },
+        { id: '222', name: 'B' },
+        { id: '333', name: 'C' },
+      ],
+    }
+  })
+
+  describe('#getCollection', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .post(`/v3/search/entity`)
+        .reply(200, this.mockEntityResults)
+
+      this.reqMock.query = {
+        sortby: 'name:asc',
+      }
+      await this.middleware.getCollection('entity')(this.reqMock, this.resMock, this.nextSpy)
+
+      this.actual = this.resMock.locals.results
+    })
+
+    it('should set the count', () => {
+      expect(this.actual).to.have.property('count')
+    })
+
+    it('should set the items', () => {
+      expect(this.actual).to.have.property('items').to.have.length(3)
+    })
+
+    it('should set the pagination', () => {
+      expect(this.actual).to.have.property('pagination')
+    })
+
+    it('should call next once', () => {
+      expect(this.nextSpy).to.have.been.calledOnce
+    })
+  })
+})


### PR DESCRIPTION
Recent refactor of `getCollection` in the search module means that duplication can be removed. This change is to remove `getCompanyCollection`.

In addition a unit test has been added around `getCollection` in the search module.