### PR TITLE
Add multi step form builder with address module skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "selenium-server": "^3.12.0",
     "sinon": "^5.0.10",
     "sinon-chai": "^3.1.0",
+    "supertest": "^3.3.0",
     "wavy": "^1.0.4"
   },
   "sasslintConfig": ".sass-lint.yml"

--- a/src/apps/addresses/apps/create/steps.js
+++ b/src/apps/addresses/apps/create/steps.js
@@ -1,0 +1,58 @@
+const {
+  overseasAddressForm,
+  postcodeLookupForm,
+  selectUkAddressForm,
+  ukOrOverseasForm,
+} = require('../../macros')
+
+module.exports = {
+  steps: [
+    {
+      path: '/create/step-1',
+      type: 'form',
+      heading: 'Is this a UK or overseas address?',
+      breadcrumbs: [
+        { name: 'Add an address' },
+      ],
+      macro: ukOrOverseasForm,
+      nextPath: ({ uk_or_overseas: ukOrOverseas }) => {
+        const path = {
+          uk: '/create/postcode-lookup',
+          overseas: '/create/overseas-address',
+        }
+
+        return path[ukOrOverseas]
+      },
+    },
+    {
+      path: '/create/postcode-lookup',
+      type: 'form',
+      heading: 'Add a company address',
+      breadcrumbs: [
+        { name: 'Add an address' },
+      ],
+      macro: postcodeLookupForm,
+      nextPath: '/create/select-uk-address',
+    },
+    {
+      path: '/create/select-uk-address',
+      type: 'form',
+      heading: 'Add a company address',
+      breadcrumbs: [
+        { name: 'Add an address' },
+      ],
+      macro: selectUkAddressForm,
+      nextPath: '/',
+    },
+    {
+      path: '/create/overseas-address',
+      type: 'form',
+      heading: 'Add a company address',
+      breadcrumbs: [
+        { name: 'Add an address' },
+      ],
+      macro: overseasAddressForm,
+      nextPath: '/',
+    },
+  ],
+}

--- a/src/apps/addresses/index.js
+++ b/src/apps/addresses/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/src/apps/addresses/macros/index.js
+++ b/src/apps/addresses/macros/index.js
@@ -1,0 +1,11 @@
+const overseasAddressForm = require('./overseas-address-form')
+const postcodeLookupForm = require('./postcode-lookup-form')
+const selectUkAddressForm = require('./select-uk-address-form')
+const ukOrOverseasForm = require('./uk-or-overseas-form')
+
+module.exports = {
+  overseasAddressForm,
+  postcodeLookupForm,
+  selectUkAddressForm,
+  ukOrOverseasForm,
+}

--- a/src/apps/addresses/macros/overseas-address-form.js
+++ b/src/apps/addresses/macros/overseas-address-form.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  return {
+    buttonText: 'Continue',
+    children: [
+    ],
+  }
+}

--- a/src/apps/addresses/macros/postcode-lookup-form.js
+++ b/src/apps/addresses/macros/postcode-lookup-form.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  return {
+    buttonText: 'Continue',
+    children: [
+    ],
+  }
+}

--- a/src/apps/addresses/macros/select-uk-address-form.js
+++ b/src/apps/addresses/macros/select-uk-address-form.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  return {
+    buttonText: 'Continue',
+    children: [
+    ],
+  }
+}

--- a/src/apps/addresses/macros/uk-or-overseas-form.js
+++ b/src/apps/addresses/macros/uk-or-overseas-form.js
@@ -1,0 +1,17 @@
+module.exports = () => {
+  return {
+    buttonText: 'Continue',
+    children: [
+      {
+        macroName: 'MultipleChoiceField',
+        label: 'Address',
+        name: 'uk_or_overseas',
+        type: 'radio',
+        options: [
+          { value: 'uk', label: 'UK address' },
+          { value: 'overseas', label: 'Overseas address' },
+        ],
+      },
+    ],
+  }
+}

--- a/src/apps/addresses/router.sub-app.js
+++ b/src/apps/addresses/router.sub-app.js
@@ -1,0 +1,8 @@
+const router = require('express').Router()
+
+const { build } = require('../../modules/form/journey-builder')
+const createSteps = require('./apps/create/steps')
+
+router.use('/addresses', build(createSteps))
+
+module.exports = router

