### PR TITLE
Use new trading_names field

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -86,6 +86,11 @@ const coreTeamLabels = {
   adviser_on_core_team: 'Adviser on core team',
 }
 
+const knownAsLabels = {
+  trading_names: 'Trading names',
+  company_number: 'Companies House number',
+}
+
 const businessHierarchyLabels = {
   headquarter_type: 'Headquarter type',
   subsidiaries: 'Subsidiaries',
@@ -106,6 +111,7 @@ module.exports = {
   exportDetailsLabels,
   address,
   coreTeamLabels,
+  knownAsLabels,
   businessHierarchyLabels,
   additionalBusinessInformationLabels,
 }

--- a/src/apps/companies/transformers/company-to-known-as-view.js
+++ b/src/apps/companies/transformers/company-to-known-as-view.js
@@ -1,17 +1,17 @@
 /* eslint-disable camelcase */
 const { get, pickBy } = require('lodash')
 
-const { companyDetailsLabels } = require('../labels')
+const { knownAsLabels } = require('../labels')
 const { getDataLabels } = require('../../../lib/controller-utils')
 
 module.exports = ({
-  trading_name,
+  trading_names,
   companies_house_data,
 }) => {
   const company_number = get(companies_house_data, 'company_number')
 
   const viewRecord = {
-    trading_name: trading_name || 'None',
+    trading_names: trading_names && trading_names.length ? trading_names : 'None',
     company_number: company_number ? [
       company_number,
       {
@@ -24,5 +24,5 @@ module.exports = ({
     ] : null,
   }
 
-  return pickBy(getDataLabels(viewRecord, companyDetailsLabels))
+  return pickBy(getDataLabels(viewRecord, knownAsLabels))
 }

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -10,7 +10,7 @@ Feature: Company business details
     And the Company summary key value details are not displayed
     And the One List Corp is known as key value details are displayed
       | key                       | value                        |
-      | Trading name              | company.tradingName          |
+      | Trading names             | company.tradingName          |
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
       | One List tier             | company.oneListTier          |

--- a/test/unit/apps/companies/transformers/company-to-known-as-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-known-as-view.test.js
@@ -4,7 +4,10 @@ describe('#transformCompanyToKnownAsView', () => {
   context('when all information is populated', () => {
     beforeEach(() => {
       this.actual = transformCompanyToKnownAsView({
-        trading_name: 'trading name',
+        trading_names: [
+          'trading name 1',
+          'trading name 2',
+        ],
         companies_house_data: {
           company_number: '123456',
         },
@@ -12,7 +15,10 @@ describe('#transformCompanyToKnownAsView', () => {
     })
 
     it('should set the trading name', () => {
-      expect(this.actual['Trading name']).to.equal('trading name')
+      expect(this.actual['Trading names']).to.deep.equal([
+        'trading name 1',
+        'trading name 2',
+      ])
     })
 
     it('should set the Companies House number', () => {
@@ -36,7 +42,7 @@ describe('#transformCompanyToKnownAsView', () => {
     })
 
     it('should set the trading name to "None"', () => {
-      expect(this.actual['Trading name']).to.equal('None')
+      expect(this.actual['Trading names']).to.equal('None')
     })
 
     it('should not set the Companies House number', () => {


### PR DESCRIPTION
https://trello.com/c/0hu6YBSW/551-implement-full-business-details-page

Use the new `trading_names` field rather than the `trading_name` field.

## Before
![screenshot 2018-12-19 at 14 45 13](https://user-images.githubusercontent.com/1150417/50227104-dbdd3680-039c-11e9-933b-ae60ab3cc81f.png)

## After
![screenshot 2018-12-19 at 14 45 28](https://user-images.githubusercontent.com/1150417/50227112-e0095400-039c-11e9-99ae-1ef099bb1556.png)