### PR TITLE
Add company advisers tab under feature flag

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -31,6 +31,10 @@ const LOCAL_NAV = [
     ],
   },
   {
+    path: 'advisers',
+    label: 'Advisers',
+  },
+  {
     path: 'interactions',
     label: 'Interactions',
     permissions: [

--- a/src/apps/companies/controllers/advisers.js
+++ b/src/apps/companies/controllers/advisers.js
@@ -1,0 +1,22 @@
+const { notFound } = require('../../../middleware/errors')
+
+function renderAdvisers (req, res, next) {
+  if (!res.locals.features['companies-advisers']) {
+    return notFound(req, res, next)
+  }
+
+  try {
+    const { name, id } = res.locals.company
+
+    res
+      .breadcrumb(name, `/companies/${id}`)
+      .breadcrumb('Advisers')
+      .render('companies/views/advisers')
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderAdvisers,
+}

--- a/src/apps/companies/middleware/local-navigation.js
+++ b/src/apps/companies/middleware/local-navigation.js
@@ -13,7 +13,8 @@ function setCompaniesLocalNav (req, res, next) {
 
   const navItems = LOCAL_NAV.filter((navItem) => {
     return (navItem.path !== 'subsidiaries' || headquarterType === 'ghq') &&
-        (navItem.path !== 'timeline' || companyNumber)
+        (navItem.path !== 'timeline' || companyNumber) &&
+        (navItem.path !== 'advisers' || res.locals.features['companies-advisers'])
   })
 
   setLocalNav(navItems)(req, res, next)

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -26,6 +26,7 @@ const { renderDocuments } = require('./controllers/documents')
 const { renderAddGlobalHQ } = require('./controllers/hierarchies')
 const { renderSubsidiaries } = require('./controllers/subsidiaries')
 const { renderLinkSubsidiary } = require('./controllers/subsidiaryLink')
+const { renderAdvisers } = require('./controllers/advisers')
 
 const {
   renderExports,
@@ -116,6 +117,8 @@ router.get('/:companyId/contacts',
   getCompanyContactCollection,
   renderContacts
 )
+
+router.get('/:companyId/advisers', renderAdvisers)
 
 router.get('/:companyId/interactions',
   setInteractionsReturnUrl,

--- a/src/apps/companies/views/advisers.njk
+++ b/src/apps/companies/views/advisers.njk
@@ -1,0 +1,6 @@
+{% extends "./_layout-view.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Company advisers</h2>
+
+{% endblock %}

--- a/test/unit/apps/companies/controllers/advisers.test.js
+++ b/test/unit/apps/companies/controllers/advisers.test.js
@@ -1,0 +1,74 @@
+const { assign } = require('lodash')
+
+const companyMock = require('~/test/unit/data/companies/companies-house.json')
+
+describe('Company contact list controller', () => {
+  beforeEach(() => {
+    this.reqMock = assign({}, globalReq, {
+      session: {
+        token: 'abcd',
+      },
+    })
+    this.resMock = assign({}, globalRes, {
+      locals: {
+        company: companyMock,
+        features: {},
+      },
+      breadcrumb: sinon.stub().returnsThis(),
+      render: sinon.spy(),
+      query: {},
+    })
+    this.nextSpy = sinon.spy()
+
+    this.controller = require('~/src/apps/companies/controllers/advisers')
+  })
+
+  describe('#renderAdvisers', () => {
+    context('when the feature flag is enabled', () => {
+      beforeEach(() => {
+        this.resMock.locals.features['companies-advisers'] = true
+
+        this.controller.renderAdvisers(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should add two breadcrumbs', () => {
+        expect(this.resMock.breadcrumb).to.have.been.calledTwice
+      })
+
+      it('should add the company breadcrumb', () => {
+        expect(this.resMock.breadcrumb).to.be.calledWith('Mercury Trading Ltd', '/companies/15387806')
+      })
+
+      it('should add the Advisers breadcrumb', () => {
+        expect(this.resMock.breadcrumb).to.be.calledWith('Advisers')
+      })
+
+      it('should render the correct template', () => {
+        expect(this.resMock.render).to.be.calledWith('companies/views/advisers')
+      })
+
+      it('should not call next', () => {
+        expect(this.nextSpy).to.not.be.called
+      })
+    })
+
+    context('when the feature flag is not enabled', () => {
+      beforeEach(() => {
+        this.controller.renderAdvisers(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not add breadcrumbs', () => {
+        expect(this.resMock.breadcrumb).to.not.be.called
+      })
+
+      it('should not render the template', () => {
+        expect(this.resMock.render).to.not.be.called
+      })
+
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledOnce
+        expect(this.nextSpy).to.be.calledWith(sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Not Found')))
+      })
+    })
+  })
+})

--- a/test/unit/apps/companies/middleware/local-navigation.test.js
+++ b/test/unit/apps/companies/middleware/local-navigation.test.js
@@ -22,6 +22,7 @@ describe('Companies local navigation', () => {
         headquarter_type: null,
         company_number: null,
       }
+      this.res.locals.features = {}
 
       setCompaniesLocalNav(this.req, this.res, this.next)
     })
@@ -42,6 +43,7 @@ describe('Companies local navigation', () => {
         },
         company_number: null,
       }
+      this.res.locals.features = {}
 
       setCompaniesLocalNav(this.req, this.res, this.next)
     })
@@ -62,6 +64,7 @@ describe('Companies local navigation', () => {
         },
         company_number: null,
       }
+      this.res.locals.features = {}
 
       setCompaniesLocalNav(this.req, this.res, this.next)
     })
@@ -82,6 +85,7 @@ describe('Companies local navigation', () => {
         },
         company_number: '1234',
       }
+      this.res.locals.features = {}
 
       setCompaniesLocalNav(this.req, this.res, this.next)
     })
@@ -102,6 +106,7 @@ describe('Companies local navigation', () => {
         },
         company_number: null,
       }
+      this.res.locals.features = {}
 
       setCompaniesLocalNav(this.req, this.res, this.next)
     })
