### PR TITLE
Add check for companies-new-layout flag

### DIFF
--- a/src/apps/companies/controllers/advisers.js
+++ b/src/apps/companies/controllers/advisers.js
@@ -5,7 +5,7 @@ const { coreTeamLabels } = require('../labels')
 
 async function renderAdvisers (req, res, next) {
   try {
-    const { company } = res.locals
+    const { company, features } = res.locals
     const token = req.session.token
     const { global_account_manager: globalAccountManager, adviser_on_core_team: adviserOnCoreTeam, location, team } = coreTeamLabels
     const columns = {
@@ -23,7 +23,9 @@ async function renderAdvisers (req, res, next) {
     const coreTeam = await getOneListGroupCoreTeam(token, company.id)
       .then(transformCoreTeamToCollection)
 
-    const view = company.duns_number ? 'companies/views/advisers' : 'companies/views/_deprecated/advisers'
+    const view = (company.duns_number || features['companies-new-layout'])
+      ? 'companies/views/advisers'
+      : 'companies/views/_deprecated/advisers'
 
     res
       .breadcrumb(company.name, `/companies/${company.id}`)

--- a/src/apps/companies/controllers/audit.js
+++ b/src/apps/companies/controllers/audit.js
@@ -6,8 +6,10 @@ const { transformApiResponseToCollection } = require('../../../modules/api/trans
 async function renderAuditLog (req, res, next) {
   const token = req.session.token
   const page = req.query.page || 1
-  const { company } = res.locals
-  const view = company.duns_number ? 'companies/views/audit' : 'companies/views/_deprecated/audit'
+  const { company, features } = res.locals
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/audit'
+    : 'companies/views/_deprecated/audit'
 
   try {
     const auditLog = await getCompanyAuditLog(token, company.id, page)

--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -4,7 +4,7 @@ const { contactFiltersFields, companyContactSortForm } = require('../../contacts
 const { buildSelectedFiltersSummary } = require('../../builders')
 
 function renderContacts (req, res) {
-  const { company } = res.locals
+  const { company, features } = res.locals
   const filtersFields = filter(contactFiltersFields, (field) => {
     return ['name', 'archived'].includes(field.name)
   })
@@ -21,7 +21,9 @@ function renderContacts (req, res) {
     url: `/contacts/create?company=${company.id}`,
   }]
 
-  const view = company.duns_number ? 'companies/views/contacts' : 'companies/views/_deprecated/contacts'
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/contacts'
+    : 'companies/views/_deprecated/contacts'
 
   res
     .breadcrumb(company.name, `/companies/${company.id}`)

--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -6,9 +6,9 @@ const {
 } = require('../transformers')
 
 async function renderDetails (req, res) {
-  const { company } = res.locals
+  const { company, features } = res.locals
 
-  if (company.duns_number) {
+  if (company.duns_number || features['companies-new-layout']) {
     return res.redirect('interactions')
   }
 

--- a/src/apps/companies/controllers/documents.js
+++ b/src/apps/companies/controllers/documents.js
@@ -1,6 +1,8 @@
 function renderDocuments (req, res) {
-  const { company } = res.locals
-  const view = company.duns_number ? 'companies/views/documents' : 'companies/views/_deprecated/documents'
+  const { company, features } = res.locals
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/documents'
+    : 'companies/views/_deprecated/documents'
 
   return res
     .breadcrumb(company.name, `/companies/${company.id}`)

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -8,9 +8,11 @@ const { transformCompanyToExportDetailsView } = require('../transformers')
 const { exportDetailsLabels } = require('../labels')
 
 function renderExports (req, res) {
-  const { company } = res.locals
+  const { company, features } = res.locals
   const exportDetails = transformCompanyToExportDetailsView(company)
-  const view = company.duns_number ? 'companies/views/exports-view' : 'companies/views/_deprecated/exports-view'
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/exports-view'
+    : 'companies/views/_deprecated/exports-view'
 
   res
     .breadcrumb(company.name, `/companies/${company.id}`)
@@ -37,8 +39,10 @@ function populateExportForm (req, res, next) {
 }
 
 function renderExportEdit (req, res) {
-  const { company } = res.locals
-  const view = company.duns_number ? 'companies/views/exports-edit' : 'companies/views/_deprecated/exports-edit'
+  const { company, features } = res.locals
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/exports-edit'
+    : 'companies/views/_deprecated/exports-edit'
 
   res
     .breadcrumb(company.name, `/companies/${company.id}`)

--- a/src/apps/companies/controllers/investments.js
+++ b/src/apps/companies/controllers/investments.js
@@ -4,16 +4,17 @@ const { transformApiResponseToCollection } = require('../../../modules/api/trans
 
 async function renderInvestments (req, res, next) {
   const { token } = req.session
-  const { company } = res.locals
-  const page = req.query.page || 1
-  const view = company.duns_number ? 'companies/views/investments' : 'companies/views/_deprecated/investments'
+  const { company, features } = res.locals
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/investments'
+    : 'companies/views/_deprecated/investments'
   const actionButtons = company.archived ? undefined : [{
     label: 'Add investment project',
     url: `/investments/projects/create/${company.id}`,
   }]
 
   try {
-    const results = await getCompanyInvestmentProjects(token, company.id, page)
+    const results = await getCompanyInvestmentProjects(token, company.id, req.query.page)
       .then(transformApiResponseToCollection(
         { query: req.query },
         transformInvestmentProjectToListItem,

--- a/src/apps/companies/controllers/orders.js
+++ b/src/apps/companies/controllers/orders.js
@@ -5,8 +5,10 @@ const { transformOrderToListItem } = require('../../omis/transformers')
 async function renderOrders (req, res, next) {
   const token = req.session.token
   const page = req.query.page || 1
-  const { company } = res.locals
-  const view = company.duns_number ? 'companies/views/orders' : 'companies/views/_deprecated/orders'
+  const { company, features } = res.locals
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/orders'
+    : 'companies/views/_deprecated/orders'
   const actionButtons = company.archived ? undefined : [{
     label: 'Add order',
     url: `/omis/create?company=${company.id}&skip-company=true`,

--- a/src/apps/companies/controllers/subsidiary-link.js
+++ b/src/apps/companies/controllers/subsidiary-link.js
@@ -1,12 +1,15 @@
 const { companyDetailsLabels } = require('../labels')
 
 function renderLinkSubsidiary (req, res) {
-  const { company } = res.locals
+  const { company, features } = res.locals
+  const view = features['companies-new-layout']
+    ? 'companies/views/link-subsidiary.njk'
+    : 'companies/views/_deprecated/link-subsidiary.njk'
 
   res
     .breadcrumb(company.name, `/companies/${company.id}`)
     .breadcrumb(companyDetailsLabels.link_subsidiary)
-    .render('companies/views/_deprecated/link-subsidiary.njk')
+    .render(view)
 }
 
 module.exports = {

--- a/src/apps/companies/controllers/timeline.js
+++ b/src/apps/companies/controllers/timeline.js
@@ -5,8 +5,10 @@ const { transformApiResponseToCollection } = require('../../../modules/api/trans
 async function renderTimeline (req, res, next) {
   const token = req.session.token
   const page = req.query.page || 1
-  const { company } = res.locals
-  const view = company.duns_number ? 'companies/views/timeline' : 'companies/views/_deprecated/timeline'
+  const { company, features } = res.locals
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/timeline'
+    : 'companies/views/_deprecated/timeline'
 
   try {
     const timeline = await getCompanyTimeline(token, company.id, page)

--- a/src/apps/companies/views/link-subsidiary.njk
+++ b/src/apps/companies/views/link-subsidiary.njk
@@ -1,0 +1,37 @@
+{% extends "_layouts/template.njk" %}
+
+{% block local_header %}
+  {% call LocalHeader({ heading: heading }) %}{% endcall %}
+{% endblock %}
+
+{% block body_main_content %}
+
+  {% set summaryActionsHTML %}
+    <a id="return-to-subsidiaries-list" class="button button--secondary" href="{{'/companies/' + company.id + '/subsidiaries'}}">Back</a>
+  {% endset %}
+
+  {{ EntitySearchForm({
+    inputName: 'term',
+    inputLabel: 'Search and select a subsidiary',
+    inputPlaceholder: 'Search for company',
+    inputHint: 'Search for the registered company name, company number or address',
+    searchTerm: searchTerm,
+    isLabelHidden: false,
+    action: '/companies/' + company.id + '/hierarchies/subsidiaries/search'
+  }) }}
+
+  {{ CollectionContent(results | assign({
+    highlightTerm: searchTerm,
+    countLabel: 'company',
+    query: QUERY,
+    actionButtons: actionButtons
+  })) }}
+
+  {{ Message({
+    type: 'muted',
+    text: 'If you can’t find the company you’re looking for, try a different search term, check the company’s website or any email correspondence that contains company registration details'
+  }) }}
+
+  {{ Pagination(companies.pagination) }}
+
+{% endblock %}

--- a/test/unit/apps/companies/controllers/advisers.test.js
+++ b/test/unit/apps/companies/controllers/advisers.test.js
@@ -84,5 +84,31 @@ describe('Company contact list controller', () => {
         { text: 'Advisers' },
       ], 'companies/views/advisers', 'One List Corp')
     })
+
+    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        nock(config.apiRoot)
+          .get(`/v3/company/${companyMock.id}/one-list-group-core-team`)
+          .reply(200, coreTeamMock)
+
+        await renderAdvisers(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests([
+        { text: companyMock.name, href: `/companies/${companyMock.id}` },
+        { text: 'Advisers' },
+      ], 'companies/views/advisers', 'Mercury Trading Ltd')
+    })
   })
 })

--- a/test/unit/apps/companies/controllers/audit.test.js
+++ b/test/unit/apps/companies/controllers/audit.test.js
@@ -88,6 +88,27 @@ describe('Company audit controller', () => {
 
       commonTests(dnbCompanyMock.id, 'companies/views/audit')
     })
+
+    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        this.getCompanyAuditLogStub.resolves(auditLogMock)
+
+        await this.controller.renderAuditLog(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests(companyMock.id, 'companies/views/audit')
+    })
   })
 
   context('when audit rejects', () => {

--- a/test/unit/apps/companies/controllers/contacts.test.js
+++ b/test/unit/apps/companies/controllers/contacts.test.js
@@ -91,6 +91,33 @@ describe('Company contact list controller', () => {
       })
     })
 
+    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        this.controller.renderContacts(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+        )
+      })
+
+      commonTests(companyMock.id, 'companies/views/contacts')
+
+      it('should set the correct add button', () => {
+        const props = this.middlewareParameters.resMock.render.args[0][1]
+
+        expect(props.actionButtons).to.deep.equal([{
+          label: 'Add contact',
+          url: `/contacts/create?company=${companyMock.id}`,
+        }])
+      })
+    })
+
     context('when the company is archived', () => {
       beforeEach(() => {
         this.middlewareParameters = buildMiddlewareParameters({

--- a/test/unit/apps/companies/controllers/details.test.js
+++ b/test/unit/apps/companies/controllers/details.test.js
@@ -111,5 +111,35 @@ describe('Companies details controller', () => {
         expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
       })
     })
+
+    context('when the company is a Data Hub company and the companies new layout feature is enabled', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: minimalCompany,
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        await renderDetails(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy
+        )
+      })
+
+      it('should not render the template', () => {
+        expect(this.middlewareParameters.resMock.render).to.not.be.called
+      })
+
+      it('should not add breadcrumbs', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.not.be.called
+      })
+
+      it('should redirect to interactions', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith('interactions')
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+      })
+    })
   })
 })

--- a/test/unit/apps/companies/controllers/documents.test.js
+++ b/test/unit/apps/companies/controllers/documents.test.js
@@ -89,5 +89,28 @@ describe('Companies documents controller', () => {
 
       commonTests(dnbCompanyMock.name, dnbCompanyMock.id, 'companies/views/documents', archivedDocumentsPath)
     })
+
+    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+      const archivedDocumentsPath = 'mock-document-url'
+
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: {
+            ...companyMock,
+            archived_documents_url_path: archivedDocumentsPath,
+          },
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        renderDocuments(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+        )
+      })
+
+      commonTests(companyMock.name, companyMock.id, 'companies/views/documents', archivedDocumentsPath)
+    })
   })
 })

