### PR TITLE
Integrate with companies core-team endpoint

### DIFF
--- a/src/apps/companies/controllers/advisers.js
+++ b/src/apps/companies/controllers/advisers.js
@@ -6,10 +6,10 @@ function renderAdvisers (req, res, next) {
   }
 
   try {
-    const { name, id } = res.locals.company
+    const { name: companyName, id: companyId } = res.locals.company
 
     res
-      .breadcrumb(name, `/companies/${id}`)
+      .breadcrumb(companyName, `/companies/${companyId}`)
       .breadcrumb('Advisers')
       .render('companies/views/advisers')
   } catch (error) {

--- a/src/apps/companies/controllers/advisers.js
+++ b/src/apps/companies/controllers/advisers.js
@@ -1,17 +1,26 @@
 const { notFound } = require('../../../middleware/errors')
+const { getCoreTeam } = require('../repos')
+const { transformCoreTeamToCollection } = require('../transformers')
 
-function renderAdvisers (req, res, next) {
+async function renderAdvisers (req, res, next) {
   if (!res.locals.features['companies-advisers']) {
     return notFound(req, res, next)
   }
 
   try {
     const { name: companyName, id: companyId } = res.locals.company
+    const token = req.session.token
+
+    const coreTeam = await getCoreTeam(token, companyId)
+      .then(transformCoreTeamToCollection)
 
     res
       .breadcrumb(companyName, `/companies/${companyId}`)
       .breadcrumb('Advisers')
-      .render('companies/views/advisers')
+      .render('companies/views/advisers', {
+        companyName,
+        coreTeam,
+      })
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -78,6 +78,12 @@ const exportDetailsLabels = {
   futureInterestCountries: 'Future countries of interest',
 }
 
+const coreTeamLabels = {
+  region: 'Region',
+  country: 'Country',
+  team: 'Team',
+}
+
 module.exports = {
   companyDetailsLabels,
   chDetailsLabels,
@@ -86,4 +92,5 @@ module.exports = {
   accountManagementDisplayLabels,
   exportDetailsLabels,
   address,
+  coreTeamLabels,
 }

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -105,6 +105,12 @@ function getCompanySubsidiaries (token, companyId, page = 1) {
   })
 }
 
+function getCoreTeam (token, companyId) {
+  return authorisedRequest(token, {
+    url: `${config.apiRoot}/v3/company/${companyId}/core-team`,
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
@@ -115,4 +121,5 @@ module.exports = {
   getCompanyAuditLog,
   getCompanyTimeline,
   getCompanySubsidiaries,
+  getCoreTeam,
 }

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -103,6 +103,7 @@ router.use('/:companyId', handleRoutePermissions(LOCAL_NAV), setCompaniesLocalNa
 
 router.get('/:companyId', redirectToFirstNavItem)
 router.get('/:companyId/details', renderDetails)
+router.get('/:companyId/advisers', renderAdvisers)
 
 router.get('/:companyId/hierarchies/ghq/search', getGlobalHQCompaniesCollection, renderAddGlobalHQ)
 router.get('/:companyId/hierarchies/ghq/:globalHqId/add', setGlobalHQ)
@@ -117,8 +118,6 @@ router.get('/:companyId/contacts',
   getCompanyContactCollection,
   renderContacts
 )
-
-router.get('/:companyId/advisers', renderAdvisers)
 
 router.get('/:companyId/interactions',
   setInteractionsReturnUrl,

--- a/src/apps/companies/transformers/core-team-to-collection.js
+++ b/src/apps/companies/transformers/core-team-to-collection.js
@@ -1,0 +1,25 @@
+const { get, compact } = require('lodash')
+
+const { coreTeamLabels } = require('../labels')
+
+function getSubTitle (isGlobalAccountManager) {
+  return isGlobalAccountManager ? { value: 'Global Account Manager' } : undefined
+}
+
+module.exports = function transformCoreTeamToCollection (advisers) {
+  return advisers.map(({ adviser, is_global_account_manager: isGlobalAccountManager }) => {
+    const region = get(adviser, 'dit_team.uk_region.name')
+    const metaItems = [
+      region ? { label: coreTeamLabels.region, value: region } : null,
+      { label: coreTeamLabels.country, value: get(adviser, 'dit_team.country.name') },
+      { label: coreTeamLabels.team, value: get(adviser, 'dit_team.name') },
+    ]
+
+    return {
+      name: adviser.name,
+      type: 'adviser',
+      subTitle: getSubTitle(isGlobalAccountManager),
+      meta: compact(metaItems),
+    }
+  })
+}

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -6,6 +6,7 @@ const transformCompanyToListItem = require('./company-to-list-item')
 const transformCompanyToOneListView = require('./company-to-one-list-view')
 const transformCompanyToView = require('./company-to-view')
 const transformCompanyToSubsidiaryListItem = require('./company-to-subsidary-list-item')
+const transformCoreTeamToCollection = require('./core-team-to-collection')
 
 module.exports = {
   transformCompaniesHouseToListItem,
@@ -16,4 +17,5 @@ module.exports = {
   transformCompanyToOneListView,
   transformCompanyToSubsidiaryListItem,
   transformCompanyToView,
+  transformCoreTeamToCollection,
 }

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -14,6 +14,6 @@ module.exports = {
   transformCompanyToForm,
   transformCompanyToListItem,
   transformCompanyToOneListView,
-  transformCompanyToView,
   transformCompanyToSubsidiaryListItem,
+  transformCompanyToView,
 }

--- a/src/apps/companies/views/advisers.njk
+++ b/src/apps/companies/views/advisers.njk
@@ -1,6 +1,10 @@
 {% extends "./_layout-view.njk" %}
 
+{% from "_macros/entity/entity-list.njk" import EntityList %}
+
 {% block main_grid_right_column %}
-  <h2 class="heading-medium">Company advisers</h2>
+  <h2 class="heading-medium">Advisers assigned to {{ companyName }}</h2>
+
+  {{ EntityList({ items: coreTeam }) }}
 
 {% endblock %}

--- a/test/acceptance/features/companies/advisers-collection.feature
+++ b/test/acceptance/features/companies/advisers-collection.feature
@@ -1,0 +1,8 @@
+@companies-advisers-collection @collection
+Feature: View collection of advisers for a company
+
+  @companies-advisers-collection--view
+  Scenario: View companies adviser collection
+    When I navigate to the `companies.advisers` page using `company` `One List Corp` fixture
+    Then details content heading should contain "Advisers assigned to One List Corp"
+    And I can view the entity list

--- a/test/acceptance/features/companies/local-nav.feature
+++ b/test/acceptance/features/companies/local-nav.feature
@@ -9,6 +9,7 @@ Feature: Companies local nav
       | text                      |
       | Details                   |
       | Contacts                  |
+      | Advisers                  |
       | Interactions              |
       | Investment                |
       | Export                    |
@@ -24,6 +25,7 @@ Feature: Companies local nav
       | text                      |
       | Details                   |
       | Contacts                  |
+      | Advisers                  |
       | Investment                |
       | Export                    |
       | Audit history             |
@@ -36,6 +38,7 @@ Feature: Companies local nav
       | text                      |
       | Details                   |
       | Contacts                  |
+      | Advisers                  |
       | Investment                |
       | Export                    |
       | Orders (OMIS)             |

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -77,6 +77,12 @@ Then(/^details heading should contain "(.+)"$/, async (value) => {
     .assert.containsText('@heading', value)
 })
 
+Then(/^details content heading should contain "(.+)"$/, async (value) => {
+  await Details
+    .waitForElementPresent('@contentHeading')
+    .assert.containsText('@contentHeading', value)
+})
+
 Then(/^details view data for "(.+)" should contain what I entered for "(.+)" field$/, async function (detailsItemName, fieldName) {
   const detail = await Details.getDetailFor(detailsItemName)
 

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -146,6 +146,11 @@ Then(/^I can view the collection$/, async function () {
     .assert.visible('@collection')
 })
 
+Then(/^I can view the entity list/, async function () {
+  await Collection
+    .assert.visible('@entityList')
+})
+
 Then(/^I see the list in A-Z alphabetical order$/, async function () {
   const firstFieldIsLessThanSecondField = this.state.list.firstItem.field.toLowerCase() < this.state.list.secondItem.field.toLowerCase()
   const bothFieldsAreTheSame = this.state.list.firstItem.field === this.state.list.secondItem.field

--- a/test/acceptance/pages/collection.js
+++ b/test/acceptance/pages/collection.js
@@ -15,6 +15,7 @@ const getSelectorForMetaListItemValue = (text) => {
 module.exports = {
   elements: {
     collection: '.c-collection',
+    entityList: '.c-entity-list',
   },
   commands: [
     {

--- a/test/acceptance/pages/companies/advisers.js
+++ b/test/acceptance/pages/companies/advisers.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { company } = require('../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(company, { name: companyName })
+    const companyId = fixture ? fixture.id : company.ukLtd.id
+
+    return `${process.env.QA_HOST}/companies/${companyId}/advisers`
+  },
+  elements: {},
+}

--- a/test/acceptance/pages/details.js
+++ b/test/acceptance/pages/details.js
@@ -3,6 +3,7 @@ const { getSelectorForElementWithText } = require('../helpers/selectors')
 module.exports = {
   elements: {
     heading: '.c-local-header__heading',
+    contentHeading: '.heading-medium',
     localNav: '.c-local-nav',
     documentsLink: {
       selector: '//a[contains(.,"View files and documents")][contains(@aria-labelledby,"external-link-label")]',

--- a/test/unit/apps/companies/controllers/advisers.test.js
+++ b/test/unit/apps/companies/controllers/advisers.test.js
@@ -1,6 +1,8 @@
 const { assign } = require('lodash')
 
+const config = require('~/config')
 const companyMock = require('~/test/unit/data/companies/companies-house.json')
+const coreTeamMock = require('~/test/unit/data/companies/core-team.json')
 
 describe('Company contact list controller', () => {
   beforeEach(() => {
@@ -25,10 +27,14 @@ describe('Company contact list controller', () => {
 
   describe('#renderAdvisers', () => {
     context('when the feature flag is enabled', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .get(`/v3/company/${companyMock.id}/core-team`)
+          .reply(200, coreTeamMock)
+
         this.resMock.locals.features['companies-advisers'] = true
 
-        this.controller.renderAdvisers(this.reqMock, this.resMock, this.nextSpy)
+        await this.controller.renderAdvisers(this.reqMock, this.resMock, this.nextSpy)
       })
 
       it('should add two breadcrumbs', () => {
@@ -45,6 +51,14 @@ describe('Company contact list controller', () => {
 
       it('should render the correct template', () => {
         expect(this.resMock.render).to.be.calledWith('companies/views/advisers')
+      })
+
+      it('should set the company name', () => {
+        expect(this.resMock.render.args[0][1].companyName).to.equal('Mercury Trading Ltd')
+      })
+
+      it('should set the core team', () => {
+        expect(this.resMock.render.args[0][1].coreTeam).to.not.be.null
       })
 
       it('should not call next', () => {

--- a/test/unit/apps/companies/transformers/core-team-to-collection.test.js
+++ b/test/unit/apps/companies/transformers/core-team-to-collection.test.js
@@ -1,0 +1,84 @@
+const transformCoreTeamToCollection = require('~/src/apps/companies/transformers/core-team-to-collection')
+
+describe('#transformCoreTeamToCollection', () => {
+  beforeEach(() => {
+    this.coreTeamMock = require('~/test/unit/data/companies/core-team.json')
+  })
+
+  context('when the core team member is a global account manager and from a UK region', () => {
+    beforeEach(() => {
+      this.collection = transformCoreTeamToCollection(this.coreTeamMock)
+    })
+
+    it('should have 1 item in the collection', () => {
+      expect(this.collection.length).to.equal(1)
+    })
+
+    it('should set the name', () => {
+      expect(this.collection[0].name).to.equal('Travis Greene')
+    })
+
+    it('should set the type', () => {
+      expect(this.collection[0].type).to.equal('adviser')
+    })
+
+    it('should set the subtitle', () => {
+      expect(this.collection[0].subTitle.value).to.equal('Global Account Manager')
+    })
+
+    it('should set the meta with region', () => {
+      expect(this.collection[0].meta).to.deep.equal([
+        {
+          'label': 'Region',
+          'value': 'London',
+        },
+        {
+          'label': 'Country',
+          'value': 'United Kingdom',
+        },
+        {
+          'label': 'Team',
+          'value': 'IST - Sector Advisory Services',
+        },
+      ])
+    })
+  })
+
+  context('when the core team member is not a global account manager and not from a UK region', () => {
+    beforeEach(() => {
+      this.coreTeamMock[0].is_global_account_manager = false
+      delete this.coreTeamMock[0].adviser.dit_team.uk_region
+
+      this.collection = transformCoreTeamToCollection(this.coreTeamMock)
+    })
+
+    it('should have 1 item in the collection', () => {
+      expect(this.collection.length).to.equal(1)
+    })
+
+    it('should set the name', () => {
+      expect(this.collection[0].name).to.equal('Travis Greene')
+    })
+
+    it('should set the type', () => {
+      expect(this.collection[0].type).to.equal('adviser')
+    })
+
+    it('should not set the subtitle', () => {
+      expect(this.collection[0].subTitle).to.be.undefined
+    })
+
+    it('should set the meta without region', () => {
+      expect(this.collection[0].meta).to.deep.equal([
+        {
+          'label': 'Country',
+          'value': 'United Kingdom',
+        },
+        {
+          'label': 'Team',
+          'value': 'IST - Sector Advisory Services',
+        },
+      ])
+    })
+  })
+})

--- a/test/unit/data/companies/core-team.json
+++ b/test/unit/data/companies/core-team.json
@@ -1,0 +1,23 @@
+[
+  {
+    "adviser": {
+      "name": "Travis Greene",
+      "first_name": "Travis",
+      "last_name": "Greene",
+      "dit_team": {
+        "name": "IST - Sector Advisory Services",
+        "uk_region": {
+          "name": "London",
+          "id": "874cd12a-6095-e211-a939-e4115bead28a"
+        },
+        "country": {
+          "name": "United Kingdom",
+          "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+        },
+        "id": "fc3a6667-cfe9-e511-8ffa-e4115bead28a"
+      },
+      "id": "8eefe6b4-2816-4e47-94b5-a13409dcef70"
+    },
+    "is_global_account_manager": true
+  }
+]


### PR DESCRIPTION
This change integrates with the new Leeloo companies `core-team` endpoint, as follows:
- integration
- updated unit tests
- acceptance test

As the feature evolves, I will add more tests. Expecting the appearance to change as we get more involvement from design.

<img width="805" alt="screen shot 2018-07-31 at 15 31 20" src="https://user-images.githubusercontent.com/1150417/43466184-de4ae686-94d6-11e8-934d-9a838e022a4a.png">
