### PR TITLE
Hide feature flagged investment local nav items

### DIFF
--- a/src/apps/investment-projects/middleware/local-nav.js
+++ b/src/apps/investment-projects/middleware/local-nav.js
@@ -1,0 +1,15 @@
+const { setLocalNav } = require('../../middleware')
+const { LOCAL_NAV } = require('../constants')
+
+function setLocalNavForApp (req, res, next) {
+  const navItems = LOCAL_NAV.filter((navItem) => {
+    return (navItem.path !== 'propositions' || res.locals.features['proposition-documents']) &&
+      (navItem.path !== 'evidence' || res.locals.features['investment-evidence'])
+  })
+
+  setLocalNav(navItems)(req, res, next)
+}
+
+module.exports = {
+  setLocalNavForApp,
+}

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,12 +1,12 @@
 const router = require('express').Router()
 
 const { ENTITIES } = require('../search/constants')
-const { DEFAULT_COLLECTION_QUERY, LOCAL_NAV, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
+const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
 
 const { getRequestBody } = require('../../middleware/collection')
 const { getCollection } = require('../../modules/search/middleware/collection')
 
-const { setLocalNav, setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
+const { setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
 const { shared } = require('./middleware')
 const {
   getBriefInvestmentSummary,
@@ -41,6 +41,7 @@ const { renderAddEvidence } = require('./apps/evidence/controllers/create')
 const { postUpload } = require('../documents/middleware/upload')
 
 const { setInteractionsDetails, setCompanyDetails } = require('./middleware/interactions')
+const { setLocalNavForApp } = require('./middleware/local-nav')
 const { setPropositionsReturnUrl } = require('./middleware/propositions')
 const { setEvidenceReturnUrl, setEvidenceDocumentsOptions, getDownloadLink, deleteEvidence } = require('./middleware/evidence')
 
@@ -73,7 +74,7 @@ const propositionsRouter = require('../propositions/router.sub-app')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
-router.use('/:investmentId', setLocalNav(LOCAL_NAV))
+router.use('/:investmentId', setLocalNavForApp)
 
 router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)

--- a/test/unit/apps/investment-projects/middleware/local-nav.test.js
+++ b/test/unit/apps/investment-projects/middleware/local-nav.test.js
@@ -1,0 +1,107 @@
+const { setLocalNavForApp } = require('~/src/apps/investment-projects/middleware/local-nav.js')
+
+describe('Local nav middleware', () => {
+  beforeEach(() => {
+    this.req = {
+      baseUrl: 'base',
+    }
+    this.res = {}
+    this.nextSpy = sinon.spy()
+  })
+
+  context('#setLocalNavForApp', () => {
+    context('when feature flags are not enabled and the user does not have permissions', () => {
+      beforeEach(() => {
+        this.res = {
+          ...this.res,
+          locals: {
+            features: {},
+            user: {
+              permissions: [],
+            },
+          },
+        }
+
+        setLocalNavForApp(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set the local nav without items that are feature flagged or require permissions', () => {
+        expect(this.res.locals.localNavItems.map(item => item.label)).to.deep.equal([
+          'Project details',
+          'Project team',
+          'Evaluations',
+          'Audit history',
+        ])
+      })
+    })
+
+    context('when feature flags are not enabled and the user has view permissions', () => {
+      beforeEach(() => {
+        this.res = {
+          ...this.res,
+          locals: {
+            features: {},
+            user: {
+              permissions: [
+                'interaction.view_all_interaction',
+                'proposition.view_all_proposition',
+                'investment.view_investmentproject_document',
+                'evidence.read_all_evidencedocument',
+              ],
+            },
+          },
+        }
+
+        setLocalNavForApp(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set the local nav without items that are feature flagged and with items that require permissions', () => {
+        expect(this.res.locals.localNavItems.map(item => item.label)).to.deep.equal([
+          'Project details',
+          'Project team',
+          'Interactions',
+          'Evaluations',
+          'Audit history',
+          'Documents',
+        ])
+      })
+    })
+
+    context('when feature flags are enabled and the user has view permissions', () => {
+      beforeEach(() => {
+        this.res = {
+          ...this.res,
+          locals: {
+            features: {
+              'proposition-documents': true,
+              'investment-evidence': true,
+            },
+            user: {
+              permissions: [
+                'interaction.view_all_interaction',
+                'proposition.view_all_proposition',
+                'investment.view_investmentproject_document',
+                'evidence.read_all_evidencedocument',
+              ],
+            },
+          },
+        }
+
+        setLocalNavForApp(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set the local nav with items that are feature flagged and require permissions', () => {
+        expect(this.res.locals.localNavItems.map(item => item.label)).to.deep.equal([
+          'Project details',
+          'Project team',
+          'Interactions',
+          'Propositions',
+          'Evaluations',
+          'Audit history',
+          'Documents',
+          'Evidence',
+        ])
+      })
+    })
+  })
+})


### PR DESCRIPTION
Recent document upload developments need to be hidden by default until they are ready to be enabled. This will allow us to deploy to production.