### PR TITLE
Front end for Interactions CSV export

### DIFF
--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -20,7 +20,7 @@ const QUERY_FIELDS = [
   'date_before',
   'sortby',
   'dit_team',
-  'service'
+  'service',
 ]
 
 const APP_PERMISSIONS = [ GLOBAL_NAV_ITEM ]

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -11,6 +11,18 @@ const GLOBAL_NAV_ITEM = {
   order: 4,
 }
 
+const QUERY_FIELDS = [
+  'kind',
+  'sector_descends',
+  'communication_channel',
+  'dit_adviser',
+  'date_after',
+  'date_before',
+  'sortby',
+  'dit_team',
+  'service'
+]
+
 const APP_PERMISSIONS = [ GLOBAL_NAV_ITEM ]
 
 const POLICY_FEEDBACK_PERMISSIONS = {
@@ -68,6 +80,7 @@ const IST_ONLY_SERVICES = [
 ]
 
 module.exports = {
+  QUERY_FIELDS,
   APP_PERMISSIONS,
   DEFAULT_COLLECTION_QUERY,
   GLOBAL_NAV_ITEM,

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -1,10 +1,19 @@
+const qs = require('querystring')
 const { collectionFilterFields } = require('../macros')
 const { buildSelectedFiltersSummary, buildFieldsWithSelectedEntities } = require('../../builders')
 const { getOptions } = require('../../../lib/options')
+const { buildExportAction } = require('../../../lib/export-helper')
 
 const FILTER_CONSTANTS = require('../../../lib/filter-constants')
 const QUERY_STRING = FILTER_CONSTANTS.INTERACTIONS.SECTOR.PRIMARY.QUERY_STRING
 const SECTOR = FILTER_CONSTANTS.INTERACTIONS.SECTOR.NAME
+
+const exportOptions = {
+  targetPermission: 'interaction.export_interaction',
+  urlFragment: 'interactions',
+  maxItems: FILTER_CONSTANTS.COMPANIES.SECTOR.MAX_EXPORT_ITEMS,
+  entityName: 'interaction',
+}
 
 async function getInteractionOptions (token) {
   const sectorOptions = await getOptions(token, SECTOR, { queryString: QUERY_STRING })
@@ -34,9 +43,11 @@ async function renderInteractionList (req, res, next) {
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, query)
     const selectedFilters = await buildSelectedFiltersSummary(filtersFieldsWithSelectedOptions, query)
+    const exportAction = await buildExportAction(qs.stringify(req.query), user.permissions, exportOptions)
 
     res.render('_layouts/collection', {
       selectedFilters,
+      exportAction,
       filtersFields: filtersFieldsWithSelectedOptions,
       title: 'Interactions',
       countLabel: 'interaction',

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -43,5 +43,4 @@ router
 
 router.get('/:interactionId', handlePolicyPermissions('view'), renderDetailsPage)
 
-
 module.exports = router

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -1,10 +1,12 @@
 const router = require('express').Router()
 
-const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS } = require('./constants')
+const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
 
 const { renderEditPage } = require('./controllers/edit')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderInteractionList } = require('./controllers/list')
+const { exportCollection } = require('../../modules/search/middleware/collection')
+const { getRequestBody } = require('../../middleware/collection')
 
 const { setDefaultQuery, handleRoutePermissions } = require('../middleware')
 const {
@@ -28,11 +30,18 @@ router.get('/',
   renderInteractionList
 )
 
+router.get('/export',
+  setDefaultQuery(DEFAULT_COLLECTION_QUERY),
+  getRequestBody(QUERY_FIELDS),
+  exportCollection('interaction')
+)
+
 router
   .route('/:interactionId/:kind/edit')
   .post(handlePolicyPermissions('edit'), postDetails, renderEditPage)
   .get(handlePolicyPermissions('edit'), renderEditPage)
 
 router.get('/:interactionId', handlePolicyPermissions('view'), renderDetailsPage)
+
 
 module.exports = router

--- a/src/lib/filter-constants.js
+++ b/src/lib/filter-constants.js
@@ -35,6 +35,7 @@ const FILTER_CONSTANTS = {
         NAME: 'sector_descends',
         QUERY_STRING: '?level__lte=0',
       },
+      MAX_EXPORT_ITEMS: 5000,
     },
   },
 }

--- a/test/unit/apps/interactions/controllers/list.test.js
+++ b/test/unit/apps/interactions/controllers/list.test.js
@@ -13,6 +13,9 @@ describe('interaction list', () => {
           permissions: [],
         },
       },
+      query: {
+        sortby: 'date:desc',
+      },
     }
 
     this.res = {

--- a/test/unit/lib/export-helper.test.js
+++ b/test/unit/lib/export-helper.test.js
@@ -1,0 +1,60 @@
+const qs = require('querystring')
+const { buildExportAction } = require('~/src/lib/export-helper')
+
+const queryString = {
+  sortby: 'date:desc',
+  custom: true,
+}
+
+const exportOptions = {
+  targetPermission: 'interaction.export_interaction',
+  urlFragment: 'interactions',
+  maxItems: 5000,
+  entityName: 'interaction',
+}
+
+describe('#export helper', () => {
+  context('When a user has not got permission to export', () => {
+    beforeEach(() => {
+      const user = {
+        permissions: [],
+      }
+      this.exportAction = buildExportAction(qs.stringify(queryString), user.permissions, exportOptions)
+    })
+
+    it('should return false if the user has not got permission', () => {
+      expect(this.exportAction.enabled).to.equal(false)
+    })
+  })
+
+  context('When a user has permission to export', () => {
+    beforeEach(() => {
+      const user = {
+        permissions: [
+          'interaction.export_interaction',
+        ],
+      }
+      this.exportAction = buildExportAction(qs.stringify(queryString), user.permissions, exportOptions)
+    })
+
+    it('should return true if the user has permission', () => {
+      expect(this.exportAction.enabled).to.equal(true)
+    })
+
+    it('should return a buildMessage function for the macro', () => {
+      expect(this.exportAction.buildMessage).to.be.a('function')
+    })
+
+    it('should return a url for the export link/button', () => {
+      expect(this.exportAction.url).to.equal('interactions/export?sortby=date%3Adesc&custom=true')
+    })
+
+    it('should return a maximum of 5000 results to export', () => {
+      expect(this.exportAction.maxItems).to.equal(5000)
+    })
+
+    it('should return a invalidNumberOfItems function for the macro', () => {
+      expect(this.exportAction.invalidNumberOfItems).to.be.a('function')
+    })
+  })
+})


### PR DESCRIPTION
## Problem
As an investment project team member, I want to download a subset of interactions from the Interactions section of Data Hub so that I can monitor my / my team's performance.

## Solution
* Add a button to enable a user to download the interaction list

* The button should only be enabled once filters have been applied, such that there are fewer than 5,000 results

* The button should not be shown at all to LEP and DA users

![screen shot 2018-11-07 at 09 50 46](https://user-images.githubusercontent.com/10154302/48123762-a65c0e00-e272-11e8-98a6-46b3e3303b39.png)

