### PR TITLE
Hide "Add interaction" button for archived companies

### DIFF
--- a/src/apps/companies/controllers/interactions.js
+++ b/src/apps/companies/controllers/interactions.js
@@ -1,15 +1,17 @@
 function renderInteractions (req, res, next) {
   try {
-    const { name, id } = res.locals.company
+    const { name, id, archived } = res.locals.company
+
+    const actionButtons = archived ? undefined : [{
+      label: 'Add interaction',
+      url: `/companies/${id}/interactions/create`,
+    }]
 
     res
       .breadcrumb(name, `/companies/${id}`)
       .breadcrumb('Interactions')
       .render('companies/views/interactions', {
-        actionButtons: [{
-          label: 'Add interaction',
-          url: `/companies/${id}/interactions/create`,
-        }],
+        actionButtons,
       })
   } catch (error) {
     next(error)

--- a/src/apps/companies/controllers/interactions.js
+++ b/src/apps/companies/controllers/interactions.js
@@ -8,7 +8,7 @@ function renderInteractions (req, res, next) {
       .render('companies/views/interactions', {
         actionButtons: [{
           label: 'Add interaction',
-          url: `/companies/${req.params.companyId}/interactions/create`,
+          url: `/companies/${id}/interactions/create`,
         }],
       })
   } catch (error) {

--- a/test/acceptance/features/interactions/add.feature
+++ b/test/acceptance/features/interactions/add.feature
@@ -257,3 +257,9 @@ Feature: Add a new interaction in Data hub
     Then the net receipt field is hidden
     When I change form dropdown "service" to Bank Referral
     Then the service fields are hidden
+
+  @interactions-add--archived-company
+  Scenario: Archived company without Add interaction button
+
+    When I navigate to the `companies.interactions` page using `company` `Archived Ltd` fixture
+    And I should not see the "Add interaction" button


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Add interaction` button should be hidden if a company has been archived. If the button is visible then data is being added where it should not be.

### Solution

Hide the `Add interaction` button for archived companies

<img width="803" alt="screen shot 2018-07-26 at 16 40 00" src="https://user-images.githubusercontent.com/1150417/43272747-a7c701ae-90f2-11e8-9cbe-300a645c8c38.png">

