### PR TITLE
Use new layout flag over redirect query when archiving/unarchiving

### DIFF
--- a/src/apps/companies/controllers/archive.js
+++ b/src/apps/companies/controllers/archive.js
@@ -2,44 +2,48 @@
 const { archiveCompany: archive, unarchiveCompany: unarchive } = require('../repos')
 const logger = require('../../../../config/logger')
 
+function getDetailsUrl (features, company) {
+  return features['companies-new-layout'] ? `/companies/${company.id}/business-details` : `/companies/${company.id}`
+}
+
 async function archiveCompany (req, res) {
-  const { company } = res.locals
+  const { company, features } = res.locals
   const { archived_reason, archived_reason_other } = req.body
   const reason = archived_reason_other || archived_reason
-  const returnUrl = req.query.redirect || `/companies/${company.id}`
+  const detailsUrl = getDetailsUrl(features, company)
 
   if (!reason) {
     req.flash('error', 'A reason must be supplied to archive a company')
-    return res.redirect(returnUrl)
+    return res.redirect(detailsUrl)
   }
 
   try {
     await archive(req.session.token, company.id, reason)
 
     req.flash('success', 'Company archived')
-    res.redirect(returnUrl)
+    res.redirect(detailsUrl)
   } catch (error) {
     logger.error(error)
 
     req.flash('error', 'Company could not be archived')
-    res.redirect(returnUrl)
+    res.redirect(detailsUrl)
   }
 }
 
 async function unarchiveCompany (req, res) {
-  const { company } = res.locals
-  const returnUrl = req.query.redirect || `/companies/${company.id}`
+  const { company, features } = res.locals
+  const detailsUrl = getDetailsUrl(features, company)
 
   try {
     await unarchive(req.session.token, company.id)
 
     req.flash('success', 'Company unarchived')
-    res.redirect(returnUrl)
+    res.redirect(detailsUrl)
   } catch (error) {
     logger.error(error)
 
     req.flash('error', 'Company could not be archived')
-    res.redirect(returnUrl)
+    res.redirect(detailsUrl)
   }
 }
 

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -31,7 +31,7 @@
       This company was archived on {{company.archived_on | formatDate}} by {{company.archived_by.first_name}} {{company.archived_by.last_name}}. <br>
       <strong>Reason:</strong> {{company.archived_reason}}<br>
       <br>
-      <a href="/companies/{{company.id}}/unarchive?redirect=business-details">Unarchive</a>
+      <a href="/companies/{{company.id}}/unarchive">Unarchive</a>
     {% endcall %}
   {% endif %}
 
@@ -130,7 +130,7 @@
         options: ['Company is dissolved'],
         csrfToken: csrfToken,
         error: form.errors.reason,
-        url: '/companies/' + company.id + '/archive?redirect=business-details'
+        url: '/companies/' + company.id + '/archive'
       } %}
     {% endcall %}
   {% endif %}

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -1,6 +1,6 @@
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
-const companyMock = require('~/test/unit/data/companies/company.json')
+const companyMock = require('~/test/unit/data/companies/minimal-company.json')
 
 describe('Company controller, archive', () => {
   beforeEach(() => {
@@ -146,16 +146,16 @@ describe('Company controller, archive', () => {
       })
     })
 
-    context('when there is a redirect', () => {
+    context('when the companies new layout feature is enabled', () => {
       beforeEach(async () => {
         this.middlewareParameters = buildMiddlewareParameters({
-          requestQuery: {
-            redirect: '/redirect/here',
-          },
           requestBody: {
             archived_reason: 'Archived reason',
           },
           company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
         })
 
         this.stub.unarchiveCompany.resolves(companyMock)
@@ -166,7 +166,7 @@ describe('Company controller, archive', () => {
       commonTests({
         stubName: 'archiveCompany',
         expectedFlash: 'success',
-        expectedPath: '/redirect/here',
+        expectedPath: `/companies/${companyMock.id}/business-details`,
       })
     })
   })
@@ -191,13 +191,16 @@ describe('Company controller, archive', () => {
         })
       })
 
-      context('when there is a redirect', () => {
+      context('when the companies new layout feature is enabled', () => {
         beforeEach(async () => {
           this.middlewareParameters = buildMiddlewareParameters({
             requestQuery: {
               redirect: '/redirect/here',
             },
             company: companyMock,
+            features: {
+              'companies-new-layout': true,
+            },
           })
 
           this.stub.unarchiveCompany.resolves(companyMock)
@@ -208,7 +211,7 @@ describe('Company controller, archive', () => {
         commonTests({
           stubName: 'unarchiveCompany',
           expectedFlash: 'success',
-          expectedPath: '/redirect/here',
+          expectedPath: `/companies/${companyMock.id}/business-details`,
         })
       })
     })


### PR DESCRIPTION
https://trello.com/c/5ZazZcfQ/830-add-companies-new-layout-feature-flag-for-switching-on-off-layout-for-data-hub-companies

The dependency on the redirect query string parameter is unnecessary as there will be a flag that can achieve the same outcome.

The outcome of this change can be seen by enabling the `companies-new-layout` flag locally and then archiving/unarchiving a Data Hub company.
