### PR TITLE
Bug - Styling issue with tab headers...

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -34,10 +34,6 @@ $_first-element-spacing: $default-spacing-unit * 3;
   .c-breadcrumb {
     margin-top: $default-spacing-unit / 2;
 
-    & + * {
-      margin-top: $_first-element-spacing;
-    }
-
     & + .grid-row {
       .c-entity-search {
         margin-top: 0;

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -14,11 +14,7 @@ $_first-element-spacing: $default-spacing-unit * 3;
   }
 
   .c-local-header__heading:first-child {
-    margin-top: $_first-element-spacing;
-  }
-
-  &[class*="c-local-header--"] {
-    padding-bottom: $default-spacing-unit;
+    margin: $_first-element-spacing 0 $default-spacing-unit;
   }
 
   .c-message-list {
@@ -26,18 +22,13 @@ $_first-element-spacing: $default-spacing-unit * 3;
 
     &+.grid-row {
       .c-local-header__heading:first-child {
-        margin-top: 0;
+        margin: 0 0 $default-spacing-unit;
       }
     }
   }
 
   .c-entity-search {
     margin-top: $baseline-grid-unit * 20.5;
-    padding-bottom: $baseline-grid-unit * 6.25;
-  }
-
-  .c-entity-search__aggregations {
-    margin-bottom: -$baseline-grid-unit * 14.25;
   }
 
   .c-breadcrumb {

--- a/assets/stylesheets/components/form/_entity-search.scss
+++ b/assets/stylesheets/components/form/_entity-search.scss
@@ -25,6 +25,7 @@ $search-button-width: 50px;
 .c-entity-search--global {
   .c-form-group {
     max-width: none;
+    margin-bottom: $default-spacing-unit * 2;
   }
 }
 

--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -26,8 +26,8 @@
           {{ MessageList({ items: messages }) }}
         {% endif %}
 
-        <div class="grid-row">
-          <div class="column-{{ 'two-thirds' if props.actions else 'full' }}">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-{{ 'two-thirds' if props.actions else 'full' }}">
             {% if props.headingBefore %}
               <div class="c-local-header__heading-before">
                 {{ props.headingBefore | safe }}
@@ -44,7 +44,7 @@
           </div>
 
           {% if props.actions %}
-            <div class="column-one-third c-local-header__actions">
+            <div class="govuk-grid-column-one-third c-local-header__actions">
               {{ props.actions | safe }}
             </div>
           {% endif %}


### PR DESCRIPTION
## Problem
The tabs on the home page seem to flow over the local header background so layout looks broken.
![screen shot 2019-01-09 at 14 51 09](https://user-images.githubusercontent.com/10154302/50908653-0bbead80-1422-11e9-93c6-db37bf32a27b.png)

## Solution
Update styles to fix layout. Also apply GovUK's new classes where applicable.
![screen shot 2019-01-09 at 15 04 59](https://user-images.githubusercontent.com/10154302/50908713-301a8a00-1422-11e9-937f-bdc305d4c3d6.png)

Trello - https://trello.com/c/TRl8L3ZT/466-styling-issue-with-tab-headers
