### PR TITLE
Add cypress test for D&B GHQ on One List, viewing business details

### DIFF
--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -31,7 +31,7 @@
       This company was archived on {{company.archived_on | formatDate}} by {{company.archived_by.first_name}} {{company.archived_by.last_name}}. <br>
       <strong>Reason:</strong> {{company.archived_reason}}<br>
       <br>
-      <a href="/companies/{{company.id}}/unarchive">Unarchive</a>
+      <a href="/companies/{{company.id}}/unarchive" data-auto-id="businessDetailsUnarchive">Unarchive</a>
     {% endcall %}
   {% endif %}
 
@@ -43,17 +43,20 @@
         </p>
         <p>
           If you think the information is incomplete or incorrect, <a href="/support">get in touch using the support form</a>.
-        </p>'
+        </p>',
+      attributes: {
+        'data-auto-id': 'businessDetailsWhereDoesInformation'
+      }
     }) }}
   {% endif %}
 
-  {% call DetailsContainer({ heading: 'About ' + company.name, editUrl: editUrl }) %}
-    {% component 'key-value-table', items=aboutDetails %}
+  {% call DetailsContainer({ heading: 'About ' + company.name, editUrl: editUrl, dataAutoId: 'aboutDetailsContainer' }) %}
+    {% component 'key-value-table', items=aboutDetails, dataAutoId='aboutDetails' %}
   {% endcall %}
 
   {% if oneListDetails %}
-    {% call DetailsContainer({ heading: 'Global Account Manager – One List', editUrl: editUrl }) %}
-      {% component 'key-value-table', items=oneListDetails %}
+    {% call DetailsContainer({ heading: 'Global Account Manager – One List', editUrl: editUrl, dataAutoId: 'oneListDetailsContainer' }) %}
+      {% component 'key-value-table', items=oneListDetails, dataAutoId='oneListDetails' %}
 
       <p>
         <a href="advisers">See all advisers on the core team</a>
@@ -61,12 +64,12 @@
     {% endcall %}
   {% endif %}
 
-  {% call DetailsContainer({ heading: 'Business hierarchy', editUrl: editUrl }) %}
-    {% component 'key-value-table', items=businessHierarchyDetails %}
+  {% call DetailsContainer({ heading: 'Business hierarchy', editUrl: editUrl, dataAutoId: 'businessHierarchyDetailsContainer' }) %}
+    {% component 'key-value-table', items=businessHierarchyDetails, dataAutoId='businessHierarchyDetails' %}
   {% endcall %}
 
-  {% call DetailsContainer({ heading: 'DIT sector', editUrl: editUrl }) %}
-    <table class="table--key-value">
+  {% call DetailsContainer({ heading: 'DIT sector', editUrl: editUrl, dataAutoId: 'sectorDetailsContainer' }) %}
+    <table class="table--key-value" data-auto-id="sectorDetails">
       <tbody>
       {% for sector in sectorDetails %}
         <tr>
@@ -78,7 +81,7 @@
   {% endcall %}
 
   {% if regionDetails %}
-    {% call DetailsContainer({ heading: 'DIT region', editUrl: editUrl }) %}
+    {% call DetailsContainer({ heading: 'DIT region', editUrl: editUrl, dataAutoId: 'regionDetailsContainer' }) %}
       <table class="table--key-value">
         <tbody>
           <tr>
@@ -89,10 +92,10 @@
     {% endcall %}
   {% endif %}
 
-  {% call DetailsContainer({ heading: 'Addresses', editUrl: editUrl }) %}
+  {% call DetailsContainer({ heading: 'Addresses', editUrl: editUrl, dataAutoId: 'addressesDetailsContainer' }) %}
     <table class="table--key-value">
       <tbody>
-        <tr>
+        <tr data-auto-id="businessDetailsAddress">
           {% if addressesDetails.trading.address %}
             {{ AddressCell(addressesDetails.trading.meta, addressesDetails.trading.address) }}
           {% endif %}
@@ -105,7 +108,7 @@
   {% endcall %}
 
   {% if archivedDocumentPath %}
-    {% call DetailsContainer({ heading: 'Documents from CDMS' }) %}
+    {% call DetailsContainer({ heading: 'Documents from CDMS', dataAutoId: 'documentsContainer' }) %}
       <table class="table--key-value">
         <tbody>
         <tr>
@@ -122,7 +125,7 @@
   {% endif %}
 
   {% if not company.archived and not company.duns_number %}
