### PR TITLE
Bug - Set policy feedback option on tests

### DIFF
--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -84,7 +84,7 @@ function transformInteractionResponseToViewRecord ({
     documents: transformDocumentsLink(archived_documents_url_path),
     policy_issue_types: displayPolicyTypes,
     policy_areas: displayPolicyAreas,
-    policy_feedback_notes: newlineToBr(escape(notes)),
+    policy_feedback_notes: newlineToBr(escape(policy_feedback_notes)),
   }
 
   const result = {}

--- a/test/acceptance/pages/interactions/interaction.js
+++ b/test/acceptance/pages/interactions/interaction.js
@@ -43,6 +43,7 @@ module.exports = {
     eventNo: 'label[for=field-is_event-2]',
     event: '#field-event',
     policyFeedbackYes: 'label[for=field-was_policy_feedback_provided-1]',
+    policyFeedbackNo: 'label[for=field-was_policy_feedback_provided-2]',
     policyIssueType1: 'label[for=field-policy_issue_types-1]',
     policyIssueType2: 'label[for=field-policy_issue_types-2]',
     policyIssueType3: 'label[for=field-policy_issue_types-3]',
@@ -91,6 +92,10 @@ module.exports = {
               interaction.service = service
               done()
             })
+          })
+          .perform((done) => {
+            this.click('@policyFeedbackNo')
+            done()
           })
           .perform((done) => {
             this.getText('@ditAdviser', (result) => {


### PR DESCRIPTION
## Problem
As the backend has changed to set the policy feedback option value the form no longer has 'no' (state) set to default which means the tests will fail as they expect this value to be there.
![screen shot 2019-01-18 at 16 47 16](https://user-images.githubusercontent.com/10154302/51424949-50d6a280-1bcd-11e9-92af-77d1c7474806.png)

Also the generic notes value is being added in the feedback notes field so when you fill in notes it gets added to feedback as well.

## Solution
Update tests so 'no' is selected when adding a basic interaction without feedback and update the feedback notes value state to use feedback notes and not generic notes. 
