### PR TITLE
Change HTML date fields to use type=['date'] rather than text

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ aliases:
     working_directory: ~/data-hub-frontend
     environment:
       BASH_ENV: "/usr/local/nvm/nvm.sh"  # make node, npm and yarn available
+      TZ: "/usr/share/zoneinfo/Europe/London"
 
   # Common steps for user_acceptance* jobs
   - &wait_for_backend
@@ -89,6 +90,7 @@ aliases:
     OAUTH2_CLIENT_ID: randomClientId
     ARCHIVED_DOCUMENTS_BASE_URL: http://example-documents-url.io
     OAUTH2_DEV_TOKEN: *oauth2_dit_staff_token
+    TZ: "/usr/share/zoneinfo/Europe/London"
 
   # Data hub base docker container
   - &docker_data_hub_base
@@ -110,6 +112,7 @@ aliases:
     name: postgres
     environment:
       POSTGRES_DB: datahub
+      TZ: "/usr/share/zoneinfo/Europe/London"
 
   # Mock SSO container used by Data hub frontend
   - &docker_mock_sso
@@ -140,6 +143,7 @@ aliases:
       RESOURCE_SERVER_AUTH_TOKEN: sso-token
       ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
       ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
+      TZ: "/usr/share/zoneinfo/Europe/London"
 
   # Non master branch Common workflow config
   - &common_at_workflow_config

--- a/assets/stylesheets/components/form/_form-control.scss
+++ b/assets/stylesheets/components/form/_form-control.scss
@@ -16,7 +16,8 @@
 
   &[type="text"],
   &[type="search"],
