### PR TITLE
Hide "Remove subsidiary" link when company is archived

### DIFF
--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -20,7 +20,7 @@ async function renderSubsidiaries (req, res, next) {
       .then(transformApiResponseToSearchCollection(
         { query },
         ENTITIES,
-        transformCompanyToSubsidiaryListItem,
+        transformCompanyToSubsidiaryListItem(res.locals.company),
       ))
 
     const subsidiaries = {

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -27,6 +27,7 @@ module.exports = function transformCompanyToListItem ({
   modified_on,
   headquarter_type,
   global_headquarters,
+  parentCompanyArchived,
 } = {}) {
   if (!id) { return }
 
@@ -86,24 +87,24 @@ module.exports = function transformCompanyToListItem ({
   }
 
   if (global_headquarters) {
-    const { name, id } = global_headquarters
+    const { name: ghqName, id: ghqId } = global_headquarters
 
     meta.push({
       label: 'Global HQ',
-      value: name,
-      url: `/companies/${id}`,
+      value: ghqName,
+      url: `/companies/${ghqId}`,
     })
+
+    if (!parentCompanyArchived) {
+      meta.push({
+        label: '',
+        value: 'Remove subsidiary',
+        url: `/companies/${id}/hierarchies/ghq/remove`,
+      })
+    }
   }
 
   meta.push(address)
-
-  if (global_headquarters) {
-    meta.push({
-      label: '',
-      value: 'Remove subsidiary',
-      url: `/companies/${id}/hierarchies/ghq/remove`,
-    })
-  }
 
   const url = id ? `/companies/${id}` : `/companies/view/ch/${companies_house_data.company_number}`
 

--- a/src/apps/companies/transformers/company-to-subsidary-list-item.js
+++ b/src/apps/companies/transformers/company-to-subsidary-list-item.js
@@ -1,7 +1,12 @@
 const transformCompanyToListItem = require('./company-to-list-item')
 
-module.exports = function transformCompanyToSubsidiaryListItem (company) {
-  const listItem = transformCompanyToListItem(company)
-  listItem.meta = listItem.meta.filter(metaItem => metaItem.label !== 'Global HQ')
-  return listItem
+module.exports = function transformCompanyToSubsidiaryListItem ({ archived: parentCompanyArchived }) {
+  return (company) => {
+    const listItem = transformCompanyToListItem({
+      ...company,
+      parentCompanyArchived,
+    })
+    listItem.meta = listItem.meta.filter(metaItem => metaItem.label !== 'Global HQ')
+    return listItem
+  }
 }

--- a/test/acceptance/features/companies/subsidiaries.feature
+++ b/test/acceptance/features/companies/subsidiaries.feature
@@ -44,3 +44,5 @@ Feature: Company subsidiaries
   Scenario: Archived company without Link a subsidiary button
     When I navigate to the `companies.subsidiaries` page using `company` `Archived Ltd` fixture
     And I should not see the "Link a subsidiary" button
+    And I can view the collection
+    And I should not see the "Remove subsidiary" link

--- a/test/unit/apps/companies/controllers/subsidiaries.test.js
+++ b/test/unit/apps/companies/controllers/subsidiaries.test.js
@@ -63,8 +63,8 @@ describe('company subsidiaries controller', () => {
           { label: 'Sector', value: 'Retail' },
           { label: 'Country', type: 'badge', value: 'United Kingdom' },
           { label: 'UK region', type: 'badge', value: 'North West' },
-          { label: 'Primary address', value: '66 Marcham Road, Bordley, BD23 8RZ, United Kingdom' },
           { label: '', value: 'Remove subsidiary', url: '/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/hierarchies/ghq/remove' },
+          { label: 'Primary address', value: '66 Marcham Road, Bordley, BD23 8RZ, United Kingdom' },
         ],
         subTitle: {
           type: 'datetime',

--- a/test/unit/apps/companies/transformers/company-to-list-item.test.js
+++ b/test/unit/apps/companies/transformers/company-to-list-item.test.js
@@ -210,20 +210,55 @@ describe('transformCompanyToListItem', () => {
 
   context('global headquarters information', () => {
     context('contains the global headquarters information', () => {
-      beforeEach(() => {
-        this.listItem = transformCompanyToListItem(companyData)
+      context('and the parent company is not archived', () => {
+        beforeEach(() => {
+          this.listItem = transformCompanyToListItem(companyData)
+        })
+
+        it('should include the headquarter info in the result', () => {
+          expect(this.listItem.meta).to.containSubset([{
+            label: 'Global HQ',
+            value: 'Mars Exports Ltd',
+            url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+          }])
+        })
+
+        it('should include the "Remove subsidiary" link in the result', () => {
+          expect(this.listItem.meta).to.containSubset([{
+            label: '',
+            value: 'Remove subsidiary',
+            url: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/hierarchies/ghq/remove',
+          }])
+        })
       })
 
-      it('should not include the headquarter info in the result', () => {
-        expect(this.listItem.meta).to.containSubset([{
-          label: 'Global HQ',
-          value: 'Mars Exports Ltd',
-          url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
-        }])
+      context('and the parent company is archived', () => {
+        beforeEach(() => {
+          this.listItem = transformCompanyToListItem({
+            ...companyData,
+            parentCompanyArchived: true,
+          })
+        })
+
+        it('should include the headquarter info in the result', () => {
+          expect(this.listItem.meta).to.containSubset([{
+            label: 'Global HQ',
+            value: 'Mars Exports Ltd',
+            url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+          }])
+        })
+
+        it('should not include the "Remove subsidiary" link in the result', () => {
+          expect(this.listItem.meta).to.not.containSubset([{
+            label: '',
+            value: 'Remove subsidiary',
+            url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd/hierarchies/ghq/remove',
+          }])
+        })
       })
     })
 
-    context('should not contain the headquarter information', () => {
+    context('does not contain the headquarter information', () => {
       beforeEach(() => {
         this.listItem = transformCompanyToListItem({
           ...companyData,


### PR DESCRIPTION
https://trello.com/c/2jdMTGvb/29-prevent-editing-of-archived-company-records

### Problem

The `Remove subsidiary` link should be hidden if a company has been archived. If the link is visible then data is being removed where it should not be.

### Solution

Hide the `Remove subsidiary` link for archived companies.

<img width="781" alt="screen shot 2018-08-01 at 16 55 22" src="https://user-images.githubusercontent.com/1150417/43533061-cea6727e-95ab-11e8-8315-fff9fda19502.png">
