### PR TITLE
Add policy area filter to the interactions page

### DIFF
--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -26,6 +26,7 @@ async function getInteractionOptions (token, req, res) {
   const teamOptions = await getOptions(token, 'team', { includeDisabled: true })
   const types = await getOptions(token, 'policy-issue-type')
   const advisers = await getAdvisers(token)
+  const areas = await getOptions(token, 'policy-area')
 
   const activeAdvisers = filterActiveAdvisers({
     advisers: advisers.results,
@@ -35,6 +36,7 @@ async function getInteractionOptions (token, req, res) {
   const adviserOptions = activeAdvisers.map(transformAdviserToOption)
 
   return {
+    areas,
     sectorOptions,
     serviceOptions,
     teamOptions,

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -50,6 +50,7 @@ const filters = {
   sector_descends: 'Sector',
   service: 'Service',
   was_policy_feedback_provided: 'Policy feedback',
+  policy_areas: 'Policy areas',
   policy_issue_types: 'Policy issue type',
 }
 

--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -12,6 +12,7 @@ module.exports = function ({
   teamOptions,
   adviserOptions,
   userAgent,
+  areas,
   types,
 }) {
   return [
@@ -88,6 +89,13 @@ module.exports = function ({
       options: [
         { value: 'true', label: 'Includes policy feedback' },
       ],
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      type: 'checkbox',
+      name: 'policy_areas',
+      modifier: 'option-select',
+      options: areas,
     },
     {
       macroName: 'MultipleChoiceField',

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -58,6 +58,7 @@ function getInteractionsRequestBody (req, res, next) {
     'dit_team',
     'service',
     'was_policy_feedback_provided',
+    'policy_areas',
     'policy_issue_types',
   ])
 

--- a/test/unit/apps/interactions/controllers/list.test.js
+++ b/test/unit/apps/interactions/controllers/list.test.js
@@ -55,6 +55,11 @@ describe('interaction list', () => {
           { id: 'ad1', name: 'ad1', is_active: true, dit_team: { name: 'ad1' } },
         ],
       },
+      policyAreaOptions: [
+        { id: '1', name: 'pa1', disabled_on: null },
+        { id: '2', name: 'pa2', disabled_on: yesterday },
+        { id: '3', name: 'pa3', disabled_on: null },
+      ],
       policyIssueType: [
         { id: '1', name: 'pt1', disabled_on: null },
         { id: '2', name: 'pt2', disabled_on: yesterday },
@@ -71,6 +76,8 @@ describe('interaction list', () => {
       .reply(200, this.metadataMock.sectorOptions)
       .get('/adviser/?limit=100000&offset=0')
       .reply(200, this.metadataMock.adviserOptions)
+      .get('/metadata/policy-area/')
+      .reply(200, this.metadataMock.policyAreaOptions)
       .get('/metadata/policy-issue-type/')
       .reply(200, this.metadataMock.policyIssueType)
   })


### PR DESCRIPTION
## Problem
Users need a filter on the interactions page where they can filter by policy areas.

## Solution
Add a new filter to filter policy areas.
![screenshot 2019-01-23 at 10 16 33](https://user-images.githubusercontent.com/10154302/51599747-4895a480-1ef8-11e9-9b70-26250a7e4f68.png)



Trello - https://trello.com/c/tokQER6w/482-add-policy-area-filter-to-interactions-entity-page
