### PR TITLE
Add state function to remove for step

### DIFF
--- a/src/modules/form/state/current.js
+++ b/src/modules/form/state/current.js
@@ -65,10 +65,16 @@ const remove = (session, journeyKey) => {
   unset(session, sessionKey)
 }
 
+const removeStep = (session, journeyKey, stepPath) => {
+  const currentState = getCurrent(session, journeyKey)
+  unset(currentState, `steps.${stepPath}`)
+}
+
 module.exports = {
   update,
   getCurrent,
   reduceSteps,
   getField,
   remove,
+  removeStep,
 }

--- a/test/unit/modules/form/state/current.test.js
+++ b/test/unit/modules/form/state/current.test.js
@@ -509,4 +509,45 @@ describe('Current form state', () => {
       expect(this.actual).to.equal('field_2')
     })
   })
+
+  describe('#removeStep', () => {
+    beforeEach(() => {
+      this.session = {
+        'multi-step': {
+          '/base/step-1': {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+              },
+              '/step-2': {
+                data: {
+                  field_2: 'field_2',
+                },
+              },
+            },
+          },
+        },
+      }
+
+      state.removeStep(this.session, '/base/step-1', '/step-2')
+    })
+
+    it('should remove the specified step only', () => {
+      expect(this.session).to.deep.equal({
+        'multi-step': {
+          '/base/step-1': {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+  })
 })


### PR DESCRIPTION
It will be necessary to invalidate state for steps within a journey as the user will be able to change directions or select a value that impacts a subsequent step.