### PR TITLE
Hide "Link a subsidiary" button for archived companies

### DIFF
--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -10,12 +10,9 @@ async function renderSubsidiaries (req, res, next) {
     const query = req.query
     const page = query.page || '1'
 
-    const {
-      id: companyId,
-      name: companyName,
-    } = res.locals.company
 
     const actionButtons = [{
+    const { id: companyId, name: companyName, archived: companyArchived } = res.locals.company
       label: companyDetailsLabels.link_a_subsidiary,
       url: `/companies/${companyId}/subsidiaries/link`,
     }]

--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -10,9 +10,8 @@ async function renderSubsidiaries (req, res, next) {
     const query = req.query
     const page = query.page || '1'
 
-
-    const actionButtons = [{
     const { id: companyId, name: companyName, archived: companyArchived } = res.locals.company
+    const actionButtons = companyArchived ? undefined : [{
       label: companyDetailsLabels.link_a_subsidiary,
       url: `/companies/${companyId}/subsidiaries/link`,
     }]

--- a/test/acceptance/features/companies/subsidiaries.feature
+++ b/test/acceptance/features/companies/subsidiaries.feature
@@ -39,3 +39,8 @@ Feature: Company subsidiaries
     And I change "headquarter_type" radio button option to "Not a headquarters"
     And I submit the form
     Then I see the success message
+
+  @companies-subsidiaries--archived-company
+  Scenario: Archived company without Link a subsidiary button
+    When I navigate to the `companies.subsidiaries` page using `company` `Archived Ltd` fixture
+    And I should not see the "Link a subsidiary" button

--- a/test/acceptance/features/companies/subsidiaries.feature
+++ b/test/acceptance/features/companies/subsidiaries.feature
@@ -1,7 +1,7 @@
-@companies-heirarchies @heirarchies
-Feature: Company details
+@companies-subsidiaries @subsidiaries
+Feature: Company subsidiaries
 
-@companies-heirarchies-set-hq
+  @companies-subsidiaries--set-hq
   Scenario: Set a company to a Global HQ
     When I navigate to the `companies.fixture` page using `company` `Lambda plc` fixture
     Then I click the "Edit company details" link
@@ -9,9 +9,8 @@ Feature: Company details
     And I submit the form
     Then I see the success message
 
-@companies-heirarchies-link
+  @companies-subsidiaries--link
   Scenario: Add a subsidiary
-
     When I navigate to the `companies.fixture` page using `company` `Lambda plc` fixture
     Then I click the "Subsidiaries" link
     Then I click the "Link a subsidiary" link
@@ -20,21 +19,20 @@ Feature: Company details
     And I choose the first item in the collection
     Then I see the success message
 
-@companies-heirarchies-details
-
+  @companies-subsidiaries--details
   Scenario: View subsidiaries
     When I navigate to the `companies.fixture` page using `company` `Lambda plc` fixture
     Then I click the "Subsidiaries" link
     And I can view the collection
 
-@companies-heirarchies-remove-subsidiary
+  @companies-subsidiaries--remove-subsidiary
   Scenario: Remove a subsidiary
     When I navigate to the `companies.fixture` page using `company` `Lambda plc` fixture
     Then I click the "Subsidiaries" link
     And I click the "Remove subsidiary" link
     Then I see the success message
 
-@companies-heirarchies-teardown
+  @companies-subsidiaries--teardown
   Scenario: Company can be set back to 'not a headquarters' again
     When I navigate to the `companies.fixture` page using `company` `Lambda plc` fixture
     Then I click the "Edit company details" link

--- a/test/acceptance/pages/companies/subsidiaries.js
+++ b/test/acceptance/pages/companies/subsidiaries.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { company } = require('../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(company, { name: companyName })
+    const companyId = fixture ? fixture.id : company.ukLtd.id
+
+    return `${process.env.QA_HOST}/companies/${companyId}/subsidiaries`
+  },
+  elements: {},
+}

--- a/test/unit/apps/companies/controllers/subsidiaries.test.js
+++ b/test/unit/apps/companies/controllers/subsidiaries.test.js
@@ -87,6 +87,33 @@ describe('company subsidiaries controller', () => {
     })
   })
 
+  context('when the company is archived', () => {
+    beforeEach(async () => {
+      this.resMock = {
+        ...this.resMock,
+        locals: {
+          ...this.resMock.locals,
+          company: {
+            ...this.resMock.locals.company,
+            archived: true,
+          },
+        },
+      }
+
+      nock(config.apiRoot)
+        .get('/v3/company?limit=10&offset=0&sortby=name&global_headquarters_id=72fda78f-bdc3-44dc-9c22-c8ac82f7bda4')
+        .reply(200, subsidiaryData)
+
+      await subsidiariesController.renderSubsidiaries(this.reqMock, this.resMock, this.nextSpy)
+    })
+
+    it('should not set actions buttons', () => {
+      const props = this.resMock.render.args[0][1]
+
+      expect(props.actionButtons).to.be.undefined
+    })
+  })
+
   context('when there are no subsidiaries', () => {
     beforeEach(async () => {
       nock(config.apiRoot)


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Link a subsidiary` button should be hidden if a company has been archived. If the button is visible then data is being added where it should not be.

### Solution

Hide the `Link a subsidiary` button for archived companies

Included with this change:
- code tidy up

<img width="793" alt="screen shot 2018-08-01 at 14 13 39" src="https://user-images.githubusercontent.com/1150417/43523707-2cb65670-9595-11e8-84fa-9d733fc77996.png">

