### PR TITLE
Add form state management

### DIFF
--- a/src/modules/form/helpers.js
+++ b/src/modules/form/helpers.js
@@ -1,0 +1,16 @@
+const { isString, trimEnd, trimStart } = require('lodash')
+
+const getFullRoute = (baseUrl, step) => {
+  return `${trimEnd(baseUrl, '/')}/${trimStart(step.path, '/')}`
+}
+
+const getNextPath = (step, requestBody) => {
+  if (step.nextPath) {
+    return isString(step.nextPath) ? step.nextPath : step.nextPath(requestBody)
+  }
+}
+
+module.exports = {
+  getFullRoute,
+  getNextPath,
+}

--- a/src/modules/form/state/current.js
+++ b/src/modules/form/state/current.js
@@ -1,0 +1,40 @@
+const { get, set, last } = require('lodash')
+
+const MULTI_STEP_KEY = 'multi-step'
+
+const update = (session, journeyKey, path, { data, completed, addBrowseHistory }) => {
+  const currentState = getCurrent(session, journeyKey)
+
+  const stepDataKey = `steps.${path}.data`
+  const stepData = {
+    ...data,
+    ...get(currentState, stepDataKey),
+  }
+  set(currentState, stepDataKey, stepData)
+
+  if (completed) {
+    const pathCompletedKey = `steps.${path}.completed`
+    set(currentState, pathCompletedKey, completed)
+  }
+
+  if (addBrowseHistory) {
+    const browseHistory = get(currentState, 'browseHistory', [])
+    if (last(browseHistory) !== path) {
+      browseHistory.push(path)
+      set(currentState, 'browseHistory', browseHistory)
+    }
+  }
+
+  const sessionKey = `${MULTI_STEP_KEY}.${journeyKey}`
+  set(session, sessionKey, currentState)
+}
+
+const getCurrent = (session, journeyKey) => {
+  const sessionKey = `${MULTI_STEP_KEY}.${journeyKey}`
+  return get(session, sessionKey, {})
+}
+
+module.exports = {
+  update,
+  getCurrent,
+}

--- a/src/modules/form/state/middleware.js
+++ b/src/modules/form/state/middleware.js
@@ -1,0 +1,18 @@
+const { getFullRoute } = require('../helpers')
+
+const setJourneyDetails = (journey, currentStep, currentStepId) => {
+  return (req, res, next) => {
+    res.locals.journey = {
+      currentStep,
+      currentStepId,
+      ...journey,
+      key: getFullRoute(req.baseUrl, journey.steps[0]),
+    }
+
+    next()
+  }
+}
+
+module.exports = {
+  setJourneyDetails,
+}

