### PR TITLE
Present different audit view for dnb company

### DIFF
--- a/src/apps/companies/controllers/audit.js
+++ b/src/apps/companies/controllers/audit.js
@@ -6,19 +6,20 @@ const { transformApiResponseToCollection } = require('../../../modules/api/trans
 async function renderAuditLog (req, res, next) {
   const token = req.session.token
   const page = req.query.page || 1
-  const { id, name } = res.locals.company
+  const { company } = res.locals
+  const view = company.duns_number ? 'companies/views/audit' : 'companies/views/_deprecated/audit'
 
   try {
-    const auditLog = await getCompanyAuditLog(token, id, page)
+    const auditLog = await getCompanyAuditLog(token, company.id, page)
       .then(transformApiResponseToCollection(
-        { entityType: 'audit' },
+        {},
         transformAuditLogToListItem(companyDetailsLabels)
       ))
 
     res
-      .breadcrumb(name, `/companies/${id}`)
+      .breadcrumb(company.name, `/companies/${company.id}`)
       .breadcrumb('Audit history')
-      .render('companies/views/audit', {
+      .render(view, {
         auditLog,
       })
   } catch (error) {

--- a/src/apps/companies/views/_deprecated/audit.njk
+++ b/src/apps/companies/views/_deprecated/audit.njk
@@ -1,0 +1,6 @@
+{% extends "./_layout-view.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Audit history</h2>
+  {{ CollectionContent(auditLog) }}
+{% endblock %}

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -1,5 +1,6 @@
 module.exports = ({
   requestBody,
+  requestQuery = {},
   company,
   contact,
   interaction,
@@ -13,6 +14,7 @@ module.exports = ({
         token: '1234',
       },
       body: requestBody,
+      query: requestQuery,
     },
     resMock: {
       breadcrumb: sinon.stub().returnsThis(),


### PR DESCRIPTION
https://trello.com/c/b48CtT07/501-split-out-companies-views-in-order-to-accommodate-new-design-for-companies-with-a-duns-number

If a company does not have a DUNS number then present the _deprecated view

This is similar to #1652 .