### PR TITLE
Hide "Edit export markets" for archived company

### DIFF
--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -5,9 +5,11 @@
 
   {% component 'key-value-table', items=exportDetails %}
 
-  <p class="actions">
-    <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
-  </p>
+  {% if not company.archived %}
+    <p class="actions">
+      <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
+    </p>
+  {% endif %}
 
   <div class="section">
     <h2 class="heading-medium">Export wins</h2>

--- a/test/acceptance/features/companies/exports.feature
+++ b/test/acceptance/features/companies/exports.feature
@@ -17,3 +17,8 @@ Feature: Company export save
       | Export win category          | company.exportWinCategory         |
       | Currently exporting to       | company.currentlyExportingTo      |
       | Future countries of interest | company.futureCountriesOfInterest |
+
+  @companies-export--archived-company
+  Scenario: Archived company without Edit export markets button
+    When I navigate to the `companies.exports` page using `company` `Archived Ltd` fixture
+    And I should not see the "Edit export markets" button


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Edit export markets` button should be hidden if a company has been archived. If the button is visible then data is being added where it should not be.

### Solution

Hide the `Edit export markets` button for archived companies

<img width="806" alt="screen shot 2018-08-01 at 13 30 43" src="https://user-images.githubusercontent.com/1150417/43521803-3912aabe-958f-11e8-9d19-8f4f2858da0d.png">
