### PR TITLE
Add sector details to business details for company

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -92,6 +92,7 @@ const QUERY_FIELDS = [
 ]
 
 const NONE_TEXT = 'None'
+const NOT_SET_TEXT = 'Not set'
 
 module.exports = {
   GLOBAL_NAV_ITEM,
@@ -100,4 +101,5 @@ module.exports = {
   APP_PERMISSIONS,
   QUERY_FIELDS,
   NONE_TEXT,
+  NOT_SET_TEXT,
 }

--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -3,6 +3,7 @@ const {
   transformCompanyToKnownAsView,
   transformCompanyToOneListView,
   transformCompanyToBusinessHierarchyView,
+  transformCompanyToSectorView,
 } = require('../transformers')
 const {
   getCompanySubsidiaries,
@@ -20,6 +21,7 @@ async function renderBusinessDetails (req, res) {
       knownAsDetails: transformCompanyToKnownAsView(company),
       oneListDetails: transformCompanyToOneListView(company),
       businessHierarchyDetails: transformCompanyToBusinessHierarchyView(company, subsidiaries.count),
+      sectorDetails: transformCompanyToSectorView(company),
     })
 }
 

--- a/src/apps/companies/transformers/company-to-sector-view.js
+++ b/src/apps/companies/transformers/company-to-sector-view.js
@@ -1,0 +1,12 @@
+const { get } = require('lodash')
+
+const { getPrimarySectorName } = require('../../../../common/transform-sectors')
+const { NOT_SET_TEXT } = require('../constants')
+
+module.exports = ({
+  sector,
+}) => {
+  return [
+    getPrimarySectorName(get(sector, 'name', NOT_SET_TEXT)),
+  ]
+}

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -6,6 +6,7 @@ const transformCompanyToForm = require('./company-to-form')
 const transformCompanyToKnownAsView = require('./company-to-known-as-view')
 const transformCompanyToListItem = require('./company-to-list-item')
 const transformCompanyToOneListView = require('./company-to-one-list-view')
+const transformCompanyToSectorView = require('./company-to-sector-view')
 const transformCompanyToView = require('./company-to-view')
 const transformCompanyToSubsidiaryListItem = require('./company-to-subsidiary-list-item')
 const transformCoreTeamToCollection = require('./one-list-core-team-to-collection')
