### PR TITLE
Present different details view for Dun & Bradstreet company

### DIFF
--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -12,10 +12,11 @@ async function renderDetails (req, res) {
   const company = res.locals.company
   const coreTeam = await getOneListGroupCoreTeam(req.session.token, company.id)
   const globalAccountManager = find(coreTeam, adviser => adviser.is_global_account_manager)
+  const view = company.duns_number ? 'companies/views/details' : 'companies/views/_deprecated/details'
 
   res
     .breadcrumb(company.name)
-    .render('companies/views/details', {
+    .render(view, {
       companyDetails: transformCompanyToView(company),
       accountManagementDetails: transformCompanyToOneListView(company, globalAccountManager),
       chDetails: company.companies_house_data ? transformCompaniesHouseToView(company.companies_house_data) : null,

--- a/src/apps/companies/views/_deprecated/details.njk
+++ b/src/apps/companies/views/_deprecated/details.njk
@@ -1,0 +1,66 @@
+{% extends "../_layout-view.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">
+    {% if company.headquarter_type.name === 'ghq' %}
+      Global headquarters summary
+    {% else %}
+      Company summary
+    {% endif %}
+  </h2>
+
+  {% if chDetails %}
+    {% call Message({ type: 'muted', element: 'div' }) %}
+      {% component 'key-value-table', items=chDetails %}
+      <p>Powered by data from <strong>Companies House</strong></p>
+    {% endcall %}
+  {% endif %}
+
+  {% if companyDetails %}
+    {% component 'key-value-table', variant='striped', items=companyDetails %}
+  {% endif %}
+
+  {% if company.id %}
+    {% if not company.archived %}
+      <p><a href="/companies/{{company.id}}/edit" class="button button--secondary">Edit company details</a></p>
+    {% endif %}
+  {% else %}
+    <p><a href="/companies/add/{{company.company_number}}" class="button">Add company</a></p>
+  {% endif %}
+
+  {% if company.one_list_group_tier %}
+    <div class="section">
+      <h2 class="heading-medium">Global Account Manager – One List</h2>
+      {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
+
+      {# when the "companies-advisers" flag check is removed then the HiddenContent block should also be removed #}
+      {% if features['companies-advisers'] %}
+        <p>
+          <a href="advisers">See all advisers on the core team</a>
+        </p>
+      {% else %}
+        {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
+          {% call Message({ type: 'muted' }) %}
+            If you need to change the One List tier or Global Account Manager for this company,
+            go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
+            or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+          {% endcall %}
+        {% endcall %}
+      {% endif %}
+
+    </div>
+  {% endif %}
+
+  {% if company.id and not company.archived %}
+    <h2 class="heading-medium">Archive company</h2>
+    <p>Archive this company if it is no longer required or active.</p>
+
+    {% component 'archive-form', {
+      label: 'Archive reason',
+      options: ['Company is dissolved'],
+      csrfToken: csrfToken,
+      error: form.errors.reason,
+      url: '/companies/' + company.id + '/archive'
+    } %}
+  {% endif %}
+{% endblock %}

--- a/test/unit/apps/companies/controllers/details.test.js
+++ b/test/unit/apps/companies/controllers/details.test.js
@@ -2,6 +2,7 @@ const { renderDetails } = require('~/src/apps/companies/controllers/details')
 
 const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
 const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
+const dunAndBradstreetCompany = require('~/test/unit/data/companies/dnb-company.json')
 const oneListGroupCoreTeam = require('~/test/unit/data/companies/one-list-group-core-team.json')
 const config = require('~/config')
 
@@ -24,20 +25,18 @@ describe('Companies details controller', () => {
 
     nock(config.apiRoot)
       .get(`/v3/company/${minimalCompany.id}/one-list-group-core-team`)
+      .reply(200, [])
+
+    nock(config.apiRoot)
+      .get(`/v3/company/${dunAndBradstreetCompany.id}/one-list-group-core-team`)
       .reply(200, oneListGroupCoreTeam)
   })
 
   describe('#renderDetails', () => {
-    context('when the company contains companes house data', () => {
-      beforeEach(async () => {
-        this.res.locals.company = companiesHouseCompany
-
-        await renderDetails(this.req, this.res, this.next)
-      })
-
+    const commonTests = (template) => {
       it('should render the correct template', () => {
         const templateName = this.res.render.firstCall.args[0]
-        expect(templateName).to.equal('companies/views/details')
+        expect(templateName).to.equal(template)
       })
 
       it('should include company details', () => {
@@ -50,11 +49,6 @@ describe('Companies details controller', () => {
         expect(options.accountManagementDetails).to.not.be.null
       })
 
-      it('should include companies house details', () => {
-        const options = this.res.render.firstCall.args[1]
-        expect(options.chDetails).to.not.be.null
-      })
-
       it('should include one list information', () => {
         const options = this.res.render.firstCall.args[1]
         expect(options.accountManagementDetails).to.not.be.null
@@ -63,6 +57,21 @@ describe('Companies details controller', () => {
       it('should include a link to the One List support email', () => {
         const options = this.res.render.firstCall.args[1]
         expect(options.oneListEmail).to.equal(config.oneList.email)
+      })
+    }
+
+    context('when the company contains Companies House data', () => {
+      beforeEach(async () => {
+        this.res.locals.company = companiesHouseCompany
+
+        await renderDetails(this.req, this.res, this.next)
+      })
+
+      commonTests('companies/views/_deprecated/details')
+
+      it('should include companies house details', () => {
+        const options = this.res.render.firstCall.args[1]
+        expect(options.chDetails).to.not.be.null
       })
     })
 
@@ -73,34 +82,26 @@ describe('Companies details controller', () => {
         await renderDetails(this.req, this.res, this.next)
       })
 
-      it('should render the correct template', () => {
-        const templateName = this.res.render.firstCall.args[0]
-        expect(templateName).to.equal('companies/views/details')
-      })
+      commonTests('companies/views/_deprecated/details')
 
-      it('should include company details', () => {
-        const options = this.res.render.firstCall.args[1]
-        expect(options.companyDetails).to.not.be.null
-      })
-
-      it('should include account management details', () => {
-        const options = this.res.render.firstCall.args[1]
-        expect(options.accountManagementDetails).to.not.be.null
-      })
-
-      it('should not include companies house details', () => {
+      it('should not include Companies House details', () => {
         const options = this.res.render.firstCall.args[1]
         expect(options.chDetails).to.be.null
       })
+    })
 
-      it('should include one list information', () => {
-        const options = this.res.render.firstCall.args[1]
-        expect(options.accountManagementDetails).to.not.be.null
+    context('when the company is populated by data from Dun & Bradstreet', () => {
+      beforeEach(async () => {
+        this.res.locals.company = dunAndBradstreetCompany
+
+        await renderDetails(this.req, this.res, this.next)
       })
 
-      it('should include a link to the One List support email', () => {
+      commonTests('companies/views/details')
+
+      it('should not include Companies House details', () => {
         const options = this.res.render.firstCall.args[1]
-        expect(options.oneListEmail).to.equal(config.oneList.email)
+        expect(options.chDetails).to.be.null
       })
     })
   })

--- a/test/unit/data/companies/dnb-company.json
+++ b/test/unit/data/companies/dnb-company.json
@@ -1,0 +1,87 @@
+{
+  "id": "375094ac-f79a-43e5-9c88-059a7caa17f0",
+  "reference_code": "",
+  "name": "One List Corp",
+  "trading_name": null,
+  "uk_based": false,
+  "company_number": null,
+  "vat_number": "",
+  "duns_number": "123456789",
+  "registered_address_1": "12 St George's Road",
+  "registered_address_2": null,
+  "registered_address_town": "Paris",
+  "registered_address_county": null,
+  "registered_address_postcode": "75001",
+  "registered_address_country": {
+    "name": "France",
+    "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "created_on": "2015-10-26T11:00:00Z",
+  "modified_on": "2017-11-26T11:00:00Z",
+  "archived": false,
+  "archived_documents_url_path": "",
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "description": "This is a dummy company for testing the One List",
+  "transferred_by": null,
+  "transferred_on": null,
+  "transferred_to": null,
+  "transfer_reason": "",
+  "website": null,
+  "trading_address_1": null,
+  "trading_address_2": null,
+  "trading_address_town": null,
+  "trading_address_county": null,
+  "trading_address_postcode": null,
+  "trading_address_country": null,
+  "business_type": {
+    "name": "Company",
+    "id": "98d14e94-5d95-e211-a939-e4115bead28a"
+  },
+  "one_list_group_tier": {
+    "name": "Tier A - Strategic Account",
+    "id": "b91bf800-8d53-e311-aef3-441ea13961e2"
+  },
+  "companies_house_data": null,
+  "contacts": [],
+  "employee_range": {
+    "name": "500+",
+    "id": "41afd8d0-5d95-e211-a939-e4115bead28a"
+  },
+  "export_to_countries": [],
+  "future_interest_countries": [],
+  "headquarter_type": {
+    "name": "ghq",
+    "id": "43281c5e-92a4-4794-867b-b4d5f801e6f3"
+  },
+  "one_list_group_global_account_manager": {
+    "name": "Travis Greene",
+    "first_name": "Travis",
+    "last_name": "Greene",
+    "dit_team": {
+      "name": "IST - Sector Advisory Services",
+      "uk_region": {
+        "name": "London",
+        "id": "874cd12a-6095-e211-a939-e4115bead28a"
+      },
+      "country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "id": "fc3a6667-cfe9-e511-8ffa-e4115bead28a"
+    },
+    "id": "8eefe6b4-2816-4e47-94b5-a13409dcef70"
+  },
+  "global_headquarters": null,
+  "sector": {
+    "name": "Retail",
+    "id": "355f977b-8ac3-e211-a646-e4115bead28a"
+  },
+  "turnover_range": {
+    "name": "£33.5M+",
+    "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
+  },
+  "uk_region": null,
+  "export_experience_category": null
+}


### PR DESCRIPTION
https://trello.com/c/mxr2vWMa/486-show-a-different-company-view-for-companies-with-a-db-number

Dun & Bradstreet companies will present different details using a new design with a horizontal menu. This change checks if the company has a `duns_number` and then presents a separate view template. Subsequent iterations will change the view presented to the user.

At this stage the views presented to the user appear to be the same, both using the left local navigation.

## Dun & Bradstreet company
<img width="696" alt="screenshot 2018-12-07 at 06 21 01" src="https://user-images.githubusercontent.com/1150417/49631040-77a79380-f9e8-11e8-9af3-3c336af435b3.png">

## Companies not from Dun & Bradstreet data
<img width="669" alt="screenshot 2018-12-07 at 06 20 35" src="https://user-images.githubusercontent.com/1150417/49631049-7f673800-f9e8-11e8-89e6-442ba375956d.png">
