### PR TITLE
Present and redirect to new views if new layout flag enabled

### DIFF
--- a/src/apps/companies/controllers/hierarchies.js
+++ b/src/apps/companies/controllers/hierarchies.js
@@ -1,10 +1,13 @@
-function renderAddGlobalHQ (req, res, next) {
-  const { id: companyId, name: companyName } = res.locals.company
+function renderAddGlobalHQ (req, res) {
+  const { company, features } = res.locals
+  const view = features['companies-new-layout']
+    ? 'companies/views/add-global-hq.njk'
+    : 'companies/views/_deprecated/add-global-hq.njk'
 
   res
-    .breadcrumb(companyName, `/companies/${companyId}`)
+    .breadcrumb(company.name, `/companies/${company.id}`)
     .breadcrumb('Link Global HQ')
-    .render('companies/views/_deprecated/add-global-hq.njk')
+    .render(view)
 }
 
 module.exports = {

--- a/src/apps/companies/middleware/hierarchies.js
+++ b/src/apps/companies/middleware/hierarchies.js
@@ -6,21 +6,28 @@ function transformErrorMessage (error) {
   return get(error, 'global_headquarters', ['There has been an error'])[0]
 }
 
+function getDetailsUrl (features, companyId) {
+  return features['companies-new-layout']
+    ? `/companies/${companyId}/business-details`
+    : `/companies/${companyId}/details`
+}
+
 async function setGlobalHQ (req, res, next) {
   const token = req.session.token
   const companyId = req.params.companyId
   const globalHqId = req.params.globalHqId
   const body = { global_headquarters: globalHqId }
+  const detailsUrl = getDetailsUrl(res.locals.features, companyId)
 
   try {
-    const response = await updateCompany(token, companyId, body)
+    await updateCompany(token, companyId, body)
 
     req.flash('success', 'You’ve linked the Global Headquarters')
-    return res.redirect(`/companies/${response.id}/details`)
+    return res.redirect(detailsUrl)
   } catch (error) {
     if (error.statusCode === 400) {
       req.flash('error', transformErrorMessage(error.error))
-      return res.redirect(`/companies/${companyId}/details`)
+      return res.redirect(detailsUrl)
     }
     next(error)
   }
@@ -30,16 +37,17 @@ async function removeGlobalHQ (req, res, next) {
   const token = req.session.token
   const companyId = req.params.companyId
   const body = { global_headquarters: null }
+  const detailsUrl = getDetailsUrl(res.locals.features, companyId)
 
   try {
-    const response = await updateCompany(token, companyId, body)
+    await updateCompany(token, companyId, body)
 
     req.flash('success', 'You’ve removed the link to Global Headquarters')
-    return res.redirect(`/companies/${response.id}/details`)
+    return res.redirect(detailsUrl)
   } catch (error) {
     if (error.statusCode === 400) {
       req.flash('error', transformErrorMessage(error.error))
-      return res.redirect(`/companies/${companyId}/details`)
+      return res.redirect(detailsUrl)
     }
     next(error)
   }

--- a/src/apps/companies/views/add-global-hq.njk
+++ b/src/apps/companies/views/add-global-hq.njk
@@ -1,0 +1,33 @@
+{% extends "_layouts/template.njk" %}
+
+{% block local_header %}
+  {% call LocalHeader({ heading: heading }) %}{% endcall %}
+{% endblock %}
+
+{% block body_main_content %}
+
+  {{ EntitySearchForm({
+    inputName: 'term',
+    inputLabel: 'Search and select the Global HQ',
+    inputPlaceholder: 'Search for company',
+    inputHint: 'Search for the registered company name, company number or address',
+    searchTerm: searchTerm,
+    isLabelHidden: false,
+    action: '/companies/' + company.id + '/hierarchies/ghq/search'
+  }) }}
+
+  {{ CollectionContent(results | assign({
+    highlightTerm: searchTerm,
+    countLabel: 'company',
+    listModifier: 'block-links',
+    query: QUERY
+  })) }}
+
+  {{ Message({
+    type: 'muted',
+    text: 'If you can’t find the company you’re looking for, it may not be a Global HQ. You should check if it is a Global HQ by clicking ‘Companies’ at the top of the page and searching for it there.'
+  }) }}
+
+  {{ Pagination(companies.pagination) }}
+
+{% endblock %}

--- a/test/unit/apps/companies/middleware/hierarchies.test.js
+++ b/test/unit/apps/companies/middleware/hierarchies.test.js
@@ -1,259 +1,453 @@
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+
 const config = require('~/config')
-const hierarchiesMiddleware = require('~/src/apps/companies/middleware/hierarchies')
+const { setGlobalHQ, removeGlobalHQ, addSubsidiary } = require('~/src/apps/companies/middleware/hierarchies')
+
+const globalHeadquartersId = '1'
+const subsidiaryCompanyId = '2'
 
 describe('Company hierarchies middleware', () => {
-  beforeEach(() => {
-    this.resMock = {
-      ...globalRes,
-      redirect: sinon.spy(),
-    }
-
-    this.reqMock = {
-      ...globalReq,
-      session: {},
-      params: {},
-      flash: sinon.spy(),
-    }
-
-    this.nextSpy = sinon.spy()
-
-    this.globalHeadquartersId = '1'
-    this.subsidiaryCompanyId = '2'
-  })
-
   describe('#setGlobalHQ', () => {
-    beforeEach(() => {
-      this.reqMock.params = {
-        companyId: this.subsidiaryCompanyId,
-        globalHqId: this.globalHeadquartersId,
-      }
-    })
-
-    context('company update works', () => {
+    context('when company update is successful', () => {
       beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+            globalHqId: globalHeadquartersId,
+          },
+        })
+
         nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.globalHeadquartersId,
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
           })
-          .reply(200, { id: this.subsidiaryCompanyId })
+          .reply(200, { id: subsidiaryCompanyId })
 
-        await hierarchiesMiddleware.setGlobalHQ(this.reqMock, this.resMock, this.nextSpy)
-      })
-
-      it('should call the API with the correct params', () => {
-        expect(nock.isDone()).to.be.true
+        await setGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
       it('should redirect', () => {
-        expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.subsidiaryCompanyId}/details`)
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
       })
 
       it('should call flash', () => {
-        expect(this.reqMock.flash).to.have.been.calledOnce
-        expect(this.reqMock.flash).to.be.calledWith('success', 'You’ve linked the Global Headquarters')
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve linked the Global Headquarters')
       })
     })
 
-    context('updateCompany returns error 500', () => {
+    context('when company update is successful and the companies new layout feature is enabled', () => {
       beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+            globalHqId: globalHeadquartersId,
+          },
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
         nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.globalHeadquartersId,
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
+          })
+          .reply(200, { id: subsidiaryCompanyId })
+
+        await setGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should redirect', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/business-details`)
+      })
+
+      it('should call flash', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve linked the Global Headquarters')
+      })
+    })
+
+    context('when company update fails with a server error', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+            globalHqId: globalHeadquartersId,
+          },
+        })
+
+        nock(config.apiRoot)
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
           })
           .reply(500, 'Error message')
 
