### PR TITLE
Set was_policy_feedback_provided when adding event attendees

### DIFF
--- a/src/apps/events/attendees/controllers/create.js
+++ b/src/apps/events/attendees/controllers/create.js
@@ -33,6 +33,7 @@ async function createAttendee (req, res, next) {
       kind: 'service_delivery',
       service: get(event, 'service.id'),
       subject: `Attended ${event.name}`,
+      was_policy_feedback_provided: false,
     }
 
     await saveInteraction(token, serviceDelivery)

--- a/test/unit/apps/events/attendees/controllers/create.test.js
+++ b/test/unit/apps/events/attendees/controllers/create.test.js
@@ -52,6 +52,7 @@ describe('Create attendee controller', () => {
           kind: 'service_delivery',
           service: '9484b82b-3499-e211-a939-e4115bead28a',
           subject: 'Attended A United Kingdom Get together',
+          was_policy_feedback_provided: false,
         })
         .reply(200, {})
 


### PR DESCRIPTION
This explicitly sets `was_policy_feedback_provided` to `false` when adding attendees to events (which creates a service delivery).

This is because `was_policy_feedback_provided` will soon be enforced as a required field for interactions in the API.
