### PR TITLE
Update next path when redirecting to the next step

### DIFF
--- a/src/modules/form/middleware.js
+++ b/src/modules/form/middleware.js
@@ -45,8 +45,9 @@ const postDetails = async (req, res, next) => {
       res.redirect(req.baseUrl + getNextPath(currentStep, req.body))
     })
   } else {
-    state.update(req.session, key, currentStep.path, { completed: true })
-    res.redirect(req.baseUrl + getNextPath(currentStep, req.body))
+    const nextPath = getNextPath(currentStep, req.body)
+    state.update(req.session, key, currentStep.path, { completed: true, nextPath })
+    res.redirect(req.baseUrl + nextPath)
   }
 }
 

--- a/test/unit/modules/form/middleware.test.js
+++ b/test/unit/modules/form/middleware.test.js
@@ -84,6 +84,11 @@ describe('#postDetails', () => {
       expect(actual).to.be.false
     })
 
+    it('should not set the next path', () => {
+      const actual = this.req.session['multi-step']['/base/step-1'].steps['/step-1'].nextPath
+      expect(actual).to.be.undefined
+    })
+
     it('should call next once', () => {
       expect(this.nextSpy).to.be.calledWithExactly()
       expect(this.nextSpy).to.have.been.calledOnce
@@ -140,6 +145,11 @@ describe('#postDetails', () => {
     it('should set the step completed to true', () => {
       const actual = this.req.session['multi-step']['/base/step-1'].steps['/step-1'].completed
       expect(actual).to.be.true
+    })
+
+    it('should set the next path', () => {
+      const actual = this.req.session['multi-step']['/base/step-1'].steps['/step-1'].nextPath
+      expect(actual).to.equal('/step-2')
     })
 
     it('should not call next', () => {
@@ -291,6 +301,11 @@ describe('#postDetails', () => {
       expect(actual).to.be.false
     })
 
+    it('should not set the next path', () => {
+      const actual = this.req.session['multi-step']['/base/step-1'].steps['/step-1'].nextPath
+      expect(actual).to.be.undefined
+    })
+
     it('should not remove the journey from state', () => {
       const actual = this.req.session['multi-step']['/base/step-1']
       expect(actual).to.not.be.undefined
@@ -371,6 +386,11 @@ describe('#postDetails', () => {
     it('should set the step completed to false', () => {
       const actual = this.req.session['multi-step']['/base/step-1'].steps['/step-1'].completed
       expect(actual).to.be.false
+    })
+
+    it('should not set the next path', () => {
+      const actual = this.req.session['multi-step']['/base/step-1'].steps['/step-1'].nextPath
+      expect(actual).to.be.undefined
     })
 
     it('should not remove the journey from state', () => {


### PR DESCRIPTION
Maintain next path in state when redirecting to the next step. This is required for invalidating state when next path changes.
