### PR TITLE
Hide "Edit company details" when company archived

### DIFF
--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -21,7 +21,9 @@
   {% endif %}
 
   {% if company.id %}
-    <p><a href="/companies/{{company.id}}/edit" class="button button--secondary">Edit company details</a></p>
+    {% if not company.archived %}
+      <p><a href="/companies/{{company.id}}/edit" class="button button--secondary">Edit company details</a></p>
+    {% endif %}
   {% else %}
     <p><a href="/companies/add/{{company.company_number}}" class="button">Add company</a></p>
   {% endif %}

--- a/test/acceptance/features/companies/edit.feature
+++ b/test/acceptance/features/companies/edit.feature
@@ -39,4 +39,10 @@ Feature: Company details
     Then I cannot see the field "headquarter_type"
     And I cannot see the field "sector"
 
+  @companies-edit--archived-company
+  Scenario: Archived company without Edit company details button
+
+    When I navigate to the `companies.details` page using `company` `Archived Ltd` fixture
+    And I should not see the "Edit company details" button
+
   # TODO add more editing and viewing in details work

--- a/test/acceptance/pages/companies/details.js
+++ b/test/acceptance/pages/companies/details.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { company } = require('../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(company, { name: companyName })
+    const companyId = fixture ? fixture.id : company.ukLtd.id
+
+    return `${process.env.QA_HOST}/companies/${companyId}/details`
+  },
+  elements: {},
+}


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Edit company details` button should be hidden if a company has been archived. If the button is visible then data is being added where it should not be.

### Solution

Hide the `Edit company details` button for archived companies

<img width="778" alt="screen shot 2018-08-01 at 11 51 22" src="https://user-images.githubusercontent.com/1150417/43517637-53d722c0-9581-11e8-8d4c-0f3b9bfdbc59.png">

