### PR TITLE
Rename parent to global headquarters to avoid disambiguation

### DIFF
--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -27,7 +27,7 @@ module.exports = function transformCompanyToListItem ({
   modified_on,
   headquarter_type,
   global_headquarters,
-  parentCompanyArchived,
+  global_headquarters_archived,
 } = {}) {
   if (!id) { return }
 
@@ -95,7 +95,7 @@ module.exports = function transformCompanyToListItem ({
       url: `/companies/${ghqId}`,
     })
 
-    if (!parentCompanyArchived) {
+    if (!global_headquarters_archived) {
       meta.push({
         label: '',
         value: 'Remove subsidiary',

--- a/src/apps/companies/transformers/company-to-subsidary-list-item.js
+++ b/src/apps/companies/transformers/company-to-subsidary-list-item.js
@@ -1,10 +1,10 @@
 const transformCompanyToListItem = require('./company-to-list-item')
 
-module.exports = function transformCompanyToSubsidiaryListItem ({ archived: parentCompanyArchived }) {
+module.exports = function transformCompanyToSubsidiaryListItem ({ archived: globalHeadquartersArchived }) {
   return (company) => {
     const listItem = transformCompanyToListItem({
       ...company,
-      parentCompanyArchived,
+      global_headquarters_archived: globalHeadquartersArchived,
     })
     listItem.meta = listItem.meta.filter(metaItem => metaItem.label !== 'Global HQ')
     return listItem

--- a/test/acceptance/features/investment-projects/team.feature
+++ b/test/acceptance/features/investment-projects/team.feature
@@ -7,7 +7,7 @@ Feature: View team for an investment project
     Then the Client relationship management data details are displayed
       | Role                        | Adviser                                          | Team                                             |
       | Client relationship manager | investmentProject.clientRelationshipManager.name | investmentProject.clientRelationshipManager.team |
-      | Global Account Manager      | investmentProject.globalAccountManager.name      |                                                  |
+      | Global Account Manager      | investmentProject.globalAccountManager.name      | IST - Sector Advisory Services                   |
 
   @investment-projects-team--view--lep @lep
   Scenario: View investment project team

--- a/test/acceptance/pages/companies/company.js
+++ b/test/acceptance/pages/companies/company.js
@@ -36,7 +36,7 @@ module.exports = {
     sector: '#field-sector',
     website: '#field-website',
     description: '#field-description',
-    parentCompanySearch: '#field-term',
+    companiesHouseSearchField: '#field-term',
     collectionsCompanyNameInput: '#field-name',
     collectionResultsCompanyName: '.c-entity-list li:first-child .c-entity__title > a',
     xhrTargetElement: '#xhr-outlet',
@@ -269,7 +269,7 @@ module.exports = {
         return this
       },
 
-      createUkPrivateOrPublicLimitedCompany (parentCompany, details = {}, callback) {
+      createUkPrivateOrPublicLimitedCompany (companiesHouseCompany, details = {}, callback) {
         const company = assign({}, {
           tradingName: appendUid(faker.company.companyName()),
           website: faker.internet.url(),
@@ -289,8 +289,8 @@ module.exports = {
               .click('@continueButton')
 
             // step 2
-              .waitForElementPresent('@parentCompanySearch')
-              .setValue('@parentCompanySearch', parentCompany.name)
+              .waitForElementPresent('@companiesHouseSearchField')
+              .setValue('@companiesHouseSearchField', companiesHouseCompany.name)
               .submitForm('form')
 
             // step 3
@@ -350,9 +350,9 @@ module.exports = {
                   .click('@saveAndCreateButton')
 
                 callback(assign({}, company, {
-                  heading: parentCompany.name,
-                  primaryAddress: getAddress(parentCompany),
-                  country: parentCompany.country,
+                  heading: companiesHouseCompany.name,
+                  primaryAddress: getAddress(companiesHouseCompany),
+                  country: companiesHouseCompany.country,
                   uniqueSearchTerm: getUid(company.tradingName),
                   globalHeadquarters: companyRadioButtons.headquarterType.text !== 'Global HQ' ? 'Link the Global HQ' : '',
                 }))

--- a/test/unit/apps/companies/middleware/collection.test.js
+++ b/test/unit/apps/companies/middleware/collection.test.js
@@ -91,7 +91,7 @@ describe('Company collection middleware', () => {
 
   describe('#getGlobalHQCompaniesCollection', () => {
     beforeEach(async () => {
-      this.resMock.locals.company = { id: 'mock-parent-company-id' }
+      this.resMock.locals.company = { id: 'mock-global-headquarters-id' }
     })
 
     context('no searchTerm', () => {
@@ -163,7 +163,7 @@ describe('Company collection middleware', () => {
 
   describe('#getSubsidiaryCompaniesCollection', () => {
     beforeEach(async () => {
-      this.resMock.locals.company = { id: 'mock-parent-company-id' }
+      this.resMock.locals.company = { id: 'mock-global-headquarters-id' }
     })
 
     context('no searchTerm', () => {

--- a/test/unit/apps/companies/middleware/hierarchies.test.js
+++ b/test/unit/apps/companies/middleware/hierarchies.test.js
@@ -17,7 +17,7 @@ describe('Company hierarchies middleware', () => {
 
     this.nextSpy = sinon.spy()
 
-    this.parentCompanyId = '1'
+    this.globalHeadquartersId = '1'
     this.subsidiaryCompanyId = '2'
   })
 
@@ -25,7 +25,7 @@ describe('Company hierarchies middleware', () => {
     beforeEach(() => {
       this.reqMock.params = {
         companyId: this.subsidiaryCompanyId,
-        globalHqId: this.parentCompanyId,
+        globalHqId: this.globalHeadquartersId,
       }
     })
 
@@ -33,7 +33,7 @@ describe('Company hierarchies middleware', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.parentCompanyId,
+            global_headquarters: this.globalHeadquartersId,
           })
           .reply(200, { id: this.subsidiaryCompanyId })
 
@@ -59,7 +59,7 @@ describe('Company hierarchies middleware', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.parentCompanyId,
+            global_headquarters: this.globalHeadquartersId,
           })
           .reply(500, 'Error message')
 
@@ -83,7 +83,7 @@ describe('Company hierarchies middleware', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.parentCompanyId,
+            global_headquarters: this.globalHeadquartersId,
           })
           .reply(400, { error: 'Error message' })
 
@@ -180,7 +180,7 @@ describe('Company hierarchies middleware', () => {
   describe('#addSubsidiary', () => {
     beforeEach(() => {
       this.reqMock.params = {
-        companyId: this.parentCompanyId,
+        companyId: this.globalHeadquartersId,
         subsidiaryCompanyId: this.subsidiaryCompanyId,
       }
     })
@@ -189,7 +189,7 @@ describe('Company hierarchies middleware', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.parentCompanyId,
+            global_headquarters: this.globalHeadquartersId,
           })
           .reply(200, { id: this.subsidiaryCompanyId })
 
@@ -202,7 +202,7 @@ describe('Company hierarchies middleware', () => {
 
       it('should redirect', () => {
         expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.parentCompanyId}/subsidiaries`)
+        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.globalHeadquartersId}/subsidiaries`)
       })
 
       it('should call flash', () => {
@@ -215,7 +215,7 @@ describe('Company hierarchies middleware', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.parentCompanyId,
+            global_headquarters: this.globalHeadquartersId,
           })
           .reply(500, 'Error message')
 
@@ -239,7 +239,7 @@ describe('Company hierarchies middleware', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.parentCompanyId,
+            global_headquarters: this.globalHeadquartersId,
           })
           .reply(400, { error: 'Error message' })
 
@@ -248,7 +248,7 @@ describe('Company hierarchies middleware', () => {
 
       it('should redirect', () => {
         expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.parentCompanyId}/subsidiaries`)
+        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.globalHeadquartersId}/subsidiaries`)
       })
 
       it('should call flash', () => {

--- a/test/unit/apps/companies/transformers/company-to-list-item.test.js
+++ b/test/unit/apps/companies/transformers/company-to-list-item.test.js
@@ -210,7 +210,7 @@ describe('transformCompanyToListItem', () => {
 
   context('global headquarters information', () => {
     context('contains the global headquarters information', () => {
-      context('and the parent company is not archived', () => {
+      context('and its global headquarters is not archived', () => {
         beforeEach(() => {
           this.listItem = transformCompanyToListItem(companyData)
         })
@@ -232,11 +232,11 @@ describe('transformCompanyToListItem', () => {
         })
       })
 
-      context('and the parent company is archived', () => {
+      context('and its global headquarters is archived', () => {
         beforeEach(() => {
           this.listItem = transformCompanyToListItem({
             ...companyData,
-            parentCompanyArchived: true,
+            global_headquarters_archived: true,
           })
         })
 

--- a/test/unit/data/companies/ghq-company-transformed-results.json
+++ b/test/unit/data/companies/ghq-company-transformed-results.json
@@ -3,7 +3,7 @@
     {
       "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd",
       "name": "Mars Exports Ltd",
-      "url": "/companies/mock-parent-company-id/hierarchies/ghq/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd/add",
+      "url": "/companies/mock-global-headquarters-id/hierarchies/ghq/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd/add",
       "meta": [
         {
           "label": "Sector",
@@ -34,7 +34,7 @@
     {
       "id": "cf8d6dd0-1d26-450f-931a-f2de21146549",
       "name": "Cole, Stoltenberg and Russel",
-      "url": "/companies/mock-parent-company-id/hierarchies/ghq/cf8d6dd0-1d26-450f-931a-f2de21146549/add",
+      "url": "/companies/mock-global-headquarters-id/hierarchies/ghq/cf8d6dd0-1d26-450f-931a-f2de21146549/add",
       "meta": [
         {
           "label": "Sector",

--- a/test/unit/data/companies/subsidiary-company-transformed-results.json
+++ b/test/unit/data/companies/subsidiary-company-transformed-results.json
@@ -3,7 +3,7 @@
     {
       "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd",
       "name": "Mars Exports Ltd",
-      "url": "\/companies\/mock-parent-company-id\/hierarchies\/subsidiaries\/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd\/add",
+      "url": "\/companies\/mock-global-headquarters-id\/hierarchies\/subsidiaries\/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd\/add",
       "meta": [
         {
           "label": "Sector",
@@ -29,7 +29,7 @@
     {
       "id": "731bdcc1-f685-4c8e-bd66-b356b2c16995",
       "name": "Mars Components Ltd",
-      "url": "\/companies\/mock-parent-company-id\/hierarchies\/subsidiaries\/731bdcc1-f685-4c8e-bd66-b356b2c16995\/add",
+      "url": "\/companies\/mock-global-headquarters-id\/hierarchies\/subsidiaries\/731bdcc1-f685-4c8e-bd66-b356b2c16995\/add",
       "meta": [
         {
           "label": "Sector",


### PR DESCRIPTION
A parent/child relationship between companies assumes that there can be more levels (e.g. a child company with its own child).

The hierarchy we have at the moment is Global HQ and subsidiaries so it's better to avoid the word 'parent' and use global headquarters instead.

Also note that a Global HQ might not be the direct parent of a subsidiary in real life so using 'parent' is not 100% correct. We don't want to map the real world relationships between companies as it's too unnecessarily complex.
