### PR TITLE
Bug - Date filters should effect the number of projects exported

### DIFF
--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -89,7 +89,7 @@ router.get('/',
 
 router.get('/export',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
-  getRequestBody(QUERY_FIELDS),
+  getRequestBody(QUERY_FIELDS, QUERY_DATE_FIELDS),
   exportCollection('investment_project'),
 )
 


### PR DESCRIPTION
## Problem
In the investment projects section the date filters are not effecting the number of records you export when downloading the .csv file.

## Solution
When using the date filters make sure that the number of records returned in the user interface is the same as the number in the exported .csv file after selecting the download option. 
