### PR TITLE
Add company known as to business details view

### DIFF
--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -1,0 +1,20 @@
+/* eslint-disable camelcase */
+const {
+  transformCompanyToKnownAsView,
+} = require('../transformers')
+
+async function renderBusinessDetails (req, res) {
+  const company = res.locals.company
+
+  res
+    .breadcrumb(company.name, `/companies/${company.id}`)
+    .breadcrumb('Business details')
+    .render('companies/views/business-details', {
+      heading: 'Business details',
+      knownAsDetails: transformCompanyToKnownAsView(company),
+    })
+}
+
+module.exports = {
+  renderBusinessDetails,
+}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -15,6 +15,7 @@ const {
 const { renderCompanyList } = require('./controllers/list')
 const { renderForm } = require('./controllers/edit')
 const { renderDetails } = require('./controllers/details')
+const { renderBusinessDetails } = require('./controllers/business-details')
 const { renderInvestments } = require('./controllers/investments')
 const { renderOrders } = require('./controllers/orders')
 const { renderAuditLog } = require('./controllers/audit')
@@ -103,6 +104,7 @@ router.use('/:companyId', handleRoutePermissions(LOCAL_NAV), setCompaniesLocalNa
 
 router.get('/:companyId', redirectToFirstNavItem)
 router.get('/:companyId/details', renderDetails)
+router.get('/:companyId/business-details', renderBusinessDetails)
 router.get('/:companyId/advisers', renderAdvisers)
 
 router.get('/:companyId/hierarchies/ghq/search', getGlobalHQCompaniesCollection, renderAddGlobalHQ)

--- a/src/apps/companies/transformers/company-to-known-as-view.js
+++ b/src/apps/companies/transformers/company-to-known-as-view.js
@@ -1,0 +1,28 @@
+/* eslint-disable camelcase */
+const { get, pickBy } = require('lodash')
+
+const { companyDetailsLabels } = require('../labels')
+const { getDataLabels } = require('../../../lib/controller-utils')
+
+module.exports = ({
+  trading_name,
+  companies_house_data,
+}) => {
+  const company_number = get(companies_house_data, 'company_number')
+
+  const viewRecord = {
+    trading_name: trading_name || 'None',
+    company_number: company_number ? [
+      company_number,
+      {
+        url: `https://beta.companieshouse.gov.uk/company/${company_number}`,
+        name: 'View on Companies House website',
+        hint: '(Opens in a new window)',
+        hintId: 'external-link-label',
+        newWindow: true,
+      },
+    ] : null,
+  }
+
+  return pickBy(getDataLabels(viewRecord, companyDetailsLabels))
+}

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -2,6 +2,7 @@ const transformCompaniesHouseToListItem = require('./companies-house-to-list-ite
 const transformCompaniesHouseToView = require('./companies-house-to-view')
 const transformCompanyToExportDetailsView = require('./company-to-export-details-view')
 const transformCompanyToForm = require('./company-to-form')
+const transformCompanyToKnownAsView = require('./company-to-known-as-view')
 const transformCompanyToListItem = require('./company-to-list-item')
 const transformCompanyToOneListView = require('./company-to-one-list-view')
 const transformCompanyToView = require('./company-to-view')
@@ -13,6 +14,7 @@ module.exports = {
   transformCompaniesHouseToView,
   transformCompanyToExportDetailsView,
   transformCompanyToForm,
+  transformCompanyToKnownAsView,
   transformCompanyToListItem,
   transformCompanyToOneListView,
   transformCompanyToSubsidiaryListItem,

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -1,0 +1,11 @@
+{% extends "_layouts/full-column.njk" %}
+
+{% block main_column %}
+
+  <div class="section">
+    <h2 class="heading-medium">{{ company.name }} is known as</h2>
+
+    {% component 'key-value-table', items=knownAsDetails %}
+  </div>
+
+{% endblock %}

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -12,6 +12,20 @@
  #   } %}
  #}
 
+{% macro link(url, name, newWindow, hintId, hint) %}
+  <a href="{{ url }}"
+    {% if hintId %} aria-labelledby="{{ hintId }}"{% endif %}
+    {% if newWindow %} target="_blank"{% endif %}
+    >
+    {{- name -}}
+  </a>
+  {% if hint %}
+    <span {% if hintId %}id="{{ hintId }}"{% endif %}>
+      {{- hint -}}
+    </span>
+  {% endif  %}
+{% endmacro %}
+
 {% if items|length %}
   <table class="table--key-value{{ ' table--' + variant if variant }}">
     <tbody>
@@ -20,21 +34,7 @@
         <tr>
           <th>{{ label }}</th>
           <td>
-            {% if data.url %}
-              <a
-                {% if data.hintId %}aria-labelledby="{{ data.hintId }}"{% endif %}
-                href="{{ data.url }}"
-              >
-                {{- data.name -}}
-              </a>
-              {% if data.hint %}
-                <span
-                  {% if data.hintId %}id="{{ data.hintId }}"{% endif %}
-                >
-                  {{- data.hint -}}
-                </span>
-              {% endif  %}
-            {% elif data | isArray %}
+            {% if data | isArray %}
               <ul>
                {% for item in data | removeNilAndEmpty %}
                  {% if item.type == 'document' %}
@@ -48,12 +48,18 @@
                      {% endif %}
                   </li>
                  {% else %}
-                   <li>{{ item }}</li>
+                   {% if item.url %}
+                     <li>{{ link(item.url, item.name, item.newWindow, item.hintId, item.hint) }}</li>
+                   {% else %}
+                     <li>{{ item }}</li>
+                   {% endif %}
                  {% endif %}
                {% endfor %}
               </ul>
             {% elif data | isPlainObject %}
-              {% if data.type == "date" %}
+              {% if data.url %}
+                {{ link(data.url, data.name, data.newWindow, data.hintId, data.hint) }}
+              {% elif data.type == "date" %}
                 {{ data.name | formatDate }}
               {% elif data.type == "currency" %}
                 {{ data.name | formatCurrency }}

--- a/src/templates/_layouts/full-column.njk
+++ b/src/templates/_layouts/full-column.njk
@@ -1,0 +1,9 @@
+{% extends "./datahub-base.njk" %}
+
+{% block body_main_content %}
+  <div class="grid-row">
+    <div class="column-full">
+      {% block main_column %}{% endblock %}
+    </div>
+  </div>
+{% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -1,0 +1,12 @@
+@companies-business-details
+Feature: Company business details
+
+  @companies-business-details--ghq-one-list
+  Scenario: View details for a Dun & Bradstreet GHQ company on the One List
+
+    When I navigate to the `companies.business-details` page using `company` `One List Corp` fixture
+    Then the heading should be "Business details"
+    And the Company summary key value details are not displayed
+    And the One List Corp is known as key value details are displayed
+      | key                       | value                        |
+      | Trading name              | company.tradingName          |

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -61,6 +61,7 @@ module.exports = {
     oneListCorp: {
       id: '375094ac-f79a-43e5-9c88-059a7caa17f0',
       name: 'One List Corp',
+      tradingName: 'None',
       address1: '12 St George\'s Road',
       town: 'Paris',
       postcode: '75001',

--- a/test/acceptance/pages/companies/business-details.js
+++ b/test/acceptance/pages/companies/business-details.js
@@ -1,0 +1,14 @@
+const { find } = require('lodash')
+
+const { company } = require('../../fixtures')
+
+module.exports = {
+  url: function companyFixtureUrl (companyName) {
+    const fixture = find(company, { name: companyName })
+    const companyId = fixture ? fixture.id : company.ukLtd.id
+
+    return `${process.env.QA_HOST}/companies/${companyId}/business-details`
+  },
+  elements: {
+  },
+}

--- a/test/unit/apps/companies/controllers/business-details.test.js
+++ b/test/unit/apps/companies/controllers/business-details.test.js
@@ -1,0 +1,44 @@
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+
+const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
+
+const { renderBusinessDetails } = require('~/src/apps/companies/controllers/business-details')
+
+describe('#renderBusinessDetails', () => {
+  context('when blah', () => {
+    beforeEach(async () => {
+      this.middlewareParameters = buildMiddlewareParameters({
+        company: dnbCompanyMock,
+      })
+
+      await renderBusinessDetails(
+        this.middlewareParameters.reqMock,
+        this.middlewareParameters.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should set the company breadcrumb', () => {
+      const expectedName = dnbCompanyMock.name
+      const expectedUrl = `/companies/${dnbCompanyMock.id}`
+
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWithExactly(expectedName, expectedUrl)
+    })
+
+    it('should set the business details breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWithExactly('Business details')
+    })
+
+    it('should render the business details view', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[0]).to.equal('companies/views/business-details')
+    })
+
+    it('should set the heading', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[1].heading).to.equal('Business details')
+    })
+
+    it('set the known as details', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[1].knownAsDetails).to.not.be.undefined
+    })
+  })
+})

--- a/test/unit/apps/companies/transformers/company-to-known-as-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-known-as-view.test.js
@@ -1,0 +1,46 @@
+const transformCompanyToKnownAsView = require('~/src/apps/companies/transformers/company-to-known-as-view')
+
+describe('#transformCompanyToKnownAsView', () => {
+  context('when all information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToKnownAsView({
+        trading_name: 'trading name',
+        companies_house_data: {
+          company_number: '123456',
+        },
+      })
+    })
+
+    it('should set the trading name', () => {
+      expect(this.actual['Trading name']).to.equal('trading name')
+    })
+
+    it('should set the Companies House number', () => {
+      expect(this.actual['Companies House number'][0]).to.equal('123456')
+    })
+
+    it('should set the Companies House link', () => {
+      expect(this.actual['Companies House number'][1]).to.deep.equal({
+        url: 'https://beta.companieshouse.gov.uk/company/123456',
+        name: 'View on Companies House website',
+        hint: '(Opens in a new window)',
+        hintId: 'external-link-label',
+        newWindow: true,
+      })
+    })
+  })
+
+  context('when no information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToKnownAsView({})
+    })
+
+    it('should set the trading name to "None"', () => {
+      expect(this.actual['Trading name']).to.equal('None')
+    })
+
+    it('should not set the Companies House number', () => {
+      expect(this.actual['Companies House number']).be.undefined
+    })
+  })
+})

