### PR TITLE
Present new layout for subsidiaries if enabled

### DIFF
--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -7,18 +7,18 @@ const { ENTITIES } = require('../../search/constants')
 async function renderSubsidiaries (req, res, next) {
   try {
     const token = req.session.token
-    const query = req.query
-    const page = query.page || '1'
-    const { company } = res.locals
-    const view = company.duns_number ? 'companies/views/subsidiaries' : 'companies/views/_deprecated/subsidiaries'
+    const { company, features } = res.locals
+    const view = (company.duns_number || features['companies-new-layout'])
+      ? 'companies/views/subsidiaries'
+      : 'companies/views/_deprecated/subsidiaries'
     const actionButtons = company.archived || company.duns_number ? undefined : [{
       label: companyDetailsLabels.link_a_subsidiary,
       url: `/companies/${company.id}/subsidiaries/link`,
     }]
 
-    const subsidiaryCollection = await getCompanySubsidiaries(token, company.id, page)
+    const subsidiaryCollection = await getCompanySubsidiaries(token, company.id, req.query.page)
       .then(transformApiResponseToSearchCollection(
-        { query },
+        { query: req.query },
         ENTITIES,
         transformCompanyToSubsidiaryListItem(res.locals.company),
       ))

--- a/test/unit/apps/companies/controllers/subsidiaries.test.js
+++ b/test/unit/apps/companies/controllers/subsidiaries.test.js
@@ -180,4 +180,40 @@ describe('company subsidiaries controller', () => {
       expect(props.actionButtons).to.be.undefined
     })
   })
+
+  context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v3/company?limit=10&offset=0&sortby=name&global_headquarters_id=${companyMock.id}`)
+        .reply(200, subsidiariesMock)
+
+      this.middlewareParameters = buildMiddlewareParameters({
+        company: companyMock,
+        features: {
+          'companies-new-layout': true,
+        },
+      })
+
+      await renderSubsidiaries(
+        this.middlewareParameters.reqMock,
+        this.middlewareParameters.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+
+      this.subsidiaries = this.middlewareParameters.resMock.render.firstCall.args[1].subsidiaries
+    })
+
+    commonTests({
+      expectedBreadcrumb: 'SAMSUNG BIOEPIS UK LIMITED',
+      expectedTemplate: 'companies/views/subsidiaries',
+      expectedHeading: 'Subsidiaries of SAMSUNG BIOEPIS UK LIMITED',
+      expectedCount: 1,
+    })
+
+    it('should not set actions buttons', () => {
+      const props = this.middlewareParameters.resMock.render.args[0][1]
+
+      expect(props.actionButtons).to.be.undefined
+    })
+  })
 })


### PR DESCRIPTION
https://trello.com/c/5ZazZcfQ/830-add-companies-new-layout-feature-flag-for-switching-on-off-layout-for-data-hub-companies

## Change
If the `companies-new-layout` flag is enabled then the new layout will be presented for Data Hub companies. This change specifically targets the `companies` `Subsidiaries` view.

## Known issue
The `Why can I not link a subsidiary?` should not be displayed for Data Hub companies. A separate PR will be raised for this.

## Before
![screenshot 2019-03-07 at 17 27 47](https://user-images.githubusercontent.com/1150417/53976425-e63ae100-40fe-11e9-84b8-351492c39217.png)

## After
![screenshot 2019-03-07 at 17 31 00](https://user-images.githubusercontent.com/1150417/53976414-e20ec380-40fe-11e9-87a3-0938e0211f3b.png)