--- a/src/modules/form/journey-builder.js
+++ b/src/modules/form/journey-builder.js
@@ -1,0 +1,44 @@
+const express = require('express')
+
+const { isString } = require('lodash')
+
+const getRender = (step) => {
+  return (req, res) => {
+    (step.breadcrumbs || []).forEach((breadcrumb) => {
+      res.breadcrumb(breadcrumb.name, breadcrumb.url)
+    })
+
+    res.render(`_layouts/${step.type}`, {
+      heading: step.heading,
+      form: {
+        ...step.macro(res.locals),
+        errors: res.locals.errors,
+      },
+    })
+  }
+}
+
+const getNextPath = (step, requestBody, baseUrl) => {
+  const routePath = isString(step.nextPath) ? step.nextPath : step.nextPath(requestBody)
+  return baseUrl + routePath
+}
+
+const build = (journey) => {
+  const router = express.Router()
+
+  journey.steps.forEach(step => {
+    const middleware = step.middleware || []
+    const render = getRender(step)
+    router.route(step.path)
+      .get(...middleware, render)
+      .post(...middleware, (req, res) => {
+        res.redirect(getNextPath(step, req.body, req.baseUrl))
+      })
+  })
+
+  return router
+}
+
+module.exports = {
+  build,
+}

--- a/src/templates/_layouts/form.njk
+++ b/src/templates/_layouts/form.njk
@@ -1,0 +1,7 @@
+{% extends "_layouts/two-column.njk" %}
+
+{% block main_grid_left_column %}{% endblock %}
+
+{% block main_grid_right_column %}
+  {{ Form(form) }}
+{% endblock %}