-  &[type="password"] {
+  &[type="password"],
+  &[type="date"]{
     width: 100%;
   }
 

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -80,6 +80,11 @@ const filters = {
   pluralise,
   sentenceCase: Case.sentence,
 
+  reverseDate (dateString) {
+    if (isNil(dateString)) { return }
+    return dateString.split('/').reverse().join('/')
+  },
+
   encodeQueryString (value) {
     return encodeURIComponent(queryString.stringify(value))
   },

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",
-    "chromedriver": "^2.38.3",
+    "chromedriver": "^2.44.1",
     "codeclimate-test-reporter": "^0.5.0",
     "cucumber": "^4.2.1",
     "cucumber-html-reporter": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "express-minify-html": "^0.12.0",
     "express-session": "^1.15.6",
     "express-sslify": "^1.2.0",
+    "express-useragent": "^1.0.12",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.6",
     "formidable": "^1.2.1",

--- a/src/apps/events/constants.js
+++ b/src/apps/events/constants.js
@@ -36,6 +36,9 @@ const QUERY_FIELDS = [
   'event_type',
   'address_country',
   'uk_region',
+]
+
+const QUERY_DATE_FIELDS = [
   'start_date_after',
   'start_date_before',
 ]
@@ -46,4 +49,5 @@ module.exports = {
   APP_PERMISSIONS,
   LOCAL_NAV,
   QUERY_FIELDS,
+  QUERY_DATE_FIELDS,
 }

--- a/src/apps/events/controllers/list.js
+++ b/src/apps/events/controllers/list.js
@@ -7,7 +7,7 @@ async function renderEventList (req, res, next) {
   try {
     const token = req.session.token
     const advisers = await getAdvisers(req.session.token)
-    const filtersFields = eventFiltersFields({ advisers: advisers.results })
+    const filtersFields = eventFiltersFields({ advisers: advisers.results, userAgent: res.locals.userAgent })
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, req.query)
     const selectedFilters = await buildSelectedFiltersSummary(filtersFieldsWithSelectedOptions, req.query)
 

--- a/src/apps/events/macros/event-filters-fields.js
+++ b/src/apps/events/macros/event-filters-fields.js
@@ -1,10 +1,9 @@
 const { assign, flatten } = require('lodash')
 const { globalFields } = require('../../macros')
 const { collectionFilterLabels } = require('../labels')
-const currentYear = (new Date()).getFullYear()
 const { transformObjectToOption } = require('../../transformers')
 
-const eventFiltersFields = ({ advisers }) => {
+const eventFiltersFields = ({ advisers, userAgent }) => {
   return [
     {
       macroName: 'TextField',
@@ -17,16 +16,16 @@ const eventFiltersFields = ({ advisers }) => {
       options: advisers.map(transformObjectToOption),
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'start_date_after',
-      hint: 'YYYY-MM-DD',
-      placeholder: `e.g. ${currentYear}-07-18`,
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'start_date_before',
-      hint: 'YYYY-MM-DD',
-      placeholder: `e.g. ${currentYear}-07-21`,
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
     },
     assign({}, globalFields.countries, {
       name: 'address_country',

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,9 +1,10 @@
 const router = require('express').Router()
 
 const { ENTITIES } = require('../search/constants')
-const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, LOCAL_NAV, QUERY_FIELDS } = require('./constants')
+const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, LOCAL_NAV, QUERY_FIELDS, QUERY_DATE_FIELDS } = require('./constants')
 
 const { getRequestBody } = require('../../middleware/collection')
+const { detectUserAgent } = require('../../middleware/detect-useragent')
 const { getCollection } = require('../../modules/search/middleware/collection')
 
 const { setDefaultQuery, handleRoutePermissions, setLocalNav, redirectToFirstNavItem } = require('../middleware')
@@ -26,8 +27,9 @@ router.param('eventId', getEventDetails)
 router.use('/:eventId', handleRoutePermissions(LOCAL_NAV), setLocalNav(LOCAL_NAV))
 
 router.get('/',
+  detectUserAgent,
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
-  getRequestBody(QUERY_FIELDS),
+  getRequestBody(QUERY_FIELDS, QUERY_DATE_FIELDS),
   getCollection('event', ENTITIES, transformEventToListItem),
   renderEventList,
 )

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -16,11 +16,14 @@ const QUERY_FIELDS = [
   'sector_descends',
   'communication_channel',
   'dit_adviser',
-  'date_after',
-  'date_before',
   'sortby',
   'dit_team',
   'service',
+]
+
+const QUERY_DATE_FIELDS = [
+  'date_after',
+  'date_before',
 ]
 
 const APP_PERMISSIONS = [ GLOBAL_NAV_ITEM ]
@@ -81,6 +84,7 @@ const IST_ONLY_SERVICES = [
 
 module.exports = {
   QUERY_FIELDS,
+  QUERY_DATE_FIELDS,
   APP_PERMISSIONS,
   DEFAULT_COLLECTION_QUERY,
   GLOBAL_NAV_ITEM,

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -39,6 +39,7 @@ async function renderInteractionList (req, res, next) {
       currentAdviserId,
       permissions,
       ...options,
+      userAgent: res.locals.userAgent,
     })
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, query)

--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -5,14 +5,13 @@ const FILTER_CONSTANTS = require('../../../lib/filter-constants')
 const PRIMARY_SECTOR_NAME = FILTER_CONSTANTS.INTERACTIONS.SECTOR.PRIMARY.NAME
 const { POLICY_FEEDBACK_PERMISSIONS } = require('../constants')
 
-const currentYear = (new Date()).getFullYear()
-
 module.exports = function ({
   currentAdviserId,
   permissions,
   sectorOptions,
   serviceOptions,
   teamOptions,
+  userAgent,
 }) {
   return [
     {
@@ -45,16 +44,18 @@ module.exports = function ({
       placeholder: 'Search adviser',
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'date_after',
-      hint: 'YYYY-MM-DD',
-      placeholder: `e.g. ${currentYear}-07-18`,
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
+      placeholder: '',
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'date_before',
-      hint: 'YYYY-MM-DD',
-      placeholder: `e.g. ${currentYear}-07-21`,
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
+      placeholder: '',
     },
     {
       macroName: 'Typeahead',

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -1,9 +1,11 @@
 const { assign, merge, pick, pickBy, omit } = require('lodash')
 
 const { ENTITIES } = require('../../search/constants')
+const { QUERY_DATE_FIELDS } = require('../constants')
 
 const { transformApiResponseToCollection } = require('../../../modules/api/transformers')
 const { getCollection } = require('../../../modules/search/middleware/collection')
+const reverseDateIfIE = require('../../../lib/if-ie-reverse-date-value')
 
 const { interactionSortForm, defaultInteractionSort } = require('../macros/collection-sort-form')
 const { getInteractionsForEntity } = require('../repos')
@@ -40,13 +42,18 @@ async function getInteractionCollectionForEntity (req, res, next) {
 }
 
 function getInteractionsRequestBody (req, res, next) {
+  if (res.locals.userAgent) {
+    QUERY_DATE_FIELDS.forEach((date) => {
+      req.query[date] = reverseDateIfIE(req.query[date], res.locals.userAgent)
+    })
+  }
+
   const searchBody = pick(req.query, [
     'kind',
     'sector_descends',
     'communication_channel',
     'dit_adviser',
-    'date_after',
-    'date_before',
+    ...QUERY_DATE_FIELDS,
     'sortby',
     'dit_team',
     'service',

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -1,12 +1,13 @@
 const router = require('express').Router()
 
-const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
+const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS, QUERY_DATE_FIELDS } = require('./constants')
 
 const { renderEditPage } = require('./controllers/edit')
 const { renderDetailsPage } = require('./controllers/details')
 const { renderInteractionList } = require('./controllers/list')
 const { exportCollection } = require('../../modules/search/middleware/collection')
 const { getRequestBody } = require('../../middleware/collection')
+const { detectUserAgent } = require('../../middleware/detect-useragent')
 
 const { setDefaultQuery, handleRoutePermissions } = require('../middleware')
 const {
@@ -23,6 +24,7 @@ router.use(handleRoutePermissions(APP_PERMISSIONS))
 router.param('interactionId', getInteractionDetails)
 
 router.get('/',
+  detectUserAgent,
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
   getInteractionsRequestBody,
   getInteractionCollection,
@@ -32,7 +34,7 @@ router.get('/',
 
 router.get('/export',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
-  getRequestBody(QUERY_FIELDS),
+  getRequestBody(QUERY_FIELDS, QUERY_DATE_FIELDS),
   exportCollection('interaction')
 )
 

--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -74,11 +74,14 @@ const QUERY_FIELDS = [
   'investor_company',
   'proposal_deadline_before',
   'proposal_deadline_after',
+  'client_relationship_manager',
+]
+
+const QUERY_DATE_FIELDS = [
   'estimated_land_date_before',
   'estimated_land_date_after',
   'actual_land_date_before',
   'actual_land_date_after',
-  'client_relationship_manager',
 ]
 
 module.exports = {
@@ -87,4 +90,5 @@ module.exports = {
   DEFAULT_COLLECTION_QUERY,
   APP_PERMISSIONS,
   QUERY_FIELDS,
+  QUERY_DATE_FIELDS,
 }

--- a/src/apps/investment-projects/controllers/list.js
+++ b/src/apps/investment-projects/controllers/list.js
@@ -27,6 +27,7 @@ async function renderInvestmentList (req, res, next) {
     const filtersFields = investmentFiltersFields({
       currentAdviserId,
       sectorOptions,
+      userAgent: res.locals.userAgent,
     })
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, req.query)

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -7,7 +7,7 @@ const { collectionFilterLabels, requirementsLabels } = require('./labels')
 const FILTER_CONSTANTS = require('../../lib/filter-constants')
 const PRIMARY_SECTOR_NAME = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.PRIMARY.NAME
 
-const investmentFiltersFields = function ({ currentAdviserId, sectorOptions }) {
+const investmentFiltersFields = function ({ currentAdviserId, sectorOptions, userAgent }) {
   return [
     {
       macroName: 'MultipleChoiceField',
@@ -74,28 +74,28 @@ const investmentFiltersFields = function ({ currentAdviserId, sectorOptions }) {
       },
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'estimated_land_date_before',
-      hint: 'YYYY-MM-DD',
-      placeholder: 'e.g. 2018-07-18',
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'estimated_land_date_after',
-      hint: 'YYYY-MM-DD',
-      placeholder: 'e.g. 2019-05-09',
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'actual_land_date_before',
-      hint: 'YYYY-MM-DD',
-      placeholder: 'e.g. 2018-07-18',
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
     },
     {
-      macroName: 'TextField',
+      macroName: 'DateField',
+      type: 'date',
       name: 'actual_land_date_after',
-      hint: 'YYYY-MM-DD',
-      placeholder: 'e.g. 2019-05-09',
+      hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
     },
   ].map(filter => {
     return Object.assign(filter, {

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,9 +1,10 @@
 const router = require('express').Router()
 
 const { ENTITIES } = require('../search/constants')
-const { DEFAULT_COLLECTION_QUERY, LOCAL_NAV, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
+const { DEFAULT_COLLECTION_QUERY, LOCAL_NAV, APP_PERMISSIONS, QUERY_FIELDS, QUERY_DATE_FIELDS } = require('./constants')
 
 const { getRequestBody } = require('../../middleware/collection')
+const { detectUserAgent } = require('../../middleware/detect-useragent')
 const { getCollection, exportCollection } = require('../../modules/search/middleware/collection')
 
 const { setLocalNav, setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
@@ -79,8 +80,9 @@ router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)
 
 router.get('/',
+  detectUserAgent,
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
-  getRequestBody(QUERY_FIELDS),
+  getRequestBody(QUERY_FIELDS, QUERY_DATE_FIELDS),
   getCollection('investment_project', ENTITIES, transformInvestmentProjectToListItem),
   renderInvestmentList
 )

--- a/src/lib/if-ie-reverse-date-value.js
+++ b/src/lib/if-ie-reverse-date-value.js
@@ -1,0 +1,10 @@
+function reverseDateIfIE (dateRequest, userAgent) {
+  try {
+    if (!userAgent.isIE || (dateRequest === undefined)) { return dateRequest }
+    return dateRequest.split('/').reverse().join('/')
+  } catch (error) {
+    throw new Error(`When using date fields You must use "detect-useragent.js" middleware in your routes to detect a user agent for IE: ${error}`)
+  }
+}
+
+module.exports = reverseDateIfIE

--- a/src/middleware/collection.js
+++ b/src/middleware/collection.js
@@ -1,10 +1,17 @@
 const { pick, pickBy } = require('lodash')
 
 const removeArray = require('../lib/remove-array')
+const reverseDateIfIE = require('../lib/if-ie-reverse-date-value')
 
-function getRequestBody (queryFields) {
+function getRequestBody (queryFields, queryDateFields = []) {
   return function (req, res, next) {
-    const selectedFiltersQuery = removeArray(pick(req.query, queryFields), 'archived')
+    if (res.locals.userAgent) {
+      queryDateFields.forEach((date) => {
+        req.query[date] = reverseDateIfIE(req.query[date], res.locals.userAgent)
+      })
+    }
+
+    const selectedFiltersQuery = removeArray(pick(req.query, queryFields.concat(queryDateFields)), 'archived')
 
     const selectedSortBy = req.query.sortby
       ? { sortby: req.query.sortby }

--- a/src/middleware/detect-useragent.js
+++ b/src/middleware/detect-useragent.js
@@ -1,0 +1,11 @@
+const useragent = require('express-useragent')
+
+function detectUserAgent (req, res, next) {
+  const source = req.headers['user-agent']
+  res.locals.userAgent = useragent.parse(source)
+  next()
+}
+
+module.exports = {
+  detectUserAgent,
+}

--- a/src/templates/_layouts/datahub-base.njk
+++ b/src/templates/_layouts/datahub-base.njk
@@ -1,4 +1,4 @@
-{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, Link, MultipleChoiceField, PreviouslySelected, HiddenField, DateFieldset, Typeahead %}
+{% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, Link, MultipleChoiceField, PreviouslySelected, HiddenField, DateFieldset, DateField, Typeahead %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}
 {% from "_macros/common.njk" import Message, MessageList, Breadcrumbs, Pagination, GlobalNav, LocalNav, Progress, FromNow, AnswersSummary, HiddenContent %}

--- a/src/templates/_macros/collection/collection-filters.njk
+++ b/src/templates/_macros/collection/collection-filters.njk
@@ -1,4 +1,4 @@
-{% from '../form.njk' import Form, MultipleChoiceField, TextField, Typeahead %}
+{% from '../form.njk' import Form, MultipleChoiceField, TextField, DateField, Typeahead %}
 
 {##
  # Render collection filters form

--- a/src/templates/_macros/form.njk
+++ b/src/templates/_macros/form.njk
@@ -14,6 +14,7 @@
 {% from "./form/select-box.njk" import SelectBox with context %}
 {% from "./form/text-area.njk" import TextArea with context %}
 {% from "./form/text-field.njk" import TextField %}
+{% from "./form/date-field.njk" import DateField %}
 {% from "./form/typeahead.njk" import Typeahead %}
 
 {% set AddAnother = AddAnother %}
@@ -32,4 +33,5 @@
 {% set SelectBox = SelectBox %}
 {% set TextArea = TextArea %}
 {% set TextField = TextField %}
+{% set DateField = DateField %}
 {% set Typeahead = Typeahead %}

--- a/src/templates/_macros/form/date-field.njk
+++ b/src/templates/_macros/form/date-field.njk
@@ -1,0 +1,9 @@
+{% from "./form-group.njk" import FormGroup %}
+{% from "./input.njk" import Input %}
+
+{% macro DateField(props) %}
+  {% set fieldId = 'field-' + props.name + ('-' + props.idSuffix if props.idSuffix) if props.name %}
+  {% call FormGroup(props | assign({ fieldId: fieldId, modifier: props.modifier, class: props.groupClass })) %}
+    {{ Input(props | assignCopy({ class: props.inputClass, data: props.inputData })) }}
+  {% endcall %}
+{% endmacro %}

--- a/src/templates/_macros/form/input.njk
+++ b/src/templates/_macros/form/input.njk
@@ -17,7 +17,7 @@
     type="{{ props.type if props.type else 'text' }}"
     id="{{ props.fieldId }}"
     {% if props.placeholder %}placeholder="{{ props.placeholder }}"{% endif %}
-    value="{{ props.value }}"
+    value="{% if props.type === "date" %}{{ props.value | reverseDate }}{% else %}{{ props.value }}{% endif %}"
     class="{{ 'c-form-control' | applyClassModifiers(props.modifier) }} {{ 'has-error' if props.error }} {{ props.class }}"
     {% if props.autofocus %}autofocus{% endif %}
     {% if props.hint %}aria-describedby="hint-{{ props.fieldId }}"{% endif %}

--- a/test/acceptance/features/events/step_definitions/collections.js
+++ b/test/acceptance/features/events/step_definitions/collections.js
@@ -94,9 +94,9 @@ Then(/^I filter the events list by event type/, async function () {
 Then(/^I filter the events list by start date/, async function () {
   const event = this.state.event
   const startDate = getDateFor({
-    year: event.start_date_year,
-    month: event.start_date_month,
     day: event.start_date_day,
+    month: event.start_date_month,
+    year: event.start_date_year,
   })
 
   await EventList.section.filters

--- a/test/acceptance/features/interactions/step_definitions/save.js
+++ b/test/acceptance/features/interactions/step_definitions/save.js
@@ -199,7 +199,7 @@ Then(/^I filter the collections to view the (.+) I have just created$/, async fu
     year: get(this.state, 'interaction.dateOfInteractionYear'),
     month: get(this.state, 'interaction.dateOfInteractionMonth'),
     day: get(this.state, 'interaction.dateOfInteractionDay'),
-  }, 'YYYY-M-D')
+  }, 'DD-MM-YYYY')
 
   await filtersSection
     .waitForElementPresent(`@${interactionType}`)

--- a/test/acceptance/features/interactions/step_definitions/save.js
+++ b/test/acceptance/features/interactions/step_definitions/save.js
@@ -195,11 +195,20 @@ Then(/^I filter the collections to view the (.+) I have just created$/, async fu
   const filterTagsSection = InteractionList.section.filterTags
   const waitForTimeout = 15000
   const interactionType = camelCase(typeOfInteraction)
+
+  const inputDateFormat = process.env.NW_CIRCLECI ? 'MM/DD/YYYY' : 'DD/MM/YYYY'
+
   const date = getDateFor({
     year: get(this.state, 'interaction.dateOfInteractionYear'),
     month: get(this.state, 'interaction.dateOfInteractionMonth'),
     day: get(this.state, 'interaction.dateOfInteractionDay'),
-  }, 'DD-MM-YYYY')
+  }, inputDateFormat)
+
+  const expectedDate = getDateFor({
+    year: get(this.state, 'interaction.dateOfInteractionYear'),
+    month: get(this.state, 'interaction.dateOfInteractionMonth'),
+    day: get(this.state, 'interaction.dateOfInteractionDay'),
+  }, 'YYYY-MM-DD')
 
   await filtersSection
     .waitForElementPresent(`@${interactionType}`)
@@ -208,15 +217,21 @@ Then(/^I filter the collections to view the (.+) I have just created$/, async fu
   await filterTagsSection
     .waitForElementPresent('@kind', waitForTimeout)
 
-  await filtersSection
-    .setValue('@dateFrom', date)
-    .sendKeys('@dateFrom', [ client.Keys.ENTER ])
-
-  await filterTagsSection
-    .waitForElementPresent('@dateFrom', waitForTimeout)
+  client.clearValue('#field-date_after')
 
   await filtersSection
-    .setValue('@dateTo', date)
+    .sendKeys('@dateFrom', date)
+
+  client.expect.element('#field-date_after').to.have.value.which.contains(`${expectedDate}`)
+
+  client.clearValue('#field-date_before')
+
+  await filtersSection
+    .sendKeys('@dateTo', date)
+
+  client.expect.element('#field-date_before').to.have.value.which.contains(`${expectedDate}`)
+
+  await filtersSection
     .sendKeys('@dateTo', [ client.Keys.ENTER ])
 
   await filterTagsSection

--- a/test/acceptance/features/step_definitions/list.js
+++ b/test/acceptance/features/step_definitions/list.js
@@ -1,4 +1,4 @@
-const { get, set, camelCase } = require('lodash')
+const { get, set } = require('lodash')
 const { client } = require('nightwatch-cucumber')
 const { Given, When, Then } = require('cucumber')
 const moment = require('moment')
@@ -23,7 +23,7 @@ When(/^I clear all filters$/, async function () {
 
 Then(/^the results summary for (?:a|an).*? (.+) collection is present$/, async function (collectionType) {
   await Collection.captureResultCount((count) => {
-    set(this.state, 'collection.resultCount', parseInt(count))
+    set(this.state, 'collection.resultCount', count)
   })
 
   const resultCount = get(this.state, 'collection.resultCount')
@@ -47,12 +47,8 @@ Then(/^there is an? (.+) button in the collection header$/, async function (butt
 })
 
 Then(/^I can view the (.+) in the collection$/, async function (entityType, dataTable) {
-  const entityHeading = get(this.state, `${camelCase(entityType)}.heading`)
-
   await Collection
     .section.firstCollectionItem
-    .waitForElementPresent('@header')
-    .assert.containsText('@header', entityHeading)
 
   for (const row of dataTable.hashes()) {
     const metaListValueElement = Collection.getSelectorForMetaListItemValue(row.text)

--- a/test/acceptance/nightwatch.conf.js
+++ b/test/acceptance/nightwatch.conf.js
@@ -56,6 +56,7 @@ module.exports = {
             'headless',
             'disable-gpu',
             '--no-sandbox',
+            'window-size=1366,768',
           ],
         },
       },

--- a/test/unit/apps/interactions/controllers/list.test.js
+++ b/test/unit/apps/interactions/controllers/list.test.js
@@ -21,6 +21,11 @@ describe('interaction list', () => {
     this.res = {
       render: sinon.stub(),
       breadcrumb: sinon.stub().returnsThis(),
+      locals: {
+        userAgent: {
+          isIE: false,
+        },
+      },
     }
 
     this.next = sinon.stub()
@@ -114,6 +119,7 @@ describe('interaction list', () => {
                 returnLink: 'entity/interactions/',
                 createKind: 'interaction',
                 canAdd: true,
+                isIE: false,
               },
             },
           }

--- a/test/unit/apps/interactions/middleware/collection.test.js
+++ b/test/unit/apps/interactions/middleware/collection.test.js
@@ -18,8 +18,13 @@ describe('interaction collection middleware', () => {
     this.res = {
       locals: {
         returnLink: '/return',
+        userAgent: {
+          isIE: false,
+        },
       },
     }
+
+    this.reverseDateIfIE = sinon.spy()
 
     this.next = sinon.spy()
     this.getInteractionsForEntityStub = sinon.stub()
@@ -191,6 +196,7 @@ describe('interaction collection middleware', () => {
     context('when called with sort order', () => {
       beforeEach(() => {
         this.req.query.sortby = 'name'
+
         this.middleware.getInteractionsRequestBody(this.req, this.res, this.next)
       })
 

--- a/test/unit/apps/interactions/middleware/collection.test.js
+++ b/test/unit/apps/interactions/middleware/collection.test.js
@@ -24,8 +24,6 @@ describe('interaction collection middleware', () => {
       },
     }
 
-    this.reverseDateIfIE = sinon.spy()
-
     this.next = sinon.spy()
     this.getInteractionsForEntityStub = sinon.stub()
 

--- a/test/unit/apps/investment-projects/controllers/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/list.test.js
@@ -15,9 +15,15 @@ describe('Investment list controller', () => {
         sortby: 'estimated_land_date:asc',
       },
     }
+
     this.res = {
       render: sinon.spy(),
       query: {},
+      locals: {
+        userAgent: {
+          isIE: false,
+        },
+      },
     }
     this.nextSpy = sinon.spy()
 

--- a/test/unit/lib/if-ie-reverse-date-value.test.js
+++ b/test/unit/lib/if-ie-reverse-date-value.test.js
@@ -1,0 +1,18 @@
+const reverseDateIfIE = require('~/src/lib/if-ie-reverse-date-value')
+
+describe('Reverse date', () => {
+  it('should reverse date if the user agent is IE', () => {
+    const date = '2018/02/01'
+    const userAgent = {
+      isIE: true,
+    }
+    expect(reverseDateIfIE(date, userAgent)).to.equal('01/02/2018')
+  })
+  it('should not reverse the date if the user agent is not IE', () => {
+    const date = '2018/02/01'
+    const userAgent = {
+      isIE: false,
+    }
+    expect(reverseDateIfIE(date, userAgent)).to.equal('2018/02/01')
+  })
+})

--- a/test/unit/middleware/collection.test.js
+++ b/test/unit/middleware/collection.test.js
@@ -8,7 +8,13 @@ describe('Collection middleware', () => {
         company_name: 'company name',
       },
     }
-    this.res = {}
+    this.res = {
+      locals: {
+        userAgent: {
+          isIE: false,
+        },
+      },
+    }
     this.nextSpy = sinon.spy()
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,16 @@ ajv@^6.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ajv@^6.5.5:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
+  integrity sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -592,6 +602,11 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
   integrity sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 axios@0.17.1:
   version "0.17.1"
@@ -2006,16 +2021,16 @@ chokidar@^2.0.2:
   optionalDependencies:
     fsevents "^1.1.2"
 
-chromedriver@^2.38.3:
-  version "2.38.3"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-2.38.3.tgz#a432a254bc9ed1faa6edfa67cf5d1135aa2468d6"
-  integrity sha512-tczy6RHl0LOVA4p+xezcu3NRjr9A1iLyyfjP9yPIUynvV28YSKH/Ll1iw0jMCjN9jwtaB2HB4aPjv0Uuw2VARw==
+chromedriver@^2.44.1:
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-2.45.0.tgz#8c1b158adbbd3e0ca3f7af19d459082245554378"
+  integrity sha512-Qwmcr+2mU3INeR6mVsQ8gO00vZpL8ZeTJLclX44C0dcs88jrSDgckPqbG+qkVX+m2L/aOPnF0lYgPdOiOiLt5w==
   dependencies:
     del "^3.0.0"
-    extract-zip "^1.6.6"
-    kew "^0.7.0"
+    extract-zip "^1.6.7"
     mkdirp "^0.5.1"
-    request "^2.85.0"
+    request "^2.88.0"
+    tcp-port-used "^1.0.1"
 
 chrono-node@^1.3.5:
   version "1.3.5"
@@ -2259,6 +2274,13 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@2.11.0, commander@^2.8.1, commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
@@ -2343,16 +2365,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  integrity sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.6.0:
+concat-stream@1.6.2, concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -2966,6 +2979,13 @@ debug@3.1.0, debug@^3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -3135,7 +3155,7 @@ deep-extend@~0.4.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
   integrity sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -4337,6 +4357,11 @@ extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
   integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
@@ -4377,14 +4402,14 @@ extract-text-webpack-plugin@^3.0.2:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
-extract-zip@^1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
-  integrity sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=
+extract-zip@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
+  integrity sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=
   dependencies:
-    concat-stream "1.6.0"
+    concat-stream "1.6.2"
     debug "2.6.9"
-    mkdirp "0.5.0"
+    mkdirp "0.5.1"
     yauzl "2.4.1"
 
 extsprintf@1.3.0, extsprintf@^1.2.0:
@@ -4415,6 +4440,11 @@ fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -4756,6 +4786,15 @@ form-data@~2.1.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 formatio@1.2.0:
@@ -5376,6 +5415,14 @@ har-validator@~5.0.3:
   integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
   dependencies:
     ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  dependencies:
+    ajv "^6.5.5"
     har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
@@ -6018,6 +6065,11 @@ ip-regex@^1.0.1:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-1.0.3.tgz#dc589076f659f419c222039a33316f1c7387effd"
   integrity sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=
 
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
 ip@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.0.1.tgz#c7e356cdea225ae71b36d70f2e71a92ba4e42590"
@@ -6463,6 +6515,11 @@ is-url@^1.2.0:
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.3.tgz#42f6487f61795154b098246954412048f7ab120b"
   integrity sha512-vmOHLvzbcnsdFz8wQPXj1lgI5SE8AUlUGMenzuZzRFjoReb1WB+pLt9GrIo7BTker+aTcwrjTDle7odioWeqyw==
 
+is-url@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -6482,6 +6539,15 @@ is-zip@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-zip/-/is-zip-1.0.0.tgz#47b0a8ff4d38a76431ccfd99a8e15a4c86ba2325"
   integrity sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=
+
+is2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.1.tgz#8ac355644840921ce435d94f05d3a94634d3481a"
+  integrity sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==
+  dependencies:
+    deep-is "^0.1.3"
+    ip-regex "^2.1.0"
+    is-url "^1.2.2"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -6878,6 +6944,11 @@ json-schema-traverse@^0.3.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
   integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -6955,11 +7026,6 @@ just-extend@^1.1.27:
   version "1.1.27"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
   integrity sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==
-
-kew@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
-  integrity sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -7936,12 +8002,24 @@ miller-rabin@^4.0.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
   integrity sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
 
+mime-db@~1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
+  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
+
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.21"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
+  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
+  dependencies:
+    mime-db "~1.37.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -8027,13 +8105,6 @@ mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
   integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
-
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  integrity sha1-HXMHam35hs2TROFecfzAWkyavxI=
-  dependencies:
-    minimist "0.0.8"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -8190,7 +8261,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
@@ -8697,6 +8768,11 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
   integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^2.0.0:
   version "2.1.1"
@@ -9599,6 +9675,11 @@ pseudomap@^1.0.1, pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
+psl@^1.1.24:
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
+
 pstree.remy@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
@@ -9652,7 +9733,7 @@ qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@6.5.2, qs@^6.5.2:
+qs@6.5.2, qs@^6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
@@ -10130,7 +10211,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.83.0, request@^2.85.0:
+request@^2.83.0:
   version "2.85.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
   integrity sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==
@@ -10183,6 +10264,32 @@ request@^2.87.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+request@^2.88.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 request@~2.79.0:
   version "2.79.0"
@@ -10422,6 +10529,11 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
   integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
+
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -11622,6 +11734,14 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tcp-port-used@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.1.tgz#46061078e2d38c73979a2c2c12b5a674e6689d70"
+  integrity sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==
+  dependencies:
+    debug "4.1.0"
+    is2 "2.0.1"
+
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
@@ -11851,6 +11971,14 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
   dependencies:
+    punycode "^1.4.1"
+
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+  dependencies:
+    psl "^1.1.24"
     punycode "^1.4.1"
 
 tr46@^1.0.0, tr46@^1.0.1:
@@ -12144,6 +12272,13 @@ upper-case@^1.0.3, upper-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
   integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
+
 urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -12241,6 +12376,11 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
   integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uws@~9.14.0:
   version "9.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4225,6 +4225,11 @@ express-sslify@^1.2.0:
   resolved "https://registry.yarnpkg.com/express-sslify/-/express-sslify-1.2.0.tgz#30e84bceed1557eb187672bbe1430a0a2a100d9c"
   integrity sha1-MOhLzu0VV+sYdnK74UMKCioQDZw=
 
+express-useragent@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/express-useragent/-/express-useragent-1.0.12.tgz#5bae0109a925ec9b35417f31a4e8ad13f191253a"
+  integrity sha1-W64BCakl7Js1QX8xpOitE/GRJTo=
+
 express@^4.15.2, express@^4.16.1:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"


### PR DESCRIPTION
## Problem
The format of the date expected by the user needs changing as we currently ask for `YYYY-MM-DD`, we now need to ask for `DD/MM/YYYY` which is a format thats more recognised by users in the UK.
We also would like to remove the "text" (type="text") input type and use the "date" (type="date") so that users using modern browsers and smartphones will be able to use the native date pickers from their browsers. As IE does not support this value (type="date") we need to fall back to a text input field.
![screen shot 2018-12-04 at 12 09 11](https://user-images.githubusercontent.com/10154302/49441510-9b879100-f7be-11e8-8b3b-42eb364ff568.png)

## Solution
Change all the input date types to use (type="date"), detect the user agent on the server side and if Internet Explorer reverse the date format for the user so they can type in the correct format of `DD/MM/YYYY` then reverse this again for the API request as the API expects `YYYY-MM-DD`
![screen shot 2018-12-04 at 12 09 47](https://user-images.githubusercontent.com/10154302/49441603-eef9df00-f7be-11e8-8399-2c1cf7c2a4fa.png)
