### PR TITLE
Make Global Account Manager read-only under "Edit client relationship management"

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -69,7 +69,7 @@ const hqLabels = {
 
 const accountManagementDisplayLabels = {
   one_list_tier: 'One List tier',
-  one_list_account_owner: 'Global account manager',
+  one_list_account_owner: 'Global Account Manager',
 }
 
 const exportDetailsLabels = {

--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -34,8 +34,8 @@
 
     {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
       {% call Message({ type: 'muted' }) %}
-        If you need to change the One List tier or Global account manager for this company,
         please click <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">here</a>
+        If you need to change the One List tier or Global Account Manager for this company,
         or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
       {% endcall %}
     {% endcall %}

--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -34,8 +34,8 @@
 
     {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
       {% call Message({ type: 'muted' }) %}
-        please click <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">here</a>
         If you need to change the One List tier or Global Account Manager for this company,
+        go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
         or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
       {% endcall %}
     {% endcall %}

--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -144,7 +144,7 @@ const labels = {
     view: roleAdviserTeam,
     edit: {
       client_relationship_manager: 'Client relationship manager',
-      account_manager: 'Account manager',
+      global_account_manager: 'Global Account Manager',
     },
   },
   teamMembersLabels: {

--- a/src/apps/investment-projects/transformers/team.js
+++ b/src/apps/investment-projects/transformers/team.js
@@ -40,7 +40,7 @@ function transformClientRelationshipManagementForView (investmentData) {
     result.push({
       team,
       adviser: `${firstName} ${lastName}`,
-      role: 'Global account manager',
+      role: 'Global Account Manager',
     })
   }
 

--- a/src/apps/investment-projects/views/team/edit-client-relationship-management.njk
+++ b/src/apps/investment-projects/views/team/edit-client-relationship-management.njk
@@ -1,9 +1,5 @@
 {% extends "../_layout.njk" %}
 
-{% set phase = investmentData.stage.name %}
-{% set crm = investmentData.client_relationship_manager %}
-{% set rsa = investmentData.referral_source_adviser %}
-
 {% block main_grid_right_column %}
   <h2 class="heading-medium">Edit client relationship management</h2>
 

--- a/src/apps/investment-projects/views/team/edit-client-relationship-management.njk
+++ b/src/apps/investment-projects/views/team/edit-client-relationship-management.njk
@@ -17,14 +17,19 @@
       initialOption: '-- Select an adviser --'
     }) }}
 
-    {{ MultipleChoiceField({
-      name: 'account_manager',
-      label: form.labels.account_manager,
-      error: form.errors.account_manager,
-      options: form.options.accountManagers,
-      value: form.state.account_manager,
-      initialOption: '-- Select an adviser --'
-    }) }}
+    {{ FormGroup({} | assign(props, {
+      label: form.labels.global_account_manager,
+      name: 'global_account_manager',
+      innerHTML: form.state.global_account_manager
+    })) }}
+
+    {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
+      {% call Message({ type: 'muted' }) %}
+        If you need to change the Global Account Manager for this company,
+        go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
+        or email <a href="mailto:{{form.oneListEmail}}">{{form.oneListEmail}}</a>.
+      {% endcall %}
+    {% endcall %}
 
   {% endcall %}
 {% endblock %}

--- a/test/acceptance/features/companies/account-management-save.feature
+++ b/test/acceptance/features/companies/account-management-save.feature
@@ -9,9 +9,9 @@ Feature: Save account management details for a company
     Then the Account management key value details are displayed
       | key                       | value                   |
       | One List tier             | None                    |
-      | Global account manager    | None                    |
+      | Global Account Manager    | None                    |
     When the Account management details are updated
     Then the Account management key value details are displayed
       | key                       | value                       |
       | One List tier             | None                        |
-      | Global account manager    | company.oneListAccountOwner |
+      | Global Account Manager    | company.oneListAccountOwner |

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -27,7 +27,7 @@ Feature: Create a new company
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | Global account manager    | None                       |
+      | Global Account Manager    | None                       |
 
   @companies-save--uk-non-private-or-non-public-ltd-company
   Scenario: Create a UK non-private or non-public limited company
@@ -51,7 +51,7 @@ Feature: Create a new company
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | Global account manager    | None                       |
+      | Global Account Manager    | None                       |
 
   @companies-save--foreign
   Scenario: Create a foreign company
@@ -75,7 +75,7 @@ Feature: Create a new company
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                            |
       | One List tier             | None                             |
-      | Global account manager    | None                             |
+      | Global Account Manager    | None                             |
 
   @companies-save--foreign-uk-branch
   Scenario: Create a UK branch of a foreign company
@@ -99,4 +99,4 @@ Feature: Create a new company
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                      |
       | One List tier             | None                       |
-      | Global account manager    | None                       |
+      | Global Account Manager    | None                       |

--- a/test/acceptance/features/investment-projects/team.feature
+++ b/test/acceptance/features/investment-projects/team.feature
@@ -7,7 +7,7 @@ Feature: View team for an investment project
     Then the Client relationship management data details are displayed
       | Role                        | Adviser                                          | Team                                             |
       | Client relationship manager | investmentProject.clientRelationshipManager.name | investmentProject.clientRelationshipManager.team |
-      | Global account manager      | investmentProject.globalAccountManager.name      |                                                  |
+      | Global Account Manager      | investmentProject.globalAccountManager.name      |                                                  |
 
   @investment-projects-team--view--lep @lep
   Scenario: View investment project team

--- a/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
@@ -16,7 +16,7 @@ describe('transformCompanyToOneListView', () => {
 
     it('indicate there is no one list account management information', () => {
       expect(this.viewRecord).to.deep.equal({
-        'Global account manager': 'None',
+        'Global Account Manager': 'None',
         'One List tier': 'None',
       })
     })
@@ -40,7 +40,7 @@ describe('transformCompanyToOneListView', () => {
 
     it('indicate there is no one list account management information', () => {
       expect(this.viewRecord).to.deep.equal({
-        'Global account manager': 'The owner',
+        'Global Account Manager': 'The owner',
         'One List tier': 'The classification',
       })
     })

--- a/test/unit/apps/companies/transformers/core-team-to-collection.test.js
+++ b/test/unit/apps/companies/transformers/core-team-to-collection.test.js
@@ -5,7 +5,7 @@ describe('#transformCoreTeamToCollection', () => {
     this.coreTeamMock = require('~/test/unit/data/companies/core-team.json')
   })
 
-  context('when the core team member is a global account manager and from a UK region', () => {
+  context('when the core team member is a Global Account Manager and from a UK region', () => {
     beforeEach(() => {
       this.collection = transformCoreTeamToCollection(this.coreTeamMock)
     })
@@ -44,7 +44,7 @@ describe('#transformCoreTeamToCollection', () => {
     })
   })
 
-  context('when the core team member is not a global account manager and not from a UK region', () => {
+  context('when the core team member is not a Global Account Manager and not from a UK region', () => {
     beforeEach(() => {
       this.coreTeamMock[0].is_global_account_manager = false
       delete this.coreTeamMock[0].adviser.dit_team.uk_region

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -38,19 +38,19 @@ describe('Investment form middleware - client relationship management', () => {
         })
     })
 
-    it('should populate the form state with the existing client relationship management if there is data', (done) => {
+    it('should populate the form state with the existing client relationship management', async () => {
+      const globalAccountManager = investmentData.investor_company.one_list_account_owner
       const expectedFormState = {
         client_relationship_manager: investmentData.client_relationship_manager.id,
-        account_manager: investmentData.investor_company.account_manager.id,
+        global_account_manager: `${globalAccountManager.first_name} ${globalAccountManager.last_name}`,
       }
 
-      this.controller.populateForm({
+      await this.controller.populateForm({
         session: {
           token: 'mock-token',
         },
       }, this.resMock, () => {
         expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
-        done()
       })
     })
 
@@ -61,24 +61,6 @@ describe('Investment form middleware - client relationship management', () => {
         },
       }, this.resMock, () => {
         expect(this.resMock.locals.form.hiddenFields).to.deep.equal({ investor_company: investmentData.investor_company.id })
-        done()
-      })
-    })
-
-    it('should not throw an error if you render a form for a company with no account manager', (done) => {
-      this.resMock.locals.investmentData.investor_company.account_manager = null
-
-      const expectedFormState = {
-        client_relationship_manager: investmentData.client_relationship_manager.id,
-        account_manager: null,
-      }
-
-      this.controller.populateForm({
-        session: {
-          token: 'mock-token',
-        },
-      }, this.resMock, () => {
-        expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
         done()
       })
     })
@@ -94,15 +76,15 @@ describe('Investment form middleware - client relationship management', () => {
       })
     })
 
-    it('should include button text and a return link', (done) => {
-      this.controller.populateForm({
+    it('should include button text, return link and One List email', async () => {
+      await this.controller.populateForm({
         session: {
           token: 'mock-token',
         },
       }, this.resMock, () => {
         expect(this.resMock.locals.form.buttonText).to.equal('Save')
         expect(this.resMock.locals.form.returnLink).to.equal(`/investment-projects/${investmentData.id}/team`)
-        done()
+        expect(this.resMock.locals.form.oneListEmail).to.equal('one.list@example.com')
       })
     })
 
@@ -138,17 +120,6 @@ describe('Investment form middleware - client relationship management', () => {
         ]
 
         expect(this.resMock.locals.form.options.clientRelationshipManagers).to.deep.equal(expectedOptions)
-      })
-
-      it('includes all active adviser options for account manager', () => {
-        const expectedOptions = [
-          { label: 'Jeff Smith', value: '1' },
-          { label: 'John Smith', value: '2' },
-          { label: 'Zac Smith', value: '3' },
-          { label: 'Jim Smith', value: '5' },
-        ]
-
-        expect(this.resMock.locals.form.options.accountManagers).to.deep.equal(expectedOptions)
       })
     })
   })

--- a/test/unit/apps/investment-projects/transformers/team.test.js
+++ b/test/unit/apps/investment-projects/transformers/team.test.js
@@ -128,7 +128,7 @@ describe('Investment project transformers', () => {
         team: 'Team Fred',
       }, {
         adviser: 'John Brown',
-        role: 'Global account manager',
+        role: 'Global Account Manager',
         team: 'Johns Team',
       }]
 

--- a/test/unit/data/investment/investment-data-account-manager.json
+++ b/test/unit/data/investment/investment-data-account-manager.json
@@ -89,7 +89,11 @@
     "headquarter_type": null,
     "classification": null,
     "parent": null,
-    "one_list_account_owner": null
+    "one_list_account_owner": {
+      "id": "05346184-9b98-e211-a939-e4115bead28b",
+      "first_name": "Travis",
+      "last_name": "Greene"
+    }
   },
   "intermediate_company": null,
   "client_contacts": [],


### PR DESCRIPTION
https://trello.com/c/nJirzoiM/112-investment-project-make-global-account-manager-readonly

# Problem
The `Edit client relationship management` view currently allows the user to edit the `Account manager`.

# Solution
- Change the `Account manager` field to `Global Account Manager` and map to `one_list_account_owner`
- Present `Global Account Manager` as text

# Further development
- There are no acceptance tests around `Edit client relationship management` so the next PR will introduce these

# Before
<img width="778" alt="screen shot 2018-08-09 at 16 22 53" src="https://user-images.githubusercontent.com/1150417/43908705-9139ac12-9bf0-11e8-8bfc-d447bb06a76f.png">

# After
<img width="777" alt="screen shot 2018-08-09 at 16 14 47" src="https://user-images.githubusercontent.com/1150417/43908653-694cb9f6-9bf0-11e8-88a0-3cfa11d323a1.png">