### PR TITLE
Update multiple XHR containers

### DIFF
--- a/assets/javascripts/lib/xhr.js
+++ b/assets/javascripts/lib/xhr.js
@@ -15,15 +15,18 @@ history.listen((location, action) => {
 })
 
 const XHR = {
-  getOutlet () {
-    return document.getElementById('xhr-outlet')
-  },
-
   injectResponseInHtml (data) {
-    const outlet = this.getOutlet()
-    if (!outlet) { return }
+    const dataDocument = document.createRange().createContextualFragment(data)
 
-    outlet.outerHTML = data
+    const xhrContainers = document.querySelectorAll('[data-xhr]')
+    xhrContainers.forEach((xhrContainer) => {
+      const xhrContainerId = xhrContainer.getAttribute('data-xhr')
+
+      const newContent = dataDocument.querySelector(`[data-xhr="${xhrContainerId}"]`)
+      if (newContent) {
+        xhrContainer.outerHTML = newContent.outerHTML
+      }
+    })
   },
 
   updateOutlet (res, params) {
@@ -42,14 +45,7 @@ const XHR = {
     return res
   },
 
-  request (url, params = {}, showLoader = true) {
-    const outlet = this.getOutlet()
-    if (!outlet) { return }
-
-    if (showLoader) {
-      outlet.classList.add('u-loading')
-    }
-
+  request (url, params = {}) {
     if (params) {
       const url = `?${queryString.stringify(params)}`
       history.push(url)

--- a/src/apps/companies/views/_deprecated/contacts.njk
+++ b/src/apps/companies/views/_deprecated/contacts.njk
@@ -24,7 +24,7 @@ filtersFields: filtersFields,
 action: CURRENT_PATH
 }) }}
 {% block xhr_content %}
-<article id="xhr-outlet">
+<article data-xhr="626a8527-e238-4d1d-bfb0-83c3e5939d76">
   {{ CollectionContent(contactResults | assign({
   countLabel: 'contact',
   sortForm: assign({}, sortForm, {action: CURRENT_PATH}),

--- a/src/apps/companies/views/_deprecated/interactions.njk
+++ b/src/apps/companies/views/_deprecated/interactions.njk
@@ -24,7 +24,7 @@
 {% endif %}
 
 {% block xhr_content %}
-<article id="xhr-outlet">
+<article data-xhr="1702eedb-af56-4b97-90a9-f9d958175f43">
   {{
   CollectionContent(results | assignCopy({
   countLabel: 'interaction',

--- a/src/apps/companies/views/contacts.njk
+++ b/src/apps/companies/views/contacts.njk
@@ -28,7 +28,7 @@
   }}
 
   {% block xhr_content %}
-    <article id="xhr-outlet">
+    <article data-xhr="217d4b49-c852-481d-b5fe-47d7b09b1ca2">
       {{
         CollectionContent(contactResults | assign({
           countLabel: 'contact',

--- a/src/apps/companies/views/interactions.njk
+++ b/src/apps/companies/views/interactions.njk
@@ -25,7 +25,7 @@
     {% endif %}
 
     {% block xhr_content %}
-      <article id="xhr-outlet">
+      <article data-xhr="bcdf4545-3160-4893-82d0-fd34b57bed8b">
         {{
           CollectionContent(results | assignCopy({
             countLabel: 'interaction',

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -330,7 +330,7 @@
     <hr>
 
     {% block xhr_content %}
-      <div id="xhr-outlet">
+      <div data-xhr="4dddfbfb-bdf6-425e-8ebe-15499aa8fe57">
         <h2>Advisers selected</h2>
         <ul>
           {% for adviser in advisers %}

--- a/src/apps/contacts/views/interactions.njk
+++ b/src/apps/contacts/views/interactions.njk
@@ -7,7 +7,7 @@
   </p>
 
   {% block xhr_content %}
-    <article id="xhr-outlet">
+    <article data-xhr="31fa63e9-1923-4565-af98-93c07a4a4f0d">
       {{
         CollectionContent(results | assignCopy({
           countLabel: 'interaction',

--- a/src/apps/events/attendees/views/list.njk
+++ b/src/apps/events/attendees/views/list.njk
@@ -16,7 +16,7 @@
   {% endif %}
 
   {% block xhr_content %}
-    <article id="xhr-outlet">
+    <article data-xhr="e7681e5b-fed6-4d5d-adeb-f7c769a5d3d0">
       {{ CollectionContent(attendees) }}
     </article>
   {% endblock %}

--- a/src/templates/_layouts/collection.njk
+++ b/src/templates/_layouts/collection.njk
@@ -13,7 +13,7 @@
     </div>
 
     {% block xhr_content %}
-      <article class="column-two-thirds" id="xhr-outlet">
+      <article class="column-two-thirds" data-xhr="c781e8b1-9747-4b2e-8655-68b14ea49126">
         {% block collection_results %}
           {{ CollectionContent(results | assign({
             countLabel: countLabel,

--- a/test/acceptance/pages/companies/company.js
+++ b/test/acceptance/pages/companies/company.js
@@ -38,7 +38,6 @@ module.exports = {
     companiesHouseSearchField: '#field-term',
     collectionsCompanyNameInput: '#field-name',
     collectionResultsCompanyName: '.c-entity-list li:first-child .c-entity__title > a',
-    xhrTargetElement: '#xhr-outlet',
   },
   commands: [
     {
@@ -472,14 +471,6 @@ module.exports = {
         return this
       },
 
-      searchForCompanyInCollection (companyName) {
-        this.api.url(`${process.env.QA_HOST}/companies`)
-        return this
-          .waitForElementPresent('@collectionsCompanyNameInput')
-          .setValue('@collectionsCompanyNameInput', [companyName, this.api.Keys.ENTER]) // press enter
-          .waitForElementNotVisible('@xhrTargetElement') // wait for xhr results to come back
-          .waitForElementVisible('@xhrTargetElement')
-      },
     },
   ],
   sections: {

--- a/test/acceptance/pages/events/list.js
+++ b/test/acceptance/pages/events/list.js
@@ -20,7 +20,6 @@ module.exports = {
     h1Element: '.c-local-header__heading',
     addEventButton: getButtonWithText('Add event'),
     sortBy: '#field-sortby',
-    xhrTargetElement: '#xhr-outlet',
   },
   sections: {
     filterTags: {

--- a/test/unit/assets/javascripts/lib/xhr.test.js
+++ b/test/unit/assets/javascripts/lib/xhr.test.js
@@ -4,7 +4,9 @@ const createMemoryHistory = require('history').createMemoryHistory
 const HTML = `
   <html>
     <body>
-      <div id="xhr-outlet"></div>
+      <div data-xhr="1"></div>
+      <div data-xhr="2"></div>
+      <div data-xhr="3">Not updated</div>
     </body>
   </html>`
 
@@ -16,12 +18,19 @@ describe('XHR', () => {
     history.location = {}
     global.window = new JSDOM(HTML).window
     global.document = global.window.document
+    global.document.createRange = () => {
+      return {
+        createContextualFragment (data) {
+          return new JSDOM(data).window.document
+        },
+      }
+    }
     XHR = proxyquire('~/assets/javascripts/lib/xhr', {
       'history': { createBrowserHistory: () => history },
     })
   })
 
-  describe('updateOutlet', () => {
+  describe('#updateOutlet', () => {
     it('should call history.push if params are provided', () => {
       const res = { data: {} }
       const params = { a: 1, b: 2 }
@@ -41,6 +50,27 @@ describe('XHR', () => {
       const params = { a: 1, b: 2 }
       XHR.updateOutlet(res, params)
       expect(window.location.assign).to.be.calledWith('?a=1&b=2')
+    })
+  })
+
+  describe('#injectResponseInHtml', () => {
+    beforeEach(() => {
+      XHR.injectResponseInHtml('<div data-xhr="1"><p>Updated 1</p></div><div data-xhr="2"><p>Updated 2</p></div>')
+    })
+
+    it('should update container 1', () => {
+      const container1 = global.window.document.querySelector(`[data-xhr="1"]`)
+      expect(container1.innerHTML).to.equal('<p>Updated 1</p>')
+    })
+
+    it('should update container 2', () => {
+      const container2 = global.window.document.querySelector(`[data-xhr="2"]`)
+      expect(container2.innerHTML).to.equal('<p>Updated 2</p>')
+    })
+
+    it('should not update container 3', () => {
+      const container3 = global.window.document.querySelector(`[data-xhr="3"]`)
+      expect(container3.innerHTML).to.equal('Not updated')
     })
   })
 })


### PR DESCRIPTION
https://trello.com/c/RYDiTBjc/694-move-selected-filters-to-left-hand-column

## Problem
Current the `XHR` code allows updating of a single element by referencing ID `xhr-outlet`. The change to move the filter summary to the left column means that multiple containers need updating.

## Solution
Add the `data-xhr` attribute to containers that need updating. Once the `XHR` `request` is complete, the `data-xhr` IDs are iterated over to update all containers.