### PR TITLE
Bug - use correct contacts query param (missing underscore)

### DIFF
--- a/src/apps/contacts/middleware/interactions.js
+++ b/src/apps/contacts/middleware/interactions.js
@@ -4,7 +4,7 @@ function setInteractionsDetails (req, res, next) {
   res.locals.interactions = {
     returnLink: `/contacts/${req.params.contactId}/interactions/`,
     entityName: `${res.locals.contact.first_name} ${res.locals.contact.last_name}`,
-    query: { contacts_id: req.params.contactId },
+    query: { contacts__id: req.params.contactId },
     view: 'contacts/views/interactions',
     canAdd: true,
   }

--- a/test/unit/apps/contacts/middleware/interactions.test.js
+++ b/test/unit/apps/contacts/middleware/interactions.test.js
@@ -41,7 +41,7 @@ describe('Contacts interactions middleware', () => {
     })
 
     it('should set the interactions query', () => {
-      expect(this.res.locals.interactions.query).to.deep.equal({ contacts_id: '1' })
+      expect(this.res.locals.interactions.query).to.deep.equal({ contacts__id: '1' })
     })
 
     it('should allow interactions to be added', () => {


### PR DESCRIPTION
## Problem
When querying the interactions via contacts we are using the wrong query param, we currently use `contacts_id` and it should be `contacts__id`.

## Solution
Add missing underscore to query param.