### PR TITLE
Reuse link assertion steps for Documents link

### DIFF
--- a/test/acceptance/features/companies/documents.feature
+++ b/test/acceptance/features/companies/documents.feature
@@ -4,12 +4,12 @@ Feature: Company documents
   @companies-documents--document-link
   Scenario: Company has documents
     When I navigate to the `companies.documents` page using `company` `Venus Ltd` fixture
-    Then view should contain the Documents link
+    Then I should see the "View files and documents" link
 
   @companies-documents--no-document-link
   Scenario: Company does not have documents
     When I navigate to the `companies.documents` page using `company` `Lambda plc` fixture
-    Then view should not contain the Documents link
+    Then I should not see the "View files and documents" link
 
   @companies-documents--lep @lep
   Scenario: Navigate to documents as LEP

--- a/test/acceptance/features/contacts/documents.feature
+++ b/test/acceptance/features/contacts/documents.feature
@@ -4,12 +4,12 @@ Feature: Contact details
   @contact-documents--link
   Scenario: Contact has Documents link
     When I navigate to the `contacts.documents` page using `contact` `Johnny Cakeman` fixture
-    Then view should contain the Documents link
+    Then I should see the "View files and documents" link
 
   @contact-documents--no-documents-link
   Scenario: Contact does not have Documents link
     When I navigate to the `contacts.documents` page using `contact` `Georgina Clark` fixture
-    Then view should not contain the Documents link
+    Then I should not see the "View files and documents" link
 
   @contact-documents--lep @lep
   Scenario: Navigate to documents as LEP

--- a/test/acceptance/features/interactions/step_definitions/details.js
+++ b/test/acceptance/features/interactions/step_definitions/details.js
@@ -3,18 +3,6 @@ const { Then } = require('cucumber')
 
 const Interaction = client.page.interactions.interaction()
 
-Then(/^the interaction details Documents link is displayed$/, async function () {
-  await Interaction
-    .section.details
-    .assert.visible('@documentsLink')
-})
-
-Then(/^the interaction details Documents link is not displayed$/, async function () {
-  await Interaction
-    .section.details
-    .assert.elementNotPresent('@documentsLink')
-})
-
 Then('I see the service delivery details', async function () {
   const button = Interaction.getButtonSelectorWithText('Edit service delivery')
 

--- a/test/acceptance/features/investment-projects/documents.feature
+++ b/test/acceptance/features/investment-projects/documents.feature
@@ -4,12 +4,12 @@ Feature: Investment project documents
   @investment-projects-documents--document-link
   Scenario: Investment project has documents
     When I navigate to the `investments.documents` page using `investment project` `New hotel (commitment to invest)` fixture
-    Then view should contain the Documents link
+    Then I should see the "View files and documents" link
 
   @investment-projects-documents--no-document-link
   Scenario: Investment project does not have documents
     When I navigate to the `investments.documents` page using `investment project` `New rollercoaster` fixture
-    Then view should not contain the Documents link
+    Then I should not see the "View files and documents" link
 
   @investment-projects-documents--lep @lep
   Scenario: Navigate to documents as LEP

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -140,14 +140,6 @@ Then(/^there should not be a local nav$/, async () => {
     .assert.elementNotPresent('@localNav')
 })
 
-Then(/^view should (not\s?)?contain the Documents link$/, async (noDocumentsLink) => {
-  const tag = noDocumentsLink ? '@noDocumentsMessage' : '@documentsLink'
-
-  await Details
-    .waitForElementPresent(tag)
-    .assert.visible(tag)
-})
-
 Then(/^the (.+) key value details are displayed$/, async function (tableTitle, dataTable) {
   const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
   const tableSelector = Details.getSelectorForKeyValueTable(tableTitle)

--- a/test/acceptance/pages/details.js
+++ b/test/acceptance/pages/details.js
@@ -19,11 +19,6 @@ module.exports = {
     heading: '.c-local-header__heading',
     contentHeading: '.heading-medium',
     localNav: '.c-local-nav',
-    documentsLink: {
-      selector: '//a[contains(.,"View files and documents")][contains(@aria-labelledby,"external-link-label")]',
-      locateStrategy: 'xpath',
-    },
-    noDocumentsMessage: getSelectorForElementWithText('There are no files or documents', { el: '//article//p' }),
   },
   commands: [
     {

--- a/test/acceptance/pages/events/event.js
+++ b/test/acceptance/pages/events/event.js
@@ -2,7 +2,7 @@ const faker = require('faker')
 const { addWeeks, format } = require('date-fns')
 const { get, camelCase, isNull, pickBy, keys, assign } = require('lodash')
 
-const { getButtonWithText, getLinkWithText } = require('../../helpers/selectors')
+const { getButtonWithText } = require('../../helpers/selectors')
 const { getDateFor } = require('../../helpers/date')
 const { appendUid, getUid } = require('../../helpers/uuid')
 
@@ -148,12 +148,4 @@ module.exports = {
       },
     },
   ],
-  sections: {
-    details: {
-      selector: '.table--key-value',
-      elements: {
-        documentsLink: getLinkWithText('Documents'),
-      },
-    },
-  },
 }

--- a/test/acceptance/pages/interactions/interaction.js
+++ b/test/acceptance/pages/interactions/interaction.js
@@ -4,7 +4,6 @@ const { assign, forEach, keys } = require('lodash')
 const {
   getSelectorForElementWithText,
   getButtonWithText,
-  getLinkWithText,
 } = require('../../helpers/selectors')
 const { generateFutureDate } = require('../../helpers/date')
 const { appendUid } = require('../../helpers/uuid')
@@ -188,12 +187,4 @@ module.exports = {
       },
     },
   ],
-  sections: {
-    details: {
-      selector: '.table--key-value',
-      elements: {
-        documentsLink: getLinkWithText('Documents'),
-      },
-    },
-  },
 }


### PR DESCRIPTION
This is just a tidy up of existing code as it was not reusing steps that are convenient for asserting links.