### PR TITLE
Fix bug as updating state should overwrite data

### DIFF
--- a/src/modules/form/state/current.js
+++ b/src/modules/form/state/current.js
@@ -15,8 +15,8 @@ const update = (session, journeyKey, path, { data, completed, addBrowseHistory }
 
   const stepDataKey = `steps.${path}.data`
   const stepData = {
-    ...data,
     ...get(currentState, stepDataKey),
+    ...data,
   }
   set(currentState, stepDataKey, stepData)
 

--- a/test/unit/modules/form/state/current.test.js
+++ b/test/unit/modules/form/state/current.test.js
@@ -115,6 +115,46 @@ describe('Current form state', () => {
       })
     })
 
+    context('when updating state for a step', () => {
+      beforeEach(() => {
+        const session = {
+          'multi-step': {
+            '/base/step-1': {
+              steps: {
+                '/step-1': {
+                  data: {
+                    field_1: 'field_1',
+                  },
+                },
+              },
+            },
+          },
+        }
+        const data = {
+          field_1: 'new_field_1',
+        }
+        const journeyKey = '/base/step-1'
+
+        state.update(session, journeyKey, '/step-1', { data })
+
+        this.actual = state.getCurrent(session, journeyKey)
+      })
+
+      it('should update state', () => {
+        const expected = {
+          steps: {
+            '/step-1': {
+              data: {
+                field_1: 'new_field_1',
+              },
+            },
+          },
+        }
+
+        expect(this.actual).to.deep.equal(expected)
+      })
+    })
+
     context('when updating state with a new completed step', () => {
       context('when completed is true', () => {
         beforeEach(() => {


### PR DESCRIPTION
New values were being overwritten by old values. This change ensure that the new values are applied to the object last, and therefore overwrite old values.