### PR TITLE
Add DIT region section to business details

### DIFF
--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -6,6 +6,7 @@ const {
   transformCompanyToOneListView,
   transformCompanyToBusinessHierarchyView,
   transformCompanyToSectorView,
+  transformCompanyToRegionView,
   transformCompanyToAddressesView,
   transformCompanyToAdditionalInformationView,
 } = require('../transformers')
@@ -26,6 +27,7 @@ async function renderBusinessDetails (req, res) {
       oneListDetails: transformCompanyToOneListView(company),
       businessHierarchyDetails: transformCompanyToBusinessHierarchyView(company, subsidiaries.count),
       sectorDetails: transformCompanyToSectorView(company),
+      regionDetails: transformCompanyToRegionView(company),
       addressesDetails: transformCompanyToAddressesView(company),
       additionalInformationDetails: transformCompanyToAdditionalInformationView(company),
       archivedDocumentPath: isEmpty(company.archived_documents_url_path) ? undefined : company.archived_documents_url_path,

--- a/src/apps/companies/transformers/company-to-region-view.js
+++ b/src/apps/companies/transformers/company-to-region-view.js
@@ -1,0 +1,10 @@
+/* eslint-disable camelcase */
+const { get } = require('lodash')
+
+const { NOT_SET_TEXT } = require('../constants')
+
+module.exports = ({
+  uk_region,
+}) => {
+  return get(uk_region, 'name', NOT_SET_TEXT)
+}

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -8,6 +8,7 @@ const transformCompanyToForm = require('./company-to-form')
 const transformCompanyToKnownAsView = require('./company-to-known-as-view')
 const transformCompanyToListItem = require('./company-to-list-item')
 const transformCompanyToOneListView = require('./company-to-one-list-view')
+const transformCompanyToRegionView = require('./company-to-region-view')
 const transformCompanyToSectorView = require('./company-to-sector-view')
 const transformCompanyToView = require('./company-to-view')
 const transformCompanyToSubsidiaryListItem = require('./company-to-subsidiary-list-item')
@@ -24,6 +25,7 @@ module.exports = {
   transformCompanyToKnownAsView,
   transformCompanyToListItem,
   transformCompanyToOneListView,
+  transformCompanyToRegionView,
   transformCompanyToSectorView,
   transformCompanyToSubsidiaryListItem,
   transformCompanyToView,

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -58,6 +58,18 @@
   </div>
 
   <div class="section">
+    <h2 class="heading-medium">DIT region</h2>
+
+    <table class="table--key-value">
+      <tbody>
+      <tr>
+        <td>{{ regionDetails }}</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="section">
     <h2 class="heading-medium">Addresses</h2>
 
     <table class="table--key-value">

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -21,6 +21,9 @@ Feature: Company business details
     And the DIT sector values are displayed
       | value                     |
       | Retail                    |
+    And the DIT region values are displayed
+      | value                     |
+      | Not set                   |
     And address 1 should have badges
       | value                     |
       | Trading                   |

--- a/test/unit/apps/companies/transformers/company-to-region-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-region-view.test.js
@@ -1,0 +1,30 @@
+const transformCompanyToRegionView = require('~/src/apps/companies/transformers/company-to-region-view')
+
+describe('#transformCompanyToRegionView', () => {
+  const commonTests = (expectedSectors) => {
+    it('should set the region', () => {
+      expect(this.actual).to.deep.equal(expectedSectors)
+    })
+  }
+
+  context('when all information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToRegionView({
+        uk_region: {
+          name: 'North West',
+        },
+      })
+    })
+
+    commonTests('North West')
+  })
+
+  context('when no information is populated', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToRegionView({
+      })
+    })
+
+    commonTests('Not set')
+  })
+})


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

Add `DIT region` section to `Business details` for a company.

![screenshot 2018-12-19 at 13 48 28](https://user-images.githubusercontent.com/1150417/50224586-2d35f780-0396-11e9-8767-4a866f696c00.png)
