### PR TITLE
Update "About business" for businesses populated by data from Data Hub

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -88,8 +88,10 @@ const coreTeamLabels = {
 }
 
 const aboutLabels = {
+  business_type: 'Business type',
   trading_names: 'Trading names',
   company_number: 'Companies House number',
+  vat_number: 'VAT number',
   turnover: 'Annual turnover',
   number_of_employees: 'Number of employees',
   website: 'Website',

--- a/src/apps/companies/transformers/company-to-about-view.js
+++ b/src/apps/companies/transformers/company-to-about-view.js
@@ -3,19 +3,8 @@ const { get, pickBy, isEmpty } = require('lodash')
 
 const { aboutLabels } = require('../labels')
 const { getDataLabels } = require('../../../lib/controller-utils')
-const { NONE_TEXT, NOT_AVAILABLE_TEXT } = require('../constants')
+const { NOT_SET_TEXT } = require('../constants')
 
-module.exports = ({
-  trading_names,
-  companies_house_data,
-  website,
-  number_of_employees,
-  turnover,
-}) => {
-  const company_number = get(companies_house_data, 'company_number')
-
-  const viewRecord = {
-    trading_names: isEmpty(trading_names) ? NONE_TEXT : trading_names,
     company_number: company_number ? [
       company_number,
       {
@@ -26,7 +15,9 @@ module.exports = ({
         newWindow: true,
       },
     ] : null,
-    turnover: turnover ? [
+function transformTurnover (turnover, turnover_range) {
+  if (turnover) {
+    return [
       `USD ${turnover}`,
       {
         name: 'This is an estimated number',
@@ -36,8 +27,19 @@ module.exports = ({
           text: 'This is an estimated number',
         },
       },
-    ] : NOT_AVAILABLE_TEXT,
-    number_of_employees: number_of_employees ? [
+    ]
+  }
+
+  if (turnover_range) {
+    return turnover_range.name
+  }
+
+  return NOT_SET_TEXT
+}
+
+function transformNumberOfEmployees (number_of_employees, employee_range) {
+  if (number_of_employees) {
+    return [
       {
         name: number_of_employees,
         type: 'number',
@@ -50,7 +52,6 @@ module.exports = ({
           text: 'This is an estimated number',
         },
       },
-    ] : NOT_AVAILABLE_TEXT,
     website: isEmpty(website) ? NOT_AVAILABLE_TEXT : {
       name: website,
       url: website,
@@ -58,6 +59,36 @@ module.exports = ({
       hintId: 'external-link-label',
       newWindow: true,
     },
+    ]
+  }
+
+  if (employee_range) {
+    return employee_range.name
+  }
+
+  return NOT_SET_TEXT
+}
+
+module.exports = ({
+  vat_number,
+  duns_number,
+  business_type,
+  trading_names,
+  companies_house_data,
+  turnover,
+  turnover_range,
+  number_of_employees,
+  employee_range,
+  website,
+}) => {
+  const company_number = get(companies_house_data, 'company_number')
+
+  const viewRecord = {
+    vat_number,
+    business_type: duns_number ? null : get(business_type, 'name'),
+    trading_names: isEmpty(trading_names) ? NOT_SET_TEXT : trading_names,
+    turnover: transformTurnover(turnover, turnover_range),
+    number_of_employees: transformNumberOfEmployees(number_of_employees, employee_range),
   }
 
   return pickBy(getDataLabels(viewRecord, aboutLabels))

--- a/src/apps/companies/transformers/company-to-about-view.js
+++ b/src/apps/companies/transformers/company-to-about-view.js
@@ -5,16 +5,6 @@ const { aboutLabels } = require('../labels')
 const { getDataLabels } = require('../../../lib/controller-utils')
 const { NOT_SET_TEXT } = require('../constants')
 
-    company_number: company_number ? [
-      company_number,
-      {
-        url: `https://beta.companieshouse.gov.uk/company/${company_number}`,
-        name: 'View on Companies House website',
-        hint: '(Opens in a new window)',
-        hintId: 'external-link-label',
-        newWindow: true,
-      },
-    ] : null,
 function transformTurnover (turnover, turnover_range) {
   if (turnover) {
     return [
@@ -30,11 +20,7 @@ function transformTurnover (turnover, turnover_range) {
     ]
   }
 
-  if (turnover_range) {
-    return turnover_range.name
-  }
-
-  return NOT_SET_TEXT
+  return get(turnover_range, 'name', NOT_SET_TEXT)
 }
 
 function transformNumberOfEmployees (number_of_employees, employee_range) {
@@ -52,21 +38,39 @@ function transformNumberOfEmployees (number_of_employees, employee_range) {
           text: 'This is an estimated number',
         },
       },
-    website: isEmpty(website) ? NOT_AVAILABLE_TEXT : {
-      name: website,
-      url: website,
-      hint: '(Opens in a new window)',
-      hintId: 'external-link-label',
-      newWindow: true,
-    },
     ]
   }
 
-  if (employee_range) {
-    return employee_range.name
+  return get(employee_range, 'name', NOT_SET_TEXT)
+}
+
+function transformCompanyNumber (company_number) {
+  if (company_number) {
+    return [
+      company_number,
+      {
+        url: `https://beta.companieshouse.gov.uk/company/${company_number}`,
+        name: 'View on Companies House website',
+        hint: '(Opens in a new window)',
+        hintId: 'external-link-label',
+        newWindow: true,
+      },
+    ]
+  }
+}
+
+function transformWebsite (website) {
+  if (isEmpty(website)) {
+    return NOT_SET_TEXT
   }
 
-  return NOT_SET_TEXT
+  return {
+    name: website,
+    url: website,
+    hint: '(Opens in a new window)',
+    hintId: 'external-link-label',
+    newWindow: true,
+  }
 }
 
 module.exports = ({
@@ -87,8 +91,10 @@ module.exports = ({
     vat_number,
     business_type: duns_number ? null : get(business_type, 'name'),
     trading_names: isEmpty(trading_names) ? NOT_SET_TEXT : trading_names,
+    company_number: transformCompanyNumber(company_number),
     turnover: transformTurnover(turnover, turnover_range),
     number_of_employees: transformNumberOfEmployees(number_of_employees, employee_range),
+    website: transformWebsite(website),
   }
 
   return pickBy(getDataLabels(viewRecord, aboutLabels))

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -10,10 +10,10 @@ Feature: Company business details
     And the Company summary key value details are not displayed
     And the About One List Corp key value details are displayed
       | key                       | value                        |
-      | Trading names             | company.tradingName          |
-      | Annual turnover           | Not available                |
-      | Number of employees       | Not available                |
-      | Website                   | Not available                |
+      | Trading names             | Not set                      |
+      | Annual turnover           | company.turnoverRange        |
+      | Number of employees       | company.employeeRange        |
+      | Website                   | Not set                      |
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
       | One List tier             | company.oneListTier          |
@@ -47,10 +47,11 @@ Feature: Company business details
     And the "Where does information on this page come from?" details summary should not be displayed
     And the About Venus Ltd key value details are displayed
       | key                       | value                        |
-      | Trading names             | company.tradingName          |
-      | Annual turnover           | Not available                |
-      | Number of employees       | Not available                |
-      | Website                   | Not available                |
+      | Business type             | company.businessType         |
+      | Trading names             | Not set                      |
+      | Annual turnover           | Not set                      |
+      | Number of employees       | Not set                      |
+      | Website                   | Not set                      |
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
       | One List tier             | company.oneListTier          |
@@ -89,8 +90,7 @@ Feature: Company business details
       | Trading names             | company.tradingName          |
       | Annual turnover           | company.annualTurnover       |
       | Number of employees       | company.numberOfEmployees    |
-      | Website                   | Not available                |
-    And the Global Account Manager – One List key value details are not displayed
+      | Website                   | Not set                      |
     And the Business hierarchy key value details are displayed
       | key                       | value                        |
       | Subsidiaries              | company.subsidiaries         |

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -47,12 +47,12 @@ module.exports = {
     ukLtd: {
       id: '0f5216e0-849f-11e6-ae22-56b6b6499611',
       name: 'Venus Ltd',
-      tradingName: 'None',
       address1: '66 Marcham Road',
       town: 'Bordley',
       postcode: 'BD23 8RZ',
       country: 'United Kingdom',
       primaryAddress: '66 Marcham Road, Bordley, BD23 8RZ, United Kingdom',
+      businessType: 'Company',
       ukRegion: 'North West',
       headquarterType: 'Global HQ - Archived Ltd',
       subsidiaries: 'None',
@@ -65,7 +65,6 @@ module.exports = {
     oneListCorp: {
       id: '375094ac-f79a-43e5-9c88-059a7caa17f0',
       name: 'One List Corp',
-      tradingName: 'None',
       address1: '12 St George\'s Road',
       town: 'Paris',
       postcode: '75001',

--- a/test/unit/apps/companies/transformers/company-to-about-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-about-view.test.js
@@ -1,6 +1,6 @@
 const transformCompanyToAboutView = require('~/src/apps/companies/transformers/company-to-about-view')
 const { aboutLabels } = require('~/src/apps/companies/labels')
-const { NONE_TEXT, NOT_AVAILABLE_TEXT } = require('~/src/apps/companies/constants')
+const { NOT_SET_TEXT } = require('~/src/apps/companies/constants')
 
 describe('#transformCompanyToKnownAsView', () => {
   const commonTests = (expectedTradingNames, expectedWebsite, expectedEmployees, expectedTurnover) => {
@@ -21,90 +21,203 @@ describe('#transformCompanyToKnownAsView', () => {
     })
   }
 
-  context('when all information is populated', () => {
-    beforeEach(() => {
-      this.actual = transformCompanyToAboutView({
-        trading_names: [
+  context('when business data is from Dun & Bradstreet', () => {
+    context('when all information is populated', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToAboutView({
+          duns_number: '1',
+          business_type: {
+            name: 'Company',
+          },
+          trading_names: [
+            'trading name 1',
+            'trading name 2',
+          ],
+          companies_house_data: {
+            company_number: '123456',
+          },
+          website: 'www.company.com',
+          turnover: 100000,
+          number_of_employees: 200,
+        })
+      })
+
+      commonTests(
+        [
           'trading name 1',
           'trading name 2',
         ],
-        companies_house_data: {
-          company_number: '123456',
+        {
+          url: 'www.company.com',
+          name: 'www.company.com',
+          hint: '(Opens in a new window)',
+          hintId: 'external-link-label',
+          newWindow: true,
         },
-        website: 'www.company.com',
-        turnover: 100000,
-        number_of_employees: 200,
+        [
+          {
+            name: 200,
+            type: 'number',
+          },
+          {
+            details: {
+              summaryText: 'What does that mean?',
+              text: 'This is an estimated number',
+            },
+            name: 'This is an estimated number',
+            type: 'details',
+          },
+        ],
+        [
+          'USD 100000',
+          {
+            details: {
+              summaryText: 'What does that mean?',
+              text: 'This is an estimated number',
+            },
+            name: 'This is an estimated number',
+            type: 'details',
+          },
+        ],
+      )
+
+      it('should not set the business type', () => {
+        expect(this.actual['Business type']).to.not.exist
+      })
+
+      it('should set the Companies House number', () => {
+        expect(this.actual['Companies House number'][0]).to.equal('123456')
+      })
+
+      it('should set the Companies House link', () => {
+        expect(this.actual['Companies House number'][1]).to.deep.equal({
+          url: 'https://beta.companieshouse.gov.uk/company/123456',
+          name: 'View on Companies House website',
+          hint: '(Opens in a new window)',
+          hintId: 'external-link-label',
+          newWindow: true,
+        })
       })
     })
 
-    commonTests(
-      [
-        'trading name 1',
-        'trading name 2',
-      ],
-      {
-        url: 'www.company.com',
-        name: 'www.company.com',
-        hint: '(Opens in a new window)',
-        hintId: 'external-link-label',
-        newWindow: true,
-      },
-      [
-        {
-          name: 200,
-          type: 'number',
-        },
-        {
-          details: {
-            summaryText: 'What does that mean?',
-            text: 'This is an estimated number',
+    context('when minimal information is populated', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToAboutView({
+          duns_number: '1',
+          business_type: {
+            name: 'Company',
           },
-          name: 'This is an estimated number',
-          type: 'details',
-        },
-      ],
-      [
-        'USD 100000',
-        {
-          details: {
-            summaryText: 'What does that mean?',
-            text: 'This is an estimated number',
-          },
-          name: 'This is an estimated number',
-          type: 'details',
-        },
-      ],
-    )
+        })
+      })
 
-    it('should set the Companies House number', () => {
-      expect(this.actual['Companies House number'][0]).to.equal('123456')
-    })
+      commonTests(
+        NOT_SET_TEXT,
+        NOT_SET_TEXT,
+        NOT_SET_TEXT,
+        NOT_SET_TEXT,
+      )
 
-    it('should set the Companies House link', () => {
-      expect(this.actual['Companies House number'][1]).to.deep.equal({
-        url: 'https://beta.companieshouse.gov.uk/company/123456',
-        name: 'View on Companies House website',
-        hint: '(Opens in a new window)',
-        hintId: 'external-link-label',
-        newWindow: true,
+      it('should not set the business type', () => {
+        expect(this.actual['Business type']).to.not.exist
+      })
+
+      it('should not set the Companies House number', () => {
+        expect(this.actual['Companies House number']).to.not.exist
       })
     })
   })
 
-  context('when no information is populated', () => {
-    beforeEach(() => {
-      this.actual = transformCompanyToAboutView({})
+  context('when business data is from Data Hub', () => {
+    context('when all information is populated', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToAboutView({
+          business_type: {
+            name: 'Company',
+          },
+          trading_names: [
+            'trading name 1',
+            'trading name 2',
+          ],
+          companies_house_data: {
+            company_number: '123456',
+          },
+          vat_number: '0123456789',
+          turnover_range: {
+            name: '£33.5M+',
+          },
+          employee_range: {
+            name: '500+',
+          },
+          website: 'www.company.com',
+        })
+      })
+
+      commonTests(
+        [
+          'trading name 1',
+          'trading name 2',
+        ],
+        {
+          url: 'www.company.com',
+          name: 'www.company.com',
+          hint: '(Opens in a new window)',
+          hintId: 'external-link-label',
+          newWindow: true,
+        },
+        '500+',
+        '£33.5M+',
+      )
+
+      it('should set the Companies House number', () => {
+        expect(this.actual['Companies House number'][0]).to.equal('123456')
+      })
+
+      it('should set the Companies House link', () => {
+        expect(this.actual['Companies House number'][1]).to.deep.equal({
+          url: 'https://beta.companieshouse.gov.uk/company/123456',
+          name: 'View on Companies House website',
+          hint: '(Opens in a new window)',
+          hintId: 'external-link-label',
+          newWindow: true,
+        })
+      })
+
+      it('should set the business type', () => {
+        expect(this.actual['Business type']).to.equal('Company')
+      })
+
+      it('should set the VAT number', () => {
+        expect(this.actual['VAT number']).to.equal('0123456789')
+      })
     })
 
-    commonTests(
-      NONE_TEXT,
-      NOT_AVAILABLE_TEXT,
-      NOT_AVAILABLE_TEXT,
-      NOT_AVAILABLE_TEXT,
-    )
+    context('when minimal information is populated', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToAboutView({
+          business_type: {
+            name: 'Company',
+          },
+        })
+      })
 
-    it('should not set the Companies House number', () => {
-      expect(this.actual['Companies House number']).be.undefined
+      commonTests(
+        NOT_SET_TEXT,
+        NOT_SET_TEXT,
+        NOT_SET_TEXT,
+        NOT_SET_TEXT,
+      )
+
+      it('should not set the Companies House number', () => {
+        expect(this.actual['Companies House number']).to.not.exist
+      })
+
+      it('should set the business type', () => {
+        expect(this.actual['Business type']).to.equal('Company')
+      })
+
+      it('should not set the VAT number', () => {
+        expect(this.actual['VAT number']).to.not.exist
+      })
     })
   })
 })


### PR DESCRIPTION
<!--- Add Jira ticket number this work relates to at the beginning of the Title -->

## Change
This change is for businesses populated with data from Data Hub and not Dun & Bradstreet. It includes:
- add business type
- add VAT number
- use turnover range
- use employee range
- refactor

## Demo
https://datahub-beta2-pr-1749.herokuapp.com/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd/business-details

![screenshot 2019-02-15 at 15 56 04](https://user-images.githubusercontent.com/1150417/52868178-82924900-313a-11e9-97a6-29a8c79c6c3d.png)
