### PR TITLE
refactor csv export functions into library

### DIFF
--- a/src/apps/investment-projects/controllers/list.js
+++ b/src/apps/investment-projects/controllers/list.js
@@ -4,40 +4,11 @@ const { merge, omit } = require('lodash')
 const { buildSelectedFiltersSummary, buildFieldsWithSelectedEntities } = require('../../builders')
 const { getOptions } = require('../../../lib/options')
 const { investmentFiltersFields, investmentSortForm } = require('../macros')
+const { buildExportAction } = require('../../../lib/export-helper')
 
 const FILTER_CONSTANTS = require('../../../lib/filter-constants')
 const QUERY_STRING = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.PRIMARY.QUERY_STRING
 const SECTOR = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.NAME
-const MAX_EXPORT_ITEMS = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.MAX_EXPORT_ITEMS
-
-function hasExportPermission (userPermissions) {
-  return userPermissions.includes('investment.export_investmentproject')
-}
-
-function tooManyItems (resultCount) {
-  return resultCount > MAX_EXPORT_ITEMS
-}
-
-function buildExportMessage (resultCount) {
-  if (tooManyItems(resultCount)) {
-    return `Filter to less than ${MAX_EXPORT_ITEMS} projects to download`
-  }
-  return `You can now download these ${resultCount} projects`
-}
-
-function buildExportAction (userPermissions, queryString) {
-  if (!hasExportPermission(userPermissions)) {
-    return {
-      enabled: false,
-    }
-  }
-  return {
-    enabled: true,
-    buildMessage: (count) => buildExportMessage(count),
-    url: 'investment-projects' + queryString,
-    tooManyItems,
-  }
-}
 
 async function renderInvestmentList (req, res, next) {
   try {
@@ -60,7 +31,15 @@ async function renderInvestmentList (req, res, next) {
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, req.query)
     const selectedFilters = await buildSelectedFiltersSummary(filtersFieldsWithSelectedOptions, req.query)
-    const exportAction = await buildExportAction(user.permissions, '/export?' + qs.stringify(req.query))
+
+    const exportOptions = {
+      targetPermission: 'investment.export_investmentproject',
+      urlFragment: 'investment-projects',
+      maxItems: FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.MAX_EXPORT_ITEMS,
+      entityPlural: 'projects',
+    }
+
+    const exportAction = await buildExportAction(qs.stringify(req.query), user.permissions, exportOptions)
 
     res.render('_layouts/collection', {
       sortForm,

--- a/src/apps/investment-projects/controllers/list.js
+++ b/src/apps/investment-projects/controllers/list.js
@@ -36,7 +36,7 @@ async function renderInvestmentList (req, res, next) {
       targetPermission: 'investment.export_investmentproject',
       urlFragment: 'investment-projects',
       maxItems: FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.MAX_EXPORT_ITEMS,
-      entityPlural: 'projects',
+      entityName: 'project',
     }
 
     const exportAction = await buildExportAction(qs.stringify(req.query), user.permissions, exportOptions)

--- a/src/lib/export-helper.js
+++ b/src/lib/export-helper.js
@@ -1,0 +1,40 @@
+const { pluralise } = require('../../config/nunjucks/filters')
+
+function hasExportPermission (userPermissions, targetPermission) {
+  return userPermissions.includes(targetPermission)
+}
+
+function invalidNumberOfItems (resultCount, maxItems) {
+  return resultCount === 0 || resultCount >= maxItems
+}
+
+function buildExportMessage (resultCount, exportOptions) {
+  if (resultCount >= exportOptions.maxItems) {
+    return `Filter to fewer than ${exportOptions.maxItems} ${pluralise(exportOptions.entityName)} to download`
+  }
+  if (resultCount === 1) {
+    return `You can now download this ${exportOptions.entityName}`
+  }
+  if (resultCount === 0) {
+    return `There are no ${pluralise(exportOptions.entityName)} to download`
+  }
+  return `You can now download these ${resultCount} ${pluralise(exportOptions.entityName)}`
+}
+
+function buildExportAction (queryString, userPermissions, exportOptions) {
+  if (!hasExportPermission(userPermissions, exportOptions.targetPermission)) {
+    return {
+      enabled: false,
+    }
+  }
+  return {
+    enabled: true,
+    buildMessage: (count) => buildExportMessage(count, exportOptions),
+    url: `${exportOptions.urlFragment}/export?${queryString}`,
+    invalidNumberOfItems,
+  }
+}
+
+module.exports = {
+  buildExportAction,
+}

--- a/src/templates/_macros/collection/collection-header.njk
+++ b/src/templates/_macros/collection/collection-header.njk
@@ -85,7 +85,7 @@
         {{ props.exportAction.buildMessage(count) }}
       </span>
       <span class="c-collection__header-actions">
-        {% if not props.exportAction.tooManyItems(count) %}
+        {% if not props.exportAction.invalidNumberOfItems(count) %}
           <a class="button" download href="{{ props.exportAction.url }}">Download</a>
         {% endif %}
       </span>

--- a/test/unit/apps/investment-projects/controllers/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/list.test.js
@@ -66,7 +66,7 @@ describe('Investment list controller', () => {
         })
 
         it('should return a function that can check if items have been filtered enough to export', () => {
-          expect(this.exportAction.tooManyItems).to.be.a('function')
+          expect(this.exportAction.invalidNumberOfItems).to.be.a('function')
         })
 
         it('should return a url to download the csv', () => {
@@ -74,7 +74,15 @@ describe('Investment list controller', () => {
         })
 
         it('should output a message if further filtering is required', () => {
-          expect(this.exportAction.buildMessage(MAX_EXPORT_ITEMS + 1)).to.equal(`Filter to less than ${MAX_EXPORT_ITEMS} projects to download`)
+          expect(this.exportAction.buildMessage(MAX_EXPORT_ITEMS)).to.equal(`Filter to fewer than ${MAX_EXPORT_ITEMS} projects to download`)
+        })
+
+        it('should use the singular and an appropriate message when only one item is downloadable', () => {
+          expect(this.exportAction.buildMessage(1)).to.equal('You can now download this project')
+        })
+
+        it('should disable itself and warn the user if there is nothing to download', () => {
+          expect(this.exportAction.buildMessage(0)).to.equal('There are no projects to download')
         })
 
         commonTests()


### PR DESCRIPTION
This moves the common functions from Stu's CSV export work into a library as preparation for adding export to other entities. As Lee likes screenshots...

![image](https://user-images.githubusercontent.com/161962/47021360-2fd85e80-d153-11e8-8f31-5afc9c82bfb5.png)
