### PR TITLE
Removing the document nav item when a project code starts with 'DHP'

### DIFF
--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -46,7 +46,7 @@ const LOCAL_NAV = [
   },
   {
     path: 'documents',
-    label: 'Documents',
+    label: 'CDMS documents',
     permissions: [
       'investment.view_investmentproject_document',
     ],

--- a/src/apps/investment-projects/middleware/local-navigation.js
+++ b/src/apps/investment-projects/middleware/local-navigation.js
@@ -1,0 +1,20 @@
+const { setLocalNav } = require('../../middleware')
+const { LOCAL_NAV } = require('../constants')
+
+const DHP = 'DHP'
+const DOCUMENTS = 'documents'
+
+const isProjectNew = (investment) => investment.project_code.startsWith(DHP)
+
+const filterDocNavItemIfProjectIsNew = (investment) => {
+  const isNew = isProjectNew(investment)
+  return LOCAL_NAV.filter(({ path }) => !(path === DOCUMENTS && isNew))
+}
+
+const setInvestmentsLocalNav = (req, res, next) => {
+  const { investment } = res.locals
+  const navItems = investment ? filterDocNavItemIfProjectIsNew(investment) : LOCAL_NAV
+  setLocalNav(navItems)(req, res, next)
+}
+
+module.exports = setInvestmentsLocalNav

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -1,13 +1,14 @@
 const router = require('express').Router()
 
 const { ENTITIES } = require('../search/constants')
-const { DEFAULT_COLLECTION_QUERY, LOCAL_NAV, APP_PERMISSIONS, QUERY_FIELDS, QUERY_DATE_FIELDS } = require('./constants')
+const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS, QUERY_DATE_FIELDS } = require('./constants')
 
 const { getRequestBody } = require('../../middleware/collection')
 const { detectUserAgent } = require('../../middleware/detect-useragent')
 const { getCollection, exportCollection } = require('../../modules/search/middleware/collection')
 
-const { setLocalNav, setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
+const setInvestmentsLocalNav = require('./middleware/local-navigation')
+const { setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
 const { shared } = require('./middleware')
 const {
   getBriefInvestmentSummary,
@@ -74,8 +75,7 @@ const propositionsRouter = require('../propositions/router.sub-app')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
-router.use('/:investmentId', setLocalNav(LOCAL_NAV))
-
+router.use('/:investmentId', setInvestmentsLocalNav)
 router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)
 

--- a/test/acceptance/features/investment-projects/local-nav.feature
+++ b/test/acceptance/features/investment-projects/local-nav.feature
@@ -13,7 +13,6 @@ Feature: Investment projects local nav
       | Evaluations               |
       | Propositions              |
       | Audit history             |
-      | Documents                 |
       | Evidence                  |
 
   @investment-projects-local-nav--lep @lep

--- a/test/unit/apps/investment-projects/middleware/local-navigation.test.js
+++ b/test/unit/apps/investment-projects/middleware/local-navigation.test.js
@@ -1,0 +1,56 @@
+const setInvestmentsLocalNav = require('~/src/apps/investment-projects/middleware/local-navigation')
+
+describe('Investment projects local navigation', () => {
+  beforeEach(() => {
+    this.req = {}
+
+    this.res = {
+      locals: {
+        investment: {},
+        user: {
+          permissions: [
+            'investment.view_investmentproject_document',
+          ],
+        },
+      },
+    }
+
+    this.next = sinon.stub()
+  })
+
+  context('when a project code starts with \'DHP\' it is a new project', () => {
+    beforeEach(() => {
+      this.res.locals.investment.project_code = 'DHP-00000001'
+      setInvestmentsLocalNav(this.req, this.res, this.next)
+    })
+
+    it('should filter out the documents nav item', () => {
+      const documentsNavItem = this.res.locals.localNavItems.find(item => item.path === 'documents')
+      expect(documentsNavItem).to.be.undefined
+    })
+  })
+
+  context('when a project code starts with \'P\' it is an old project (CDMS)', () => {
+    beforeEach(() => {
+      this.res.locals.investment.project_code = 'P-30016857'
+      setInvestmentsLocalNav(this.req, this.res, this.next)
+    })
+
+    it('should keep the documents nav item', () => {
+      const documentsNavItem = this.res.locals.localNavItems.find(item => item.path === 'documents')
+      expect(documentsNavItem).to.be.ok
+    })
+  })
+
+  context('when a project code starts with a number it is a very old project (pre-dates CDMS)', () => {
+    beforeEach(() => {
+      this.res.locals.investment.project_code = '016020'
+      setInvestmentsLocalNav(this.req, this.res, this.next)
+    })
+
+    it('should keep the documents nav item', () => {
+      const documentsNavItem = this.res.locals.localNavItems.find(item => item.path === 'documents')
+      expect(documentsNavItem).to.be.ok
+    })
+  })
+})


### PR DESCRIPTION
Currently there are 3 types of project codes, the oldest is 1 and
the latest is 3:

1. 016020 (really old)
2. P-30016857 (CDMS)
3. DHP-00000007 (Data Hub)

At present the document nav item is displayed for all 3 scenarios. This
work excludes the document nav item when the project is new, all new
projects have a code that start with 'DHP'. The documents nav item is
specifically and solely for the S3 migrated documents that are
associated with project codes such as 1 & 2.

https://uktrade.atlassian.net/browse/IPBETA-9
