### PR TITLE
Add "See all advisers on the core team" link

### DIFF
--- a/src/apps/companies/views/details.njk
+++ b/src/apps/companies/views/details.njk
@@ -33,13 +33,21 @@
       <h2 class="heading-medium">Global Account Manager – One List</h2>
       {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
 
-      {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
-        {% call Message({ type: 'muted' }) %}
-          If you need to change the One List tier or Global Account Manager for this company,
-          go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
-          or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+      {# when the "companies-advisers" flag check is removed then the HiddenContent block should also be removed #}
+      {% if features['companies-advisers'] %}
+        <p>
+          <a href="advisers">See all advisers on the core team</a>
+        </p>
+      {% else %}
+        {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
+          {% call Message({ type: 'muted' }) %}
+            If you need to change the One List tier or Global Account Manager for this company,
+            go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
+            or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+          {% endcall %}
         {% endcall %}
-      {% endcall %}
+      {% endif %}
+
     </div>
   {% endif %}
 

--- a/test/acceptance/features/companies/details.feature
+++ b/test/acceptance/features/companies/details.feature
@@ -20,6 +20,7 @@ Feature: Company details
       | key                       | value                        |
       | One List tier             | company.oneListTier          |
       | Global Account Manager    | company.globalAccountManager |
+    And I should see the "See all advisers on the core team" link
 
 
   @companies-details--subsidiary-company-no-one-list
@@ -39,3 +40,4 @@ Feature: Company details
       | Country                   | company.country              |
     And the Global headquarters summary key value details are not displayed
     And the Global Account Manager – One List key value details are not displayed
+    And I should not see the "See all advisers on the core team" link


### PR DESCRIPTION
https://trello.com/c/Csv7MkLW/408-add-core-team-link-from-company-details-page

This change covers two scenarios:
1. `See all advisers on the core team` link should be shown for GHQ when on the One List and the `companies-advisers` feature flag is enabled
2. `See all advisers on the core team` link should not be shown for company that is not on the One List

Not covered in this change:
- `See all advisers on the core team` should be shown for subsidiaries of a parent company on the One List (there will be a follow up PR)

## Example of GHQ on the One List
<img width="697" alt="screenshot 2018-11-20 at 15 10 49" src="https://user-images.githubusercontent.com/1150417/48782701-ac240b80-ecd6-11e8-907b-27fb6a8a31c4.png">

## Example of company not on the One List
<img width="681" alt="screenshot 2018-11-20 at 15 11 01" src="https://user-images.githubusercontent.com/1150417/48782731-bc3beb00-ecd6-11e8-87d5-e8acc955274b.png">

