### PR TITLE
Correct setting of interactions returnLink

### DIFF
--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -34,16 +34,22 @@ async function getHiddenFields (req, res, interactionId) {
   return hiddenFields
 }
 
+const getReturnLink = (res, interactionId) => {
+  const urlPrefix = (res.locals.interactions && res.locals.interactions.returnLink) || '/interactions/'
+  return interactionId ? `${urlPrefix}${interactionId}` : urlPrefix
+}
+
 async function buildForm (req, res, interactionId) {
   const options = await getInteractionOptions(req, res)
   const hiddenFields = await getHiddenFields(req, res, interactionId)
+  const returnLink = getReturnLink(res, interactionId)
 
   const formProperties = {
     ...options,
-    returnLink: interactionId ? `/interactions/${interactionId}` : res.locals.returnLink,
+    hiddenFields,
+    returnLink,
     returnText: interactionId ? 'Return without saving' : 'Cancel',
     buttonText: interactionId ? 'Save and return' : `Add ${lowerCase(req.params.kind)}`,
-    hiddenFields,
   }
 
   const form = formConfigs[req.params.kind](formProperties)

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -30,7 +30,7 @@ async function getInteractionCollectionForEntity (req, res, next) {
       .then(transformApiResponseToCollection(
         { query: req.query },
         transformInteractionToListItem,
-        transformInteractionListItemToHaveUrlPrefix(res.locals.returnLink)
+        transformInteractionListItemToHaveUrlPrefix(res.locals.interactions.returnLink)
       ))
 
     next()

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -12,8 +12,7 @@ const { transformInteractionToListItem, transformInteractionListItemToHaveUrlPre
 async function getInteractionCollection (req, res, next) {
   getCollection('interaction',
     ENTITIES,
-    transformInteractionToListItem,
-    transformInteractionListItemToHaveUrlPrefix(res.locals.returnLink)
+    transformInteractionToListItem
   )(req, res, next)
 }
 

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -14,8 +14,8 @@ async function postDetails (req, res, next) {
 
     req.flash('success', `${sentence(req.params.kind)} ${res.locals.interaction ? 'updated' : 'created'}`)
 
-    if (res.locals.returnLink) {
-      return res.redirect(res.locals.returnLink + result.id)
+    if (res.locals.interactions && res.locals.interactions.returnLink) {
+      return res.redirect(res.locals.interactions.returnLink + result.id)
     }
 
     return res.redirect(`/interactions/${result.id}`)

--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -151,7 +151,9 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '2',
           name: 'Fred Bloggs',
         },
-        returnLink: '/',
+        interactions: {
+          returnLink: '/',
+        },
         entityName: 'Fred Bloggs',
       }
 

--- a/test/unit/apps/interactions/controllers/edit.policy-feedback.test.js
+++ b/test/unit/apps/interactions/controllers/edit.policy-feedback.test.js
@@ -162,7 +162,9 @@ describe('Interaction edit controller (Policy feedback)', () => {
           id: '2',
           name: 'Fred Bloggs',
         },
-        returnLink: '/',
+        interactions: {
+          returnLink: '/',
+        },
         entityName: 'Fred Bloggs',
       }
 

--- a/test/unit/apps/interactions/controllers/edit.service.test.js
+++ b/test/unit/apps/interactions/controllers/edit.service.test.js
@@ -152,7 +152,9 @@ describe('Interaction edit controller (Service delivery)', () => {
           id: '2',
           name: 'Fred Bloggs',
         },
-        returnLink: '/',
+        interactions: {
+          returnLink: '/',
+        },
         entityName: 'Fred Bloggs',
       }
 

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -74,7 +74,9 @@ describe('Interaction details middleware', () => {
         company: {
           id: '1',
         },
-        returnLink: '/return/',
+        interactions: {
+          returnLink: '/return/',
+        },
       },
     }
 


### PR DESCRIPTION
I noticed two issues with the interactions code:
* functionality which depended on the `returnLink` was not redirecting correctly because the `returnLink` is embedded in the `res.locals.interactions` object after a recent refactor
* there was unnecessary transformations for `getInteractionCollection` middleware because this function is not used to get interactions for an entity