### PR TITLE
Remove nowrap style

### DIFF
--- a/assets/stylesheets/components/form/_typeahead.scss
+++ b/assets/stylesheets/components/form/_typeahead.scss
@@ -42,8 +42,9 @@
 
 .multiselect__option {
   border-bottom: 1px solid $grey-2;
-  overflow: hidden;
+  white-space: normal;
   width: 100%;
+  line-height: 24px;
 
   .highlight {
     font-weight: 600;


### PR DESCRIPTION
## Problem
Search results are hidden due to no-wrapping being applied on the styling
![screen shot 2018-11-29 at 12 34 22](https://user-images.githubusercontent.com/10154302/49222513-fa6e9400-f3d3-11e8-96c8-bfd6c9985e34.png)

## Solution
The results need to wrap so you can read them clearly
![screen shot 2018-11-29 at 12 37 40](https://user-images.githubusercontent.com/10154302/49222552-0bb7a080-f3d4-11e8-9621-307124ba8916.png)

