### PR TITLE
Feature/investment csv download link

### DIFF
--- a/assets/stylesheets/components/_collection.scss
+++ b/assets/stylesheets/components/_collection.scss
@@ -37,6 +37,13 @@
   line-height: 1;
 }
 
+// Export button
+
+.c-collection__export-message {
+  color: $black;
+  line-height: $default-spacing-unit * 2;
+}
+
 // Filter summary
 
 .c-collection__filter-summary {

--- a/src/apps/investment-projects/controllers/list.js
+++ b/src/apps/investment-projects/controllers/list.js
@@ -1,4 +1,5 @@
-const { get, merge, omit } = require('lodash')
+const qs = require('querystring')
+const { merge, omit } = require('lodash')
 
 const { buildSelectedFiltersSummary, buildFieldsWithSelectedEntities } = require('../../builders')
 const { getOptions } = require('../../../lib/options')
@@ -7,14 +8,44 @@ const { investmentFiltersFields, investmentSortForm } = require('../macros')
 const FILTER_CONSTANTS = require('../../../lib/filter-constants')
 const QUERY_STRING = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.PRIMARY.QUERY_STRING
 const SECTOR = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.NAME
+const MAX_EXPORT_ITEMS = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.MAX_EXPORT_ITEMS
+
+function hasExportPermission (userPermissions) {
+  return userPermissions.includes('investment.export_investmentproject')
+}
+
+function tooManyItems (resultCount) {
+  return resultCount > MAX_EXPORT_ITEMS
+}
+
+function buildExportMessage (resultCount) {
+  if (tooManyItems(resultCount)) {
+    return `Filter to less than ${MAX_EXPORT_ITEMS} projects to download`
+  }
+  return `You can now download these ${resultCount} projects`
+}
+
+function buildExportAction (userPermissions, queryString) {
+  if (!hasExportPermission(userPermissions)) {
+    return {
+      enabled: false,
+    }
+  }
+  return {
+    enabled: true,
+    buildMessage: (count) => buildExportMessage(count),
+    url: 'investment-projects' + queryString,
+    tooManyItems,
+  }
+}
 
 async function renderInvestmentList (req, res, next) {
   try {
-    const token = req.session.token
+    const { token, user } = req.session
+    const currentAdviserId = user.id
     const queryString = QUERY_STRING
-    const currentAdviserId = get(req.session, 'user.id')
     const sortForm = merge({}, investmentSortForm, {
-      hiddenFields: Object.assign({}, omit(req.query, 'sortby')),
+      hiddenFields: { ...omit(req.query, 'sortby') },
       children: [
         { value: req.query.sortby },
       ],
@@ -29,10 +60,12 @@ async function renderInvestmentList (req, res, next) {
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, req.query)
     const selectedFilters = await buildSelectedFiltersSummary(filtersFieldsWithSelectedOptions, req.query)
+    const exportAction = await buildExportAction(user.permissions, '/export?' + qs.stringify(req.query))
 
     res.render('_layouts/collection', {
       sortForm,
       selectedFilters,
+      exportAction,
       filtersFields: filtersFieldsWithSelectedOptions,
       title: 'Investment Projects',
       countLabel: 'project',

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -4,7 +4,7 @@ const { ENTITIES } = require('../search/constants')
 const { DEFAULT_COLLECTION_QUERY, LOCAL_NAV, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
 
 const { getRequestBody } = require('../../middleware/collection')
-const { getCollection } = require('../../modules/search/middleware/collection')
+const { getCollection, exportCollection } = require('../../modules/search/middleware/collection')
 
 const { setLocalNav, setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
 const { shared } = require('./middleware')
@@ -83,6 +83,12 @@ router.get('/',
   getRequestBody(QUERY_FIELDS),
   getCollection('investment_project', ENTITIES, transformInvestmentProjectToListItem),
   renderInvestmentList
+)
+
+router.get('/export',
+  setDefaultQuery(DEFAULT_COLLECTION_QUERY),
+  getRequestBody(QUERY_FIELDS),
+  exportCollection('investment_project', 'Data Hub - Investment Projects'),
 )
 
 router.post('/:investmentId/details', archive.archiveInvestmentProjectHandler, details.detailsGetHandler)

--- a/src/lib/filter-constants.js
+++ b/src/lib/filter-constants.js
@@ -24,6 +24,7 @@ const FILTER_CONSTANTS = {
         NAME: 'sector_descends',
         QUERY_STRING: '?level__lte=0',
       },
+      MAX_EXPORT_ITEMS: 5000,
     },
   },
   INTERACTIONS: {

--- a/src/lib/stream-to-file.js
+++ b/src/lib/stream-to-file.js
@@ -1,0 +1,11 @@
+// req must be request not request-promise
+function streamToFile (req, res, filename, type = 'txt') {
+  res.attachment(filename)
+  res.type(type)
+  req.pipe(res)
+  return req
+}
+
+module.exports = {
+  streamToFile,
+}

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -1,6 +1,5 @@
-const { assign } = require('lodash')
-
 const authorisedRequest = require('../../lib/authorised-request')
+const authorisedRawRequest = require('../../lib/authorised-raw-request')
 const config = require('../../../config')
 
 function search ({ token, searchTerm = '', searchEntity, requestBody, isAggregation = true, limit = 10, page = 1 }) {
@@ -9,16 +8,18 @@ function search ({ token, searchTerm = '', searchEntity, requestBody, isAggregat
     url: isAggregation ? searchUrl : `${searchUrl}/${searchEntity}`,
     method: isAggregation ? 'GET' : 'POST',
   }
-  requestBody = assign({}, requestBody, {
+  requestBody = {
+    ...requestBody,
     term: searchTerm,
     limit,
     offset: (page * limit) - limit,
-  })
+  }
 
   if (isAggregation) {
-    options.qs = assign(requestBody, {
+    options.qs = {
+      ...requestBody,
       entity: searchEntity,
-    })
+    }
   } else {
     options.body = requestBody
   }
@@ -30,6 +31,21 @@ function search ({ token, searchTerm = '', searchEntity, requestBody, isAggregat
     })
 }
 
+function exportSearch ({ token, searchTerm = '', searchEntity, requestBody }) {
+  const searchUrl = `${config.apiRoot}/v3/search`
+  const options = {
+    url: `${searchUrl}/${searchEntity}/export`,
+    method: 'POST',
+    body: {
+      ...requestBody,
+      term: searchTerm,
+    },
+  }
+
+  return authorisedRawRequest(token, options)
+}
+
 module.exports = {
+  exportSearch,
   search,
 }

--- a/src/templates/_layouts/collection.njk
+++ b/src/templates/_layouts/collection.njk
@@ -21,6 +21,7 @@
             selectedFilters: selectedFilters,
             highlightTerm: highlightTerm,
             actionButtons: actionButtons,
+            exportAction: exportAction,
             query: QUERY
           })) }}
         {% endblock %}

--- a/src/templates/_macros/collection/collection-header.njk
+++ b/src/templates/_macros/collection/collection-header.njk
@@ -79,5 +79,18 @@
       </div>
     {% endif %}
 
+    {% if props.exportAction.enabled %}
+    <div class="c-collection__header-row">
+      <span class="c-collection__export-message">
+        {{ props.exportAction.buildMessage(count) }}
+      </span>
+      <span class="c-collection__header-actions">
+        {% if not props.exportAction.tooManyItems(count) %}
+          <a class="button" download href="{{ props.exportAction.url }}">Download</a>
+        {% endif %}
+      </span>
+    </div>
+    {% endif %}
+
   </header>
 {% endmacro %}

--- a/test/unit/apps/investment-projects/controllers/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/list.test.js
@@ -1,56 +1,97 @@
-const investmentsListData = require('~/test/unit/data/investment/investment-data.json')
-const { transformInvestmentProjectToListItem } = require('~/src/apps/investment-projects/transformers')
+const MAX_EXPORT_ITEMS = require('~/src/lib/filter-constants.js').INVESTMENT_PROJECTS.SECTOR.MAX_EXPORT_ITEMS
 
 describe('Investment list controller', () => {
   beforeEach(() => {
-    this.transformedInvestmentProjects = {}
+    this.error = new Error('error')
     this.next = sinon.spy()
     this.req = {
       session: {
+        user: {
+          id: '1234',
+          name: 'Fred Smith',
+          permissions: [],
+        },
         token: 'abcd',
       },
-      query: {},
+      query: {
+        sortby: 'estimated_land_date:asc',
+      },
     }
     this.res = {
       render: sinon.spy(),
       query: {},
     }
 
-    this.getInvestmentsStub = sinon.stub().resolves(investmentsListData)
-    this.transformApiResponseToCollectionStub = sinon.stub().returns(this.transformedInvestmentProjects)
-
     this.buildSelectedFiltersSummaryStub = sinon.spy()
 
-    this.controller = proxyquire('~/src/apps/investment-projects/controllers/list', {
+    const controller = proxyquire('~/src/apps/investment-projects/controllers/list', {
       '../../builders': {
         buildSelectedFiltersSummary: this.buildSelectedFiltersSummaryStub,
+        buildFieldsWithSelectedEntities: sinon.stub(),
+      },
+      '../../../lib/options': {
+        getOptions: sinon.stub(),
       },
     })
 
+    this.renderInvestmentList = controller.renderInvestmentList
     this.next = sinon.spy()
   })
 
   describe('#renderInvestmentList', () => {
-    context('when there are investments to render', () => {
-      beforeEach(async () => {
-        await this.controller.renderInvestmentList(this.req, this.res, this.next)
+    context('when the list renders successfully', () => {
+      const commonTests = () => {
+        it('should not catch an error', () => {
+          expect(this.next).to.not.have.been.called
+        })
+
+        it('should render the view', () => {
+          expect(this.res.render).to.have.been.calledOnce
+        })
+      }
+
+      context('when the user is allowed to export projects', () => {
+        beforeEach(async () => {
+          this.req.session.user.permissions = ['investment.export_investmentproject']
+          await this.renderInvestmentList(this.req, this.res, this.next)
+          this.exportAction = this.res.render.firstCall.args[1].exportAction
+        })
+
+        it('should enable the export button', () => {
+          expect(this.exportAction.enabled).to.equal(true)
+        })
+
+        it('should return a function to build the export status message', () => {
+          expect(this.exportAction.buildMessage).to.be.a('function')
+        })
+
+        it('should return a function that can check if items have been filtered enough to export', () => {
+          expect(this.exportAction.tooManyItems).to.be.a('function')
+        })
+
+        it('should return a url to download the csv', () => {
+          expect(this.exportAction.url).to.equal('investment-projects/export?sortby=estimated_land_date%3Aasc')
+        })
+
+        it('should output a message if further filtering is required', () => {
+          expect(this.exportAction.buildMessage(MAX_EXPORT_ITEMS + 1)).to.equal(`Filter to less than ${MAX_EXPORT_ITEMS} projects to download`)
+        })
+
+        commonTests()
       })
 
-      it('should render collection page with locals', () => {
-        this.controller.renderInvestmentList(this.req, this.res, this.next)
-
-        it('should get interactions from the repository', () => {
-          expect(this.getInvestmentsStub).to.be.calledWith('abcd')
+      context('when the user is not allowed to export projects', () => {
+        beforeEach(async () => {
+          this.req.session.user.permissions = []
+          await this.renderInvestmentList(this.req, this.res, this.next)
         })
 
-        it('should call the transformer to convert investment project for display', () => {
-          expect(this.transformApiResponseToCollectionStub).to.be.calledWith({ entityType: 'interaction' }, transformInvestmentProjectToListItem)
+        it('should not enable the export button', () => {
+          const exportAction = this.res.render.firstCall.args[1].exportAction
+          expect(exportAction).to.deep.equal({ enabled: false })
         })
 
-        it('should return investment projects', () => {
-          const renderOptions = this.res.render.firstCall.args[1]
-          expect(renderOptions).to.have.property('investment-projects')
-        })
+        commonTests()
       })
     })
   })

--- a/test/unit/lib/stream-to-file.test.js
+++ b/test/unit/lib/stream-to-file.test.js
@@ -1,0 +1,34 @@
+const { streamToFile } = require('~/src/lib/stream-to-file')
+
+describe('#streamToFile', () => {
+  context('when streaming from the remote api', () => {
+    beforeEach(() => {
+      this.attachmentStub = sinon.spy()
+      this.typeStub = sinon.spy()
+      this.pipeStub = sinon.spy()
+
+      this.resMock = {
+        attachment: this.attachmentStub,
+        type: this.typeStub,
+      }
+
+      this.reqMock = {
+        pipe: this.pipeStub,
+      }
+
+      streamToFile(this.reqMock, this.resMock, 'test-filename.csv', 'mime/test')
+    })
+
+    it('sets the attachment filename', () => {
+      expect(this.attachmentStub).to.calledWith('test-filename.csv')
+    })
+
+    it('sets the attachment type', () => {
+      expect(this.typeStub).to.calledWith('mime/test')
+    })
+
+    it('pipes the response', () => {
+      expect(this.pipeStub).to.be.calledWith(this.resMock)
+    })
+  })
+})

--- a/test/unit/modules/search/middleware/collection-export.test.js
+++ b/test/unit/modules/search/middleware/collection-export.test.js
@@ -1,0 +1,51 @@
+const config = require('~/config')
+
+describe('Collection middleware', () => {
+  context('#collectionExport', () => {
+    beforeEach(() => {
+      const streamToFileStub = sinon.spy()
+      const { exportCollection } = proxyquire('~/src/modules/search/middleware/collection', {
+        '../../../lib/stream-to-file': {
+          streamToFile: streamToFileStub,
+        },
+      })
+      this.exportCollection = exportCollection
+      this.streamToFileStub = streamToFileStub
+
+      this.reqMock = {
+        session: {
+          token: '1234',
+        },
+      }
+
+      this.resMock = sinon.spy()
+      this.nextSpy = sinon.spy()
+    })
+
+    describe('#exportCollection', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .post(`/v3/search/entity/export`)
+          .reply(200, this.resMock)
+
+        this.reqMock.query = {
+          sortby: 'name:asc',
+        }
+        await this.exportCollection('entity', 'test-file')(this.reqMock, this.resMock, this.nextSpy).catch(e => { throw e })
+      })
+
+      it('should set the attachment filename', () => {
+        expect(this.streamToFileStub.args[0][2]).to.equal('test-file.csv')
+      })
+
+      it('should pass the response to the file streamer', () => {
+        expect(this.streamToFileStub).to.be.calledOnce
+        expect(this.streamToFileStub.args[0][1]).to.equal(this.resMock)
+      })
+
+      it('should not return an error to the next handler', () => {
+        expect(this.nextSpy).to.not.be.called
+      })
+    })
+  })
+})


### PR DESCRIPTION
Users with permission on the investments projects page can download a CSV of results if there are 5000 or less results.

This PR supersedes #1546 

Notes on review of the previous PR:
 - [x] Make download a simple link
 - [x] Change wording to show amount of records that will be downloaded
 ~- [ ] Clean up authorised-request and simplify authorised-raw-request
Currently having a look at this.~
 This has been moved to it's own branch
- [x] Tests

**Screenshot before**
![image](https://user-images.githubusercontent.com/179677/46148574-4ed48680-c260-11e8-97cc-7d858da4b936.png)


**Screenshot after**
![image](https://user-images.githubusercontent.com/179677/46148540-3a908980-c260-11e8-8ec4-8e1c3d69432f.png)
