### PR TITLE
336 Bugfix/hide add contact when archived

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ npm*.log
 yarn-error.log
 stats.json
 package-lock.json
+.vscode/launch.json
+.vscode/settings.json
 
 # Tests
 .nyc_output

--- a/src/apps/companies/views/contacts.njk
+++ b/src/apps/companies/views/contacts.njk
@@ -14,8 +14,8 @@
   </summary>
   <div class="details__content" id="details-content-0" aria-hidden="false">
     <p class="c-message c-message--muted">Contacts cannot be added to an archived company.
-    <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
-        </p>
+      <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
+    </p>
   </div>
 </details>
 {% endif %}

--- a/src/apps/companies/views/contacts.njk
+++ b/src/apps/companies/views/contacts.njk
@@ -1,23 +1,40 @@
 {% extends "./_layout-view.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="heading-medium">Contacts</h2>
+<h2 class="heading-medium">Contacts</h2>
 
-  {{ CollectionFilters({
-      query: QUERY,
-      filtersFields: filtersFields,
-      action: CURRENT_PATH
-  }) }}
-  {% block xhr_content %}
-    <article id="xhr-outlet">
-      {{ CollectionContent(contactResults | assign({
-          countLabel: 'contact',
-          sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
-          selectedFilters: selectedFilters,
-          query: QUERY,
-          action: CURRENT_PATH,
-          actionButtons: actionButtons
-      })) }}
-    </article>
-  {% endblock %}
+
+
+{% if company.archived %}
+<details role="group">
+  <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+    <span class="details__summary">
+      Why can I not add a contact?
+    </span>
+  </summary>
+  <div class="details__content" id="details-content-0" aria-hidden="false">
+    <p class="c-message c-message--muted">Contacts cannot be added to an archived company.
+    <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
+        </p>
+  </div>
+</details>
+{% endif %}
+
+{{ CollectionFilters({
+query: QUERY,
+filtersFields: filtersFields,
+action: CURRENT_PATH
+}) }}
+{% block xhr_content %}
+<article id="xhr-outlet">
+  {{ CollectionContent(contactResults | assign({
+  countLabel: 'contact',
+  sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
+  selectedFilters: selectedFilters,
+  query: QUERY,
+  action: CURRENT_PATH,
+  actionButtons: actionButtons
+  })) }}
+</article>
+{% endblock %}
 {% endblock %}

--- a/src/apps/companies/views/interactions.njk
+++ b/src/apps/companies/views/interactions.njk
@@ -22,7 +22,11 @@
     {% endblock %}
   {% else %}
     {% call Message({ type: 'info' }) %}
-      You currently have no contacts for this company. To add an interaction you must first <a href="/contacts/create?company={{company.id}}">add a contact</a>.
+      You currently have no contacts for this company.
+      {% if not company.archived %}
+        To add an interaction you must first <a href="/contacts/create?company={{company.id}}">add a contact</a>.
+      {% endif %}
+
     {% endcall %}
   {% endif %}
 {% endblock %}

--- a/src/apps/companies/views/interactions.njk
+++ b/src/apps/companies/views/interactions.njk
@@ -1,32 +1,51 @@
 {% extends "./_layout-view.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="heading-medium">Company interactions</h2>
+<h2 class="heading-medium">Company interactions</h2>
 
-  {% if company.contacts.length %}
-    <p>
-      An interaction could be a meeting, call, email or another activity where you have been in touch with a company.
+{% if company.contacts.length %}
+<p>
+  An interaction could be a meeting, call, email or another activity where you have been in touch with a company.
+</p>
+
+{% if company.archived %}
+<details role="group">
+  <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+    <span class="details__summary">
+      Why can I not add an interaction?
+    </span>
+  </summary>
+  <div class="details__content" id="details-content-0" aria-hidden="false">
+    <p class="c-message c-message--muted">Interactions cannot be added to an archived company.
+      <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
     </p>
+  </div>
+</details>
+{% endif %}
 
-    {% block xhr_content %}
-      <article id="xhr-outlet">
-        {{
-          CollectionContent(results | assignCopy({
-            countLabel: 'interaction',
-            sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
-            actionButtons: actionButtons,
-            query: QUERY
-          }))
-        }}
-      </article>
-    {% endblock %}
-  {% else %}
-    {% call Message({ type: 'info' }) %}
-      You currently have no contacts for this company.
-      {% if not company.archived %}
-        To add an interaction you must first <a href="/contacts/create?company={{company.id}}">add a contact</a>.
-      {% endif %}
+{% block xhr_content %}
+<article id="xhr-outlet">
+  {{
+  CollectionContent(results | assignCopy({
+  countLabel: 'interaction',
+  sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
+  actionButtons: actionButtons,
+  query: QUERY
+  }))
+  }}
+</article>
+{% endblock %}
+{% else %}
+{% call Message({ type: 'info' }) %}
 
-    {% endcall %}
-  {% endif %}
+You currently have no contacts for this company.
+
+{% if not company.archived %}
+To add an interaction you must first <a href="/contacts/create?company={{company.id}}">add a contact</a>.
+{% else %}
+
+{% endif %}
+
+{% endcall %}
+{% endif %}
 {% endblock %}

--- a/src/apps/companies/views/investments.njk
+++ b/src/apps/companies/views/investments.njk
@@ -3,6 +3,22 @@
 {% block main_grid_right_column %}
   <h2 class="heading-medium">Investment projects</h2>
 
+  {% if company.archived %}
+    <details role="group">
+      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+        <span class="details__summary">
+          Why can I not add an investment project?
+        </span>
+      </summary>
+      <div class="details__content" id="details-content-0" aria-hidden="false">
+        <p class="c-message c-message--muted">Investment projects cannot be added to an archived company.
+          <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
+        </p>
+      </div>
+    </details>
+  {% endif %}
+
+
   {{
     CollectionContent(results | assignCopy({
       sort: sort,

--- a/src/apps/companies/views/orders.njk
+++ b/src/apps/companies/views/orders.njk
@@ -3,6 +3,21 @@
 {% block main_grid_right_column %}
   <h2 class="heading-medium">Orders (OMIS)</h2>
 
+  {% if company.archived %}
+    <details role="group">
+      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+        <span class="details__summary">
+          Why can I not add an order?
+        </span>
+      </summary>
+      <div class="details__content" id="details-content-0" aria-hidden="false">
+        <p class="c-message c-message--muted">Orders cannot be added to an archived company.
+          <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
+        </p>
+      </div>
+    </details>
+  {% endif %}
+
   {{
     CollectionContent(results | assignCopy({
       sort: sort,

--- a/src/apps/companies/views/subsidiaries.njk
+++ b/src/apps/companies/views/subsidiaries.njk
@@ -1,5 +1,21 @@
 {% extends "./_layout-view.njk" %}
 
 {% block main_grid_right_column %}
+
+  {% if company.archived %}
+    <details role="group">
+      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+        <span class="details__summary">
+          Why can I not link a subsidiary?
+        </span>
+      </summary>
+      <div class="details__content" id="details-content-0" aria-hidden="false">
+        <p class="c-message c-message--muted">Subsidiaries cannot be linked to an archived company.
+          <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
+        </p>
+      </div>
+    </details>
+  {% endif %}
+
   {{ CollectionContent(subsidiaries) }}
 {% endblock %}

--- a/test/acceptance/features/companies/interactions-collection.feature
+++ b/test/acceptance/features/companies/interactions-collection.feature
@@ -8,6 +8,11 @@ Feature: View collection of interactions for a company
     And I can view the collection
     And the result count should be greater than 0
 
+  @companies-interactions-collection--view-archived-company
+  Scenario: View companies interaction collection for archived company without contacts
+    When I navigate to the `companies.interactions` page using `company` `Contactless Archived Ltd` fixture
+    Then I should not see the "add a contact" link
+
   @companies-interactions-collection--filter # TODO
 
   @companies-interactions-collection--sort # TODO

--- a/test/acceptance/features/companies/subsidiaries.feature
+++ b/test/acceptance/features/companies/subsidiaries.feature
@@ -46,3 +46,5 @@ Feature: Company subsidiaries
     And I should not see the "Link a subsidiary" button
     And I can view the collection
     And I should not see the "Remove subsidiary" link
+    And the page should contain text "Why can I not link a subsidiary"
+

--- a/test/acceptance/features/step_definitions/common.js
+++ b/test/acceptance/features/step_definitions/common.js
@@ -69,6 +69,13 @@ Then(/^I should not see the "([^"]*)?" (link|button)$/, async function (linkText
     .useCss()
 })
 
+Then(/^I should see the "([^"]*)?" (link|button)$/, async function (linkText, type) {
+  await client
+    .useXpath()
+    .assert.elementPresent(`//a[text()='${linkText}']`)
+    .useCss()
+})
+
 Then(/^I am on the `(.+)` page$/, async function (pageName) {
   try {
     const page = get(client.page, pageName)()
@@ -81,6 +88,10 @@ Then(/^I am on the `(.+)` page$/, async function (pageName) {
   } catch (error) {
     throw new Error(error)
   }
+})
+
+Then(/^the page should contain text "(.*?)"$/, (text) => {
+  return client.expect.element('body').text.to.contain(text)
 })
 
 Then(/^I should see the correct text on the `(.+)` page$/, async function (pageName, data) {

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -80,6 +80,10 @@ module.exports = {
       employeeRange: '500+',
       turnoverRange: '£33.5M+',
     },
+    archivedContactless: {
+      id: '346f78a5-1d23-4213-b4c2-bf48246a13c4',
+      name: 'Contactless Archived Ltd',
+    },
   },
   contact: {
     georginaClark: {


### PR DESCRIPTION
This ticket covers preventing certain actions being performed against an archived company 

Pages affected: 
- Subsidiaries
- Contacts 
- Interactions
- Investment
- Orders (OMIS) 
