### PR TITLE
Display "Not set" when global account manager is not set

### DIFF
--- a/src/apps/investment-projects/middleware/forms/client-relationship-management.js
+++ b/src/apps/investment-projects/middleware/forms/client-relationship-management.js
@@ -18,12 +18,13 @@ async function populateForm (req, res, next) {
       advisers: advisersResponse.results,
       includeAdviser: clientRelationshipManager,
     }).map(transformObjectToOption)
+    const globalAccountManager = firstName && lastName ? `${firstName} ${lastName}` : 'Not set'
 
     res.locals.form = Object.assign({}, res.locals.form, {
       labels: clientRelationshipManagementLabels.edit,
       state: {
         client_relationship_manager: clientRelationshipManager,
-        global_account_manager: `${firstName} ${lastName}`,
+        global_account_manager: globalAccountManager,
       },
       options: {
         clientRelationshipManagers: clientRelationshipManagerOptions,

--- a/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/client-relationship-management.test.js
@@ -38,19 +38,40 @@ describe('Investment form middleware - client relationship management', () => {
         })
     })
 
-    it('should populate the form state with the existing client relationship management', async () => {
-      const globalAccountManager = investmentData.investor_company.one_list_account_owner
-      const expectedFormState = {
-        client_relationship_manager: investmentData.client_relationship_manager.id,
-        global_account_manager: `${globalAccountManager.first_name} ${globalAccountManager.last_name}`,
-      }
+    context('when the global account manager is set', () => {
+      it('should populate the form state with the existing client relationship management', async () => {
+        const globalAccountManager = investmentData.investor_company.one_list_account_owner
+        const expectedFormState = {
+          client_relationship_manager: investmentData.client_relationship_manager.id,
+          global_account_manager: `${globalAccountManager.first_name} ${globalAccountManager.last_name}`,
+        }
 
-      await this.controller.populateForm({
-        session: {
-          token: 'mock-token',
-        },
-      }, this.resMock, () => {
-        expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
+        await this.controller.populateForm({
+          session: {
+            token: 'mock-token',
+          },
+        }, this.resMock, () => {
+          expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
+        })
+      })
+    })
+
+    context('when the global account manager is not set', () => {
+      it('should populate the form state with the existing client relationship management', async () => {
+        this.resMock.locals.investmentData.investor_company.one_list_account_owner = null
+
+        const expectedFormState = {
+          client_relationship_manager: investmentData.client_relationship_manager.id,
+          global_account_manager: 'Not set',
+        }
+
+        await this.controller.populateForm({
+          session: {
+            token: 'mock-token',
+          },
+        }, this.resMock, () => {
+          expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
+        })
       })
     })
 


### PR DESCRIPTION
# Problem
Interface is displaying `Undefined Undefined` when the global account manager has not been set for an investment project investor company.

# Solution
Check that the `first_name` and `last_name` are populated and display `Not set` if data is unavailable.

# Before
<img width="782" alt="screen shot 2018-09-24 at 15 25 56" src="https://user-images.githubusercontent.com/1150417/45958807-47b73980-c010-11e8-9330-7772a240b4bc.png">

# After
<img width="758" alt="screen shot 2018-09-24 at 15 26 25" src="https://user-images.githubusercontent.com/1150417/45958816-4e45b100-c010-11e8-838a-33bdc2a96304.png">