### PR TITLE
Remove Advisor.use_cdms_auth from test data

### DIFF
--- a/test/unit/data/investment/interaction/advisers.json
+++ b/test/unit/data/investment/interaction/advisers.json
@@ -9,7 +9,6 @@
       "first_name": "Tom",
       "last_name": "Thumb",
       "email": "tom.thumb@test-email.com",
-      "use_cdms_auth": false,
       "dit_team": {
         "id": "b83ade1c-9798-e211-a939-e4115bead28a",
         "name": "Achme Hub"

--- a/test/unit/data/investment/interaction/interaction.json
+++ b/test/unit/data/investment/interaction/interaction.json
@@ -8,7 +8,6 @@
     "first_name": "Fred",
     "last_name": "Langer",
     "email": "Fred.Langer@dfgsds.sds.uk",
-    "use_cdms_auth": false,
     "dit_team": {
       "id": "107c51d4-9698-e211-a939-e4115bead28a",
       "name": "Achme Embassy Vienna Austria"
@@ -94,7 +93,6 @@
       "is_staff": false,
       "is_active": true,
       "date_joined": "2017-02-08T15:34:49.888000",
-      "use_cdms_auth": true,
       "dit_team": "8710dd28-9798-e211-a939-e4115bead28a",
       "groups": [],
       "user_permissions": []
@@ -198,7 +196,6 @@
       "is_staff": false,
       "is_active": true,
       "date_joined": "2017-02-08T15:34:49.888000",
-      "use_cdms_auth": true,
       "dit_team": "8710dd28-9798-e211-a939-e4115bead28a",
       "groups": [],
       "user_permissions": []
@@ -214,7 +211,6 @@
       "is_staff": false,
       "is_active": true,
       "date_joined": "2017-02-08T15:34:49.888000",
-      "use_cdms_auth": true,
       "dit_team": "8710dd28-9798-e211-a939-e4115bead28a",
       "groups": [],
       "user_permissions": []

--- a/test/unit/data/investment/interaction/interactions.json
+++ b/test/unit/data/investment/interaction/interactions.json
@@ -13,7 +13,6 @@
         "first_name": "Anonymous",
         "last_name": "Lang",
         "email": "Anonymous.lang@fco.example.uk",
-        "use_cdms_auth": false,
         "dit_team": {
           "id": "107c51d4-9698-e211-a939-e4115bead28a",
           "name": "Achme Embassy Vienna Austria"
@@ -99,7 +98,6 @@
           "is_staff": false,
           "is_active": true,
           "date_joined": "2017-02-08T15:34:49.888000",
-          "use_cdms_auth": true,
           "dit_team": "8710dd28-9798-e211-a939-e4115bead28a",
           "groups": [],
           "user_permissions": []
@@ -203,7 +201,6 @@
           "is_staff": false,
           "is_active": true,
           "date_joined": "2017-02-08T15:34:49.888000",
-          "use_cdms_auth": true,
           "dit_team": "8710dd28-9798-e211-a939-e4115bead28a",
           "groups": [],
           "user_permissions": []
@@ -219,7 +216,6 @@
           "is_staff": false,
           "is_active": true,
           "date_joined": "2017-02-08T15:34:49.888000",
-          "use_cdms_auth": true,
           "dit_team": "8710dd28-9798-e211-a939-e4115bead28a",
           "groups": [],
           "user_permissions": []


### PR DESCRIPTION
I believe the legacy field `use_cdms_auth` ended up in the test data by mistake so this removes it from the codebase.