### PR TITLE
Add ability to update next path for a step

### DIFF
--- a/src/modules/form/state/current.js
+++ b/src/modules/form/state/current.js
@@ -10,7 +10,7 @@ const {
 
 const MULTI_STEP_KEY = 'multi-step'
 
-const update = (session, journeyKey, path, { data, completed, addBrowseHistory }) => {
+const update = (session, journeyKey, path, { data, completed, addBrowseHistory, nextPath }) => {
   const currentState = getCurrent(session, journeyKey)
 
   const stepDataKey = `steps.${path}.data`
@@ -30,6 +30,10 @@ const update = (session, journeyKey, path, { data, completed, addBrowseHistory }
       browseHistory.push(path)
       set(currentState, 'browseHistory', browseHistory)
     }
+  }
+
+  if (nextPath) {
+    set(currentState, `steps.${path}.nextPath`, nextPath)
   }
 }
 

--- a/test/unit/modules/form/state/current.test.js
+++ b/test/unit/modules/form/state/current.test.js
@@ -317,6 +317,83 @@ describe('Current form state', () => {
         })
       })
     })
+
+    context('when updating next path', () => {
+      context('when the next path is set', () => {
+        beforeEach(() => {
+          const session = {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      field_1: 'field_1',
+                    },
+                  },
+                },
+              },
+            },
+          }
+          const journeyKey = '/base/step-1'
+
+          state.update(session, journeyKey, '/step-1', { nextPath: '/step-2' })
+
+          this.actual = state.getCurrent(session, journeyKey)
+        })
+
+        it('should set the step next path', () => {
+          const expected = {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+                nextPath: '/step-2',
+              },
+            },
+          }
+
+          expect(this.actual).to.deep.equal(expected)
+        })
+      })
+
+      context('when the next path is not set', () => {
+        beforeEach(() => {
+          const session = {
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      field_1: 'field_1',
+                    },
+                  },
+                },
+              },
+            },
+          }
+          const journeyKey = '/base/step-1'
+
+          state.update(session, journeyKey, '/step-1', {})
+
+          this.actual = state.getCurrent(session, journeyKey)
+        })
+
+        it('should not set the step next path', () => {
+          const expected = {
+            steps: {
+              '/step-1': {
+                data: {
+                  field_1: 'field_1',
+                },
+              },
+            },
+          }
+
+          expect(this.actual).to.deep.equal(expected)
+        })
+      })
+    })
   })
 
   describe('#getCurrent', () => {
@@ -331,6 +408,7 @@ describe('Current form state', () => {
                     field_1: 'field_1',
                   },
                   completed: true,
+                  nextPath: '/step-2',
                 },
               },
             },
@@ -348,6 +426,7 @@ describe('Current form state', () => {
                 field_1: 'field_1',
               },
               completed: true,
+              nextPath: '/step-2',
             },
           },
         }
@@ -381,6 +460,7 @@ describe('Current form state', () => {
                     field_1: 'field_1',
                   },
                   completed: true,
+                  nextPath: '/another-step-2',
                 },
               },
             },


### PR DESCRIPTION
This will be useful for knowing if the next path changes and therefore invalidating state.

There will be a subsequent PR for invalidating state.
