### PR TITLE
Add archive information to business details for Data Hub companies

### DIFF
--- a/src/apps/companies/controllers/archive.js
+++ b/src/apps/companies/controllers/archive.js
@@ -28,7 +28,7 @@ async function archiveCompany (req, res) {
 
 async function unarchiveCompany (req, res) {
   const { id } = res.locals.company
-  const returnUrl = `/companies/${id}`
+  const returnUrl = req.query.redirect || `/companies/${id}`
 
   try {
     await unarchive(req.session.token, id)

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -24,6 +24,15 @@
 {% block body_main_content %}
   <p>This page shows information about this business and how it is related to other businesses</p>
 
+  {% if company.archived %}
+    {% call Message({ type: 'info' }) %}
+      This company was archived on {{company.archived_on | formatDate}} by {{company.archived_by.first_name}} {{company.archived_by.last_name}}. <br>
+      <strong>Reason:</strong> {{company.archived_reason}}<br>
+      <br>
+      <a href="/companies/{{company.id}}/unarchive?redirect=business-details">Unarchive</a>
+    {% endcall %}
+  {% endif %}
+
   {% if company.duns_number %}
     {{ govukDetails({
       summaryText: 'Where does information on this page come from?',

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -7,7 +7,7 @@ Feature: Company business details
     When I navigate to the `companies.business-details` page using `company` `One List Corp` fixture
     Then the heading should be "Business details"
     And the "Where does information on this page come from?" details summary should be displayed
-    And the Company summary key value details are not displayed
+    And I should not see the "Unarchive" link
     And the About One List Corp key value details are displayed
       | key                       | value                        |
       | Trading names             | Not set                      |
@@ -45,6 +45,7 @@ Feature: Company business details
     When I navigate to the `companies.business-details` page using `company` `Venus Ltd` fixture
     Then the heading should be "Business details"
     And the "Where does information on this page come from?" details summary should not be displayed
+    And I should not see the "Unarchive" link
     And the About Venus Ltd key value details are displayed
       | key                       | value                        |
       | Business type             | company.businessType         |
@@ -84,7 +85,7 @@ Feature: Company business details
     When I navigate to the `companies.business-details` page using `company` `DnB Corp` fixture
     Then the heading should be "Business details"
     And the "Where does information on this page come from?" details summary should be displayed
-    And the Company summary key value details are not displayed
+    And I should not see the "Unarchive" link
     And the About DnB Corp key value details are displayed
       | key                       | value                        |
       | Trading names             | company.tradingName          |
@@ -110,3 +111,41 @@ Feature: Company business details
       | Italy                     |
     And the Documents from CDMS key value details are not displayed
 
+
+  @companies-business-details--archived
+  Scenario: View details for an archived Data Hub company
+
+    When I navigate to the `companies.business-details` page using `company` `Archived Ltd` fixture
+    Then the heading should be "Business details"
+    And the "Where does information on this page come from?" details summary should not be displayed
+    And I should see the "Unarchive" link
+    And the About Archived Ltd key value details are displayed
+      | key                       | value                        |
+      | Business type             | company.businessType         |
+      | Trading names             | Not set                      |
+      | Annual turnover           | company.turnoverRange        |
+      | Number of employees       | company.employeeRange        |
+      | Website                   | Not set                      |
+    And the Global Account Manager – One List key value details are displayed
+      | key                       | value                        |
+      | One List tier             | company.oneListTier          |
+      | Global Account Manager    | company.globalAccountManager |
+    And the Business hierarchy key value details are displayed
+      | key                       | value                        |
+      | Headquarter type          | company.headquarterType      |
+      | Subsidiaries              | company.subsidiaries         |
+    And the DIT sector values are displayed
+      | value                     |
+      | Retail                    |
+    And the DIT region values are not displayed
+    And address 1 should have badges
+      | value                     |
+      | Trading                   |
+      | Registered                |
+    And address 1 should be
+      | value                     |
+      | 16 Getabergsvagen         |
+      | Geta                      |
+      | 22340                     |
+      | Malta                     |
+    And the Documents from CDMS key value details are not displayed

--- a/test/acceptance/fixtures.js
+++ b/test/acceptance/fixtures.js
@@ -124,10 +124,13 @@ module.exports = {
       primaryAddress: '16 Getabergsvagen, Geta, 22340, Aland Islands',
       businessType: 'Company',
       headquarterType: 'Global HQ',
+      subsidiaries: '1 subsidiary',
       sector: 'Retail',
       description: 'This is a dummy company for testing archived features',
       employeeRange: '500+',
       turnoverRange: '£33.5M+',
+      oneListTier: 'Tier A - Strategic Account',
+      globalAccountManager: 'Travis Greene\nIST - Sector Advisory Services\nLondon',
     },
     archivedContactless: {
       id: '346f78a5-1d23-4213-b4c2-bf48246a13c4',

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -149,20 +149,43 @@ describe('Company controller, archive', () => {
 
   describe('#unarchiveCompany', () => {
     context('when save returns successfully', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
+      context('when there is not a redirect', () => {
+        beforeEach(async () => {
+          this.middlewareParameters = buildMiddlewareParameters({
+            company: companyMock,
+          })
+
+          this.stub.unarchiveCompany.resolves(companyMock)
+
+          await this.controller.unarchiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
         })
 
-        this.stub.unarchiveCompany.resolves(companyMock)
-
-        await this.controller.unarchiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
+        commonTests({
+          stubName: 'unarchiveCompany',
+          expectedFlash: 'success',
+          expectedPath: `/companies/${companyMock.id}`,
+        })
       })
 
-      commonTests({
-        stubName: 'unarchiveCompany',
-        expectedFlash: 'success',
-        expectedPath: `/companies/${companyMock.id}`,
+      context('when there is a redirect', () => {
+        beforeEach(async () => {
+          this.middlewareParameters = buildMiddlewareParameters({
+            requestQuery: {
+              redirect: '/redirect/here',
+            },
+            company: companyMock,
+          })
+
+          this.stub.unarchiveCompany.resolves(companyMock)
+
+          await this.controller.unarchiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
+        })
+
+        commonTests({
+          stubName: 'unarchiveCompany',
+          expectedFlash: 'success',
+          expectedPath: '/redirect/here',
+        })
       })
     })
 

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -1,194 +1,191 @@
-const tokenMock = '12345abcde'
-const companyMock = {
-  id: '9999',
-  company_number: '10620176',
-  companies_house_data: null,
-  name: 'ADALEOP LTD',
-  registered_address_1: '13 HOWICK PARK AVENUE',
-  registered_address_2: 'PENWORTHAM',
-  registered_address_town: 'PRESTON',
-  registered_address_county: '',
-  registered_address_postcode: 'PR1 0LS',
-}
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+
+const companyMock = require('~/test/unit/data/companies/company.json')
 
 describe('Company controller, archive', () => {
   beforeEach(() => {
-    this.archiveCompanyStub = sinon.stub()
-    this.unarchiveCompanyStub = sinon.stub()
+    this.stub = {
+      archiveCompany: sinon.stub(),
+      unarchiveCompany: sinon.stub(),
+    }
+
     this.errorLoggerSpy = sinon.spy()
-    this.redirectSpy = sinon.spy()
-    this.flashSpy = sinon.spy()
 
     this.controller = proxyquire('~/src/apps/companies/controllers/archive', {
       '../repos': {
-        archiveCompany: this.archiveCompanyStub,
-        unarchiveCompany: this.unarchiveCompanyStub,
+        archiveCompany: this.stub.archiveCompany,
+        unarchiveCompany: this.stub.unarchiveCompany,
       },
       '../../../../config/logger': {
         error: this.errorLoggerSpy,
       },
     })
-
-    this.reqMock = {
-      flash: this.flashSpy,
-      session: {
-        token: tokenMock,
-      },
-      body: {},
-    }
-    this.resMock = {
-      redirect: this.redirectSpy,
-      locals: {
-        company: companyMock,
-      },
-    }
   })
 
-  describe('archiveCompany()', () => {
+  const commonTests = ({ stubName, expectedReason, expectedFlash, expectedPath }) => {
+    if (stubName) {
+      it('should call archive company with correct args', () => {
+        const expectedToken = this.middlewareParameters.reqMock.session.token
+
+        if (expectedReason) {
+          expect(this.stub[stubName]).to.have.been.calledWith(expectedToken, companyMock.id, expectedReason)
+        } else {
+          expect(this.stub[stubName]).to.have.been.calledWith(expectedToken, companyMock.id)
+        }
+
+        expect(this.stub[stubName]).to.have.been.calledOnce
+      })
+    }
+
+    it('should set a success on flash', () => {
+      expect(this.middlewareParameters.reqMock.flash.args[0][0]).to.equal(expectedFlash)
+      expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+    })
+
+    it('should redirect back to company', () => {
+      expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(expectedPath)
+      expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+    })
+  }
+
+  describe('#archiveCompany', () => {
     context('when no reason is supplied', () => {
       beforeEach(() => {
-        this.controller.archiveCompany(this.reqMock, this.resMock)
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {},
+          company: companyMock,
+        })
+
+        this.controller.archiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
       })
 
-      it('should set an error on flash', () => {
-        expect(this.flashSpy.args[0][0]).to.equal('error')
-        expect(this.flashSpy).to.have.been.calledOnce
-      })
-
-      it('should redirect back to company', () => {
-        expect(this.redirectSpy).to.have.been.calledWith(`/companies/${companyMock.id}`)
-        expect(this.redirectSpy).to.have.been.calledOnce
+      commonTests({
+        expectedFlash: 'error',
+        expectedPath: `/companies/${companyMock.id}`,
       })
 
       it('should not attempt to archive company', () => {
-        expect(this.archiveCompanyStub).not.to.have.been.called
+        expect(this.stub.archiveCompany).not.to.have.been.called
       })
     })
 
     context('when a reason is supplied', () => {
-      beforeEach(() => {
-        this.reasonMock = 'Archived reason'
-        this.reqMock.body.archived_reason = this.reasonMock
-      })
-
       context('when save returns successfully', () => {
-        beforeEach(() => {
-          this.archiveCompanyStub.resolves(companyMock)
-        })
-
         context('with a default reason', () => {
           beforeEach(async () => {
-            await this.controller.archiveCompany(this.reqMock, this.resMock)
+            this.middlewareParameters = buildMiddlewareParameters({
+              requestBody: {
+                archived_reason: 'Archived reason',
+              },
+              company: companyMock,
+            })
+
+            this.stub.archiveCompany.resolves(companyMock)
+
+            await this.controller.archiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
           })
 
-          it('should call archive company with correct args', () => {
-            expect(this.archiveCompanyStub).to.have.been.calledWith(tokenMock, companyMock.id, this.reasonMock)
-            expect(this.archiveCompanyStub).to.have.been.calledOnce
-          })
-
-          it('should set a success on flash', () => {
-            expect(this.flashSpy.args[0][0]).to.equal('success')
-            expect(this.flashSpy).to.have.been.calledOnce
-          })
-
-          it('should redirect back to company', () => {
-            expect(this.redirectSpy).to.have.been.calledWith(`/companies/${companyMock.id}`)
-            expect(this.redirectSpy).to.have.been.calledOnce
+          commonTests({
+            stubName: 'archiveCompany',
+            expectedReason: 'Archived reason',
+            expectedFlash: 'success',
+            expectedPath: `/companies/${companyMock.id}`,
           })
         })
 
         context('with a custom reason', () => {
           beforeEach(async () => {
-            this.reasonMock = 'Other'
-            this.customReasonMock = 'My custom reason'
-            this.reqMock.body.archived_reason = this.reasonMock
-            this.reqMock.body.archived_reason_other = this.customReasonMock
+            this.middlewareParameters = buildMiddlewareParameters({
+              requestBody: {
+                archived_reason: 'Other',
+                archived_reason_other: 'My custom reason',
+              },
+              company: companyMock,
+            })
 
-            await this.controller.archiveCompany(this.reqMock, this.resMock)
+            this.stub.archiveCompany.resolves(companyMock)
+
+            await this.controller.archiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
           })
 
-          it('should call archive company with custom reason', () => {
-            expect(this.archiveCompanyStub).to.have.been.calledWith(tokenMock, companyMock.id, this.customReasonMock)
-            expect(this.archiveCompanyStub).to.have.been.calledOnce
+          commonTests({
+            stubName: 'archiveCompany',
+            expectedReason: 'My custom reason',
+            expectedFlash: 'success',
+            expectedPath: `/companies/${companyMock.id}`,
           })
         })
       })
 
       context('when save rejects with an error', () => {
         beforeEach(async () => {
-          this.errorMock = {
-            errorCode: 500,
-          }
-          this.archiveCompanyStub.rejects(this.errorMock)
+          this.middlewareParameters = buildMiddlewareParameters({
+            requestBody: {
+              archived_reason: 'Other',
+              archived_reason_other: 'My custom reason',
+            },
+            company: companyMock,
+          })
 
-          await this.controller.archiveCompany(this.reqMock, this.resMock)
+          this.stub.archiveCompany.rejects({ errorCode: 500 })
+
+          await this.controller.archiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
+        })
+
+        commonTests({
+          stubName: 'archiveCompany',
+          expectedReason: 'My custom reason',
+          expectedFlash: 'error',
+          expectedPath: `/companies/${companyMock.id}`,
         })
 
         it('should send error to logger', () => {
-          expect(this.errorLoggerSpy).to.have.been.calledWith(this.errorMock)
+          expect(this.errorLoggerSpy).to.have.been.calledWith({ errorCode: 500 })
           expect(this.errorLoggerSpy).to.have.been.calledOnce
-        })
-
-        it('should set an error on flash', () => {
-          expect(this.flashSpy.args[0][0]).to.equal('error')
-          expect(this.flashSpy).to.have.been.calledOnce
-        })
-
-        it('should redirect back to company', () => {
-          expect(this.redirectSpy).to.have.been.calledWith(`/companies/${companyMock.id}`)
-          expect(this.redirectSpy).to.have.been.calledOnce
         })
       })
     })
   })
 
-  describe('unarchiveCompany()', () => {
+  describe('#unarchiveCompany', () => {
     context('when save returns successfully', () => {
       beforeEach(async () => {
-        this.unarchiveCompanyStub.resolves(companyMock)
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+        })
 
-        await this.controller.unarchiveCompany(this.reqMock, this.resMock)
+        this.stub.unarchiveCompany.resolves(companyMock)
+
+        await this.controller.unarchiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
       })
 
-      it('should call unarchive company with correct args', () => {
-        expect(this.unarchiveCompanyStub).to.have.been.calledWith(tokenMock, companyMock.id)
-        expect(this.unarchiveCompanyStub).to.have.been.calledOnce
-      })
-
-      it('should set a success on flash', () => {
-        expect(this.flashSpy.args[0][0]).to.equal('success')
-        expect(this.flashSpy).to.have.been.calledOnce
-      })
-
-      it('should redirect back to company', () => {
-        expect(this.redirectSpy).to.have.been.calledWith(`/companies/${companyMock.id}`)
-        expect(this.redirectSpy).to.have.been.calledOnce
+      commonTests({
+        stubName: 'unarchiveCompany',
+        expectedFlash: 'success',
+        expectedPath: `/companies/${companyMock.id}`,
       })
     })
 
     context('when save rejects with an error', () => {
       beforeEach(async () => {
-        this.errorMock = {
-          errorCode: 500,
-        }
-        this.unarchiveCompanyStub.rejects(this.errorMock)
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+        })
 
-        await this.controller.unarchiveCompany(this.reqMock, this.resMock)
+        this.stub.unarchiveCompany.rejects({ errorCode: 500 })
+
+        await this.controller.unarchiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
+      })
+
+      commonTests({
+        stubName: 'unarchiveCompany',
+        expectedFlash: 'error',
+        expectedPath: `/companies/${companyMock.id}`,
       })
 
       it('should send error to logger', () => {
-        expect(this.errorLoggerSpy).to.have.been.calledWith(this.errorMock)
+        expect(this.errorLoggerSpy).to.have.been.calledWith({ errorCode: 500 })
         expect(this.errorLoggerSpy).to.have.been.calledOnce
-      })
-
-      it('should set an error on flash', () => {
-        expect(this.flashSpy.args[0][0]).to.equal('error')
-        expect(this.flashSpy).to.have.been.calledOnce
-      })
-
-      it('should redirect back to company', () => {
-        expect(this.redirectSpy).to.have.been.calledWith(`/companies/${companyMock.id}`)
-        expect(this.redirectSpy).to.have.been.calledOnce
       })
     })
   })

--- a/test/unit/data/companies/dnb-company.json
+++ b/test/unit/data/companies/dnb-company.json
@@ -1,4 +1,4 @@
-{
+  {
   "id": "375094ac-f79a-43e5-9c88-059a7caa17f0",
   "reference_code": "",
   "name": "One List Corp",

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -16,6 +16,7 @@ module.exports = ({
       },
       body: requestBody,
       query: requestQuery,
+      flash: sinon.spy(),
     },
     resMock: {
       breadcrumb,


### PR DESCRIPTION
https://trello.com/c/6hVsrI5X/752-add-archive-information-on-business-details-dh-data

## Change
This change adds the archive information to the top of the `Business details` view for an archived company populated from Data Hub.

Included:
- refactor of unit tests
- add option to redirect after archive
- add section to business details

## Before
![screenshot 2019-02-21 at 15 55 20](https://user-images.githubusercontent.com/1150417/53182554-9aae1080-35f1-11e9-89e2-91353c725798.png)

## After
![screenshot 2019-02-21 at 15 54 46](https://user-images.githubusercontent.com/1150417/53182564-a1d51e80-35f1-11e9-9c05-1b9f3d559610.png)
