### PR TITLE
Feature add policy type filter to interactions

### DIFF
--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -24,6 +24,7 @@ async function getInteractionOptions (token, req, res) {
   const sectorOptions = await getOptions(token, SECTOR, { queryString: QUERY_STRING })
   const serviceOptions = await getOptions(token, 'service', { includeDisabled: true })
   const teamOptions = await getOptions(token, 'team', { includeDisabled: true })
+  const types = await getOptions(token, 'policy-issue-type')
   const advisers = await getAdvisers(token)
 
   const activeAdvisers = filterActiveAdvisers({
@@ -38,6 +39,7 @@ async function getInteractionOptions (token, req, res) {
     serviceOptions,
     teamOptions,
     adviserOptions,
+    types,
   }
 }
 

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -50,6 +50,7 @@ const filters = {
   sector_descends: 'Sector',
   service: 'Service',
   was_policy_feedback_provided: 'Policy feedback',
+  policy_issue_types: 'Policy issue type',
 }
 
 module.exports = {

--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -12,6 +12,7 @@ module.exports = function ({
   teamOptions,
   adviserOptions,
   userAgent,
+  types,
 }) {
   return [
     {
@@ -87,6 +88,13 @@ module.exports = function ({
       options: [
         { value: 'true', label: 'Includes policy feedback' },
       ],
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      type: 'checkbox',
+      name: 'policy_issue_types',
+      modifier: 'option-select',
+      options: types,
     },
   ].map(filter => {
     return {

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -58,6 +58,7 @@ function getInteractionsRequestBody (req, res, next) {
     'dit_team',
     'service',
     'was_policy_feedback_provided',
+    'policy_issue_types',
   ])
 
   req.body = {

--- a/test/unit/apps/interactions/controllers/list.test.js
+++ b/test/unit/apps/interactions/controllers/list.test.js
@@ -1,3 +1,5 @@
+const moment = require('moment')
+
 const config = require('~/config')
 const { renderInteractionList, renderInteractionsForEntity } = require('~/src/apps/interactions/controllers/list')
 
@@ -30,6 +32,8 @@ describe('interaction list', () => {
 
     this.next = sinon.stub()
 
+    const yesterday = moment().subtract(1, 'days').toISOString()
+
     this.metadataMock = {
       teamOptions: [
         { id: 'te1', name: 'te1', disabled_on: null },
@@ -51,6 +55,11 @@ describe('interaction list', () => {
           { id: 'ad1', name: 'ad1', is_active: true, dit_team: { name: 'ad1' } },
         ],
       },
+      policyIssueType: [
+        { id: '1', name: 'pt1', disabled_on: null },
+        { id: '2', name: 'pt2', disabled_on: yesterday },
+        { id: '3', name: 'pt3', disabled_on: null },
+      ],
     }
 
     nock(config.apiRoot)
@@ -62,6 +71,8 @@ describe('interaction list', () => {
       .reply(200, this.metadataMock.sectorOptions)
       .get('/adviser/?limit=100000&offset=0')
       .reply(200, this.metadataMock.adviserOptions)
+      .get('/metadata/policy-issue-type/')
+      .reply(200, this.metadataMock.policyIssueType)
   })
 
   context('#renderInteractionList', () => {


### PR DESCRIPTION
## Problem
We need to be able to filter interactions by policy type

Trello - https://trello.com/c/woMbmMY3/483-add-policy-type-filter-to-interactions-entity-page

## Solution
Add new policy type filter to interactions page
![screenshot 2019-01-25 at 09 06 17](https://user-images.githubusercontent.com/10154302/51735945-ac4ad980-2080-11e9-9969-238c72e6f692.png)

