### PR TITLE
Fix Nav Persistency

### DIFF
--- a/src/apps/builders.js
+++ b/src/apps/builders.js
@@ -1,4 +1,4 @@
-const { assign, at, castArray, get, has, keyBy, isArray, isFunction, isEmpty, isString, map, pick, pickBy, some } = require('lodash')
+const { assign, at, castArray, get, has, keyBy, includes, isArray, isFunction, isEmpty, isString, map, pick, pickBy, some } = require('lodash')
 const { getOptions } = require('../lib/options')
 
 function getDeepObjectValuesForKey (object, keyName, values = []) {
@@ -156,6 +156,14 @@ function filterNonSsoUserProfileItem (permittedApps, bypassSSO) {
 function buildNavObject (req, navItem, permittedApps = [], bypassSSO = false) {
   const { path: url, label } = navItem
   const isActive = req.path.startsWith(url)
+
+  /**
+   * Nav should always default to DH proprietary links
+   */
+
+  if (!includes(permittedApps, 'datahub-crm')) {
+    permittedApps.push({ key: 'datahub-crm' })
+  }
 
   if (filterNonSsoUserProfileItem(permittedApps, bypassSSO)(navItem)) {
     return {

--- a/test/unit/apps/builders.test.js
+++ b/test/unit/apps/builders.test.js
@@ -537,16 +537,16 @@ describe('Global builders', () => {
       ]
     })
 
-    it('should return undefined when navItem doesn`t match permitted applications', () => {
+    it('should return `datahub-crm` when navItem doesn`t match permitted applications', () => {
       const navItem = {
         path: '/gaia',
         label: 'Gaia',
-        key: 'gaia',
+        key: 'datahub-crm',
       }
 
       const actual = this.builders.buildNavObject(this.req, navItem, this.permittedApps)
 
-      expect(actual).to.equal(undefined)
+      expect(actual).to.deep.equal({ label: 'Gaia', url: '/gaia', isActive: true })
     })
 
     it('should return and object with values from navItem when it matches permitted applications', () => {


### PR DESCRIPTION
There are some scenarios when the user doesn't yet have access to
permitted applications and in that case the nav shows empty. Add a
fallback property with the data-hub key to always show the apps which
are part of DataHub

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
