### PR TITLE
Remove adviser sort option

### DIFF
--- a/src/apps/interactions/macros/collection-sort-form.js
+++ b/src/apps/interactions/macros/collection-sort-form.js
@@ -1,8 +1,6 @@
 const options = [
   { value: '-date', label: 'Newest' },
   { value: 'company__name', label: 'Company: A-Z' },
-  { value: 'dit_adviser__first_name,dit_adviser__last_name', label: 'Adviser: A-Z' },
-  { value: '-dit_adviser__first_name,-dit_adviser__last_name', label: 'Adviser: Z-A' },
   { value: 'subject', label: 'Subject: A-Z' },
 ]
 


### PR DESCRIPTION
## Problem
Trello - https://trello.com/c/3oCYV1Po/561-remove-sort-by-adviser-sorting-options

We need to remove the 'Sort by Adviser (A-Z)' as it does not work and as a result not being used. This feature is also obsolete as we will soon be dealing with multiple advisors.

## Solution
Remove the options to sort the interactions by advisors.