### PR TITLE
Hide/show Global Account Manager - One List section

### DIFF
--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -28,18 +28,20 @@
     <p><a href="/companies/add/{{company.company_number}}" class="button">Add company</a></p>
   {% endif %}
 
-  <div class="section">
-    <h2 class="heading-medium">Global Account Manager – One List</h2>
-    {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
+  {% if company.classification %}
+    <div class="section">
+      <h2 class="heading-medium">Global Account Manager – One List</h2>
+      {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
 
-    {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
-      {% call Message({ type: 'muted' }) %}
-        If you need to change the One List tier or Global Account Manager for this company,
-        go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
-        or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+      {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
+        {% call Message({ type: 'muted' }) %}
+          If you need to change the One List tier or Global Account Manager for this company,
+          go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
+          or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+        {% endcall %}
       {% endcall %}
-    {% endcall %}
-  </div>
+    </div>
+  {% endif %}
 
   {% if company.id and not company.archived %}
     <h2 class="heading-medium">Archive company</h2>

--- a/test/acceptance/features/companies/details.feature
+++ b/test/acceptance/features/companies/details.feature
@@ -1,0 +1,41 @@
+@companies-details
+Feature: Company details
+
+  @companies-details--ghq-one-list
+  Scenario: View details for a GHQ on the One List
+
+    When I navigate to the `companies.details` page using `company` `One List Corp` fixture
+    Then the Company summary key value details are not displayed
+    And the Global headquarters summary key value details are displayed
+      | key                       | value                        |
+      | Business type             | company.businessType         |
+      | Primary address           | company.primaryAddress       |
+      | Headquarter type          | company.headquarterType      |
+      | Sector                    | company.sector               |
+      | Business description      | company.description          |
+      | Number of employees       | company.employeeRange        |
+      | Annual turnover           | company.turnoverRange        |
+      | Country                   | company.country              |
+    And the Global Account Manager – One List key value details are displayed
+      | key                       | value                        |
+      | One List tier             | company.oneListTier          |
+      | Global Account Manager    | company.globalAccountManager |
+
+
+  @companies-details--subsidiary-company-no-one-list
+  Scenario: View details for a company not on the One List
+
+    When I navigate to the `companies.details` page using `company` `Mars Exports Ltd` fixture
+    Then the Company summary key value details are displayed
+      | key                       | value                        |
+      | Business type             | company.businessType         |
+      | Primary address           | company.primaryAddress       |
+      | Headquarter type          | company.headquarterType      |
+      | Global HQ                 | company.globalHeadquarters   |
+      | Sector                    | company.sector               |
+      | Business description      | company.description          |
+      | Number of employees       | company.employeeRange        |
+      | Annual turnover           | company.turnoverRange        |
+      | Country                   | company.country              |
+    And the Global headquarters summary key value details are not displayed
+    And the Global Account Manager – One List key value details are not displayed

--- a/test/acceptance/features/companies/save.feature
+++ b/test/acceptance/features/companies/save.feature
@@ -19,15 +19,11 @@ Feature: Create a new company
       | UK region                 | company.ukRegion           |
       | Headquarter type          | company.headquarterType    |
       | Global HQ                 | company.globalHeadquarters |
-      | Sector                    | company.sector    |
+      | Sector                    | company.sector             |
       | Website                   | company.website            |
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global Account Manager – One List key value details are displayed
-      | key                       | value                      |
-      | One List tier             | None                       |
-      | Global Account Manager    | None                       |
 
   @companies-save--uk-non-private-or-non-public-ltd-company
   Scenario: Create a UK non-private or non-public limited company
@@ -43,15 +39,11 @@ Feature: Create a new company
       | UK region                 | company.ukRegion           |
       | Headquarter type          | company.headquarterType    |
       | Global HQ                 | company.globalHeadquarters |
-      | Sector                    | company.sector    |
+      | Sector                    | company.sector             |
       | Website                   | company.website            |
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global Account Manager – One List key value details are displayed
-      | key                       | value                      |
-      | One List tier             | None                       |
-      | Global Account Manager    | None                       |
 
   @companies-save--foreign
   Scenario: Create a foreign company
@@ -66,16 +58,12 @@ Feature: Create a new company
       | Primary address           | company.primaryAddress           |
       | Headquarter type          | company.headquarterType          |
       | Global HQ                 | company.globalHeadquarters       |
-      | Sector                    | company.sector          |
+      | Sector                    | company.sector                   |
       | Website                   | company.website                  |
       | Business description      | company.description              |
       | Number of employees       | company.employeeRange            |
       | Annual turnover           | company.turnoverRange            |
       | Country                   | company.registeredAddressCountry |
-    And the Global Account Manager – One List key value details are displayed
-      | key                       | value                            |
-      | One List tier             | None                             |
-      | Global Account Manager    | None                             |
 
   @companies-save--foreign-uk-branch
   Scenario: Create a UK branch of a foreign company
@@ -91,12 +79,8 @@ Feature: Create a new company
       | UK region                 | company.ukRegion           |
       | Headquarter type          | company.headquarterType    |
       | Global HQ                 | company.globalHeadquarters |
-      | Sector                    | company.sector    |
+      | Sector                    | company.sector             |
       | Website                   | company.website            |
       | Business description      | company.description        |
       | Number of employees       | company.employeeRange      |
       | Annual turnover           | company.turnoverRange      |
-    And the Global Account Manager – One List key value details are displayed
-      | key                       | value                      |
-      | One List tier             | None                       |
-      | Global Account Manager    | None                       |

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -156,6 +156,15 @@ Then(/^the (.+) key value details are displayed$/, async function (tableTitle, d
   await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
 })
 
+Then(/^the (.+) key value details are not displayed$/, async function (tableTitle) {
+  const tableSelector = Details.getSelectorForKeyValueTable(tableTitle)
+
+  await Details
+    .api.useXpath()
+    .assert.elementNotPresent(tableSelector.selector)
+    .useCss()
+})
+
 Then(/^the key value details are displayed$/, async function (dataTable) {
   const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
   const tableSelector = Details.getSelectorForKeyValueTable()

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -35,6 +35,14 @@ module.exports = {
       town: 'New York',
       postcode: '765413',
       country: 'United States',
+      primaryAddress: '12 First Street, New York, 765413, United States',
+      businessType: 'Partnership',
+      headquarterType: 'Not a headquarters',
+      globalHeadquarters: 'Link the Global HQ',
+      sector: 'Retail',
+      description: 'This is a dummy company for testing',
+      employeeRange: '500+',
+      turnoverRange: '£33.5M+',
     },
     ukLtd: {
       id: '0f5216e0-849f-11e6-ae22-56b6b6499611',
@@ -50,7 +58,7 @@ module.exports = {
       description: 'This is a dummy company for testing',
       referenceCode: 'ORG-10096257',
     },
-    oneList: {
+    oneListCorp: {
       id: '375094ac-f79a-43e5-9c88-059a7caa17f0',
       name: 'One List Corp',
       address1: '12 St George\'s Road',
@@ -64,6 +72,8 @@ module.exports = {
       description: 'This is a dummy company for testing the One List',
       employeeRange: '500+',
       turnoverRange: '£33.5M+',
+      oneListTier: 'Tier A - Strategic Account',
+      globalAccountManager: 'Travis Greene',
     },
     archived: {
       id: '346f78a5-1d23-4213-b4c2-bf48246a13c3',


### PR DESCRIPTION
https://trello.com/c/SL0tSVdG/387-only-show-global-account-manager-section-if-a-company-is-on-the-onelist

## Included in this change
- Show `Global Account Manager - One List` section for GHQ companies on the One List
- Do not show `Global Account Manager - One List` section for companies not on the One List

## Not included in this change
- Subsidiaries of parent companies that are on the One List should show the `Global Account Manager - One List` section (another PR will follow)

## Example of GHQ on the One List
<img width="509" alt="screenshot 2018-11-20 at 13 29 34" src="https://user-images.githubusercontent.com/1150417/48777508-a45e6a00-ecca-11e8-8b2b-b6269586b0a1.png">

## Example of company not on the One List
<img width="525" alt="screenshot 2018-11-20 at 13 30 16" src="https://user-images.githubusercontent.com/1150417/48777523-ab857800-ecca-11e8-81e7-d48a42fa4c0c.png">
