### PR TITLE
Add companies-new-layout flag check to present streamlined local navigation for Data Hub companies

### DIFF
--- a/src/apps/companies/middleware/local-navigation.js
+++ b/src/apps/companies/middleware/local-navigation.js
@@ -5,9 +5,9 @@ const { setLocalNav } = require('../../middleware')
 const { DEPRECATED_LOCAL_NAV, LOCAL_NAV } = require('../constants')
 
 function setCompaniesLocalNav (req, res, next) {
-  const { company } = res.locals
+  const { company, features } = res.locals
 
-  if (company.duns_number) {
+  if (company.duns_number || features['companies-new-layout']) {
     const navItems = LOCAL_NAV.filter(({ path }) => {
       return (path !== 'advisers' || company.one_list_group_tier)
     })

--- a/test/unit/apps/companies/middleware/local-navigation.test.js
+++ b/test/unit/apps/companies/middleware/local-navigation.test.js
@@ -91,6 +91,46 @@ describe('Companies local navigation', () => {
     })
   })
 
+  context('when the companies new layout flag is enabled', () => {
+    context('default menu items', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: {
+            id: '1234',
+            headquarter_type: null,
+            company_number: null,
+          },
+          user: {
+            permissions: [
+              'company.view_company_timeline',
+              'interaction.view_all_interaction',
+              'company.view_contact',
+              'investment.view_all_investmentproject',
+              'order.view_order',
+            ],
+          },
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        setCompaniesLocalNav(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests([
+        'Interactions',
+        'Company contacts',
+        'Investment',
+        'Export',
+        'Orders',
+      ])
+    })
+  })
+
   context('when the company does not have a DUNS number', () => {
     context('default menu items', () => {
       beforeEach(() => {

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -12,6 +12,7 @@ module.exports = ({
   investment,
   companiesHouseRecord,
   features = {},
+  user,
 }) => {
   return {
     reqMock: {
@@ -36,6 +37,7 @@ module.exports = ({
         investment,
         companiesHouseRecord,
         features,
+        user,
       },
     },
     nextSpy: sinon.spy(),


### PR DESCRIPTION
https://trello.com/c/5ZazZcfQ/830-add-companies-new-layout-feature-flag-for-switching-on-off-layout-for-data-hub-companies

## Change
When the `companies-new-layout` flag is enabled then less items should be available in the local navigation for Data Hub companies.

You can see this by enabling the flag locally and browsing to a Data Hub company.

## Screenshot
![screenshot 2019-03-05 at 17 34 52](https://user-images.githubusercontent.com/1150417/53824988-2bc7a480-3f6d-11e9-88cd-8600d07e7d33.png)
