### PR TITLE
Update typeahead to use new params for search adviser API

### DIFF
--- a/assets/javascripts/vue/filters.js
+++ b/assets/javascripts/vue/filters.js
@@ -1,5 +1,5 @@
 function highlight (str, words) {
-  if (!words) { return str }
+  if (!str || !words) { return str }
 
   const queryWords = words.split(' ').filter((word) => word.length >= 1)
   const openTag = '<span class=\'highlight\'>'

--- a/assets/stylesheets/components/form/_typeahead.scss
+++ b/assets/stylesheets/components/form/_typeahead.scss
@@ -43,6 +43,8 @@
   color: $text-colour;
   margin: 0 $default-spacing-unit / 2 0 0;
   overflow: initial;
+  white-space: normal;
+  line-height: 1.4;
 }
 
 .multiselect__input:focus,

--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -1,4 +1,4 @@
-const { get, isEmpty } = require('lodash')
+const { get } = require('lodash')
 const config = require('../../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
@@ -19,11 +19,9 @@ function getAdviser (token, id) {
 }
 
 async function fetchAdviserSearchResults (token, params) {
-  if (!isEmpty(params.term)) {
-    const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}&is_active=${params.is_active}`
-    const adviserResults = await authorisedRequest(token, { url })
-    return adviserResults.results
-  }
+  const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}&is_active=${params.is_active}`
+  const adviserResults = await authorisedRequest(token, { url })
+  return adviserResults.results
 }
 
 module.exports = {

--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -18,45 +18,16 @@ function getAdviser (token, id) {
   return authorisedRequest(token, `${config.apiRoot}/adviser/${id}/`)
 }
 
-function fetchAdviserSearchResults (token, firstName, lastName) {
-  let url = `${config.apiRoot}/adviser/?first_name__icontains=${firstName}`
-  if (!isEmpty(lastName)) url += `&last_name__icontains=${lastName}`
-
-  return authorisedRequest(token, { url })
-}
-
-function adviserNameSort (a, b) {
-  if (a.name.toLowerCase() < b.name.toLowerCase()) return -1
-  if (a.name.toLowerCase() > b.name.toLowerCase()) return 1
-  return 0
-}
-
-async function adviserSearch (token, term) {
-  if (isEmpty(term)) {
-    return
+async function fetchAdviserSearchResults (token, params) {
+  if (!isEmpty(params.term)) {
+    const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}&is_active=${params.is_active}`
+    const adviserResults = await authorisedRequest(token, { url })
+    return adviserResults.results
   }
-
-  const [firstName, lastName] = term.trim().toLowerCase().split(' ')
-  const adviserResults = await fetchAdviserSearchResults(token, firstName, lastName)
-
-  // API only supports contains, so filter out results that don't start with term
-  // Then reduce the result down to id and name
-  // And finally sort things
-  const filteredAdvisers = adviserResults.results
-    .filter((adviser) => {
-      if (isEmpty(lastName)) {
-        return adviser.first_name.toLowerCase().startsWith(firstName)
-      }
-      return adviser.first_name.toLowerCase().startsWith(firstName) &&
-        adviser.last_name.toLowerCase().startsWith(lastName)
-    })
-    .sort(adviserNameSort)
-
-  return filteredAdvisers
 }
 
 module.exports = {
   getAdvisers,
   getAdviser,
-  adviserSearch,
+  fetchAdviserSearchResults,
 }

--- a/src/apps/api/controllers/advisers.js
+++ b/src/apps/api/controllers/advisers.js
@@ -1,11 +1,14 @@
-const { adviserSearch } = require('../../adviser/repos')
+const { fetchAdviserSearchResults } = require('../../adviser/repos')
 const { transformAdviserToOption } = require('../../adviser/transformers')
 
 async function getAdviserOptionsHandler (req, res, next) {
   try {
     const token = req.session.token
-    const term = req.query.term
-    const advisers = await adviserSearch(token, term)
+    const params = {
+      term: req.query.autocomplete,
+      is_active: req.query.is_active,
+    }
+    const advisers = await fetchAdviserSearchResults(token, params)
 
     res.json(advisers.map(transformAdviserToOption))
   } catch (error) {

--- a/src/apps/api/controllers/options.js
+++ b/src/apps/api/controllers/options.js
@@ -11,7 +11,8 @@ async function getOptionsHandler (req, res, next) {
   try {
     const options = await getOptions(token, key, {
       includeDisabled: true,
-      term: req.query.term,
+      term: req.query.autocomplete,
+      is_active: req.query.is_active,
     })
 
     res.json(options)

--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -47,70 +47,24 @@ describe('Adviser repository', () => {
       this.bertSmith = {
         id: '1',
         name: 'Bert Smith',
-        is_active: false,
-        last_login: null,
-        first_name: 'Bert',
-        last_name: 'Smith',
-        email: 'bert.smith@mockexample.com',
-        contact_email: '',
-        telephone_number: '',
-        dit_team: {
-          id: 't1',
-          name: 'Team E',
-          role: 'r1',
-          uk_region: null,
-          country: 'c1',
-        },
-      }
-
-      this.albertAsmee = {
-        id: '2',
-        name: 'Albert Asmee',
-        is_active: false,
-        last_login: null,
-        first_name: 'Albert',
-        last_name: 'Asmee',
-        email: 'albert.asmee@mockexample.com',
-        contact_email: '',
-        telephone_number: '',
-        dit_team: {
-          id: 't1',
-          name: 'Team E',
-          role: 'r1',
-          uk_region: null,
-          country: 'c1',
-        },
       }
     })
 
-    context('when searching for a single name', () => {
+    context('when searching for a term', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
-          .get('/adviser/?first_name__icontains=be')
+          .get('/adviser/?autocomplete=be&is_active=true')
           .reply(200, {
-            results: [this.bertSmith, this.albertAsmee],
+            results: [this.bertSmith],
           })
 
-        this.advisers = await repos.adviserSearch('1234', 'be')
+        this.advisers = await repos.fetchAdviserSearchResults('1234', {
+          term: 'be',
+          is_active: true,
+        })
       })
 
-      it('should return the result that starts with be', () => {
-        expect(this.advisers).to.deep.equal([this.bertSmith])
-      })
-    })
-
-    context('when searching for a full name', () => {
-      beforeEach(async () => {
-        nock(config.apiRoot)
-          .get('/adviser/?first_name__icontains=be&last_name__icontains=sm')
-          .reply(200, {
-            results: [this.bertSmith, this.albertAsmee],
-          })
-
-        this.advisers = await repos.adviserSearch('1234', 'be sm')
-      })
-
-      it('should return the result that starts with be and sm', () => {
+      it('should return the results', () => {
         expect(this.advisers).to.deep.equal([this.bertSmith])
       })
     })

--- a/test/unit/apps/api/controllers/advisers.test.js
+++ b/test/unit/apps/api/controllers/advisers.test.js
@@ -1,7 +1,7 @@
 const { assign } = require('lodash')
 
 const config = require('~/config')
-const { getAdviserOptionsHandler } = require('~/src//apps/api/controllers/advisers')
+const { getAdviserOptionsHandler } = require('~/src/apps/api/controllers/advisers')
 
 describe('Adviser options API controller', () => {
   beforeEach(() => {
@@ -40,14 +40,15 @@ describe('Adviser options API controller', () => {
   context('when called with a name for an adviser', () => {
     beforeEach(async () => {
       nock(config.apiRoot)
-        .get('/adviser/?first_name__icontains=be')
+        .get('/adviser/?autocomplete=be&is_active=true')
         .reply(200, {
           results: [this.bertSmith],
         })
 
       const reqMock = assign({}, this.reqMock, {
         query: {
-          term: 'be',
+          autocomplete: 'be',
+          is_active: true,
         },
       })
 

--- a/test/unit/apps/api/controllers/options.test.js
+++ b/test/unit/apps/api/controllers/options.test.js
@@ -73,7 +73,7 @@ describe('options API controller', () => {
             entity: 'uk-region',
           },
           query: {
-            term: 'isle',
+            autocomplete: 'isle',
           },
         })
 

--- a/test/unit/assets/javascripts/vue/filters.js
+++ b/test/unit/assets/javascripts/vue/filters.js
@@ -1,0 +1,7 @@
+const { highlight } = require('../../../../assets/javascripts/vue/filters')
+
+describe.only('#Highlight', () => {
+  it('should highlight a single character', () => {
+
+  })
+})

--- a/test/unit/assets/javascripts/vue/filters.js
+++ b/test/unit/assets/javascripts/vue/filters.js
@@ -1,7 +1,35 @@
-const { highlight } = require('../../../../assets/javascripts/vue/filters')
+const { highlight } = require('../../../../../assets/javascripts/vue/filters')
 
-describe.only('#Highlight', () => {
-  it('should highlight a single character', () => {
-
+describe('#Highlight', () => {
+  context('when I search for a single character', () => {
+    const str = 'Mike Brodin'
+    it('should highlight the single character if the search was set in uppercase', () => {
+      expect(highlight(str, 'M')).to.equal('<span class=\'highlight\'>M</span>ike Brodin')
+    })
+    it('should highlight a single character if the search was set in lowercase', () => {
+      expect(highlight(str, 'm')).to.equal('<span class=\'highlight\'>M</span>ike Brodin')
+    })
+  })
+  context('when I search for a two characters', () => {
+    const str = 'Mike Brodin'
+    it('should highlight two characters if the search was set in uppercase', () => {
+      expect(highlight(str, 'MI')).to.equal('<span class=\'highlight\'>Mi</span>ke Brodin')
+    })
+    it('should highlight two characters if the search was set in lowercase', () => {
+      expect(highlight(str, 'mi')).to.equal('<span class=\'highlight\'>Mi</span>ke Brodin')
+    })
+  })
+  context('when I search for a character from the last name', () => {
+    const str = 'Mike Brodin'
+    it('should highlight the character in the last name', () => {
+      expect(highlight(str, 'B')).to.equal('Mike <span class=\'highlight\'>B</span>rodin')
+    })
+  })
+  context('when I search for a character or word that has no result', () => {
+    const str = 'Mike Brodin'
+    it('should return the str with no highlighting', () => {
+      expect(highlight(str, 'Z')).to.equal('Mike Brodin')
+      expect(highlight(str, 'Foo')).to.equal('Mike Brodin')
+    })
   })
 })

--- a/test/vue/typeahead.test.js
+++ b/test/vue/typeahead.test.js
@@ -161,6 +161,7 @@ describe('Typeahead', () => {
           entity: 'adviser',
           multipleSelectOptions: false,
           options: [],
+          isActive: true,
         }
         asyncSearch = Typeahead.methods.asyncSearch.bind(instance)
       })
@@ -181,7 +182,7 @@ describe('Typeahead', () => {
 
         it('should have fetched suggestions', () => {
           expect(axios.get).to.have.been.calledOnce
-          expect(axios.get).to.be.calledWith('/api/options/adviser?term=fred')
+          expect(axios.get).to.be.calledWith('/api/options/adviser?autocomplete=fred&is_active=true')
         })
 
         it('should store the return options', () => {


### PR DESCRIPTION
## Problem
- The API search behaviour has changed and we can now search for advisors by team name as well as the first name/last name. 

- Long selected options in the typeahead need to be wrapped as they are currently overflowing their containers.
![screenshot 2019-02-13 at 14 46 11](https://user-images.githubusercontent.com/10154302/52719740-21357300-2f9e-11e9-8a04-8c0fdad48fb2.png)

Trello - https://trello.com/c/HgyRp7Bu/506-search-behaviour-for-add-advisor-type-ahead

## Solution
- Update the search params in the typeahead to call the search API with:
`autocomplete`
`is_active`

instead of the old params `first_name__icontains` and `last_name__icontains`
- Update styles to wrap long content in selected options
