### PR TITLE
Add Companies House number field to edit company

### DIFF
--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -64,7 +64,7 @@ async function renderForm (req, res, next) {
         showTradingAddress,
         isOnOneList: !isEmpty(get(res.locals.company, 'one_list_group_tier')),
         companyDetails: res.locals.company ? transformCompanyToView(res.locals.company) : {},
-        showCompanyNumber: businessType === UK_BRANCH_OF_FOREIGN_COMPANY_ID,
+        showCompanyNumberForUkBranch: businessType === UK_BRANCH_OF_FOREIGN_COMPANY_ID,
         oneListEmail: config.oneList.email,
       })
   } catch (error) {

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -111,7 +111,7 @@
     }) }}
 
     {% if not companiesHouseRecord %}
-      {% if showCompanyNumber %}
+      {% if showCompanyNumberForUkBranch %}
         {{ TextField({
           name: 'company_number',
           label: 'BR Companies House number',

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -73,6 +73,17 @@
       error: errors.trading_names
     }) }}
 
+    {% if formData.company_number and not showCompanyNumberForUkBranch %}
+      <div class="c-form-group">
+        <label class="c-form-group__label">
+          <span class="c-form-group__label-text">Companies House number</span>
+        </label>
+        <div class="c-form-group__inner">
+          {{ formData.company_number }}
+        </div>
+      </div>
+    {% endif %}
+
     {% if not isForeign %}
       {{ TextField({
         name: 'vat_number',

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -8,7 +8,7 @@
 
 {% block body_main_content %}
   <div class="section">
-    <h2 class="heading-medium">Business type</h2>
+    <h2 class="govuk-heading-s">Business type</h2>
     {{ MetaList({
         items: [
           {

--- a/test/unit/apps/companies/controllers/edit.test.js
+++ b/test/unit/apps/companies/controllers/edit.test.js
@@ -139,7 +139,7 @@ describe('Company edit controller', () => {
       })
 
       it('should show the company number field', () => {
-        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.true
+        expect(this.getCalledRenderLocals().showCompanyNumberForUkBranch).to.be.true
       })
 
       it('should not show the trading address fields', () => {
@@ -215,7 +215,7 @@ describe('Company edit controller', () => {
       })
 
       it('should show the company number field', () => {
-        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.true
+        expect(this.getCalledRenderLocals().showCompanyNumberForUkBranch).to.be.true
       })
 
       it('should not show the trading address fields', () => {
@@ -274,7 +274,7 @@ describe('Company edit controller', () => {
       })
 
       it('should not show the company number field', () => {
-        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.false
+        expect(this.getCalledRenderLocals().showCompanyNumberForUkBranch).to.be.false
       })
 
       it('should not show the trading address fields', () => {
@@ -333,7 +333,7 @@ describe('Company edit controller', () => {
       })
 
       it('should not show the company number field', () => {
-        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.false
+        expect(this.getCalledRenderLocals().showCompanyNumberForUkBranch).to.be.false
       })
 
       it('should not show the trading address fields', () => {
@@ -406,7 +406,7 @@ describe('Company edit controller', () => {
       })
 
       it('should not show the company number field', () => {
-        expect(this.getCalledRenderLocals().showCompanyNumber).to.be.false
+        expect(this.getCalledRenderLocals().showCompanyNumberForUkBranch).to.be.false
       })
 
       it('should not show the trading address fields', () => {


### PR DESCRIPTION
https://trello.com/c/9ZK4KVpo/753-update-edit-business-form

## Change
Adds a `Companies House number` non editable field to the `Edit` view of a company.

## Before
<img width="764" alt="screenshot 2019-02-25 at 15 06 47" src="https://user-images.githubusercontent.com/1150417/53346679-6a2ae700-390f-11e9-9ff4-703a403ab2e8.png">

## After
<img width="804" alt="screenshot 2019-02-25 at 15 06 24" src="https://user-images.githubusercontent.com/1150417/53346696-6f883180-390f-11e9-8d95-48fa266ac229.png">
