### PR TITLE
Update business details "About business" heading

### DIFF
--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -36,7 +36,7 @@
     }) }}
   {% endif %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">{{ company.name }} is known as</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">About {{ company.name }}</h2>
 
   {% component 'key-value-table', items=knownAsDetails %}
 

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -8,7 +8,7 @@ Feature: Company business details
     Then the heading should be "Business details"
     And the "Where does information on this page come from?" details summary should be displayed
     And the Company summary key value details are not displayed
-    And the One List Corp is known as key value details are displayed
+    And the About One List Corp key value details are displayed
       | key                       | value                        |
       | Trading names             | company.tradingName          |
     And the Global Account Manager – One List key value details are displayed
@@ -47,7 +47,7 @@ Feature: Company business details
     When I navigate to the `companies.business-details` page using `company` `Venus Ltd` fixture
     Then the heading should be "Business details"
     And the "Where does information on this page come from?" details summary should not be displayed
-    And the Venus Ltd is known as key value details are displayed
+    And the About Venus Ltd key value details are displayed
       | key                       | value                        |
       | Trading names             | company.tradingName          |
     And the Global Account Manager – One List key value details are displayed


### PR DESCRIPTION
https://trello.com/c/EVOxqRcV/728-update-about-business-name-section-db

## Change
Previously the heading was `Business is known as` and needs to be `About business`.

## Before
![screenshot 2019-02-14 at 17 04 08](https://user-images.githubusercontent.com/1150417/52803835-c45bba80-307a-11e9-9076-8c116a632d2d.png)

## After
![screenshot 2019-02-14 at 17 02 44](https://user-images.githubusercontent.com/1150417/52803823-bc037f80-307a-11e9-80f0-efb29e327766.png)

