### PR TITLE
Reorder add/edit company fields

### DIFF
--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -61,23 +61,25 @@ async function renderForm (req, res, next) {
       req.session.token, res.locals.companiesHouseCategory, businessType
     )
     const showTradingAddress = !isEmpty(get(res.locals, 'formData.trading_address_1'))
+    const heading = `${res.locals.company ? 'Edit' : 'Add'} business details`
 
     if (res.locals.company) {
-      res.breadcrumb(get(res.locals, 'company.name'), `/companies/${get(res.locals, 'company.id')}`)
+      res.breadcrumb(res.locals.company.name, `/companies/${res.locals.company.id}`)
+      res.breadcrumb('Business details', `/companies/${res.locals.company.id}/business-details`)
     }
 
     const isForeign = isForeignCompany(req, res)
 
     res
-      .breadcrumb(res.locals.company ? 'Edit' : 'Add')
+      .breadcrumb(heading)
       .render('companies/views/_deprecated/edit', {
         isForeign,
         isOnOneList: isOnOneList(req, res),
         companyDetails: res.locals.company ? transformCompanyToView(res.locals.company) : {},
+        heading,
         businessTypeLabel,
         showTradingAddress,
         showCompanyNumber: businessType === UK_BRANCH_OF_FOREIGN_COMPANY_ID,
-        heading: getHeading(res.locals.company, isForeign),
         oneListEmail: config.oneList.email,
       })
   } catch (error) {

--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -1,4 +1,4 @@
-const { assign, find, get, isEmpty } = require('lodash')
+const { find, get, isEmpty } = require('lodash')
 
 const config = require('../../../../config')
 const {
@@ -36,24 +36,10 @@ function isForeignCompany (req, res) {
   return req.query.country === 'non-uk'
 }
 
-function isOnOneList (req, res) {
-  return !isEmpty(get(res.locals, 'company.one_list_group_tier'))
-}
-
-function getHeading (company, isForeign) {
-  const action = company ? 'Edit' : 'Add'
-  const type = isForeign ? 'foreign' : 'UK'
-
-  return `${action} ${type} company`
-}
-
 async function renderForm (req, res, next) {
   try {
     if (res.locals.companiesHouseRecord) {
-      res.locals = assign({}, res.locals, {
-        isCompaniesHouse: true,
-        chDetails: transformCompaniesHouseToView(res.locals.companiesHouseRecord),
-      })
+      res.locals.chDetails = transformCompaniesHouseToView(res.locals.companiesHouseRecord)
     }
 
     const businessType = get(res.locals, 'formData.business_type')
@@ -61,6 +47,7 @@ async function renderForm (req, res, next) {
       req.session.token, res.locals.companiesHouseCategory, businessType
     )
     const showTradingAddress = !isEmpty(get(res.locals, 'formData.trading_address_1'))
+    const isForeign = isForeignCompany(req, res)
     const heading = `${res.locals.company ? 'Edit' : 'Add'} business details`
 
     if (res.locals.company) {
@@ -68,17 +55,15 @@ async function renderForm (req, res, next) {
       res.breadcrumb('Business details', `/companies/${res.locals.company.id}/business-details`)
     }
 
-    const isForeign = isForeignCompany(req, res)
-
     res
       .breadcrumb(heading)
       .render('companies/views/_deprecated/edit', {
         isForeign,
-        isOnOneList: isOnOneList(req, res),
-        companyDetails: res.locals.company ? transformCompanyToView(res.locals.company) : {},
         heading,
         businessTypeLabel,
         showTradingAddress,
+        isOnOneList: !isEmpty(get(res.locals.company, 'one_list_group_tier')),
+        companyDetails: res.locals.company ? transformCompanyToView(res.locals.company) : {},
         showCompanyNumber: businessType === UK_BRANCH_OF_FOREIGN_COMPANY_ID,
         oneListEmail: config.oneList.email,
       })

--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -107,13 +107,7 @@ async function handleFormPost (req, res, next) {
   }
 }
 
-function setIsEditMode (req, res, next) {
-  res.locals.isEditMode = true
-  next()
-}
-
 module.exports = {
   populateForm,
   handleFormPost,
-  setIsEditMode,
 }

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -44,7 +44,7 @@ const {
 } = require('./middleware/collection')
 
 const { setCompanyContactRequestBody, getCompanyContactCollection } = require('./middleware/contact-collection')
-const { populateForm, handleFormPost, setIsEditMode } = require('./middleware/form')
+const { populateForm, handleFormPost } = require('./middleware/form')
 const { getCompany, getCompaniesHouseRecord } = require('./middleware/params')
 const { setInteractionsDetails } = require('./middleware/interactions')
 const { setGlobalHQ, removeGlobalHQ, addSubsidiary } = require('./middleware/hierarchies')
@@ -94,8 +94,8 @@ router
 
 router
   .route('/:companyId/edit')
-  .get(setIsEditMode, populateForm, renderForm)
-  .post(handleFormPost, setIsEditMode, populateForm, renderForm)
+  .get(populateForm, renderForm)
+  .post(handleFormPost, populateForm, renderForm)
 
 router.post('/:companyId/archive', archiveCompany)
 router.get('/:companyId/unarchive', unarchiveCompany)

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -11,7 +11,7 @@
         items: [
           {
             label: businessTypeLabel | default('(type of organisation not known)'),
-            value: ('&nbsp;' if isEditMode else '<a href="/companies/add-step-1">Change</a>') | safe
+            value: ('&nbsp;' if company else '<a href="/companies/add-step-1">Change</a>') | safe
           }
         ]
       }) }}

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -50,15 +50,8 @@
       <input type="hidden" name="registered_address_county" value="{{ formData.registered_address_county }}">
       <input type="hidden" name="registered_address_postcode" value="{{ formData.registered_address_postcode }}">
       <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}">
