### PR TITLE
Progress bar stage (e.g. node on the bar) colour change

### DIFF
--- a/assets/stylesheets/components/_progress.scss
+++ b/assets/stylesheets/components/_progress.scss
@@ -1,6 +1,11 @@
 @import "../settings";
 @import "../tools";
 
+@mixin progress-bar-node {
+  background-color: $govuk-blue;
+  border: 2px solid $govuk-blue;
+}
+
 $_section-width: 25%;
 
 .c-progress {
@@ -58,17 +63,14 @@ $_section-width: 25%;
 
   &.is-complete {
     border-color: $govuk-blue;
-
     &::before {
-      background-color: $govuk-blue;
-      border: 2px solid $govuk-blue;
+      @include progress-bar-node;
     }
   }
 
   &.is-active {
     &::before {
-      background-color: $white;
-      border: 2px solid $govuk-blue;
+      @include progress-bar-node;
     }
   }
 


### PR DESCRIPTION
At present when a particular stage is active the background colour is
white despite the previous completed stages being blue. We can improve
the UX by changing the active state to blue which indicates where you
are in the process more clearly.

https://uktrade.atlassian.net/browse/IPBETA-8