### PR TITLE
Add policy feedback filter for interactions

### DIFF
--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -49,6 +49,7 @@ const filters = {
   dit_team: 'Teams',
   sector_descends: 'Sector',
   service: 'Service',
+  was_policy_feedback_provided: 'Policy feedback',
 }
 
 module.exports = {

--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -72,6 +72,15 @@ module.exports = function ({
       modifier: 'option-select',
       options: sectorOptions,
     },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'was_policy_feedback_provided',
+      type: 'checkbox',
+      modifier: 'option-select',
+      options: [
+        { value: 'true', label: 'Includes policy feedback' },
+      ],
+    },
   ].map(filter => {
     return {
       ...filter,

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -57,6 +57,7 @@ function getInteractionsRequestBody (req, res, next) {
     'sortby',
     'dit_team',
     'service',
+    'was_policy_feedback_provided',
   ])
 
   req.body = {


### PR DESCRIPTION
## Problem
The user cannot filter interactions that have policy feedback

## Solution
Add a filter to the interaction page that will filter all interactions that include policy feedback
![screen shot 2019-01-09 at 13 49 43](https://user-images.githubusercontent.com/10154302/50904043-30f9ee80-1417-11e9-823d-f066ad6a9a8e.png)

Trello - https://trello.com/c/srDQpZ0C/457-add-policy-feedback-filter-to-interactions-entity-page