### PR TITLE
Add Description to business details view

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -95,6 +95,7 @@ const aboutLabels = {
   turnover: 'Annual turnover',
   number_of_employees: 'Number of employees',
   website: 'Website',
+  description: 'Description',
 }
 
 const businessHierarchyLabels = {

--- a/src/apps/companies/transformers/company-to-about-view.js
+++ b/src/apps/companies/transformers/company-to-about-view.js
@@ -84,11 +84,13 @@ module.exports = ({
   number_of_employees,
   employee_range,
   website,
+  description,
 }) => {
   const company_number = get(companies_house_data, 'company_number')
 
   const viewRecord = {
     vat_number,
+    description,
     business_type: duns_number ? null : get(business_type, 'name'),
     trading_names: isEmpty(trading_names) ? NOT_SET_TEXT : trading_names,
     company_number: transformCompanyNumber(company_number),

--- a/src/apps/companies/views/_deprecated/edit.njk
+++ b/src/apps/companies/views/_deprecated/edit.njk
@@ -121,6 +121,14 @@
       error: errors.website
     }) }}
 
+    {{ TextField({
+      name: 'description',
+      label: 'Business description',
+      optional: true,
+      value: formData.description,
+      error: errors.description
+    }) }}
+
     {% if not companiesHouseRecord %}
       {% if showCompanyNumberForUkBranch %}
         {{ TextField({
@@ -364,14 +372,6 @@
         error: errors.headquarter_type
       }) }}
     {% endif %}
-
-    {{ TextField({
-      name: 'description',
-      label: 'Business description',
-      optional: true,
-      value: formData.description,
-      error: errors.description
-    }) }}
 
   {% endcall %}
 {% endblock %}

--- a/test/acceptance/features/companies/business-details.feature
+++ b/test/acceptance/features/companies/business-details.feature
@@ -14,6 +14,7 @@ Feature: Company business details
       | Annual turnover           | company.turnoverRange        |
       | Number of employees       | company.employeeRange        |
       | Website                   | Not set                      |
+      | Description               | company.description          |
     And the "About One List Corp" Edit link should not be displayed
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
@@ -59,6 +60,7 @@ Feature: Company business details
       | Annual turnover           | Not set                      |
       | Number of employees       | Not set                      |
       | Website                   | Not set                      |
+      | Description               | company.description          |
     And the "About Venus Ltd" Edit link should be displayed
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |
@@ -103,6 +105,7 @@ Feature: Company business details
       | Annual turnover           | company.annualTurnover       |
       | Number of employees       | company.numberOfEmployees    |
       | Website                   | Not set                      |
+      | Description               | company.description          |
     And the "About DnB Corp" Edit link should not be displayed
     And the Business hierarchy key value details are displayed
       | key                       | value                        |
@@ -141,6 +144,7 @@ Feature: Company business details
       | Annual turnover           | company.turnoverRange        |
       | Number of employees       | company.employeeRange        |
       | Website                   | Not set                      |
+      | Description               | company.description          |
     And the "About Archived Ltd" Edit link should not be displayed
     And the Global Account Manager – One List key value details are displayed
       | key                       | value                        |

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -35,6 +35,7 @@ describe('Companies business details', () => {
         'Annual turnover': '£33.5M+',
         'Number of employees': '500+',
         'Website': 'Not set',
+        'Description': 'This is a dummy company for testing the One List',
       })
     })
 

--- a/test/unit/apps/companies/transformers/company-to-about-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-about-view.test.js
@@ -39,6 +39,7 @@ describe('#transformCompanyToKnownAsView', () => {
           website: 'www.company.com',
           turnover: 100000,
           number_of_employees: 200,
+          description: 'description',
         })
       })
 
@@ -98,6 +99,10 @@ describe('#transformCompanyToKnownAsView', () => {
           newWindow: true,
         })
       })
+
+      it('should set the description', () => {
+        expect(this.actual.Description).to.equal('description')
+      })
     })
 
     context('when minimal information is populated', () => {
@@ -124,6 +129,10 @@ describe('#transformCompanyToKnownAsView', () => {
       it('should not set the Companies House number', () => {
         expect(this.actual['Companies House number']).to.not.exist
       })
+
+      it('should not set the description', () => {
+        expect(this.actual.Description).to.not.exist
+      })
     })
   })
 
@@ -149,6 +158,7 @@ describe('#transformCompanyToKnownAsView', () => {
             name: '500+',
           },
           website: 'www.company.com',
+          description: 'description',
         })
       })
 
@@ -189,6 +199,10 @@ describe('#transformCompanyToKnownAsView', () => {
       it('should set the VAT number', () => {
         expect(this.actual['VAT number']).to.equal('0123456789')
       })
+
+      it('should set the description', () => {
+        expect(this.actual.Description).to.equal('description')
+      })
     })
 
     context('when minimal information is populated', () => {
@@ -217,6 +231,10 @@ describe('#transformCompanyToKnownAsView', () => {
 
       it('should not set the VAT number', () => {
         expect(this.actual['VAT number']).to.not.exist
+      })
+
+      it('should not set the description', () => {
+        expect(this.actual.Description).to.not.exist
       })
     })
   })


### PR DESCRIPTION
https://trello.com/c/CIOcJQgw/766-add-description-to-business-details-view-for-data-hub-companies

## Change
This change:
- adds the `Description` to the `Business details` view for all businesses
- moves the `Description` up on the `Edit` view for a business

## Before (business details)
<img width="770" alt="Screenshot 2019-03-11 at 15 25 58" src="https://user-images.githubusercontent.com/1150417/54135990-c7945d00-4412-11e9-8ef8-a8a7ff212393.png">

## After (business details)
<img width="710" alt="Screenshot 2019-03-11 at 15 27 50" src="https://user-images.githubusercontent.com/1150417/54135999-cc591100-4412-11e9-97e8-e0d90bf2af2e.png">

## Before (edit business)
<img width="313" alt="Screenshot 2019-03-11 at 15 26 46" src="https://user-images.githubusercontent.com/1150417/54136009-d2e78880-4412-11e9-80d0-6beace9ec8b4.png">

## After (edit business)
<img width="287" alt="Screenshot 2019-03-11 at 15 28 43" src="https://user-images.githubusercontent.com/1150417/54136018-d844d300-4412-11e9-8448-0e3ba0963b7e.png">