--- a/test/unit/modules/form/journey-builder.test.js
+++ b/test/unit/modules/form/journey-builder.test.js
@@ -1,0 +1,210 @@
+const express = require('express')
+const request = require('supertest')
+const { endsWith } = require('lodash')
+
+describe('#build', () => {
+  beforeEach(() => {
+    this.breadcrumbSpy = sinon.spy()
+    this.redirectSpy = sinon.spy()
+    this.setOptionsSpy1 = sinon.stub().callsFake((req, res, next) => { next() })
+    this.setOptionsSpy2 = sinon.stub().callsFake((req, res, next) => { next() })
+    this.journeyBuilder = require('~/src/modules/form/journey-builder.js')
+
+    this.app = express()
+    this.app.set('views', `${process.cwd()}/src/templates`)
+    this.app.set('view engine', 'njk')
+    this.app.use((req, res, next) => {
+      req.baseUrl = '/base'
+      res.breadcrumb = this.breadcrumbSpy
+      next()
+    })
+    this.app.engine('njk', (path, options, callback) => {
+      callback(null, JSON.stringify({ path, options }))
+    })
+
+    this.journey = {
+      steps: [
+        {
+          path: '/step-1',
+          middleware: [
+            this.setOptionsSpy1,
+            this.setOptionsSpy2,
+          ],
+          type: 'form',
+          heading: 'Add something',
+          breadcrumbs: [
+            { name: 'Add something', url: '/url' },
+          ],
+          macro: () => { return { children: [] } },
+          nextPath: ({ selected }) => {
+            const paths = {
+              'step-2-value': '/step-2',
+              'step-3-value': '/step-3',
+            }
+            return paths[selected]
+          },
+        },
+      ],
+    }
+  })
+
+  context('when rendering the view', () => {
+    const commonTests = () => {
+      it('should render the form template', () => {
+        const render = JSON.parse(this.response.res.text)
+        expect(endsWith(render.path, 'form.njk')).to.be.true
+      })
+
+      it('should render the heading', () => {
+        const render = JSON.parse(this.response.res.text)
+        expect(render.options.heading).to.equal('Add something')
+      })
+
+      it('should render the form', () => {
+        const render = JSON.parse(this.response.res.text)
+        const expected = {
+          children: [],
+          errors: { error: 'This field is required' },
+        }
+        expect(render.options.form).to.deep.equal(expected)
+      })
+
+      it('should render the breadcrumbs', () => {
+        expect(this.breadcrumbSpy).have.been.calledWith('Add something', '/url')
+        expect(this.breadcrumbSpy).to.have.been.calledOnce
+      })
+    }
+
+    context('when middleware has been specified', () => {
+      beforeEach(async () => {
+        this.app.use((req, res, next) => {
+          res.locals.errors = { error: 'This field is required' }
+          next()
+        })
+        this.app.use(this.journeyBuilder.build(this.journey))
+
+        this.response = await request(this.app).get('/step-1')
+      })
+
+      commonTests()
+
+      it('should call the middleware', () => {
+        expect(this.setOptionsSpy1).to.be.calledOnce
+        expect(this.setOptionsSpy2).to.be.calledOnce
+      })
+    })
+
+    context('when middleware has not been specified', () => {
+      beforeEach(async () => {
+        delete this.journey.steps[0].middleware
+        this.app.use((req, res, next) => {
+          res.locals.errors = { error: 'This field is required' }
+          next()
+        })
+        this.app.use(this.journeyBuilder.build(this.journey))
+
+        this.response = await request(this.app).get('/step-1')
+      })
+
+      commonTests()
+    })
+  })
+
+  context('when submitting the form', () => {
+    context('when middleware has been specified', () => {
+      context('when the value for step 2 has been selected', () => {
+        beforeEach(async () => {
+          this.app.use((req, res, next) => {
+            req.body = { selected: 'step-2-value' }
+            next()
+          })
+          this.app.use(this.journeyBuilder.build(this.journey))
+
+          this.response = await request(this.app).post('/step-1')
+        })
+
+        it('should call the middleware', async () => {
+          expect(this.setOptionsSpy1).to.be.calledOnce
+          expect(this.setOptionsSpy2).to.be.calledOnce
+        })
+
+        it('should redirect to step 2', () => {
+          expect(this.response.statusCode).to.equal(302)
+          expect(this.response.headers.location).to.equal('/base/step-2')
+        })
+
+        it('should not render a template', () => {
+          expect(this.response.res.text).to.equal('Found. Redirecting to /base/step-2')
+        })
+      })
+
+      context('when the value for step 3 has been selected', () => {
+        beforeEach(async () => {
+          this.app.use((req, res, next) => {
+            req.body = { selected: 'step-3-value' }
+            next()
+          })
+          this.app.use(this.journeyBuilder.build(this.journey))
+
+          this.response = await request(this.app).post('/step-1')
+        })
+
+        it('should call the middleware', async () => {
+          expect(this.setOptionsSpy1).to.be.calledOnce
+          expect(this.setOptionsSpy2).to.be.calledOnce
+        })
+
+        it('should redirect to step 3', () => {
+          expect(this.response.statusCode).to.equal(302)
+          expect(this.response.headers.location).to.equal('/base/step-3')
+        })
+
+        it('should not render a template', () => {
+          expect(this.response.res.text).to.equal('Found. Redirecting to /base/step-3')
+        })
+      })
+    })
+
+    context('when middleware has not been specified', () => {
+      context('when the value for step 2 has been selected', () => {
+        beforeEach(async () => {
+          delete this.journey.steps[0].middleware
+          this.app.use((req, res, next) => {
+            req.body = { selected: 'step-2-value' }
+            next()
+          })
+          this.app.use(this.journeyBuilder.build(this.journey))
+
+          this.response = await request(this.app).post('/step-1')
+        })
+
+        it('should redirect to step 2', () => {
+          expect(this.response.statusCode).to.equal(302)
+          expect(this.response.headers.location).to.equal('/base/step-2')
+        })
+
+        it('should not render a template', () => {
+          expect(this.response.res.text).to.equal('Found. Redirecting to /base/step-2')
+        })
+      })
+    })
+
+    context('when the next path is a string', () => {
+      beforeEach(async () => {
+        this.journey.steps[0].nextPath = '/finish'
+        this.app.use(this.journeyBuilder.build(this.journey))
+
+        this.response = await request(this.app).post('/step-1')
+      })
+
+      it('should redirect to step 2', () => {
+        expect(this.response.statusCode).to.equal(302)
+        expect(this.response.headers.location).to.equal('/base/finish')
+      })
+
+      it('should not render a template', () => {
+        expect(this.response.res.text).to.equal('Found. Redirecting to /base/finish')
+      })
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -10294,6 +10294,28 @@ sum-up@^1.0.1:
   dependencies:
     chalk "^1.0.0"
 
+superagent@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
+
+supertest@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-3.3.0.tgz#79b27bd7d34392974ab33a31fa51a3e23385987e"
+  dependencies:
+    methods "^1.1.2"
+    superagent "^3.8.3"
+
 supports-color@3.1.2, supports-color@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"


### PR DESCRIPTION
https://trello.com/c/h3I90SsV/234-add-address-front-end-module

# Description

Before tackling the work to introduce an address module, it is essential to work on implementing multiple step forms. This has been a source of our over complicated code.

All forms follow the same pattern:
1. Present a form
2. POST/PATCH to server
3. If there are errors then present errors, otherwise present success message

This is the first in a series of pull requests to introduce multiple step forms. A basic skeleton implementation of the address module has been included to show how it will work.

![address-module](https://user-images.githubusercontent.com/1150417/46295263-865c6f00-c58f-11e8-88df-c963d862a7bf.gif)


# Run local

To run this locally you could add create address functionality to `companies` by adding the following to `router.js`:

```
const addressesRouter = require('../addresses/router.sub-app')
...
router.use('/:companyId', addressesRouter)
```

# Outstanding

Key pieces that are still outstanding:
- client-side validation (partial validation is required for each step)
- POST/PATCH to API
- handle API errors
- persist state across multiple steps
- further development of address module