### PR TITLE
Update query fields for policy feedback CSV export

### DIFF
--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -19,6 +19,9 @@ const QUERY_FIELDS = [
   'sortby',
   'dit_team',
   'service',
+  'was_policy_feedback_provided',
+  'policy_areas',
+  'policy_issue_types',
 ]
 
 const QUERY_DATE_FIELDS = [


### PR DESCRIPTION
## Problem
[Trello ticket](https://trello.com/c/bL78dppv/542-bug-download-on-policy-feedback-interactions-always-returns-5000-results-even-if-filtered-results-are-less)

When you filter interactions by policy feedback you should be able to download the results in a CSV file. Currently this does not work and you download 5000 random results.

## Solution
Update the query fields on the export route so you get the filtered policy feedback results in the CSV file download.
