### PR TITLE
Adding likelihood to land

### DIFF
--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -75,6 +75,7 @@ const QUERY_FIELDS = [
   'proposal_deadline_before',
   'proposal_deadline_after',
   'client_relationship_manager',
+  'likelihood_to_land',
 ]
 
 const QUERY_DATE_FIELDS = [
@@ -82,6 +83,8 @@ const QUERY_DATE_FIELDS = [
   'estimated_land_date_after',
   'actual_land_date_before',
   'actual_land_date_after',
+  'client_relationship_manager',
+  'likelihood_to_land',
 ]
 
 module.exports = {

--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -33,6 +33,7 @@ const labels = {
       associated_non_fdi_r_and_d_project: 'Non-FDI R&D project',
       new_tech_to_uk: 'New-to-world tech',
       export_revenue: 'Export revenue',
+      likelihood_to_land: 'Likelihood to land',
     },
     edit: {
       government_assistance: 'Is this project receiving government financial assistance?',
@@ -45,6 +46,7 @@ const labels = {
       client_cannot_provide_total_investment: 'Can client provide total investment value?',
       client_cannot_provide_foreign_investment: 'Can client provide foreign equity investment value?',
       fdi_value: 'Project value',
+      likelihood_to_land: 'Likelihood to land',
     },
   },
   requirementsLabels: {
@@ -138,6 +140,7 @@ const labels = {
       status: 'Status',
       uk_region_location: 'UK Region',
       investor_company_country: 'Country of origin',
+      likelihood_to_land: 'Likelihood to land',
     },
   },
   clientRelationshipManagementLabels: {

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -74,6 +74,15 @@ const investmentFiltersFields = function ({ currentAdviserId, sectorOptions, use
       },
     },
     {
+      macroName: 'MultipleChoiceField',
+      name: 'likelihood_to_land',
+      type: 'checkbox',
+      modifier: 'option-select',
+      options () {
+        return metadata.likelihoodToLandOptions.map(transformObjectToOption)
+      },
+    },
+    {
       macroName: 'DateField',
       type: 'date',
       name: 'estimated_land_date_before',

--- a/src/apps/investment-projects/middleware/forms/value.js
+++ b/src/apps/investment-projects/middleware/forms/value.js
@@ -19,6 +19,7 @@ async function populateForm (req, res, next) {
     options: {
       averageSalaryRange: await getOptions(token, 'salary-range', { createdOn }),
       fdiValue: await getOptions(token, 'fdi-value', { createdOn, sorted: false }),
+      likelihoodToLand: await getOptions(token, 'likelihood-to-land', { createdOn, sorted: false }),
     },
   }
 

--- a/src/apps/investment-projects/transformers/value.js
+++ b/src/apps/investment-projects/transformers/value.js
@@ -34,6 +34,7 @@ function transformInvestmentValueForView ({
   non_fdi_r_and_d_budget,
   id,
   associated_non_fdi_r_and_d_project,
+  likelihood_to_land,
 }) {
   function formatBoolean (boolean, { pos, neg }) {
     if (isNull(boolean)) { return null }
@@ -65,6 +66,7 @@ function transformInvestmentValueForView ({
       pos: 'Yes, will create significant export revenue',
       neg: 'No, will not create significant export revenue',
     }),
+    likelihood_to_land: likelihood_to_land,
     average_salary: get(average_salary, 'name'),
     sector_name: get(sector, 'name'),
     account_tier: get(investor_company, 'one_list_group_tier.name'),

--- a/src/apps/investment-projects/views/value-edit.njk
+++ b/src/apps/investment-projects/views/value-edit.njk
@@ -96,6 +96,15 @@
     {% endif %}
 
     {{ MultipleChoiceField({
+      name: 'likelihood_to_land',
+      label: form.labels.likelihood_to_land,
+      value: form.state.likelihood_to_land,
+      error: errors.messages.likelihood_to_land,
+      initialOption: '-- Select a likelihood to land value --',
+      options: form.options.likelihoodToLand
+    }) }}
+
+    {{ MultipleChoiceField({
       name: 'government_assistance',
       type: 'radio',
       modifier: 'inline',

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -94,6 +94,7 @@ const metadataItems = [
   ['investment-investor-type', 'investmentInvestorTypeOptions'],
   ['investment-involvement', 'investmentInvolvementOptions'],
   ['export-experience-category', 'exportExperienceCategory'],
+  ['likelihood-to-land', 'likelihoodToLandOptions'],
 ]
 
 const restrictedServiceKeys = [

--- a/test/unit/apps/investment-projects/middleware/forms/value.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/value.test.js
@@ -18,6 +18,11 @@ const metadataMock = {
     { id: '2', name: 'f2', disabled_on: yesterday },
     { id: '3', name: 'f3', disabled_on: null },
   ],
+  likelihoodToLandOptions: [
+    { id: '1', name: 'Low', disabled_on: null },
+    { id: '2', name: 'Medium', disabled_on: null },
+    { id: '3', name: 'High', disabled_on: null },
+  ],
 }
 
 describe('Investment form middleware - investment value', () => {
@@ -46,6 +51,8 @@ describe('Investment form middleware - investment value', () => {
       .reply(200, metadataMock.salaryRangeOptions)
       .get('/metadata/fdi-value/')
       .reply(200, metadataMock.fdiValueOptions)
+      .get('/metadata/likelihood-to-land/')
+      .reply(200, metadataMock.likelihoodToLandOptions)
   })
 
   describe('#populateForm', () => {

--- a/test/unit/apps/investment-projects/transformers/value.test.js
+++ b/test/unit/apps/investment-projects/transformers/value.test.js
@@ -29,6 +29,7 @@ describe('Investment project transformers', () => {
           non_fdi_r_and_d_budget: false,
           id: 1,
           associated_non_fdi_r_and_d_project: null,
+          likelihood_to_land: null,
         })
       })
 
@@ -47,6 +48,7 @@ describe('Investment project transformers', () => {
           account_tier: undefined,
           business_activities: 'No',
           associated_non_fdi_r_and_d_project: 'Not linked to a non-FDI R&D project',
+          likelihood_to_land: null,
         }
 
         expect(this.actualInvestmentValue).to.deep.equal(expectedInvestmentValue)
@@ -90,6 +92,10 @@ describe('Investment project transformers', () => {
             id: 'ac035522-ad0b-4eeb-87f4-0ce964e4b999',
             project_code: 'DHP-00000460',
           },
+          likelihood_to_land: {
+            name: 'Low',
+            id: 'b3515282-dc36-487a-a5af-320cde165575',
+          },
         })
       })
 
@@ -125,6 +131,10 @@ describe('Investment project transformers', () => {
                 url: '/investment-projects/1/remove-associated',
               },
             ],
+          },
+          likelihood_to_land: {
+            name: 'Low',
+            id: 'b3515282-dc36-487a-a5af-320cde165575',
           },
         }
 
@@ -169,6 +179,10 @@ describe('Investment project transformers', () => {
             id: 'ac035522-ad0b-4eeb-87f4-0ce964e4b999',
             project_code: 'DHP-00000460',
           },
+          likelihood_to_land: {
+            name: 'Low',
+            id: 'b3515282-dc36-487a-a5af-320cde165575',
+          },
         })
       })
 
@@ -198,6 +212,10 @@ describe('Investment project transformers', () => {
                 url: '/investment-projects/1/remove-associated',
               },
             ],
+          },
+          likelihood_to_land: {
+            'name': 'Low',
+            'id': 'b3515282-dc36-487a-a5af-320cde165575',
           },
         }
 


### PR DESCRIPTION
* Filter projects based on their `likelihood to land` by selecting a
  filter of which there are 3: Low, Medium and High.

* Edit a projects `likelihood to land` setting via a dropdown in the
  detail/edit page, again Low, Medium and High.

https://uktrade.atlassian.net/browse/IPBETA-156
https://uktrade.atlassian.net/browse/IPBETA-163