### PR TITLE
Hide/show business details One List section if business is on One List

### DIFF
--- a/src/apps/companies/transformers/company-to-one-list-view.js
+++ b/src/apps/companies/transformers/company-to-one-list-view.js
@@ -21,10 +21,12 @@ module.exports = ({
   one_list_group_global_account_manager,
   one_list_group_tier,
 }) => {
-  const viewRecord = {
-    one_list_group_global_account_manager: transformGlobalAccountManager(one_list_group_global_account_manager || {}),
-    one_list_tier: get(one_list_group_tier, 'name', NONE_TEXT),
-  }
+  if (one_list_group_tier) {
+    const viewRecord = {
+      one_list_group_global_account_manager: transformGlobalAccountManager(one_list_group_global_account_manager || {}),
+      one_list_tier: one_list_group_tier.name,
+    }
 
-  return getDataLabels(viewRecord, accountManagementDisplayLabels)
+    return getDataLabels(viewRecord, accountManagementDisplayLabels)
+  }
 }

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -41,13 +41,15 @@
   {% component 'key-value-table', items=aboutDetails %}
 
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">Global Account Manager – One List</h2>
+  {% if oneListDetails %}
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">Global Account Manager – One List</h2>
 
-  {% component 'key-value-table', items=oneListDetails %}
+    {% component 'key-value-table', items=oneListDetails %}
 
-  <p>
-    <a href="advisers">See all advisers on the core team</a>
-  </p>
+    <p>
+      <a href="advisers">See all advisers on the core team</a>
+    </p>
+  {% endif %}
 
 
   <h2 class="govuk-heading-m govuk-!-margin-top-9">Business hierarchy</h2>

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -90,10 +90,7 @@ Feature: Company business details
       | Annual turnover           | company.annualTurnover       |
       | Number of employees       | company.numberOfEmployees    |
       | Website                   | Not available                |
-    And the Global Account Manager – One List key value details are displayed
-      | key                       | value                        |
-      | One List tier             | None                         |
-      | Global Account Manager    | None                         |
+    And the Global Account Manager – One List key value details are not displayed
     And the Business hierarchy key value details are displayed
       | key                       | value                        |
       | Subsidiaries              | company.subsidiaries         |
@@ -112,3 +109,4 @@ Feature: Company business details
       | 001122                    |
       | Italy                     |
     And the Documents from CDMS key value details are not displayed
+

--- a/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-one-list-view.test.js
@@ -13,7 +13,7 @@ describe('transformCompanyToOneListView', () => {
     })
   }
 
-  context('when One List tier and Global Account Manager information exists', () => {
+  context('when the business is on the One List', () => {
     beforeEach(() => {
       this.actual = transformCompanyToOneListView(dnbCompany)
     })
@@ -25,7 +25,7 @@ describe('transformCompanyToOneListView', () => {
     ])
   })
 
-  context('when One List tier and Global Account Manager information exists', () => {
+  context('when the business is not on the One List', () => {
     beforeEach(() => {
       const company = {
         ...dnbCompany,
@@ -36,7 +36,9 @@ describe('transformCompanyToOneListView', () => {
       this.actual = transformCompanyToOneListView(company)
     })
 
-    commonTests('None', 'None')
+    it('should not set One List details', () => {
+      expect(this.actual).to.not.exist
+    })
   })
 
   context('when Global Account Manager if from outside UK', () => {


### PR DESCRIPTION
https://trello.com/c/em2el4Rv/732-only-show-business-details-global-account-manager-section-for-one-list-companies

## Change
If the business is not on the One List then the `Global Account Manager – One List` section should not be shown on the `business-details` view. If the business is on the One List then the section is shown.

## On One List
![screenshot 2019-02-15 at 11 51 06](https://user-images.githubusercontent.com/1150417/52855080-4ea62c00-3118-11e9-8534-77972359e73a.png)


## Not on One List
An example of this can be seen by directly browsing to https://datahub-beta2-pr-1748.herokuapp.com/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd/business-details

![screenshot 2019-02-15 at 11 52 05](https://user-images.githubusercontent.com/1150417/52855070-49e17800-3118-11e9-8a25-bb62bdb9bdc6.png)
