### PR TITLE
Remove parent field from test data

### DIFF
--- a/test/unit/data/api-response-intermediary-company.json
+++ b/test/unit/data/api-response-intermediary-company.json
@@ -127,7 +127,6 @@
                 "trading_address_country": null,
                 "headquarter_type": null,
                 "classification": null,
-                "parent": null,
                 "one_list_account_owner": null,
                 "export_to_countries": [],
                 "future_interest_countries": []
@@ -205,6 +204,5 @@
     "trading_address_country": null,
     "headquarter_type": null,
     "classification": null,
-    "parent": null,
     "one_list_account_owner": null
 }

--- a/test/unit/data/companies/companies-house-company.json
+++ b/test/unit/data/companies/companies-house-company.json
@@ -89,7 +89,6 @@
     "name": "ehq"
   },
   "one_list_account_owner": null,
-  "parent": null,
   "sector": {
       "name": "Aerospace : Manufacturing and Assembly : Space Technology",
       "id": "b622c9d2-5f95-e211-a939-e4115bead28a"

--- a/test/unit/data/companies/datahub-only-company.json
+++ b/test/unit/data/companies/datahub-only-company.json
@@ -67,7 +67,6 @@
     "name": "ehq"
   },
   "one_list_account_owner": null,
-  "parent": null,
   "sector": {
       "name": "Aerospace : Manufacturing and Assembly : Space Technology",
       "id": "b622c9d2-5f95-e211-a939-e4115bead28a"

--- a/test/unit/data/companies/ghq-company-search-response.json
+++ b/test/unit/data/companies/ghq-company-search-response.json
@@ -85,7 +85,6 @@
       "trading_address_country": null,
       "trading_address_postcode": "",
       "classification": null,
-      "parent": null,
       "global_headquarters": null,
       "one_list_account_owner": null,
       "export_experience_category": null
@@ -147,7 +146,6 @@
       "trading_address_country": null,
       "trading_address_postcode": "",
       "classification": null,
-      "parent": null,
       "global_headquarters": null,
       "one_list_account_owner": null,
       "export_experience_category": null

--- a/test/unit/data/companies/minimal-company.json
+++ b/test/unit/data/companies/minimal-company.json
@@ -40,7 +40,6 @@
   "export_to_countries": [],
   "headquarter_type": null,
   "one_list_account_owner": null,
-  "parent": null,
   "sector": {
       "name": "Aerospace : Manufacturing and Assembly : Space Technology",
       "id": "b622c9d2-5f95-e211-a939-e4115bead28a"

--- a/test/unit/data/companies/subsidiary-company-search-response.json
+++ b/test/unit/data/companies/subsidiary-company-search-response.json
@@ -49,7 +49,6 @@
       "global_headquarters": null,
       "headquarter_type": null,
       "one_list_account_owner": null,
-      "parent": null,
       "registered_address_country": {
         "id": "81756b9a-5d95-e211-a939-e4115bead28a",
         "name": "United States"
@@ -128,7 +127,6 @@
       "global_headquarters": null,
       "headquarter_type": null,
       "one_list_account_owner": null,
-      "parent": null,
       "registered_address_country": {
         "id": "80756b9a-5d95-e211-a939-e4115bead28a",
         "name": "United Kingdom"

--- a/test/unit/data/company.json
+++ b/test/unit/data/company.json
@@ -228,6 +228,5 @@
     "name": "Mars Exports Ltd"
   },
   "classification": null,
-  "parent": null,
   "one_list_account_owner": null
 }

--- a/test/unit/data/investment/interaction/interaction.json
+++ b/test/unit/data/investment/interaction/interaction.json
@@ -84,7 +84,6 @@
       "trading_address_country": null,
       "headquarter_type": null,
       "classification": null,
-      "parent": null,
       "one_list_account_owner": null,
       "export_to_countries": [],
       "future_interest_countries": []
@@ -189,7 +188,6 @@
       "trading_address_country": null,
       "headquarter_type": null,
       "classification": null,
-      "parent": null,
       "one_list_account_owner": null,
       "export_to_countries": [],
       "future_interest_countries": []

--- a/test/unit/data/investment/interaction/interactions.json
+++ b/test/unit/data/investment/interaction/interactions.json
@@ -89,7 +89,6 @@
           "trading_address_country": null,
           "headquarter_type": null,
           "classification": null,
-          "parent": null,
           "one_list_account_owner": null,
           "export_to_countries": [],
           "future_interest_countries": []
@@ -194,7 +193,6 @@
           "trading_address_country": null,
           "headquarter_type": null,
           "classification": null,
-          "parent": null,
           "one_list_account_owner": null,
           "export_to_countries": [],
           "future_interest_countries": []

--- a/test/unit/data/investment/investment-data-account-manager.json
+++ b/test/unit/data/investment/investment-data-account-manager.json
@@ -88,7 +88,6 @@
     "trading_address_country": null,
     "headquarter_type": null,
     "classification": null,
-    "parent": null,
     "one_list_account_owner": {
       "id": "05346184-9b98-e211-a939-e4115bead28b",
       "first_name": "Travis",

--- a/test/unit/data/investment/investment-data-uk-company.json
+++ b/test/unit/data/investment/investment-data-uk-company.json
@@ -80,7 +80,6 @@
       "id": "b91bf800-8d53-e311-aef3-441ea13961e2",
       "name": "Tier A - Strategic Account"
     },
-    "parent": null,
     "one_list_account_owner": null
   },
   "intermediate_company": null,
@@ -281,7 +280,6 @@
       "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",
       "name": "Undefined"
     },
