### PR TITLE
Add policy feedback flag in interaction cards

### DIFF
--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -31,6 +31,7 @@ const APP_PERMISSIONS = [ GLOBAL_NAV_ITEM ]
 const INTERACTION_NAMES = {
   interaction: 'Interaction',
   service_delivery: 'Service delivery',
+  policy_feedback: 'Policy feedback',
 }
 
 const SERVICE_DELIVERY_STATUS_COMPLETED = '47329c18-6095-e211-a939-e4115bead28a'

--- a/src/apps/interactions/transformers/interaction-to-list-item.js
+++ b/src/apps/interactions/transformers/interaction-to-list-item.js
@@ -12,8 +12,10 @@ function transformInteractionToListItem ({
   dit_adviser,
   dit_team,
   service,
+  was_policy_feedback_provided,
 }) {
   return {
+    was_policy_feedback_provided,
     id,
     type: 'interaction',
     name: subject || 'No subject',
@@ -48,7 +50,11 @@ function transformInteractionToListItem ({
         label: 'Service',
         value: service,
       },
-    ],
+    ].concat(was_policy_feedback_provided ? {
+      label: 'Type',
+      type: 'badge',
+      value: INTERACTION_NAMES.policy_feedback,
+    } : null),
   }
 }
 

--- a/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
@@ -1,5 +1,6 @@
 const transformInteractionToListItem = require('~/src/apps/interactions/transformers/interaction-to-list-item')
 const mockInteraction = require('~/test/unit/data/interactions/search-interaction.json')
+const mockInteractionWithFeedback = require('~/test/unit/data/interactions/search-interaction-with-feedback.json')
 
 describe('#transformInteractionToListItem', () => {
   context('when the source is an interaction', () => {
@@ -10,6 +11,7 @@ describe('#transformInteractionToListItem', () => {
 
     it('should transform data from interaction response to list item', () => {
       expect(this.transformed).to.deep.equal({
+        was_policy_feedback_provided: false,
         id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
         type: 'interaction',
         name: 'Test interactions',
@@ -63,6 +65,7 @@ describe('#transformInteractionToListItem', () => {
               name: 'Test service',
             },
           },
+          null,
         ],
       })
     })
@@ -104,6 +107,7 @@ describe('#transformInteractionToListItem', () => {
 
     it('should transform data from interaction response to list item', () => {
       expect(this.transformed).to.deep.equal({
+        was_policy_feedback_provided: false,
         id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
         type: 'interaction',
         name: 'Test interactions',
@@ -156,6 +160,150 @@ describe('#transformInteractionToListItem', () => {
               id: '1231231231312',
               name: 'Test service',
             },
+          },
+          null,
+        ],
+      })
+    })
+  })
+
+  context('when the source is an interaction and has feedback', () => {
+    beforeEach(() => {
+      this.transformed = transformInteractionToListItem(mockInteractionWithFeedback)
+    })
+    it('should transform data from interaction response to list item', () => {
+      expect(this.transformed).to.deep.equal({
+        was_policy_feedback_provided: true,
+        id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
+        type: 'interaction',
+        name: 'Test interactions',
+        meta: [
+          {
+            label: 'Type',
+            type: 'badge',
+            value: 'Interaction',
+          },
+          {
+            label: 'Date',
+            type: 'date',
+            value: '2017-05-31T00:00:00',
+          },
+          {
+            label: 'Contact',
+            value: {
+              id: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+              first_name: 'Jackson',
+              last_name: 'Whitfield',
+              name: 'Jackson Whitfield',
+            },
+          },
+          {
+            label: 'Company',
+            value: {
+              id: 'dcdabbc9-1781-e411-8955-e4115bead28a',
+              name: 'Samsung',
+            },
+          },
+          {
+            label: 'Adviser',
+            value: {
+              id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+              first_name: 'Test',
+              last_name: 'CMU 1',
+              name: 'Test CMU 1',
+            },
+          },
+          {
+            label: 'Service provider',
+            value: {
+              id: '222',
+              name: 'Team',
+            },
+          },
+          {
+            label: 'Service',
+            value: {
+              id: '1231231231312',
+              name: 'Test service',
+            },
+          },
+          {
+            label: 'Type',
+            type: 'badge',
+            value: 'Policy feedback',
+          },
+        ],
+      })
+    })
+  })
+
+  context('when the source is an service delivery and has feedback', () => {
+    beforeEach(() => {
+      this.transformed = transformInteractionToListItem({
+        ...mockInteractionWithFeedback,
+        kind: 'service_delivery',
+      })
+    })
+    it('should transform data from interaction response to list item', () => {
+      expect(this.transformed).to.deep.equal({
+        was_policy_feedback_provided: true,
+        id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
+        type: 'interaction',
+        name: 'Test interactions',
+        meta: [
+          {
+            label: 'Type',
+            type: 'badge',
+            value: 'Service delivery',
+          },
+          {
+            label: 'Date',
+            type: 'date',
+            value: '2017-05-31T00:00:00',
+          },
+          {
+            label: 'Contact',
+            value: {
+              id: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+              first_name: 'Jackson',
+              last_name: 'Whitfield',
+              name: 'Jackson Whitfield',
+            },
+          },
+          {
+            label: 'Company',
+            value: {
+              id: 'dcdabbc9-1781-e411-8955-e4115bead28a',
+              name: 'Samsung',
+            },
+          },
+          {
+            label: 'Adviser',
+            value: {
+              id: '8036f207-ae3e-e611-8d53-e4115bed50dc',
+              first_name: 'Test',
+              last_name: 'CMU 1',
+              name: 'Test CMU 1',
+            },
+          },
+          {
+            label: 'Service provider',
+            value: {
+              id: '222',
+              name: 'Team',
+            },
+          },
+          {
+            label: 'Service',
+            value: {
+              id: '1231231231312',
+              name: 'Test service',
+            },
+          },
+          {
+            label: 'Type',
+            type: 'badge',
+            value: 'Policy feedback',
           },
         ],
       })

--- a/test/unit/data/interactions/search-interaction-with-feedback.json
+++ b/test/unit/data/interactions/search-interaction-with-feedback.json
@@ -1,5 +1,5 @@
 {
-  "was_policy_feedback_provided": false,
+  "was_policy_feedback_provided": true,
   "id": "7265dc3c-e89d-45ee-8106-d1e370c1c73d",
   "company": {
     "id": "dcdabbc9-1781-e411-8955-e4115bead28a",


### PR DESCRIPTION
## Problem
When viewing an interaction list we want to see which interaction cards have policy feedback attached to them. We currently have no badge showing for the ones that have policy feedback.
![screen shot 2019-01-17 at 14 27 58](https://user-images.githubusercontent.com/10154302/51325256-6d0b0000-1a64-11e9-8f22-7b80cd51a35e.png)

## Solution
Add a policy feedback badge to all interaction cards on the interaction results page.
![screen shot 2019-01-17 at 14 28 21](https://user-images.githubusercontent.com/10154302/51325361-aba0ba80-1a64-11e9-86e2-b38755fc7fb3.png)

Trello: https://trello.com/c/f0zn7Rki/458-add-policy-feedback-flag-to-interactions-and-service-deliveries-on-the-interaction-collection-page
