### PR TITLE
WIP Update company header to include One List info

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -147,3 +147,24 @@ $_first-element-spacing: $default-spacing-unit * 3;
 .c-local-header--keyline {
   border-bottom: 1px solid $grey-3;
 }
+
+.c-local-header__description {
+  padding: $default-spacing-unit / 2;
+  background-color: $grey-3;
+
+  * + & {
+    margin-top: $default-spacing-unit;
+  }
+
+  p {
+    margin-top: 0;
+    margin-bottom: 0;
+    &:not(:last-child) {
+      margin-bottom: $default-spacing-unit / 2;
+    }
+
+    a {
+      margin-left: $default-spacing-unit / 2;
+    }
+  }
+}

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -8,11 +8,16 @@
   %}
     <p class="c-local-header__heading-after">{{ headingAddress }}</p>
 
-    {% if metaItems.length %}
-      {{ MetaList({
-        items: metaItems,
-        itemModifier: 'stacked'
-      }) }}
+    {% if company.one_list_group_tier %}
+      <div class="c-local-header__description">
+        <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>
+        <p>
+          Global Account Manager: {{ company.one_list_group_global_account_manager.name }}
+          {% if features['companies-advisers'] %}
+            <a href="/companies/{{ company.id }}/advisers">View core team</a>
+          {% endif %}
+        </p>
+      </div>
     {% endif %}
 
     {% if company.archived %}

--- a/test/acceptance/features/companies/advisers-collection.feature
+++ b/test/acceptance/features/companies/advisers-collection.feature
@@ -5,7 +5,7 @@ Feature: View advisers for a company
   Scenario: View advisers for a GHQ on the One List
 
     When I navigate to the `companies.advisers` page using `company` `One List Corp` fixture
-    Then details content heading should contain "Advisers on the core team"
+    Then there should be a sub heading "Advisers on the core team"
     And the data details 1 are displayed
       | Team                                            | Location   | Global Account Manager |
       | IST - Sector Advisory Services                  | London	   | Travis Greene          |

--- a/test/acceptance/features/companies/details.feature
+++ b/test/acceptance/features/companies/details.feature
@@ -2,10 +2,16 @@
 Feature: Company details
 
   @companies-details--ghq-one-list
-  Scenario: View details for a GHQ on the One List
+  Scenario: View details for a Dun & Bradstreet GHQ company on the One List
 
     When I navigate to the `companies.details` page using `company` `One List Corp` fixture
-    Then the Company summary key value details are not displayed
+    Then the heading should be "One List Corp"
+    And after the heading should be "12 St George's Road, Paris, 75001, France"
+    And the heading description should be
+      | paragraph                                                                |
+      | This is an account managed company (One List Tier A - Strategic Account) |
+      | Global Account Manager: Travis Greene View core team                     |
+    And the Company summary key value details are not displayed
     And the Global headquarters summary key value details are displayed
       | key                       | value                        |
       | Business type             | company.businessType         |

--- a/test/acceptance/features/events/edit.feature
+++ b/test/acceptance/features/events/edit.feature
@@ -14,7 +14,7 @@ Feature: Edit an Event in Data hub
     And I click the "Edit event" link
     When I change form text field "name" to random words
     And I submit the form
-    Then details heading should contain what I entered for "name" field
+    Then the heading should contain what I entered for "name" field
 
   @events-edit--type
   Scenario: Edit event type

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -80,24 +80,6 @@ const assertTableContent = async function (tableSelector, expectedData, tableTyp
   }
 }
 
