### PR TITLE
Present different exports view for dnb company

### DIFF
--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -8,13 +8,14 @@ const { transformCompanyToExportDetailsView } = require('../transformers')
 const { exportDetailsLabels } = require('../labels')
 
 function renderExports (req, res) {
-  const { id, name } = res.locals.company
-  const exportDetails = transformCompanyToExportDetailsView(res.locals.company)
+  const { company } = res.locals
+  const exportDetails = transformCompanyToExportDetailsView(company)
+  const view = company.duns_number ? 'companies/views/exports-view' : 'companies/views/_deprecated/exports-view'
 
   res
-    .breadcrumb(name, `/companies/${id}`)
+    .breadcrumb(company.name, `/companies/${company.id}`)
     .breadcrumb('Exports')
-    .render('companies/views/exports-view', {
+    .render(view, {
       exportDetails,
     })
 }
@@ -36,13 +37,14 @@ function populateExportForm (req, res, next) {
 }
 
 function renderExportEdit (req, res) {
-  const { id, name } = res.locals.company
+  const { company } = res.locals
+  const view = company.duns_number ? 'companies/views/exports-edit' : 'companies/views/_deprecated/exports-edit'
 
   res
-    .breadcrumb(name, `/companies/${id}`)
-    .breadcrumb('Exports', `/companies/${id}/exports`)
+    .breadcrumb(company.name, `/companies/${company.id}`)
+    .breadcrumb('Exports', `/companies/${company.id}/exports`)
     .breadcrumb('Edit')
-    .render('companies/views/exports-edit', {
+    .render(view, {
       exportDetailsLabels,
       exportExperienceCategories: metadataRepo.exportExperienceCategory.map(transformObjectToOption),
       countryOptions: metadataRepo.countryOptions.map(transformObjectToOption),

--- a/src/apps/companies/views/_deprecated/exports-edit.njk
+++ b/src/apps/companies/views/_deprecated/exports-edit.njk
@@ -1,0 +1,76 @@
+{% extends "./_layout-edit.njk" %}
+
+{% block local_header %}
+  {{ LocalHeader({
+    heading: 'Edit export markets',
+    modifier: 'light-banner'
+  }) }}
+{% endblock %}
+
+{% block main_grid_right_column %}
+  {% call Form({
+    buttonText: 'Save and return',
+    returnText: 'Return without saving',
+    returnLink: '/companies/' + company.id + '/exports',
+    hiddenFields: {
+      id: company.id
+    }
+  }) %}
+    {{ MultipleChoiceField({
+      name: 'export_experience_category',
+      label: exportDetailsLabels.exportExperienceCategory,
+      value: formData.export_experience_category,
+      options: exportExperienceCategories,
+      initialOption: '-- Select category --',
+      optional: true
+    }) }}
+
+    {# TODO: Make these work without JavaScript #}
+    {% set exportCountries = formData.export_to_countries if formData.export_to_countries.length else ['']%}
+    <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
+      <label class="c-form-group__label">
+        <span class="c-form-group__label-text">
+          Select a market this company currently exports to (optional)
+        </span>
+      </label>
+
+      {% for country in exportCountries %}
+        {{ MultipleChoiceField({
+          name: 'export_to_countries',
+          label: 'Select a market this company currently exports to',
+          value: country,
+          options: countryOptions,
+          initialOption: '-- Select country --',
+          idSuffix: loop.index,
+          optional: true,
+          isLabelHidden: true,
+          modifier: ['compact', 'AddItems']
+        }) }}
+      {% endfor %}
+    </div>
+
+    {# TODO: Make these work without JavaScript #}
+    {% set futureCountries = formData.future_interest_countries if formData.future_interest_countries.length else ['']%}
+    <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
+      <label class="c-form-group__label">
+        <span class="c-form-group__label-text">
+          Future markets of interest (optional)
+        </span>
+      </label>
+
+      {% for country in futureCountries %}
+        {{ MultipleChoiceField({
+          name: 'future_interest_countries',
+          label: 'Future markets of interest',
+          value: country,
+          options: countryOptions,
+          initialOption: '-- Select country --',
+          idSuffix: loop.index,
+          optional: true,
+          isLabelHidden: true,
+          modifier: ['compact', 'AddItems']
+        }) }}
+      {% endfor %}
+    </div>
+  {% endcall %}
+{% endblock %}

--- a/src/apps/companies/views/_deprecated/exports-view.njk
+++ b/src/apps/companies/views/_deprecated/exports-view.njk
@@ -1,0 +1,18 @@
+{% extends "./_layout-view.njk" %}
+
+{% block main_grid_right_column %}
+  <h2 class="heading-medium">Exports</h2>
+
+  {% component 'key-value-table', items=exportDetails %}
+
+  {% if not company.archived %}
+    <p class="actions">
+      <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
+    </p>
+  {% endif %}
+
+  <div class="section">
+    <h2 class="heading-medium">Export wins</h2>
+    <p><a href="http://www.exportwins.service.trade.gov.uk/">Record your win</a> on our export wins site.<p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
https://trello.com/c/b48CtT07/501-split-out-companies-views-in-order-to-accommodate-new-design-for-companies-with-a-duns-number

If a company does not have a DUNS number then present the _deprecated view

This is similar to #1652 .