### PR TITLE
Hide/show "Where does information on this page come from?" details summary

### DIFF
--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -24,16 +24,17 @@
 {% block body_main_content %}
   <p>This page shows information about this business and how it is related to other businesses</p>
 
-  {% call HiddenContent({ summary: 'Where does information on this page come from?' }) %}
-    {% call Message({ type: 'muted' }) %}
-      The information on this page that cannot be edited comes from
-      <a href="https://www.dnb.co.uk/about-us/data-cloud.html" target="_blank">Dun & Bradstreet</a>.
-      This is an external and verified source. The information is automatically updated.
-      <a href="audit">View the audit history</a>.<br />
-      If you think the information is incomplete or incorrect, <a href="/support">get in touch using the support form</a>.
-    {% endcall %}
-  {% endcall %}
-
+  {% if company.duns_number %}
+    {{ govukDetails({
+      summaryText: 'Where does information on this page come from?',
+      html: '<p>
+          The information on this page that cannot be edited comes from <a href="https://www.dnb.co.uk/about-us/data-cloud.html" target="_blank">Dun & Bradstreet</a>. This is an external and verified source. The information is automatically updated. <a href="audit">View the audit history</a>.
+        </p>
+        <p>
+          If you think the information is incomplete or incorrect, <a href="/support">get in touch using the support form</a>.
+        </p>'
+    }) }}
+  {% endif %}
 
   <h2 class="govuk-heading-m govuk-!-margin-top-9">{{ company.name }} is known as</h2>
 

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -1,4 +1,5 @@
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "details/macro.njk" import govukDetails %}
 {% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, Link, MultipleChoiceField, PreviouslySelected, HiddenField, DateFieldset, DateField, Typeahead %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -41,3 +41,11 @@ Feature: Company business details
       | Number of employees       | Not available                |
       | Websites                  | Not available                |
     And the Documents from CDMS key value details are not displayed
+
+
+  @companies-business-details--data-hub-company
+  Scenario: View business details for a Data Hub company
+
+    When I navigate to the `companies.business-details` page using `company` `Venus Ltd` fixture
+    Then the heading should be "Business details"
+    And the "Where does information on this page come from?" details summary should not be displayed

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -1,8 +1,8 @@
 @companies-business-details
 Feature: Company business details
 
-  @companies-business-details--ghq-one-list
-  Scenario: View details for a Dun & Bradstreet GHQ company on the One List
+  @companies-business-details--dun-and-bradstreet-ghq-one-list
+  Scenario: View business details for a Dun & Bradstreet GHQ company on the One List
 
     When I navigate to the `companies.business-details` page using `company` `One List Corp` fixture
     Then the heading should be "Business details"

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -158,15 +158,17 @@ Then(/^the data details ([0-9]+) are displayed$/, async function (tableNumber, d
   await assertTableContent.bind(this)(tableSelector, dataTable.hashes(), TABLE_TYPE.DATA)
 })
 
-Then(/^the "(.+)" details summary should be displayed$/, async (summary) => {
+Then(/^the "(.+)" details summary (should be|should not be) displayed$/, async (summary, should) => {
   const detailsSummarySelector = getSelectorForElementWithText(summary, {
     el: '//span',
-    className: 'details__summary',
+    className: 'govuk-details__summary-text',
     hasExactText: true,
   })
 
+  const assertion = should === 'should be' ? 'visible' : 'elementNotPresent'
+
   await Details
     .api.useXpath()
-    .waitForElementVisible(detailsSummarySelector.selector)
+    .assert[assertion](detailsSummarySelector.selector)
     .useCss()
 })


### PR DESCRIPTION
https://trello.com/c/CGOXWGE1/740-hide-show-where-does-information-on-this-page-come-from-for-db-data-hub-companies

The `Where does information on this page come from?` details summary should not be shown for companies populated from Data Hub. It is still shown for companies populated by Dun & Bradstreet data.

Included in this change is using the `govukDetails` component rather than a custom component.

This can be tested by browsing to `~/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/business-details`.

## Screenshot
<img width="807" alt="screenshot 2019-02-12 at 16 25 26" src="https://user-images.githubusercontent.com/1150417/52650834-e3274900-2ee2-11e9-91d4-a158b74860f4.png">
