### PR TITLE
Add additional business information to business details

### DIFF
--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -5,6 +5,7 @@ const {
   transformCompanyToBusinessHierarchyView,
   transformCompanyToSectorView,
   transformCompanyToAddressesView,
+  transformCompanyToAdditionalInformationView,
 } = require('../transformers')
 const {
   getCompanySubsidiaries,
@@ -24,6 +25,7 @@ async function renderBusinessDetails (req, res) {
       businessHierarchyDetails: transformCompanyToBusinessHierarchyView(company, subsidiaries.count),
       sectorDetails: transformCompanyToSectorView(company),
       addressesDetails: transformCompanyToAddressesView(company),
+      additionalInformationDetails: transformCompanyToAdditionalInformationView(company),
     })
 }
 

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -91,6 +91,12 @@ const businessHierarchyLabels = {
   subsidiaries: 'Subsidiaries',
 }
 
+const additionalBusinessInformationLabels = {
+  turnover: 'Annual turnover',
+  number_of_employees: 'Number of employees',
+  websites: 'Websites',
+}
+
 module.exports = {
   companyDetailsLabels,
   chDetailsLabels,
@@ -101,4 +107,5 @@ module.exports = {
   address,
   coreTeamLabels,
   businessHierarchyLabels,
+  additionalBusinessInformationLabels,
 }

--- a/src/apps/companies/transformers/company-to-additional-information-view.js
+++ b/src/apps/companies/transformers/company-to-additional-information-view.js
@@ -1,0 +1,27 @@
+/* eslint-disable camelcase */
+const { pickBy, isEmpty } = require('lodash')
+
+const { additionalBusinessInformationLabels } = require('../labels')
+const { getDataLabels } = require('../../../lib/controller-utils')
+
+const NOT_AVAILABLE_TEXT = 'Not available'
+
+module.exports = ({
+  website,
+  number_of_employees,
+  turnover,
+}) => {
+  const viewRecord = {
+    turnover: turnover ? `USD ${turnover}` : NOT_AVAILABLE_TEXT,
+    number_of_employees: number_of_employees || NOT_AVAILABLE_TEXT,
+    websites: isEmpty(website) ? NOT_AVAILABLE_TEXT : {
+      name: website,
+      url: website,
+      hint: '(Opens in a new window)',
+      hintId: 'external-link-label',
+      newWindow: true,
+    },
+  }
+
+  return pickBy(getDataLabels(viewRecord, additionalBusinessInformationLabels))
+}

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -1,7 +1,8 @@
 const transformCompaniesHouseToListItem = require('./companies-house-to-list-item')
 const transformCompaniesHouseToView = require('./companies-house-to-view')
-const transformCompanyToBusinessHierarchyView = require('./company-to-business-hierarchy-view')
+const transformCompanyToAdditionalInformationView = require('./company-to-additional-information-view')
 const transformCompanyToAddressesView = require('./company-to-addresses-view')
+const transformCompanyToBusinessHierarchyView = require('./company-to-business-hierarchy-view')
 const transformCompanyToExportDetailsView = require('./company-to-export-details-view')
 const transformCompanyToForm = require('./company-to-form')
 const transformCompanyToKnownAsView = require('./company-to-known-as-view')
@@ -15,8 +16,9 @@ const transformCoreTeamToCollection = require('./one-list-core-team-to-collectio
 module.exports = {
   transformCompaniesHouseToListItem,
   transformCompaniesHouseToView,
-  transformCompanyToBusinessHierarchyView,
+  transformCompanyToAdditionalInformationView,
   transformCompanyToAddressesView,
+  transformCompanyToBusinessHierarchyView,
   transformCompanyToExportDetailsView,
   transformCompanyToForm,
   transformCompanyToKnownAsView,

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -74,4 +74,10 @@
     </table>
   </div>
 
+  <div class="section">
+    <h2 class="heading-medium">Additional business information</h2>
+
+    {% component 'key-value-table', items=additionalInformationDetails %}
+  </div>
+
 {% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -31,3 +31,8 @@ Feature: Company business details
       | Paris                     |
       | 75001                     |
       | France                    |
+    And the Additional business information key value details are displayed
+      | key                       | value                        |
+      | Annual turnover           | Not available                |
+      | Number of employees       | Not available                |
+      | Websites                  | Not available                |

--- a/test/unit/apps/companies/transformers/company-to-additional-details-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-additional-details-view.test.js
@@ -1,0 +1,45 @@
+const transformCompanyToAdditionalInformationView = require('~/src/apps/companies/transformers/company-to-additional-information-view')
+const { additionalBusinessInformationLabels } = require('~/src/apps/companies/labels')
+
+describe('#transformCompanyToAdditionalInformationView', () => {
+  const commonTests = (expectedWebsites, expectedEmployees, expectedTurnover) => {
+    it('should set the websites', () => {
+      expect(this.actual[additionalBusinessInformationLabels.websites]).to.deep.equal(expectedWebsites)
+    })
+
+    it('should set the number of employees', () => {
+      expect(this.actual[additionalBusinessInformationLabels.number_of_employees]).to.equal(expectedEmployees)
+    })
+
+    it('should set the turnover', () => {
+      expect(this.actual[additionalBusinessInformationLabels.turnover]).to.equal(expectedTurnover)
+    })
+  }
+
+  context('when all information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToAdditionalInformationView({
+        website: 'www.company.com',
+        turnover: 100000,
+        number_of_employees: 200,
+      })
+    })
+
+    commonTests({
+      url: 'www.company.com',
+      name: 'www.company.com',
+      hint: '(Opens in a new window)',
+      hintId: 'external-link-label',
+      newWindow: true,
+    }, 200, 'USD 100000')
+  })
+
+  context('when no information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToAdditionalInformationView({
+      })
+    })
+
+    commonTests('Not available', 'Not available', 'Not available')
+  })
+})


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

This change adds the `Additional business information` section to the `Business details` of a company.

This is the first iteration of this section as there will be more in this section.

## Design
![screenshot 2018-12-19 at 13 19 06](https://user-images.githubusercontent.com/1150417/50222610-b6e2c680-0390-11e9-95ea-c922bcfc4490.png)

## Current implementation
![screenshot 2018-12-19 at 13 19 44](https://user-images.githubusercontent.com/1150417/50222629-c8c46980-0390-11e9-931e-d63da1379a85.png)
