### PR TITLE
Remove companies-advisers flag dependency

### DIFF
--- a/src/apps/companies/controllers/advisers.js
+++ b/src/apps/companies/controllers/advisers.js
@@ -1,14 +1,9 @@
-const { notFound } = require('../../../middleware/errors')
 const { getOneListGroupCoreTeam } = require('../repos')
 const config = require('../../../../config')
 const { transformCoreTeamToCollection } = require('../transformers')
 const { coreTeamLabels } = require('../labels')
 
 async function renderAdvisers (req, res, next) {
-  if (!res.locals.features['companies-advisers']) {
-    return notFound(req, res, next)
-  }
-
   try {
     const { company } = res.locals
     const token = req.session.token

--- a/src/apps/companies/middleware/local-navigation.js
+++ b/src/apps/companies/middleware/local-navigation.js
@@ -5,11 +5,11 @@ const { setLocalNav } = require('../../middleware')
 const { DEPRECATED_LOCAL_NAV, LOCAL_NAV } = require('../constants')
 
 function setCompaniesLocalNav (req, res, next) {
-  const { company, features } = res.locals
+  const { company } = res.locals
 
   if (company.duns_number) {
     const navItems = LOCAL_NAV.filter(({ path }) => {
-      return (path !== 'advisers' || (features['companies-advisers'] && company.one_list_group_tier))
+      return (path !== 'advisers' || company.one_list_group_tier)
     })
 
     setLocalNav(navItems)(req, res, next)
@@ -19,7 +19,7 @@ function setCompaniesLocalNav (req, res, next) {
     const navItems = DEPRECATED_LOCAL_NAV.filter(({ path }) => {
       return (path !== 'subsidiaries' || headquarterType === 'ghq') &&
         (path !== 'timeline' || company.company_number) &&
-        (path !== 'advisers' || (features['companies-advisers'] && company.one_list_group_tier))
+        (path !== 'advisers' || company.one_list_group_tier)
     })
 
     setLocalNav(navItems)(req, res, next)

--- a/src/apps/companies/views/_deprecated/details.njk
+++ b/src/apps/companies/views/_deprecated/details.njk
@@ -42,20 +42,9 @@
       <h2 class="heading-medium">Global Account Manager – One List</h2>
       {% component 'key-value-table', variant='striped', items=accountManagementDetails %}
 
-      {# when the "companies-advisers" flag check is removed then the HiddenContent block should also be removed #}
-      {% if features['companies-advisers'] %}
-        <p>
-          <a href="advisers">See all advisers on the core team</a>
-        </p>
-      {% else %}
-        {% call HiddenContent({ summary: 'Need to edit the Global Account Manager information?' }) %}
-          {% call Message({ type: 'muted' }) %}
-            If you need to change the One List tier or Global Account Manager for this company,
-            go to the <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/">Digital Workspace</a>
-            or email <a href="mailto:{{oneListEmail}}">{{oneListEmail}}</a>.
-          {% endcall %}
-        {% endcall %}
-      {% endif %}
+      <p>
+        <a href="advisers">See all advisers on the core team</a>
+      </p>
 
     </div>
   {% endif %}

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -17,9 +17,7 @@
         <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>
         <p>
           Global Account Manager: {{ company.one_list_group_global_account_manager.name }}
-          {% if features['companies-advisers'] %}
-            <a href="/companies/{{ company.id }}/advisers">View core team</a>
-          {% endif %}
+          <a href="/companies/{{ company.id }}/advisers">View core team</a>
         </p>
       </div>
     {% endif %}

--- a/test/unit/apps/companies/controllers/advisers.test.js
+++ b/test/unit/apps/companies/controllers/advisers.test.js
@@ -9,95 +9,45 @@ const { renderAdvisers } = require('~/src/apps/companies/controllers/advisers')
 
 describe('Company contact list controller', () => {
   describe('#renderAdvisers', () => {
-    context('when the feature flag is enabled', () => {
-      const commonTests = (expectedBreadcrumbs, expectedTemplate, expectedCompanyName) => {
-        it('should add two breadcrumbs', () => {
-          expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
-        })
-
-        it('should add the company breadcrumb', () => {
-          expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(expectedBreadcrumbs[0].text, expectedBreadcrumbs[0].href)
-        })
-
-        it('should add the Advisers breadcrumb', () => {
-          expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(expectedBreadcrumbs[1].text)
-        })
-
-        it('should render the correct template', () => {
-          expect(this.middlewareParameters.resMock.render).to.be.calledWith(expectedTemplate)
-        })
-
-        it('should set the company name', () => {
-          expect(this.middlewareParameters.resMock.render.args[0][1].companyName).to.equal(expectedCompanyName)
-        })
-
-        it('should set the core team', () => {
-          expect(this.middlewareParameters.resMock.render.args[0][1].coreTeam).to.not.be.null
-        })
-
-        it('should not call next', () => {
-          expect(this.middlewareParameters.nextSpy).to.not.be.called
-        })
-      }
-
-      context('when the company does not have a DUNS number', () => {
-        beforeEach(async () => {
-          this.middlewareParameters = buildMiddlewareParameters({
-            company: companyMock,
-            features: {
-              'companies-advisers': true,
-            },
-          })
-
-          nock(config.apiRoot)
-            .get(`/v3/company/${companyMock.id}/one-list-group-core-team`)
-            .reply(200, coreTeamMock)
-
-          await renderAdvisers(
-            this.middlewareParameters.reqMock,
-            this.middlewareParameters.resMock,
-            this.middlewareParameters.nextSpy,
-          )
-        })
-
-        commonTests([
-          { text: companyMock.name, href: `/companies/${companyMock.id}` },
-          { text: 'Advisers' },
-        ], 'companies/views/_deprecated/advisers', 'Mercury Trading Ltd')
+    const commonTests = (expectedBreadcrumbs, expectedTemplate, expectedCompanyName) => {
+      it('should add two breadcrumbs', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
       })
 
-      context('when the company does have a DUNS number', () => {
-        beforeEach(async () => {
-          this.middlewareParameters = buildMiddlewareParameters({
-            company: dnbCompanyMock,
-            features: {
-              'companies-advisers': true,
-            },
-          })
-
-          nock(config.apiRoot)
-            .get(`/v3/company/${dnbCompanyMock.id}/one-list-group-core-team`)
-            .reply(200, coreTeamMock)
-
-          await renderAdvisers(
-            this.middlewareParameters.reqMock,
-            this.middlewareParameters.resMock,
-            this.middlewareParameters.nextSpy,
-          )
-        })
-
-        commonTests([
-          { text: dnbCompanyMock.name, href: `/companies/${dnbCompanyMock.id}` },
-          { text: 'Advisers' },
-        ], 'companies/views/advisers', 'One List Corp')
+      it('should add the company breadcrumb', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(expectedBreadcrumbs[0].text, expectedBreadcrumbs[0].href)
       })
-    })
 
-    context('when the feature flag is not enabled', () => {
+      it('should add the Advisers breadcrumb', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(expectedBreadcrumbs[1].text)
+      })
+
+      it('should render the correct template', () => {
+        expect(this.middlewareParameters.resMock.render).to.be.calledWith(expectedTemplate)
+      })
+
+      it('should set the company name', () => {
+        expect(this.middlewareParameters.resMock.render.args[0][1].companyName).to.equal(expectedCompanyName)
+      })
+
+      it('should set the core team', () => {
+        expect(this.middlewareParameters.resMock.render.args[0][1].coreTeam).to.not.be.null
+      })
+
+      it('should not call next', () => {
+        expect(this.middlewareParameters.nextSpy).to.not.be.called
+      })
+    }
+
+    context('when the company does not have a DUNS number', () => {
       beforeEach(async () => {
         this.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
         })
+
+        nock(config.apiRoot)
+          .get(`/v3/company/${companyMock.id}/one-list-group-core-team`)
+          .reply(200, coreTeamMock)
 
         await renderAdvisers(
           this.middlewareParameters.reqMock,
@@ -106,18 +56,33 @@ describe('Company contact list controller', () => {
         )
       })
 
-      it('should not add breadcrumbs', () => {
-        expect(this.middlewareParameters.resMock.breadcrumb).to.not.be.called
+      commonTests([
+        { text: companyMock.name, href: `/companies/${companyMock.id}` },
+        { text: 'Advisers' },
+      ], 'companies/views/_deprecated/advisers', 'Mercury Trading Ltd')
+    })
+
+    context('when the company does have a DUNS number', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: dnbCompanyMock,
+        })
+
+        nock(config.apiRoot)
+          .get(`/v3/company/${dnbCompanyMock.id}/one-list-group-core-team`)
+          .reply(200, coreTeamMock)
+
+        await renderAdvisers(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
-      it('should not render the template', () => {
-        expect(this.middlewareParameters.resMock.render).to.not.be.called
-      })
-
-      it('should call next with an error', () => {
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
-        expect(this.middlewareParameters.nextSpy).to.be.calledWith(sinon.match.instanceOf(Error).and(sinon.match.has('message', 'Not Found')))
-      })
+      commonTests([
+        { text: dnbCompanyMock.name, href: `/companies/${dnbCompanyMock.id}` },
+        { text: 'Advisers' },
+      ], 'companies/views/advisers', 'One List Corp')
     })
   })
 })

--- a/test/unit/apps/companies/middleware/local-navigation.test.js
+++ b/test/unit/apps/companies/middleware/local-navigation.test.js
@@ -130,23 +130,4 @@ describe('Companies local navigation', () => {
       expect(menuItem).to.be.undefined
     })
   })
-
-  context('when the company advisers feature is enabled', () => {
-    beforeEach(() => {
-      this.res.locals.company = {
-        one_list_group_tier: {
-          id: '4321',
-          name: 'Tier A - Strategic Account',
-        },
-      }
-      this.res.locals.features = { 'companies-advisers': true }
-
-      setCompaniesLocalNav(this.req, this.res, this.next)
-    })
-
-    it('should have an advisers option', () => {
-      const menuItem = this.res.locals.localNavItems.find(item => item.path === 'advisers')
-      expect(menuItem).to.be.ok
-    })
-  })
 })


### PR DESCRIPTION
https://trello.com/c/duxHOyNe/825-remove-companies-advisers-flag-dependency

The flag check is no longer required as it has been enabled in production for several months.