### PR TITLE
Fix missing param in CSV download macro

### DIFF
--- a/src/lib/export-helper.js
+++ b/src/lib/export-helper.js
@@ -31,6 +31,7 @@ function buildExportAction (queryString, userPermissions, exportOptions) {
     enabled: true,
     buildMessage: (count) => buildExportMessage(count, exportOptions),
     url: `${exportOptions.urlFragment}/export?${queryString}`,
+    maxItems: exportOptions.maxItems,
     invalidNumberOfItems,
   }
 }

--- a/src/templates/_macros/collection/collection-header.njk
+++ b/src/templates/_macros/collection/collection-header.njk
@@ -85,7 +85,7 @@
         {{ props.exportAction.buildMessage(count) }}
       </span>
       <span class="c-collection__header-actions">
-        {% if not props.exportAction.invalidNumberOfItems(count) %}
+        {% if not props.exportAction.invalidNumberOfItems(count, props.exportAction.maxItems) %}
           <a class="button" download href="{{ props.exportAction.url }}">Download</a>
         {% endif %}
       </span>


### PR DESCRIPTION
This fixes a defect I introduced in my previous commit. Because I never passed the maxItems through to the macro, the comparison was `count > undefined` which is always false, so the button was permanently enabled. This didn't show up in unit testing as there is no test for `collection-header.njk` - I can create one that just covers this case, but I'm currently unsure how to implement it, so @yeahfro if I could borrow some of your time that would be much appreciated. 

Currently the develop branch is not releasable without this fix so it's a bit urgent.