### PR TITLE
Fix bug when updating completed for a step

### DIFF
--- a/src/modules/form/state/current.js
+++ b/src/modules/form/state/current.js
@@ -5,6 +5,7 @@ const {
   reduce,
   last,
   unset,
+  isNil,
 } = require('lodash')
 
 const MULTI_STEP_KEY = 'multi-step'
@@ -19,7 +20,7 @@ const update = (session, journeyKey, path, { data, completed, addBrowseHistory }
   }
   set(currentState, stepDataKey, stepData)
 
-  if (completed) {
+  if (!isNil(completed)) {
     const pathCompletedKey = `steps.${path}.completed`
     set(currentState, pathCompletedKey, completed)
   }

--- a/test/unit/modules/form/state/current.test.js
+++ b/test/unit/modules/form/state/current.test.js
@@ -116,40 +116,80 @@ describe('Current form state', () => {
     })
 
     context('when updating state with a new completed step', () => {
-      beforeEach(() => {
-        const session = {
-          'multi-step': {
-            '/base/step-1': {
-              steps: {
-                '/step-1': {
-                  data: {
-                    field_1: 'field_1',
+      context('when completed is true', () => {
+        beforeEach(() => {
+          const session = {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      field_1: 'field_1',
+                    },
                   },
                 },
               },
             },
-          },
-        }
-        const journeyKey = '/base/step-1'
+          }
+          const journeyKey = '/base/step-1'
 
-        state.update(session, journeyKey, '/step-1', { completed: true })
+          state.update(session, journeyKey, '/step-1', { completed: true })
 
-        this.actual = state.getCurrent(session, journeyKey)
+          this.actual = state.getCurrent(session, journeyKey)
+        })
+
+        it('should set the step completed to true', () => {
+          const expected = {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+                completed: true,
+              },
+            },
+          }
+
+          expect(this.actual).to.deep.equal(expected)
+        })
       })
 
-      it('should set the step to completed', () => {
-        const expected = {
-          steps: {
-            '/step-1': {
-              data: {
-                field_1: 'field_1',
+      context('when completed is false', () => {
+        beforeEach(() => {
+          const session = {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      field_1: 'field_1',
+                    },
+                  },
+                },
               },
-              completed: true,
             },
-          },
-        }
+          }
+          const journeyKey = '/base/step-1'
 
-        expect(this.actual).to.deep.equal(expected)
+          state.update(session, journeyKey, '/step-1', { completed: false })
+
+          this.actual = state.getCurrent(session, journeyKey)
+        })
+
+        it('should set the step completed to false', () => {
+          const expected = {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+                completed: false,
+              },
+            },
+          }
+
+          expect(this.actual).to.deep.equal(expected)
+        })
       })
     })
 


### PR DESCRIPTION
https://trello.com/c/h3I90SsV/234-add-address-front-end-module

`completed` should be treated as a tri-state boolean so the value should be set when it is `true` or `false`.
