### PR TITLE
Swap around status and stage filter boxes

### DIFF
--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -11,10 +11,12 @@ const investmentFiltersFields = function ({ currentAdviserId, sectorOptions }) {
   return [
     {
       macroName: 'MultipleChoiceField',
-      name: 'status',
+      name: 'stage',
       type: 'checkbox',
       modifier: 'option-select',
-      options: metadata.investmentStatusOptions,
+      options () {
+        return metadata.investmentStageOptions.map(transformObjectToOption)
+      },
     },
     {
       macroName: 'MultipleChoiceField',
@@ -57,12 +59,10 @@ const investmentFiltersFields = function ({ currentAdviserId, sectorOptions }) {
     },
     {
       macroName: 'MultipleChoiceField',
-      name: 'stage',
+      name: 'status',
       type: 'checkbox',
       modifier: 'option-select',
-      options () {
-        return metadata.investmentStageOptions.map(transformObjectToOption)
-      },
+      options: metadata.investmentStatusOptions,
     },
     {
       macroName: 'MultipleChoiceField',


### PR DESCRIPTION
In order to view the stage filter box (left-hand column) within
Investment Projects (initial view) the user has to scroll towards the
bottom of the page, Dave Matthews mentioned he would like to see it at
the top of the page due to its importance. The status filter box holds
less importance so this can be swapped with the stage filter box.

In short, both filter boxes are trading positions based on importance.

https://uktrade.atlassian.net/browse/IPBETA-48