-        await hierarchiesMiddleware.setGlobalHQ(this.reqMock, this.resMock, this.nextSpy)
+        await setGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
-      it('should call next', () => {
-        expect(this.nextSpy.calledOnce).to.be.true
-
-        expect(this.nextSpy).to.be.calledWith(sinon.match({
+      it('should call next with an error', () => {
+        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
+        expect(this.middlewareParameters.nextSpy).to.be.calledWith(sinon.match({
           message: '500 - "Error message"',
         }))
       })
 
       it('should not set a flash message', () => {
-        expect(this.reqMock.flash).to.not.be.called
+        expect(this.middlewareParameters.reqMock.flash).to.not.be.called
       })
     })
 
-    context('updateCompany returns error 400', () => {
+    context('when company update fails with a validation error', () => {
       beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+            globalHqId: globalHeadquartersId,
+          },
+        })
+
         nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.globalHeadquartersId,
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
           })
           .reply(400, { error: 'Error message' })
 
-        await hierarchiesMiddleware.setGlobalHQ(this.reqMock, this.resMock, this.nextSpy)
+        await setGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
       it('should redirect', () => {
-        expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.subsidiaryCompanyId}/details`)
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
       })
 
       it('should call flash', () => {
-        expect(this.reqMock.flash).to.have.been.calledOnce
-        expect(this.reqMock.flash).to.be.calledWith('error', 'There has been an error')
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('error', 'There has been an error')
+      })
+    })
+
+    context('when company update fails with a validation error and the companies new layout feature is enabled', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+            globalHqId: globalHeadquartersId,
+          },
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        nock(config.apiRoot)
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
+          })
+          .reply(400, { error: 'Error message' })
+
+        await setGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should redirect', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/business-details`)
+      })
+
+      it('should call flash', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('error', 'There has been an error')
       })
     })
   })
 
   describe('#removeGlobalHQ', () => {
-    beforeEach(() => {
-      this.reqMock.params = {
-        companyId: this.subsidiaryCompanyId,
-      }
-    })
-
-    context('updateCompany resolves', () => {
+    context('when company update is successful', () => {
       beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+          },
+        })
+
         nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
             global_headquarters: null,
           })
-          .reply(200, { id: this.subsidiaryCompanyId })
+          .reply(200, { id: subsidiaryCompanyId })
 
-        await hierarchiesMiddleware.removeGlobalHQ(this.reqMock, this.resMock, this.nextSpy)
-      })
-
-      it('should call the API with the correct params', () => {
-        expect(nock.isDone()).to.be.true
+        await removeGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
       it('should redirect', () => {
-        expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.subsidiaryCompanyId}/details`)
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
       })
 
       it('should call flash', () => {
-        expect(this.reqMock.flash).to.have.been.calledOnce
-        expect(this.reqMock.flash).to.be.calledWith('success', 'You’ve removed the link to Global Headquarters')
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve removed the link to Global Headquarters')
       })
     })
 
-    context('updateCompany returns error 500', () => {
+    context('when company update is successful and the companies new layout feature is enabled', () => {
       beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+          },
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
         nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: null,
+          })
+          .reply(200, { id: subsidiaryCompanyId })
+
+        await removeGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should redirect', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/business-details`)
+      })
+
+      it('should call flash', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve removed the link to Global Headquarters')
+      })
+    })
+
+    context('when company update fails with a server error', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+          },
+        })
+
+        nock(config.apiRoot)
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
             global_headquarters: null,
           })
           .reply(500, 'Error message')
 
