### PR TITLE
 Run Celery during acceptance tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,7 @@ aliases:
       SSO_ENABLED: 'True'
       RESOURCE_SERVER_INTROSPECTION_URL: http://localhost:8080/o/introspect  # required but not used as user with token has been created in backend setup script
       RESOURCE_SERVER_AUTH_TOKEN: sso-token
+      WEB_CONCURRENCY: 2
       ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
       ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
       TZ: "/usr/share/zoneinfo/Europe/London"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ aliases:
       CDMS_AUTH_URL: http://example.com
       DATABASE_URL: postgresql://postgres@postgres/datahub
       DATAHUB_SECRET: secret
-      DEBUG: 'True'
+      DEBUG: 'False'
       DEFAULT_BUCKET: baz
       DJANGO_SECRET_KEY: topSecret
       DJANGO_SETTINGS_MODULE: config.settings.local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,9 +121,8 @@ aliases:
       - MOCK_SSO_SCOPE: 'data-hub:internal-front-end'
 
   # Data hub backend
-  - &docker_data_hub_backend
+  - &docker_data_hub_backend_base
     image: ukti/data-hub-leeloo
-    command: ./setup-uat.sh
     environment:
       AWS_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: foo
@@ -138,12 +137,25 @@ aliases:
       ES_INDEX_PREFIX: test_index
       ES5_URL: http://localhost:9200
       POSTGRES_URL: tcp://postgres:5432
+      REDIS_BASE_URL: redis://localhost:6379
+      REDIS_CACHE_DB: 5
+      REDIS_CELERY_DB: 6
       SSO_ENABLED: 'True'
       RESOURCE_SERVER_INTROSPECTION_URL: http://localhost:8080/o/introspect  # required but not used as user with token has been created in backend setup script
       RESOURCE_SERVER_AUTH_TOKEN: sso-token
       ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
       ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
       TZ: "/usr/share/zoneinfo/Europe/London"
+
+  - &docker_data_hub_backend_api
+    <<: *docker_data_hub_backend_base
+    command: ./setup-uat.sh
+
+  - &docker_data_hub_backend_celery
+    <<: *docker_data_hub_backend_base
+    # Note: By default Celery will default to the number of CPU cores, which can be a large number on CircleCI like 36
+    # which then ends up causing out-of-memory errors
+    command: celery worker -A config -l info -Q celery,long-running --concurrency 3
 
   # Non master branch Common workflow config
   - &common_at_workflow_config
@@ -269,7 +281,8 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - *docker_data_hub_backend
+      - *docker_data_hub_backend_api
+      - *docker_data_hub_backend_celery
     parallelism: 6
     steps:
       - checkout
@@ -319,7 +332,8 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - *docker_data_hub_backend
+      - *docker_data_hub_backend_api
+      - *docker_data_hub_backend_celery
     steps:
       - checkout
       - *wait_for_backend
@@ -348,7 +362,8 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - *docker_data_hub_backend
+      - *docker_data_hub_backend_api
+      - *docker_data_hub_backend_celery
     steps:
       - checkout
       - *wait_for_backend
@@ -377,7 +392,8 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - *docker_data_hub_backend
+      - *docker_data_hub_backend_api
+      - *docker_data_hub_backend_celery
     steps:
       - checkout
       - *wait_for_backend
@@ -403,7 +419,9 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - <<: *docker_data_hub_backend
+      - <<: *docker_data_hub_backend_api
+        image: ukti/data-hub-leeloo:master
+      - <<: *docker_data_hub_backend_celery
         image: ukti/data-hub-leeloo:master
 
   # Run acceptance tests for LEP staff using the master version of the backend
@@ -418,7 +436,9 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - <<: *docker_data_hub_backend
+      - <<: *docker_data_hub_backend_api
+        image: ukti/data-hub-leeloo:master
+      - <<: *docker_data_hub_backend_celery
         image: ukti/data-hub-leeloo:master
 
   # Run acceptance tests for DA staff using the master version of the backend
@@ -433,7 +453,9 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - <<: *docker_data_hub_backend
+      - <<: *docker_data_hub_backend_api
+        image: ukti/data-hub-leeloo:master
+      - <<: *docker_data_hub_backend_celery
         image: ukti/data-hub-leeloo:master
 
   # Run acceptance tests for Policy staff using the master version of the backend
@@ -448,7 +470,9 @@ jobs:
       - *docker_elasticsearch
       - *docker_postgres
       - *docker_mock_sso
-      - <<: *docker_data_hub_backend
+      - <<: *docker_data_hub_backend_api
+        image: ukti/data-hub-leeloo:master
+      - <<: *docker_data_hub_backend_celery
         image: ukti/data-hub-leeloo:master
 
 # CircleCi workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,9 +127,7 @@ aliases:
       AWS_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: foo
       AWS_SECRET_ACCESS_KEY: bar
-      CDMS_AUTH_URL: http://example.com
       DATABASE_URL: postgresql://postgres@postgres/datahub
-      DATAHUB_SECRET: secret
       DEBUG: 'False'
       DEFAULT_BUCKET: baz
       DJANGO_SECRET_KEY: topSecret

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ aliases:
       DEFAULT_BUCKET: baz
       DJANGO_SECRET_KEY: topSecret
       DJANGO_SETTINGS_MODULE: config.settings.local
+      ENABLE_CELERY_ES_SYNC_OBJECT: 'True'
       ES_INDEX_PREFIX: test_index
       ES5_URL: http://localhost:9200
       POSTGRES_URL: tcp://postgres:5432


### PR DESCRIPTION
This runs Celery with the API when running the acceptance tests on CircleCI. (The other option is to force triggered Celery tasks to run synchronously, but that would be less realistic.)