### PR TITLE
Add CDMS documents section to business details

### DIFF
--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -1,4 +1,6 @@
 /* eslint-disable camelcase */
+const { isEmpty } = require('lodash')
+
 const {
   transformCompanyToKnownAsView,
   transformCompanyToOneListView,
@@ -26,6 +28,7 @@ async function renderBusinessDetails (req, res) {
       sectorDetails: transformCompanyToSectorView(company),
       addressesDetails: transformCompanyToAddressesView(company),
       additionalInformationDetails: transformCompanyToAdditionalInformationView(company),
+      archivedDocumentPath: isEmpty(company.archived_documents_url_path) ? undefined : company.archived_documents_url_path,
     })
 }
 

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -80,4 +80,23 @@
     {% component 'key-value-table', items=additionalInformationDetails %}
   </div>
 
+  {% if archivedDocumentPath %}
+    <div class="section">
+      <h2 class="heading-medium">Documents from CDMS</h2>
+
+      <table class="table--key-value">
+        <tbody>
+        <tr>
+          <td>
+            <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
+              View files and documents
+            </a>
+            <span id="external-link-label">(will open another website)</span>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -36,3 +36,4 @@ Feature: Company business details
       | Annual turnover           | Not available                |
       | Number of employees       | Not available                |
       | Websites                  | Not available                |
+    And the Documents from CDMS key value details are not displayed


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

This change adds the `Documents from CDMS` section to the `Business details` of a company.

Using `One List Corp` will not show the section. [Browsing to Venus Ltd](http://localhost:3000/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/business-details) will show the section.

![screenshot 2018-12-19 at 13 25 00](https://user-images.githubusercontent.com/1150417/50223397-ff02e880-0392-11e9-86ec-ad98eceadf77.png)