### PR TITLE
Add companies-new-layout flag check for Data Hub company interactions

### DIFF
--- a/src/apps/companies/middleware/interactions.js
+++ b/src/apps/companies/middleware/interactions.js
@@ -1,6 +1,8 @@
 function setInteractionsDetails (req, res, next) {
-  const { company } = res.locals
-  const view = company.duns_number ? 'companies/views/interactions' : 'companies/views/_deprecated/interactions'
+  const { company, features } = res.locals
+  const view = (company.duns_number || features['companies-new-layout'])
+    ? 'companies/views/interactions'
+    : 'companies/views/_deprecated/interactions'
 
   res.locals.interactions = {
     view,

--- a/test/unit/apps/companies/middleware/interactions.test.js
+++ b/test/unit/apps/companies/middleware/interactions.test.js
@@ -1,0 +1,86 @@
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+
+const companyMock = require('~/test/unit/data/companies/minimal-company.json')
+const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
+const { setInteractionsDetails } = require('~/src/apps/companies/middleware/interactions')
+
+describe('Interactions middleware', () => {
+  describe('#setInteractionsDetails', () => {
+    const commonTests = ({
+      expectedTemplate,
+      expectedReturnLink,
+      expectedEntityName,
+      expectedQuery,
+      expectedAddFlag,
+    }) => {
+      it('should set the view', () => {
+        expect(this.middlewareParameters.resMock.locals.interactions.view).to.equal(expectedTemplate)
+      })
+
+      it('should set the return link', () => {
+        expect(this.middlewareParameters.resMock.locals.interactions.returnLink).to.equal(expectedReturnLink)
+      })
+
+      it('should set the entity name', () => {
+        expect(this.middlewareParameters.resMock.locals.interactions.entityName).to.equal(expectedEntityName)
+      })
+
+      it('should set the query', () => {
+        expect(this.middlewareParameters.resMock.locals.interactions.query).to.deep.equal(expectedQuery)
+      })
+
+      it('should set the add flag', () => {
+        expect(this.middlewareParameters.resMock.locals.interactions.canAdd).to.equal(expectedAddFlag)
+      })
+
+      it('should call next once', () => {
+        expect(this.middlewareParameters.nextSpy).to.be.calledWithExactly()
+        expect(this.middlewareParameters.nextSpy).to.be.calledOnce
+      })
+    }
+
+    context('when the company does not have a DUNS number', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+        })
+
+        setInteractionsDetails(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests({
+        expectedTemplate: 'companies/views/_deprecated/interactions',
+        expectedReturnLink: '/companies/72fda78f-bdc3-44dc-9c22-c8ac82f7bda4/interactions/',
+        expectedEntityName: 'SAMSUNG BIOEPIS UK LIMITED',
+        expectedQuery: { company_id: '72fda78f-bdc3-44dc-9c22-c8ac82f7bda4' },
+        expectedAddFlag: true,
+      })
+    })
+    
+    context('when the company does have a DUNS number', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: dnbCompanyMock,
+        })
+
+        setInteractionsDetails(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests({
+        expectedTemplate: 'companies/views/interactions',
+        expectedReturnLink: '/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/interactions/',
+        expectedEntityName: 'One List Corp',
+        expectedQuery: { company_id: '375094ac-f79a-43e5-9c88-059a7caa17f0' },
+        expectedAddFlag: true,
+      })
+    })
+  })
+})

--- a/test/unit/apps/companies/middleware/interactions.test.js
+++ b/test/unit/apps/companies/middleware/interactions.test.js
@@ -60,7 +60,32 @@ describe('Interactions middleware', () => {
         expectedAddFlag: true,
       })
     })
-    
+
+    context('when the company does not have a DUNS number and the companies new layout flag is enabled', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          company: companyMock,
+          features: {
+            'companies-new-layout': true,
+          },
+        })
+
+        setInteractionsDetails(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      commonTests({
+        expectedTemplate: 'companies/views/interactions',
+        expectedReturnLink: '/companies/72fda78f-bdc3-44dc-9c22-c8ac82f7bda4/interactions/',
+        expectedEntityName: 'SAMSUNG BIOEPIS UK LIMITED',
+        expectedQuery: { company_id: '72fda78f-bdc3-44dc-9c22-c8ac82f7bda4' },
+        expectedAddFlag: true,
+      })
+    })
+
     context('when the company does have a DUNS number', () => {
       beforeEach(() => {
         this.middlewareParameters = buildMiddlewareParameters({


### PR DESCRIPTION
https://trello.com/c/5ZazZcfQ/830-add-companies-new-layout-feature-flag-for-switching-on-off-layout-for-data-hub-companies

## Change
Present the new layout for Data Hub company interactions if the `companies-new-layout` flag is enabled.

## Before
![screenshot 2019-03-05 at 17 33 14](https://user-images.githubusercontent.com/1150417/53824837-c96ea400-3f6c-11e9-9553-c29f7a0b3d9b.png)

## After
![screenshot 2019-03-05 at 17 32 52](https://user-images.githubusercontent.com/1150417/53824847-cf648500-3f6c-11e9-9be1-978b259d7c83.png)
