### PR TITLE
Fixes an Investment project broken link within Interactions.

### DIFF
--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -77,7 +77,7 @@ function transformInteractionResponseToViewRecord ({
       name: date,
     },
     dit_adviser,
-    investment_project: transformEntityLink(investment_project, 'investment-projects'),
+    investment_project: transformEntityLink(investment_project, 'investments/projects'),
     event: transformEntityLink(event, 'events', defaultEventText),
     communication_channel: communication_channel,
     documents: transformDocumentsLink(archived_documents_url_path),

--- a/test/acceptance/features/interactions/investments.project.feature
+++ b/test/acceptance/features/interactions/investments.project.feature
@@ -1,0 +1,9 @@
+@interactions-investments-project
+Feature: Investment project link
+
+  @interactions-investments-project--investment-link
+  Scenario: Interaction has an Investment project link
+    When I navigate to the `interactions.fixture` page using `interaction` `Provided funding information` fixture
+    Then there should not be a local nav
+    And I click the "New hotel (FDI)" link
+    Then I am taken to the "New hotel (FDI)" page

--- a/test/unit/apps/interactions/transformers/interaction-response-to-view.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-response-to-view.test.js
@@ -58,7 +58,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
           name: 'Priyanka Karunan',
         },
         'Investment project': {
-          url: '/investment-projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
+          url: '/investments/projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
           name: 'Test project',
         },
         'Communication channel': {
@@ -122,7 +122,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
           name: 'Priyanka Karunan',
         },
         'Investment project': {
-          url: '/investment-projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
+          url: '/investments/projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
           name: 'Test project',
         },
         'Communication channel': {


### PR DESCRIPTION
When looking at an interaction the investment project link is broken.
This fix addresses the issue by updating the link, the unit tests and
adding a new acceptance test to ensure it doesn't happen again.

https://www.datahub.staging.uktrade.io/interactions/c611db63-2b7c-437a-a681-eb6015bb413f

![broken-link](https://user-images.githubusercontent.com/964268/53564233-3ee20b00-3b4e-11e9-9d10-9f11535fbaa5.png)