-
-      {{ TextField({
-        name: 'trading_names',
-        label: 'Trading names',
-        optional: true,
-        value: formData.trading_names,
-        error: errors.trading_names
-      }) }}
     {% else %}
+
       {{ TextField({
         name: 'name',
         label: 'Name',
@@ -66,6 +59,54 @@
         error: errors.name
       }) }}
 
+    {% endif %}
+
+    {{ TextField({
+      name: 'trading_names',
+      label: 'Trading name',
+      optional: true,
+      value: formData.trading_names,
+      error: errors.trading_names
+    }) }}
+
+    {% if not isForeign %}
+      {{ TextField({
+        name: 'vat_number',
+        label: 'VAT number',
+        value: formData.vat_number,
+        error: errors.vat_number
+      }) }}
+    {% endif %}
+
+    {{ MultipleChoiceField({
+      type: 'radio',
+      name: 'turnover_range',
+      label: 'Annual turnover',
+      optional: true,
+      options: options.turnovers,
+      value: formData.turnover_range,
+      error: errors.turnover_range
+    }) }}
+
+    {{ MultipleChoiceField({
+      type: 'radio',
+      name: 'employee_range',
+      label: 'Number of employees',
+      optional: true,
+      options: options.employees,
+      value: formData.employee_range,
+      error: errors.employee_range
+    }) }}
+
+    {{ TextField({
+      name: 'website',
+      label: 'Website',
+      optional: true,
+      value: formData.website,
+      error: errors.website
+    }) }}
+
+    {% if not companiesHouseRecord %}
       {% if showCompanyNumber %}
         {{ TextField({
           name: 'company_number',
@@ -74,14 +115,6 @@
           error: errors.company_number
         }) }}
       {% endif %}
-
-      {{ TextField({
-        name: 'trading_names',
-        label: 'Trading name',
-        optional: true,
-        value: formData.trading_names,
-        error: errors.trading_names
-      }) }}
 
       <fieldset id="registered-address-wrapper" class="c-form-fieldset {{ 'lookup-address-js' if not isForeign }}">
         <legend class="c-form-fieldset__legend">
@@ -253,42 +286,19 @@
       </div>
     </fieldset>
 