-Then(/^details heading should contain what I entered for "(.+)" field$/, async function (fieldName) {
-  await Details
-    .waitForElementPresent('@heading')
-    .assert.containsText('@heading', this.state[fieldName])
-})
-
-Then(/^details heading should contain "(.+)"$/, async (value) => {
-  await Details
-    .waitForElementPresent('@heading')
-    .assert.containsText('@heading', value)
-})
-
-Then(/^details content heading should contain "(.+)"$/, async (value) => {
-  await Details
-    .waitForElementPresent('@contentHeading')
-    .assert.containsText('@contentHeading', value)
-})
-
 Then(/^details view data for "(.+)" should contain what I entered for "(.+)" field$/, async function (detailsItemName, fieldName) {
   const detail = await Details.getDetailFor(detailsItemName)
 
@@ -116,28 +98,6 @@ Then(/^details view data for "(.+)" should contain "(.+)"$/, async (detailsItemN
     .waitForElementPresent(detail.selector)
     .assert.containsText(detail.selector, value)
     .useCss()
-})
-
-Then(/^there should be a local nav$/, async (dataTable) => {
-  const expectedLocalNav = dataTable.hashes()
-
-  await Details.api.elements('css selector', '.c-local-nav__link', (result) => {
-    client.expect(result.value.length).to.equal(expectedLocalNav.length)
-  })
-
-  for (const row of expectedLocalNav) {
-    const localNavItemSelector = Details.getLocalNavItemSelector(row.text)
-    await Details
-      .api.useXpath()
-      .waitForElementPresent(localNavItemSelector.selector)
-      .assert.visible(localNavItemSelector.selector)
-      .useCss()
-  }
-})
-
-Then(/^there should not be a local nav$/, async () => {
-  await Details
-    .assert.elementNotPresent('@localNav')
 })
 
 Then(/^the (.+) key value details are displayed$/, async function (tableTitle, dataTable) {

--- a/test/acceptance/features/step_definitions/location.js
+++ b/test/acceptance/features/step_definitions/location.js
@@ -102,6 +102,13 @@ Then(/^the heading should be "(.+)"$/, async (value) => {
     .assert.containsText('@header', value)
 })
 
+Then(/^the heading should contain what I entered for "(.+)" field$/, async function (fieldName) {
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', this.state[fieldName])
+})
+
 Then(/^after the heading should be "(.+)"$/, async (value) => {
   await Location
     .section.localHeader
@@ -120,6 +127,12 @@ Then(/^the heading description should be$/, async (data) => {
   }
 })
 
+Then(/^there should be a sub heading "(.+)"$/, async (value) => {
+  await Location
+    .waitForElementPresent('@subHeading')
+    .assert.containsText('@subHeading', value)
+})
+
 Then(/^I see the ([0-9]+) error page$/, async function (statusCode) {
   const headingSelector = Location.getHeading('//h3', statusCode).selector
 
@@ -127,4 +140,26 @@ Then(/^I see the ([0-9]+) error page$/, async function (statusCode) {
     .api.useXpath()
     .assert.visible(headingSelector)
     .useCss()
+})
+
+Then(/^there should be a local nav$/, async (dataTable) => {
+  const expectedLocalNav = dataTable.hashes()
+
+  await Location.api.elements('css selector', '.c-local-nav__link', (result) => {
+    client.expect(result.value.length).to.equal(expectedLocalNav.length)
+  })
+
+  for (const row of expectedLocalNav) {
+    const localNavItemSelector = Location.section.localNav.getLocalNavLinkSelector(row.text)
+    await Location
+      .api.useXpath()
+      .waitForElementPresent(localNavItemSelector.selector)
+      .assert.visible(localNavItemSelector.selector)
+      .useCss()
+  }
+})
+
+Then(/^there should not be a local nav$/, async () => {
+  await Location.section.localNav
+    .assert.elementNotPresent(Location.section.localNav.selector)
 })

--- a/test/acceptance/features/step_definitions/location.js
+++ b/test/acceptance/features/step_definitions/location.js
@@ -95,6 +95,31 @@ Then(/^the (.+) local header is displayed$/, async function (entityType, dataTab
   }
 })
 
+Then(/^the heading should be "(.+)"$/, async (value) => {
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@header')
+    .assert.containsText('@header', value)
+})
+
+Then(/^after the heading should be "(.+)"$/, async (value) => {
+  await Location
+    .section.localHeader
+    .waitForElementPresent('@headerAfter')
+    .assert.containsText('@headerAfter', value)
+})
+
+Then(/^the heading description should be$/, async (data) => {
+  for (const row of data.hashes()) {
+    const headerDescriptionParagraphSelector = Location.section.localHeader.getSelectorForHeaderDescriptionParagraph(row.paragraph)
+
+    await Location
+      .api.useXpath()
+      .waitForElementVisible(headerDescriptionParagraphSelector.selector)
+      .useCss()
+  }
+})
+
 Then(/^I see the ([0-9]+) error page$/, async function (statusCode) {
   const headingSelector = Location.getHeading('//h3', statusCode).selector
 

--- a/test/acceptance/features/support/step_definitions/support.js
+++ b/test/acceptance/features/support/step_definitions/support.js
@@ -1,6 +1,6 @@
 const { client } = require('nightwatch-cucumber')
 const { Then, When } = require('cucumber')
-const { get, set } = require('lodash')
+const { get } = require('lodash')
 
 const Support = client.page.support()
 
@@ -14,13 +14,6 @@ Then(/^the support fields have error messages$/, async function () {
     .assert.visible('@titleError')
     .assert.visible('@chooseOneOfTheseError')
     .assert.visible('@emailError')
-})
-
-Then(/^a new support request is created$/, async function () {
-  await Support
-    .createSupportTicket({}, (supportRequest) => {
-      set(this.state, 'supportRequest', supportRequest)
-    })
 })
 
 Then(/^the success message contains the ticket ID/, async function () {

--- a/test/acceptance/pages/companies/details.js
+++ b/test/acceptance/pages/companies/details.js
@@ -9,5 +9,6 @@ module.exports = {
 
     return `${process.env.QA_HOST}/companies/${companyId}/details`
   },
-  elements: {},
+  elements: {
+  },
 }

--- a/test/acceptance/pages/details.js
+++ b/test/acceptance/pages/details.js
@@ -20,23 +20,11 @@ const getSelectorForTable = (title, className) => {
 
 module.exports = {
   elements: {
-    heading: '.c-local-header__heading',
-    contentHeading: '.heading-medium',
-    localNav: '.c-local-nav',
   },
   commands: [
     {
       getDetailFor (label) {
         return getSelectorForElementWithText(label, { el: '//th', child: '/following-sibling::td' })
-      },
-      getLocalNavItemSelector (text) {
-        return getSelectorForElementWithText(
-          text,
-          {
-            el: '//a',
-            className: 'c-local-nav__link',
-          },
-        )
       },
       getSelectorForKeyValueTable (title) {
         return getSelectorForTable(title, 'table--key-value')

--- a/test/acceptance/pages/location.js
+++ b/test/acceptance/pages/location.js
@@ -9,6 +9,9 @@ const getDetailsTabSelector = (text) => getSelectorForElementWithText(text,
 
 module.exports = {
   url: process.env.QA_HOST,
+  elements: {
+    subHeading: '.heading-medium',
+  },
   sections: {
     localHeader: {
       selector: '.c-local-header',

--- a/test/acceptance/pages/location.js
+++ b/test/acceptance/pages/location.js
@@ -23,11 +23,21 @@ module.exports = {
               }
             )
           },
+          getSelectorForHeaderDescriptionParagraph (text) {
+            return getSelectorForElementWithText(text,
+              {
+                el: '//div',
+                className: 'c-local-header__description',
+                child: '/p',
+              }
+            )
+          },
         },
       ],
       elements: {
         header: '.c-local-header__heading',
         headerLink: '.c-local-header__heading-before a',
+        headerAfter: '.c-local-header__heading-after',
       },
     },
     localNav: {

--- a/test/acceptance/pages/support.js
+++ b/test/acceptance/pages/support.js
@@ -1,6 +1,3 @@
-const { assign } = require('lodash')
-const faker = require('faker')
-
 const { getButtonWithText } = require('../helpers/selectors')
 
 module.exports = {
@@ -8,46 +5,6 @@ module.exports = {
   elements: {
     flashMessage: '.c-message-list li:first-child',
   },
-  commands: [
-    {
-      createSupportTicket (details = {}, callback) {
-        const supportRequest = assign({}, {
-          title: faker.lorem.words(),
-          description: faker.lorem.sentence(),
-          email: faker.internet.email(),
-          webBrowser: faker.random.words(),
-        }, details)
-        const supportRequestRadioOptions = {}
-
-        return this.section.form
-          .waitForElementPresent('@sendButton')
-          .api.perform((done) => {
-            this.getRadioOption({ name: 'feedback_type' }, (result) => {
-              supportRequestRadioOptions.employeeRange = result
-              done()
-            })
-          })
-          .perform(() => {
-            for (const key in supportRequest) {
-              if (supportRequest[key]) {
-                this.section.form
-                  .setValue(`@${key}`, supportRequest[key])
-              }
-            }
-            for (const key in supportRequestRadioOptions) {
-              this.api.useCss()
-                .click(supportRequestRadioOptions[key].labelSelector)
-            }
-          })
-          .perform(() => {
-            this.section.form
-              .click('@sendButton')
-
-            callback(assign({}, supportRequest, supportRequestRadioOptions))
-          })
-      },
-    },
-  ],
   sections: {
     form: {
       selector: 'form',


### PR DESCRIPTION
https://trello.com/c/CS26iwOf/491-implement-new-company-header-for-companies-with-a-duns-number

First iteration of new company header. There will be a follow up PR to add `Global HQ` badge.

![screenshot 2018-12-17 at 12 30 20](https://user-images.githubusercontent.com/1150417/50087363-b82cbb80-01f7-11e9-8b17-ea2352e773a4.png)
