### PR TITLE
Adding three investment tabs/routes to investment-projects

### DIFF
--- a/assets/stylesheets/components/_pagination.scss
+++ b/assets/stylesheets/components/_pagination.scss
@@ -74,15 +74,6 @@
   color: $grey-1;
 }
 
-.c-pagination__navigation {
-  @include clearfix;
-}
-
-.c-pagination__summary {
-  margin-top: $default-spacing-unit;
-  color: $grey-1;
-}
-
 @include media(mobile) {
   @include _pageless;
 }

--- a/src/apps/investment-projects/constants.js
+++ b/src/apps/investment-projects/constants.js
@@ -57,6 +57,21 @@ const LOCAL_NAV = [
   },
 ]
 
+const INVESTMENT_TAB_ITEMS = [
+  {
+    path: 'projects',
+    label: 'Projects',
+  },
+  {
+    path: 'profiles',
+    label: 'Investor profiles',
+  },
+  {
+    path: 'opportunities',
+    label: 'UK Opportunities',
+  },
+]
+
 const DEFAULT_COLLECTION_QUERY = {
   sortby: 'estimated_land_date:asc',
 }
@@ -91,6 +106,7 @@ const QUERY_DATE_FIELDS = [
 module.exports = {
   GLOBAL_NAV_ITEM,
   LOCAL_NAV,
+  INVESTMENT_TAB_ITEMS,
   DEFAULT_COLLECTION_QUERY,
   APP_PERMISSIONS,
   QUERY_FIELDS,

--- a/src/apps/investment-projects/controllers/opportunities.js
+++ b/src/apps/investment-projects/controllers/opportunities.js
@@ -1,0 +1,5 @@
+const renderOpportunitiesView = (req, res, next) => {
+  res.render('investment-projects/views/opportunities', {})
+}
+
+module.exports = { renderOpportunitiesView }

--- a/src/apps/investment-projects/controllers/profiles.js
+++ b/src/apps/investment-projects/controllers/profiles.js
@@ -1,0 +1,5 @@
+const renderProfilesView = (req, res, next) => {
+  res.render('investment-projects/views/profiles', {})
+}
+
+module.exports = { renderProfilesView }

--- a/src/apps/investment-projects/controllers/projects.js
+++ b/src/apps/investment-projects/controllers/projects.js
@@ -1,0 +1,79 @@
+const qs = require('querystring')
+const { merge, omit, get } = require('lodash')
+
+const { buildSelectedFiltersSummary, buildFieldsWithSelectedEntities } = require('../../builders')
+const { getOptions } = require('../../../lib/options')
+const { investmentFiltersFields, investmentSortForm } = require('../macros')
+const { buildExportAction } = require('../../../lib/export-helper')
+const { transformAdviserToOption } = require('../../adviser/transformers')
+const { filterActiveAdvisers } = require('../../adviser/filters')
+const { getAdvisers } = require('../../adviser/repos')
+
+const FILTER_CONSTANTS = require('../../../lib/filter-constants')
+const QUERY_STRING = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.PRIMARY.QUERY_STRING
+const SECTOR = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.NAME
+
+const renderProjectsView = view => {
+  return async (req, res, next) => {
+    try {
+      const { token, user } = req.session
+      const currentAdviserId = user.id
+      const queryString = QUERY_STRING
+      const sortForm = merge({}, investmentSortForm, {
+        hiddenFields: { ...omit(req.query, 'sortby') },
+        children: [
+          { value: req.query.sortby },
+        ],
+      })
+
+      const sectorOptions = await getOptions(token, SECTOR, { queryString })
+      const advisers = await getAdvisers(token)
+      const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
+
+      const activeAdvisers = filterActiveAdvisers({
+        advisers: advisers.results,
+        includeAdviser: currentAdviser,
+      })
+
+      const filtersFields = investmentFiltersFields({
+        currentAdviserId,
+        sectorOptions,
+        adviserOptions: activeAdvisers.map(transformAdviserToOption),
+        userAgent: res.locals.userAgent,
+      })
+
+      const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, req.query)
+      const selectedFilters = await buildSelectedFiltersSummary(filtersFieldsWithSelectedOptions, req.query)
+
+      const exportOptions = {
+        targetPermission: 'investment.export_investmentproject',
+        urlFragment: 'investment-projects',
+        maxItems: FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.MAX_EXPORT_ITEMS,
+        entityName: 'project',
+      }
+
+      const exportAction = await buildExportAction(qs.stringify(req.query), user.permissions, exportOptions)
+
+      const props = {
+        sortForm,
+        selectedFilters,
+        exportAction,
+        filtersFields: filtersFieldsWithSelectedOptions,
+        title: 'Investment Projects',
+        countLabel: 'project',
+        actionButtons: [{
+          label: 'Create profile',
+          url: '/',
+        }],
+      }
+
+      res.render(view, props)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = {
+  renderProjectsView,
+}

--- a/src/apps/investment-projects/middleware/investments-tab-items.js
+++ b/src/apps/investment-projects/middleware/investments-tab-items.js
@@ -1,0 +1,16 @@
+const { INVESTMENT_TAB_ITEMS } = require('../constants')
+
+const setInvestmentTabItems = (req, res, next) => {
+  res.locals.investmentTabItems = INVESTMENT_TAB_ITEMS
+    .map((item) => {
+      const url = `${req.baseUrl}/${item.path}`
+      return {
+        ...item,
+        url,
+        isActive: res.locals.CURRENT_PATH === url,
+      }
+    })
+  next()
+}
+
+module.exports = setInvestmentTabItems

--- a/src/apps/investment-projects/middleware/local-navigation.js
+++ b/src/apps/investment-projects/middleware/local-navigation.js
@@ -11,10 +11,10 @@ const filterDocNavItemIfProjectIsNew = (investment) => {
   return LOCAL_NAV.filter(({ path }) => !(path === DOCUMENTS && isNew))
 }
 
-const setInvestmentsLocalNav = (req, res, next) => {
+const setLocalNavigation = (req, res, next) => {
   const { investment } = res.locals
   const navItems = investment ? filterDocNavItemIfProjectIsNew(investment) : LOCAL_NAV
   setLocalNav(navItems)(req, res, next)
 }
 
-module.exports = setInvestmentsLocalNav
+module.exports = setLocalNavigation

--- a/src/apps/investment-projects/router.js
+++ b/src/apps/investment-projects/router.js
@@ -7,7 +7,8 @@ const { getRequestBody } = require('../../middleware/collection')
 const { detectUserAgent } = require('../../middleware/detect-useragent')
 const { getCollection, exportCollection } = require('../../modules/search/middleware/collection')
 
-const setInvestmentsLocalNav = require('./middleware/local-navigation')
+const setInvestmentTabItems = require('./middleware/investments-tab-items')
+const setLocalNavigation = require('./middleware/local-navigation')
 const { setDefaultQuery, redirectToFirstNavItem, handleRoutePermissions } = require('../middleware')
 const { shared } = require('./middleware')
 const {
@@ -36,7 +37,10 @@ const {
   valueFormMiddleware,
 } = require('./middleware/forms')
 
-const { renderInvestmentList } = require('./controllers/list')
+const { renderProjectsView } = require('./controllers/projects')
+const { renderProfilesView } = require('./controllers/profiles')
+const { renderOpportunitiesView } = require('./controllers/opportunities')
+
 const { renderPropositionList } = require('./controllers/propositions')
 const { renderEvidenceView } = require('./controllers/evidence')
 const { renderAddEvidence } = require('./apps/evidence/controllers/create')
@@ -73,18 +77,38 @@ const { transformInvestmentProjectToListItem } = require('./transformers')
 const interactionsRouter = require('../interactions/router.sub-app')
 const propositionsRouter = require('../propositions/router.sub-app')
 
-router.use(handleRoutePermissions(APP_PERMISSIONS))
-
-router.use('/:investmentId', setInvestmentsLocalNav)
-router.param('investmentId', shared.getInvestmentDetails)
-router.param('companyId', shared.getCompanyDetails)
-
-router.get('/',
+const projectsMiddleware = [
   detectUserAgent,
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
   getRequestBody(QUERY_FIELDS, QUERY_DATE_FIELDS),
   getCollection('investment_project', ENTITIES, transformInvestmentProjectToListItem),
-  renderInvestmentList
+]
+
+router.use(handleRoutePermissions(APP_PERMISSIONS))
+
+router.use('/:investmentId', setLocalNavigation)
+router.param('investmentId', shared.getInvestmentDetails)
+router.param('companyId', shared.getCompanyDetails)
+
+router.get('/',
+  projectsMiddleware,
+  renderProjectsView('_layouts/collection')
+)
+
+router.get('/projects',
+  projectsMiddleware,
+  setInvestmentTabItems,
+  renderProjectsView('investment-projects/views/projects'),
+)
+
+router.get('/profiles',
+  setInvestmentTabItems,
+  renderProfilesView,
+)
+
+router.get('/opportunities',
+  setInvestmentTabItems,
+  renderOpportunitiesView,
 )
 
 router.get('/export',

--- a/src/apps/investment-projects/views/opportunities.njk
+++ b/src/apps/investment-projects/views/opportunities.njk
@@ -1,0 +1,10 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {{ TabbedLocalNav({ items: investmentTabItems }) }}
+    </div>
+  </div>
+  <h1>Opportunities</h1>
+{% endblock %}

--- a/src/apps/investment-projects/views/profiles.njk
+++ b/src/apps/investment-projects/views/profiles.njk
@@ -1,0 +1,10 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {{ TabbedLocalNav({ items: investmentTabItems }) }}
+    </div>
+  </div>
+  <h1>Profiles</h1>
+{% endblock %}

--- a/src/apps/investment-projects/views/projects.njk
+++ b/src/apps/investment-projects/views/projects.njk
@@ -1,0 +1,29 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {{ TabbedLocalNav({ items: investmentTabItems }) }}
+    </div>
+  </div>
+  <div class="grid-row">
+    <div class="column-one-third">
+      {{ CollectionFilters({
+        query: QUERY,
+        filtersFields: filtersFields,
+        action: CURRENT_PATH
+      }) }}
+    </div>
+    <article class="column-two-thirds" data-xhr="c781e8b1-9747-4b2e-8655-68b14ea49126">
+      {{ CollectionContent(results | assign({
+        countLabel: countLabel,
+        sortForm: assign({}, sortForm, { action: CURRENT_PATH }),
+        selectedFilters: selectedFilters,
+        highlightTerm: highlightTerm,
+        actionButtons: actionButtons,
+        exportAction: exportAction,
+        query: QUERY
+      })) }}
+    </article>
+  </div>
+{% endblock %}

--- a/src/templates/_macros/collection-header/_collection-header.scss
+++ b/src/templates/_macros/collection-header/_collection-header.scss
@@ -1,51 +1,68 @@
-@import "~govuk-frontend/helpers/all";
-@import "~govuk-frontend/settings/all";
+@import "../../../../assets/stylesheets/settings";
+@import "../../../../assets/stylesheets/tools";
 
 .c-collection__header-row {
-  @include govuk-font($size: 16);
-
-  padding: govuk-spacing(2) 0 govuk-spacing(2) 0;
-  border-bottom: 1px solid govuk-colour("grey-2");
+  @include clearfix;
+  @include core-font(16);
+  padding-bottom: ($default-spacing-unit / 2);
 
   &:first-child {
-    border-bottom: govuk-spacing(1) solid $govuk-text-colour;
+    border-bottom: 5px solid $text-colour;
   }
 
-  @include govuk-media-query($from: tablet) {
-    display: flex;
-    flex-flow: row wrap;
-    align-items: center;
+  &:not(first-child) {
+    padding-top: ($default-spacing-unit / 2);
+    border-bottom: 1px solid $grey-2;
   }
 }
 
 .c-collection__header-intro {
-  @include govuk-font($size: 24);
-}
-
-.c-collection__result-count {
-  @include govuk-font($size: 36, $weight: bold, $line-height: 1);
-}
-
-.c-collection__header-actions {
-  margin-top: govuk-spacing(2);
-  margin-left: auto;
-
-  @include govuk-media-query($from: tablet) {
-    margin-top: 0;
-  }
-}
-
-.c-collection__summary {
-  width: 100%;
-}
-
-.c-collection__filter-tag {
-  margin: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+  @include core-font(24);
   display: inline-block;
 }
 
+.c-collection__header-actions {
+  @include media(tablet) {
+    float: right;
+
+    * + * {
+      margin-left: $default-spacing-unit;
+    }
+  }
+}
+
+.c-collection__result-count {
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+// Export button
+
+.c-collection__export-message {
+  color: $black;
+  line-height: $default-spacing-unit * 2;
+}
+
+// Filter summary
+
+.c-collection__filter-summary {
+  clear: both;
+}
+
+.c-collection__filter-tag {
+  color: $text-colour;
+  display: inline-block;
+  position: relative;
+  margin-right: $default-spacing-unit / 2;
+  margin-top: $default-spacing-unit / 2;
+  padding: 0 ($default-spacing-unit / 2);
+  background: $grey-4;
+  cursor: default;
+}
+
 .c-collection__filter-label {
-  color: govuk-colour("grey-1");
+  color: $grey-1;
 
   &::after {
     content: ":";
@@ -53,33 +70,74 @@
 }
 
 .c-collection__filter-value {
-  @include govuk-font($size: 16, $weight: bold);
+  font-weight: 600;
 }
 
-.c-collection__filter-remove-all {
-  margin-left: govuk-spacing(2);
-  display: inline-block;
+.c-collection__filter-remove {
+  position: absolute;
+  top: $baseline-grid-unit;
+  right: $baseline-grid-unit;
+  text-decoration: none;
+  float: right;
+  font-size: 24px;
+  line-height: .7;
 
   &:link,
   &:visited {
-    color: $govuk-link-colour;
+    color: $text-colour;
+  }
+
+  &:hover {
+    color: $red;
   }
 }
 
-.c-collection__sort-form {
-  margin-top: govuk-spacing(2);
+.c-collection__filter-remove-all {
+  display: inline-block;
+  line-height: 1.2;
+  margin-top: $default-spacing-unit / 2;
+  margin-bottom: $default-spacing-unit / 2;
 
-  @include govuk-media-query($from: tablet) {
-    margin-top: 0;
+  &:link,
+  &:visited {
+    color: $link-colour;
   }
+}
+
+.c-collection__pagination-summary {
+  color: $grey-1;
+  line-height: $default-spacing-unit * 2;
+}
+
+.c-collection__sort-form {
+  margin-top: $default-spacing-unit / 2;
+  display: flex;
 
   .c-form-group--inline {
     display: flex;
     align-items: center;
   }
 
-  .c-form-group__label-text {
-    margin-right: govuk-spacing(1);
+  .c-form-group__label {
     margin-bottom: 0;
+    margin-right: $default-spacing-unit / 2;
+  }
+
+  @include media(tablet) {
+    margin-top: 0;
+    float: right;
+  }
+
+  .button {
+    margin-left: $default-spacing-unit / 2;
+    margin-bottom: 2px;
+  }
+}
+
+.c-collection__total-cost {
+  padding-top: $default-spacing-unit / 2;
+
+  .c-collection__total-cost__value{
+    font-weight: 600;
   }
 }

--- a/src/templates/_macros/collection-header/template.njk
+++ b/src/templates/_macros/collection-header/template.njk
@@ -7,7 +7,6 @@
 {% set actionButtons = props.actionButtons | default([]) | castArray %}
 
 <header class="c-collection__header">
-
   <div class="c-collection__header-row">
     <div class="c-collection__header-intro">
       <span class="c-collection__result-count">{{ count | formatNumber }}</span>
@@ -20,71 +19,71 @@
       {% endif %}
     </div>
 
-    {% if actionButtons.length %}
+    {% if props.selectedFilters | length or actionButtons.length %}
       <div class="c-collection__header-actions">
+        {% if props.selectedFilters | length %}
+          <a
+            href="?{{ buildQuery({}, { custom: true, sortby: props.sortForm.children[0].value }) }}"
+            class="c-collection__filter-remove-all js-xhr js-ClearInputs"
+            data-target-selector=".c-collection-filters"
+            aria-label="Reset filter results"
+          >
+            Remove all filters
+          </a>
+        {% endif %}
+
         {% for actionButton in actionButtons %}
-          <a class="button" href="{{ actionButton.url }}">{{ actionButton.label }}</a>
+          <a class="button button--secondary" href="{{ actionButton.url }}">{{ actionButton.label }}</a>
         {% endfor %}
       </div>
     {% endif %}
 
-    {% if props.selectedFilters | length %}
-      <div class="c-collection__summary">
+    {% if props.selectedFilters %}
+      <div class="c-collection__filter-summary">
         {% for name, filter in props.selectedFilters %}
           <span class="c-collection__filter-tag">
-            <span class="c-collection__filter-label">{{ filter.label }}</span>
-            <span class="c-collection__filter-value">
-              {%- if 'date' in name -%}
-                {{ filter.valueLabel | formatDate }}
-              {%- else -%}
-                {{ filter.valueLabel }}
-              {%- endif -%}
+              <span class="c-collection__filter-label">{{ filter.label }}</span>
+              <span class="c-collection__filter-value">
+                {%- if 'date' in name -%}
+                  {{ filter.valueLabel | formatDate }}
+                {%- else -%}
+                  {{ filter.valueLabel }}
+                {%- endif -%}
+              </span>
             </span>
-          </span>
         {% endfor %}
-
-        <a
-          href="?{{ buildQuery({}, { custom: true, sortby: props.sortForm.children[0].value }) }}"
-          class="c-collection__filter-remove-all js-xhr js-ClearInputs"
-          data-target-selector=".c-collection-filters"
-          aria-label="Reset filter results"
-        >
-          Remove all filters
-        </a>
       </div>
     {% endif %}
 
-    {# TODO this needs to be an array of items and not explicitly referencing a field #}
     {% if props.summary %}
-      <div class="c-collection__summary">
-        <span class="c-collection__filter-tag">
-          Total value:
-          <span class="c-collection__filter-value">
-            £{{ (totalCost / 100) | formatNumber }}
-          </span>
-        </span>
+      <div class="c-collection__total-cost">
+        Total value: <span class="c-collection__total-cost__value">£{{ (totalCost / 100) | formatNumber }}</span>
       </div>
     {% endif %}
-
   </div>
 
-  {% if (count > 1 and props.sortForm) or props.exportAction.enabled %}
+  {% if props.sortForm or props.pagination %}
     <div class="c-collection__header-row">
-      {{ Form(props.sortForm) if props.sortForm }}
-
-      {% if props.exportAction.enabled %}
-        <span class="c-collection__header-actions">
-          {% if not props.exportAction.invalidNumberOfItems(count, props.exportAction.maxItems) %}
-            <a class="button button--secondary" download href="{{ props.exportAction.url }}">Download</a>
-          {% endif %}
-        </span>
+      {% if props.pagination %}
+        <span class="c-collection__pagination-summary">
+            Page {{ props.pagination.currentPage }} of {{ props.pagination.totalPages }}
+          </span>
       {% endif %}
+
+      {{ Form(props.sortForm) if props.sortForm and count > 1 }}
     </div>
   {% endif %}
 
   {% if props.exportAction.enabled %}
     <div class="c-collection__header-row">
-      {{ props.exportAction.buildMessage(count) }}
+      <span class="c-collection__export-message">
+        {{ props.exportAction.buildMessage(count) }}
+      </span>
+      <span class="c-collection__header-actions">
+        {% if not props.exportAction.invalidNumberOfItems(count, props.exportAction.maxItems) %}
+          <a class="button" download href="{{ props.exportAction.url }}">Download</a>
+        {% endif %}
+      </span>
     </div>
   {% endif %}
 

--- a/src/templates/_macros/common/pagination.njk
+++ b/src/templates/_macros/common/pagination.njk
@@ -24,39 +24,31 @@
   {% if pagination %}
     <nav
       class="c-pagination {{ 'c-pagination--pageless' if not showPages }}"
-      aria-label="pagination: total {{ pagination.totalPages }} pages">
-
-      <div class="c-pagination__navigation">
-        {% if pagination.prev -%}
-          <a href="{{ pagination.prev }}" class="c-pagination__label c-pagination__label--prev">Previous</a>
-        {%- endif %}
-
-        {% if showPages -%}
-          <ul class="c-pagination__list">
-            {% for page in pagination.pages -%}
-              <li class="c-pagination__list-item">
-                {% if page.url -%}
-                  <a href="{{ page.url }}" class="c-pagination__label {{ 'is-current' if page.label == pagination.currentPage }}">
-                    {{- page.label -}}
-                  </a>
-                {% else -%}
-                  <span class="c-pagination__label c-pagination__label--truncation">
-                    {{- page.label -}}
-                  </span>
-                {%- endif %}
-              </li>
-            {%- endfor %}
-          </ul>
-        {%- endif %}
-
-        {% if pagination.next -%}
-          <a href="{{ pagination.next }}" class="c-pagination__label c-pagination__label--next">Next</a>
-        {%- endif %}
-      </div>
-
-      <div class="c-pagination__summary">
-        Page {{ pagination.currentPage }} of {{ pagination.totalPages }}
-      </div>
+      aria-label="pagination: total {{ pagination.totalPages }} pages"
+    >
+      {% if pagination.prev -%}
+        <a href="{{ pagination.prev }}" class="c-pagination__label c-pagination__label--prev">Previous</a>
+      {%- endif %}
+      {% if showPages -%}
+        <ul class="c-pagination__list">
+          {% for page in pagination.pages -%}
+            <li class="c-pagination__list-item">
+              {% if page.url -%}
+                <a href="{{ page.url }}" class="c-pagination__label {{ 'is-current' if page.label == pagination.currentPage }}">
+                  {{- page.label -}}
+                </a>
+              {% else -%}
+                <span class="c-pagination__label c-pagination__label--truncation">
+                  {{- page.label -}}
+                </span>
+              {%- endif %}
+            </li>
+          {%- endfor %}
+        </ul>
+      {%- endif %}
+      {% if pagination.next -%}
+        <a href="{{ pagination.next }}" class="c-pagination__label c-pagination__label--next">Next</a>
+      {%- endif %}
     </nav>
   {% endif %}
 {% endmacro %}

--- a/test/acceptance/features/interactions/step_definitions/save.js
+++ b/test/acceptance/features/interactions/step_definitions/save.js
@@ -200,7 +200,7 @@ Then(/^the net receipt field is hidden/, async function () {
  */
 Then(/^I filter the collections to view the (.+) I have just created$/, async function (typeOfInteraction) {
   const filtersSection = InteractionList.section.filters
-  const summarySection = InteractionList.section.summary
+  const filterTagsSection = InteractionList.section.filterTags
   const waitForTimeout = 15000
   const interactionType = camelCase(typeOfInteraction)
 
@@ -222,7 +222,7 @@ Then(/^I filter the collections to view the (.+) I have just created$/, async fu
     .waitForElementPresent(`@${interactionType}`)
     .click(`@${interactionType}`)
 
-  await summarySection
+  await filterTagsSection
     .waitForElementPresent('@kind', waitForTimeout)
 
   client.clearValue('#field-date_after')
@@ -242,6 +242,6 @@ Then(/^I filter the collections to view the (.+) I have just created$/, async fu
   await filtersSection
     .sendKeys('@dateTo', [ client.Keys.ENTER ])
 
-  await summarySection
+  await filterTagsSection
     .waitForElementPresent('@dateTo', waitForTimeout)
 })

--- a/test/acceptance/pages/interactions/list.js
+++ b/test/acceptance/pages/interactions/list.js
@@ -17,8 +17,8 @@ module.exports = {
     interactionsTab: 'a[href*="/search/interactions"]',
   },
   sections: {
-    summary: {
-      selector: '.c-collection__summary',
+    filterTags: {
+      selector: '.c-collection__filter-summary',
       elements: {
         kind: getFilterTagSelector('Kind'),
         communicationChannel: getFilterTagSelector('Communication channel'),

--- a/test/unit/apps/investment-projects/controllers/projects.tab.test.js
+++ b/test/unit/apps/investment-projects/controllers/projects.tab.test.js
@@ -1,0 +1,116 @@
+const config = require('~/config')
+
+describe('Investment project controller - /views/projects', () => {
+  const metadataMock = {
+    sectorOptions: [
+      { id: 's1', name: 's1', disabled_on: null },
+    ],
+    adviserOptions: {
+      results: [
+        { id: 'ad1', name: 'ad1', is_active: true, dit_team: { name: 'ad1' } },
+      ],
+    },
+  }
+
+  beforeEach(() => {
+    this.req = {
+      session: {
+        user: {
+          id: '1234',
+          name: 'Fred Smith',
+          permissions: [],
+        },
+        token: 'abcd',
+      },
+      query: {
+        sortby: 'estimated_land_date:asc',
+      },
+    }
+
+    this.res = {
+      render: sinon.spy(),
+      query: {},
+      locals: {
+        userAgent: {
+          isIE: false,
+        },
+      },
+    }
+    this.nextSpy = sinon.spy()
+
+    nock(config.apiRoot)
+      .get('/metadata/sector/?level__lte=0')
+      .reply(200, metadataMock.sectorOptions)
+      .get('/adviser/?limit=100000&offset=0')
+      .reply(200, metadataMock.adviserOptions)
+  })
+
+  describe('#renderProjectsView', () => {
+    context('when the list renders successfully', () => {
+      beforeEach(async () => {
+        const controller = require('~/src/apps/investment-projects/controllers/projects')
+
+        const renderProjectsView = controller.renderProjectsView('investment-projects/views/projects')
+        await renderProjectsView(this.req, this.res, this.nextSpy)
+      })
+
+      it('should render', () => {
+        expect(this.res.render).to.be.calledOnce
+      })
+
+      it('should render the projects template', () => {
+        expect(this.res.render.firstCall.args[0]).to.equal('investment-projects/views/projects')
+      })
+
+      it('should render the view with a title', () => {
+        expect(this.res.render.firstCall.args[1].title).to.equal('Investment Projects')
+      })
+
+      it('should render the view with a count label', () => {
+        expect(this.res.render.firstCall.args[1].countLabel).to.equal('project')
+      })
+
+      it('should render the view with a sort form', () => {
+        expect(this.res.render.firstCall.args[1].sortForm).to.exist
+      })
+
+      it('should render the view with selected filters', () => {
+        expect(this.res.render.firstCall.args[1].selectedFilters).to.exist
+      })
+
+      it('should render the view with an export action', () => {
+        expect(this.res.render.firstCall.args[1].exportAction).to.deep.equal({ enabled: false })
+      })
+
+      it('should render the view with filter fields', () => {
+        expect(this.res.render.firstCall.args[1].filtersFields).to.exist
+      })
+    })
+
+    context('when there is an error', () => {
+      beforeEach(async () => {
+        this.error = new Error('error')
+        const erroneousSpy = sinon.stub().throws(this.error)
+
+        const controller = proxyquire('~/src/apps/investment-projects/controllers/projects', {
+          '../../builders': {
+            buildSelectedFiltersSummary: erroneousSpy,
+            buildFieldsWithSelectedEntities: sinon.stub(),
+          },
+        })
+
+        const renderProjectsView = controller.renderProjectsView('investment-projects/views/projects')
+        await renderProjectsView(this.req, this.res, this.nextSpy)
+      })
+
+      it('should not render the view', () => {
+        expect(this.res.render).to.not.be.called
+      })
+
+      it('should call next with an error', () => {
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+        expect(this.nextSpy).to.have.been.calledOnce
+      })
+    })
+  })
+})

--- a/test/unit/apps/investment-projects/controllers/projects.test.js
+++ b/test/unit/apps/investment-projects/controllers/projects.test.js
@@ -1,6 +1,6 @@
 const config = require('~/config')
 
-describe('Investment list controller', () => {
+describe('Investment project controller - _layouts/collection', () => {
   const metadataMock = {
     sectorOptions: [
       { id: 's1', name: 's1', disabled_on: null },
@@ -45,12 +45,13 @@ describe('Investment list controller', () => {
       .reply(200, metadataMock.adviserOptions)
   })
 
-  describe('#renderInvestmentList', () => {
+  describe('#renderProjectsView', () => {
     context('when the list renders successfully', () => {
       beforeEach(async () => {
-        const controller = require('~/src/apps/investment-projects/controllers/list')
+        const controller = require('~/src/apps/investment-projects/controllers/projects')
 
-        await controller.renderInvestmentList(this.req, this.res, this.nextSpy)
+        const renderProjectsView = controller.renderProjectsView('_layouts/collection')
+        await renderProjectsView(this.req, this.res, this.nextSpy)
       })
 
       it('should render', () => {
@@ -91,14 +92,15 @@ describe('Investment list controller', () => {
         this.error = new Error('error')
         const erroneousSpy = sinon.stub().throws(this.error)
 
-        const controller = proxyquire('~/src/apps/investment-projects/controllers/list', {
+        const controller = proxyquire('~/src/apps/investment-projects/controllers/projects', {
           '../../builders': {
             buildSelectedFiltersSummary: erroneousSpy,
             buildFieldsWithSelectedEntities: sinon.stub(),
           },
         })
 
-        await controller.renderInvestmentList(this.req, this.res, this.nextSpy)
+        const renderProjectsView = controller.renderProjectsView('_layouts/collection')
+        await renderProjectsView(this.req, this.res, this.nextSpy)
       })
 
       it('should not render the view', () => {

--- a/test/unit/apps/investment-projects/middleware/local-navigation.test.js
+++ b/test/unit/apps/investment-projects/middleware/local-navigation.test.js
@@ -1,4 +1,4 @@
-const setInvestmentsLocalNav = require('~/src/apps/investment-projects/middleware/local-navigation')
+const setLocalNavigation = require('~/src/apps/investment-projects/middleware/local-navigation')
 
 describe('Investment projects local navigation', () => {
   beforeEach(() => {
@@ -21,7 +21,7 @@ describe('Investment projects local navigation', () => {
   context('when a project code starts with \'DHP\' it is a new project', () => {
     beforeEach(() => {
       this.res.locals.investment.project_code = 'DHP-00000001'
-      setInvestmentsLocalNav(this.req, this.res, this.next)
+      setLocalNavigation(this.req, this.res, this.next)
     })
 
     it('should filter out the documents nav item', () => {
@@ -33,7 +33,7 @@ describe('Investment projects local navigation', () => {
   context('when a project code starts with \'P\' it is an old project (CDMS)', () => {
     beforeEach(() => {
       this.res.locals.investment.project_code = 'P-30016857'
-      setInvestmentsLocalNav(this.req, this.res, this.next)
+      setLocalNavigation(this.req, this.res, this.next)
     })
 
     it('should keep the documents nav item', () => {
@@ -45,7 +45,7 @@ describe('Investment projects local navigation', () => {
   context('when a project code starts with a number it is a very old project (pre-dates CDMS)', () => {
     beforeEach(() => {
       this.res.locals.investment.project_code = '016020'
-      setInvestmentsLocalNav(this.req, this.res, this.next)
+      setLocalNavigation(this.req, this.res, this.next)
     })
 
     it('should keep the documents nav item', () => {


### PR DESCRIPTION
Note: this is work in progress.

Adding three new tabs into investment projects
  - Projects
  - Profiles
  - Opportunities

Each one of these tabs has a corresponding route
  - /investment-projects/projects
  - /investment-projects/profiles
  - /investment-projects/opportunities

Before going live and once prudent to do so /investment-projects will be renamed
to /investments, all Data Hub links will be updated accordingly.

The current investment list has been moved into the the projects tab, however, the current
implementation remains unchanged apart from code reuse across both routes.

To be clear:
/investment-projects and /investment-projects/projects are identical except the latter is
within a tab. The former will be removed once we're good to go.

There is no feature flag as the new functionality is hidden behind new routes which the user
has no link to.

Acceptance tests to follow.

https://uktrade.atlassian.net/browse/IPBETA-226