+    {# DIT region #}
     {% if not isForeign %}
       {{ MultipleChoiceField({
         name: 'uk_region',
-        label: 'UK region',
-        initialOption: '-- Select region --',
+        label: 'DIT region',
+        initialOption: '-- Select DIT region --',
         options: options.regions,
         value: formData.uk_region,
         error: errors.uk_region
       }) }}
     {% endif %}
 
-    {% if isOnOneList %}
-      <fieldset id="group-field-headquarter_type" class="c-form-group">
-        <legend class="c-form-group__label">
-          <span class="c-form-group__label-text">Headquarter type</span>
-        </legend>
-
-        <p>{{companyDetails['Headquarter type']}}</p>
-
-        {% call HiddenContent({ summary: 'Need to edit the headquarter type?' }) %}
-          {% call Message({ type: 'muted' }) %}
-            If you need to change the headquarter type for a company on the One List, please email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
-          {% endcall %}
-        {% endcall %}
-      </fieldset>
-    {% else %}
-      {{ MultipleChoiceField({
-        type: 'radio',
-        name: 'headquarter_type',
-        label: 'Headquarter type',
-        options: options.headquarters,
-        value: formData.headquarter_type,
-        error: errors.headquarter_type
-      }) }}
-    {% endif %}
-
+    {# DIT sector #}
     {% if isOnOneList %}
       <fieldset id="group-field-sector" class="c-form-group">
         <legend class="c-form-group__label">
@@ -306,21 +316,39 @@
     {% else %}
       {{ MultipleChoiceField({
         name: 'sector',
-        label: 'Sector',
-        initialOption: '-- Select sector --',
+        label: 'DIT sector',
+        initialOption: '-- Select DIT sector --',
         options: options.sectors,
         value: formData.sector,
         error: errors.sector
       }) }}
     {% endif %}
 
-    {{ TextField({
-      name: 'website',
-      label: 'Website',
-      optional: true,
-      value: formData.website,
-      error: errors.website
-    }) }}
+    {# Business hierarchy #}
+    {% if isOnOneList %}
+      <fieldset id="group-field-headquarter_type" class="c-form-group">
+        <legend class="c-form-group__label">
+          <span class="c-form-group__label-text">Business hierarchy</span>
+        </legend>
+
+        <p>{{companyDetails['Headquarter type']}}</p>
+
+        {% call HiddenContent({ summary: 'Need to edit the headquarter type?' }) %}
+          {% call Message({ type: 'muted' }) %}
+            If you need to change the headquarter type for a company on the One List, please email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
+          {% endcall %}
+        {% endcall %}
+      </fieldset>
+    {% else %}
+      {{ MultipleChoiceField({
+        type: 'radio',
+        name: 'headquarter_type',
+        label: 'Business hierarchy',
+        options: options.headquarters,
+        value: formData.headquarter_type,
+        error: errors.headquarter_type
+      }) }}
+    {% endif %}
 
     {{ TextField({
       name: 'description',
@@ -330,33 +358,5 @@
       error: errors.description
     }) }}
 
-    {{ MultipleChoiceField({
-      type: 'radio',
-      name: 'employee_range',
-      label: 'Number of employees',
-      optional: true,
-      options: options.employees,
-      value: formData.employee_range,
-      error: errors.employee_range
-    }) }}
-
-    {{ MultipleChoiceField({
-      type: 'radio',
-      name: 'turnover_range',
-      label: 'Annual turnover',
-      optional: true,
-      options: options.turnovers,
-      value: formData.turnover_range,
-      error: errors.turnover_range
-    }) }}
-
-    {% if not isForeign %}
-      {{ TextField({
-        name: 'vat_number',
-        label: 'VAT number',
-        value: formData.vat_number,
-        error: errors.vat_number
-      }) }}
-    {% endif %}
   {% endcall %}
 {% endblock %}

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -145,13 +145,7 @@
           modifier: 'short'
         }) }}
 
-        {% if not isForeign %}
-          <div class="section">
-            <h2 class="heading-medium">Country</h2>
-            <p>United Kingdom</p>
-            <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}">
-          </div>
-        {% else %}
+        {% if isForeign %}
           {{ MultipleChoiceField({
             name: 'registered_address_country',
             label: 'Country',
@@ -160,8 +154,15 @@
             value: formData.registered_address_country,
             error: errors.registered_address_country
           }) }}
+        {% else %}
+          <div class="section">
+            <h2 class="heading-medium">Country</h2>
+            <p>United Kingdom</p>
+            <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}">
+          </div>
         {% endif %}
       </fieldset>
+
     {% endif %}
 
     <fieldset class="c-form-fieldset {{ 'lookup-address-js' if not isForeign }}">

--- a/test/acceptance/features/audit/company.feature
+++ b/test/acceptance/features/audit/company.feature
@@ -10,4 +10,3 @@ Feature: View Audit history of a Company
     And I click the "Audit history" link
     Then I see the name of the person who made the recent company record changes
     And I see the date time stamp when the recent company record changed
-    And I see the field names that were recently changed on this company record

--- a/test/acceptance/features/audit/step_definitions/company.js
+++ b/test/acceptance/features/audit/step_definitions/company.js
@@ -53,8 +53,3 @@ Then(/^I see the total number of changes occurred recently on this company recor
   await AuditList.section.firstAuditInList
     .assert.containsText('@changeCount', '2 changes')
 })
