### PR TITLE
Hide Name field for editing a company

### DIFF
--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -4,6 +4,8 @@
   <button class="button button--secondary postcode-lookup-button" type="button">Find UK address</button>
 {% endset %}
 
+{% set isEditing = true if company.id else false %}
+
 {% block body_main_content %}
   <div class="section">
     <h2 class="heading-medium">Business type</h2>
@@ -26,9 +28,9 @@
   {% endif %}
 
   {% call Form({
-    buttonText: 'Save and return' if company.id else 'Add company',
-    returnLink: '/companies/' + company.id if company.id else '/companies/add-step-1',
-    returnText: 'Return without saving' if company.id else 'Back',
+    buttonText: 'Save and return' if isEditing else 'Add company',
+    returnLink: '/companies/' + company.id if isEditing else '/companies/add-step-1',
+    returnText: 'Return without saving' if isEditing else 'Back',
     actionExtension: {
         country : 'non-uk' if isForeign else 'uk'
     },

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -54,12 +54,14 @@
       <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}">
     {% else %}
 
-      {{ TextField({
-        name: 'name',
-        label: 'Name',
-        value: formData.name,
-        error: errors.name
-      }) }}
+      {% if not isEditing %}
+        {{ TextField({
+          name: 'name',
+          label: 'Name',
+          value: formData.name,
+          error: errors.name
+        }) }}
+      {% endif %}
 
     {% endif %}
 


### PR DESCRIPTION
https://trello.com/c/C0imZORr/750-add-edit-business-details-button-to-business-details-dh-data

## Change
The `Name` field should not be available when editing a company. It should still be available for creating new companies.

## Before
<img width="761" alt="screenshot 2019-02-25 at 13 42 46" src="https://user-images.githubusercontent.com/1150417/53341539-b6702a00-3903-11e9-996a-11a421dc586c.png">

## After
<img width="793" alt="screenshot 2019-02-25 at 13 43 02" src="https://user-images.githubusercontent.com/1150417/53341546-bcfea180-3903-11e9-919f-be0aec18cc28.png">
