### PR TITLE
Add address details to business details for company

### DIFF
--- a/assets/stylesheets/_deprecated/components/_table.scss
+++ b/assets/stylesheets/_deprecated/components/_table.scss
@@ -27,6 +27,10 @@
     padding: 0;
     margin: 0;
   }
+
+  div + ul {
+    margin-top: $default-spacing-unit / 2;
+  }
 }
 
 .table--striped {

--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -4,6 +4,7 @@ const {
   transformCompanyToOneListView,
   transformCompanyToBusinessHierarchyView,
   transformCompanyToSectorView,
+  transformCompanyToAddressesView,
 } = require('../transformers')
 const {
   getCompanySubsidiaries,
@@ -22,6 +23,7 @@ async function renderBusinessDetails (req, res) {
       oneListDetails: transformCompanyToOneListView(company),
       businessHierarchyDetails: transformCompanyToBusinessHierarchyView(company, subsidiaries.count),
       sectorDetails: transformCompanyToSectorView(company),
+      addressesDetails: transformCompanyToAddressesView(company),
     })
 }
 

--- a/src/apps/companies/transformers/company-to-addresses-view.js
+++ b/src/apps/companies/transformers/company-to-addresses-view.js
@@ -1,0 +1,48 @@
+/* eslint-disable camelcase */
+const { get, compact, pickBy } = require('lodash')
+
+const transformAddress = (company, prefix) => {
+  const addressParts = compact([
+    get(company, `${prefix}address_1`),
+    get(company, `${prefix}address_2`),
+    get(company, `${prefix}address_town`),
+    get(company, `${prefix}address_county`),
+    get(company, `${prefix}address_postcode`),
+    get(company, `${prefix}address_country.name`),
+  ])
+
+  if (addressParts.length) {
+    return addressParts
+  }
+}
+
+function transformMetaItem (value) {
+  return {
+    value,
+    label: 'Type',
+    type: 'badge',
+  }
+}
+
+module.exports = (company) => {
+  const registeredAddress = transformAddress(company, 'registered_')
+  const tradingAddress = transformAddress(company, 'trading_')
+
+  const viewRecord = {
+    registered: {
+      address: registeredAddress,
+      meta: compact([
+        tradingAddress ? null : transformMetaItem('Trading'),
+        transformMetaItem('Registered'),
+      ]),
+    },
+    trading: tradingAddress ? {
+      address: tradingAddress,
+      meta: [
+        transformMetaItem('Trading'),
+      ],
+    } : null,
+  }
+
+  return pickBy(viewRecord)
+}

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -1,6 +1,7 @@
 const transformCompaniesHouseToListItem = require('./companies-house-to-list-item')
 const transformCompaniesHouseToView = require('./companies-house-to-view')
 const transformCompanyToBusinessHierarchyView = require('./company-to-business-hierarchy-view')
+const transformCompanyToAddressesView = require('./company-to-addresses-view')
 const transformCompanyToExportDetailsView = require('./company-to-export-details-view')
 const transformCompanyToForm = require('./company-to-form')
 const transformCompanyToKnownAsView = require('./company-to-known-as-view')
