### PR TITLE
Client-side fix for the name attribute suffix issue

### DIFF
--- a/assets/javascripts/lib/helpers.js
+++ b/assets/javascripts/lib/helpers.js
@@ -163,23 +163,21 @@ function resetFieldValues (element) {
  *
  * @returns {nodeElement}
  */
-function regenIds (wrapper) {
+function regenIds (wrapper, attr = 'id') {
   Array
     .from(wrapper.querySelectorAll('*[id]'))
     .forEach((element) => {
-      const oldId = element.id
+      const oldId = element[attr]
 
       // If the element has a name, use that as part of the new ID
-      const name = element.name || ''
-      const newId = generateID(name)
-      const newName = generateID(name)
+      const item = element[attr] || ''
+      const newItem = generateID(item)
 
-      element.id = newId
-      element.name = newName
+      element[attr] = newItem
 
       const relatedLabel = wrapper.querySelector(`[for="${oldId}"]`)
       if (relatedLabel) {
-        relatedLabel.setAttribute('for', newId)
+        relatedLabel.setAttribute('for', newItem)
       }
     })
 

--- a/assets/javascripts/modules/add-items.js
+++ b/assets/javascripts/modules/add-items.js
@@ -51,6 +51,7 @@ const AddItems = {
     addButtonText: 'Add another {{itemName}}',
     removeButtonSelector: `.${removeButtonClass}`,
     removeButtonText: 'Remove',
+    encType: false,
   },
 
   init (wrapper = document, options) {
@@ -60,6 +61,7 @@ const AddItems = {
     this.cacheEls()
     this.bindEvents()
     this.render()
+    this.setEncType()
   },
 
   cacheEls () {
@@ -161,9 +163,26 @@ const AddItems = {
     this.render()
   },
 
+  setEncType () {
+    const pageForm = document.querySelector('form')
+
+    if (pageForm && pageForm.enctype) {
+      this.encType = pageForm.enctype
+    }
+  },
+
+  getItemAttribute () {
+    if (this.encType === 'multipart/form-data') {
+      return 'name'
+    } else {
+      return 'id'
+    }
+  },
+
   addItem () {
     const lastItem = this.wrapper.querySelector(`${this.settings.itemSelector}:last-of-type`)
-    const newItem = regenIds(this.template.cloneNode(true))
+    const attr = this.getItemAttribute()
+    const newItem = regenIds(this.template.cloneNode(true), attr)
 
     resetFieldValues(newItem)
 

--- a/test/unit/assets/javascripts/modules/add-items.test.js
+++ b/test/unit/assets/javascripts/modules/add-items.test.js
@@ -148,6 +148,18 @@ describe('Add another', () => {
         expect(secondTextField.id).to.not.equal(firstTextField.id)
       })
 
+      it('should not create a new NAME for elements with an existing NAME', () => {
+        const addButtonElement = this.wrapper.querySelector('.js-AddItems__add')
+        addButtonElement.click()
+        const fieldsets = Array.from(this.wrapper.querySelectorAll('fieldset'))
+
+        const firstTextField = fieldsets[0].querySelector('input')
+        const secondTextField = fieldsets[1].querySelector('input')
+
+        expect(secondTextField.name).to.have.length.above(0)
+        expect(secondTextField.name).to.equal(firstTextField.name)
+      })
+
       it('should re-assign "for" attributes to their associated new field', () => {
         const addButtonElement = this.wrapper.querySelector('.js-AddItems__add')
         addButtonElement.click()


### PR DESCRIPTION
Because form ecription type `multipart/form-data` required for document upload doesn't take any input attributes other than name,
to be able to submit multiple documents, we need a unique `name` for each input. Initially we reused the same functionality as for creating multiple inputs, but this was generating unique `id`'s for each input.
With this fix we added some logic that checks for the form type and changes the attribute that needs the unique suffix, while not breaking the functionality of other components sharing this script.

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
