### PR TITLE
Add One List details to company business details view

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -91,10 +91,13 @@ const QUERY_FIELDS = [
   'headquarter_type',
 ]
 
+const NONE_TEXT = 'None'
+
 module.exports = {
   GLOBAL_NAV_ITEM,
   LOCAL_NAV,
   DEFAULT_COLLECTION_QUERY,
   APP_PERMISSIONS,
   QUERY_FIELDS,
+  NONE_TEXT,
 }

--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 const {
   transformCompanyToKnownAsView,
+  transformCompanyToOneListView,
 } = require('../transformers')
 
 async function renderBusinessDetails (req, res) {
@@ -12,6 +13,7 @@ async function renderBusinessDetails (req, res) {
     .render('companies/views/business-details', {
       heading: 'Business details',
       knownAsDetails: transformCompanyToKnownAsView(company),
+      oneListDetails: transformCompanyToOneListView(company),
     })
 }
 

--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -1,24 +1,19 @@
-const { find } = require('lodash')
-
 const config = require('../../../../config')
 const {
   transformCompanyToView,
   transformCompaniesHouseToView,
   transformCompanyToOneListView,
 } = require('../transformers')
-const { getOneListGroupCoreTeam } = require('../repos')
 
 async function renderDetails (req, res) {
   const company = res.locals.company
-  const coreTeam = await getOneListGroupCoreTeam(req.session.token, company.id)
-  const globalAccountManager = find(coreTeam, adviser => adviser.is_global_account_manager)
   const view = company.duns_number ? 'companies/views/details' : 'companies/views/_deprecated/details'
 
   res
     .breadcrumb(company.name)
     .render(view, {
       companyDetails: transformCompanyToView(company),
-      accountManagementDetails: transformCompanyToOneListView(company, globalAccountManager),
+      accountManagementDetails: transformCompanyToOneListView(company),
       chDetails: company.companies_house_data ? transformCompaniesHouseToView(company.companies_house_data) : null,
       oneListEmail: config.oneList.email,
     })

--- a/src/apps/companies/transformers/company-to-one-list-view.js
+++ b/src/apps/companies/transformers/company-to-one-list-view.js
@@ -3,25 +3,27 @@ const { get, compact } = require('lodash')
 
 const { getDataLabels } = require('../../../lib/controller-utils')
 const { accountManagementDisplayLabels } = require('../labels')
+const { NONE_TEXT } = require('../constants')
 
-const NONE_TEXT = 'None'
-
-const transformOneListAccountOwner = (globalAccountManager) => {
-  const region = get(globalAccountManager, 'adviser.dit_team.uk_region.name')
-  const country = get(globalAccountManager, 'adviser.dit_team.country.name')
+const transformGlobalAccountManager = ({ dit_team, name }) => {
+  const region = get(dit_team, 'uk_region.name')
+  const country = get(dit_team, 'country.name')
   const items = compact([
-    get(globalAccountManager, 'adviser.name'),
-    get(globalAccountManager, 'adviser.dit_team.name'),
+    name,
+    get(dit_team, 'name'),
     region || country,
   ])
 
   return items.length ? items : NONE_TEXT
 }
 
-module.exports = function transformCompanyToOneListView (company, globalAccountManager) {
+module.exports = ({
+  one_list_group_global_account_manager,
+  one_list_group_tier,
+}) => {
   const viewRecord = {
-    one_list_group_global_account_manager: transformOneListAccountOwner(globalAccountManager),
-    one_list_tier: get(company, 'one_list_group_tier.name', NONE_TEXT),
+    one_list_group_global_account_manager: transformGlobalAccountManager(one_list_group_global_account_manager || {}),
+    one_list_tier: get(one_list_group_tier, 'name', NONE_TEXT),
   }
 
   return getDataLabels(viewRecord, accountManagementDisplayLabels)

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -8,4 +8,16 @@
     {% component 'key-value-table', items=knownAsDetails %}
   </div>
 
+  {% if company.one_list_group_tier %}
+    <div class="section">
+      <h2 class="heading-medium">Global Account Manager – One List</h2>
+
+      {% component 'key-value-table', items=oneListDetails %}
+
+      <p>
+        <a href="advisers">See all advisers on the core team</a>
+      </p>
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -10,3 +10,7 @@ Feature: Company business details
     And the One List Corp is known as key value details are displayed
       | key                       | value                        |
       | Trading name              | company.tradingName          |
+    And the Global Account Manager – One List key value details are displayed
+      | key                       | value                        |
+      | One List tier             | company.oneListTier          |
+      | Global Account Manager    | company.globalAccountManager |

--- a/test/unit/apps/companies/controllers/business-details.test.js
+++ b/test/unit/apps/companies/controllers/business-details.test.js
@@ -5,7 +5,7 @@ const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
 const { renderBusinessDetails } = require('~/src/apps/companies/controllers/business-details')
 
 describe('#renderBusinessDetails', () => {
-  context('when blah', () => {
+  context('when rendering the view', () => {
     beforeEach(async () => {
       this.middlewareParameters = buildMiddlewareParameters({
         company: dnbCompanyMock,
@@ -39,6 +39,10 @@ describe('#renderBusinessDetails', () => {
 
     it('set the known as details', () => {
       expect(this.middlewareParameters.resMock.render.firstCall.args[1].knownAsDetails).to.not.be.undefined
+    })
+
+    it('set the One List details', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[1].oneListDetails).to.not.be.undefined
     })
   })
 })

--- a/test/unit/apps/companies/controllers/details.test.js
+++ b/test/unit/apps/companies/controllers/details.test.js
@@ -3,7 +3,6 @@ const { renderDetails } = require('~/src/apps/companies/controllers/details')
 const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
 const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
 const dunAndBradstreetCompany = require('~/test/unit/data/companies/dnb-company.json')
-const oneListGroupCoreTeam = require('~/test/unit/data/companies/one-list-group-core-team.json')
 const config = require('~/config')
 
 describe('Companies details controller', () => {
@@ -22,14 +21,6 @@ describe('Companies details controller', () => {
       breadcrumb: sinon.stub().returnsThis(),
       render: sinon.stub(),
     }
-
-    nock(config.apiRoot)
-      .get(`/v3/company/${minimalCompany.id}/one-list-group-core-team`)
-      .reply(200, [])
-
-    nock(config.apiRoot)
-      .get(`/v3/company/${dunAndBradstreetCompany.id}/one-list-group-core-team`)
-      .reply(200, oneListGroupCoreTeam)
   })
 
   describe('#renderDetails', () => {

--- a/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
@@ -1,84 +1,67 @@
-const { find, set } = require('lodash')
-
 const transformCompanyToOneListView = require('~/src/apps/companies/transformers/company-to-one-list-view')
 
-const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
-const oneListGroupCoreTeam = require('~/test/unit/data/companies/one-list-group-core-team.json')
+const dnbCompany = require('~/test/unit/data/companies/dnb-company.json')
 
 describe('transformCompanyToOneListView', () => {
-  context('when One List tier and Global Account Manager information exists', () => {
-    beforeEach(() => {
-      const company = {
-        ...minimalCompany,
-        one_list_group_tier: {
-          name: 'Tier A - Strategic Account',
-          id: 'b91bf800-8d53-e311-aef3-441ea13961e2',
-        },
-      }
-
-      const globalAccountManager = find(oneListGroupCoreTeam, adviser => adviser.is_global_account_manager)
-
-      this.actual = transformCompanyToOneListView(company, globalAccountManager)
-    })
-
+  const commonTests = (expectedOneListTier, expectedGlobalAccountManager) => {
     it('should set the One List tier', () => {
-      expect(this.actual['One List tier']).to.equal('Tier A - Strategic Account')
+      expect(this.actual['One List tier']).to.equal(expectedOneListTier)
     })
 
     it('should set the Global Account Manager', () => {
-      const expected = [
-        'Travis Greene',
-        'IST - Sector Advisory Services',
-        'London',
-      ]
-
-      expect(this.actual['Global Account Manager']).to.deep.equal(expected)
+      expect(this.actual['Global Account Manager']).to.deep.equal(expectedGlobalAccountManager)
     })
+  }
+
+  context('when One List tier and Global Account Manager information exists', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToOneListView(dnbCompany)
+    })
+
+    commonTests('Tier A - Strategic Account', [
+      'Travis Greene',
+      'IST - Sector Advisory Services',
+      'London',
+    ])
   })
 
   context('when One List tier and Global Account Manager information exists', () => {
     beforeEach(() => {
       const company = {
-        ...minimalCompany,
+        ...dnbCompany,
         one_list_group_tier: null,
+        one_list_group_global_account_manager: null,
       }
 
-      const globalAccountManager = undefined
-
-      this.actual = transformCompanyToOneListView(company, globalAccountManager)
+      this.actual = transformCompanyToOneListView(company)
     })
 
-    it('should set the One List tier to None', () => {
-      expect(this.actual['One List tier']).to.equal('None')
-    })
-
-    it('should set the Global Account Manager to None', () => {
-      expect(this.actual['Global Account Manager']).to.equal('None')
-    })
+    commonTests('None', 'None')
   })
 
   context('when Global Account Manager if from outside UK', () => {
     beforeEach(() => {
       const company = {
-        ...minimalCompany,
-        one_list_group_tier: null,
+        ...dnbCompany,
+        one_list_group_global_account_manager: {
+          ...dnbCompany.one_list_group_global_account_manager,
+          dit_team: {
+            ...dnbCompany.one_list_group_global_account_manager.dit_team,
+            uk_region: null,
+            country: {
+              name: 'France',
+            },
+          },
+        },
       }
 
-      const globalAccountManager = find(oneListGroupCoreTeam, adviser => adviser.is_global_account_manager)
-      set(globalAccountManager, 'adviser.dit_team.uk_region', null)
-      set(globalAccountManager, 'adviser.dit_team.country', { name: 'France' })
-
-      this.actual = transformCompanyToOneListView(company, globalAccountManager)
+      this.actual = transformCompanyToOneListView(company)
     })
 
-    it('set the Global Account Manager', () => {
-      const expected = [
-        'Travis Greene',
-        'IST - Sector Advisory Services',
-        'France',
-      ]
-
-      expect(this.actual['Global Account Manager']).to.deep.equal(expected)
-    })
+    commonTests('Tier A - Strategic Account', [
+      'Travis Greene',
+      'IST - Sector Advisory Services',
+      'France',
+    ])
   })
 })


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

This change adds the `Global Account Manager - One List` to the `business details` view of a company with a DUNS number.

Included with this change is a refactor of the company to One List view transformer.

![screenshot 2018-12-18 at 09 37 40](https://user-images.githubusercontent.com/1150417/50145177-d9011980-02a8-11e9-889c-69fc54592c33.png)