--- a/src/modules/form/state/middleware.js
+++ b/src/modules/form/state/middleware.js
@@ -1,4 +1,60 @@
-const { getFullRoute } = require('../helpers')
+const {
+  isEmpty,
+  get,
+  map,
+  compact,
+  find,
+} = require('lodash')
+
+const state = require('../state/current')
+const { getFullRoute, getNextPath } = require('../helpers')
+
+const mapStepsWithState = (steps, currentState) => {
+  return compact(map(steps, (step, stepId) => {
+    const completed = get(currentState, `steps.${step.path}.completed`, false)
+    const data = get(currentState, `steps.${step.path}.data`, {})
+
+    return {
+      completed,
+      id: stepId,
+      path: step.path,
+      nextPath: getNextPath(step, data),
+      validateJourney: step.validateJourney,
+    }
+  }))
+}
+
+const isValidJourney = (steps, currentStepId, currentState) => {
+  const stepsWithState = mapStepsWithState(steps, currentState)
+
+  const hasCompletedPreviousStep = (step) => {
+    if (step.id === 0 || step.validateJourney === false) {
+      return true
+    }
+
+    const previousStep = find(stepsWithState, stepWithState => stepWithState.nextPath === step.path)
+    return previousStep && previousStep.completed ? hasCompletedPreviousStep(previousStep) : false
+  }
+
+  const currentStepWithState = find(stepsWithState, stepWithState => stepWithState.id === currentStepId)
+  return hasCompletedPreviousStep(currentStepWithState)
+}
+
+const validateState = (req, res, next) => {
+  const { key, steps, currentStepId } = res.locals.journey
+  const currentState = state.getCurrent(req.session, key)
+  const isStartingJourney = isEmpty(currentState.steps) && currentStepId === 0
+
+  if (isStartingJourney) {
+    return next()
+  }
+
+  if (isValidJourney(steps, currentStepId, currentState)) {
+    return next()
+  }
+
+  res.redirect(key)
+}
 
 const setJourneyDetails = (journey, currentStep, currentStepId) => {
   return (req, res, next) => {
@@ -15,4 +71,5 @@ const setJourneyDetails = (journey, currentStep, currentStepId) => {
 
 module.exports = {
   setJourneyDetails,
+  validateState,
 }

--- a/src/modules/form/state/middleware.js
+++ b/src/modules/form/state/middleware.js
@@ -56,6 +56,15 @@ const validateState = (req, res, next) => {
   res.redirect(key)
 }
 
+const updateState = (req, res, next) => {
+  const { key, currentStep } = res.locals.journey
+  const currentStepPath = currentStep.path
+
+  state.update(req.session, key, currentStepPath, { data: req.body })
+
+  next()
+}
+
 const setJourneyDetails = (journey, currentStep, currentStepId) => {
   return (req, res, next) => {
     res.locals.journey = {
@@ -72,4 +81,5 @@ const setJourneyDetails = (journey, currentStep, currentStepId) => {
 module.exports = {
   setJourneyDetails,
   validateState,
+  updateState,
 }

--- a/test/unit/modules/form/state/current.test.js
+++ b/test/unit/modules/form/state/current.test.js
@@ -1,0 +1,319 @@
+const state = require('~/src/modules/form/state/current.js')
+
+describe('Current form state', () => {
+  describe('#update', () => {
+    context('when adding state for a step', () => {
+      beforeEach(() => {
+        const session = {
+          'multi-step': {
+            '/base/step-1': {},
+          },
+        }
+        const data = {
+          field_1: 'field_1',
+        }
+        const journeyKey = '/base/step-1'
+
+        state.update(session, journeyKey, '/step-1', { data })
+
+        this.actual = state.getCurrent(session, journeyKey)
+      })
+
+      it('should update state', () => {
+        const expected = {
+          steps: {
+            '/step-1': {
+              data: {
+                field_1: 'field_1',
+              },
+            },
+          },
+        }
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+
+    context('when adding state for a step and state exist for another journey', () => {
+      beforeEach(() => {
+        const session = {
+          'multi-step': {
+            '/base/another-step-1': {
+              steps: {
+                '/another-step-1': {
+                  data: {
+                    another_field_1: 'another_field_1',
+                  },
+                },
+              },
+            },
+          },
+        }
+        const data = {
+          field_1: 'field_1',
+        }
+
+        state.update(session, '/base/step-1', '/step-1', { data })
+
+        this.actual = state.getCurrent(session, '/base/another-step-1')
+      })
+
+      it('should not alter state for the other journey', () => {
+        const expected = {
+          steps: {
+            '/another-step-1': {
+              data: {
+                another_field_1: 'another_field_1',
+              },
+            },
+          },
+        }
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+
+    context('when appending state for a step', () => {
+      beforeEach(() => {
+        const session = {
+          'multi-step': {
+            '/base/step-1': {
+              steps: {
+                '/step-1': {
+                  data: {
+                    field_1: 'field_1',
+                  },
+                },
+              },
+            },
+          },
+        }
+        const data = {
+          field_1: 'field_1',
+          field_2: 'field_2',
+        }
+        const journeyKey = '/base/step-1'
+
+        state.update(session, journeyKey, '/step-1', { data })
+
+        this.actual = state.getCurrent(session, journeyKey)
+      })
+
+      it('should update state', () => {
+        const expected = {
+          steps: {
+            '/step-1': {
+              data: {
+                field_1: 'field_1',
+                field_2: 'field_2',
+              },
+            },
+          },
+        }
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+
+    context('when updating state with a new completed step', () => {
+      beforeEach(() => {
+        const session = {
+          'multi-step': {
+            '/base/step-1': {
+              steps: {
+                '/step-1': {
+                  data: {
+                    field_1: 'field_1',
+                  },
+                },
+              },
+            },
+          },
+        }
+        const journeyKey = '/base/step-1'
+
+        state.update(session, journeyKey, '/step-1', { completed: true })
+
+        this.actual = state.getCurrent(session, journeyKey)
+      })
+
+      it('should set the step to completed', () => {
+        const expected = {
+          steps: {
+            '/step-1': {
+              data: {
+                field_1: 'field_1',
+              },
+              completed: true,
+            },
+          },
+        }
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+
+    context('when updating browse history', () => {
+      context('when rendering a step for the first time', () => {
+        beforeEach(() => {
+          const session = {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      field_1: 'field_1',
+                    },
+                  },
+                },
+              },
+            },
+          }
+          const journeyKey = '/base/step-1'
+
+          state.update(session, journeyKey, '/step-1', { addBrowseHistory: true })
+
+          this.actual = state.getCurrent(session, journeyKey)
+        })
+
+        it('should add the step to the browse history', () => {
+          const expected = {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+              },
+            },
+            browseHistory: [
+              '/step-1',
+            ],
+          }
+
+          expect(this.actual).to.deep.equal(expected)
+        })
+      })
+
+      context('when refreshing a step', () => {
+        beforeEach(() => {
+          const session = {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      field_1: 'field_1',
+                    },
+                  },
+                },
+                browseHistory: [
+                  '/step-1',
+                ],
+              },
+            },
+          }
+          const journeyKey = '/base/step-1'
+
+          state.update(session, journeyKey, '/step-1', { addBrowseHistory: true })
+
+          this.actual = state.getCurrent(session, journeyKey)
+        })
+
+        it('should add the step to the browse history', () => {
+          const expected = {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+              },
+            },
+            browseHistory: [
+              '/step-1',
+            ],
+          }
+
+          expect(this.actual).to.deep.equal(expected)
+        })
+      })
+    })
+  })
+
+  describe('#getCurrent', () => {
+    context('when state exists', () => {
+      beforeEach(() => {
+        const session = {
+          'multi-step': {
+            '/base/step-1': {
+              steps: {
+                '/step-1': {
+                  data: {
+                    field_1: 'field_1',
+                  },
+                  completed: true,
+                },
+              },
+            },
+          },
+        }
+
+        this.actual = state.getCurrent(session, '/base/step-1')
+      })
+
+      it('should return current state', () => {
+        const expected = {
+          steps: {
+            '/step-1': {
+              data: {
+                field_1: 'field_1',
+              },
+              completed: true,
+            },
+          },
+        }
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+
+    context('when state does not exist', () => {
+      beforeEach(() => {
+        const session = {}
+
+        this.actual = state.getCurrent(session, '/base/step-1')
+      })
+
+      it('should return the default state for this form', () => {
+        const expected = {}
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+
+    context('when state exists for another multi step form', () => {
+      beforeEach(() => {
+        const session = {
+          'multi-step': {
+            '/base/another-step-1': {
+              steps: {
+                '/step-1': {
+                  data: {
+                    field_1: 'field_1',
+                  },
+                  completed: true,
+                },
+              },
+            },
+          },
+        }
+        this.actual = state.getCurrent(session, '/base/step-1')
+      })
+
+      it('should return the default state for this form', () => {
+        const expected = {}
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+  })
+})

--- a/test/unit/modules/form/state/middleware.test.js
+++ b/test/unit/modules/form/state/middleware.test.js
@@ -1,4 +1,4 @@
-const { validateState, setJourneyDetails } = require('~/src/modules/form/state/middleware.js')
+const { validateState, updateState, setJourneyDetails } = require('~/src/modules/form/state/middleware.js')
 const steps = require('../steps.js')()
 
 describe('Form state middleware', () => {
@@ -197,6 +197,52 @@ describe('Form state middleware', () => {
       it('should not redirect', () => {
         expect(this.res.redirect).to.not.be.called
       })
+    })
+  })
+
+  describe('#updateState', () => {
+    beforeEach(() => {
+      this.req = {
+        session: {},
+        baseUrl: '/base',
+        body: {
+          selectedAtStep1: 'step-3-value',
+        },
+      }
+      this.res = {
+        locals: {
+          journey: {
+            steps,
+            currentStep: steps[0],
+            currentStepId: 0,
+            key: '/base/step-1',
+          },
+        },
+        redirect: sinon.spy(),
+      }
+      this.nextSpy = sinon.spy()
+
+      updateState(this.req, this.res, this.nextSpy)
+    })
+
+    it('should update state', () => {
+      expect(this.req.session).to.deep.equal({
+        'multi-step': {
+          '/base/step-1': {
+            steps: {
+              '/step-1': {
+                data: {
+                  selectedAtStep1: 'step-3-value',
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+
+    it('should call next once', () => {
+      expect(this.nextSpy).to.be.calledOnce
     })
   })
 })

--- a/test/unit/modules/form/state/middleware.test.js
+++ b/test/unit/modules/form/state/middleware.test.js
@@ -1,0 +1,39 @@
+const { setJourneyDetails } = require('~/src/modules/form/state/middleware.js')
+
+const steps = require('../steps.js')()
+
+describe('Form state middleware', () => {
+  describe('#setJourneyDetails', () => {
+    beforeEach(() => {
+      this.req = {
+        baseUrl: '/base',
+      }
+      this.res = {
+        locals: {},
+      }
+      this.nextSpy = sinon.spy()
+
+      setJourneyDetails({ steps }, steps[1], 1)(this.req, this.res, this.nextSpy)
+    })
+
+    it('should set the current step', () => {
+      expect(this.res.locals.journey.currentStep).to.deep.equal(steps[1])
+    })
+
+    it('should set the current step ID', () => {
+      expect(this.res.locals.journey.currentStepId).to.equal(1)
+    })
+
+    it('should set the steps', () => {
+      expect(this.res.locals.journey.steps).to.deep.equal(steps)
+    })
+
+    it('should set the key', () => {
+      expect(this.res.locals.journey.key).to.equal('/base/step-1')
+    })
+
+    it('should call next once', () => {
+      expect(this.nextSpy).to.be.calledOnce
+    })
+  })
+})

--- a/test/unit/modules/form/state/middleware.test.js
+++ b/test/unit/modules/form/state/middleware.test.js
@@ -1,4 +1,4 @@
-const { validateState, updateState, setJourneyDetails } = require('~/src/modules/form/state/middleware.js')
+const { validateState, updateState, setFormDetails, setJourneyDetails } = require('~/src/modules/form/state/middleware.js')
 const steps = require('../steps.js')()
 
 describe('Form state middleware', () => {
@@ -243,6 +243,140 @@ describe('Form state middleware', () => {
 
     it('should call next once', () => {
       expect(this.nextSpy).to.be.calledOnce
+    })
+  })
+
+  describe('#setFormDetails', () => {
+    context('when setting form details for the first step', () => {
+      beforeEach(() => {
+        this.req = {
+          session: {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      selectedAtStep1: 'step-3-value',
+                    },
+                    completed: true,
+                  },
+                  '/step-3': {
+                    data: {
+                      selectedAtStep3: 'step-5-value',
+                    },
+                    completed: true,
+                  },
+                },
+              },
+            },
+          },
+          baseUrl: '/base',
+          body: {
+            selectedAtStep1: 'step-3-value',
+          },
+        }
+        this.res = {
+          locals: {
+            journey: {
+              steps,
+              currentStep: steps[0],
+              currentStepId: 0,
+              key: '/base/step-1',
+            },
+          },
+          redirect: sinon.spy(),
+        }
+        this.nextSpy = sinon.spy()
+
+        setFormDetails(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set state on locals', () => {
+        expect(this.res.locals.form.state).to.deep.equal({
+          selectedAtStep1: 'step-3-value',
+          selectedAtStep3: 'step-5-value',
+        })
+      })
+
+      it('should set the return link', () => {
+        expect(this.res.locals.form.returnLink).to.equal('/base')
+      })
+
+      it('should set the return text', () => {
+        expect(this.res.locals.form.returnText).to.equal('Cancel')
+      })
+
+      it('should call next once', () => {
+        expect(this.nextSpy).to.be.calledOnce
+      })
+    })
+
+    context('when setting form details for subsequent steps', () => {
+      beforeEach(() => {
+        this.req = {
+          session: {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      selectedAtStep1: 'step-3-value',
+                    },
+                    completed: true,
+                  },
+                  '/step-3': {
+                    data: {
+                      selectedAtStep3: 'step-5-value',
+                    },
+                    completed: true,
+                  },
+                },
+                browseHistory: [
+                  '/step-1',
+                  '/step-3',
+                ],
+              },
+            },
+          },
+          baseUrl: '/base',
+          body: {
+            selectedAtStep1: 'step-3-value',
+          },
+        }
+        this.res = {
+          locals: {
+            journey: {
+              steps,
+              currentStep: steps[4],
+              currentStepId: 4,
+              key: '/base/step-1',
+            },
+          },
+          redirect: sinon.spy(),
+        }
+        this.nextSpy = sinon.spy()
+
+        setFormDetails(this.req, this.res, this.nextSpy)
+      })
+
+      it('should set state on locals', () => {
+        expect(this.res.locals.form.state).to.deep.equal({
+          selectedAtStep1: 'step-3-value',
+          selectedAtStep3: 'step-5-value',
+        })
+      })
+
+      it('should set the return link', () => {
+        expect(this.res.locals.form.returnLink).to.equal('/base/step-3')
+      })
+
+      it('should set the return text', () => {
+        expect(this.res.locals.form.returnText).to.equal('Back')
+      })
+
+      it('should call next once', () => {
+        expect(this.nextSpy).to.be.calledOnce
+      })
     })
   })
 })

--- a/test/unit/modules/form/steps.js
+++ b/test/unit/modules/form/steps.js
@@ -1,0 +1,68 @@
+module.exports = (middleware) => {
+  return [
+    {
+      middleware: middleware,
+      path: '/step-1',
+      type: 'form',
+      heading: 'Add something',
+      breadcrumbs: [
+        { name: 'Add something', url: '/url' },
+      ],
+      macro: () => { return { children: [] } },
+      nextPath: ({ selectedAtStep1 }) => {
+        const paths = {
+          'step-2-value': '/step-2',
+          'step-3-value': '/step-3',
+        }
+        return paths[selectedAtStep1]
+      },
+    },
+    {
+      path: '/step-2',
+      type: 'form',
+      heading: 'Add something',
+      breadcrumbs: [
+        { name: 'Add something', url: '/url' },
+      ],
+      macro: () => { return { children: [] } },
+      nextPath: '/finish',
+      validateJourney: false,
+    },
+    {
+      path: '/step-3',
+      type: 'form',
+      heading: 'Add something',
+      breadcrumbs: [
+        { name: 'Add something', url: '/url' },
+      ],
+      macro: () => { return { children: [] } },
+      nextPath: ({ selectedAtStep3 }) => {
+        const paths = {
+          'step-4-value': '/step-4',
+          'step-5-value': '/step-5',
+        }
+        return paths[selectedAtStep3]
+      },
+    },
+    {
+      path: '/step-4',
+      type: 'form',
+      heading: 'Add something',
+      breadcrumbs: [
+        { name: 'Add something', url: '/url' },
+      ],
+      macro: () => { return { children: [] } },
+      nextPath: '/finish',
+    },
+    {
+      path: '/step-5',
+      type: 'form',
+      heading: 'Add something',
+      breadcrumbs: [
+        { name: 'Add something', url: '/url' },
+      ],
+      macro: () => { return { children: [] } },
+      nextPath: '/finish',
+    },
+  ]
+}


### PR DESCRIPTION
https://trello.com/c/h3I90SsV/234-add-address-front-end-module

This change introduces:
- code for persisting state in a multi step form
- middleware for validating state
- middleware for updating state
- middleware for setting form details, return link and text depending on current step and state

The next PR will integrate these changes with the journey builder.

To put this more into context, `journey-builder` will change to:

```javascript const build = (journey) => {
  const router = express.Router()

  journey.steps.forEach((currentStep, currentStepId) => {
    router.route(currentStep.path)
      .get(
        setPrerequisites(journey, currentStep, currentStepId),
        validateState,
        ...getMiddleware(currentStep),
        setFormDetails,
        setBreadcrumbs,
        render
      )
      .post(
        setPrerequisites(journey, currentStep, currentStepId),
        validateState,
        ...getMiddleware(currentStep),
        updateState,
        postDetails,
        setFormDetails,
        setBreadcrumbs,
        render
      )
  })

  return router
}