### PR TITLE
Present different contacts view for dnb company

### DIFF
--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -4,7 +4,7 @@ const { contactFiltersFields, companyContactSortForm } = require('../../contacts
 const { buildSelectedFiltersSummary } = require('../../builders')
 
 function renderContacts (req, res) {
-  const { id: companyId, name: companyName, archived: companyArchived } = res.locals.company
+  const { company } = res.locals
   const filtersFields = filter(contactFiltersFields, (field) => {
     return ['name', 'archived'].includes(field.name)
   })
@@ -16,14 +16,17 @@ function renderContacts (req, res) {
     ],
   })
 
-  const actionButtons = companyArchived ? undefined : [{
+  const actionButtons = company.archived ? undefined : [{
     label: 'Add contact',
-    url: `/contacts/create?company=${companyId}`,
+    url: `/contacts/create?company=${company.id}`,
   }]
+
+  const view = company.duns_number ? 'companies/views/contacts' : 'companies/views/_deprecated/contacts'
+
   res
-    .breadcrumb(companyName, `/companies/${companyId}`)
+    .breadcrumb(company.name, `/companies/${company.id}`)
     .breadcrumb('Contacts')
-    .render('companies/views/contacts', {
+    .render(view, {
       sortForm,
       filtersFields,
       actionButtons,

--- a/src/apps/companies/views/_deprecated/contacts.njk
+++ b/src/apps/companies/views/_deprecated/contacts.njk
@@ -1,0 +1,40 @@
+{% extends "./_layout-view.njk" %}
+
+{% block main_grid_right_column %}
+<h2 class="heading-medium">Contacts</h2>
+
+
+
+{% if company.archived %}
+<details role="group">
+  <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+    <span class="details__summary">
+      Why can I not add a contact?
+    </span>
+  </summary>
+  <div class="details__content" id="details-content-0" aria-hidden="false">
+    <p class="c-message c-message--muted">Contacts cannot be added to an archived company.
+      <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
+    </p>
+  </div>
+</details>
+{% endif %}
+
+{{ CollectionFilters({
+query: QUERY,
+filtersFields: filtersFields,
+action: CURRENT_PATH
+}) }}
+{% block xhr_content %}
+<article id="xhr-outlet">
+  {{ CollectionContent(contactResults | assign({
+  countLabel: 'contact',
+  sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
+  selectedFilters: selectedFilters,
+  query: QUERY,
+  action: CURRENT_PATH,
+  actionButtons: actionButtons
+  })) }}
+</article>
+{% endblock %}
+{% endblock %}


### PR DESCRIPTION
https://trello.com/c/b48CtT07/501-split-out-companies-views-in-order-to-accommodate-new-design-for-companies-with-a-duns-number

If a company does not have a DUNS number then present the _deprecated view

This is similar to #1652 .