### PR TITLE
Hide "Add order" button for archived companies

### DIFF
--- a/src/apps/companies/controllers/orders.js
+++ b/src/apps/companies/controllers/orders.js
@@ -5,7 +5,7 @@ const { transformOrderToListItem } = require('../../omis/transformers')
 async function renderOrders (req, res, next) {
   const token = req.session.token
   const page = req.query.page || 1
-  const { id, name } = res.locals.company
+  const { id, name, archived } = res.locals.company
 
   try {
     const results = await search({
@@ -22,15 +22,17 @@ async function renderOrders (req, res, next) {
         transformOrderToListItem,
       ))
 
+    const actionButtons = archived ? undefined : [{
+      label: 'Add order',
+      url: `/omis/create?company=${id}&skip-company=true`,
+    }]
+
     res
       .breadcrumb(name, `/companies/${id}`)
       .breadcrumb('Orders (OMIS)')
       .render('companies/views/orders', {
         results,
-        actionButtons: [{
-          label: 'Add order',
-          url: `/omis/create?company=${id}&skip-company=true`,
-        }],
+        actionButtons,
       })
   } catch (error) {
     next(error)

--- a/test/acceptance/features/omis/create.feature
+++ b/test/acceptance/features/omis/create.feature
@@ -53,3 +53,9 @@ Feature: Create new order using company ID
     And I should see the correct text on the `omis.create.summary` page
       | elementPath     | expectedText                     |
       | sector.sector   | omis.create.sector.sectorField   |
+
+
+  @omis-create--archived-company
+  Scenario: Archived company without Add order button
+    When I navigate to the `companies.orders` page using `company` `Archived Ltd` fixture
+    And I should not see the "Add order" button

--- a/test/unit/apps/companies/controllers/orders.test.js
+++ b/test/unit/apps/companies/controllers/orders.test.js
@@ -104,6 +104,27 @@ describe('Company investments controller', () => {
         })
       })
     })
+
+    context('when the company is archived', () => {
+      beforeEach(async () => {
+        this.resMock = {
+          ...this.resMock,
+          locals: {
+            ...this.resMock.locals,
+            company: {
+              ...this.resMock.locals.company,
+              archived: true,
+            },
+          },
+        }
+
+        await this.controller.renderOrders(this.reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should not send buttons to the template', () => {
+        expect(this.renderSpy.args[0][1].actionButtons).to.be.undefined
+      })
+    })
   })
 
   context('when search rejects', () => {


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Add order` button should be hidden if a company has been archived. If the button is visible then data is being added where it should not be.

### Solution

Hide the `Add order` button for archived companies

<img width="794" alt="screen shot 2018-07-31 at 16 06 04" src="https://user-images.githubusercontent.com/1150417/43468387-b813c884-94db-11e8-9957-ef58adcdbf66.png">

