### PR TITLE
Fix proposition download link

### DIFF
--- a/src/apps/documents/transformers.js
+++ b/src/apps/documents/transformers.js
@@ -17,54 +17,25 @@ function transformLabelsToShowFiles (key, labels) {
 }
 
 function getDownloadLinkOrState (file, proposition_id, investment_project_id) {
-  const output = {
-    type: 'document',
+  const items = {
+    'virus_scanned': ({ id, av_clean }) => {
+      return av_clean
+        ? {
+          url: `/investments/projects/${investment_project_id}/propositions/${proposition_id}/download/${id}`,
+          name: 'Download',
+        }
+        : {
+          type: 'error',
+          name: 'The file didn\'t pass virus scanning, contact your administrator',
+        }
+    },
+    'not_virus_scanned': () => 'File not virus scanned',
+    'virus_scanning_scheduled': () => 'Virus scanning scheduled',
+    'virus_scanning_in_progress': () => 'File is being scanned, try again in a few moments',
+    'virus_scanning_failed': () => 'Virus scanning failed, contact your administrator',
   }
 
-  switch (file.status) {
-    case 'virus_scanned':
-      if (file.av_clean) {
-        return {
-          ...output,
-          status: 'av_clean',
-          message: 'Download',
-          href: `/investments/projects/${investment_project_id}/propositions/${proposition_id}/download/${file.id}`,
-        }
-      } else {
-        return {
-          ...output,
-          status: 'scan_failed',
-          message: 'The file didn\'t pass virus scanning, contact your administrator',
-        }
-      }
-    case 'not_virus_scanned':
-      return {
-        ...output,
-        message: 'File not virus scanned',
-      }
-    case 'virus_scanning_scheduled':
-      return {
-        ...output,
-        message: 'Virus scanning scheduled',
-      }
-    case 'virus_scanning_in_progress':
-      return {
-        ...output,
-        message: 'File is being scanned, try again in a few moments',
-      }
-
-    case 'virus_scanning_failed':
-      return {
-        ...output,
-        message: 'Virus scanning failed, contact your administrator',
-      }
-
-    default:
-      return {
-        ...output,
-        message: 'Virus scanning failed, contact your administrator',
-      }
-  }
+  return items[file.status](file)
 }
 
 function transformFilesResultsToDetails (files, proposition_id, investment_project_id) {

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -41,6 +41,10 @@
   </div>
 {% endmacro %}
 
+{% macro error(data) %}
+  <span class="c-message--error">{{ data.name }}</span>
+{% endmacro %}
+
 {% macro renderItem(data) %}
   {% if data.url %}
     {{ link(data) }}
@@ -60,6 +64,8 @@
     {% else %}
       {{ item.message }}
     {% endif %}
+  {% elif data.type === 'error' %}
+    {{ error(data) }}
   {% else %}
     {{ data.name or data | escapeHtml | safe }}
   {% endif %}

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -56,14 +56,6 @@
     {{ data.name | formatNumber }}
   {% elif data.type === 'details' %}
     {{ details(data) }}
-  {% elif data.type === 'document' %} {# TODO specifically referencing "document" should not be here #}
-    {% if item.status == 'av_clean' %}
-      <a href="{{ item.href }}">{{ item.message }}</a>
-    {% elif item.status == 'scan_failed' %}
-      <span class="c-message--error">{{ item.message }}</span>
-    {% else %}
-      {{ item.message }}
-    {% endif %}
   {% elif data.type === 'error' %}
     {{ error(data) }}
   {% else %}

--- a/test/unit/apps/propositions/transformers.test.js
+++ b/test/unit/apps/propositions/transformers.test.js
@@ -74,31 +74,36 @@ describe('Proposition transformers', () => {
           'Modified on': { type: 'date', name: '2018-05-03T09:49:03.038168Z' },
           Deadline: { type: 'date', name: '2018-05-20' },
           'Assigned to':
-            { first_name: 'Joseph',
+            {
+              first_name: 'Joseph',
               last_name: 'Wright of Derby ',
               name: 'Joseph Wright of Derby',
-              id: '14d9f881-4df4-421b-8181-874f9dc83b76' },
+              id: '14d9f881-4df4-421b-8181-874f9dc83b76',
+            },
           Details: {
             url: undefined,
             name: undefined,
           },
           'File 1':
-            [ 'il_fullxfull.826924229_2xdo.jpg',
-              { type: 'document',
-                status: 'av_clean',
-                message: 'Download',
-                href: '/investments/projects/65e77d82-8ebb-4ee7-b6ac-8c5945c512db/propositions/7d68565a-fc0e-422c-8ce3-df92cd40a64a/download/1a85b301-56ae-4073-97db-a42604c40bea' } ],
+            ['il_fullxfull.826924229_2xdo.jpg',
+              {
+                name: 'Download',
+                url: '/investments/projects/65e77d82-8ebb-4ee7-b6ac-8c5945c512db/propositions/7d68565a-fc0e-422c-8ce3-df92cd40a64a/download/1a85b301-56ae-4073-97db-a42604c40bea',
+              },
+            ],
           'File 2':
-            [ 'totally_not_a_virus.zip',
-              { type: 'document',
-                status: 'scan_failed',
-                message: 'The file didn\'t pass virus scanning, contact your administrator' } ],
+            ['totally_not_a_virus.zip',
+              {
+                name: 'The file didn\'t pass virus scanning, contact your administrator',
+                type: 'error',
+              },
+            ],
           'File 3':
-            [ '780-rainbow-teacosy-1.jpg',
-              { type: 'document',
-                status: 'av_clean',
-                message: 'Download',
-                href: '/investments/projects/65e77d82-8ebb-4ee7-b6ac-8c5945c512db/propositions/7d68565a-fc0e-422c-8ce3-df92cd40a64a/download/1eab8de6-0a9a-4152-95d0-a3eca9ef6a8f' }],
+            ['780-rainbow-teacosy-1.jpg',
+              {
+                name: 'Download',
+                url: '/investments/projects/65e77d82-8ebb-4ee7-b6ac-8c5945c512db/propositions/7d68565a-fc0e-422c-8ce3-df92cd40a64a/download/1eab8de6-0a9a-4152-95d0-a3eca9ef6a8f',
+              }],
         })
       })
     })