@@ -109,6 +114,34 @@ describe('Companies local navigation', () => {
     it('should not have a timeline option', () => {
       const menuItem = this.res.locals.localNavItems.find(item => item.path === 'timeline')
       expect(menuItem).to.be.undefined
+    })
+  })
+
+  context('when the company advisers feature is not enabled', () => {
+    beforeEach(() => {
+      this.res.locals.company = {}
+      this.res.locals.features = {}
+
+      setCompaniesLocalNav(this.req, this.res, this.next)
+    })
+
+    it('should not have an advisers option', () => {
+      const menuItem = this.res.locals.localNavItems.find(item => item.path === 'advisers')
+      expect(menuItem).to.be.undefined
+    })
+  })
+
+  context('when the company advisers feature is enabled', () => {
+    beforeEach(() => {
+      this.res.locals.company = {}
+      this.res.locals.features = { 'companies-advisers': true }
+
+      setCompaniesLocalNav(this.req, this.res, this.next)
+    })
+
+    it('should have an advisers option', () => {
+      const menuItem = this.res.locals.localNavItems.find(item => item.path === 'advisers')
+      expect(menuItem).to.be.ok
     })
   })
 })


### PR DESCRIPTION
Introducing the `Company advisers` view as a separate tab when viewing a company. This is the simplest implementation and will be iterated on. Details about this change:
- feature is behind a feature flag `company-advisers`
- feature flag has been applied to local navigation and middleware that renders advisers
- unit tests have been introduced which also consider the feature flag (we can always rip out later)

<img width="883" alt="screen shot 2018-07-25 at 13 46 02" src="https://user-images.githubusercontent.com/1150417/43201713-2e318fc6-9011-11e8-937a-716c11e87e89.png">
