### PR TITLE
Overriding the govuk_fronted_toolkit font-stack

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -1,6 +1,8 @@
 $images-dir: "/images/";
 
 @import "~govuk-frontend/all";
+
+$toolkit-font-stack: Arial, sans-serif;
 @import "_deprecated/trade-elements";
 
 @import "~vue-multiselect/dist/vue-multiselect.min.css";


### PR DESCRIPTION
Override the toolkit's font-stack from `"nta", Arial, sans-serif` to `Arial, sans-serif;`

https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_font_stack.scss#L12
