### PR TITLE
Present different documents view for dnb company

### DIFF
--- a/src/apps/companies/controllers/documents.js
+++ b/src/apps/companies/controllers/documents.js
@@ -1,14 +1,12 @@
-const { get } = require('lodash')
-
-function renderDocuments (req, res, next) {
-  const { id: companyId, name: companyName } = get(res.locals, 'company')
-  const archivedDocumentPath = get(res.locals, 'company.archived_documents_url_path')
+function renderDocuments (req, res) {
+  const { company } = res.locals
+  const view = company.duns_number ? 'companies/views/documents' : 'companies/views/_deprecated/documents'
 
   return res
-    .breadcrumb(companyName, `/companies/${companyId}`)
+    .breadcrumb(company.name, `/companies/${company.id}`)
     .breadcrumb('Documents')
-    .render('companies/views/documents', {
-      archivedDocumentPath,
+    .render(view, {
+      archivedDocumentPath: company.archived_documents_url_path,
     })
 }
 

--- a/src/apps/companies/views/_deprecated/documents.njk
+++ b/src/apps/companies/views/_deprecated/documents.njk
@@ -1,0 +1,17 @@
+{% extends "./_layout-view.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Documents</h2>
+  <p>
+    {% if archivedDocumentPath %}
+      <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
+        View files and documents
+      </a>
+      <br>
+      <span id="external-link-label">(will open another website)</span>
+    {% else %}
+      There are no files or documents
+    {% endif %}
+  </p>
+
+{% endblock %}


### PR DESCRIPTION
https://trello.com/c/b48CtT07/501-split-out-companies-views-in-order-to-accommodate-new-design-for-companies-with-a-duns-number

If a company does not have a DUNS number then present the _deprecated view

This is similar to #1652 .