### PR TITLE
Remove initial CSS rule values as this isn't supported by IE

### DIFF
--- a/assets/stylesheets/objects/base/_global-header.scss
+++ b/assets/stylesheets/objects/base/_global-header.scss
@@ -40,7 +40,7 @@
     width: 100%;
 
     @include govuk-media-query($from: tablet) {
-      width: initial;
+      width: auto;
       display: inline-block;
       list-style: none;
     }
@@ -105,7 +105,7 @@
     border-bottom: 1px solid govuk-colour("grey-1");
 
     @include govuk-media-query($from: tablet) {
-      width: initial;
+      width: auto;
       display: inline;
       list-style: none;
       padding: 14px 0;
@@ -135,7 +135,8 @@
     }
 
     @include govuk-media-query($from: tablet) {
-      display: initial;
+      display: inline-block;
+      width: auto;
       font-size: 16px;
       padding: 10px;
     }


### PR DESCRIPTION
## Problem
As the `initial` value is being used in CSS rules for the global navigation, IE has a broken navigation layout.
![screenshot 2019-02-27 at 15 16 25](https://user-images.githubusercontent.com/10154302/53500642-ad698f00-3aa2-11e9-8f68-b8c767a6ebb6.png)

## Solution
Replace the `initial` value with `auto`
![screenshot 2019-02-27 at 15 13 11](https://user-images.githubusercontent.com/10154302/53500697-c1ad8c00-3aa2-11e9-865e-e4d30cebdcd3.png)
