### PR TITLE
BUG - OMIS exports complete list even with filters on

### DIFF
--- a/src/apps/omis/apps/list/router.js
+++ b/src/apps/omis/apps/list/router.js
@@ -2,7 +2,7 @@ const router = require('express').Router()
 
 const { ENTITIES } = require('../../../search/constants')
 
-const QUERY_FIELDS = require('../../constants')
+const { QUERY_FIELDS } = require('../../constants')
 
 const { getCollection, exportCollection } = require('../../../../modules/search/middleware/collection')
 const { setDefaultQuery } = require('../../../middleware')


### PR DESCRIPTION
## Problem
When a user searches Orders (OMIS) and filters to a list thats under 5000 results the download button should be visible which allows you to export the list as a `.csv` file. Currently the button downloads all results and not filtered results.

## Solution 
We are not deconstructing the QUERY_FIELDS obj from the `constants` file so the query isn't set properly when filtering.