### PR TITLE
Add details summary to business details

### DIFF
--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -19,6 +19,16 @@
 
 {% block main_column %}
 
+  {% call HiddenContent({ summary: 'Where does information on this page come from?' }) %}
+    {% call Message({ type: 'muted' }) %}
+      The information on this page that cannot be edited comes from
+      <a href="https://www.dnb.co.uk/about-us/data-cloud.html" target="_blank">Dun & Bradstreet</a>.
+      This is an external and verified source. The information is automatically updated.
+      <a href="audit">View the audit history</a>.<br />
+      If you think the information is incomplete or incorrect, <a href="/support">get in touch using the support form</a>.
+    {% endcall %}
+  {% endcall %}
+
   <div class="section">
     <h2 class="heading-medium">{{ company.name }} is known as</h2>
 

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -6,6 +6,7 @@ Feature: Company business details
 
     When I navigate to the `companies.business-details` page using `company` `One List Corp` fixture
     Then the heading should be "Business details"
+    And the "Where does information on this page come from?" details summary should be displayed
     And the Company summary key value details are not displayed
     And the One List Corp is known as key value details are displayed
       | key                       | value                        |

--- a/test/acceptance/features/companies/step_definitions/business-details.js
+++ b/test/acceptance/features/companies/step_definitions/business-details.js
@@ -33,7 +33,7 @@ Then(/^address ([0-9]+) should have badges/, async function (addressNumber, data
 
     await BusinessDetailsPage
       .api.useXpath()
-      .waitForElementPresent(addressSelector.selector + badgeSelector.selector)
+      .waitForElementVisible(addressSelector.selector + badgeSelector.selector)
       .useCss()
   }
 })
@@ -46,7 +46,7 @@ Then(/^address ([0-9]+) should be/, async function (addressNumber, dataTable) {
 
     await BusinessDetailsPage
       .api.useXpath()
-      .waitForElementPresent(addressSelector.selector + addressLineSelector.selector)
+      .waitForElementVisible(addressSelector.selector + addressLineSelector.selector)
       .useCss()
   }
 })

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -2,7 +2,12 @@ const { client } = require('nightwatch-cucumber')
 const { Then } = require('cucumber')
 const { get, includes, startsWith, keys } = require('lodash')
 
-const { getKeyValueTableRowValueCell, getTableValueCell, getDataTableRowCell } = require('../../helpers/selectors')
+const {
+  getKeyValueTableRowValueCell,
+  getTableValueCell,
+  getDataTableRowCell,
+  getSelectorForElementWithText,
+} = require('../../helpers/selectors')
 const formatters = require('../../helpers/formatters')
 
 const Details = client.page.details()
@@ -148,4 +153,17 @@ Then(/^the data details ([0-9]+) are displayed$/, async function (tableNumber, d
 
   await assertTableRowCount(tableSelector, dataTable.hashes())
   await assertTableContent.bind(this)(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
+})
+
+Then(/^the "(.+)" details summary should be displayed$/, async (summary) => {
+  const detailsSummarySelector = getSelectorForElementWithText(summary, {
+    el: '//span',
+    className: 'details__summary',
+    hasExactText: true,
+  })
+
+  await Details
+    .api.useXpath()
+    .waitForElementVisible(detailsSummarySelector.selector)
+    .useCss()
 })


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

Adds the summary content to the `Business details` screen for a company.

![screenshot 2018-12-19 at 14 21 26](https://user-images.githubusercontent.com/1150417/50225848-8bb0a500-0399-11e9-975c-33992bb72228.png)