--- a/test/unit/components/key-value-table.test.js
+++ b/test/unit/components/key-value-table.test.js
@@ -71,7 +71,7 @@ describe('Key/value table component', () => {
     expect(component.querySelector('td').innerHTML
       .trim()
       .replace(/\s+/g, ' '))
-      .to.equal(`<a aria-labelledby="${hintId}" href="${url}">${name}</a> <span id="${hintId}">${hint}</span>`)
+      .to.equal(`<a href="${url}" aria-labelledby="${hintId}">${name}</a> <span id="${hintId}">${hint}</span>`)
   })
 
   it('should render a table with an object with a name', () => {
@@ -154,5 +154,35 @@ describe('Key/value table component', () => {
     )
 
     expect(component.className).to.contain('table--custom-variant')
+  })
+
+  context('when the item data is an array', () => {
+    it('should add the items to the table', () => {
+      const component = renderComponentToDom(
+        'key-value-table',
+        {
+          items: {
+            'First label': [
+              'first',
+              {
+                url: 'url',
+                name: 'name',
+                newWindow: true,
+              },
+            ],
+          },
+        }
+      )
+
+      expect(component.className).to.contain('table--key-value')
+      const rows = component.querySelectorAll('tr')
+      expect(rows.length).to.equal(1)
+      expect(rows[0].querySelector('th').textContent).to.equal('First label')
+      expect(rows[0].querySelector('td').querySelector('li:nth-child(1)').textContent).to.equal('first')
+      expect(rows[0].querySelector('td').querySelector('li:nth-child(2)').innerHTML
+        .trim()
+        .replace(/\s+/g, ' '))
+        .to.equal(`<a href="url" target="_blank">name</a>`)
+    })
   })
 })


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

This change adds the `{companyName} is known as` to a new `Business details` view for the company.

## Included in this change
- Updates to `key-value-table` component so that cell lists can include links
- Add new `Business details`
- Start acceptance tests


## More to come
- Evolve acceptance tests to cover more scenarios
- More `Business details` sections


## One List Corp business details
![screenshot 2018-12-18 at 07 15 10](https://user-images.githubusercontent.com/1150417/50138045-16f44280-0295-11e9-9934-91a3b99f0a0d.png)


## Companies House number
At this stage there is not an example with a Companies House number, but if there was it would look like:

![screenshot 2018-12-18 at 07 19 42](https://user-images.githubusercontent.com/1150417/50138114-502cb280-0295-11e9-8e39-fce57961576f.png)