--- a/test/unit/components/key-value-table.test.js
+++ b/test/unit/components/key-value-table.test.js
@@ -166,6 +166,33 @@ describe('Key/value table component', () => {
     })
   })
 
+  context('when there is one item and the data is an error', () => {
+    beforeEach(() => {
+      const component = renderComponentToDom('key-value-table', {
+        items: {
+          'Label 1': {
+            name: 'Error message',
+            type: 'error',
+          },
+        },
+      })
+
+      this.rows = component.querySelectorAll('tr')
+    })
+
+    it('should render one row', () => {
+      expect(this.rows.length).to.equal(1)
+    })
+
+    it('should render a label', () => {
+      expect(this.rows[0].querySelector('th').textContent).to.equal('Label 1')
+    })
+
+    it('should render the error message', () => {
+      expect(this.rows[0].querySelector('td span.c-message--error').textContent).to.equal('Error message')
+    })
+  })
+
   context('when there is one item and the data is an object with a name', () => {
     beforeEach(() => {
       const component = renderComponentToDom('key-value-table', {

--- a/test/unit/data/documents/files-response.json
+++ b/test/unit/data/documents/files-response.json
@@ -3,10 +3,10 @@
     "id": "e5de035f-86d5-4cc1-80a3-4b7f03876da8",
     "av_clean": true,
     "created_by": {
-    "first_name": "DIT",
-    "last_name": "Staff",
-    "name": "DIT Staff",
-    "id": "bfd60ca7-b458-4ec1-a75c-dab535d7ceb0"
+      "first_name": "DIT",
+      "last_name": "Staff",
+      "name": "DIT Staff",
+      "id": "bfd60ca7-b458-4ec1-a75c-dab535d7ceb0"
     },
     "created_on": "2018-08-09T14:54:22.252545Z",
     "uploaded_on": "2018-08-09T14:54:22.621718Z",


### PR DESCRIPTION
https://trello.com/c/LZQrc8eG/849-fix-proposition-download-link

## Problem
There was a regression when refactoring the key value table which means that `Download` links were not being rendered correctly.

## Fix
The transformation of the links now returns an `object` containing `name` and `url` fields. This removes the dependency on `download` specific types in the shared key value table component.

In addition more unit tests have been introduced to cover more scenarios.

## Before
![screenshot 2019-03-06 at 22 15 24](https://user-images.githubusercontent.com/1150417/53917879-7cb6c600-405d-11e9-9a50-400fc1543ad7.png)

## After
![screenshot 2019-03-06 at 22 15 05](https://user-images.githubusercontent.com/1150417/53917887-80e2e380-405d-11e9-8fe7-3c8c186029dc.png)
