### PR TITLE
Show total value on OMIS orders

### DIFF
--- a/assets/stylesheets/components/_collection.scss
+++ b/assets/stylesheets/components/_collection.scss
@@ -133,3 +133,11 @@
     margin-bottom: 2px;
   }
 }
+
+.c-collection__total-cost {
+  padding-top: $default-spacing-unit / 2;
+
+  .c-collection__total-cost__value{
+    font-weight: 600;
+  }
+}

--- a/src/modules/api/transformers/api-response-to-collection.js
+++ b/src/modules/api/transformers/api-response-to-collection.js
@@ -36,6 +36,7 @@ function transformApiResponseToCollection (options = {}, ...itemTransformers) {
     return assign({}, {
       items,
       count: response.count,
+      summary: response.summary,
       pagination: buildPagination(options.query, response),
     })
   }

--- a/src/templates/_macros/collection/collection-header.njk
+++ b/src/templates/_macros/collection/collection-header.njk
@@ -13,6 +13,7 @@
 #}
 {% macro CollectionHeader(props) %}
   {% set buildQuery = buildQuery or props.buildQuery %}
+  {% set totalCost = props.summary.total_subtotal_cost %}
   {% set count = props.count | default('0') %}
   {% set countLabel = props.countLabel | default('result') %}
   {% set actionButtons = props.actionButtons | default([]) | castArray %}
@@ -65,6 +66,12 @@
           {% endfor %}
         </div>
       {% endif %}
+
+      {% if props.summary %}
+        <div class="c-collection__total-cost">
+          Total value: <span class="c-collection__total-cost__value">£{{ totalCost | formatNumber }}</span>
+        </div>
+      {% endif %}
     </div>
 
     {% if props.sortForm or props.pagination %}
@@ -80,16 +87,16 @@
     {% endif %}
 
     {% if props.exportAction.enabled %}
-    <div class="c-collection__header-row">
+      <div class="c-collection__header-row">
       <span class="c-collection__export-message">
         {{ props.exportAction.buildMessage(count) }}
       </span>
-      <span class="c-collection__header-actions">
+        <span class="c-collection__header-actions">
         {% if not props.exportAction.invalidNumberOfItems(count, props.exportAction.maxItems) %}
           <a class="button" download href="{{ props.exportAction.url }}">Download</a>
         {% endif %}
       </span>
-    </div>
+      </div>
     {% endif %}
 
   </header>

--- a/test/unit/apps/investment-projects/controllers/create/equity-source.test.js
+++ b/test/unit/apps/investment-projects/controllers/create/equity-source.test.js
@@ -150,6 +150,7 @@ describe('Investment start controller', () => {
         const expected = {
           aggregations: undefined,
           count: 0,
+          summary: undefined,
           highlightTerm: undefined,
           items: [],
           pagination: null,


### PR DESCRIPTION
## Problem
Users would like to see the total value of orders on a collection list page.

## Solution
Show the total value at the top of the collection list.
![screenshot 2019-01-28 at 15 24 50](https://user-images.githubusercontent.com/10154302/51846475-8daf4180-2311-11e9-9c0f-39ceea109e00.png)

