### PR TITLE
Pre reqs for refactored address module

### DIFF
--- a/assets/stylesheets/components/_form.scss
+++ b/assets/stylesheets/components/_form.scss
@@ -5,4 +5,5 @@
 @import "form/form-fieldset";
 @import "form/multiple-choice";
 @import "form/entity-search";
+@import "form/previously-selected";
 @import "form/typeahead";

--- a/assets/stylesheets/components/form/_previously-selected.scss
+++ b/assets/stylesheets/components/form/_previously-selected.scss
@@ -1,0 +1,11 @@
+@import "../../settings";
+
+.previously-selected {
+
+  p {
+    font-size: 36px;
+    line-height: 1;
+    margin-bottom: $default-spacing-unit;
+  }
+
+}

--- a/src/apps/addresses/macros/select-uk-address-form.js
+++ b/src/apps/addresses/macros/select-uk-address-form.js
@@ -1,7 +1,41 @@
-module.exports = () => {
+module.exports = ({
+  returnLink,
+  errors = {},
+  state = {},
+  addresses = [],
+  postcode,
+}) => {
   return {
+    returnLink,
     buttonText: 'Continue',
     children: [
+      {
+        macroName: 'PreviouslySelected',
+        label: 'Postcode',
+        value: postcode,
+        url: 'postcode-lookup',
+        name: 'previous_postcode',
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        type: 'radio',
+        name: 'address',
+        label: 'Select an address',
+        options: addresses,
+        validations: [
+          {
+            type: 'required',
+            message: 'Address is required',
+          },
+        ],
+        error: errors.address,
+        value: state.address,
+      },
+      {
+        macroName: 'Link',
+        url: 'manual-uk-address',
+        text: 'I can\'t find the address in the list',
+      },
     ],
   }
 }

--- a/src/apps/addresses/services/lookup.js
+++ b/src/apps/addresses/services/lookup.js
@@ -1,0 +1,58 @@
+const {
+  map,
+  trim,
+  pickBy,
+  isEmpty,
+  isNil,
+  join,
+  compact,
+} = require('lodash')
+const request = require('request-promise')
+
+const config = require('../../../../config')
+const logger = require('../../../../config/logger')
+
+const transformLookupAddressToObject = (address, postcode) => {
+  const addressParts = map(address.split(','), address => trim(address))
+  const parsed = pickBy({
+    postcode,
+    county: isEmpty(addressParts[5]) || isEmpty(addressParts[6]) ? null : addressParts[6],
+    city: isEmpty(addressParts[5]) ? addressParts[6] : addressParts[5],
+    address1: isEmpty(addressParts[2]) ? addressParts[0] : addressParts[0] + ' - ' + addressParts[1],
+    address2: isEmpty(addressParts[2]) ? addressParts[1] : addressParts[2],
+  }, value => !isNil(value) && !isEmpty(value))
+
+  return {
+    ...parsed,
+    id: address,
+    name: transformAddressObjectToSingleLineString(parsed),
+  }
+}
+
+const transformAddressObjectToSingleLineString = (address) => {
+  return join(compact([
+    address.address1,
+    address.address2,
+    address.city,
+    address.county,
+  ]), ', ')
+}
+
+const getAddresses = async (postcode) => {
+  const apiUrl = config.postcodeLookup.baseUrl
+  const apiKey = config.postcodeLookup.apiKey
+  const url = apiUrl.replace('{postcode}', postcode).replace('{api-key}', apiKey)
+
+  try {
+    const response = await request.get(url)
+    const addresses = JSON.parse(response).Addresses
+
+    return map(addresses, (address) => transformLookupAddressToObject(address, postcode))
+  } catch (error) {
+    logger.error(error)
+  }
+}
+
+module.exports = {
+  getAddresses,
+}

--- a/src/modules/form/current-journey.js
+++ b/src/modules/form/current-journey.js
@@ -1,0 +1,13 @@
+const state = require('./state/current')
+
+module.exports = () => {
+  return (req, res, next) => {
+    req.currentJourney = {
+      getField (fieldName) {
+        return state.getField(req.session, res.locals.journey.key, fieldName)
+      },
+    }
+
+    next()
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,7 @@ const i18n = require('i18n-future').middleware()
 
 const title = require('./middleware/title')
 const breadcrumbs = require('./middleware/breadcrumbs')
+const currentJourney = require('./modules/form/current-journey')
 const nunjucks = require('../config/nunjucks')
 const headers = require('./middleware/headers')
 const locals = require('./middleware/locals')
@@ -98,6 +99,8 @@ app.use('/fonts', express.static(path.join(config.buildDir, 'fonts')))
 app.use(title())
 app.use(breadcrumbs.init())
 app.use(breadcrumbs.setHome())
+
+app.use(currentJourney())
 
 app.use(flash())
 

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -1,4 +1,4 @@
-{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, HiddenField, DateFieldset, Typeahead %}
+{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, PreviouslySelected, HiddenField, DateFieldset, Typeahead %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Message, MessageList, Breadcrumbs, Pagination, GlobalNav, LocalNav, Progress, FromNow, AnswersSummary, HiddenContent %}

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -1,4 +1,4 @@
-{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, MultipleChoiceField, PreviouslySelected, HiddenField, DateFieldset, Typeahead %}
+{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, Link, MultipleChoiceField, PreviouslySelected, HiddenField, DateFieldset, Typeahead %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Message, MessageList, Breadcrumbs, Pagination, GlobalNav, LocalNav, Progress, FromNow, AnswersSummary, HiddenContent %}

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -8,6 +8,7 @@
 {% from "./form/hidden-field.njk" import HiddenField %}
 {% from "./form/input.njk" import Input %}
 {% from "./form/multiple-choice-field.njk" import MultipleChoiceField %}
+{% from "./form/previously-selected.njk" import PreviouslySelected %}
 {% from "./form/multi-step-form.njk" import MultiStepForm with context %}
 {% from "./form/select-box.njk" import SelectBox with context %}
 {% from "./form/text-area.njk" import TextArea with context %}
@@ -25,6 +26,7 @@
 {% set Input = Input %}
 {% set MultiStepForm = MultiStepForm %}
 {% set MultipleChoiceField = MultipleChoiceField %}
+{% set PreviouslySelected = PreviouslySelected %}
 {% set SelectBox = SelectBox %}
 {% set TextArea = TextArea %}
 {% set TextField = TextField %}

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -7,6 +7,7 @@
 {% from "./form/form-group.njk" import FormGroup with context %}
 {% from "./form/hidden-field.njk" import HiddenField %}
 {% from "./form/input.njk" import Input %}
+{% from "./form/link.njk" import Link %}
 {% from "./form/multiple-choice-field.njk" import MultipleChoiceField %}
 {% from "./form/previously-selected.njk" import PreviouslySelected %}
 {% from "./form/multi-step-form.njk" import MultiStepForm with context %}
@@ -24,6 +25,7 @@
 {% set FormGroup = FormGroup %}
 {% set HiddenField = HiddenField %}
 {% set Input = Input %}
+{% set Link = Link %}
 {% set MultiStepForm = MultiStepForm %}
 {% set MultipleChoiceField = MultipleChoiceField %}
 {% set PreviouslySelected = PreviouslySelected %}

--- a/src/templates/_macros/form/link.njk
+++ b/src/templates/_macros/form/link.njk
@@ -1,0 +1,15 @@
+{% from "./form-group.njk" import FormGroup %}
+
+{##
+ # Render a link within a form
+ # @param {object} props - An object containing field properties
+ # @param {array} [props.url] - URL for link
+ # @param {array} [props.url] - Text for link
+ #}
+{% macro Link(props) %}
+  <div class="c-form-group">
+    <p>
+      <a href="{{ props.url }}">{{ props.text }}</a>
+    </p>
+  </div>
+{% endmacro %}

--- a/src/templates/_macros/form/previously-selected.njk
+++ b/src/templates/_macros/form/previously-selected.njk
@@ -1,0 +1,18 @@
+{% from "./form-group.njk" import FormGroup %}
+
+{##
+ # Render a field showing a previously selected value and "Change" link
+ # @param {object} props - An object containing field properties
+ # @param {array} [props.value] - previously selected value
+ # @param {array} [props.url] - URL to change selected value
+ #}
+{% macro PreviouslySelected(props) %}
+  {% set fieldId = 'field-' + props.name if props.name %}
+
+  {% call FormGroup(props | assign({ fieldId: fieldId })) %}
+    <div class="previously-selected">
+      <p>{{ props.value }}</p>
+      <a href="{{ props.url }}">Change</a>
+    </div>
+  {% endcall %}
+{% endmacro %}

--- a/test/unit/apps/addresses/services/lookup.test.js
+++ b/test/unit/apps/addresses/services/lookup.test.js
@@ -1,0 +1,121 @@
+describe('Address lookup service', () => {
+  describe('#getAddresses', () => {
+    beforeEach(() => {
+      this.loggerErrorSpy = sinon.spy()
+
+      this.lookup = proxyquire('~/src/apps/addresses/services/lookup.js', {
+        '../../../../config': {
+          postcodeLookup: {
+            baseUrl: 'https://addresses.com/{postcode}?api-key={api-key}',
+            apiKey: 'postcode_key',
+          },
+        },
+        '../../../../config/logger': {
+          error: this.loggerErrorSpy,
+        },
+      })
+    })
+
+    context('Address variation 1', () => {
+      beforeEach(async () => {
+        nock('https://addresses.com')
+          .get('/postcode?api-key=postcode_key')
+          .reply(200, {
+            Addresses: [
+              'zero, one, two, , , five, six',
+            ],
+          })
+
+        this.actual = await this.lookup.getAddresses('postcode')
+      })
+
+      it('should return addresses', () => {
+        expect(this.actual).to.deep.equal([
+          {
+            postcode: 'postcode',
+            county: 'six',
+            city: 'five',
+            address1: 'zero - one',
+            address2: 'two',
+            id: 'zero, one, two, , , five, six',
+            name: 'zero - one, two, five, six',
+          },
+        ])
+      })
+    })
+
+    context('Address variation 2', () => {
+      beforeEach(async () => {
+        nock('https://addresses.com')
+          .get('/postcode?api-key=postcode_key')
+          .reply(200, {
+            Addresses: [
+              'zero, one, two, , , , ',
+            ],
+          })
+
+        this.actual = await this.lookup.getAddresses('postcode')
+      })
+
+      it('should return addresses', () => {
+        expect(this.actual).to.deep.equal([
+          {
+            postcode: 'postcode',
+            address1: 'zero - one',
+            address2: 'two',
+            id: 'zero, one, two, , , , ',
+            name: 'zero - one, two',
+          },
+        ])
+      })
+    })
+
+    context('Address variation 3', () => {
+      beforeEach(async () => {
+        nock('https://addresses.com')
+          .get('/postcode?api-key=postcode_key')
+          .reply(200, {
+            Addresses: [
+              'zero, one, , , , five, ',
+            ],
+          })
+
+        this.actual = await this.lookup.getAddresses('postcode')
+      })
+
+      it('should return addresses', () => {
+        expect(this.actual).to.deep.equal([
+          {
+            postcode: 'postcode',
+            city: 'five',
+            address1: 'zero',
+            address2: 'one',
+            id: 'zero, one, , , , five, ',
+            name: 'zero, one, five',
+          },
+        ])
+      })
+    })
+
+    context('when the lookup API responds with an error', () => {
+      beforeEach(async () => {
+        nock('https://addresses.com')
+          .get('/postcode?api-key=postcode_key')
+          .reply(500, 'Error message')
+
+        this.actual = await this.lookup.getAddresses('postcode')
+      })
+
+      it('should not return addresses', () => {
+        expect(this.actual).to.be.undefined
+      })
+
+      it('should log an error', () => {
+        expect(this.loggerErrorSpy).to.have.been.calledOnce
+        expect(this.loggerErrorSpy).to.have.been.calledWith(sinon.match({
+          message: '500 - "Error message"',
+        }))
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/xG2aQSQn/317-tidy-up-address-module-work

This pull request includes several small changes as follows:
- introduction of `current-journey` application level middleware which will allow `req.currentJourney.getField('field_name')` on validated journeys
- a refactored address lookup service (there will be another PR to deprecate the old code)
- a previously selected macro for use within multi step forms so the user can see what they selected in a previous step
- a link macro for manually browsing to another form step

![screenshot 2018-11-14 at 16 52 36](https://user-images.githubusercontent.com/1150417/48499696-ea31b300-e830-11e8-8f70-ebb2d3b3297f.png)
