### PR TITLE
Add partial validation for multiple steps

### DIFF
--- a/src/apps/addresses/macros/uk-or-overseas-form.js
+++ b/src/apps/addresses/macros/uk-or-overseas-form.js
@@ -1,4 +1,6 @@
-module.exports = () => {
+module.exports = ({
+  errors = {},
+}) => {
   return {
     buttonText: 'Continue',
     children: [
@@ -11,6 +13,13 @@ module.exports = () => {
           { value: 'uk', label: 'UK address' },
           { value: 'overseas', label: 'Overseas address' },
         ],
+        validations: [
+          {
+            type: 'required',
+            message: 'Select an address type',
+          },
+        ],
+        error: errors.uk_or_overseas,
       },
     ],
   }

--- a/src/modules/form/errors.js
+++ b/src/modules/form/errors.js
@@ -1,0 +1,35 @@
+const { compact, map, reduce } = require('lodash')
+
+const validators = require('./validators')
+
+const getErrorMessages = (validations, requestBody, fieldName) => {
+  return compact(map(validations || [], (validation) => {
+    const canValidate = !validation.when || validation.when(requestBody)
+    const hasPassedValidation = validators[validation.type](requestBody[fieldName])
+    if (canValidate && !hasPassedValidation) {
+      return validation.message
+    }
+  }))
+}
+
+const getErrors = (children, requestBody) => {
+  const errors = reduce(
+    children,
+    (child, { name, validations, options }) => {
+      const fieldErrorMessages = getErrorMessages(validations, requestBody, name)
+      const subFieldErrors = reduce(options, (option, { children }) => (getErrors(children, requestBody)), {})
+
+      return {
+        ...(fieldErrorMessages.length ? { [name]: fieldErrorMessages } : undefined),
+        ...subFieldErrors,
+      }
+    },
+    {}
+  )
+
+  return errors || {}
+}
+
+module.exports = {
+  getErrors,
+}

--- a/src/modules/form/validators.js
+++ b/src/modules/form/validators.js
@@ -1,0 +1,5 @@
+const { isNil, isEmpty } = require('lodash')
+
+module.exports = {
+  required: value => !(isNil(value) || isEmpty(value)),
+}

--- a/test/unit/modules/form/errors.test.js
+++ b/test/unit/modules/form/errors.test.js
@@ -1,0 +1,131 @@
+const { getErrors } = require('~/src/modules/form/errors.js')
+
+describe('errors', () => {
+  describe('#getErrors', () => {
+    context('when field 1 validation is not conditional', () => {
+      beforeEach(() => {
+        const children = [
+          {
+            name: 'field_1',
+            validations: [
+              {
+                type: 'required',
+                message: 'You must select field 1',
+              },
+            ],
+          },
+        ]
+        this.errors = getErrors(children, {})
+      })
+
+      it('should map the errors to an object', () => {
+        expect(this.errors).to.deep.equal({
+          field_1: [ 'You must select field 1' ],
+        })
+      })
+    })
+
+    context('when field 1 validation is conditional', () => {
+      context('when the conditional field value implies field 1 needs to be validated', () => {
+        beforeEach(() => {
+          const children = [
+            {
+              name: 'field_1',
+              validations: [
+                {
+                  type: 'required',
+                  message: 'You must select field 1',
+                  when: ({ field_2: field2 }) => field2 === 'selected',
+                },
+              ],
+            },
+          ]
+          this.errors = getErrors(children, { field_2: 'selected' })
+        })
+
+        it('should map the errors to an object', () => {
+          expect(this.errors).to.deep.equal({
+            field_1: [ 'You must select field 1' ],
+          })
+        })
+      })
+
+      context('when the conditional field value implies field 1 does not need to be validated', () => {
+        beforeEach(() => {
+          const children = [
+            {
+              name: 'field_1',
+              validations: [
+                {
+                  type: 'required',
+                  message: 'You must select field 1',
+                  when: ({ field_2: field2 }) => field2 === 'selected',
+                },
+              ],
+            },
+          ]
+          this.errors = getErrors(children, { field_2: 'not selected' })
+        })
+
+        it('should not map any errors', () => {
+          expect(this.errors).to.deep.equal({})
+        })
+      })
+    })
+
+    context('when field 1 has children with validation', () => {
+      beforeEach(() => {
+        const children = [
+          {
+            name: 'field_1',
+            validations: [
+              {
+                type: 'required',
+                message: 'You must select field 1',
+              },
+            ],
+            options: [
+              {
+                children: [
+                  {
+                    name: 'sub_field_1',
+                    validations: [
+                      {
+                        type: 'required',
+                        message: 'You must select sub field 1',
+                      },
+                    ],
+                    options: [
+                      {
+                        children: [
+                          {
+                            name: 'sub_sub_field_1',
+                            validations: [
+                              {
+                                type: 'required',
+                                message: 'You must select sub sub field 1',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+        this.errors = getErrors(children, {})
+      })
+
+      it('should map the errors to an object', () => {
+        expect(this.errors).to.deep.equal({
+          field_1: [ 'You must select field 1' ],
+          sub_field_1: [ 'You must select sub field 1' ],
+          sub_sub_field_1: [ 'You must select sub sub field 1' ],
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/h3I90SsV/234-add-address-front-end-module

Next iteration of multiple step forms introducing partial validation for a step which must pass in order to move to the next step.

# Example
To demonstrate usage I have applied an example to the addresses module.

<img width="700" alt="screen shot 2018-10-02 at 16 36 18" src="https://user-images.githubusercontent.com/1150417/46359627-862ca400-c661-11e8-9da9-28faa22a60d7.png">


# Outstanding
Key pieces that are still outstanding:

- POST/PATCH to API
- handle API errors
- persist state across multiple steps
- further development of address module