-    {% call DetailsContainer({ heading: 'Archive company' }) %}
+    {% call DetailsContainer({ heading: 'Archive company', dataAutoId: 'archiveCompanyContainer' }) %}
       <p>Archive this company if it is no longer required or active.</p>
 
       {% component 'archive-form', {

--- a/src/templates/_components/archive-form.njk
+++ b/src/templates/_components/archive-form.njk
@@ -23,6 +23,9 @@
   {% if url %}
     action="{{ url }}"
   {% endif %}
+  {% if dataAutoId %}
+    data-auto-id="{{ dataAutoId }}"
+  {% endif %}
 >
   <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -64,7 +64,11 @@
 {% endmacro %}
 
 {% if items | length %}
-  <table class="table--key-value{{ ' table--' + variant if variant }}">
+  <table class="table--key-value{{ ' table--' + variant if variant }}"
+    {% if dataAutoId %}
+      data-auto-id="{{ dataAutoId }}"
+    {% endif %}
+  >
     <tbody>
       {% for label, data in items %}
         <tr>

--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -18,7 +18,7 @@
   {% set modifier = props.modifier | concat('') | reverse | join(' c-local-header--') if props.modifier %}
 
   {% if props %}
-    <header class="c-local-header {{ modifier }}" aria-label="local header">
+    <header class="c-local-header {{ modifier }}" aria-label="local header" data-auto-id="localHeader">
       <div class="govuk-width-container">
         {% if breadcrumbs|length > 1 %}
           {{ govukBreadcrumbs({ items: breadcrumbs }) }}

--- a/src/templates/_macros/details-container/template.njk
+++ b/src/templates/_macros/details-container/template.njk
@@ -1,4 +1,8 @@
-<div class="c-details-container">
+<div class="c-details-container"
+  {% if props.dataAutoId %}
+    data-auto-id="{{ props.dataAutoId }}"
+  {% endif %}
+>
   {% if props.heading %}
     <h2 class="govuk-heading-m" style="margin-bottom: 0">{{ props.heading }}</h2>
   {% endif %}

--- a/test/functional/cypress/fixtures/one-list-corp.json
+++ b/test/functional/cypress/fixtures/one-list-corp.json
@@ -1,0 +1,4 @@
+{
+  "id": "375094ac-f79a-43e5-9c88-059a7caa17f0",
+  "name": "One List Corp",
+}

--- a/test/functional/cypress/selectors/company-business-details.js
+++ b/test/functional/cypress/selectors/company-business-details.js
@@ -1,0 +1,17 @@
+module.exports = () => {
+  return {
+    unarchiveLink: '[data-auto-id="businessDetailsUnarchive"]',
+    whereDoesInformation: '[data-auto-id="businessDetailsWhereDoesInformation"]',
+    address: (cellNumber) => {
+      const cellSelector = `[data-auto-id="businessDetailsAddress"] td:nth-child(${cellNumber})`
+      return {
+        badge: (badgeNumber) => {
+          return `${cellSelector} div div:nth-child(${badgeNumber}) span.c-badge`
+        },
+        line: (lineNumber) => {
+          return `${cellSelector} ul li:nth-child(${lineNumber})`
+        },
+      }
+    },
+  }
+}

--- a/test/functional/cypress/selectors/details-container.js
+++ b/test/functional/cypress/selectors/details-container.js
@@ -1,0 +1,8 @@
+module.exports = (dataAutoId) => {
+  const containerSelector = `[data-auto-id="${dataAutoId}"]`
+  return {
+    container: containerSelector,
+    heading: `${containerSelector} h2`,
+    editLink: `${containerSelector} a.c-details-container__edit-link`,
+  }
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -1,4 +1,8 @@
+exports.companyBusinessDetails = require('./company-business-details')
 exports.companyInteraction = require('./company-interaction')
+exports.detailsContainer = require('./details-container')
 exports.interactionDetails = require('./interaction-details')
+exports.keyValueTable = require('./key-value-table')
+exports.localHeader = require('./local-header')
 exports.nav = require('./nav')
 exports.addInteraction = require('./add-interaction')

--- a/test/functional/cypress/selectors/key-value-table.js
+++ b/test/functional/cypress/selectors/key-value-table.js
@@ -1,0 +1,11 @@
+module.exports = (dataAutoId) => {
+  const tableSelector = `[data-auto-id="${dataAutoId}"]`
+  return {
+    keyCell: (rowNumber) => {
+      return `${tableSelector} tr:nth-child(${rowNumber}) th`
+    },
+    valueCell: (rowNumber) => {
+      return `${tableSelector} tr:nth-child(${rowNumber}) td`
+    },
+  }
+}

--- a/test/functional/cypress/selectors/local-header.js
+++ b/test/functional/cypress/selectors/local-header.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+  const localHeaderSelector = '[data-auto-id="localHeader"]'
+  return {
+    heading: `${localHeaderSelector} h1.c-local-header__heading`,
+  }
+}

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -1,0 +1,134 @@
+const { keys, forEach } = require('lodash')
+
+const oneListCorp = require('../../fixtures/one-list-corp.json')
+const selectors = require('../../selectors/index.js')
+
+describe('Companies business details', () => {
+  context('when viewing business details for a Dun & Bradstreet GHQ company on the One List not in the UK', () => {
+    before(() => {
+      cy.visit(`/companies/${oneListCorp.id}/business-details`)
+    })
+
+    it('should display the "Business details" heading', () => {
+      cy.get(selectors.localHeader().heading).should('have.text', 'Business details')
+    })
+
+    it('should display the "Where does information on this page come from?" details summary', () => {
+      cy.get(selectors.companyBusinessDetails().whereDoesInformation).should('be.visible')
+    })
+
+    it('should not display the "Unarchive" link', () => {
+      cy.get(selectors.companyBusinessDetails().unarchiveLink).should('not.exist')
+    })
+
+    it('should display the "About" details container heading', () => {
+      assertDetailsContainerHeading('aboutDetailsContainer', 'About One List Corp')
+    })
+
+    it('should not display the "About" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('aboutDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "About" details', () => {
+      assertKeyValueTable('aboutDetails', {
+        'Trading names': 'Not set',
+        'Annual turnover': '£33.5M+',
+        'Number of employees': '500+',
+        'Website': 'Not set',
+      })
+    })
+
+    it('should display the "Global Account Manager - One List" details container heading', () => {
+      assertDetailsContainerHeading('oneListDetailsContainer', 'Global Account Manager – One List')
+    })
+
+    it('should not display the "Global Account Manager - One List" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('oneListDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "Global Account Manager - One List" details', () => {
+      assertKeyValueTable('oneListDetails', {
+        'One List tier': 'Tier A - Strategic Account',
+        'Global Account Manager': 'Travis GreeneIST - Sector Advisory ServicesLondon',
+      })
+    })
+
+    it('should display the "Business hierarchy" details container heading', () => {
+      assertDetailsContainerHeading('businessHierarchyDetailsContainer', 'Business hierarchy')
+    })
+
+    it('should not display the "Business hierarchy" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('businessHierarchyDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "Business hierarchy" details', () => {
+      assertKeyValueTable('businessHierarchyDetails', {
+        'Headquarter type': 'Global HQ',
+        'Subsidiaries': 'None',
+      })
+    })
+
+    it('should display the "DIT sector" details container heading', () => {
+      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
+    })
+
+    it('should not display the "DIT sector" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "DIT sector" details', () => {
+      assertValueTable('sectorDetails', [
+        'Retail',
+      ])
+    })
+
+    it('should not display the "DIT region" details container', () => {
+      cy.get(selectors.detailsContainer('regionDetailsContainer').container).should('not.exist')
+    })
+
+    it('should display the "Addresses" details container heading', () => {
+      assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
+    })
+
+    it('should not display the "Addresses" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('addressesDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the address', () => {
+      const addressSelector = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
+      cy.get(addressSelector.line(1)).should('have.text', '12 St George\'s Road')
+      cy.get(addressSelector.line(2)).should('have.text', 'Paris')
+      cy.get(addressSelector.line(3)).should('have.text', '75001')
+      cy.get(addressSelector.line(4)).should('have.text', 'France')
+    })
+
+    it('should not display the "Documents from CDMS" details container', () => {
+      cy.get(selectors.detailsContainer('documentsContainer').container).should('not.exist')
+    })
+
+    it('should not display the "Archive company" details container', () => {
+      cy.get(selectors.detailsContainer('archiveCompanyContainer').container).should('not.exist')
+    })
+  })
+
+  const assertDetailsContainerHeading = (dataAutoId, expected) => {
+    cy.get(selectors.detailsContainer(dataAutoId).heading).should('have.text', expected)
+  }
+
+  const assertKeyValueTable = (dataAutoId, expected) => {
+    forEach(keys(expected), (key, i) => {
+      const rowNumber = i + 1
+      cy.get(selectors.keyValueTable(dataAutoId).keyCell(rowNumber)).should('have.text', key)
+      cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expected[key])
+    })
+  }
+
+  const assertValueTable = (dataAutoId, expected) => {
+    forEach(expected, (expectedValue, i) => {
+      const rowNumber = i + 1
+      cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expectedValue)
+    })
+  }
+})


### PR DESCRIPTION
This test is intended as a replacement for the [`View business details for a Dun & Bradstreet GHQ company on the One List not in the UK` Nightwatch scenario](https://github.com/uktrade/data-hub-frontend/blob/8980f97f224d258e12b1a7fe7a0955735c4744ac/test/acceptance/features/companies/business-details.feature#L4).

Over time, I will replace all of the scenarios to remove `business-details.feature`.