### PR TITLE
Rename navigation labels

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -74,6 +74,7 @@ const config = {
   mediumDateTimeFormat: 'D MMM YYYY, h:mma',
   paginationMaxResults: 10000,
   performanceDashboardsUrl: process.env.PERFORMANCE_DASHBOARDS_URL || 'https://mi.exportwins.service.trade.gov.uk',
+  findExportersUrl: process.env.FIND_EXPORTERS_URL || 'https://find-exporters.datahub.trade.gov.uk',
   archivedDocumentsBaseUrl: process.env.ARCHIVED_DOCUMENTS_BASE_URL,
   oauth: {
     url: process.env.OAUTH2_AUTH_URL,

--- a/src/apps/global-nav-items.js
+++ b/src/apps/global-nav-items.js
@@ -20,6 +20,9 @@ const SORTED_APP_GLOBAL_NAV_ITEMS = sortBy(APP_GLOBAL_NAV_ITEMS, (globalNavItem)
 const GLOBAL_NAV_ITEMS = concat(SORTED_APP_GLOBAL_NAV_ITEMS, {
   path: config.performanceDashboardsUrl,
   label: 'MI dashboards',
+}, {
+  path: config.findExportersUrl,
+  label: 'Find exporters',
 })
 
 module.exports = GLOBAL_NAV_ITEMS

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -4,7 +4,7 @@ const DEFAULT_COLLECTION_QUERY = {
 
 const GLOBAL_NAV_ITEM = {
   path: '/interactions',
-  label: 'Interactions and services',
+  label: 'Interactions',
   permissions: [
     'interaction.view_all_interaction',
   ],

--- a/src/apps/interactions/index.js
+++ b/src/apps/interactions/index.js
@@ -1,7 +1,7 @@
 const router = require('./router')
 
 module.exports = {
-  displayName: 'Interactions and services',
+  displayName: 'Interactions',
   mountpath: '/interactions',
   router,
 }

--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -2,7 +2,7 @@ const { concat } = require('lodash')
 
 const GLOBAL_NAV_ITEM = {
   path: '/investment-projects',
-  label: 'Investment projects',
+  label: 'Investments',
   permissions: [
     'investment.view_associated_investmentproject',
     'investment.view_all_investmentproject',

--- a/test/acceptance/features/dashboard/dashboard.feature
+++ b/test/acceptance/features/dashboard/dashboard.feature
@@ -10,10 +10,11 @@ Feature: Dashboard
       | Companies                 |
       | Contacts                  |
       | Events                    |
-      | Interactions and services |
-      | Investment projects       |
+      | Interactions              |
+      | Investments               |
       | Orders (OMIS)             |
       | MI dashboards             |
+      | Find exporters            |
 
   @dashboard--global-nav-lep @lep
   Scenario: Display global nav for LEP user
@@ -23,8 +24,10 @@ Feature: Dashboard
       | text                      |
       | Companies                 |
       | Contacts                  |
-      | Investment projects       |
+      | Investments               |
       | MI dashboards             |
+      | Find exporters            |
+
 
   @dashboard--global-nav-da @da
   Scenario: Display global nav for DA user
@@ -34,6 +37,7 @@ Feature: Dashboard
       | text                      |
       | Companies                 |
       | Contacts                  |
-      | Investment projects       |
+      | Investments               |
       | Orders (OMIS)             |
       | MI dashboards             |
+      | Find exporters            |

--- a/test/acceptance/pages/dashboard.js
+++ b/test/acceptance/pages/dashboard.js
@@ -37,6 +37,7 @@ module.exports = {
         investmentProjects: getGlobalNavAnchorWithText('Investment projects'),
         ordersOmis: getGlobalNavAnchorWithText('Orders (OMIS)'),
         miDashboards: getGlobalNavAnchorWithText('MI dashboards'),
+        findExporters: getGlobalNavAnchorWithText('Find exporters'),
       },
     },
   },


### PR DESCRIPTION
In order to fit more application links in the global header some lables
need to be renamed.

* Change existing label names
* Add `Find exporters` link to the nav

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