--- a/test/unit/apps/companies/controllers/exports.test.js
+++ b/test/unit/apps/companies/controllers/exports.test.js
@@ -77,6 +77,24 @@ describe('Company export controller', () => {
 
       commonTests(dnbCompanyMock, 'companies/views/exports-view')
     })
+
+    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        this.controller.renderExports(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+        )
+      })
+
+      commonTests(companyMock, 'companies/views/exports-view')
+    })
   })
 
   describe('#populateExportForm', () => {
@@ -197,6 +215,25 @@ describe('Company export controller', () => {
       beforeEach(() => {
         this.middlewareParameters = buildMiddlewareParameters({
           company: dnbCompanyMock,
+        })
+
+        this.controller.renderExportEdit(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests('companies/views/exports-edit')
+    })
+
+    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
         })
 
         this.controller.renderExportEdit(

--- a/test/unit/apps/companies/controllers/investments.test.js
+++ b/test/unit/apps/companies/controllers/investments.test.js
@@ -59,6 +59,9 @@ describe('Company investments controller', () => {
           this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)
 
           this.middlewareParameters = buildMiddlewareParameters({
+            requestQuery: {
+              page: 1,
+            },
             company: companyMock,
           })
 
@@ -77,9 +80,10 @@ describe('Company investments controller', () => {
           this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)
 
           this.middlewareParameters = buildMiddlewareParameters({
-            company: {
-              ...dnbCompanyMock,
+            requestQuery: {
+              page: 1,
             },
+            company: dnbCompanyMock,
           })
 
           await this.controller.renderInvestments(
@@ -90,6 +94,30 @@ describe('Company investments controller', () => {
         })
 
         commonTests(dnbCompanyMock.id, 'companies/views/investments')
+      })
+
+      context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+        beforeEach(async () => {
+          this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)
+
+          this.middlewareParameters = buildMiddlewareParameters({
+            requestQuery: {
+              page: 1,
+            },
+            company: companyMock,
+            features: {
+              'companies-new-layout': true,
+            },
+          })
+
+          await this.controller.renderInvestments(
+            this.middlewareParameters.reqMock,
+            this.middlewareParameters.resMock,
+            this.middlewareParameters.nextSpy,
+          )
+        })
+
+        commonTests(companyMock.id, 'companies/views/investments')
       })
     })
 

--- a/test/unit/apps/companies/controllers/orders.test.js
+++ b/test/unit/apps/companies/controllers/orders.test.js
@@ -4,7 +4,7 @@ const ordersMock = require('~/test/unit/data/omis/collection.json')
 const companyMock = require('~/test/unit/data/company.json')
 const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
 
-describe('Company investments controller', () => {
+describe('Company orders controller', () => {
   beforeEach(() => {
     this.searchStub = sinon.stub()
     this.transformOrderToListItemSpy = sinon.spy()
@@ -23,7 +23,7 @@ describe('Company investments controller', () => {
     })
   })
 
-  context('when investments returns successfully', () => {
+  context('when orders returns successfully', () => {
     context('with default page number', () => {
       const commonTests = (expectedCompanyId, expectedTemplate) => {
         it('should call search with correct arguments', () => {
@@ -81,14 +81,33 @@ describe('Company investments controller', () => {
         commonTests(companyMock.id, 'companies/views/_deprecated/orders')
       })
 
+      context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+        beforeEach(async () => {
+          this.searchStub.resolves(ordersMock.results)
+
+          this.middlewareParameters = buildMiddlewareParameters({
+            company: companyMock,
+            features: {
+              'companies-new-layout': true,
+            },
+          })
+
+          await this.controller.renderOrders(
+            this.middlewareParameters.reqMock,
+            this.middlewareParameters.resMock,
+            this.middlewareParameters.nextSpy,
+          )
+        })
+
+        commonTests(companyMock.id, 'companies/views/orders')
+      })
+
       context('when the company does have a DNB number', () => {
         beforeEach(async () => {
           this.searchStub.resolves(ordersMock.results)
 
           this.middlewareParameters = buildMiddlewareParameters({
-            company: {
-              ...dnbCompanyMock,
-            },
+            company: dnbCompanyMock,
           })
 
           await this.controller.renderOrders(

--- a/test/unit/apps/companies/controllers/subsidiary-link.test.js
+++ b/test/unit/apps/companies/controllers/subsidiary-link.test.js
@@ -1,0 +1,62 @@
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+
+const companyMock = require('~/test/unit/data/companies/minimal-company.json')
+const { renderLinkSubsidiary } = require('~/src/apps/companies/controllers/subsidiary-link')
+
+describe('Subsidiary link controller', () => {
+  describe('#renderLinkSubsidiary', () => {
+    const commonTests = (expectedTemplate) => {
+      it('should add two breadcrumbs', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledTwice
+      })
+
+      it('should add the company breadcrumb', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(companyMock.name, `/companies/${companyMock.id}`)
+      })
+
+      it('should add the "Link subsidiary" breadcrumb', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith('Link subsidiary')
+      })
+
+      it('should render the view', () => {
+        expect(this.middlewareParameters.resMock.render).to.be.calledWith(expectedTemplate)
+        expect(this.middlewareParameters.resMock.render).to.be.calledOnce
+      })
+    }
+
+    context('when the companies new layout flag is enabled', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+        })
+
+        renderLinkSubsidiary(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests('companies/views/_deprecated/link-subsidiary.njk')
+    })
+
+    context('when the companies new layout flag is not enabled', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        renderLinkSubsidiary(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests('companies/views/link-subsidiary.njk')
+    })
+  })
+})

--- a/test/unit/apps/companies/controllers/timeline.test.js
+++ b/test/unit/apps/companies/controllers/timeline.test.js
@@ -29,7 +29,7 @@ describe('Company timeline controller', () => {
         })
       }
 
-      context('when rendering for a company without a DUNS number', () => {
+      context('when the company does not have a DUNS number', () => {
         beforeEach(async () => {
           nock(config.apiRoot)
             .get(`/v3/company/${companyMock.id}/timeline?limit=10&offset=0`)
@@ -52,7 +52,7 @@ describe('Company timeline controller', () => {
         ], 'companies/views/_deprecated/timeline')
       })
 
-      context('when rendering for a company with a DUNS number', () => {
+      context('when the company does have a DUNS number', () => {
         beforeEach(async () => {
           nock(config.apiRoot)
             .get(`/v3/company/${dnbCompanyMock.id}/timeline?limit=10&offset=0`)
@@ -71,6 +71,32 @@ describe('Company timeline controller', () => {
 
         commonTests([
           { text: dnbCompanyMock.name, href: `/companies/${dnbCompanyMock.id}` },
+          { text: 'Timeline' },
+        ], 'companies/views/timeline')
+      })
+
+      context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+        beforeEach(async () => {
+          nock(config.apiRoot)
+            .get(`/v3/company/${companyMock.id}/timeline?limit=10&offset=0`)
+            .reply(200, timelineMock)
+
+          this.middlewareParameters = buildMiddlewareParameters({
+            company: companyMock,
+            features: {
+              'companies-new-layout': true,
+            },
+          })
+
+          await renderTimeline(
+            this.middlewareParameters.reqMock,
+            this.middlewareParameters.resMock,
+            this.middlewareParameters.nextSpy,
+          )
+        })
+
+        commonTests([
+          { text: companyMock.name, href: `/companies/${companyMock.id}` },
           { text: 'Timeline' },
         ], 'companies/views/timeline')
       })


### PR DESCRIPTION
https://trello.com/c/5ZazZcfQ/830-add-companies-new-layout-feature-flag-for-switching-on-off-layout-for-data-hub-companies

If the `companies-new-layout` flag is enabled then the new layout will be presented for both Data Hub and D&B companies.

To demo this locally you can enable the `companies-new-layout` and browse to a Data Hub company.

This change does not cover all of the company views as some pieces have been separated into smaller PRs.