-    "parent": null,
     "one_list_account_owner": null
   },
   "requirements_complete": true,

--- a/test/unit/data/investment/investment-data.json
+++ b/test/unit/data/investment/investment-data.json
@@ -77,7 +77,6 @@
     "trading_address_country": null,
     "headquarter_type": null,
     "classification": null,
-    "parent": null,
     "one_list_account_owner": null
   },
   "intermediate_company": null,

--- a/test/unit/data/search/companiesHouseAndLtdCompanies.json
+++ b/test/unit/data/search/companiesHouseAndLtdCompanies.json
@@ -58,7 +58,6 @@
       "trading_address_country": null,
       "trading_address_postcode": null,
       "headquarter_type": null,
-      "parent": null,
       "one_list_account_owner": null,
       "level": 0
     },
@@ -121,7 +120,6 @@
       "trading_address_country": null,
       "trading_address_postcode": null,
       "headquarter_type": null,
-      "parent": null,
       "one_list_account_owner": null,
       "level": 0
     },
@@ -184,7 +182,6 @@
       "trading_address_country": null,
       "trading_address_postcode": null,
       "headquarter_type": null,
-      "parent": null,
       "one_list_account_owner": null,
       "level": 0
     }

--- a/test/unit/data/search/company.json
+++ b/test/unit/data/search/company.json
@@ -48,7 +48,6 @@
       "modified_on": "2017-05-25T11:15:27.272221",
       "name": "abc defg ltd",
       "one_list_account_owner": null,
-      "parent": null,
       "registered_address_1": "2 Foo st.",
       "registered_address_2": null,
       "registered_address_country": {
@@ -104,7 +103,6 @@
       "modified_on": "2017-05-25T11:15:27.283250",
       "name": "abc defg us ltd",
       "one_list_account_owner": null,
-      "parent": null,
       "registered_address_1": "3 Foo st.",
       "registered_address_2": null,
       "registered_address_country": {
@@ -166,7 +164,6 @@
       "modified_on": "2017-05-25T11:15:27.237129",
       "name": "name0",
       "one_list_account_owner": null,
-      "parent": null,
       "registered_address_1": "0 Foo st.",
       "registered_address_2": null,
       "registered_address_country": {


### PR DESCRIPTION
The field `parent` is not being used so this gets rid of it from the test data.
It will be probably deleted from the backend eventually as well.