### PR TITLE
Add edit buttons to editable sections of business details

### DIFF
--- a/src/apps/companies/views/_deprecated/advisers.njk
+++ b/src/apps/companies/views/_deprecated/advisers.njk
@@ -1,10 +1,8 @@
 {% extends "./template.njk" %}
 
-{% from "_macros/entity/entity-list.njk" import EntityList %}
-
 {% block main_grid_right_column %}
 
-  <h2 class="govuk-heading-m">Advisers on the core team</h2>
+  {% call DetailsContainer({ heading: 'Advisers on the core team' }) %}
 
     {% if company.global_headquarters.name %}
       <p>This company is a subsidiary of the {{company.global_headquarters.name}}, an account managed company on the One List ({{company.one_list_group_tier.name}})</p>
@@ -24,6 +22,8 @@
       data: coreTeam.teamMembers
     } %}
 
+  {% endcall %}
+
   {% call HiddenContent({ summary: 'Need to find out more, or edit the core team or One List tier information?' }) %}
     {% call Message({ type: 'muted' }) %}
       For more information, or if you need to change the One List tier or account management team for this company,
@@ -32,4 +32,5 @@
       or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>
     {% endcall %}
   {% endcall %}
+
 {% endblock %}

--- a/src/apps/companies/views/_deprecated/details.njk
+++ b/src/apps/companies/views/_deprecated/details.njk
@@ -1,56 +1,50 @@
 {% extends "./template.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">
-    {% if company.headquarter_type.name === 'ghq' %}
-      Global headquarters summary
-    {% else %}
-      Company summary
-    {% endif %}
-  </h2>
 
-  {% if chDetails %}
-    {% call Message({ type: 'muted', element: 'div' }) %}
+  {% call DetailsContainer({ heading: 'Global headquarters summary' if company.headquarter_type.name === 'ghq' else 'Company summary' }) %}
+    {% if chDetails %}
+      {% call Message({ type: 'muted', element: 'div' }) %}
       {% component 'key-value-table', items=chDetails %}
-      <p>Powered by data from <strong>Companies House</strong></p>
-    {% endcall %}
-  {% endif %}
-
-  {% if companyDetails %}
-    {% component 'key-value-table', variant='striped', items=companyDetails %}
-  {% endif %}
-
-  {% if company.id %}
-    {% if not company.archived %}
-      {% if company.duns_number %}
-        {% call HiddenContent({ summary: 'Why can I not edit the company information?' }) %}
-          {% call Message({ type: 'muted' }) %}
-            Information for this company comes from an external and verified source. The information is automatically updated.
-            If you think the information is incomplete or incorrect, get in touch <a href="/support">using the support form</a>
-          {% endcall %}
-        {% endcall %}
-      {% else %}
-        <p><a href="/companies/{{company.id}}/edit" class="button button--secondary">Edit company details</a></p>
-      {% endif %}
+        <p>Powered by data from <strong>Companies House</strong></p>
+      {% endcall %}
     {% endif %}
-  {% else %}
-    <p><a href="/companies/add/{{company.company_number}}" class="button">Add company</a></p>
-  {% endif %}
+
+    {% if companyDetails %}
+      {% component 'key-value-table', variant='striped', items=companyDetails %}
+    {% endif %}
+
+    {% if company.id %}
+      {% if not company.archived %}
+        {% if company.duns_number %}
+          {% call HiddenContent({ summary: 'Why can I not edit the company information?' }) %}
+            {% call Message({ type: 'muted' }) %}
+              Information for this company comes from an external and verified source. The information is automatically updated.
+              If you think the information is incomplete or incorrect, get in touch <a href="/support">using the support form</a>
+            {% endcall %}
+          {% endcall %}
+        {% else %}
+          <p><a href="/companies/{{company.id}}/edit" class="button button--secondary">Edit company details</a></p>
+        {% endif %}
+      {% endif %}
+    {% else %}
+      <p><a href="/companies/add/{{company.company_number}}" class="button">Add company</a></p>
+    {% endif %}
+  {% endcall %}
 
   {% if company.one_list_group_tier %}
-    <div class="section">
-      <h2 class="heading-medium">Global Account Manager – One List</h2>
-      {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
+    {% call DetailsContainer({ heading: 'Global Account Manager – One List' }) %}
+      {% component 'key-value-table', items=accountManagementDetails, variant='striped' %}
 
       <p>
         <a href="advisers">See all advisers on the core team</a>
       </p>
 
-    </div>
+    {% endcall %}
   {% endif %}
 
   {% if not company.archived and not company.duns_number %}
-      <h2 class="heading-medium">Archive company</h2>
+    {% call DetailsContainer({ heading: 'Archive company' }) %}
       <p>Archive this company if it is no longer required or active.</p>
 
       {% component 'archive-form', {
@@ -60,5 +54,6 @@
         error: form.errors.reason,
         url: '/companies/' + company.id + '/archive'
       } %}
+    {% endcall %}
   {% endif %}
 {% endblock %}

--- a/src/apps/companies/views/_deprecated/exports-view.njk
+++ b/src/apps/companies/views/_deprecated/exports-view.njk
@@ -1,18 +1,19 @@
 {% extends "./template.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">Exports</h2>
 
-  {% component 'key-value-table', items=exportDetails %}
+  {% call DetailsContainer({ heading: 'Exports' }) %}
+    {% component 'key-value-table', items=exportDetails %}
 
-  {% if not company.archived %}
-    <p class="actions">
-      <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
-    </p>
-  {% endif %}
+    {% if not company.archived %}
+      <p class="actions">
+        <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
+      </p>
+    {% endif %}
+  {% endcall %}
 
-  <div class="section">
-    <h2 class="heading-medium">Export wins</h2>
+  {% call DetailsContainer({ heading: 'Export wins' }) %}
     <p><a href="http://www.exportwins.service.trade.gov.uk/">Record your win</a> on our export wins site.<p>
-  </div>
+  {% endcall %}
+
 {% endblock %}

--- a/src/apps/companies/views/advisers.njk
+++ b/src/apps/companies/views/advisers.njk
@@ -2,25 +2,27 @@
 
 {% block body_main_content %}
 
-  <h2 class="govuk-heading-m">Advisers on the core team</h2>
+  {% call DetailsContainer({ heading: 'Advisers on the core team' }) %}
 
-  {% if company.global_headquarters.name %}
-    <p>This company is a subsidiary of the {{company.global_headquarters.name}}, an account managed company on the One List ({{company.one_list_group_tier.name}})</p>
-  {% else %}
-    <p>This is an account managed company on the One List ({{company.one_list_group_tier.name}})</p>
-  {% endif %}
+    {% if company.global_headquarters.name %}
+      <p>This company is a subsidiary of the {{company.global_headquarters.name}}, an account managed company on the One List ({{company.one_list_group_tier.name}})</p>
+    {% else %}
+      <p>This is an account managed company on the One List ({{company.one_list_group_tier.name}})</p>
+    {% endif %}
 
-  {% component 'data-table', {
-    variant: 'equal-columns',
-    columns: columns.global_account_manager,
-    data: coreTeam.accountManagers
-  } %}
+    {% component 'data-table', {
+      variant: 'equal-columns',
+      columns: columns.global_account_manager,
+      data: coreTeam.accountManagers
+    } %}
 
-  {% component 'data-table', {
-    variant: 'equal-columns',
-    columns: columns.adviser_core_team,
-    data: coreTeam.teamMembers
-  } %}
+    {% component 'data-table', {
+      variant: 'equal-columns',
+      columns: columns.adviser_core_team,
+      data: coreTeam.teamMembers
+    } %}
+
+  {% endcall %}
 
   {% call HiddenContent({ summary: 'Need to find out more, or edit the core team or One List tier information?' }) %}
     {% call Message({ type: 'muted' }) %}

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -1,5 +1,7 @@
 {% extends "_layouts/template.njk" %}
 
+{% set editUrl = '/companies/' + company.id + '/edit' if not company.duns_number and not company.archived %}
+
 {% macro AddressCell(meta, address) %}
   <td>
     {{
@@ -45,97 +47,92 @@
     }) }}
   {% endif %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">About {{ company.name }}</h2>
-
-  {% component 'key-value-table', items=aboutDetails %}
-
+  {% call DetailsContainer({ heading: 'About ' + company.name, editUrl: editUrl }) %}
+    {% component 'key-value-table', items=aboutDetails %}
+  {% endcall %}
 
   {% if oneListDetails %}
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">Global Account Manager – One List</h2>
+    {% call DetailsContainer({ heading: 'Global Account Manager – One List', editUrl: editUrl }) %}
+      {% component 'key-value-table', items=oneListDetails %}
 
-    {% component 'key-value-table', items=oneListDetails %}
-
-    <p>
-      <a href="advisers">See all advisers on the core team</a>
-    </p>
+      <p>
+        <a href="advisers">See all advisers on the core team</a>
+      </p>
+    {% endcall %}
   {% endif %}
 
+  {% call DetailsContainer({ heading: 'Business hierarchy', editUrl: editUrl }) %}
+    {% component 'key-value-table', items=businessHierarchyDetails %}
+  {% endcall %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">Business hierarchy</h2>
-
-  {% component 'key-value-table', items=businessHierarchyDetails %}
-
-
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">DIT sector</h2>
-
-  <table class="table--key-value">
-    <tbody>
-    {% for sector in sectorDetails %}
-      <tr>
-        <td>{{ sector }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
-
-
-  {% if regionDetails %}
-    <h2 class="govuk-heading-m govuk-!-margin-top-9">DIT region</h2>
-
+  {% call DetailsContainer({ heading: 'DIT sector', editUrl: editUrl }) %}
     <table class="table--key-value">
       <tbody>
-      <tr>
-        <td>{{ regionDetails }}</td>
-      </tr>
+      {% for sector in sectorDetails %}
+        <tr>
+          <td>{{ sector }}</td>
+        </tr>
+      {% endfor %}
       </tbody>
     </table>
+  {% endcall %}
+
+  {% if regionDetails %}
+    {% call DetailsContainer({ heading: 'DIT region', editUrl: editUrl }) %}
+      <table class="table--key-value">
+        <tbody>
+          <tr>
+            <td>{{ regionDetails }}</td>
+          </tr>
+        </tbody>
+      </table>
+    {% endcall %}
   {% endif %}
 
-
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">Addresses</h2>
-
-  <table class="table--key-value">
-    <tbody>
-    <tr>
-      {% if addressesDetails.trading.address %}
-        {{ AddressCell(addressesDetails.trading.meta, addressesDetails.trading.address) }}
-      {% endif %}
-      {% if addressesDetails.registered.address %}
-        {{ AddressCell(addressesDetails.registered.meta, addressesDetails.registered.address) }}
-      {% endif %}
-    </tr>
-    </tbody>
-  </table>
-
+  {% call DetailsContainer({ heading: 'Addresses', editUrl: editUrl }) %}
+    <table class="table--key-value">
+      <tbody>
+        <tr>
+          {% if addressesDetails.trading.address %}
+            {{ AddressCell(addressesDetails.trading.meta, addressesDetails.trading.address) }}
+          {% endif %}
+          {% if addressesDetails.registered.address %}
+            {{ AddressCell(addressesDetails.registered.meta, addressesDetails.registered.address) }}
+          {% endif %}
+        </tr>
+      </tbody>
+    </table>
+  {% endcall %}
 
   {% if archivedDocumentPath %}
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">Documents from CDMS</h2>
-
-  <table class="table--key-value">
-    <tbody>
-    <tr>
-      <td>
-        <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
-          View files and documents
-        </a>
-        <span id="external-link-label">(will open another website)</span>
-      </td>
-    </tr>
-    </tbody>
-  </table>
+    {% call DetailsContainer({ heading: 'Documents from CDMS' }) %}
+      <table class="table--key-value">
+        <tbody>
+        <tr>
+          <td>
+            <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
+              View files and documents
+            </a>
+            <span id="external-link-label">(will open another website)</span>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    {% endcall %}
   {% endif %}
 
   {% if not company.archived and not company.duns_number %}
-  <h2 class="govuk-heading-m govuk-!-margin-top-9">Archive company</h2>
-  <p>Archive this company if it is no longer required or active.</p>
+    {% call DetailsContainer({ heading: 'Archive company' }) %}
+      <p>Archive this company if it is no longer required or active.</p>
 
-  {% component 'archive-form', {
-    label: 'Archive reason',
-    options: ['Company is dissolved'],
-    csrfToken: csrfToken,
-    error: form.errors.reason,
-    url: '/companies/' + company.id + '/archive?redirect=business-details'
-  } %}
+      {% component 'archive-form', {
+        label: 'Archive reason',
+        options: ['Company is dissolved'],
+        csrfToken: csrfToken,
+        error: form.errors.reason,
+        url: '/companies/' + company.id + '/archive?redirect=business-details'
+      } %}
+    {% endcall %}
   {% endif %}
 
 {% endblock %}

--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -2,19 +2,18 @@
 
 {% block body_main_content %}
 
-  <h2 class="govuk-heading-m">Exports</h2>
+  {% call DetailsContainer({ heading: 'Exports' }) %}
+    {% component 'key-value-table', items=exportDetails %}
 
-  {% component 'key-value-table', items=exportDetails %}
+    {% if not company.archived %}
+      <p class="actions">
+        <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
+      </p>
+    {% endif %}
+  {% endcall %}
 
-  {% if not company.archived %}
-    <p class="actions">
-      <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
-    </p>
-  {% endif %}
-
-  <div class="section">
-    <h2 class="heading-medium">Export wins</h2>
+  {% call DetailsContainer({ heading: 'Export wins' }) %}
     <p><a href="http://www.exportwins.service.trade.gov.uk/">Record your win</a> on our export wins site.<p>
-  </div>
+  {% endcall %}
 
 {% endblock %}

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -149,6 +149,12 @@ function renderMetaList (req, res) {
     })
 }
 
+function renderDetailsContainer (req, res) {
+  return res
+    .breadcrumb('Details container')
+    .render('components/views/details-container')
+}
+
 module.exports = {
   renderEntityList,
   renderIndex,
@@ -160,4 +166,5 @@ module.exports = {
   renderKeyValueTables,
   renderHiddenText,
   renderMetaList,
+  renderDetailsContainer,
 }

--- a/src/apps/components/router.js
+++ b/src/apps/components/router.js
@@ -13,6 +13,7 @@ const {
   renderKeyValueTables,
   renderHiddenText,
   renderMetaList,
+  renderDetailsContainer,
 } = require('./controllers')
 
 const { adviserLookup } = require('./middleware')
@@ -35,6 +36,7 @@ router
   .get('/keyvaluetables', renderKeyValueTables)
   .get('/hidden-text', renderHiddenText)
   .get('/meta-list', renderMetaList)
+  .get('/details-container', renderDetailsContainer)
   .all('/form', adviserLookup, renderFormElements)
 
 module.exports = router

--- a/src/apps/components/views/details-container.njk
+++ b/src/apps/components/views/details-container.njk
@@ -1,0 +1,15 @@
+{% extends "./_layout.njk" %}
+
+{% from "_macros/details-container/macro.njk" import DetailsContainer %}
+
+{% block body_main_content %}
+
+  {% call DetailsContainer({ heading: 'Example with Edit link', editUrl: '/components' }) %}
+    <p>Example content</p>
+  {% endcall %}
+
+  {% call DetailsContainer({ heading: 'Example without Edit link' }) %}
+    <p>Example content</p>
+  {% endcall %}
+
+{% endblock %}

--- a/src/apps/components/views/index.njk
+++ b/src/apps/components/views/index.njk
@@ -33,5 +33,8 @@
     <li>
       <a href="components/hidden-text">Hidden text</a>
     </li>
+    <li>
+      <a href="components/details-container">Details container</a>
+    </li>
   </ul>
 {% endblock %}

--- a/src/apps/contacts/views/details.njk
+++ b/src/apps/contacts/views/details.njk
@@ -1,24 +1,30 @@
 {% extends "./template.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">Contact details</h2>
-  {% component 'key-value-table', variant='striped', items=contactDetails, id='contact-details' %}
+
+  {% call DetailsContainer({ heading: 'Contact details' }) %}
+    {% component 'key-value-table', variant='striped', items=contactDetails, id='contact-details' %}
+
+    {% if not contact.archived %}
+      <p>
+        <a href="/contacts/{{id}}/edit" class="button button--secondary">Edit contact</a>
+      </p>
+    {% endif %}
+  {% endcall %}
 
   {% if not contact.archived %}
-    <p>
-      <a href="/contacts/{{id}}/edit" class="button button--secondary">Edit contact</a>
-    </p>
+    {% call DetailsContainer({ heading: 'Archive contact' }) %}
+      <p>Archive this contact if it is no longer required or active.</p>
 
-    <h2 class="heading-medium">Archive contact</h2>
-    <p>Archive this contact if it is no longer required or active.</p>
-
-    {% component 'archive-form', {
-      label: 'Archive reason',
-      options: reasonForArchiveOptions,
-      optionsPrefix: reasonForArchiveOptionsPrefix,
-      csrfToken: csrfToken,
-      error: form.errors.reason,
-      url: '/contacts/' + contact.id + '/archive'
-    } %}
+      {% component 'archive-form', {
+        label: 'Archive reason',
+        options: reasonForArchiveOptions,
+        optionsPrefix: reasonForArchiveOptionsPrefix,
+        csrfToken: csrfToken,
+        error: form.errors.reason,
+        url: '/contacts/' + contact.id + '/archive'
+      } %}
+    {% endcall %}
   {% endif %}
+
 {% endblock %}

--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block main_grid_right_column %}
-   {% component 'key-value-table', variant='striped', items=interactionViewRecord %}
+  {% component 'key-value-table', variant='striped', items=interactionViewRecord %}
   <a class="button button--secondary" href="{{interaction.id}}/{{ interaction.kind | kebabCase }}/edit">
     Edit {{ interaction.kind | lowerCase }}
   </a>

--- a/src/apps/investment-projects/views/details.njk
+++ b/src/apps/investment-projects/views/details.njk
@@ -15,34 +15,38 @@
 {% block main_grid_right_column %}
   {{ super() }}
 
-  <h2 class="govuk-heading-m">Investment project summary</h2>
-  {% component 'key-value-table', items=details, variant='striped' %}
-  {{ renderButton('details', 'Edit summary', true) }}
+  {% call DetailsContainer({ heading: 'Investment project summary' }) %}
+    {% component 'key-value-table', items=details, variant='striped' %}
+    {{ renderButton('details', 'Edit summary', true) }}
+  {% endcall %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">Requirements and location</h2>
-  {% component 'key-value-table', items=requirements, variant='striped' %}
+  {% call DetailsContainer({ heading: 'Requirements and location' }) %}
+    {% component 'key-value-table', items=requirements, variant='striped' %}
 
-  {% if isRequirementsStarted %}
-    {{ renderButton('requirements', 'Edit requirements', true) }}
-  {% else %}
-    {{ Message({
-      type: 'muted',
-      text: 'Please complete this section to move to Assign PM stage'
-    }) }}
+    {% if isRequirementsStarted %}
+      {{ renderButton('requirements', 'Edit requirements', true) }}
+    {% else %}
+      {{ Message({
+        type: 'muted',
+        text: 'Please complete this section to move to Assign PM stage'
+      }) }}
 
-    {{ renderButton('requirements', 'Add requirements') }}
-  {% endif %}
+      {{ renderButton('requirements', 'Add requirements') }}
+    {% endif %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">Value</h2>
-  {% if values | length > 1 %}
-    {% component 'key-value-table', items=values, variant='striped' %}
-    {{ renderButton('value', 'Edit value', true) }}
-  {% else %}
-    {{ Message({
-      type: 'muted',
-      text: 'Please complete ‘Total investment’ and ‘Number of new jobs’ to move to Assign PM stage'
-    }) }}
-    {{ renderButton('value', 'Add value') }}
-  {% endif %}
+  {% endcall %}
+
+  {% call DetailsContainer({ heading: 'Value' }) %}
+    {% if values | length > 1 %}
+      {% component 'key-value-table', items=values, variant='striped' %}
+      {{ renderButton('value', 'Edit value', true) }}
+    {% else %}
+      {{ Message({
+        type: 'muted',
+        text: 'Please complete ‘Total investment’ and ‘Number of new jobs’ to move to Assign PM stage'
+      }) }}
+      {{ renderButton('value', 'Add value') }}
+    {% endif %}
+  {% endcall %}
 
 {% endblock %}

--- a/src/apps/investment-projects/views/evaluation.njk
+++ b/src/apps/investment-projects/views/evaluation.njk
@@ -9,13 +9,16 @@
     }) }}
   {% endif %}
 
-  <h2 class="govuk-heading-m">Project value (Test D)</h2>
-  {% component 'key-value-table', items=value | collectionDefault('Not Known') %}
+  {% call DetailsContainer({ heading: 'Project value (Test D)' }) %}
+    {% component 'key-value-table', items=value | collectionDefault('Not Known') %}
+  {% endcall %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">FDI (Test A)</h2>
-  {% component 'key-value-table', items=fdi | collectionDefault('Not Known') %}
+  {% call DetailsContainer({ heading: 'FDI (Test A)' }) %}
+    {% component 'key-value-table', items=fdi | collectionDefault('Not Known') %}
+  {% endcall %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">Project Landing (Test C)</h2>
-  {% component 'key-value-table', items=landing | collectionDefault('Not Known') %}
+  {% call DetailsContainer({ heading: 'Project Landing (Test C)' }) %}
+    {% component 'key-value-table', items=landing | collectionDefault('Not Known') %}
+  {% endcall %}
 
 {% endblock %}

--- a/src/apps/investment-projects/views/team/details.njk
+++ b/src/apps/investment-projects/views/team/details.njk
@@ -1,49 +1,50 @@
 {% extends "../template.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">Client relationship management</h2>
 
-  {% component 'data-table', {
-    columns: clientRelationshipManagementLabels.view,
-    data: clientRelationshipManagementData
-  } %}
-
-  <a href="edit-client-relationship-management" class="button button--secondary">Change</a>
-
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">Project management</h2>
-
-  {% if stage == 'Prospect' %}
-    {{ Message({
-      type: 'muted',
-      text: 'Will be assigned during "Assign PM" stage.'
-    }) }}
-  {% elif projectManagementData %}
+  {% call DetailsContainer({ heading: 'Client relationship management' }) %}
     {% component 'data-table', {
-      columns: projectManagementLabels.view,
-      data: projectManagementData
+      columns: clientRelationshipManagementLabels.view,
+      data: clientRelationshipManagementData
     } %}
-    <p><a href="edit-project-management" class="button button--secondary">Change</a></p>
-  {% else %}
+    <a href="edit-client-relationship-management" class="button button--secondary">Change</a>
+  {% endcall %}
+
+  {% call DetailsContainer({ heading: 'Project management' }) %}
+    {% if stage == 'Prospect' %}
+      {{ Message({
+        type: 'muted',
+        text: 'Will be assigned during "Assign PM" stage.'
+      }) }}
+    {% elif projectManagementData %}
+      {% component 'data-table', {
+        columns: projectManagementLabels.view,
+        data: projectManagementData
+      } %}
+      <p><a href="edit-project-management" class="button button--secondary">Change</a></p>
+    {% else %}
+      {{ Message({
+        type: 'muted',
+        text: 'Once both a Project Manager and a Project Assurance have been assigned, the project will move to "Active" stage.'
+      }) }}
+      <p><a href="edit-project-management" class="button">Assign</a></p>
+    {% endif %}
+  {% endcall %}
+
+  {% call DetailsContainer({ heading: 'Project specialist and team members' }) %}
+    {% component 'data-table', {
+      columns: teamMembersLabels.view,
+      data: teamMembersData
+    } %}
+
+    <a href="edit-team-members" class="button button--secondary">Change</a>
+  {% endcall %}
+
+  {% call DetailsContainer({ heading: 'Success verifier' }) %}
     {{ Message({
       type: 'muted',
-      text: 'Once both a Project Manager and a Project Assurance have been assigned, the project will move to "Active" stage.'
+      text: 'Will be assigned during "Verify win" stage.'
     }) }}
-    <p><a href="edit-project-management" class="button">Assign</a></p>
-  {% endif %}
+  {% endcall %}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">Project specialist and team members</h2>
-
-  {% component 'data-table', {
-    columns: teamMembersLabels.view,
-    data: teamMembersData
-  } %}
-
-  <a href="edit-team-members" class="button button--secondary">Change</a>
-
-  <h2 class="govuk-heading-m govuk-!-margin-top-7">Success verifier</h2>
-
-  {{ Message({
-    type: 'muted',
-    text: 'Will be assigned during "Verify win" stage.'
-  }) }}
 {% endblock %}

--- a/src/apps/investment-projects/views/team/edit-project-management.njk
+++ b/src/apps/investment-projects/views/team/edit-project-management.njk
@@ -5,9 +5,9 @@
 {% set rsa = investment.referral_source_adviser %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">Assign project management</h2>
-
-  {% component 'key-value-table', items=briefInvestmentSummary, variant='striped' %}
+  {% call DetailsContainer({ heading: 'Assign project management' }) %}
+    {% component 'key-value-table', items=briefInvestmentSummary, variant='striped' %}
+  {% endcall %}
 
   {% call Form(form) %}
     {{ MultipleChoiceField({

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -1,5 +1,6 @@
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "details/macro.njk" import govukDetails %}
+{% from '_macros/details-container/macro.njk' import DetailsContainer %}
 {% from "_macros/form.njk" import FormGroup, Fieldset, TextField, AddAnother, Link, MultipleChoiceField, PreviouslySelected, HiddenField, DateFieldset, DateField, Typeahead %}
 {% from "_macros/form.njk" import EntitySearchForm, Form, MultiStepForm with context %}
 {% from "_macros/common.njk" import LocalHeader with context %}

--- a/src/templates/_macros/_all.scss
+++ b/src/templates/_macros/_all.scss
@@ -1,1 +1,2 @@
 @import "collection-header/collection-header";
+@import "details-container/details-container";

--- a/src/templates/_macros/details-container/_details-container.scss
+++ b/src/templates/_macros/details-container/_details-container.scss
@@ -1,0 +1,25 @@
+@import "~govuk-frontend/helpers/all";
+@import "~govuk-frontend/settings/all";
+
+.c-details-container {
+  display: flex;
+  flex-flow: row wrap;
+
+  &:not(:first-child) {
+    margin-top: govuk-spacing(8);
+  }
+}
+
+.c-details-container__edit-link {
+  @include govuk-font($size: 24);
+
+  margin-left: auto;
+}
+
+.c-details-container__content {
+  width: 100%;
+
+  & > :not(table):first-child {
+    margin-top: govuk-spacing(4);
+  }
+}

--- a/src/templates/_macros/details-container/macro.njk
+++ b/src/templates/_macros/details-container/macro.njk
@@ -1,0 +1,3 @@
+{% macro DetailsContainer(props) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/templates/_macros/details-container/template.njk
+++ b/src/templates/_macros/details-container/template.njk
@@ -1,0 +1,15 @@
+<div class="c-details-container">
+  {% if props.heading %}
+    <h2 class="govuk-heading-m" style="margin-bottom: 0">{{ props.heading }}</h2>
+  {% endif %}
+
+  {% if props.editUrl %}
+    <a href="{{ props.editUrl }}" class="c-details-container__edit-link">Edit</a>
+  {% endif %}
+
+  {% if caller %}
+    <div class="c-details-container__content">
+      {{ caller() }}
+    </div>
+  {% endif %}
+</div>

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -14,17 +14,21 @@ Feature: Company business details
       | Annual turnover           | company.turnoverRange        |
       | Number of employees       | company.employeeRange        |
       | Website                   | Not set                      |
+    And the "About One List Corp" Edit link should not be displayed
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
       | One List tier             | company.oneListTier          |
       | Global Account Manager    | company.globalAccountManager |
+    And the "Global Account Manager – One List" Edit link should not be displayed
     And the Business hierarchy key value details are displayed
       | key                       | value                        |
       | Headquarter type          | company.headquarterType      |
       | Subsidiaries              | company.subsidiaries         |
+    And the "Business hierarchy" Edit link should not be displayed
     And the DIT sector values are displayed
       | value                     |
       | Retail                    |
+    And the "DIT sector" Edit link should not be displayed
     And the DIT region values are not displayed
     And address 1 should have badges
       | value                     |
@@ -36,6 +40,7 @@ Feature: Company business details
       | Paris                     |
       | 75001                     |
       | France                    |
+    And the "Addresses" Edit link should not be displayed
     And the Documents from CDMS key value details are not displayed
     And I should not see the "Archive" button
 
@@ -54,20 +59,25 @@ Feature: Company business details
       | Annual turnover           | Not set                      |
       | Number of employees       | Not set                      |
       | Website                   | Not set                      |
+    And the "About Venus Ltd" Edit link should be displayed
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
       | One List tier             | company.oneListTier          |
       | Global Account Manager    | company.globalAccountManager |
+    And the "Global Account Manager – One List" Edit link should be displayed
     And the Business hierarchy key value details are displayed
       | key                       | value                        |
       | Headquarter type          | company.headquarterType      |
       | Subsidiaries              | company.subsidiaries         |
+    And the "Business hierarchy" Edit link should be displayed
     And the DIT sector values are displayed
       | value                     |
       | Retail                    |
+    And the "DIT sector" Edit link should be displayed
     And the DIT region values are displayed
       | value                     |
       | North West                |
+    And the "DIT region" Edit link should be displayed
     And address 1 should have badges
       | value                     |
       | Trading                   |
@@ -78,6 +88,7 @@ Feature: Company business details
       | Bordley                   |
       | BD23 8RZ                  |
       | United Kingdom            |
+    And the "Addresses" Edit link should be displayed
     And I should see the "Archive" button
 
 
@@ -94,12 +105,15 @@ Feature: Company business details
       | Annual turnover           | company.annualTurnover       |
       | Number of employees       | company.numberOfEmployees    |
       | Website                   | Not set                      |
+    And the "About DnB Corp" Edit link should not be displayed
     And the Business hierarchy key value details are displayed
       | key                       | value                        |
       | Subsidiaries              | company.subsidiaries         |
+    And the "Business hierarchy" Edit link should not be displayed
     And the DIT sector values are displayed
       | value                     |
       | Retail                    |
+    And the "DIT region" Edit link should not be displayed
     And the DIT region values are not displayed
     And address 1 should have badges
       | value                     |
@@ -111,6 +125,7 @@ Feature: Company business details
       | Rome                      |
       | 001122                    |
       | Italy                     |
+    And the "Addresses" Edit link should not be displayed
     And the Documents from CDMS key value details are not displayed
     And I should not see the "Archive" button
 
@@ -129,17 +144,21 @@ Feature: Company business details
       | Annual turnover           | company.turnoverRange        |
       | Number of employees       | company.employeeRange        |
       | Website                   | Not set                      |
+    And the "About Archived Ltd" Edit link should not be displayed
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
       | One List tier             | company.oneListTier          |
       | Global Account Manager    | company.globalAccountManager |
+    And the "Global Account Manager – One List" Edit link should not be displayed
     And the Business hierarchy key value details are displayed
       | key                       | value                        |
       | Headquarter type          | company.headquarterType      |
       | Subsidiaries              | company.subsidiaries         |
+    And the "Business hierarchy" Edit link should not be displayed
     And the DIT sector values are displayed
       | value                     |
       | Retail                    |
+    And the "DIT sector" Edit link should not be displayed
     And the DIT region values are not displayed
     And address 1 should have badges
       | value                     |
@@ -151,5 +170,6 @@ Feature: Company business details
       | Geta                      |
       | 22340                     |
       | Malta                     |
+    And the "Addresses" Edit link should not be displayed
     And the Documents from CDMS key value details are not displayed
     And I should not see the "Archive" button

--- a/test/acceptance/features/companies/step_definitions/business-details.js
+++ b/test/acceptance/features/companies/step_definitions/business-details.js
@@ -8,7 +8,7 @@ const BusinessDetailsPage = client.page.companies['business-details']()
 const getAddressSelector = (tableNumber) => {
   return getSelectorForElementWithText('Addresses', {
     el: '//h2',
-    child: `/following-sibling::table[${tableNumber}]`,
+    child: `/following-sibling::div/table[${tableNumber}]`,
   })
 }
 

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -181,3 +181,14 @@ Then(/^the "(.+)" details summary (should be|should not be) displayed$/, async (
     .assert[assertion](detailsSummarySelector.selector)
     .useCss()
 })
+
+Then(/^the "(.+)" Edit link (should be|should not be) displayed/, async function (heading, should) {
+  const editLinkSelector = getSelectorForElementWithText(heading, { el: '//h2', child: '//following-sibling::a' })
+
+  const assertion = should === 'should be' ? 'visible' : 'elementNotPresent'
+
+  await Details
+    .api.useXpath()
+    .assert[assertion](editLinkSelector.selector)
+    .useCss()
+})

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -122,7 +122,7 @@ function getLinkWithText (text, className) {
 const getSelectorForDetailsSectionEditButton = (sectionTitle, buttonText = 'Edit') => {
   return getSelectorForElementWithText(sectionTitle, {
     el: '//h2',
-    child: '/following-sibling::p[1]/a[contains(.,"Edit")]',
+    child: '/following-sibling::div/p[1]/a[contains(.,"Edit")]',
   })
 }
 

--- a/test/acceptance/pages/details.js
+++ b/test/acceptance/pages/details.js
@@ -14,7 +14,7 @@ const getSelectorForTable = (title, className) => {
 
   return getSelectorForElementWithText(title, {
     el: '//h2',
-    child: '/following-sibling::table[1]',
+    child: '//following-sibling::div/table[1]',
   })
 }
 

--- a/test/unit/macros/details-container/macro.test.js
+++ b/test/unit/macros/details-container/macro.test.js
@@ -1,0 +1,55 @@
+const { getMacros } = require('~/test/unit/macro-helper')
+const detailsContainerMacro = getMacros('details-container/macro')
+
+describe('Details container', () => {
+  context('when there are no props', () => {
+    beforeEach(() => {
+      this.component = detailsContainerMacro.renderToDom('DetailsContainer')
+    })
+
+    it('should render the container', () => {
+      expect(this.component.className.trim()).to.equal('c-details-container')
+    })
+
+    it('should not render the heading', () => {
+      expect(this.component.querySelector('h2')).to.not.exist
+    })
+
+    it('should not render the edit link', () => {
+      expect(this.component.querySelector('a')).to.not.exist
+    })
+
+    it('should render any caller content', () => {
+      expect(this.component.querySelector('.c-details-container__content')).to.not.exist
+    })
+  })
+
+  context('when there is all props', () => {
+    beforeEach(() => {
+      this.component = detailsContainerMacro.renderWithCallerToDom('DetailsContainer', {
+        heading: 'heading',
+        editUrl: '/edit',
+      })('<caller></caller>')
+    })
+
+    it('should render the container', () => {
+      expect(this.component.className.trim()).to.equal('c-details-container')
+    })
+
+    it('should render the heading', () => {
+      expect(this.component.querySelector('h2').textContent.trim()).to.equal('heading')
+    })
+
+    it('should render the edit link', () => {
+      const editLink = this.component.querySelector('a')
+
+      expect(editLink.textContent.trim()).to.equal('Edit')
+      expect(editLink.getAttribute('href')).to.equal('/edit')
+    })
+
+    it('should render the caller content', () => {
+      expect(this.component.querySelector('.c-details-container__content')).to.exist
+      expect(this.component.querySelector('caller')).to.exist
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/C0imZORr/750-add-edit-buttons-to-business-details-dh-data

## Change
Companies populated from Data Hub need `Edit` links next to editable sections of the `Business details` screens. These links are not shown for archived or D&B companies.

Included in this change is a `Details container` component. An example can be viewed at `~/components/details-container`. This will ultimately address inconsistency issues around presenting details and associated `Edit` link/button.

The `Details container` has been integrated across all applications.

## Screenshot
![screenshot 2019-02-28 at 15 33 39](https://user-images.githubusercontent.com/1150417/53577988-98f2c880-3b6e-11e9-9639-49239664bd91.png)
