### PR TITLE
Redirect to correct URL after saving company

### DIFF
--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -61,6 +61,14 @@ async function populateForm (req, res, next) {
   }
 }
 
+function getDetailsUrl (features, currentCompany, savedCompany) {
+  const isEditingCompanyInNewLayout = features['companies-new-layout'] && currentCompany
+
+  return isEditingCompanyInNewLayout
+    ? `/companies/${savedCompany.id}/business-details`
+    : `/companies/${savedCompany.id}`
+}
+
 async function handleFormPost (req, res, next) {
   try {
     const token = req.session.token
@@ -88,9 +96,10 @@ async function handleFormPost (req, res, next) {
     }
 
     const savedCompany = await companyFormService.saveCompanyForm(token, req.body)
+    const detailsUrl = getDetailsUrl(res.locals.features, res.locals.company, savedCompany)
 
     req.flash('success', 'Company record updated')
-    res.redirect(`/companies/${savedCompany.id}`)
+    res.redirect(detailsUrl)
   } catch (response) {
     if (response.errors) {
       // Leeloo has inconsistant structure to return errors.

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -7,8 +7,9 @@ module.exports = ({
   company,
   contact,
   interaction,
-  investment,
   order,
+  investment,
+  companiesHouseRecord,
   features = {},
 }) => {
   return {
@@ -31,6 +32,7 @@ module.exports = ({
         interaction,
         order,
         investment,
+        companiesHouseRecord,
         features,
       },
     },


### PR DESCRIPTION
https://trello.com/c/5ZazZcfQ/830-add-companies-new-layout-feature-flag-for-switching-on-off-layout-for-data-hub-companies

If the new layout flag is enabled and a company is being edited then redirect to business details
view. In all other scenarios, redirect to default company view.

The outcome of this change can be seen by enabling the `companies-new-layout` flag locally and then editing details by browsing to `Business details` for a Data Hub company, and then click the `Edit` link.