@@ -15,6 +16,7 @@ module.exports = {
   transformCompaniesHouseToListItem,
   transformCompaniesHouseToView,
   transformCompanyToBusinessHierarchyView,
+  transformCompanyToAddressesView,
   transformCompanyToExportDetailsView,
   transformCompanyToForm,
   transformCompanyToKnownAsView,

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -1,5 +1,22 @@
 {% extends "_layouts/full-column.njk" %}
 
+{% macro AddressCell(meta, address) %}
+  <td>
+    {{
+      MetaList({
+        items: meta,
+        modifier: 'stacked',
+        itemModifier: 'stacked'
+      })
+    }}
+    <ul>
+      {% for element in address %}
+        <li>{{ element }}</li>
+      {% endfor %}
+    </ul>
+  </td>
+{% endmacro %}
+
 {% block main_column %}
 
   <div class="section">
@@ -36,6 +53,23 @@
           <td>{{ sector }}</td>
         </tr>
       {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="section">
+    <h2 class="heading-medium">Addresses</h2>
+
+    <table class="table--key-value">
+      <tbody>
+      <tr>
+        {% if addressesDetails.trading.address %}
+          {{ AddressCell(addressesDetails.trading.meta, addressesDetails.trading.address) }}
+        {% endif %}
+        {% if addressesDetails.registered.address %}
+          {{ AddressCell(addressesDetails.registered.meta, addressesDetails.registered.address) }}
+        {% endif %}
+      </tr>
       </tbody>
     </table>
   </div>

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -21,3 +21,13 @@ Feature: Company business details
     And the DIT sector values are displayed
       | value                     |
       | Retail                    |
+    And address 1 should have badges
+      | value                     |
+      | Trading                   |
+      | Registered                |
+    And address 1 should be
+      | value                     |
+      | 12 St George's Road       |
+      | Paris                     |
+      | 75001                     |
+      | France                    |

--- a/test/acceptance/features/companies/step_definitions/business-details.js
+++ b/test/acceptance/features/companies/step_definitions/business-details.js
@@ -1,0 +1,52 @@
+const { client } = require('nightwatch-cucumber')
+const { Then } = require('cucumber')
+
+const { getSelectorForElementWithText } = require('../../../helpers/selectors')
+
+const BusinessDetailsPage = client.page.companies['business-details']()
+
+const getAddressSelector = (tableNumber) => {
+  return getSelectorForElementWithText('Addresses', {
+    el: '//h2',
+    child: `/following-sibling::table[${tableNumber}]`,
+  })
+}
+
+const getBadgeSelector = (text) => {
+  return getSelectorForElementWithText(text, {
+    el: '//span',
+    className: 'c-badge',
+  })
+}
+
+const getAddressLineSelector = (text) => {
+  return getSelectorForElementWithText(text, {
+    el: '//li',
+  })
+}
+
+Then(/^address ([0-9]+) should have badges/, async function (addressNumber, dataTable) {
+  const addressSelector = getAddressSelector(addressNumber)
+
+  for (const row of dataTable.hashes()) {
+    const badgeSelector = getBadgeSelector(row.value)
+
+    await BusinessDetailsPage
+      .api.useXpath()
+      .waitForElementPresent(addressSelector.selector + badgeSelector.selector)
+      .useCss()
+  }
+})
+
+Then(/^address ([0-9]+) should be/, async function (addressNumber, dataTable) {
+  const addressSelector = getAddressSelector(addressNumber)
+
+  for (const row of dataTable.hashes()) {
+    const addressLineSelector = getAddressLineSelector(row.value)
+
+    await BusinessDetailsPage
+      .api.useXpath()
+      .waitForElementPresent(addressSelector.selector + addressLineSelector.selector)
+      .useCss()
+  }
+})

--- a/test/unit/apps/companies/controllers/business-details.test.js
+++ b/test/unit/apps/companies/controllers/business-details.test.js
@@ -54,5 +54,9 @@ describe('#renderBusinessDetails', () => {
     it('set the business hierarchy details', () => {
       expect(this.middlewareParameters.resMock.render.firstCall.args[1].businessHierarchyDetails).to.not.be.undefined
     })
+
+    it('set the addresses details', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[1].addressesDetails).to.not.be.undefined
+    })
   })
 })

--- a/test/unit/apps/companies/transformers/company-to-addresses-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-addresses-view.test.js
@@ -1,0 +1,103 @@
+const transformCompanyToAddressesView = require('~/src/apps/companies/transformers/company-to-addresses-view')
+
+describe('#transformCompanyToAddressesView', () => {
+  context('when all information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToAddressesView({
+        registered_address_1: 'registered address 1',
+        registered_address_2: 'registered address 2',
+        registered_address_town: 'registered address town',
+        registered_address_county: 'registered address county',
+        registered_address_postcode: 'registered address postcode',
+        registered_address_country: {
+          name: 'registered address country',
+        },
+        trading_address_1: 'trading address 1',
+        trading_address_2: 'trading address 2',
+        trading_address_town: 'trading address town',
+        trading_address_county: 'trading address county',
+        trading_address_postcode: 'trading address postcode',
+        trading_address_country: {
+          name: 'trading address country',
+        },
+      })
+    })
+
+    it('should set the registered address', () => {
+      expect(this.actual.registered.address).to.deep.equal([
+        'registered address 1',
+        'registered address 2',
+        'registered address town',
+        'registered address county',
+        'registered address postcode',
+        'registered address country',
+      ])
+    })
+
+    it('should set the registered address badges', () => {
+      expect(this.actual.registered.meta).to.deep.equal([
+        {
+          value: 'Registered',
+          label: 'Type',
+          type: 'badge',
+        },
+      ])
+    })
+
+    it('should set the trading address', () => {
+      expect(this.actual.trading.address).to.deep.equal([
+        'trading address 1',
+        'trading address 2',
+        'trading address town',
+        'trading address county',
+        'trading address postcode',
+        'trading address country',
+      ])
+    })
+
+    it('should set the trading address badges', () => {
+      expect(this.actual.trading.meta).to.deep.equal([
+        {
+          value: 'Trading',
+          label: 'Type',
+          type: 'badge',
+        },
+      ])
+    })
+  })
+
+  context('when the company has the minimal address information', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToAddressesView({
+        registered_address_country: {
+          name: 'registered address country',
+        },
+      })
+    })
+
+    it('should set the registered address', () => {
+      expect(this.actual.registered.address).to.deep.equal([
+        'registered address country',
+      ])
+    })
+
+    it('should set the registered address badges', () => {
+      expect(this.actual.registered.meta).to.deep.equal([
+        {
+          value: 'Trading',
+          label: 'Type',
+          type: 'badge',
+        },
+        {
+          value: 'Registered',
+          label: 'Type',
+          type: 'badge',
+        },
+      ])
+    })
+
+    it('should not set the trading address', () => {
+      expect(this.actual.trading).to.be.undefined
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

This change adds the `Addresses` to the business details view of a company with a DUNS number.

![screenshot 2018-12-18 at 17 30 31](https://user-images.githubusercontent.com/1150417/50171560-af68e200-02ea-11e9-9dc7-a84a44d2eb01.png)
