### PR TITLE
Add business hierarchy details to business details company view

### DIFF
--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -2,10 +2,15 @@
 const {
   transformCompanyToKnownAsView,
   transformCompanyToOneListView,
+  transformCompanyToBusinessHierarchyView,
 } = require('../transformers')
+const {
+  getCompanySubsidiaries,
+} = require('../repos')
 
 async function renderBusinessDetails (req, res) {
   const company = res.locals.company
+  const subsidiaries = await getCompanySubsidiaries(req.session.token, company.id)
 
   res
     .breadcrumb(company.name, `/companies/${company.id}`)
@@ -14,6 +19,7 @@ async function renderBusinessDetails (req, res) {
       heading: 'Business details',
       knownAsDetails: transformCompanyToKnownAsView(company),
       oneListDetails: transformCompanyToOneListView(company),
+      businessHierarchyDetails: transformCompanyToBusinessHierarchyView(company, subsidiaries.count),
     })
 }
 

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -86,6 +86,11 @@ const coreTeamLabels = {
   adviser_on_core_team: 'Adviser on core team',
 }
 
+const businessHierarchyLabels = {
+  headquarter_type: 'Headquarter type',
+  subsidiaries: 'Subsidiaries',
+}
+
 module.exports = {
   companyDetailsLabels,
   chDetailsLabels,
@@ -95,4 +100,5 @@ module.exports = {
   exportDetailsLabels,
   address,
   coreTeamLabels,
+  businessHierarchyLabels,
 }

--- a/src/apps/companies/transformers/company-to-business-hierarchy-view.js
+++ b/src/apps/companies/transformers/company-to-business-hierarchy-view.js
@@ -1,0 +1,36 @@
+/* eslint-disable camelcase */
+const { get, pickBy } = require('lodash')
+
+const { getDataLabels } = require('../../../lib/controller-utils')
+const { businessHierarchyLabels, hqLabels } = require('../labels')
+const { pluralise } = require('../../../../config/nunjucks/filters')
+const { NONE_TEXT } = require('../constants')
+
+const transformHeadquarterType = (headquarter_type, global_headquarters) => {
+  if (get(headquarter_type, 'name') === 'ghq') {
+    return hqLabels.ghq
+  }
+
+  if (global_headquarters) {
+    return {
+      url: `/companies/${global_headquarters.id}`,
+      name: `Global HQ - ${global_headquarters.name}`,
+    }
+  }
+}
+
+const transformSubsidiaries = (id, subsidiariesCount) => {
+  return subsidiariesCount ? {
+    url: `/companies/${id}/subsidiaries`,
+    name: `${subsidiariesCount} ${pluralise('subsidiary', subsidiariesCount)}`,
+  } : NONE_TEXT
+}
+
+module.exports = ({ id, headquarter_type, global_headquarters }, subsidiariesCount) => {
+  const viewRecord = {
+    headquarter_type: transformHeadquarterType(headquarter_type, global_headquarters),
+    subsidiaries: transformSubsidiaries(id, subsidiariesCount),
+  }
+
+  return pickBy(getDataLabels(viewRecord, businessHierarchyLabels))
+}

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -1,5 +1,6 @@
 const transformCompaniesHouseToListItem = require('./companies-house-to-list-item')
 const transformCompaniesHouseToView = require('./companies-house-to-view')
+const transformCompanyToBusinessHierarchyView = require('./company-to-business-hierarchy-view')
 const transformCompanyToExportDetailsView = require('./company-to-export-details-view')
 const transformCompanyToForm = require('./company-to-form')
 const transformCompanyToKnownAsView = require('./company-to-known-as-view')
@@ -12,6 +13,7 @@ const transformCoreTeamToCollection = require('./one-list-core-team-to-collectio
 module.exports = {
   transformCompaniesHouseToListItem,
   transformCompaniesHouseToView,
+  transformCompanyToBusinessHierarchyView,
   transformCompanyToExportDetailsView,
   transformCompanyToForm,
   transformCompanyToKnownAsView,

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -20,4 +20,10 @@
     </div>
   {% endif %}
 
+  <div class="section">
+    <h2 class="heading-medium">Business hierarchy</h2>
+
+    {% component 'key-value-table', items=businessHierarchyDetails %}
+  </div>
+
 {% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -14,3 +14,7 @@ Feature: Company business details
       | key                       | value                        |
       | One List tier             | company.oneListTier          |
       | Global Account Manager    | company.globalAccountManager |
+    And the Business hierarchy key value details are displayed
+      | key                       | value                        |
+      | Headquarter type          | company.headquarterType      |
+      | Subsidiaries              | company.subsidiaries         |

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -69,6 +69,7 @@ module.exports = {
       primaryAddress: '12 St George\'s Road, Paris, 75001, France',
       businessType: 'Company',
       headquarterType: 'Global HQ',
+      subsidiaries: '1 subsidiary',
       sector: 'Retail',
       description: 'This is a dummy company for testing the One List',
       employeeRange: '500+',

--- a/test/unit/apps/companies/controllers/business-details.test.js
+++ b/test/unit/apps/companies/controllers/business-details.test.js
@@ -1,12 +1,18 @@
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
+const config = require('~/config')
 const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
+const subsidiariesMock = require('~/test/unit/data/companies/subsidiaries.json')
 
 const { renderBusinessDetails } = require('~/src/apps/companies/controllers/business-details')
 
 describe('#renderBusinessDetails', () => {
   context('when rendering the view', () => {
     beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v3/company?limit=10&offset=0&sortby=name&global_headquarters_id=${dnbCompanyMock.id}`)
+        .reply(200, subsidiariesMock)
+
       this.middlewareParameters = buildMiddlewareParameters({
         company: dnbCompanyMock,
       })
@@ -43,6 +49,10 @@ describe('#renderBusinessDetails', () => {
 
     it('set the One List details', () => {
       expect(this.middlewareParameters.resMock.render.firstCall.args[1].oneListDetails).to.not.be.undefined
+    })
+
+    it('set the business hierarchy details', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[1].businessHierarchyDetails).to.not.be.undefined
     })
   })
 })

--- a/test/unit/apps/companies/transformers/company-to-business-hierarchy-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-business-hierarchy-view.test.js
@@ -1,0 +1,81 @@
+const transformCompanyToBusinessHierarchyView = require('~/src/apps/companies/transformers/company-to-business-hierarchy-view')
+
+describe('#transformCompanyToBusinessHierarchyView', () => {
+  const commonTests = (expectedHeadquarterType, expectedSubsidiaries) => {
+    it('should set the headquarter type', () => {
+      expect(this.actual['Headquarter type']).to.deep.equal(expectedHeadquarterType)
+    })
+
+    it('should set the subsidiaries link', () => {
+      expect(this.actual.Subsidiaries).to.deep.equal(expectedSubsidiaries)
+    })
+  }
+
+  context('when the company is a global ultimate', () => {
+    context('when there is 1 subsidiary', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToBusinessHierarchyView({
+          id: '1',
+          headquarter_type: {
+            name: 'ghq',
+          },
+          global_headquarters: null,
+        }, 1)
+      })
+
+      commonTests('Global HQ', {
+        url: `/companies/1/subsidiaries`,
+        name: '1 subsidiary',
+      })
+    })
+
+    context('when there is multiple subsidiaries', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToBusinessHierarchyView({
+          id: '1',
+          headquarter_type: {
+            name: 'ghq',
+          },
+          global_headquarters: null,
+        }, 2)
+      })
+
+      commonTests('Global HQ', {
+        url: `/companies/1/subsidiaries`,
+        name: '2 subsidiaries',
+      })
+    })
+
+    context('when there is no subsidiaries', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToBusinessHierarchyView({
+          id: '1',
+          headquarter_type: {
+            name: 'ghq',
+          },
+          global_headquarters: null,
+        }, 0)
+      })
+
+      commonTests('Global HQ', 'None')
+    })
+  })
+
+  context('when the company is a subsidiary', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToBusinessHierarchyView({
+        id: '2',
+        headquarter_type: null,
+        global_headquarters: {
+          id: '1',
+          name: 'parent',
+        },
+      }, 0)
+    })
+
+    commonTests({
+      url: `/companies/1`,
+      name: 'Global HQ - parent',
+    }, 'None')
+  })
+})


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

This change adds the `Business hierarchy` to the business details view of a company with a DUNS number.

![screenshot 2018-12-18 at 12 01 52](https://user-images.githubusercontent.com/1150417/50152920-df00f580-02bc-11e9-82d9-7e41b127c83d.png)
