### PR TITLE
Bug - Business type changes when trying to add a foreign company without completing mandatory fields

### DIFF
--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -29,6 +29,9 @@
     buttonText: 'Save and return' if company.id else 'Add company',
     returnLink: '/companies/' + company.id if company.id else '/companies/add-step-1',
     returnText: 'Return without saving' if company.id else 'Back',
+    actionExtension: {
+        country : 'non-uk' if isForeign else 'uk'
+    },
     errors: {
       messages: errors
     },

--- a/src/templates/_macros/form/form.njk
+++ b/src/templates/_macros/form/form.njk
@@ -29,13 +29,17 @@
   {% set returnText = props.returnText or 'Back' %}
   {% set hideFormActions = props.hideFormActions or false %}
   {% set children = caller() if caller else renderAsMacro(props.children) %}
-
   <form
       method="{{ method }}"
       {% if props.enctype %}
         enctype="{{ props.enctype }}"
       {% endif %}
-      action="{{ props.action }}?_csrf={{csrfToken}}"
+      action="{{ props.action }}?_csrf={{csrfToken}}
+      {%- if props.actionExtension -%}
+        {%- for key, value in  props.actionExtension -%}
+           &{{ key }}={{ value }}
+        {%- endfor -%}
+      {%- endif -%}"
       {% if props.class %}class="{{ props.class }}"{% endif %}
       {% if props.role %}role="{{ props.role }}"{% endif %}
   >


### PR DESCRIPTION
## Problem

When creating a new Foreign Organisation, (type Company)

1. If user does not complete a mandatory field and attempts to save, the error message appears, but editable Foreign Org form changes to editable UK Company creation form.

2. Form keeps completed data, but if user attempts to change business type to foreign, then data is lost and user has to start again

## Solution
I have now added the "business_type" and the "country" params to the post action on the form as without these the form redirects to "**Add UK company**" with errors rather than "**Add foreign company**" with errors.