### PR TITLE
Adding local navigation app selection for nested apps

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -43,7 +43,12 @@ const DEPRECATED_LOCAL_NAV = [
     ],
   },
   {
-    path: 'investments/projects',
+    path: 'investments',
+    subPaths: [
+      'projects',
+      'large-capital-profile',
+      'growth-capital-profile',
+    ],
     label: 'Investment',
     permissions: [
       'investment.view_all_investmentproject',
@@ -101,7 +106,12 @@ const LOCAL_NAV = [
     label: 'Core team',
   },
   {
-    path: 'investments/projects',
+    path: 'investments',
+    subPaths: [
+      'projects',
+      'large-capital-profile',
+      'growth-capital-profile',
+    ],
     label: 'Investment',
     permissions: [
       'investment.view_all_investmentproject',

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -1,4 +1,4 @@
-const { get, isEmpty, assign, intersection, isUndefined } = require('lodash')
+const { get, isEmpty, intersection, isUndefined } = require('lodash')
 const queryString = require('qs')
 const { parse } = require('url')
 
@@ -50,14 +50,17 @@ function setLocalNav (items = []) {
   return function buildLocalNav (req, res, next) {
     const userPermissions = get(res, 'locals.user.permissions')
 
+    const isUrlActive = (url, item) => {
+      const currentPath = res.locals.CURRENT_PATH
+      return item.subPaths ? item.subPaths.some(subPath => `${url}/${subPath}` === currentPath) : currentPath === url
+    }
+
     res.locals.localNavItems = items
       .filter(filterNonPermittedItem(userPermissions))
       .map((item) => {
         const url = item.isExternal ? item.url : `${req.baseUrl}/${item.path}`
-        return assign({}, item, {
-          url,
-          isActive: res.locals.CURRENT_PATH === url,
-        })
+        const isActive = isUrlActive(url, item)
+        return { ...item, url, isActive }
       })
     next()
   }

--- a/test/unit/apps/middleware.test.js
+++ b/test/unit/apps/middleware.test.js
@@ -21,6 +21,13 @@ describe('Apps middleware', () => {
           'permission1',
         ],
       },
+      {
+        path: 'fourth',
+        label: 'Fourth',
+        subPaths: [
+          'sub-path',
+        ],
+      },
     ]
 
     it('should attach nav items props to locals', () => {
@@ -53,6 +60,22 @@ describe('Apps middleware', () => {
 
       expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
       expect(resMock.locals.localNavItems[0].isActive).to.be.true
+      expect(this.nextSpy.calledOnce).to.be.true
+    })
+
+    it('should set new isActive to true for the current path when a subPath is defined', () => {
+      const reqMock = {
+        baseUrl: '/sub-app',
+      }
+      const resMock = {
+        locals: {
+          CURRENT_PATH: '/sub-app/fourth/sub-path',
+        },
+      }
+      this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
+
+      expect(resMock.locals.localNavItems[2].url).to.equal('/sub-app/fourth')
+      expect(resMock.locals.localNavItems[2].isActive).to.be.true
       expect(this.nextSpy.calledOnce).to.be.true
     })
 
@@ -112,7 +135,17 @@ describe('Apps middleware', () => {
             ],
             url: '/sub-app/third',
             isActive: false,
-          }]
+          },
+          {
+            path: 'fourth',
+            label: 'Fourth',
+            subPaths: [
+              'sub-path',
+            ],
+            url: '/sub-app/fourth',
+            isActive: false,
+          },
+        ]
         this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
         expect(resMock.locals.localNavItems).to.deep.equal(expectedNavItems)
@@ -138,6 +171,15 @@ describe('Apps middleware', () => {
             path: 'second',
             label: 'Second',
             url: '/sub-app/second',
+            isActive: false,
+          },
+          {
+            path: 'fourth',
+            label: 'Fourth',
+            subPaths: [
+              'sub-path',
+            ],
+            url: '/sub-app/fourth',
             isActive: false,
           },
         ]


### PR DESCRIPTION
A nested app is defined as: `/companies/id/investments`

The investments nested app has additional nested apps such as
`projects`, `large-capital-profile` and `growth-capital-profile`.

1. `/companies/id/investments/projects`
2. `/companies/id/investments/large-capital-profile`
3. `/companies/id/investments/growth-capital-profile`

Currently the local navigation is only selected on 1, where 2 & 3 are
not selected when navigating to them.

This fix address both issues by introducing a subPath array on a local
nav item.

https://uktrade.atlassian.net/browse/IPBETA-321