### PR TITLE
Adding a Capital Investor Profile feature flag

### DIFF
--- a/src/apps/investment-projects/controllers/list.js
+++ b/src/apps/investment-projects/controllers/list.js
@@ -16,6 +16,7 @@ const SECTOR = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.NAME
 async function renderInvestmentList (req, res, next) {
   try {
     const { token, user } = req.session
+    const { features } = res.locals
     const currentAdviserId = user.id
     const queryString = QUERY_STRING
     const sortForm = merge({}, investmentSortForm, {
@@ -53,14 +54,23 @@ async function renderInvestmentList (req, res, next) {
 
     const exportAction = await buildExportAction(qs.stringify(req.query), user.permissions, exportOptions)
 
-    res.render('_layouts/collection', {
+    const props = {
       sortForm,
       selectedFilters,
       exportAction,
       filtersFields: filtersFieldsWithSelectedOptions,
       title: 'Investment Projects',
       countLabel: 'project',
-    })
+    }
+
+    if (features && features['capital-investor-profile']) {
+      props.actionButtons = [{
+        label: 'Create profile',
+        url: '/',
+      }]
+    }
+
+    res.render('_layouts/collection', props)
   } catch (error) {
     next(error)
   }

--- a/test/unit/apps/investment-projects/controllers/list.test.js
+++ b/test/unit/apps/investment-projects/controllers/list.test.js
@@ -111,4 +111,26 @@ describe('Investment list controller', () => {
       })
     })
   })
+
+  context('when the capital-investor-profile feature flag is not active', () => {
+    beforeEach(async () => {
+      this.res.locals.features = { 'capital-investor-profile': false }
+      const controller = require('~/src/apps/investment-projects/controllers/list')
+      await controller.renderInvestmentList(this.req, this.res, this.nextSpy)
+    })
+    it('should not display the \'Create profile\' action button ', () => {
+      expect(this.res.render.firstCall.args[1].actionButtons).to.be.undefined
+    })
+  })
+
+  context('when the capital-investor-profile feature flag is active', () => {
+    beforeEach(async () => {
+      this.res.locals.features = { 'capital-investor-profile': true }
+      const controller = require('~/src/apps/investment-projects/controllers/list')
+      await controller.renderInvestmentList(this.req, this.res, this.nextSpy)
+    })
+    it('should display the \'Create profile\' action button ', () => {
+      expect(this.res.render.firstCall.args[1].actionButtons).to.be.ok
+    })
+  })
 })


### PR DESCRIPTION
This piece of work hides a button called 'Create profile' which sits
on the right-hand-side above the Investment Projects list within the
Investment Projects app.

In future the button will enable the user to create a
Capital Investor Profile.

https://uktrade.atlassian.net/browse/IPBETA-226
