### PR TITLE
Integrate recent middleware updates with journey builder

### DIFF
--- a/src/modules/form/journey-builder.js
+++ b/src/modules/form/journey-builder.js
@@ -1,49 +1,46 @@
 const express = require('express')
-const { isString, isEmpty, set, get } = require('lodash')
 
-const { getErrors } = require('./errors')
+const {
+  validateState,
+  updateStateData,
+  updateStateBrowseHistory,
+  setFormDetails,
+} = require('./state/middleware')
+const {
+  setJourneyDetails,
+  postDetails,
+  setBreadcrumbs,
+  renderTemplate,
+} = require('./middleware')
 
-const getRender = (step) => {
-  return (req, res) => {
-    (step.breadcrumbs || []).forEach((breadcrumb) => {
-      res.breadcrumb(breadcrumb.name, breadcrumb.url)
-    })
-
-    res.render(`_layouts/${step.type}`, {
-      heading: step.heading,
-      form: {
-        ...step.macro({
-          ...res.locals,
-          errors: get(res.locals, 'form.errors.messages'),
-        }),
-        ...res.locals.form,
-      },
-    })
-  }
-}
-
-const getNextPath = (step, requestBody, baseUrl) => {
-  const routePath = isString(step.nextPath) ? step.nextPath : step.nextPath(requestBody)
-  return baseUrl + routePath
+function getMiddleware (currentStep) {
+  return currentStep.middleware || []
 }
 
 const build = (journey) => {
   const router = express.Router()
 
-  journey.steps.forEach(step => {
-    const middleware = step.middleware || []
-    const render = getRender(step)
-    router.route(step.path)
-      .get(...middleware, render)
-      .post(...middleware, (req, res, next) => {
-        const errors = getErrors(step.macro(res.locals).children, req.body)
-        if (!isEmpty(errors)) {
-          set(res.locals, 'form.errors.messages', errors)
-          return next()
-        }
-
-        res.redirect(getNextPath(step, req.body, req.baseUrl))
-      }, render)
+  journey.steps.forEach((currentStep, currentStepId) => {
+    router.route(currentStep.path)
+      .get(
+        setJourneyDetails(journey, currentStep, currentStepId),
+        validateState,
+        ...getMiddleware(currentStep),
+        setFormDetails,
+        updateStateBrowseHistory,
+        setBreadcrumbs,
+        renderTemplate,
+      )
+      .post(
+        setJourneyDetails(journey, currentStep, currentStepId),
+        validateState,
+        ...getMiddleware(currentStep),
+        updateStateData,
+        postDetails,
+        setFormDetails,
+        setBreadcrumbs,
+        renderTemplate,
+      )
   })
 
   return router

--- a/src/modules/form/journey-builder.js
+++ b/src/modules/form/journey-builder.js
@@ -5,6 +5,7 @@ const {
   updateStateData,
   updateStateBrowseHistory,
   setFormDetails,
+  invalidateStateForChangedNextPath,
 } = require('./state/middleware')
 const {
   setJourneyDetails,
@@ -35,6 +36,7 @@ const build = (journey) => {
         setJourneyDetails(journey, currentStep, currentStepId),
         validateState,
         ...getMiddleware(currentStep),
+        invalidateStateForChangedNextPath,
         updateStateData,
         postDetails,
         setFormDetails,

--- a/src/modules/form/journey-builder.js
+++ b/src/modules/form/journey-builder.js
@@ -6,6 +6,7 @@ const {
   updateStateBrowseHistory,
   setFormDetails,
   invalidateStateForChangedNextPath,
+  invalidateStateForDependentSteps,
 } = require('./state/middleware')
 const {
   setJourneyDetails,
@@ -37,6 +38,7 @@ const build = (journey) => {
         validateState,
         ...getMiddleware(currentStep),
         invalidateStateForChangedNextPath,
+        invalidateStateForDependentSteps,
         updateStateData,
         postDetails,
         setFormDetails,

--- a/test/unit/modules/form/journey-builder.test.js
+++ b/test/unit/modules/form/journey-builder.test.js
@@ -2,11 +2,13 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const request = require('supertest')
 const { endsWith } = require('lodash')
+const steps = require('./steps')
 
 describe('#build', () => {
   beforeEach(() => {
+    this.req = { session: {} }
+    this.flashSpy = sinon.spy()
     this.breadcrumbSpy = sinon.spy()
-    this.redirectSpy = sinon.spy()
     this.setOptionsStub1 = sinon.stub().callsFake((req, res, next) => { next() })
     this.setOptionsStub2 = sinon.stub().callsFake((req, res, next) => { next() })
     this.journeyBuilder = require('~/src/modules/form/journey-builder.js')
@@ -18,6 +20,8 @@ describe('#build', () => {
     this.app.set('view engine', 'njk')
     this.app.use((req, res, next) => {
       req.baseUrl = '/base'
+      req.session = this.req.session
+      req.flash = this.flashSpy
       res.breadcrumb = this.breadcrumbSpy
       next()
     })
@@ -26,43 +30,16 @@ describe('#build', () => {
     })
 
     this.journey = {
-      steps: [
-        {
-          path: '/step-1',
-          middleware: [
-            this.setOptionsStub1,
-            this.setOptionsStub2,
-          ],
-          type: 'form',
-          heading: 'Add something',
-          breadcrumbs: [
-            { name: 'Add something', url: '/url' },
-          ],
-          macro: () => { return { children: [] } },
-          nextPath: ({ selected }) => {
-            const paths = {
-              'step-2-value': '/step-2',
-              'step-3-value': '/step-3',
-            }
-            return paths[selected]
-          },
-        },
-        {
-          path: '/step-2',
-          type: 'form',
-          heading: 'Add something',
-          breadcrumbs: [
-            { name: 'Add something', url: '/url' },
-          ],
-          macro: () => { return { children: [] } },
-          nextPath: '/finish',
-        },
-      ],
+      successMessage: 'The entity has been added',
+      steps: steps([
+        this.setOptionsStub1,
+        this.setOptionsStub2,
+      ]),
     }
   })
 
-  context('when rendering the view', () => {
-    const commonTests = () => {
+  context('when rendering the form', () => {
+    const commonTests = (expectedForm) => {
       it('should render the form template', () => {
         const render = JSON.parse(this.response.res.text)
         expect(endsWith(render.path, 'form.njk')).to.be.true
@@ -75,10 +52,7 @@ describe('#build', () => {
 
       it('should render the form', () => {
         const render = JSON.parse(this.response.res.text)
-        const expected = {
-          children: [],
-        }
-        expect(render.options.form).to.deep.equal(expected)
+        expect(render.options.form).to.deep.equal(expectedForm)
       })
 
       it('should render the breadcrumbs', () => {
@@ -94,7 +68,12 @@ describe('#build', () => {
         this.response = await request(this.app).get('/step-1')
       })
 
-      commonTests()
+      commonTests({
+        children: [],
+        returnLink: '/base',
+        returnText: 'Cancel',
+        state: {},
+      })
 
       it('should call the middleware', () => {
         expect(this.setOptionsStub1).to.be.calledOnce
@@ -104,12 +83,84 @@ describe('#build', () => {
 
     context('when middleware has not been specified', () => {
       beforeEach(async () => {
+        this.app.use((req, res, next) => {
+          req.session = {
+            ...req.session,
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    data: {
+                      selectedAtStep1: 'step-3-value',
+                    },
+                    completed: true,
+                  },
+                },
+                browseHistory: [
+                  '/step-1',
+                ],
+              },
+            },
+          }
+
+          next()
+        })
+
         this.app.use(this.journeyBuilder.build(this.journey))
 
-        this.response = await request(this.app).get('/step-2')
+        this.response = await request(this.app).get('/step-3')
       })
 
-      commonTests()
+      commonTests({
+        children: [],
+        state: {
+          selectedAtStep1: 'step-3-value',
+        },
+        returnLink: '/base/step-1',
+        returnText: 'Back',
+      })
+    })
+
+    context('when rendering the first step of a multi step form having half completed another multi step form', () => {
+      beforeEach(async () => {
+        const stateFromAnotherFormJourney = {
+          'multi-step': {
+            '/base/another-step-1': {
+              steps: {
+                another_field_1: 'another_field_1',
+              },
+            },
+          },
+        }
+        this.req.session = {
+          ...this.req.session,
+          ...stateFromAnotherFormJourney,
+        }
+
+        this.app.use((req, res, next) => {
+          req.session = this.req.session
+          next()
+        })
+
+        this.app.use(this.journeyBuilder.build(this.journey))
+
+        this.response = await request(this.app).get('/step-1')
+      })
+
+      commonTests({
+        children: [],
+        returnLink: '/base',
+        returnText: 'Cancel',
+        state: {},
+      })
+
+      it('should not alter state for the other form', async () => {
+        expect(this.req.session['multi-step']['/base/another-step-1']).to.deep.equal({
+          steps: {
+            another_field_1: 'another_field_1',
+          },
+        })
+      })
     })
   })
 
@@ -119,7 +170,7 @@ describe('#build', () => {
         beforeEach(async () => {
           this.app.use(this.journeyBuilder.build(this.journey))
 
-          this.response = await request(this.app).post('/step-1').send({ selected: 'step-2-value' })
+          this.response = await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-2-value' })
         })
 
         it('should call the middleware', async () => {
@@ -141,7 +192,7 @@ describe('#build', () => {
         beforeEach(async () => {
           this.app.use(this.journeyBuilder.build(this.journey))
 
-          this.response = await request(this.app).post('/step-1').send({ selected: 'step-3-value' })
+          this.response = await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-3-value' })
         })
 
         it('should call the middleware', async () => {
@@ -161,22 +212,21 @@ describe('#build', () => {
     })
 
     context('when middleware has not been specified', () => {
-      context('when the value for step 2 has been selected', () => {
+      context('when the final value has been selected', () => {
         beforeEach(async () => {
-          delete this.journey.steps[0].middleware
-
           this.app.use(this.journeyBuilder.build(this.journey))
 
-          this.response = await request(this.app).post('/step-1').send({ selected: 'step-2-value' })
+          this.response = await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-2-value' })
+          this.response = await request(this.app).post('/step-2').send({ selectedAtStep2: 'finish' })
         })
 
-        it('should redirect to step 2', () => {
+        it('should redirect to finish', () => {
           expect(this.response.statusCode).to.equal(302)
-          expect(this.response.headers.location).to.equal('/base/step-2')
+          expect(this.response.headers.location).to.equal('/base/finish')
         })
 
         it('should not render a template', () => {
-          expect(this.response.res.text).to.equal('Found. Redirecting to /base/step-2')
+          expect(this.response.res.text).to.equal('Found. Redirecting to /base/finish')
         })
       })
     })
@@ -185,6 +235,7 @@ describe('#build', () => {
       beforeEach(async () => {
         this.app.use(this.journeyBuilder.build(this.journey))
 
+        this.response = await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-2-value' })
         this.response = await request(this.app).post('/step-2')
       })
 
@@ -203,7 +254,7 @@ describe('#build', () => {
         const form = {
           children: [
             {
-              name: 'selected',
+              name: 'selectedAtStep1',
               validations: [
                 {
                   type: 'required',
@@ -233,11 +284,225 @@ describe('#build', () => {
           ...this.form,
           errors: {
             messages: {
-              selected: [ 'You must enter a value for selected' ],
+              selectedAtStep1: [ 'You must enter a value for selected' ],
             },
           },
+          state: {},
+          returnLink: '/base',
+          returnText: 'Cancel',
         }
         expect(render.options.form).to.deep.equal(expected)
+      })
+    })
+
+    context('when completing a multi step form', () => {
+      context('when the first step has been completed', () => {
+        beforeEach(async () => {
+          this.app.use(this.journeyBuilder.build(this.journey))
+
+          await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-2-value' })
+        })
+
+        it('should persist state for the first step', async () => {
+          expect(this.req.session).to.deep.equal({
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    completed: true,
+                    nextPath: '/step-2',
+                    data: {
+                      selectedAtStep1: 'step-2-value',
+                    },
+                  },
+                },
+              },
+            },
+          })
+        })
+      })
+
+      context('when the first and second steps have been completed', () => {
+        beforeEach(async () => {
+          this.app.use(this.journeyBuilder.build(this.journey))
+
+          await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-2-value' })
+          await request(this.app).post('/step-2').send({ selectedAtStep2: 'finish' })
+        })
+
+        it('should persist state for the second step and subsequent steps', async () => {
+          expect(this.req.session).to.deep.equal({
+            'multi-step': {
+              '/base/step-1': {
+                steps: {
+                  '/step-1': {
+                    completed: true,
+                    data: {
+                      selectedAtStep1: 'step-2-value',
+                    },
+                    nextPath: '/step-2',
+                  },
+                  '/step-2': {
+                    completed: true,
+                    data: {
+                      selectedAtStep2: 'finish',
+                    },
+                    nextPath: '/finish',
+                  },
+                },
+              },
+            },
+          })
+        })
+      })
+    })
+
+    context('when trying to start a form without completing previous steps', () => {
+      beforeEach(async () => {
+        this.app.use(this.journeyBuilder.build(this.journey))
+
+        this.response = await request(this.app).get('/step-5')
+      })
+
+      it('should not call the middleware', async () => {
+        expect(this.setOptionsStub1).to.not.be.called
+        expect(this.setOptionsStub2).to.not.be.called
+      })
+
+      it('should redirect to step 1', () => {
+        expect(this.response.statusCode).to.equal(302)
+        expect(this.response.headers.location).to.equal('/base/step-1')
+      })
+
+      it('should not render a template', () => {
+        expect(this.response.res.text).to.equal('Found. Redirecting to /base/step-1')
+      })
+    })
+
+    context('when it is the final step and the API request is successful', () => {
+      beforeEach(async () => {
+        this.sendSpy = sinon.stub().callsFake((data, next) => { next() })
+        this.journey.steps[4].send = this.sendSpy
+        this.app.use(this.journeyBuilder.build(this.journey))
+
+        await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-3-value' })
+        await request(this.app).post('/step-3').send({ selectedAtStep3: 'step-5-value' })
+        this.response = await request(this.app).post('/step-5').send({ moreData: 'more' })
+      })
+
+      it('should POST to the API', () => {
+        expect(this.sendSpy).have.been.calledWith({
+          selectedAtStep1: 'step-3-value',
+          selectedAtStep3: 'step-5-value',
+          moreData: 'more',
+        })
+        expect(this.sendSpy).to.be.calledOnce
+      })
+
+      it('should remove state for the journey', () => {
+        expect(this.req.session['multi-step']['/base/step-1']).to.be.undefined
+      })
+
+      it('should set the success message', () => {
+        expect(this.flashSpy).to.be.calledWith('success', this.journey.successMessage)
+        expect(this.flashSpy).to.be.calledOnce
+      })
+
+      it('should redirect to the finish', () => {
+        expect(this.response.statusCode).to.equal(302)
+        expect(this.response.headers.location).to.equal('/base/finish')
+      })
+
+      it('should not render a template', () => {
+        expect(this.response.res.text).to.equal('Found. Redirecting to /base/finish')
+      })
+    })
+
+    context('when it is the final step and the API request is erroneous', () => {
+      beforeEach(async () => {
+        this.sendSpy = sinon.stub().callsFake((data, next) => {
+          return next({ statusCode: 400, error: 'Error messages' })
+        })
+        this.journey.steps[4].send = this.sendSpy
+        this.app.use(this.journeyBuilder.build(this.journey))
+
+        await request(this.app).get('/step-1')
+        await request(this.app).post('/step-1').send({ selectedAtStep1: 'step-3-value' })
+        await request(this.app).get('/step-3')
+        await request(this.app).post('/step-3').send({ selectedAtStep3: 'step-5-value' })
+        await request(this.app).get('/step-5')
+        this.response = await request(this.app).post('/step-5').send({ moreData: 'more' })
+      })
+
+      it('should POST to the API', () => {
+        expect(this.sendSpy).have.been.calledWith({
+          selectedAtStep1: 'step-3-value',
+          selectedAtStep3: 'step-5-value',
+          moreData: 'more',
+        })
+        expect(this.sendSpy).to.be.calledOnce
+      })
+
+      it('should not remove state for the journey', () => {
+        expect(this.req.session).to.deep.equal({
+          'multi-step': {
+            '/base/step-1': {
+              steps: {
+                '/step-1': {
+                  completed: true,
+                  data: {
+                    selectedAtStep1: 'step-3-value',
+                  },
+                  nextPath: '/step-3',
+                },
+                '/step-3': {
+                  completed: true,
+                  data: {
+                    selectedAtStep3: 'step-5-value',
+                  },
+                  nextPath: '/step-5',
+                },
+                '/step-5': {
+                  completed: false,
+                  data: {
+                    moreData: 'more',
+                  },
+                },
+              },
+              browseHistory: [
+                '/step-1',
+                '/step-3',
+                '/step-5',
+              ],
+            },
+          },
+        })
+      })
+
+      it('should not set the success message', () => {
+        expect(this.flashSpy).to.not.be.called
+      })
+
+      it('should not redirect to anywhere', () => {
+        expect(this.response.statusCode).to.equal(200)
+        expect(this.response.headers.location).to.be.undefined
+      })
+
+      it('should render step 5', () => {
+        const render = JSON.parse(this.response.res.text)
+        expect(render.options.form).to.deep.equal({
+          children: [],
+          returnLink: '/base/step-3',
+          returnText: 'Back',
+          state: {
+            selectedAtStep1: 'step-3-value',
+            selectedAtStep3: 'step-5-value',
+            moreData: 'more',
+          },
+          errors: {
+            messages: 'Error messages',
+          },
+        })
       })
     })
   })


### PR DESCRIPTION
The journey `build` function has been simplified due to recent refactoring of middleware.

The code now follows existing patterns.

Included are tests around `journey-builder`. It is understood that these are integration tests and a subsequent PR will move them to a more appropriate location.

```javascript
const build = (journey) => {
  const router = express.Router()

  journey.steps.forEach((currentStep, currentStepId) => {
    router.route(currentStep.path)
      .get(
        setJourneyDetails(journey, currentStep, currentStepId),
        validateState,
        ...getMiddleware(currentStep),
        setFormDetails,
        updateStateBrowseHistory,
        setBreadcrumbs,
        renderTemplate,
      )
      .post(
        setJourneyDetails(journey, currentStep, currentStepId),
        validateState,
        ...getMiddleware(currentStep),
        invalidateStateForChangedNextPath,
        invalidateStateForDependentSteps,
        updateStateData,
        postDetails,
        setFormDetails,
        setBreadcrumbs,
        renderTemplate,
      )
  })

  return router
}