### PR TITLE
Fix Pagination in interactions collection in Company and Contact

### DIFF
--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -29,7 +29,7 @@ async function getInteractionCollectionForEntity (req, res, next) {
 
     res.locals.results = await getInteractionsForEntity(params)
       .then(transformApiResponseToCollection(
-        { entityType: 'interaction' },
+        { query: req.query },
         transformInteractionToListItem,
         transformInteractionListItemToHaveUrlPrefix(res.locals.returnLink)
       ))

--- a/test/unit/apps/interactions/controllers/list.test.js
+++ b/test/unit/apps/interactions/controllers/list.test.js
@@ -122,9 +122,10 @@ describe('interaction list', () => {
 
         it('should render action buttons', () => {
           const actual = this.res.render.firstCall.args[1].actionButtons[0]
-          expect(actual.label).to.equal('Add interaction')
-          expect(actual.url).to.equal('entity/interactions/create/interaction')
-          expect(this.res.render).to.have.been.calledOnce
+          expect(actual).to.deep.equal({
+            label: 'Add interaction',
+            url: 'entity/interactions/create/interaction',
+          })
         })
       })
 
@@ -150,7 +151,6 @@ describe('interaction list', () => {
         it('should not render action buttons', () => {
           const actual = this.res.render.firstCall.args[1].actionButtons
           expect(actual).to.be.undefined
-          expect(this.res.render).to.have.been.calledOnce
         })
       })
     })


### PR DESCRIPTION
https://trello.com/c/6EvGswUr/347-bug-pagination-broken-in-interactions-view-in-company-and-contact-details

# Problem
Pagination is not functioning correctly. As user browse pages, they eventually get stuck at page 4 because there is no links for page 5 and beyond.

# Solution
Issue was introduced during recent refactor. The problem is that `req.query` was not being passed when transforming the collection so the current page could not be ascertained.

# Before
![screen shot 2018-09-20 at 12 20 29](https://user-images.githubusercontent.com/1150417/45815184-c853fe00-bccf-11e8-9c9a-971eca3dce6e.png)

# After
![screen shot 2018-09-20 at 12 20 54](https://user-images.githubusercontent.com/1150417/45815191-cd18b200-bccf-11e8-8d7e-ea2f0726bdec.png)
