### PR TITLE
Hotfix core team country name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub-frontend",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Data Hub Frontend",
   "main": "src/server.js",
   "repository": {

--- a/src/apps/companies/transformers/one-list-core-team-to-collection.js
+++ b/src/apps/companies/transformers/one-list-core-team-to-collection.js
@@ -1,14 +1,17 @@
 const { get } = require('lodash')
+
 const isAccountManager = adviser => adviser.is_global_account_manager
 const isAdviser = adviser => !adviser.is_global_account_manager
 
-module.exports = function transformOneListCoreTeamToCollection (advisers) {
+module.exports = (advisers) => {
   const mapAdviser = ({ adviser }) => {
-    const { name, dit_team: team } = adviser
+    const country = get(adviser.dit_team, 'country.name')
+    const location = get(adviser.dit_team, 'uk_region.name', country)
+
     return {
-      name,
-      team: team.name,
-      location: get(team, 'uk_region.name', team.country),
+      name: adviser.name,
+      team: adviser.dit_team.name,
+      location,
     }
   }
 

--- a/test/unit/apps/companies/transformers/core-team-to-collection.test.js
+++ b/test/unit/apps/companies/transformers/core-team-to-collection.test.js
@@ -1,43 +1,36 @@
 const transformOneListCoreTeamToCollection = require('~/src/apps/companies/transformers/one-list-core-team-to-collection')
 
-describe('#transformOneListCoreTeamToCollection', () => {
-  beforeEach(() => {
-    this.coreTeamMock = require('~/test/unit/data/companies/one-list-group-core-team.json')
-  })
+const coreTeamMock = require('~/test/unit/data/companies/one-list-group-core-team.json')
 
+describe('#transformOneListCoreTeamToCollection', () => {
   context('when the core team member is a Global Account Manager and from a UK region', () => {
     beforeEach(() => {
-      this.collection = transformOneListCoreTeamToCollection(this.coreTeamMock)
+      this.collection = transformOneListCoreTeamToCollection(coreTeamMock)
     })
 
-    it('should have 1 item in the collection', () => {
-      expect(this.collection.accountManagers.length).to.equal(1)
+    it('should set the account manager', () => {
+      expect(this.collection.accountManagers).to.deep.equal([
+        {
+          name: 'Travis Greene',
+          team: 'IST - Sector Advisory Services',
+          location: 'London',
+        },
+      ])
     })
 
-    it('should set the name', () => {
-      expect(this.collection.accountManagers[0].name).to.equal('Travis Greene')
-    })
-
-    it('should have an accountManager property', () => {
-      expect(typeof this.collection.accountManagers).to.equal('object')
-    })
-  })
-
-  context('when the core team member is not a Global Account Manager and not from a UK region', () => {
-    beforeEach(() => {
-      this.collection = transformOneListCoreTeamToCollection(this.coreTeamMock)
-    })
-
-    it('should have 2 items in the collection', () => {
-      expect(this.collection.teamMembers.length).to.equal(2)
-    })
-
-    it('should set the name', () => {
-      expect(this.collection.teamMembers[0].name).to.equal('Holly Collins')
-    })
-
-    it('should have a teamMember property', () => {
-      expect(typeof this.collection.teamMembers).to.equal('object')
+    it('should set the team members', () => {
+      expect(this.collection.teamMembers).to.deep.equal([
+        {
+          name: 'Holly Collins',
+          team: 'Heart of the South West LEP',
+          location: 'United Kingdom',
+        },
+        {
+          name: 'Jenny Carey',
+          team: 'IG - Specialists - Knowledge Intensive Industry',
+          location: 'London',
+        },
+      ])
     })
   })
 })

--- a/test/unit/data/companies/one-list-group-core-team.json
+++ b/test/unit/data/companies/one-list-group-core-team.json
@@ -27,10 +27,6 @@
       "last_name": "Collins",
       "dit_team": {
         "name": "Heart of the South West LEP",
-        "uk_region": {
-          "name": "South West",
-          "id": "894cd12a-6095-e211-a939-e4115bead28a"
-        },
         "country": {
           "name": "United Kingdom",
           "id": "80756b9a-5d95-e211-a939-e4115bead28a"


### PR DESCRIPTION
https://trello.com/c/ZEJntaFr/567-hotfix-object-object-country-name-is-not-being-presented-for-location

## Problem
When viewing the `Core team` for a company, the `Location` is being presented as `[object Object]` when it is a country.

## Solution
Change reference of `country` to `country.name`

## Screenshot of problem
![screenshot 2018-12-21 at 10 43 38](https://user-images.githubusercontent.com/1150417/50338859-9ab86400-050d-11e9-9811-247855518703.png)