-        await hierarchiesMiddleware.removeGlobalHQ(this.reqMock, this.resMock, this.nextSpy)
+        await removeGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
-      it('should call next', () => {
-        expect(this.nextSpy.calledOnce).to.be.true
-        expect(this.nextSpy).to.be.calledWith(sinon.match({
-          message: '500 - "Error message"',
-        }))
-      })
-    })
-
-    context('update company rejects with 400', () => {
-      beforeEach(async () => {
-        nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: null,
-          })
-          .reply(400, { error: 'Error message' })
-
-        await hierarchiesMiddleware.removeGlobalHQ(this.reqMock, this.resMock, this.nextSpy)
-      })
-
-      it('should redirect', () => {
-        expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.subsidiaryCompanyId}/details`)
-      })
-
-      it('should call flash', () => {
-        expect(this.reqMock.flash).to.have.been.calledOnce
-        expect(this.reqMock.flash).to.be.calledWith('error', 'There has been an error')
-      })
-    })
-  })
-
-  describe('#addSubsidiary', () => {
-    beforeEach(() => {
-      this.reqMock.params = {
-        companyId: this.globalHeadquartersId,
-        subsidiaryCompanyId: this.subsidiaryCompanyId,
-      }
-    })
-
-    context('company update works', () => {
-      beforeEach(async () => {
-        nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.globalHeadquartersId,
-          })
-          .reply(200, { id: this.subsidiaryCompanyId })
-
-        await hierarchiesMiddleware.addSubsidiary(this.reqMock, this.resMock, this.nextSpy)
-      })
-
-      it('should call the API with the correct params', () => {
-        expect(nock.isDone()).to.be.true
-      })
-
-      it('should redirect', () => {
-        expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.globalHeadquartersId}/subsidiaries`)
-      })
-
-      it('should call flash', () => {
-        expect(this.reqMock.flash).to.have.been.calledOnce
-        expect(this.reqMock.flash).to.be.calledWith('success', 'You’ve linked the Subsidiary')
-      })
-    })
-
-    context('updateCompany returns error 500', () => {
-      beforeEach(async () => {
-        nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.globalHeadquartersId,
-          })
-          .reply(500, 'Error message')
-
-        await hierarchiesMiddleware.addSubsidiary(this.reqMock, this.resMock, this.nextSpy)
-      })
-
-      it('should call next', () => {
-        expect(this.nextSpy.calledOnce).to.be.true
-
-        expect(this.nextSpy).to.be.calledWith(sinon.match({
+      it('should call next with an error', () => {
+        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
+        expect(this.middlewareParameters.nextSpy).to.be.calledWith(sinon.match({
           message: '500 - "Error message"',
         }))
       })
 
       it('should not set a flash message', () => {
-        expect(this.reqMock.flash).to.not.be.called
+        expect(this.middlewareParameters.reqMock.flash).to.not.be.called
       })
     })
 
-    context('updateCompany returns error 400', () => {
+    context('when company update fails with a validation error', () => {
       beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+          },
+        })
+
         nock(config.apiRoot)
-          .patch(`/v3/company/${this.subsidiaryCompanyId}`, {
-            global_headquarters: this.globalHeadquartersId,
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: null,
           })
           .reply(400, { error: 'Error message' })
 
-        await hierarchiesMiddleware.addSubsidiary(this.reqMock, this.resMock, this.nextSpy)
+        await removeGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
       it('should redirect', () => {
-        expect(this.resMock.redirect).to.have.been.calledOnce
-        expect(this.resMock.redirect).to.be.calledWith(`/companies/${this.globalHeadquartersId}/subsidiaries`)
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
       })
 
       it('should call flash', () => {
-        expect(this.reqMock.flash).to.have.been.calledOnce
-        expect(this.reqMock.flash).to.be.calledWith('error', 'There has been an error')
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('error', 'There has been an error')
+      })
+    })
+
+    context('when company update fails with a validation error and the companies new layout feature is enabled', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            companyId: subsidiaryCompanyId,
+          },
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        nock(config.apiRoot)
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: null,
+          })
+          .reply(400, { error: 'Error message' })
+
+        await removeGlobalHQ(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should redirect', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/business-details`)
+      })
+
+      it('should call flash', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('error', 'There has been an error')
+      })
+    })
+  })
+
+  describe('#addSubsidiary', () => {
+    context('when company update is successful', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            subsidiaryCompanyId,
+            companyId: globalHeadquartersId,
+          },
+        })
+
+        nock(config.apiRoot)
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
+          })
+          .reply(200, { id: subsidiaryCompanyId })
+
+        await addSubsidiary(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should redirect', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${globalHeadquartersId}/subsidiaries`)
+      })
+
+      it('should call flash', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve linked the Subsidiary')
+      })
+    })
+
+    context('when company update fails with a server error', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            subsidiaryCompanyId,
+            companyId: globalHeadquartersId,
+          },
+        })
+
+        nock(config.apiRoot)
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
+          })
+          .reply(500, 'Error message')
+
+        await addSubsidiary(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should call next with an error', () => {
+        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
+        expect(this.middlewareParameters.nextSpy).to.be.calledWith(sinon.match({
+          message: '500 - "Error message"',
+        }))
+      })
+
+      it('should not set a flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.not.be.called
+      })
+    })
+
+    context('when company update fails with a validation error', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestParams: {
+            subsidiaryCompanyId,
+            companyId: globalHeadquartersId,
+          },
+        })
+
+        nock(config.apiRoot)
+          .patch(`/v3/company/${subsidiaryCompanyId}`, {
+            global_headquarters: globalHeadquartersId,
+          })
+          .reply(400, { error: 'Error message' })
+
+        await addSubsidiary(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should redirect', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${globalHeadquartersId}/subsidiaries`)
+      })
+
+      it('should call flash', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('error', 'There has been an error')
       })
     })
   })

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -2,6 +2,7 @@ const paths = require('~/src/apps/investments/paths')
 
 module.exports = ({
   requestBody,
+  requestParams = {},
   requestQuery = {},
   breadcrumb = sinon.stub().returnsThis(),
   company,
@@ -18,6 +19,7 @@ module.exports = ({
         token: '1234',
       },
       body: requestBody,
+      params: requestParams,
       query: requestQuery,
       flash: sinon.spy(),
     },


### PR DESCRIPTION
https://trello.com/c/5ZazZcfQ/830-add-companies-new-layout-feature-flag-for-switching-on-off-layout-for-data-hub-companies

This change includes:
- refactor existing tests
- redirect to `Business details` if flag enabled
- present new layout if flag enabled

You can see the result of this change by enabling the `companies-new-layout` flag locally. When you browse to `Business details` of a Data Hub company and click `Link to the Global HQ` you will be presented with the new layout view. Linking the Global HQ will redirect back to `Business details`.

## Before
![screenshot 2019-03-05 at 17 21 30](https://user-images.githubusercontent.com/1150417/53824163-3d0fb180-3f6b-11e9-8867-92206a50bc83.png)

## After
![screenshot 2019-03-05 at 17 30 29](https://user-images.githubusercontent.com/1150417/53824681-6e3cb180-3f6c-11e9-9a74-d695c218d9b7.png)