### PR TITLE
Add global HQ badge and business details link to company header

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -18,7 +18,7 @@ $_first-element-spacing: $default-spacing-unit * 3;
   }
 
   &[class*="c-local-header--"] {
-    padding-bottom: $default-spacing-unit * 2;
+    padding-bottom: $default-spacing-unit;
   }
 
   .c-message-list {
@@ -167,4 +167,8 @@ $_first-element-spacing: $default-spacing-unit * 3;
       margin-left: $default-spacing-unit / 2;
     }
   }
+}
+
+.c-local-header__description + * {
+  margin-top: $default-spacing-unit;
 }

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -28,6 +28,10 @@
       </div>
     {% endif %}
 
+    <p>
+      <a href="/companies/{{ company.id }}/business-details">View full business details</a>
+    </p>
+
     {% if company.archived %}
       {% call Message({ type: 'info' }) %}
         This company was archived on {{company.archived_on | formatDate}} by {{company.archived_by.first_name}} {{company.archived_by.last_name}}. <br>

--- a/src/apps/companies/views/_layout-view.njk
+++ b/src/apps/companies/views/_layout-view.njk
@@ -8,6 +8,14 @@
   %}
     <p class="c-local-header__heading-after">{{ headingAddress }}</p>
 
+    {% if company.headquarter_type and company.headquarter_type.name == 'ghq' %}
+      <div class="c-meta-list">
+        <div class="c-meta-list__item">
+          <span class="c-badge">Global HQ</span>
+        </div>
+      </div>
+    {% endif %}
+
     {% if company.one_list_group_tier %}
       <div class="c-local-header__description">
         <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>

--- a/test/acceptance/features/companies/details.feature
+++ b/test/acceptance/features/companies/details.feature
@@ -12,6 +12,7 @@ Feature: Company details
       | paragraph                                                                |
       | This is an account managed company (One List Tier A - Strategic Account) |
       | Global Account Manager: Travis Greene View core team                     |
+    And I should see the "View full business details" link
     And the Company summary key value details are not displayed
     And the Global headquarters summary key value details are displayed
       | key                       | value                        |

--- a/test/acceptance/features/companies/details.feature
+++ b/test/acceptance/features/companies/details.feature
@@ -6,6 +6,7 @@ Feature: Company details
 
     When I navigate to the `companies.details` page using `company` `One List Corp` fixture
     Then the heading should be "One List Corp"
+    And the heading should contain the "Global HQ" badge
     And after the heading should be "12 St George's Road, Paris, 75001, France"
     And the heading description should be
       | paragraph                                                                |

--- a/test/acceptance/features/step_definitions/location.js
+++ b/test/acceptance/features/step_definitions/location.js
@@ -102,6 +102,16 @@ Then(/^the heading should be "(.+)"$/, async (value) => {
     .assert.containsText('@header', value)
 })
 
+Then(/^the heading should contain the "(.+)" badge$/, async (badgeValue) => {
+  const badgeSelector = Location.section.localNav.getBadge(badgeValue)
+
+  await Location.section.localHeader
+    .api.useXpath()
+    .waitForElementPresent(badgeSelector.selector)
+    .assert.visible(badgeSelector.selector)
+    .useCss()
+})
+
 Then(/^the heading should contain what I entered for "(.+)" field$/, async function (fieldName) {
   await Location
     .section.localHeader

--- a/test/acceptance/pages/location.js
+++ b/test/acceptance/pages/location.js
@@ -55,6 +55,14 @@ module.exports = {
               }
             )
           },
+          getBadge (text) {
+            return getSelectorForElementWithText(text,
+              {
+                el: '//span',
+                className: 'c-badge',
+              }
+            )
+          },
         },
       ],
       elements: {


### PR DESCRIPTION
https://trello.com/c/Xdz7tYFM/544-add-global-hq-badge-to-companies-header
https://trello.com/c/TwffPz9Z/545-add-view-full-business-details-link-to-companies-header

Change adds:
- `Global HQ` badge to company header
- `View full business details` link to company header

## Company header
<img width="935" alt="screenshot 2018-12-20 at 09 29 03" src="https://user-images.githubusercontent.com/1150417/50276413-cd912800-0439-11e9-9489-532a94aaddf4.png">