@@ -19,6 +20,7 @@ module.exports = {
   transformCompanyToKnownAsView,
   transformCompanyToListItem,
   transformCompanyToOneListView,
+  transformCompanyToSectorView,
   transformCompanyToSubsidiaryListItem,
   transformCompanyToView,
   transformCoreTeamToCollection,

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -26,4 +26,18 @@
     {% component 'key-value-table', items=businessHierarchyDetails %}
   </div>
 
+  <div class="section">
+    <h2 class="heading-medium">DIT sector</h2>
+
+    <table class="table--key-value">
+      <tbody>
+      {% for sector in sectorDetails %}
+        <tr>
+          <td>{{ sector }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
 {% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -18,3 +18,6 @@ Feature: Company business details
       | key                       | value                        |
       | Headquarter type          | company.headquarterType      |
       | Subsidiaries              | company.subsidiaries         |
+    And the DIT sector values are displayed
+      | value                     |
+      | Retail                    |

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -2,15 +2,10 @@ const { client } = require('nightwatch-cucumber')
 const { Then } = require('cucumber')
 const { get, includes, startsWith, keys } = require('lodash')
 
-const { getKeyValueTableRowValueCell, getDataTableRowCell } = require('../../helpers/selectors')
+const { getKeyValueTableRowValueCell, getTableValueCell, getDataTableRowCell } = require('../../helpers/selectors')
 const formatters = require('../../helpers/formatters')
 
 const Details = client.page.details()
-
-const getRowCellSelector = {
-  'key-value': getKeyValueTableRowValueCell,
-  'data': getDataTableRowCell,
-}
 
 const ignoredKeys = [
   'Business type', // todo: case issues
@@ -18,8 +13,15 @@ const ignoredKeys = [
 ]
 
 const TABLE_TYPE = {
-  KEY_VALUE: 'key-value',
-  DATA: 'data',
+  KEY_VALUE: {
+    rowCellSelector: getKeyValueTableRowValueCell,
+  },
+  VALUE: {
+    rowCellSelector: getTableValueCell,
+  },
+  DATA: {
+    rowCellSelector: getDataTableRowCell,
+  },
 }
 
 function getExpected (key, state) {
@@ -59,11 +61,12 @@ const assertTableContent = async function (tableSelector, expectedData, tableTyp
     const rowFirstCellKey = columnKeys[0]
 
     for (const [columnIndex, columnKey] of columnKeys.entries()) {
-      if (includes(ignoredKeys, row[rowFirstCellKey]) || columnIndex === 0 || columnKey === 'formatter') {
+      const canIgnoreKeyColumn = tableType !== TABLE_TYPE.VALUE && columnIndex === 0
+      if (includes(ignoredKeys, row[rowFirstCellKey]) || canIgnoreKeyColumn || columnKey === 'formatter') {
         continue
       }
 
-      const rowCellSelector = getRowCellSelector[tableType](row[rowFirstCellKey], columnIndex)
+      const rowCellSelector = tableType.rowCellSelector(row[rowFirstCellKey], columnIndex)
       const tableRowCellXPathSelector = tableSelector.selector + rowCellSelector.selector
       const expected = getExpected(row[columnKey], this.state)
       await Details
@@ -104,8 +107,16 @@ Then(/^the (.+) key value details are displayed$/, async function (tableTitle, d
   const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
   const tableSelector = Details.getSelectorForKeyValueTable(tableTitle)
 
-  await assertTableRowCount(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
+  await assertTableRowCount(tableSelector, expectedKeyValues)
   await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
+})
+
+Then(/^the (.+) values are displayed$/, async function (tableTitle, dataTable) {
+  const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
+  const tableSelector = Details.getSelectorForKeyValueTable(tableTitle)
+
+  await assertTableRowCount(tableSelector, expectedKeyValues)
+  await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.VALUE)
 })
 
 Then(/^the (.+) key value details are not displayed$/, async function (tableTitle) {
@@ -121,22 +132,20 @@ Then(/^the key value details are displayed$/, async function (dataTable) {
   const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
   const tableSelector = Details.getSelectorForKeyValueTable()
 
-  await assertTableRowCount(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
+  await assertTableRowCount(tableSelector, expectedKeyValues)
   await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.KEY_VALUE)
 })
 
 Then(/^the (.+) data details are displayed$/, async function (tableTitle, dataTable) {
   const tableSelector = Details.getSelectorForDataTable(tableTitle)
 
-  await assertTableRowCount(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
+  await assertTableRowCount(tableSelector, dataTable.hashes())
   await assertTableContent.bind(this)(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
 })
 
 Then(/^the data details ([0-9]+) are displayed$/, async function (tableNumber, dataTable) {
   const tableSelector = Details.getSelectorForDataTableNumber(tableNumber)
 
-  console.log(tableSelector)
-
-  await assertTableRowCount(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
+  await assertTableRowCount(tableSelector, dataTable.hashes())
   await assertTableContent.bind(this)(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
 })

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -41,6 +41,21 @@ function getKeyValueTableRowValueCell (text) {
   )
 }
 
+/**
+ * Gets XPath selector for a table cell contain text
+ * @param text
+ * @returns {{selector: string, locateStrategy: string}}
+ */
+function getTableValueCell (text) {
+  return getSelectorForElementWithText(
+    text,
+    {
+      el: '//td',
+      hasExactText: true,
+    }
+  )
+}
+
 function getDataTableRowCell (text, index) {
   return getSelectorForElementWithText(
     text,
@@ -115,6 +130,7 @@ module.exports = {
   getSelectorForElementWithText,
   getButtonWithText,
   getKeyValueTableRowValueCell,
+  getTableValueCell,
   getDataTableRowCell,
   getMetaListItemValueSelector,
   getLinkWithText,

--- a/test/unit/apps/companies/transformers/company-to-sector-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-sector-view.test.js
@@ -1,0 +1,30 @@
+const transformCompanyToSectorView = require('~/src/apps/companies/transformers/company-to-sector-view')
+
+describe('#transformCompanyToSectorView', () => {
+  const commonTests = (expectedSectors) => {
+    it('should set the sectors', () => {
+      expect(this.actual).to.deep.equal(expectedSectors)
+    })
+  }
+
+  context('when all information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToSectorView({
+        sector: {
+          name: 'Renewable Energy',
+        },
+      })
+    })
+
+    commonTests([ 'Renewable Energy' ])
+  })
+
+  context('when no information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToSectorView({
+      })
+    })
+
+    commonTests([ 'Not set' ])
+  })
+})


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

This change adds the `Sector` to the business details view of a company with a DUNS number.

![screenshot 2018-12-18 at 13 03 23](https://user-images.githubusercontent.com/1150417/50155966-63f00d00-02c5-11e9-99a5-9635bc1e4dcc.png)

