### PR TITLE
Release v5.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub-frontend",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Data Hub Frontend",
   "main": "src/server.js",
   "repository": {

--- a/src/templates/_macros/collection/collection-header.njk
+++ b/src/templates/_macros/collection/collection-header.njk
@@ -69,7 +69,7 @@
 
       {% if props.summary %}
         <div class="c-collection__total-cost">
-          Total value: <span class="c-collection__total-cost__value">£{{ totalCost | formatNumber }}</span>
+          Total value: <span class="c-collection__total-cost__value">£{{ (totalCost / 100) | formatNumber }}</span>
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- Fixes the total output value of OMIS orders. Previously we were showing the pence value in pounds.
![screenshot 2019-01-29 at 15 15 00](https://user-images.githubusercontent.com/10154302/51919511-76d52180-23db-11e9-8daf-de8670b8463c.png)

