### PR TITLE
Fix squashed header when viewing investment projects

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -1,8 +1,7 @@
 @import "../tools/mixins";
 
-$_first-element-spacing: $default-spacing-unit * 3;
-
 .c-local-header {
+  padding-bottom: $default-spacing-unit;
   @include clearfix;
 
   .l-container {
@@ -13,18 +12,8 @@ $_first-element-spacing: $default-spacing-unit * 3;
     margin-top: $default-spacing-unit;
   }
 
-  .c-local-header__heading:first-child {
-    margin: $_first-element-spacing 0 $default-spacing-unit;
-  }
-
   .c-message-list {
     margin-bottom: $default-spacing-unit;
-
-    &+.grid-row {
-      .c-local-header__heading:first-child {
-        margin: 0 0 $default-spacing-unit;
-      }
-    }
   }
 
   .c-entity-search {
@@ -32,9 +21,9 @@ $_first-element-spacing: $default-spacing-unit * 3;
   }
 
   .c-breadcrumb {
-    margin-top: $default-spacing-unit / 2;
+    margin: $default-spacing-unit / 2 0 $default-spacing-unit * 3;
 
-    & + .grid-row {
+    & + .govuk-grid-row {
       .c-entity-search {
         margin-top: 0;
       }
@@ -47,6 +36,7 @@ $_first-element-spacing: $default-spacing-unit * 3;
 
   .c-progress {
     margin-top: $default-spacing-unit;
+    margin-bottom: $default-spacing-unit * 1.5;
   }
 
   .c-progress__stage {
@@ -65,6 +55,11 @@ $_first-element-spacing: $default-spacing-unit * 3;
     background-color: $white;
     color: $fuschia;
     border-color: $fuschia;
+  }
+
+  .c-entity-search__aggregations{
+    position: relative;
+    top: $default-spacing-unit;
   }
 }
 
@@ -146,6 +141,7 @@ $_first-element-spacing: $default-spacing-unit * 3;
   p {
     margin-top: 0;
     margin-bottom: 0;
+
     &:not(:last-child) {
       margin-bottom: $default-spacing-unit / 2;
     }


### PR DESCRIPTION
## Problem
Header on Investment projects is squashed due to some previous changes to the header styling.
![screen shot 2019-01-11 at 15 20 13](https://user-images.githubusercontent.com/10154302/51048735-b5897000-15c3-11e9-8722-68ea858809e3.png)

## Solution
Fix styles so there is consistent header spacing throughout Datahub 

