### PR TITLE
Swapping out a forEach loop for the for...in loop

### DIFF
--- a/assets/javascripts/lib/xhr.js
+++ b/assets/javascripts/lib/xhr.js
@@ -19,14 +19,16 @@ const XHR = {
     const dataDocument = document.createRange().createContextualFragment(data)
 
     const xhrContainers = document.querySelectorAll('[data-xhr]')
-    xhrContainers.forEach((xhrContainer) => {
-      const xhrContainerId = xhrContainer.getAttribute('data-xhr')
-
-      const newContent = dataDocument.querySelector(`[data-xhr="${xhrContainerId}"]`)
-      if (newContent) {
-        xhrContainer.outerHTML = newContent.outerHTML
+    for (const prop in xhrContainers) {
+      if (xhrContainers.hasOwnProperty(prop)) {
+        const xhrContainer = xhrContainers[prop]
+        const xhrContainerId = xhrContainer.getAttribute('data-xhr')
+        const newContent = dataDocument.querySelector(`[data-xhr="${xhrContainerId}"]`)
+        if (newContent) {
+          xhrContainer.outerHTML = newContent.outerHTML
+        }
       }
-    })
+    }
   },
 
   updateOutlet (res, params) {


### PR DESCRIPTION
Fixes an Internet Explorer issue.

You cannot iterate over a NodeList using forEach when supporting older
browsers, however, you can in modern browsers.

The for...in loop has been supported by Internet Explorer since v6.

This fix simply swaps out forEach for for...in for browser compatibility
reasons.