### PR TITLE
Fix OMIS order total to display correct value

### DIFF
--- a/src/templates/_macros/collection/collection-header.njk
+++ b/src/templates/_macros/collection/collection-header.njk
@@ -69,7 +69,7 @@
 
       {% if props.summary %}
         <div class="c-collection__total-cost">
-          Total value: <span class="c-collection__total-cost__value">£{{ totalCost | formatNumber }}</span>
+          Total value: <span class="c-collection__total-cost__value">£{{ (totalCost / 100) | formatNumber }}</span>
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Problem
The total value of OMIS orders is showing the value in pence not pounds
![screenshot 2019-01-29 at 15 15 00](https://user-images.githubusercontent.com/10154302/51918107-d251e000-23d8-11e9-87ba-7c6f37ce7503.png)


## Solution
Divide this number so it shows the correct value
