### PR TITLE
Show the name, team and region or country in the Global Account Manager section

### DIFF
--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -1,18 +1,23 @@
+const { find } = require('lodash')
+
 const config = require('../../../../config')
 const {
   transformCompanyToView,
   transformCompaniesHouseToView,
   transformCompanyToOneListView,
 } = require('../transformers')
+const { getOneListGroupCoreTeam } = require('../repos')
 
-function renderDetails (req, res) {
+async function renderDetails (req, res) {
   const company = res.locals.company
+  const coreTeam = await getOneListGroupCoreTeam(req.session.token, company.id)
+  const globalAccountManager = find(coreTeam, adviser => adviser.is_global_account_manager)
 
   res
     .breadcrumb(company.name)
     .render('companies/views/details', {
       companyDetails: transformCompanyToView(company),
-      accountManagementDetails: transformCompanyToOneListView(company),
+      accountManagementDetails: transformCompanyToOneListView(company, globalAccountManager),
       chDetails: company.companies_house_data ? transformCompaniesHouseToView(company.companies_house_data) : null,
       oneListEmail: config.oneList.email,
     })

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -111,6 +111,12 @@ function getCoreTeam (token, companyId) {
   })
 }
 
+function getOneListGroupCoreTeam (token, companyId) {
+  return authorisedRequest(token, {
+    url: `${config.apiRoot}/v3/company/${companyId}/one-list-group-core-team`,
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
@@ -122,4 +128,5 @@ module.exports = {
   getCompanyTimeline,
   getCompanySubsidiaries,
   getCoreTeam,
+  getOneListGroupCoreTeam,
 }

--- a/src/apps/companies/transformers/company-to-one-list-view.js
+++ b/src/apps/companies/transformers/company-to-one-list-view.js
@@ -1,13 +1,27 @@
 /* eslint-disable camelcase */
-const { get } = require('lodash')
+const { get, compact } = require('lodash')
 
 const { getDataLabels } = require('../../../lib/controller-utils')
 const { accountManagementDisplayLabels } = require('../labels')
 
-module.exports = function transformCompanyToOneListView ({ one_list_account_owner, classification }) {
+const NONE_TEXT = 'None'
+
+const transformOneListAccountOwner = (globalAccountManager) => {
+  const region = get(globalAccountManager, 'adviser.dit_team.uk_region.name')
+  const country = get(globalAccountManager, 'adviser.dit_team.country.name')
+  const items = compact([
+    get(globalAccountManager, 'adviser.name'),
+    get(globalAccountManager, 'adviser.dit_team.name'),
+    region || country,
+  ])
+
+  return items.length ? items : NONE_TEXT
+}
+
+module.exports = function transformCompanyToOneListView (company, globalAccountManager) {
   const viewRecord = {
-    one_list_account_owner: get(one_list_account_owner, 'name', 'None'),
-    one_list_tier: get(classification, 'name', 'None'),
+    one_list_account_owner: transformOneListAccountOwner(globalAccountManager),
+    one_list_tier: get(company, 'one_list_group_tier.name', NONE_TEXT),
   }
 
   return getDataLabels(viewRecord, accountManagementDisplayLabels)

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -48,7 +48,7 @@
                      {% endif %}
                   </li>
                  {% else %}
-                   <li>{{ item }}{{ "," if not loop.last }}</li>
+                   <li>{{ item }}</li>
                  {% endif %}
                {% endfor %}
               </ul>

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -73,7 +73,7 @@ module.exports = {
       employeeRange: '500+',
       turnoverRange: '£33.5M+',
       oneListTier: 'Tier A - Strategic Account',
-      globalAccountManager: 'Travis Greene',
+      globalAccountManager: 'Travis Greene\nIST - Sector Advisory Services\nLondon',
     },
     archived: {
       id: '346f78a5-1d23-4213-b4c2-bf48246a13c3',

--- a/test/unit/apps/companies/controllers/details.test.js
+++ b/test/unit/apps/companies/controllers/details.test.js
@@ -1,7 +1,9 @@
-const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
-const config = require('~/config')
-const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
 const { renderDetails } = require('~/src/apps/companies/controllers/details')
+
+const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
+const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
+const oneListGroupCoreTeam = require('~/test/unit/data/companies/one-list-group-core-team.json')
+const config = require('~/config')
 
 describe('Companies details controller', () => {
   beforeEach(() => {
@@ -19,13 +21,18 @@ describe('Companies details controller', () => {
       breadcrumb: sinon.stub().returnsThis(),
       render: sinon.stub(),
     }
+
+    nock(config.apiRoot)
+      .get(`/v3/company/${minimalCompany.id}/one-list-group-core-team`)
+      .reply(200, oneListGroupCoreTeam)
   })
 
   describe('#renderDetails', () => {
     context('when the company contains companes house data', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         this.res.locals.company = companiesHouseCompany
-        renderDetails(this.req, this.res, this.next)
+
+        await renderDetails(this.req, this.res, this.next)
       })
 
       it('should render the correct template', () => {
@@ -36,6 +43,11 @@ describe('Companies details controller', () => {
       it('should include company details', () => {
         const options = this.res.render.firstCall.args[1]
         expect(options.companyDetails).to.not.be.null
+      })
+
+      it('should include account management details', () => {
+        const options = this.res.render.firstCall.args[1]
+        expect(options.accountManagementDetails).to.not.be.null
       })
 
       it('should include companies house details', () => {
@@ -55,9 +67,10 @@ describe('Companies details controller', () => {
     })
 
     context('when the company has no companies house data', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         this.res.locals.company = minimalCompany
-        renderDetails(this.req, this.res, this.next)
+
+        await renderDetails(this.req, this.res, this.next)
       })
 
       it('should render the correct template', () => {
@@ -70,7 +83,12 @@ describe('Companies details controller', () => {
         expect(options.companyDetails).to.not.be.null
       })
 
-      it('should include companies house details', () => {
+      it('should include account management details', () => {
+        const options = this.res.render.firstCall.args[1]
+        expect(options.accountManagementDetails).to.not.be.null
+      })
+
+      it('should not include companies house details', () => {
         const options = this.res.render.firstCall.args[1]
         expect(options.chDetails).to.be.null
       })

--- a/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
@@ -1,48 +1,84 @@
-const { assign } = require('lodash')
+const { find, set } = require('lodash')
 
-const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
 const transformCompanyToOneListView = require('~/src/apps/companies/transformers/company-to-one-list-view')
 
-describe('transformCompanyToOneListView', () => {
-  context('when there is one list information', () => {
-    beforeEach(() => {
-      const company = assign({}, minimalCompany, {
-        one_list_account_owner: null,
-        classification: null,
-      })
+const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
+const oneListGroupCoreTeam = require('~/test/unit/data/companies/one-list-group-core-team.json')
 
-      this.viewRecord = transformCompanyToOneListView(company)
+describe('transformCompanyToOneListView', () => {
+  context('when One List tier and Global Account Manager information exists', () => {
+    beforeEach(() => {
+      const company = {
+        ...minimalCompany,
+        one_list_group_tier: {
+          name: 'Tier A - Strategic Account',
+          id: 'b91bf800-8d53-e311-aef3-441ea13961e2',
+        },
+      }
+
+      const globalAccountManager = find(oneListGroupCoreTeam, adviser => adviser.is_global_account_manager)
+
+      this.actual = transformCompanyToOneListView(company, globalAccountManager)
     })
 
-    it('indicate there is no one list account management information', () => {
-      expect(this.viewRecord).to.deep.equal({
-        'Global Account Manager': 'None',
-        'One List tier': 'None',
-      })
+    it('should set the One List tier', () => {
+      expect(this.actual['One List tier']).to.equal('Tier A - Strategic Account')
+    })
+
+    it('should set the Global Account Manager', () => {
+      const expected = [
+        'Travis Greene',
+        'IST - Sector Advisory Services',
+        'London',
+      ]
+
+      expect(this.actual['Global Account Manager']).to.deep.equal(expected)
     })
   })
 
-  context('when there is no one list information', () => {
+  context('when One List tier and Global Account Manager information exists', () => {
     beforeEach(() => {
-      const company = assign({}, minimalCompany, {
-        one_list_account_owner: {
-          id: '1234',
-          name: 'The owner',
-        },
-        classification: {
-          id: '4321',
-          name: 'The classification',
-        },
-      })
+      const company = {
+        ...minimalCompany,
+        one_list_group_tier: null,
+      }
 
-      this.viewRecord = transformCompanyToOneListView(company)
+      const globalAccountManager = undefined
+
+      this.actual = transformCompanyToOneListView(company, globalAccountManager)
     })
 
-    it('indicate there is no one list account management information', () => {
-      expect(this.viewRecord).to.deep.equal({
-        'Global Account Manager': 'The owner',
-        'One List tier': 'The classification',
-      })
+    it('should set the One List tier to None', () => {
+      expect(this.actual['One List tier']).to.equal('None')
+    })
+
+    it('should set the Global Account Manager to None', () => {
+      expect(this.actual['Global Account Manager']).to.equal('None')
+    })
+  })
+
+  context('when Global Account Manager if from outside UK', () => {
+    beforeEach(() => {
+      const company = {
+        ...minimalCompany,
+        one_list_group_tier: null,
+      }
+
+      const globalAccountManager = find(oneListGroupCoreTeam, adviser => adviser.is_global_account_manager)
+      set(globalAccountManager, 'adviser.dit_team.uk_region', null)
+      set(globalAccountManager, 'adviser.dit_team.country', { name: 'France' })
+
+      this.actual = transformCompanyToOneListView(company, globalAccountManager)
+    })
+
+    it('set the Global Account Manager', () => {
+      const expected = [
+        'Travis Greene',
+        'IST - Sector Advisory Services',
+        'France',
+      ]
+
+      expect(this.actual['Global Account Manager']).to.deep.equal(expected)
     })
   })
 })

--- a/test/unit/data/companies/one-list-group-core-team.json
+++ b/test/unit/data/companies/one-list-group-core-team.json
@@ -1,0 +1,65 @@
+[
+  {
+    "adviser": {
+      "name": "Travis Greene",
+      "first_name": "Travis",
+      "last_name": "Greene",
+      "dit_team": {
+        "name": "IST - Sector Advisory Services",
+        "uk_region": {
+          "name": "London",
+          "id": "874cd12a-6095-e211-a939-e4115bead28a"
+        },
+        "country": {
+          "name": "United Kingdom",
+          "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+        },
+        "id": "fc3a6667-cfe9-e511-8ffa-e4115bead28a"
+      },
+      "id": "8eefe6b4-2816-4e47-94b5-a13409dcef70"
+    },
+    "is_global_account_manager": true
+  },
+  {
+    "adviser": {
+      "name": "Holly Collins",
+      "first_name": "Holly",
+      "last_name": "Collins",
+      "dit_team": {
+        "name": "Heart of the South West LEP",
+        "uk_region": {
+          "name": "South West",
+          "id": "894cd12a-6095-e211-a939-e4115bead28a"
+        },
+        "country": {
+          "name": "United Kingdom",
+          "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+        },
+        "id": "08d987f8-6525-e511-b6bc-e4115bead28a"
+      },
+      "id": "379f390a-e083-4a2c-9cea-e3b9a08606a7"
+    },
+    "is_global_account_manager": false
+  },
+  {
+    "adviser": {
+      "name": "Jenny Carey",
+      "first_name": "Jenny",
+      "last_name": "Carey",
+      "dit_team": {
+        "name": "IG - Specialists - Knowledge Intensive Industry",
+        "uk_region": {
+          "name": "London",
+          "id": "874cd12a-6095-e211-a939-e4115bead28a"
+        },
+        "country": {
+          "name": "United Kingdom",
+          "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+        },
+        "id": "c833d869-2f50-e311-a56a-e4115bead28a"
+      },
+      "id": "f1eb4363-0a37-4344-bd96-e90abeaf483e"
+    },
+    "is_global_account_manager": false
+  }
+]


### PR DESCRIPTION
https://trello.com/c/45vxGxly/388-in-the-global-account-manager-section-show-the-name-team-and-region-or-country

This changes adds `team`, `region` or `country` to the `Global Account Manager - One List` section of the company details screen.

## Before
![screenshot 2018-11-22 at 16 13 06](https://user-images.githubusercontent.com/1150417/48913901-b595ab00-ee71-11e8-89f9-df373f5b1d15.png)

## After
![screenshot 2018-11-22 at 16 13 34](https://user-images.githubusercontent.com/1150417/48913907-bb8b8c00-ee71-11e8-98a7-53bcf3d6167e.png)