### PR TITLE
Ensure reference to state object is returned

### DIFF
--- a/src/modules/form/state/current.js
+++ b/src/modules/form/state/current.js
@@ -32,14 +32,16 @@ const update = (session, journeyKey, path, { data, completed, addBrowseHistory }
       set(currentState, 'browseHistory', browseHistory)
     }
   }
-
-  const sessionKey = `${MULTI_STEP_KEY}.${journeyKey}`
-  set(session, sessionKey, currentState)
 }
 
 const getCurrent = (session, journeyKey) => {
   const sessionKey = `${MULTI_STEP_KEY}.${journeyKey}`
-  return get(session, sessionKey, {})
+
+  if (!get(session, sessionKey)) {
+    set(session, sessionKey, {})
+  }
+
+  return get(session, sessionKey)
 }
 
 const reduceSteps = (session, journeyKey) => {


### PR DESCRIPTION
If the journey is in state then it was being returned. When it was not in state then a new object was returned. This was causing issues with inconsistency.