### PR TITLE
Present different advisers view for dnb company

### DIFF
--- a/src/apps/companies/controllers/advisers.js
+++ b/src/apps/companies/controllers/advisers.js
@@ -10,7 +10,7 @@ async function renderAdvisers (req, res, next) {
   }
 
   try {
-    const { name: companyName, id: companyId } = res.locals.company
+    const { company } = res.locals
     const token = req.session.token
     const { global_account_manager: globalAccountManager, adviser_on_core_team: adviserOnCoreTeam, location, team } = coreTeamLabels
     const columns = {
@@ -25,16 +25,19 @@ async function renderAdvisers (req, res, next) {
         name: adviserOnCoreTeam,
       },
     }
-    const coreTeam = await getOneListGroupCoreTeam(token, companyId)
+    const coreTeam = await getOneListGroupCoreTeam(token, company.id)
       .then(transformCoreTeamToCollection)
+
+    const view = company.duns_number ? 'companies/views/advisers' : 'companies/views/_deprecated/advisers'
+
     res
-      .breadcrumb(companyName, `/companies/${companyId}`)
+      .breadcrumb(company.name, `/companies/${company.id}`)
       .breadcrumb('Advisers')
-      .render('companies/views/advisers', {
-        companyName,
+      .render(view, {
         coreTeam,
         columns,
         oneListEmail: config.oneList.email,
+        companyName: company.name,
       })
   } catch (error) {
     next(error)

--- a/src/apps/companies/views/_deprecated/_layout-view.njk
+++ b/src/apps/companies/views/_deprecated/_layout-view.njk
@@ -1,0 +1,32 @@
+{% extends "_layouts/two-column.njk" %}
+
+{% block local_header %}
+  {% call LocalHeader({
+      heading: company.name,
+      modifier: 'light-banner'
+    })
+  %}
+    <p class="c-local-header__heading-after">{{ headingAddress }}</p>
+
+    {% if metaItems.length %}
+      {{ MetaList({
+        items: metaItems,
+        itemModifier: 'stacked'
+      }) }}
+    {% endif %}
+
+    {% if company.archived %}
+      {% call Message({ type: 'info' }) %}
+        This company was archived on {{company.archived_on | formatDate}} by {{company.archived_by.first_name}} {{company.archived_by.last_name}}. <br>
+        <strong>Reason:</strong> {{company.archived_reason}}<br>
+        <br>
+        <a href="/companies/{{company.id}}/unarchive">Unarchive</a>
+      {% endcall %}
+    {% endif %}
+  {% endcall %}
+{% endblock %}
+
+
+{% block main_grid_left_column %}
+  {{ LocalNav({ items: localNavItems }) }}
+{% endblock %}

--- a/src/apps/companies/views/_deprecated/advisers.njk
+++ b/src/apps/companies/views/_deprecated/advisers.njk
@@ -1,0 +1,35 @@
+{% extends "./_layout-view.njk" %}
+
+{% from "_macros/entity/entity-list.njk" import EntityList %}
+
+{% block main_grid_right_column %}
+
+  <h2 class="heading-medium">Advisers on the core team</h2>
+
+    {% if company.global_headquarters.name %}
+      <p>This company is a subsidiary of the {{company.global_headquarters.name}}, an account managed company on the One List ({{company.one_list_group_tier.name}})</p>
+    {% else %}
+      <p>This is an account managed company on the One List ({{company.one_list_group_tier.name}})</p>
+    {% endif %}
+
+    {% component 'data-table', {
+      variant: 'equal-columns',
+      columns: columns.global_account_manager,
+      data: coreTeam.accountManagers
+    } %}
+
+    {% component 'data-table', {
+      variant: 'equal-columns',
+      columns: columns.adviser_core_team,
+      data: coreTeam.teamMembers
+    } %}
+
+  {% call HiddenContent({ summary: 'Need to find out more, or edit the core team or One List tier information?' }) %}
+    {% call Message({ type: 'muted' }) %}
+      For more information, or if you need to change the One List tier or account management team for this company,
+      go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital
+      Workspace</a>
+      or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>
+    {% endcall %}
+  {% endcall %}
+{% endblock %}

--- a/test/unit/apps/companies/controllers/advisers.test.js
+++ b/test/unit/apps/companies/controllers/advisers.test.js
@@ -1,87 +1,122 @@
-const { assign } = require('lodash')
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
 const config = require('~/config')
 const companyMock = require('~/test/unit/data/companies/companies-house.json')
+const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
 const coreTeamMock = require('~/test/unit/data/companies/one-list-group-core-team.json')
 
+const { renderAdvisers } = require('~/src/apps/companies/controllers/advisers')
+
 describe('Company contact list controller', () => {
-  beforeEach(() => {
-    this.reqMock = assign({}, globalReq, {
-      session: {
-        token: 'abcd',
-      },
-    })
-    this.resMock = assign({}, globalRes, {
-      locals: {
-        company: companyMock,
-        features: {},
-      },
-      breadcrumb: sinon.stub().returnsThis(),
-      render: sinon.spy(),
-      query: {},
-    })
-    this.nextSpy = sinon.spy()
-
-    this.controller = require('~/src/apps/companies/controllers/advisers')
-  })
-
   describe('#renderAdvisers', () => {
     context('when the feature flag is enabled', () => {
-      beforeEach(async () => {
-        nock(config.apiRoot)
-          .get(`/v3/company/${companyMock.id}/one-list-group-core-team`)
-          .reply(200, coreTeamMock)
+      const commonTests = (expectedBreadcrumbs, expectedTemplate, expectedCompanyName) => {
+        it('should add two breadcrumbs', () => {
+          expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
+        })
 
-        this.resMock.locals.features['companies-advisers'] = true
+        it('should add the company breadcrumb', () => {
+          expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(expectedBreadcrumbs[0].name, expectedBreadcrumbs[0].url)
+        })
 
-        await this.controller.renderAdvisers(this.reqMock, this.resMock, this.nextSpy)
+        it('should add the Advisers breadcrumb', () => {
+          expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(expectedBreadcrumbs[1].name)
+        })
+
+        it('should render the correct template', () => {
+          expect(this.middlewareParameters.resMock.render).to.be.calledWith(expectedTemplate)
+        })
+
+        it('should set the company name', () => {
+          expect(this.middlewareParameters.resMock.render.args[0][1].companyName).to.equal(expectedCompanyName)
+        })
+
+        it('should set the core team', () => {
+          expect(this.middlewareParameters.resMock.render.args[0][1].coreTeam).to.not.be.null
+        })
+
+        it('should not call next', () => {
+          expect(this.middlewareParameters.nextSpy).to.not.be.called
+        })
+      }
+
+      context('when the company does not have a DUNS number', () => {
+        beforeEach(async () => {
+          this.middlewareParameters = buildMiddlewareParameters({
+            company: companyMock,
+            features: {
+              'companies-advisers': true,
+            },
+          })
+
+          nock(config.apiRoot)
+            .get(`/v3/company/${companyMock.id}/one-list-group-core-team`)
+            .reply(200, coreTeamMock)
+
+          await renderAdvisers(
+            this.middlewareParameters.reqMock,
+            this.middlewareParameters.resMock,
+            this.middlewareParameters.nextSpy,
+          )
+        })
+
+        commonTests([
+          { name: companyMock.name, url: `/companies/${companyMock.id}` },
+          { name: 'Advisers' },
+        ], 'companies/views/_deprecated/advisers', 'Mercury Trading Ltd')
       })
 
-      it('should add two breadcrumbs', () => {
-        expect(this.resMock.breadcrumb).to.have.been.calledTwice
-      })
+      context('when the company does have a DUNS number', () => {
+        beforeEach(async () => {
+          this.middlewareParameters = buildMiddlewareParameters({
+            company: dnbCompanyMock,
+            features: {
+              'companies-advisers': true,
+            },
+          })
 
-      it('should add the company breadcrumb', () => {
-        expect(this.resMock.breadcrumb).to.be.calledWith('Mercury Trading Ltd', '/companies/15387806')
-      })
+          nock(config.apiRoot)
+            .get(`/v3/company/${dnbCompanyMock.id}/one-list-group-core-team`)
+            .reply(200, coreTeamMock)
 
-      it('should add the Advisers breadcrumb', () => {
-        expect(this.resMock.breadcrumb).to.be.calledWith('Advisers')
-      })
+          await renderAdvisers(
+            this.middlewareParameters.reqMock,
+            this.middlewareParameters.resMock,
+            this.middlewareParameters.nextSpy,
+          )
+        })
 
-      it('should render the correct template', () => {
-        expect(this.resMock.render).to.be.calledWith('companies/views/advisers')
-      })
-
-      it('should set the company name', () => {
-        expect(this.resMock.render.args[0][1].companyName).to.equal('Mercury Trading Ltd')
-      })
-
-      it('should set the core team', () => {
-        expect(this.resMock.render.args[0][1].coreTeam).to.not.be.null
-      })
-
-      it('should not call next', () => {
-        expect(this.nextSpy).to.not.be.called
+        commonTests([
+          { name: dnbCompanyMock.name, url: `/companies/${dnbCompanyMock.id}` },
+          { name: 'Advisers' },
+        ], 'companies/views/advisers', 'One List Corp')
       })
     })
 
     context('when the feature flag is not enabled', () => {
-      beforeEach(() => {
-        this.controller.renderAdvisers(this.reqMock, this.resMock, this.nextSpy)
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+        })
+
+        await renderAdvisers(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
       it('should not add breadcrumbs', () => {
-        expect(this.resMock.breadcrumb).to.not.be.called
+        expect(this.middlewareParameters.resMock.breadcrumb).to.not.be.called
       })
 
       it('should not render the template', () => {
-        expect(this.resMock.render).to.not.be.called
+        expect(this.middlewareParameters.resMock.render).to.not.be.called
       })
 
       it('should call next with an error', () => {
-        expect(this.nextSpy).to.have.been.calledOnce
-        expect(this.nextSpy).to.be.calledWith(sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Not Found')))
+        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
+        expect(this.middlewareParameters.nextSpy).to.be.calledWith(sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Not Found')))
       })
     })
   })

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -1,0 +1,32 @@
+module.exports = ({
+  requestBody,
+  company,
+  contact,
+  interaction,
+  investment,
+  order,
+  features = {},
+}) => {
+  return {
+    reqMock: {
+      session: {
+        token: '1234',
+      },
+      body: requestBody,
+    },
+    resMock: {
+      breadcrumb: sinon.stub().returnsThis(),
+      render: sinon.spy(),
+      redirect: sinon.spy(),
+      locals: {
+        company,
+        contact,
+        interaction,
+        order,
+        investmentData: investment, // todo: rename
+        features,
+      },
+    },
+    nextSpy: sinon.spy(),
+  }
+}


### PR DESCRIPTION
If a company does not have a DUNS number then present the _deprecated view. At this stage the two views are exactly the same so it is a straight copy.

Also included in this change is some unit test updates to assert the correct view is being presented for each company type.

I had concerns in the way that `req`, `res` and `next` were being built. With multiple nested `context` and `beforeEach` it was difficult to track where fields were being set. Because we build these objects in similar ways across all unit tests I am proposing a helper function `buildMiddlewareParameters`.

Note that this is not an attempt to address any major concerns around testing. It's just a tidy up.
