### PR TITLE
Bug - update contacts query param in events

### DIFF
--- a/src/apps/events/attendees/repos.js
+++ b/src/apps/events/attendees/repos.js
@@ -17,7 +17,7 @@ async function fetchEventAttendees ({ token, eventId, page = 1, sortby, limit = 
       offset,
       sortby,
       event_id: eventId,
-      contact_id: contactId,
+      contacts__id: contactId,
     }, value => !isNil(value)),
   })
 

--- a/src/apps/events/attendees/transformers.js
+++ b/src/apps/events/attendees/transformers.js
@@ -4,10 +4,10 @@ const { compact, get, pickBy } = require('lodash')
 const { attendeeLabels } = require('./labels')
 const { fetchEventAttendees } = require('./repos')
 
-function transformServiceDeliveryToAttendeeListItem ({ contact, company, date, id }) {
+function transformServiceDeliveryToAttendeeListItem ({ contacts = [], company, date, id }) {
   const metaItems = [
     { key: 'company', value: get(company, 'name'), url: `/companies/${get(company, 'id')}` },
-    { key: 'job_title', value: contact ? contact.job_title : 'Not available' },
+    { key: 'job_title', value: contacts.length ? contacts[0].job_title : 'Not available' },
     { key: 'attended_date', value: date, type: 'date' },
     { key: 'service_delivery', value: 'View or edit service delivery', url: `/interactions/${id}` },
   ]
@@ -17,11 +17,11 @@ function transformServiceDeliveryToAttendeeListItem ({ contact, company, date, i
       label: attendeeLabels[key],
     }))
 
-  const listItem = contact
+  const listItem = contacts.length
     ? {
-      id: contact.id,
+      id: contacts[0].id,
       type: 'contact',
-      name: contact.name,
+      name: contacts[0].name,
       meta: compact(metaItems),
     }
     : {
@@ -63,7 +63,7 @@ async function createContactItemToAttendeeSearchResult (token, event) {
 }
 
 function existingAttendee ({ id }, attendees) {
-  return attendees.results.find(attendee => attendee.contact.id === id)
+  return attendees.results.find(attendee => attendee.contacts[0].id === id)
 }
 
 module.exports = {

--- a/src/apps/events/attendees/transformers.js
+++ b/src/apps/events/attendees/transformers.js
@@ -63,7 +63,10 @@ async function createContactItemToAttendeeSearchResult (token, event) {
 }
 
 function existingAttendee ({ id }, attendees) {
-  return attendees.results.find(attendee => attendee.contacts[0].id === id)
+  return attendees.results.find((attendee) => {
+    const contact = attendee.contacts && attendee.contacts[0]
+    return contact ? contact.id === id : false
+  })
 }
 
 module.exports = {

--- a/test/unit/apps/events/attendees/controllers/create.test.js
+++ b/test/unit/apps/events/attendees/controllers/create.test.js
@@ -34,7 +34,7 @@ describe('Create attendee controller', () => {
       this.res.locals.event = event
 
       nock(config.apiRoot)
-        .get('/v3/interaction?limit=10&offset=0&event_id=31a9f8bd-7796-4af4-8f8c-25450860e2d1&contact_id=59c815d1-91d0-4d1f-b980-1d04157a298f')
+        .get('/v3/interaction?limit=10&offset=0&event_id=31a9f8bd-7796-4af4-8f8c-25450860e2d1&contacts__id=59c815d1-91d0-4d1f-b980-1d04157a298f')
         .reply(200, {
           count: 0,
           results: [],
@@ -110,7 +110,7 @@ describe('Create attendee controller', () => {
       this.res.locals.event = event
 
       nock(config.apiRoot)
-        .get('/v3/interaction?limit=10&offset=0&event_id=31a9f8bd-7796-4af4-8f8c-25450860e2d1&contact_id=9b1138ab-ec7b-497f-b8c3-27fed21694ef')
+        .get('/v3/interaction?limit=10&offset=0&event_id=31a9f8bd-7796-4af4-8f8c-25450860e2d1&contacts__id=9b1138ab-ec7b-497f-b8c3-27fed21694ef')
         .reply(200, attendeesData)
 
       await createAttendee(this.req, this.res, this.nextSpy)

--- a/test/unit/apps/events/attendees/transformers.test.js
+++ b/test/unit/apps/events/attendees/transformers.test.js
@@ -58,10 +58,10 @@ describe('#transformEventToAttendeeListItem', () => {
 
     context('when a valid contact is provided without a job title', () => {
       beforeEach(() => {
-        this.serviceDelivery.contact = {
+        this.serviceDelivery.contacts = [{
           id: '3333',
           name: 'Test contact',
-        }
+        }]
 
         this.transformedAttendee = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
       })
@@ -99,11 +99,11 @@ describe('#transformEventToAttendeeListItem', () => {
 
     context('when a valid contact is provided with a job title', () => {
       beforeEach(() => {
-        this.serviceDelivery.contact = {
+        this.serviceDelivery.contacts = [{
           id: '3333',
           name: 'Test contact',
           job_title: 'Director',
-        }
+        }]
 
         this.transformedAttendee = transformServiceDeliveryToAttendeeListItem(this.serviceDelivery)
       })


### PR DESCRIPTION
## Problem
The events still query the contacts using the old param value `contact_id` when it should be `contacts__id`. Also when transforming the data events is still consuming `contact` in the transformer when it should be `contacts` as the contacts is now an array which was changed around the new use of multiple contacts.

## Solution
Update the query param and update the transformer to use the right contacts.
