### PR TITLE
Hide "Add contact" button for archived companies

### DIFF
--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -4,7 +4,7 @@ const { contactFiltersFields, companyContactSortForm } = require('../../contacts
 const { buildSelectedFiltersSummary } = require('../../builders')
 
 function renderContacts (req, res) {
-  const { id: companyId, name: companyName } = res.locals.company
+  const { id: companyId, name: companyName, archived: companyArchived } = res.locals.company
   const filtersFields = filter(contactFiltersFields, (field) => {
     return ['name', 'archived'].includes(field.name)
   })
@@ -16,17 +16,18 @@ function renderContacts (req, res) {
     ],
   })
 
+  const actionButtons = companyArchived ? undefined : [{
+    label: 'Add contact',
+    url: `/contacts/create?company=${companyId}`,
+  }]
   res
     .breadcrumb(companyName, `/companies/${companyId}`)
     .breadcrumb('Contacts')
     .render('companies/views/contacts', {
       sortForm,
       filtersFields,
+      actionButtons,
       selectedFilters: buildSelectedFiltersSummary(filtersFields, req.query),
-      actionButtons: [{
-        label: 'Add contact',
-        url: `/contacts/create?company=${companyId}`,
-      }],
     })
 }
 

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -90,3 +90,9 @@ Feature: Create New Contact
     When I submit the form
     Then the contact fields have error messages
     And I see form error summary
+
+  @contacts-save--archived-company
+  Scenario: Archived company without Add contact button
+
+    When I navigate to the `companies.contacts` page using `company` `Archived Ltd` fixture
+    And I should not see the "Add contact" button

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -119,7 +119,7 @@ Feature: Create a new Investment project
       | Specific investment programme | investmentProject.specificInvestmentProgramme |
 
   @investment-projects-create--archived-company
-  Scenario: Add a Non Foreign Direct Investment (Non-FDI) Investment project
+  Scenario: Archived company without Add investment project button
 
     When I navigate to the `companies.investments` page using `company` `Archived Ltd` fixture
     And I should not see the "Add investment project" button

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -34,36 +34,61 @@ describe('Company contact list controller', () => {
   })
 
   describe('#renderContacts', () => {
-    beforeEach(() => {
-      this.controller.renderContacts(this.reqMock, this.resMock)
+    context('when the company is active', () => {
+      beforeEach(() => {
+        this.controller.renderContacts(this.reqMock, this.resMock)
+      })
+
+      it('should render collection page with locals', () => {
+        expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('sortForm'))
+        expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('filtersFields'))
+        expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('selectedFilters'))
+        expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('actionButtons'))
+        expect(this.buildSelectedFiltersSummaryStub).to.have.been.calledWith([
+          { macroName: 'foo', name: 'name' },
+          { macroName: 'bar', name: 'archived' },
+        ], this.reqMock.query)
+      })
+
+      it('should set the correct number of breadcrumbs', () => {
+        expect(this.resMock.breadcrumb).to.have.been.calledTwice
+      })
+
+      it('should render the correct template', () => {
+        expect(this.resMock.render.args[0][0]).to.equal('companies/views/contacts')
+      })
+
+      it('should set the correct add button', () => {
+        const props = this.resMock.render.args[0][1]
+
+        expect(props.actionButtons).to.deep.equal([{
+          label: 'Add contact',
+          url: `/contacts/create?company=${companyMock.id}`,
+        }])
+      })
     })
 
-    it('should render collection page with locals', () => {
-      expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('sortForm'))
-      expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('filtersFields'))
-      expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('selectedFilters'))
-      expect(this.resMock.render).to.have.been.calledWith(sinon.match.any, sinon.match.hasOwn('actionButtons'))
-      expect(this.buildSelectedFiltersSummaryStub).to.have.been.calledWith([
-        { macroName: 'foo', name: 'name' },
-        { macroName: 'bar', name: 'archived' },
-      ], this.reqMock.query)
-    })
+    context('when the company is archived', () => {
+      beforeEach(() => {
+        this.resMock = {
+          ...this.resMock,
+          locals: {
+            ...this.resMock.locals,
+            company: {
+              ...this.resMock.locals.company,
+              archived: true,
+            },
+          },
+        }
 
-    it('should set the correct number of breadcrumbs', () => {
-      expect(this.resMock.breadcrumb).to.have.been.calledTwice
-    })
+        this.controller.renderContacts(this.reqMock, this.resMock)
+      })
 
-    it('should render the correct template', () => {
-      expect(this.resMock.render.args[0][0]).to.equal('companies/views/contacts')
-    })
+      it('should not set actions buttons', () => {
+        const props = this.resMock.render.args[0][1]
 
-    it('should set the correct add button', () => {
-      const props = this.resMock.render.args[0][1]
-
-      expect(props.actionButtons).to.deep.equal([{
-        label: 'Add contact',
-        url: `/contacts/create?company=${companyMock.id}`,
-      }])
+        expect(props.actionButtons).to.be.undefined
+      })
     })
   })
 })


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Add contact` button should be hidden if a company has been archived. If the button is visible then data is being added where it should not be.

### Solution

Hide the `Add contact` button for archived companies

<img width="842" alt="screen shot 2018-07-26 at 14 49 42" src="https://user-images.githubusercontent.com/1150417/43266429-50540ca0-90e3-11e8-8752-3dcc4e945897.png">