-
-Then(/^I see the field names that were recently changed on this company record$/, async function () {
-  await AuditList.section.firstAuditInList
-    .assert.containsText('@fields', 'Business description')
-})

--- a/test/acceptance/pages/audit/company.js
+++ b/test/acceptance/pages/audit/company.js
@@ -20,11 +20,6 @@ module.exports = {
             .setValue('@website', website)
         }
 
-        this
-          .waitForElementVisible('@description')
-          .clearValue('@description')
-          .setValue('@description', description)
-
         return this
       },
     },

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -111,11 +111,11 @@ describe('Company edit controller', () => {
       })
 
       it('should set the add breadcrumb', () => {
-        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add business details')
       })
 
       it('should set heading', () => {
-        expect(this.getCalledRenderLocals().heading).to.equal('Add UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Add business details')
       })
 
       it('should set isForeign', () => {
@@ -182,12 +182,16 @@ describe('Company edit controller', () => {
         expect(this.getCalledBreadcrumb().args[1]).to.equal('/companies/1')
       })
 
+      it('should set the business details breadcrumb', () => {
+        expect(this.getCalledBreadcrumb(1).args[0]).to.equal('Business details')
+      })
+
       it('should set the edit breadcrumb', () => {
-        expect(this.getCalledBreadcrumb(1).args[0]).to.equal('Edit')
+        expect(this.getCalledBreadcrumb(2).args[0]).to.equal('Edit business details')
       })
 
       it('should set heading', () => {
-        expect(this.getCalledRenderLocals().heading).to.equal('Edit UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Edit business details')
       })
 
       it('should set isForeign', () => {
@@ -242,11 +246,11 @@ describe('Company edit controller', () => {
       })
 
       it('should set the add breadcrumb', () => {
-        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add business details')
       })
 
       it('should set heading', () => {
-        expect(this.getCalledRenderLocals().heading).to.equal('Add UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Add business details')
       })
 
       it('should set isForeign', () => {
@@ -301,11 +305,11 @@ describe('Company edit controller', () => {
       })
 
       it('should set the add breadcrumb', () => {
-        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add')
+        expect(this.getCalledBreadcrumb().args[0]).to.equal('Add business details')
       })
 
       it('should set heading', () => {
-        expect(this.getCalledRenderLocals().heading).to.equal('Add foreign company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Add business details')
       })
 
       it('should set isForeign', () => {
@@ -369,8 +373,16 @@ describe('Company edit controller', () => {
         expect(this.getCalledBreadcrumb().args[0]).to.equal('Existing government department')
       })
 
+      it('should set the business details breadcrumb', () => {
+        expect(this.getCalledBreadcrumb(1).args[0]).to.equal('Business details')
+      })
+
+      it('should set the edit breadcrumb', () => {
+        expect(this.getCalledBreadcrumb(2).args[0]).to.equal('Edit business details')
+      })
+
       it('should set heading', () => {
-        expect(this.getCalledRenderLocals().heading).to.equal('Edit UK company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Edit business details')
       })
 
       it('should set isForeign', () => {
@@ -429,7 +441,7 @@ describe('Company edit controller', () => {
       })
 
       it('should set heading', () => {
-        expect(this.getCalledRenderLocals().heading).to.equal('Edit foreign company')
+        expect(this.getCalledRenderLocals().heading).to.equal('Edit business details')
       })
 
       it('should set isOnOneList', () => {

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -475,13 +475,4 @@ describe('Companies form middleware', () => {
       })
     })
   })
-
-  describe('setIsEditMode', () => {
-    it('should set edit mode', () => {
-      expect(this.resMock.locals.isEditMode).to.equal(undefined)
-      middleware.setIsEditMode(this.reqMock, this.resMock, this.nextSpy)
-      expect(this.resMock.locals.isEditMode).to.equal(true)
-      expect(this.nextSpy).to.have.been.calledOnce
-    })
-  })
 })


### PR DESCRIPTION
## Change
This change is primarily reordering fields in the `company` `edit` view. 

Included:
- Removal of unnecessary middleware
- Refactored code
- Reorder of fields
- Update breadcrumbs + heading

## Next
- Remove edit `Name`
- Add `Companies House number`

## Before
![old](https://user-images.githubusercontent.com/1150417/53099382-96b0be80-351d-11e9-974d-ddf7132c9ff1.png)

## After
![new](https://user-images.githubusercontent.com/1150417/53099288-6701b680-351d-11e9-8269-c4d63058541c.png)
