### PR TITLE
Add involvement level filter to Investment projects...

### DIFF
--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -76,6 +76,7 @@ const QUERY_FIELDS = [
   'proposal_deadline_after',
   'client_relationship_manager',
   'likelihood_to_land',
+  'level_of_involvement_simplified',
 ]
 
 const QUERY_DATE_FIELDS = [

--- a/src/apps/investment-projects/labels.js
+++ b/src/apps/investment-projects/labels.js
@@ -137,6 +137,7 @@ const labels = {
       estimated_land_date_after: 'Estimated land date after',
       actual_land_date_before: 'Actual land date before',
       actual_land_date_after: 'Actual land date after',
+      level_of_involvement_simplified: 'Level of involvement specified',
       status: 'Status',
       uk_region_location: 'UK Region',
       investor_company_country: 'Country of origin',

--- a/src/apps/investment-projects/macros.js
+++ b/src/apps/investment-projects/macros.js
@@ -113,6 +113,17 @@ const investmentFiltersFields = function ({ currentAdviserId, sectorOptions, adv
       hint: userAgent.isIE ? 'DD/MM/YYYY' : null,
       inputClass: userAgent.isIE ? 'ie-date-field' : null,
     },
+    {
+      macroName: 'MultipleChoiceField',
+      name: 'level_of_involvement_simplified',
+      type: 'checkbox',
+      modifier: 'option-select',
+      options: [
+        { value: 'involved', label: 'Involved' },
+        { value: 'not_involved', label: 'Not involved' },
+        { value: 'unspecified', label: 'Unspecified' },
+      ],
+    },
   ].map(filter => {
     return Object.assign(filter, {
       label: collectionFilterLabels.edit[filter.name],


### PR DESCRIPTION
Trello - https://trello.com/c/TTRCQiB1/434-add-involvement-level-filter-to-the-front-end-of-investment-projects-page-in-data-hub

## Problem
We need a filter added on the Investment Project page which will filter the 'level of involvement'. The filter will have three checkbox options:
1. Involved
2. Not involved
3. Unspecified

## Solution
Add a new filter to the aside which allows the user to filter results based on the above criteria.
![screenshot 2019-01-22 at 15 21 22](https://user-images.githubusercontent.com/10154302/51545533-13d31000-1e5a-11e9-8dda-b36baa0c44fc.png)

