### PR TITLE
Use one_list_account_owner instead of account_manager for project team

### DIFF
--- a/src/apps/investment-projects/controllers/team/details.js
+++ b/src/apps/investment-projects/controllers/team/details.js
@@ -14,8 +14,8 @@ function getDetailsHandler (req, res, next) {
   try {
     const investmentData = res.locals.investmentData
 
-    const projectManagementData = transformProjectManagementForView(investmentData)
     const clientRelationshipManagementData = transformClientRelationshipManagementForView(investmentData)
+    const projectManagementData = transformProjectManagementForView(investmentData)
     const teamMembersData = investmentData.team_members.map(transformTeamMembersForView)
 
     res

--- a/src/apps/investment-projects/transformers/team.js
+++ b/src/apps/investment-projects/transformers/team.js
@@ -30,15 +30,17 @@ function transformClientRelationshipManagementForView (investmentData) {
   const result = [{
     role: 'Client relationship manager',
     adviser: getAdviserName(investmentData, 'client_relationship_manager'),
-    team: get(investmentData, 'client_relationship_manager.dit_team.name', null),
+    team: get(investmentData, 'client_relationship_manager.dit_team.name'),
   }]
-
-  const accountManager = get(investmentData, 'investor_company.account_manager.id', null)
-  if (accountManager) {
+  const globalAccountManager = get(investmentData, 'investor_company.one_list_account_owner.id')
+  if (globalAccountManager) {
+    const firstName = get(investmentData, 'investor_company.one_list_account_owner.first_name')
+    const lastName = get(investmentData, 'investor_company.one_list_account_owner.last_name')
+    const team = get(investmentData, 'investor_company.one_list_account_owner.dit_team.name')
     result.push({
-      adviser: get(investmentData, 'investor_company.account_manager.name', null),
-      role: 'Account manager',
-      team: get(investmentData, 'investor_company.account_manager.dit_team.name', null),
+      team,
+      adviser: `${firstName} ${lastName}`,
+      role: 'Global account manager',
     })
   }
 

--- a/test/acceptance/features/companies/account-management-save.feature
+++ b/test/acceptance/features/companies/account-management-save.feature
@@ -6,12 +6,12 @@ Feature: Save account management details for a company
   Scenario: Save account management details
 
     When I navigate to the `companies.fixture` page using `company` `Lambda plc` fixture
-    Then the Account management details are displayed
+    Then the Account management key value details are displayed
       | key                       | value                   |
       | One List tier             | None                    |
       | Global account manager    | None                    |
     When the Account management details are updated
-    Then the Account management details are displayed
+    Then the Account management key value details are displayed
       | key                       | value                       |
       | One List tier             | None                        |
       | Global account manager    | company.oneListAccountOwner |

--- a/test/acceptance/features/companies/exports.feature
+++ b/test/acceptance/features/companies/exports.feature
@@ -4,7 +4,7 @@ Feature: Company export save
   @companies-export-save--save
   Scenario: Save company export details
     When I navigate to the `companies.exports` page using `company` `Lambda plc` fixture
-    Then the Exports details are displayed
+    Then the Exports key value details are displayed
       | key                          | value                             |
       | Export win category          | None                              |
       | Currently exporting to       | company.currentlyExportingTo      |
@@ -12,7 +12,7 @@ Feature: Company export save
     When I click the "Edit export markets" link
     And I update the company Exports details
     And I submit the form
-    Then the Exports details are displayed
+    Then the Exports key value details are displayed
       | key                          | value                             |
       | Export win category          | company.exportWinCategory         |
       | Currently exporting to       | company.currentlyExportingTo      |

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -11,7 +11,7 @@ Feature: Create a new company
     Then I see the success message
     And the company trading name is in the search results
     When the first search result is clicked
-    Then the Company summary details are displayed
+    Then the Company summary key value details are displayed
       | key                       | value                      |
       | Business type             | company.businessType       |
       | Primary address           | company.primaryAddress     |
@@ -24,7 +24,7 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global Account Manager – One List details are displayed
+    And the Global Account Manager – One List key value details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
       | Global account manager    | None                       |
@@ -36,7 +36,7 @@ Feature: Create a new company
     Then I see the success message
     And the company is in the search results
     When the first search result is clicked
-    Then the Company summary details are displayed
+    Then the Company summary key value details are displayed
       | key                       | value                      |
       | Business type             | company.businessType       |
       | Primary address           | company.primaryAddress     |
@@ -48,7 +48,7 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global Account Manager – One List details are displayed
+    And the Global Account Manager – One List key value details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
       | Global account manager    | None                       |
@@ -60,7 +60,7 @@ Feature: Create a new company
     Then I see the success message
     And the company is in the search results
     When the first search result is clicked
-    Then the Company summary details are displayed
+    Then the Company summary key value details are displayed
       | key                       | value                            |
       | Business type             | company.businessType             |
       | Primary address           | company.primaryAddress           |
@@ -72,7 +72,7 @@ Feature: Create a new company
       | Number of employees       | company.employeeRange            |
       | Annual turnover           | company.turnoverRange            |
       | Country                   | company.registeredAddressCountry |
-    And the Global Account Manager – One List details are displayed
+    And the Global Account Manager – One List key value details are displayed
       | key                       | value                            |
       | One List tier             | None                             |
       | Global account manager    | None                             |
@@ -84,7 +84,7 @@ Feature: Create a new company
     Then I see the success message
     And the company is in the search results
     When the first search result is clicked
-    Then the Company summary details are displayed
+    Then the Company summary key value details are displayed
       | key                       | value                      |
       | Business type             | company.businessType       |
       | Primary address           | company.primaryAddress     |
@@ -96,7 +96,7 @@ Feature: Create a new company
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global Account Manager – One List details are displayed
+    And the Global Account Manager – One List key value details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
       | Global account manager    | None                       |

--- a/test/acceptance/features/contacts/save.feature
+++ b/test/acceptance/features/contacts/save.feature
@@ -13,7 +13,7 @@ Feature: Create New Contact
     When a primary contact is added
     And I submit the form
     Then I see the success message
-    Then the Contact details details are displayed
+    Then the Contact details key value details are displayed
       | key                   | value                                |
       | Job title             | contact.jobTitle                     |
       | Phone number          | contact.primaryPhoneNumber           |
@@ -34,7 +34,7 @@ Feature: Create New Contact
     When a primary contact with new company address is added
     And I submit the form
     Then I see the success message
-    Then the Contact details details are displayed
+    Then the Contact details key value details are displayed
       | key                   | value                                |
       | Job title             | contact.jobTitle                     |
       | Phone number          | contact.primaryPhoneNumber           |
@@ -55,7 +55,7 @@ Feature: Create New Contact
     When a non-primary contact is added
     And I submit the form
     Then I see the success message
-    Then the Contact details details are displayed
+    Then the Contact details key value details are displayed
       | key                   | value                                |
       | Job title             | contact.jobTitle                     |
       | Phone number          | contact.primaryPhoneNumber           |

--- a/test/acceptance/features/interactions/add.feature
+++ b/test/acceptance/features/interactions/add.feature
@@ -12,7 +12,7 @@ Feature: Add a new interaction in Data hub
     When an interaction is added
       | key                      | value                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -36,7 +36,7 @@ Feature: Add a new interaction in Data hub
     When a policy feedback is added
       | key                      | value                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -62,7 +62,7 @@ Feature: Add a new interaction in Data hub
     When a service delivery is added
       | key                      | value                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -90,7 +90,7 @@ Feature: Add a new interaction in Data hub
       | Grant offered            | 100000                                   |
       | Net receipt              | 50000                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -118,7 +118,7 @@ Feature: Add a new interaction in Data hub
       | key                      | value                                    |
       | Service                  | Tradeshow Access Programme (TAP)         |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -142,7 +142,7 @@ Feature: Add a new interaction in Data hub
     When an interaction is added
       | key                      | value                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -166,7 +166,7 @@ Feature: Add a new interaction in Data hub
     When a policy feedback is added
       | key                      | value                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -192,7 +192,7 @@ Feature: Add a new interaction in Data hub
     When a service delivery is added
       | key                      | value                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |
@@ -215,7 +215,7 @@ Feature: Add a new interaction in Data hub
     When an interaction is added
       | key                      | value                                    |
     Then I see the success message
-    And the details are displayed
+    And the key value details are displayed
       | key                      | value                                    |
       | Company                  | Venus Ltd                                |
       | Contact                  | interaction.contact                      |

--- a/test/acceptance/features/investment-projects/collection.feature
+++ b/test/acceptance/features/investment-projects/collection.feature
@@ -20,7 +20,7 @@ Feature: View a list of Investment Projects
       | Project code  |                  | isProjectCodeFormatter |
       | Valuation     | Not yet valued   |                        |
       | Created on    |                  | isRecentDateFormatter  |
-    And the Investment project summary details are displayed
+    And the Investment project summary key value details are displayed
       | key                           | value                                         |
       | Client                        | investmentProject.equitySource.name           |
       | Type of investment            | investmentProject.typeAndSubType              |

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -26,7 +26,7 @@ Feature: Create a new Investment project
       | Project code  |                  | isProjectCodeFormatter |
       | Valuation     | Not yet valued   |                        |
       | Created on    |                  | isRecentDateFormatter  |
-    And the Investment project summary details are displayed
+    And the Investment project summary key value details are displayed
       | key                           | value                                         |
       | Client                        | investmentProject.equitySource.name           |
       | Type of investment            | investmentProject.typeAndSubType              |
@@ -65,7 +65,7 @@ Feature: Create a new Investment project
       | Project code  |                  | isProjectCodeFormatter |
       | Valuation     | Not yet valued   |                        |
       | Created on    |                  | isRecentDateFormatter  |
-    And the Investment project summary details are displayed
+    And the Investment project summary key value details are displayed
       | key                           | value                                         |
       | Client                        | investmentProject.equitySource.name           |
       | Type of investment            | investmentProject.typeAndSubType              |
@@ -103,7 +103,7 @@ Feature: Create a new Investment project
       | Project code  |                  | isProjectCodeFormatter |
       | Valuation     | Not yet valued   |                        |
       | Created on    |                  | isRecentDateFormatter  |
-    And the Investment project summary details are displayed
+    And the Investment project summary key value details are displayed
       | key                           | value                                         |
       | Client                        | investmentProject.equitySource.name           |
       | Type of investment            | investmentProject.type                        |

--- a/test/acceptance/features/investment-projects/evaluations-details.feature
+++ b/test/acceptance/features/investment-projects/evaluations-details.feature
@@ -27,7 +27,7 @@ Feature: Investment projects evaluations details
       | Export revenue radio              | Yes                                            |
     Then I see the success message
     When I click the Evaluations local nav link
-    Then the Project value (Test D) details are displayed
+    Then the Project value (Test D) key value details are displayed
       | key                               | value                                          | formatter                               |
       | Primary sector                    | investmentProject.primarySector                |                                         |
       | Total investment                  | £100,000.00                                    |                                         |
@@ -39,7 +39,7 @@ Feature: Investment projects evaluations details
       | Account tier                      | Not Known                                      |                                         |
       | New GHQ/EHQ                       | investmentProject.businessActivity             | isEuropeanOrGlobalHeadquartersFormatter |
       | Export revenue                    | Yes, will create significant export revenue    |                                         |
-    And the FDI (Test A) details are displayed
+    And the FDI (Test A) key value details are displayed
       | key                               | value                                          |
       | Type of investment                | investmentProject.typeAndSubType               |
       | Foreign investor                  | Lambda plc                                     |
@@ -49,7 +49,7 @@ Feature: Investment projects evaluations details
       | Investor retains 10% voting power | No                                             |
       | New jobs                          | 100 new jobs                                   |
       | Safeguarded jobs                  | 200 safeguarded jobs                           |
-    And the Project Landing (Test C) details are displayed
+    And the Project Landing (Test C) key value details are displayed
       | key                               | value                                          |
       | UK company                        | Not Known                                      |
       | Companies House Number            | Not Known                                      |
@@ -80,7 +80,7 @@ Feature: Investment projects evaluations details
       | Export revenue radio              | No                                             |
     Then I see the success message
     When I click the Evaluations local nav link
-    Then the Project value (Test D) details are displayed
+    Then the Project value (Test D) key value details are displayed
       | key                               | value                                          | formatter                               |
       | Primary sector                    | investmentProject.primarySector                |                                         |
       | Total investment                  | Client cannot provide this information         |                                         |
@@ -92,7 +92,7 @@ Feature: Investment projects evaluations details
       | Account tier                      | Not Known                                      |                                         |
       | New GHQ/EHQ                       | investmentProject.businessActivity             | isEuropeanOrGlobalHeadquartersFormatter |
       | Export revenue                    | No, will not create significant export revenue |                                         |
-    And the FDI (Test A) details are displayed
+    And the FDI (Test A) key value details are displayed
       | key                               | value                                          |
       | Type of investment                | investmentProject.typeAndSubType               |
       | Foreign investor                  | Lambda plc                                     |
@@ -102,7 +102,7 @@ Feature: Investment projects evaluations details
       | Investor retains 10% voting power | No                                             |
       | New jobs                          | 0                                              |
       | Safeguarded jobs                  | 0                                              |
-    And the Project Landing (Test C) details are displayed
+    And the Project Landing (Test C) key value details are displayed
       | key                               | value                                          |
       | UK company                        | Not Known                                      |
       | Companies House Number            | Not Known                                      |

--- a/test/acceptance/features/investment-projects/team.feature
+++ b/test/acceptance/features/investment-projects/team.feature
@@ -1,0 +1,34 @@
+@investment-projects-team @collection
+Feature: View team for an investment project
+
+  @investment-projects-team--view
+  Scenario: View investment project team
+    When I navigate to the `investments.team` page using `investment project` `Fancy dress manufacturing` fixture
+    Then the Client relationship management data details are displayed
+      | Role                        | Adviser                                          | Team                                             |
+      | Client relationship manager | investmentProject.clientRelationshipManager.name | investmentProject.clientRelationshipManager.team |
+      | Global account manager      | investmentProject.globalAccountManager.name      |                                                  |
+
+  @investment-projects-team--view--lep @lep
+  Scenario: View investment project team
+    When I navigate to the `investments.team` page using `investment project` `New zoo (LEP)` fixture
+    Then the Client relationship management data details are displayed
+      | Role                        | Adviser                                          | Team                                             |
+      | Client relationship manager | investmentProject.clientRelationshipManager.name | investmentProject.clientRelationshipManager.team |
+
+  @investment-projects-team--view--da @da
+  Scenario: View investment project team
+    When I navigate to the `investments.team` page using `investment project` `New golf course (DA)` fixture
+    Then the Client relationship management data details are displayed
+      | Role                        | Adviser                                          | Team                                             |
+      | Client relationship manager | investmentProject.clientRelationshipManager.name | investmentProject.clientRelationshipManager.team |
+
+  @investment-projects-team--lep @lep
+  Scenario: Navigate to project team of an unauthorised project as LEP
+    When I navigate to the `investments.team` page using `investment project` `Fancy dress manufacturing` fixture
+    Then I see the 403 error page
+
+  @investment-projects-team--da @da
+  Scenario: Navigate to project team of an unauthorised project as DA
+    When I navigate to the `investments.team` page using `investment project` `Fancy dress manufacturing` fixture
+    Then I see the 403 error page

--- a/test/acceptance/features/investment-projects/value-add.feature
+++ b/test/acceptance/features/investment-projects/value-add.feature
@@ -21,7 +21,7 @@ Feature: Add value to investment project
       | New-to-world tech radio           | Yes                                              |
       | Export revenue radio              | Yes                                              |
     Then I see the success message
-    And the Value details are displayed
+    And the Value key value details are displayed
       | key                               | value                                            |
       | Total investment                  | £100,000.00                                      |
       | Foreign equity investment         | £200,000.00                                      |
@@ -53,7 +53,7 @@ Feature: Add value to investment project
       | New-to-world tech radio           | No                                             |
       | Export revenue radio              | No                                             |
     Then I see the success message
-    And the Value details are displayed
+    And the Value key value details are displayed
       | key                        | value                                           |
       | Total investment           | Client cannot provide this information          |
       | Foreign equity investment  | Client cannot provide this information          |

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -16,12 +16,11 @@ When(/^I (?:navigate|go|open|visit).*? `(.+)` page$/, async function (pageName) 
 When(/^I (?:navigate|go|open|visit).*? `(.+)` page using `(.+)` `(.+)` fixture$/, async function (pageName, entity, fixtureName) {
   try {
     const page = get(client.page, pageName)()
-
-    const fixture = find(fixtures[entity], { name: fixtureName })
+    const entityTypeKey = camelCase(entity)
+    const fixture = find(fixtures[entityTypeKey], { name: fixtureName })
 
     // TODO: Need to find a way to remove needing to store the item in state
-    const entityTypeFieldName = camelCase(entity)
-    set(this.state, entityTypeFieldName, assign({}, get(this.state, entityTypeFieldName), fixture))
+    set(this.state, entityTypeKey, assign({}, get(this.state, entityTypeKey), fixture))
 
     await page.navigate(page.url(fixtureName))
   } catch (error) {

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -1,25 +1,35 @@
 const { client } = require('nightwatch-cucumber')
 const { Then } = require('cucumber')
-const { get, includes, startsWith } = require('lodash')
+const { get, includes, startsWith, keys } = require('lodash')
 
-const { getKeyValueTableRowValueCell } = require('../../helpers/selectors')
+const { getKeyValueTableRowValueCell, getDataTableRowCell } = require('../../helpers/selectors')
 const formatters = require('../../helpers/formatters')
 
 const Details = client.page.details()
 
-function getExpectedValue (row, state) {
-  if (includes(row.value, '.') && !includes(row.value, ' ') && !startsWith(row.value, '£')) {
-    const expectedText = get(state, row.value)
+const getRowCellSelector = {
+  'key-value': getKeyValueTableRowValueCell,
+  'data': getDataTableRowCell,
+}
 
-    if (row.key === 'Client contacts') {
+const TABLE_TYPE = {
+  KEY_VALUE: 'key-value',
+  DATA: 'data',
+}
+
+function getExpected (key, state) {
+  if (includes(key, '.') && !includes(key, ' ') && !startsWith(key, '£')) {
+    const expectedText = get(state, key)
+
+    if (key === 'investmentProject.clientContact') {
       // contact in investmentProjects create form has ', job_title` appended, this split removes that to run this check
-      return expectedText.split(',')[0]
+      return { value: expectedText.split(',')[0] }
     }
 
-    return expectedText
+    return { value: expectedText }
   }
 
-  return row.value
+  return { value: key }
 }
 
 const removeFalsey = (details, state) => {
@@ -32,36 +42,45 @@ const removeFalsey = (details, state) => {
   })
 }
 
-const assertDetailsTableRowCount = async function (detailsTableSelector, expectedDetails) {
-  await Details.api.elements('xpath', `${detailsTableSelector.selector}//th`, (result) => {
-    client.expect(result.value.length, 'Table row count').to.equal(expectedDetails.length)
+const assertTableRowCount = async function (tableSelector, expectedData, tableType) {
+  await Details.api.elements('xpath', `${tableSelector.selector}/tbody/tr`, (result) => {
+    client.expect(result.value.length, 'Table row count').to.equal(expectedData.length)
   })
 }
 
-const assertDetailsTableContent = async function (detailsTableSelector, expectedDetails) {
-  for (const row of expectedDetails) {
-    if (row.key === 'Business type') {
-      // todo: case issues
-      continue
-    }
-    if (row.key === 'Sector') {
-      // todo: https://uktrade.atlassian.net/browse/DH-1086
-      continue
-    }
+const assertTableContent = async function (tableSelector, expectedData, tableType) {
+  for (const row of expectedData) {
+    const columnKeys = keys(row)
+    const rowFirstCellKey = columnKeys[0]
 
-    const rowValueSelector = getKeyValueTableRowValueCell(row.key)
-    const detailsTableRowValueXPathSelector = detailsTableSelector.selector + rowValueSelector.selector
-    const expectedValue = getExpectedValue(row, this.state)
-    await Details
-      .api.useXpath()
-      .waitForElementPresent(detailsTableRowValueXPathSelector)
-      .getText(detailsTableRowValueXPathSelector, (actual) => {
-        if (row.formatter) {
-          return client.expect(formatters[row.formatter](expectedValue, actual.value)).to.be.true
-        }
-        client.expect(actual.value).to.equal(expectedValue)
-      })
-      .useCss()
+    for (const [columnIndex, columnKey] of columnKeys.entries()) {
+      if (columnIndex === 0 || columnKey === 'formatter') {
+        continue
+      }
+
+      if (row[rowFirstCellKey] === 'Business type') {
+        // todo: case issues
+        continue
+      }
+      if (row[rowFirstCellKey] === 'Sector') {
+        // todo: https://uktrade.atlassian.net/browse/DH-1086
+        continue
+      }
+
+      const rowCellSelector = getRowCellSelector[tableType](row[rowFirstCellKey], columnIndex)
+      const tableRowCellXPathSelector = tableSelector.selector + rowCellSelector.selector
+      const expected = getExpected(row[columnKey], this.state)
+      await Details
+        .api.useXpath()
+        .waitForElementPresent(tableRowCellXPathSelector)
+        .getText(tableRowCellXPathSelector, (actual) => {
+          if (row.formatter) {
+            return client.expect(formatters[row.formatter](expected.value, actual.value), row[rowFirstCellKey]).to.be.true
+          }
+          client.expect(actual.value, row[rowFirstCellKey]).to.equal(expected.value)
+        })
+        .useCss()
+    }
   }
 }
 
@@ -133,18 +152,21 @@ Then(/^view should (not\s?)?contain the Documents link$/, async (noDocumentsLink
     .assert.visible(tag)
 })
 
-  const expectedDetails = removeFalsey(dataTable.hashes(), this.state)
-  const detailsTableSelector = Details.getSelectorForDetailsTable(detailsTableTitle)
-Then(/^the (.+) key value details are displayed$/, async function (detailsTableTitle, dataTable) {
-Then(/^the key value details are displayed$/, async function (dataTable) {
+Then(/^the (.+) key value details are displayed$/, async function (tableTitle, dataTable) {
+  const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
+  const tableSelector = Details.getSelectorForKeyValueTable(tableTitle)
 
-  await assertDetailsTableRowCount(detailsTableSelector, expectedDetails)
-  await assertDetailsTableContent.bind(this)(detailsTableSelector, expectedDetails)
+  await assertTableRowCount(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
+  await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
 })
 
-  const expectedDetails = removeFalsey(dataTable.hashes(), this.state)
-  const detailsTableSelector = Details.getSelectorForDetailsTable()
+Then(/^the key value details are displayed$/, async function (dataTable) {
+  const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
+  const tableSelector = Details.getSelectorForKeyValueTable()
 
-  await assertDetailsTableRowCount(detailsTableSelector, expectedDetails)
-  await assertDetailsTableContent.bind(this)(detailsTableSelector, expectedDetails)
+  await assertTableRowCount(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
+  await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
+})
+
+
 })

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -12,6 +12,11 @@ const getRowCellSelector = {
   'data': getDataTableRowCell,
 }
 
+const ignoredKeys = [
+  'Business type', // todo: case issues
+  'Sector', // todo: https://uktrade.atlassian.net/browse/DH-1086
+]
+
 const TABLE_TYPE = {
   KEY_VALUE: 'key-value',
   DATA: 'data',
@@ -54,16 +59,7 @@ const assertTableContent = async function (tableSelector, expectedData, tableTyp
     const rowFirstCellKey = columnKeys[0]
 
     for (const [columnIndex, columnKey] of columnKeys.entries()) {
-      if (columnIndex === 0 || columnKey === 'formatter') {
-        continue
-      }
-
-      if (row[rowFirstCellKey] === 'Business type') {
-        // todo: case issues
-        continue
-      }
-      if (row[rowFirstCellKey] === 'Sector') {
-        // todo: https://uktrade.atlassian.net/browse/DH-1086
+      if (includes(ignoredKeys, row[rowFirstCellKey]) || columnIndex === 0 || columnKey === 'formatter') {
         continue
       }
 

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -133,15 +133,15 @@ Then(/^view should (not\s?)?contain the Documents link$/, async (noDocumentsLink
     .assert.visible(tag)
 })
 
-Then(/^the (.+) details are displayed$/, async function (detailsTableTitle, dataTable) {
   const expectedDetails = removeFalsey(dataTable.hashes(), this.state)
   const detailsTableSelector = Details.getSelectorForDetailsTable(detailsTableTitle)
+Then(/^the (.+) key value details are displayed$/, async function (detailsTableTitle, dataTable) {
+Then(/^the key value details are displayed$/, async function (dataTable) {
 
   await assertDetailsTableRowCount(detailsTableSelector, expectedDetails)
   await assertDetailsTableContent.bind(this)(detailsTableSelector, expectedDetails)
 })
 
-Then(/^the details are displayed$/, async function (dataTable) {
   const expectedDetails = removeFalsey(dataTable.hashes(), this.state)
   const detailsTableSelector = Details.getSelectorForDetailsTable()
 

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -2,7 +2,7 @@ const { client } = require('nightwatch-cucumber')
 const { Then } = require('cucumber')
 const { get, includes, startsWith } = require('lodash')
 
-const { getDetailsTableRowValue } = require('../../helpers/selectors')
+const { getKeyValueTableRowValueCell } = require('../../helpers/selectors')
 const formatters = require('../../helpers/formatters')
 
 const Details = client.page.details()
@@ -49,7 +49,7 @@ const assertDetailsTableContent = async function (detailsTableSelector, expected
       continue
     }
 
-    const rowValueSelector = getDetailsTableRowValue(row.key)
+    const rowValueSelector = getKeyValueTableRowValueCell(row.key)
     const detailsTableRowValueXPathSelector = detailsTableSelector.selector + rowValueSelector.selector
     const expectedValue = getExpectedValue(row, this.state)
     await Details

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -168,5 +168,9 @@ Then(/^the key value details are displayed$/, async function (dataTable) {
   await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
 })
 
+Then(/^the (.+) data details are displayed$/, async function (tableTitle, dataTable) {
+  const tableSelector = Details.getSelectorForDataTable(tableTitle)
 
+  await assertTableRowCount(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
+  await assertTableContent.bind(this)(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
 })

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -185,10 +185,29 @@ module.exports = {
     newGolfCourse: {
       id: 'e32b3c33-80ac-4589-a8c4-dda305d726ba',
       name: 'New golf course (DA)',
+      clientRelationshipManager: {
+        name: 'Paula Churing',
+        team: 'Marketing - Marketing Team',
+      },
     },
     newZoo: {
       id: 'ba1f0b14-5fe4-4c36-bf6a-ddf115272977',
       name: 'New zoo (LEP)',
+      clientRelationshipManager: {
+        name: 'Paula Churing',
+        team: 'Marketing - Marketing Team',
+      },
+    },
+    fancyDressManufacturing: {
+      id: 'b30dee70-b2d6-48cf-9ce4-b9264854470c',
+      name: 'Fancy dress manufacturing',
+      clientRelationshipManager: {
+        name: 'Puck Head',
+        team: 'CBBC North EAST',
+      },
+      globalAccountManager: {
+        name: 'Travis Greene',
+      },
     },
   },
   proposition: {

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -41,6 +41,17 @@ function getKeyValueTableRowValueCell (text) {
   )
 }
 
+function getDataTableRowCell (text, index) {
+  return getSelectorForElementWithText(
+    text,
+    {
+      el: '//td',
+      child: `/following-sibling::td[${index}]`,
+      hasExactText: true,
+    }
+  )
+}
+
 /**
  * Gets XPath selector the selector for the meta item label value from entity lists
  * @param text
@@ -104,6 +115,7 @@ module.exports = {
   getSelectorForElementWithText,
   getButtonWithText,
   getKeyValueTableRowValueCell,
+  getDataTableRowCell,
   getMetaListItemValueSelector,
   getLinkWithText,
   getListItemMetaElementWithText,

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -30,7 +30,7 @@ function getButtonWithText (text) {
  * @param text
  * @returns {{selector: string, locateStrategy: string}}
  */
-function getDetailsTableRowValue (text) {
+function getKeyValueTableRowValueCell (text) {
   return getSelectorForElementWithText(
     text,
     {
@@ -103,7 +103,7 @@ const getSelectorForDetailsSectionEditButton = (sectionTitle, buttonText = 'Edit
 module.exports = {
   getSelectorForElementWithText,
   getButtonWithText,
-  getDetailsTableRowValue,
+  getKeyValueTableRowValueCell,
   getMetaListItemValueSelector,
   getLinkWithText,
   getListItemMetaElementWithText,

--- a/test/acceptance/pages/companies/company.js
+++ b/test/acceptance/pages/companies/company.js
@@ -4,7 +4,7 @@ const { assign } = require('lodash')
 const {
   getMetaListItemValueSelector,
   getButtonWithText,
-  getDetailsTableRowValue,
+  getKeyValueTableRowValueCell,
   getSelectorForDetailsSectionEditButton,
 } = require('../../helpers/selectors')
 const { appendUid, getUid } = require('../../helpers/uuid')
@@ -545,7 +545,7 @@ module.exports = {
     companyDetails: {
       selector: '.table--key-value',
       elements: {
-        ukRegion: getDetailsTableRowValue('UK region'),
+        ukRegion: getKeyValueTableRowValueCell('UK region'),
       },
     },
     accountManagementForm: {

--- a/test/acceptance/pages/contacts/contact.js
+++ b/test/acceptance/pages/contacts/contact.js
@@ -3,7 +3,7 @@ const { assign } = require('lodash')
 
 const {
   getSelectorForElementWithText,
-  getDetailsTableRowValue,
+  getKeyValueTableRowValueCell,
   getMetaListItemValueSelector,
 } = require('../../helpers/selectors')
 const { appendUid, getUid } = require('../../helpers/uuid')
@@ -165,14 +165,14 @@ module.exports = {
     contactDetails: {
       selector: '.table--key-value',
       elements: {
-        jobTitle: getDetailsTableRowValue('Job title'),
-        phoneNumber: getDetailsTableRowValue('Phone number'),
-        email: getDetailsTableRowValue('Email'),
-        emailMarketing: getDetailsTableRowValue('Email marketing'),
-        address: getDetailsTableRowValue('Address'),
-        alternativeTelephone: getDetailsTableRowValue('Alternative telephone'),
-        alternativeEmail: getDetailsTableRowValue('Alternative email'),
-        notes: getDetailsTableRowValue('Notes'),
+        jobTitle: getKeyValueTableRowValueCell('Job title'),
+        phoneNumber: getKeyValueTableRowValueCell('Phone number'),
+        email: getKeyValueTableRowValueCell('Email'),
+        emailMarketing: getKeyValueTableRowValueCell('Email marketing'),
+        address: getKeyValueTableRowValueCell('Address'),
+        alternativeTelephone: getKeyValueTableRowValueCell('Alternative telephone'),
+        alternativeEmail: getKeyValueTableRowValueCell('Alternative email'),
+        notes: getKeyValueTableRowValueCell('Notes'),
       },
     },
   },

--- a/test/acceptance/pages/details.js
+++ b/test/acceptance/pages/details.js
@@ -1,5 +1,19 @@
 const { getSelectorForElementWithText } = require('../helpers/selectors')
 
+const getSelectorForTable = (title, className) => {
+  if (!title) {
+    return {
+      selector: `//table[contains(@class, "${className}")][1]`,
+      locateStrategy: 'xpath',
+    }
+  }
+
+  return getSelectorForElementWithText(title, {
+    el: '//h2',
+    child: '/following-sibling::table[1]',
+  })
+}
+
 module.exports = {
   elements: {
     heading: '.c-local-header__heading',
@@ -25,18 +39,11 @@ module.exports = {
           },
         )
       },
-      getSelectorForDetailsTable (title) {
-        if (!title) {
-          return {
-            selector: '//table[contains(@class, "table--key-value")][1]',
-            locateStrategy: 'xpath',
-          }
-        }
-
-        return getSelectorForElementWithText(title, {
-          el: '//h2',
-          child: '/following-sibling::table[1]',
-        })
+      getSelectorForKeyValueTable (title) {
+        return getSelectorForTable(title, 'table--key-value')
+      },
+      getSelectorForDataTable (title) {
+        return getSelectorForTable(title, 'data-table')
       },
     },
   ],

--- a/test/acceptance/pages/investments/project.js
+++ b/test/acceptance/pages/investments/project.js
@@ -6,7 +6,7 @@ const { getDaysInMonth } = require('date-fns')
 const {
   getButtonWithText,
   getSelectorForElementWithText,
-  getDetailsTableRowValue,
+  getKeyValueTableRowValueCell,
 } = require('../../helpers/selectors')
 const {
   storeSelectValue,
@@ -259,17 +259,17 @@ module.exports = {
           elements: {
             header: getHeaderSelector('Investment project summary'),
             clientLink: getTableCellAnchorByName('Client'),
-            typeOfInvestment: getDetailsTableRowValue('Type of investment'),
-            primarySector: getDetailsTableRowValue('Primary sector'),
-            businessActivity: getDetailsTableRowValue('Business activity'),
-            clientContact: getDetailsTableRowValue('Client contacts'),
-            projectDescription: getDetailsTableRowValue('Project description'),
-            anonDescription: getDetailsTableRowValue('Anonymised description'),
-            estimatedLandDate: getDetailsTableRowValue('Estimated land date'),
-            actualLandDate: getDetailsTableRowValue('Actual land date'),
-            newOrExistingInvestor: getDetailsTableRowValue('New or existing investor'),
-            levelOfInvolvement: getDetailsTableRowValue('Level of involvement'),
-            specificInvestmentProgramme: getDetailsTableRowValue('Specific investment programme'),
+            typeOfInvestment: getKeyValueTableRowValueCell('Type of investment'),
+            primarySector: getKeyValueTableRowValueCell('Primary sector'),
+            businessActivity: getKeyValueTableRowValueCell('Business activity'),
+            clientContact: getKeyValueTableRowValueCell('Client contacts'),
+            projectDescription: getKeyValueTableRowValueCell('Project description'),
+            anonDescription: getKeyValueTableRowValueCell('Anonymised description'),
+            estimatedLandDate: getKeyValueTableRowValueCell('Estimated land date'),
+            actualLandDate: getKeyValueTableRowValueCell('Actual land date'),
+            newOrExistingInvestor: getKeyValueTableRowValueCell('New or existing investor'),
+            levelOfInvolvement: getKeyValueTableRowValueCell('Level of involvement'),
+            specificInvestmentProgramme: getKeyValueTableRowValueCell('Specific investment programme'),
           },
         },
         archive: {

--- a/test/acceptance/pages/investments/team.js
+++ b/test/acceptance/pages/investments/team.js
@@ -1,0 +1,13 @@
+const { find } = require('lodash')
+
+const { investmentProject } = require('../../fixtures')
+
+module.exports = {
+  url: function projectFixtureUrl (projectName) {
+    const fixture = find(investmentProject, { name: projectName })
+    const projectId = fixture ? fixture.id : investmentProject.newHotelCommitmentToInvest.id
+
+    return `${process.env.QA_HOST}/investment-projects/${projectId}/team`
+  },
+  elements: {},
+}

--- a/test/unit/apps/investment-projects/transformers/team.test.js
+++ b/test/unit/apps/investment-projects/transformers/team.test.js
@@ -111,9 +111,10 @@ describe('Investment project transformers', () => {
           },
         },
         investor_company: {
-          account_manager: {
+          one_list_account_owner: {
             id: '321',
-            name: 'John Brown',
+            first_name: 'John',
+            last_name: 'Brown',
             dit_team: {
               name: 'Johns Team',
             },
@@ -127,7 +128,7 @@ describe('Investment project transformers', () => {
         team: 'Team Fred',
       }, {
         adviser: 'John Brown',
-        role: 'Account manager',
+        role: 'Global account manager',
         team: 'Johns Team',
       }]
 


### PR DESCRIPTION
https://trello.com/c/XjkJQA0D/111-investment-project-use-onelistaccountowner-instead-of-accountmanager

# Problem
1. The `Project team` tab for an investment project is displaying the `account_manager` whereas it should be displaying `one_list_account_owner`
2. The label should be `Global account manager`

# Solution
The overall change is straightforward but it was also discovered that there is no acceptance tests around the `Project team` tab. Changes as follows:
- Refactor of existing acceptance table assertion code to support `data-table`
- Transformation updates
- Unit test updates

# Further development
- Further tidy up but this change was already getting large

# Before
<img width="786" alt="screen shot 2018-08-08 at 13 44 20" src="https://user-images.githubusercontent.com/1150417/43837728-53199940-9b11-11e8-9919-a0068556afb0.png">

# After
<img width="785" alt="screen shot 2018-08-08 at 13 38 56" src="https://user-images.githubusercontent.com/1150417/43837734-583dfeb6-9b11-11e8-88e1-107e788c21e7.png">