### PR TITLE
Bug fixes - Update version to v5.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub-frontend",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Data Hub Frontend",
   "main": "src/server.js",
   "repository": {

--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { camelCase, pickBy } = require('lodash')
+const { camelCase, pickBy, escape } = require('lodash')
 const { newlineToBr } = require('../../../lib/text-formatting')
 
 const config = require('../../../../config')
@@ -72,7 +72,7 @@ function transformInteractionResponseToViewRecord ({
       name: net_company_receipt,
     } : null,
     subject,
-    notes: newlineToBr(notes),
+    notes: newlineToBr(escape(notes)),
     date: {
       type: 'date',
       name: date,
@@ -84,7 +84,7 @@ function transformInteractionResponseToViewRecord ({
     documents: transformDocumentsLink(archived_documents_url_path),
     policy_issue_types: displayPolicyTypes,
     policy_areas: displayPolicyAreas,
-    policy_feedback_notes: newlineToBr(policy_feedback_notes),
+    policy_feedback_notes: newlineToBr(escape(notes)),
   }
 
   const result = {}

--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -84,7 +84,7 @@ function transformInteractionResponseToViewRecord ({
     documents: transformDocumentsLink(archived_documents_url_path),
     policy_issue_types: displayPolicyTypes,
     policy_areas: displayPolicyAreas,
-    policy_feedback_notes: newlineToBr(escape(notes)),
+    policy_feedback_notes: newlineToBr(escape(policy_feedback_notes)),
   }
 
   const result = {}

--- a/src/apps/investment-projects/transformers/project.js
+++ b/src/apps/investment-projects/transformers/project.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { assign, castArray, get, isEmpty, isPlainObject, mapValues } = require('lodash')
+const { assign, castArray, get, isEmpty, isPlainObject, mapValues, map } = require('lodash')
 const format = require('date-fns/format')
 const moment = require('moment')
 
@@ -124,6 +124,14 @@ function transformInvestmentForView ({
   estimated_land_date,
   actual_land_date,
 } = {}) {
+  function transformClientContacts (contacts) {
+    return map(contacts, ({ name, id }) => {
+      return {
+        name,
+        url: `/contacts/${id}`,
+      }
+    })[0]
+  }
   const businessActivities = castArray(business_activities).map(i => i.name)
   if (!isEmpty(other_business_activity)) {
     businessActivities.push(other_business_activity)
@@ -137,7 +145,7 @@ function transformInvestmentForView ({
     investment_type: getInvestmentTypeDetails(investment_type, fdi_type),
     sector,
     business_activities: businessActivities.join(', '),
-    client_contacts: castArray(client_contacts).map(i => i.name).join(', '),
+    client_contacts: !isEmpty(client_contacts) ? transformClientContacts(client_contacts) : null,
     description,
     anonymous_description,
     investor_type,

--- a/test/acceptance/pages/interactions/interaction.js
+++ b/test/acceptance/pages/interactions/interaction.js
@@ -43,6 +43,7 @@ module.exports = {
     eventNo: 'label[for=field-is_event-2]',
     event: '#field-event',
     policyFeedbackYes: 'label[for=field-was_policy_feedback_provided-1]',
+    policyFeedbackNo: 'label[for=field-was_policy_feedback_provided-2]',
     policyIssueType1: 'label[for=field-policy_issue_types-1]',
     policyIssueType2: 'label[for=field-policy_issue_types-2]',
     policyIssueType3: 'label[for=field-policy_issue_types-3]',
@@ -91,6 +92,10 @@ module.exports = {
               interaction.service = service
               done()
             })
+          })
+          .perform((done) => {
+            this.click('@policyFeedbackNo')
+            done()
           })
           .perform((done) => {
             this.getText('@ditAdviser', (result) => {

--- a/test/unit/apps/investment-projects/middleware/shared.js
+++ b/test/unit/apps/investment-projects/middleware/shared.js
@@ -1,5 +1,6 @@
 const { merge, cloneDeep } = require('lodash')
-
+const format = require('date-fns/format')
+const { mediumDateTimeFormat } = require('../../../../../config')
 const investmentData = require('~/test/unit/data/investment/investment-data.json')
 const investmentProjectStages = require('~/test/unit/data/investment/investment-project-stages.json')
 
@@ -136,7 +137,7 @@ describe('Investment shared middleware', () => {
             },
             {
               label: 'Created on',
-              value: '1 Jan 1970, 12:00am',
+              value: format(null, mediumDateTimeFormat),
             },
           ],
           nextStage: {

--- a/test/unit/apps/investment-projects/transformers/project.test.js
+++ b/test/unit/apps/investment-projects/transformers/project.test.js
@@ -436,8 +436,8 @@ describe('Investment project transformers', () => {
         this.result = transformInvestmentForView(data)
       })
 
-      it('should return the contact list as a string list', () => {
-        expect(this.result).to.have.property('client_contacts', 'Allen Connelly, John Brown')
+      it('should return the contact list as an object (including contact\' URL', () => {
+        expect(this.result.client_contacts).to.have.property('name')
       })
     })
 
@@ -453,8 +453,12 @@ describe('Investment project transformers', () => {
         this.result = transformInvestmentForView(data)
       })
 
-      it('should return the contact', () => {
-        expect(this.result).to.have.property('client_contacts', 'Allen Connelly')
+      it('should return an object with the contact name', () => {
+        expect(this.result.client_contacts).to.have.property('name', 'Allen Connelly')
+      })
+
+      it('should return an object with the url pointing to the contact\'s page', () => {
+        expect(this.result.client_contacts).to.have.property('url', '/contacts/7aac69c2-7af4-4c79-9622-f25eb7690f36')
       })
     })
 
@@ -468,7 +472,7 @@ describe('Investment project transformers', () => {
       })
 
       it('should return an empty client contact', () => {
-        expect(this.result).to.have.property('client_contacts', '')
+        expect(this.result).to.have.property('client_contacts', null)
       })
     })
 


### PR DESCRIPTION
## Problem
1. Some of the interaction notes contain `<` brackets which break the HTML minify parser as it thinks these are opening tags. 

2. The feedback policy option is not set to 'false' by default so acceptance tests need to be updated clicking the 'no' option before submitting.

3. Contact name are not links on Investment details Pages

## Solution
1. Escape the HTML within the interaction notes fields.
2. Update the acceptance test so each interaction that gets added without feedback selects 'no' before submitting.
3. Make contact names links on Investment details Pages
