### PR TITLE
Bugfix/header spacing issues

### DIFF
--- a/assets/stylesheets/objects/base/_global-header.scss
+++ b/assets/stylesheets/objects/base/_global-header.scss
@@ -41,6 +41,7 @@
 
     @include govuk-media-query($from: tablet) {
       width: auto;
+      width: initial;
       display: inline-block;
       list-style: none;
     }
@@ -106,6 +107,7 @@
 
     @include govuk-media-query($from: tablet) {
       width: auto;
+      width: initial;
       display: inline;
       list-style: none;
       padding: 14px 0;
@@ -135,8 +137,8 @@
     }
 
     @include govuk-media-query($from: tablet) {
-      display: inline-block;
-      width: auto;
+      display: inline;
+      display: initial;
       font-size: 16px;
       padding: 10px;
     }


### PR DESCRIPTION
Fix spacing issues on global header

Add a fallback for `inital` property which doesn't work in IE
![screenshot 2019-03-01 at 13 46 07](https://user-images.githubusercontent.com/1295319/53731378-7dd7cf80-3e72-11e9-9389-7a63b6a37ef4.png)

