### PR TITLE
Add Archive section for Data Hub companies

### DIFF
--- a/src/apps/companies/controllers/archive.js
+++ b/src/apps/companies/controllers/archive.js
@@ -3,10 +3,10 @@ const { archiveCompany: archive, unarchiveCompany: unarchive } = require('../rep
 const logger = require('../../../../config/logger')
 
 async function archiveCompany (req, res) {
-  const { id } = res.locals.company
+  const { company } = res.locals
   const { archived_reason, archived_reason_other } = req.body
   const reason = archived_reason_other || archived_reason
-  const returnUrl = `/companies/${id}`
+  const returnUrl = req.query.redirect || `/companies/${company.id}`
 
   if (!reason) {
     req.flash('error', 'A reason must be supplied to archive a company')
@@ -14,7 +14,7 @@ async function archiveCompany (req, res) {
   }
 
   try {
-    await archive(req.session.token, id, reason)
+    await archive(req.session.token, company.id, reason)
 
     req.flash('success', 'Company archived')
     res.redirect(returnUrl)
@@ -27,11 +27,11 @@ async function archiveCompany (req, res) {
 }
 
 async function unarchiveCompany (req, res) {
-  const { id } = res.locals.company
-  const returnUrl = req.query.redirect || `/companies/${id}`
+  const { company } = res.locals
+  const returnUrl = req.query.redirect || `/companies/${company.id}`
 
   try {
-    await unarchive(req.session.token, id)
+    await unarchive(req.session.token, company.id)
 
     req.flash('success', 'Company unarchived')
     res.redirect(returnUrl)

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -125,4 +125,17 @@
   </table>
   {% endif %}
 
+  {% if not company.archived and not company.duns_number %}
+  <h2 class="govuk-heading-m govuk-!-margin-top-9">Archive company</h2>
+  <p>Archive this company if it is no longer required or active.</p>
+
+  {% component 'archive-form', {
+    label: 'Archive reason',
+    options: ['Company is dissolved'],
+    csrfToken: csrfToken,
+    error: form.errors.reason,
+    url: '/companies/' + company.id + '/archive?redirect=business-details'
+  } %}
+  {% endif %}
+
 {% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -37,6 +37,7 @@ Feature: Company business details
       | 75001                     |
       | France                    |
     And the Documents from CDMS key value details are not displayed
+    And I should not see the "Archive" button
 
 
   @companies-business-details--data-hub-company-uk
@@ -77,6 +78,7 @@ Feature: Company business details
       | Bordley                   |
       | BD23 8RZ                  |
       | United Kingdom            |
+    And I should see the "Archive" button
 
 
   @companies-business-details--no-one-list
@@ -110,6 +112,7 @@ Feature: Company business details
       | 001122                    |
       | Italy                     |
     And the Documents from CDMS key value details are not displayed
+    And I should not see the "Archive" button
 
 
   @companies-business-details--archived
@@ -149,3 +152,4 @@ Feature: Company business details
       | 22340                     |
       | Malta                     |
     And the Documents from CDMS key value details are not displayed
+    And I should not see the "Archive" button

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -145,6 +145,30 @@ describe('Company controller, archive', () => {
         })
       })
     })
+
+    context('when there is a redirect', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {
+            redirect: '/redirect/here',
+          },
+          requestBody: {
+            archived_reason: 'Archived reason',
+          },
+          company: companyMock,
+        })
+
+        this.stub.unarchiveCompany.resolves(companyMock)
+
+        await this.controller.archiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
+      })
+
+      commonTests({
+        stubName: 'archiveCompany',
+        expectedFlash: 'success',
+        expectedPath: '/redirect/here',
+      })
+    })
   })
 
   describe('#unarchiveCompany', () => {


### PR DESCRIPTION
https://trello.com/c/BmY4ahQ3/751-add-archive-company-section-to-business-details-dh-data

## Change
Adds the `Archive company` section to the bottom of the `Business details` view for companies populated from Data Hub. This section will not be shown for D&B companies.

## Before
<img width="796" alt="screenshot 2019-02-25 at 16 28 32" src="https://user-images.githubusercontent.com/1150417/53352512-ce9f7380-391a-11e9-8d4d-70eb981b30cb.png">

## After
<img width="839" alt="screenshot 2019-02-25 at 16 28 06" src="https://user-images.githubusercontent.com/1150417/53352527-d4955480-391a-11e9-945b-d10fb6c995d0.png">