### PR TITLE
Remove duplicate transform function

### DIFF
--- a/src/apps/companies/controllers/audit.js
+++ b/src/apps/companies/controllers/audit.js
@@ -1,7 +1,7 @@
 const { getCompanyAuditLog } = require('../repos')
 const { transformAuditLogToListItem } = require('../../audit/transformers')
 const { companyDetailsLabels } = require('../labels')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 
 async function renderAuditLog (req, res, next) {
   const token = req.session.token

--- a/src/apps/companies/controllers/investments.js
+++ b/src/apps/companies/controllers/investments.js
@@ -1,6 +1,6 @@
 const { getCompanyInvestmentProjects } = require('../../investment-projects/repos')
 const { transformInvestmentProjectToListItem } = require('../../investment-projects/transformers')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 
 async function renderInvestments (req, res, next) {
   const token = req.session.token

--- a/src/apps/companies/controllers/orders.js
+++ b/src/apps/companies/controllers/orders.js
@@ -1,5 +1,5 @@
 const { search } = require('../../search/services')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 const { transformOrderToListItem } = require('../../omis/transformers')
 
 async function renderOrders (req, res, next) {

--- a/src/apps/companies/controllers/timeline.js
+++ b/src/apps/companies/controllers/timeline.js
@@ -1,6 +1,6 @@
 const { getCompanyTimeline } = require('../repos')
 const { transformTimelineToListItem } = require('../../timeline/transformers')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 
 async function renderTimeline (req, res, next) {
   const token = req.session.token

--- a/src/apps/companies/middleware/contact-collection.js
+++ b/src/apps/companies/middleware/contact-collection.js
@@ -7,7 +7,7 @@ const {
 } = require('lodash')
 
 const { search } = require('../../search/services')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 const { transformContactToListItem } = require('../../contacts/transformers')
 const removeArray = require('../../../lib/remove-array')
 

--- a/src/apps/contacts/controllers/audit.js
+++ b/src/apps/contacts/controllers/audit.js
@@ -1,5 +1,5 @@
 const { getContactAuditLog } = require('../repos')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 const { transformAuditLogToListItem } = require('../../audit/transformers')
 const { contactAuditLabels } = require('../labels')
 

--- a/src/apps/investment-projects/controllers/interactions.js
+++ b/src/apps/investment-projects/controllers/interactions.js
@@ -3,7 +3,7 @@ const {
   transformInteractionToListItem,
   transformInteractionListItemToHaveUrlPrefix,
 } = require('../../interactions/transformers')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 
 async function renderInteractionList (req, res, next) {
   try {

--- a/src/apps/investment-projects/controllers/propositions.js
+++ b/src/apps/investment-projects/controllers/propositions.js
@@ -3,7 +3,7 @@ const {
   transformPropositionToListItem,
   transformPropositionListItemToHaveUrlPrefix,
 } = require('../../propositions/transformers')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 
 async function renderPropositionList (req, res, next) {
   try {

--- a/src/apps/investment-projects/middleware/interactions.js
+++ b/src/apps/investment-projects/middleware/interactions.js
@@ -1,6 +1,6 @@
 const { getInteractionsForInvestment } = require('../../interactions/repos')
 const { transformInteractionToListItem } = require('../../interactions/transformers')
-const { transformApiResponseToCollection } = require('../../transformers')
+const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 const { getInvestment } = require('../repos')
 
 async function getInteractionCollection (req, res, next) {

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -3,14 +3,9 @@ const {
   filter,
   keyBy,
   snakeCase,
-  isPlainObject,
-  isFunction,
-  isEmpty,
-  assign,
 } = require('lodash')
 const { isValid, format, parse } = require('date-fns')
 
-const { buildPagination } = require('../lib/pagination')
 const { hqLabels } = require('./companies/labels')
 
 function transformObjectToOption ({ id, name }) {
@@ -94,40 +89,6 @@ function buildMetaDataObj (collection) {
   })
 }
 
-/**
- * @param {object} [options] {object}
- * @param {string} [options.searchTerm] - search term used for highlighting words in collection macro
- * @param {object} [options.query] - URL query object used in pagination
- * @param {...function} [itemTransformers] - an array of transformer functions to apply for each item in the list
- * @returns {object, undefined}
- */
-function transformApiResponseToCollection (options = {}, ...itemTransformers) {
-  /**
-   * @param {object} response - API response object
-   * @returns {function}
-   */
-  return function transformResponseToCollection (response) {
-    if (!isPlainObject(response)) { return }
-
-    let items = response.results || response.items
-
-    if (!items) { return }
-
-    itemTransformers.forEach(transformer => {
-      if (!isFunction(transformer)) { return }
-      items = items
-        .map(transformer)
-        .filter(item => !isEmpty(item))
-    })
-
-    return assign({}, {
-      items,
-      count: response.count,
-      pagination: buildPagination(options.query, response),
-    })
-  }
-}
-
 module.exports = {
   buildMetaDataObj,
   transformHQCodeToLabelledOption,
@@ -135,7 +96,6 @@ module.exports = {
   transformStringToOption,
   transformContactToOption,
   transformIdToObject,
-  transformApiResponseToCollection,
   transformDateObjectToDateString,
   transformDateStringToDateObject,
 }

--- a/src/modules/api/transformers/api-response-to-collection.js
+++ b/src/modules/api/transformers/api-response-to-collection.js
@@ -5,7 +5,7 @@ const {
   assign,
 } = require('lodash')
 
-const { buildPagination } = require('../../../lib/pagination')
+const { buildPagination } = require('../../../lib/pagination') // TODO: We should not be dependent on this
 
 /**
  * @param {object} [options] {object}

--- a/test/unit/apps/transformers.test.js
+++ b/test/unit/apps/transformers.test.js
@@ -1,12 +1,6 @@
 describe('Global transformers', () => {
   beforeEach(() => {
-    this.buildPaginationSpy = sinon.spy()
-
-    this.transformers = proxyquire('~/src/apps/transformers', {
-      '../lib/pagination': {
-        buildPagination: this.buildPaginationSpy,
-      },
-    })
+    this.transformers = require('~/src/apps/transformers')
   })
 
   describe('#transformObjectToOption', () => {
@@ -145,108 +139,6 @@ describe('Global transformers', () => {
 
       expect(actual).to.deep.equal({
         id: '123456',
-      })
-    })
-  })
-
-  describe('#transformApiResponseToCollection', () => {
-    beforeEach(() => {
-      this.mockResponse = {
-        count: 2,
-        results: [
-          { a: 'A' },
-          { b: 'B' },
-        ],
-      }
-    })
-
-    it('should return a function when high-order function is called without arguments', () => {
-      expect(this.transformers.transformApiResponseToCollection()).to.be.a('function')
-    })
-
-    it('should return undefined when returned function is called with invalid arguments', () => {
-      expect(this.transformers.transformApiResponseToCollection()()).to.be.undefined
-      expect(this.transformers.transformApiResponseToCollection()('abc')).to.be.undefined
-      expect(this.transformers.transformApiResponseToCollection()([], 'a')).to.be.undefined
-      expect(this.transformers.transformApiResponseToCollection()(null)).to.be.undefined
-      expect(this.transformers.transformApiResponseToCollection()({})).to.be.undefined
-    })
-
-    it('should return undefined if items property is not in response', () => {
-      expect(this.transformers.transformApiResponseToCollection()({ a: 'A' })).to.be.undefined
-    })
-
-    it('should return a collection object with pagination result, count and items array', () => {
-      const actual = this.transformers.transformApiResponseToCollection()(this.mockResponse)
-
-      expect(actual).to.have.property('count', 2)
-      expect(actual).to.have.property('items').to.be.an('array').and.have.length(2)
-      expect(actual).to.have.property('pagination')
-      expect(this.buildPaginationSpy).to.be.called
-    })
-
-    context('when an item transformer is specified with arguments', () => {
-      beforeEach(() => {
-        this.itemTransformerInnerSpy = sinon.spy()
-        this.itemTransformerSpy = sinon.stub().returns(this.itemTransformerInnerSpy)
-        this.itemTransformerOptions = { query: { term: 'bobby' } }
-
-        this.transformers.transformApiResponseToCollection(
-          undefined,
-          this.itemTransformerSpy(this.itemTransformerOptions)
-        )(this.mockResponse)
-      })
-
-      it('call the item transformer with the arguments', () => {
-        expect(this.itemTransformerSpy).to.be.calledWith(this.itemTransformerOptions)
-      })
-    })
-
-    context('when there are multiple item transformers', () => {
-      beforeEach(() => {
-        this.firstItemTransformerStub = sinon.stub()
-          .onCall(0).returns({ id: '0' })
-          .onCall(1).returns({ id: '1' })
-
-        this.secondItemTransformerStub = sinon.stub()
-          .onCall(0).returns({ id: 'a0' })
-          .onCall(1).returns({ id: 'a1' })
-
-        this.result = this.transformers.transformApiResponseToCollection(
-          undefined,
-          this.firstItemTransformerStub,
-          this.secondItemTransformerStub
-        )(this.mockResponse)
-      })
-
-      it('should call the first transformer for each item', () => {
-        expect(this.firstItemTransformerStub).to.be.calledTwice
-        expect(this.secondItemTransformerStub).to.be.calledTwice
-      })
-
-      it('should call the second transformer for each item', () => {
-        expect(this.secondItemTransformerStub).to.be.calledTwice
-      })
-
-      it('should pass all the items through', () => {
-        expect(this.result).to.have.property('items').to.have.length(2)
-      })
-    })
-
-    context('when the item transformer fails for an item', () => {
-      beforeEach(() => {
-        const itemTransformerStub = sinon.stub()
-          .onCall(0).returns(undefined)
-          .onCall(1).returns({ id: '1' })
-
-        this.result = this.transformers.transformApiResponseToCollection(
-          undefined,
-          itemTransformerStub
-        )(this.mockResponse)
-      })
-
-      it('should filter out undefined items', () => {
-        expect(this.result.items).to.deep.equal([{ id: '1' }])
       })
     })
   })

--- a/test/unit/modules/transformers/api-response-to-collection.test.js
+++ b/test/unit/modules/transformers/api-response-to-collection.test.js
@@ -1,0 +1,107 @@
+describe('#transformApiResponseToCollection', () => {
+  beforeEach(() => {
+    this.buildPaginationSpy = sinon.spy()
+    this.transformApiResponseToCollection = proxyquire('~/src/modules/api/transformers/api-response-to-collection.js', {
+      '../../../lib/pagination': {
+        buildPagination: this.buildPaginationSpy,
+      },
+    })
+    this.mockResponse = {
+      count: 2,
+      results: [
+        { a: 'A' },
+        { b: 'B' },
+      ],
+    }
+  })
+
+  it('should return a function when high-order function is called without arguments', () => {
+    expect(this.transformApiResponseToCollection()).to.be.a('function')
+  })
+
+  it('should return undefined when returned function is called with invalid arguments', () => {
+    expect(this.transformApiResponseToCollection()()).to.be.undefined
+    expect(this.transformApiResponseToCollection()('abc')).to.be.undefined
+    expect(this.transformApiResponseToCollection()([], 'a')).to.be.undefined
+    expect(this.transformApiResponseToCollection()(null)).to.be.undefined
+    expect(this.transformApiResponseToCollection()({})).to.be.undefined
+  })
+
+  it('should return undefined if items property is not in response', () => {
+    expect(this.transformApiResponseToCollection()({ a: 'A' })).to.be.undefined
+  })
+
+  it('should return a collection object with pagination result, count and items array', () => {
+    const actual = this.transformApiResponseToCollection()(this.mockResponse)
+
+    expect(actual).to.have.property('count', 2)
+    expect(actual).to.have.property('items').to.be.an('array').and.have.length(2)
+    expect(actual).to.have.property('pagination')
+    expect(this.buildPaginationSpy).to.be.called
+  })
+
+  context('when an item transformer is specified with arguments', () => {
+    beforeEach(() => {
+      this.itemTransformerInnerSpy = sinon.spy()
+      this.itemTransformerSpy = sinon.stub().returns(this.itemTransformerInnerSpy)
+      this.itemTransformerOptions = { query: { term: 'bobby' } }
+
+      this.transformApiResponseToCollection(
+        undefined,
+        this.itemTransformerSpy(this.itemTransformerOptions)
+      )(this.mockResponse)
+    })
+
+    it('call the item transformer with the arguments', () => {
+      expect(this.itemTransformerSpy).to.be.calledWith(this.itemTransformerOptions)
+    })
+  })
+
+  context('when there are multiple item transformers', () => {
+    beforeEach(() => {
+      this.firstItemTransformerStub = sinon.stub()
+        .onCall(0).returns({ id: '0' })
+        .onCall(1).returns({ id: '1' })
+
+      this.secondItemTransformerStub = sinon.stub()
+        .onCall(0).returns({ id: 'a0' })
+        .onCall(1).returns({ id: 'a1' })
+
+      this.result = this.transformApiResponseToCollection(
+        undefined,
+        this.firstItemTransformerStub,
+        this.secondItemTransformerStub
+      )(this.mockResponse)
+    })
+
+    it('should call the first transformer for each item', () => {
+      expect(this.firstItemTransformerStub).to.be.calledTwice
+      expect(this.secondItemTransformerStub).to.be.calledTwice
+    })
+
+    it('should call the second transformer for each item', () => {
+      expect(this.secondItemTransformerStub).to.be.calledTwice
+    })
+
+    it('should pass all the items through', () => {
+      expect(this.result).to.have.property('items').to.have.length(2)
+    })
+  })
+
+  context('when the item transformer fails for an item', () => {
+    beforeEach(() => {
+      const itemTransformerStub = sinon.stub()
+        .onCall(0).returns(undefined)
+        .onCall(1).returns({ id: '1' })
+
+      this.result = this.transformApiResponseToCollection(
+        undefined,
+        itemTransformerStub
+      )(this.mockResponse)
+    })
+
+    it('should filter out undefined items', () => {
+      expect(this.result.items).to.deep.equal([{ id: '1' }])
+    })
+  })
+})


### PR DESCRIPTION
The `transformApiResponseToCollection` was duplicated so this change removes old references and moves the tests to the appropriate location.