### PR TITLE
Remove obsolete feature flag checks

### DIFF
--- a/src/apps/investment-projects/controllers/evidence.js
+++ b/src/apps/investment-projects/controllers/evidence.js
@@ -1,11 +1,6 @@
-const { notFound } = require('../../../middleware/errors')
 const { getEvidenceForInvestment } = require('../apps/evidence/repos')
 
 async function renderEvidenceView (req, res, next) {
-  if (!res.locals.features['investment-evidence']) {
-    return notFound(req, res, next)
-  }
-
   try {
     const token = req.session.token
     const investmentId = req.params.investmentId

--- a/src/apps/propositions/controllers/upload.js
+++ b/src/apps/propositions/controllers/upload.js
@@ -1,15 +1,8 @@
-/* eslint camelcase: 0 */
 const { assign, get } = require('lodash')
-const { notFound } = require('../../../middleware/errors')
-
 const { buildFormWithStateAndErrors } = require('../../builders')
 const { uploadForm } = require('../macros')
 
 function renderUpload (req, res, next) {
-  if (!res.locals.features['proposition-documents']) {
-    return notFound(req, res, next)
-  }
-
   const proposition = get(res.locals, 'proposition.id')
   const investment = get(res.locals, 'investmentData.id')
   const selectUploadForm = buildFormWithStateAndErrors(uploadForm(


### PR DESCRIPTION
Currently we are checking for 2 feature flags:

 * Investment evidence
 * Proposition documents

Both of these features are now live so we can safely remove both of
these checks.

https://uktrade.atlassian.net/browse/IPBETA-50
