### PR TITLE
Remove hard coded timeline data source labels.

### DIFF
--- a/src/apps/timeline/labels.js
+++ b/src/apps/timeline/labels.js
@@ -3,42 +3,4 @@ const listLabels = {
   description: 'Description',
 }
 
-const sourceLabels = {
-  'citrix.webinars.attendees': 'Citrix (DIT Webinars)',
-  'citrix.webinars.webinars': 'Citrix (DIT Webinars)',
-  'citrix.webinars.registrants': 'Citrix (DIT Webinars)',
-  'dit.datahub.interactions': 'DIT (DataHub)',
-  'dit.datahub.companies': 'DIT (DataHub)',
-  'dit.datahub.contacts': 'DIT (DataHub)',
-  'dit.datahub.dit_events': 'DIT (DataHub)',
-  'dit.datahub.fdi': 'DIT (DataHub)',
-  'dit.datahub.advisors': 'DIT (DataHub)',
-  'dit.eig-contact-form': 'DIT (EIG Contact Form)',
-  'dit.eig-email-guide': 'DIT (EIG Email Guide)',
-  'dit.eig-export-ops-published': 'DIT (Export Opportunities)',
-  'dit.eig-export-opp-responses': 'DIT (Export Opportunities)',
-  'dit.export-wins': 'DIT (Export Wins)',
-  'dit.find-a-buyer.suppliers': 'DIT (FAB)',
-  'dit.find-a-buyer.buyers': 'DIT (FAB)',
-  'dit.gov-uk-contact-form': 'DIT (GOV.UK Contact Form)',
-  'companies_house.companies': 'Companies House (Companies)',
-  'companies_house.accounts': 'Companies House (Accounts)',
-  'companies_house.psc': 'Companies House (PSC)',
-  'experian.email.clicked': 'Experian (Email Campaign)',
-  'experian.email.opened': 'Experian (Email Campaign)',
-  'experian.email.sent': 'Experian (Email Campaign)',
-  'hmrc.exporters': 'HMRC (Exporters)',
-  'hmrc.importers.f0_0': 'HMRC (Importers)',
-  'hmrc.importers.f1_0': 'HMRC (Importers)',
-  'horizon.events.events': 'Horizon (Events)',
-  'horizon.events.delegates': 'Horizon (Events)',
-  'ipo.journals': 'IPO (Journals)',
-  'zendesk.organizations': 'Zendesk (Organizations)',
-  'zendesk.users': 'Zendesk (Users)',
-  'zendesk.tickets': 'Zendesk (Tickets)',
-  'zendesk.tickets.contact_dit_form': 'Zendesk (Tickets)',
-  'zendesk.tickets.iigb': 'Zendesk (Tickets)',
-  'zendesk.tickets.soo': 'Zendesk (Tickets)',
-}
-
-module.exports = { listLabels, sourceLabels }
+module.exports = { listLabels }

--- a/src/apps/timeline/transformers.js
+++ b/src/apps/timeline/transformers.js
@@ -2,16 +2,16 @@
 const dateFns = require('date-fns')
 const { mediumDateFormat } = require('../../../config')
 
-const { listLabels, sourceLabels } = require('./labels')
+const { listLabels } = require('./labels')
 
-function transformTimelineToListItem ({ data_source, datetime, description }) {
+function transformTimelineToListItem ({ data_source_label, datetime, description }) {
   return {
     type: 'timeline',
     name: dateFns.format(datetime, mediumDateFormat),
     contentMetaModifier: 'stacked',
     meta: [{
       label: listLabels.data_source,
-      value: sourceLabels[data_source],
+      value: data_source_label,
     }, {
       label: listLabels.description,
       value: description,

--- a/test/unit/apps/timeline/transformers.test.js
+++ b/test/unit/apps/timeline/transformers.test.js
@@ -4,7 +4,7 @@ describe('Timeline transformers', () => {
   context('when called with a valid source', () => {
     beforeEach(() => {
       this.actual = transformTimelineToListItem({
-        data_source: 'companies_house.companies',
+        data_source_label: 'Companies House (Companies)',
         datetime: '2017-02-04T00:00:00Z',
         description: 'Returns next due date',
       })

--- a/test/unit/data/companies/timeline.json
+++ b/test/unit/data/companies/timeline.json
@@ -5,26 +5,31 @@
   "results": [
     {
       "data_source": "companies_house.companies",
+      "data_source_label": "Companies House (Companies)",
       "datetime": "2018-10-31T00:00:00Z",
       "description": "Accounts next due date"
     },
     {
       "data_source": "companies_house.companies",
+      "data_source_label": "Companies House (Companies)",
       "datetime": "2017-02-04T00:00:00Z",
       "description": "Returns next due date"
     },
     {
       "data_source": "companies_house.companies",
+      "data_source_label": "Companies House (Companies)",
       "datetime": "2017-01-31T00:00:00Z",
       "description": "Accounts last made up date"
     },
     {
       "data_source": "companies_house.companies",
+      "data_source_label": "Companies House (Companies)",
       "datetime": "2016-01-07T00:00:00Z",
       "description": "Returns last due date"
     },
     {
       "data_source": "companies_house.companies",
+      "data_source_label": "Companies House (Companies)",
       "datetime": "2002-01-07T00:00:00Z",
       "description": "Company officially incorporated in Companies House"
     }


### PR DESCRIPTION
Previously the company source labels were hard coded. These are now available in the backend and are being pulled through.

![timeline](https://user-images.githubusercontent.com/10154302/47659355-b4cc6a80-db8c-11e8-827a-f3c77709e96d.png)
