### PR TITLE
Adding local navigation item selection for nested apps

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -43,7 +43,7 @@ const DEPRECATED_LOCAL_NAV = [
     ],
   },
   {
-    path: 'investments/projects',
+    path: 'investments',
     label: 'Investment',
     permissions: [
       'investment.view_all_investmentproject',
@@ -101,7 +101,7 @@ const LOCAL_NAV = [
     label: 'Core team',
   },
   {
-    path: 'investments/projects',
+    path: 'investments',
     label: 'Investment',
     permissions: [
       'investment.view_all_investmentproject',

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -54,9 +54,10 @@ function setLocalNav (items = []) {
       .filter(filterNonPermittedItem(userPermissions))
       .map((item) => {
         const url = item.isExternal ? item.url : `${req.baseUrl}/${item.path}`
+        const isActive = res.locals.CURRENT_PATH === url || res.locals.CURRENT_PATH.startsWith(`${url}/`)
         return assign({}, item, {
           url,
-          isActive: res.locals.CURRENT_PATH === url,
+          isActive,
         })
       })
     next()

--- a/test/unit/apps/investment-projects/middleware/local-navigation.test.js
+++ b/test/unit/apps/investment-projects/middleware/local-navigation.test.js
@@ -6,6 +6,7 @@ describe('Investment projects local navigation', () => {
 
     this.res = {
       locals: {
+        CURRENT_PATH: '',
         investment: {},
         user: {
           permissions: [

--- a/test/unit/apps/middleware.test.js
+++ b/test/unit/apps/middleware.test.js
@@ -21,38 +21,78 @@ describe('Apps middleware', () => {
           'permission1',
         ],
       },
+      {
+        path: 'fourth',
+        label: 'Fourth',
+      },
+      {
+        path: 'four',
+        label: 'Four',
+      },
     ]
 
     it('should attach nav items props to locals', () => {
       const reqMock = {
-        baseUrl: '/sub-app',
+        baseUrl: '/sub-app/id',
       }
       const resMock = {
         locals: {
-          CURRENT_PATH: '/sub-app/resource',
+          CURRENT_PATH: '/sub-app/id/resource',
         },
       }
 
       this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
-      expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
+      expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/id/first')
       expect(resMock.locals.localNavItems[0].isActive).to.be.false
       expect(this.nextSpy.calledOnce).to.be.true
     })
 
-    it('should set new isActive to true for the current path', () => {
+    it('should set isActive to true when the current path matches the nav item url', () => {
       const reqMock = {
-        baseUrl: '/sub-app',
+        baseUrl: '/sub-app/id',
       }
       const resMock = {
         locals: {
-          CURRENT_PATH: '/sub-app/first',
+          CURRENT_PATH: '/sub-app/id/first',
         },
       }
       this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
-      expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/first')
+      expect(resMock.locals.localNavItems[0].url).to.equal('/sub-app/id/first')
       expect(resMock.locals.localNavItems[0].isActive).to.be.true
+      expect(this.nextSpy.calledOnce).to.be.true
+    })
+
+    it('should set isActive to true when the current path startsWith the nav item url', () => {
+      const reqMock = {
+        baseUrl: '/sub-app/id',
+      }
+      const resMock = {
+        locals: {
+          CURRENT_PATH: '/sub-app/id/fourth/projects',
+        },
+      }
+      this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
+
+      expect(resMock.locals.localNavItems[2].url).to.equal('/sub-app/id/fourth')
+      expect(resMock.locals.localNavItems[2].isActive).to.be.true
+      expect(this.nextSpy.calledOnce).to.be.true
+    })
+
+    it('should set isActive to false when the current path does not startWith the nav item url', () => {
+      const reqMock = {
+        baseUrl: '/sub-app/id',
+      }
+      const resMock = {
+        locals: {
+          CURRENT_PATH: '/sub-app/id/fourth/projects',
+        },
+      }
+      this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
+
+      expect(resMock.locals.localNavItems[3].url).to.equal('/sub-app/id/four')
+      expect(resMock.locals.localNavItems[3].isActive).to.be.false
       expect(this.nextSpy.calledOnce).to.be.true
     })
 
@@ -65,7 +105,9 @@ describe('Apps middleware', () => {
         }
         const reqMock = {}
         const resMock = {
-          locals: {},
+          locals: {
+            CURRENT_PATH: '',
+          },
         }
 
         this.middleware.setLocalNav([mockNavItem])(reqMock, resMock, this.nextSpy)
@@ -79,11 +121,11 @@ describe('Apps middleware', () => {
     context('user permitted nav items', () => {
       it('should include permitted items', () => {
         const reqMock = {
-          baseUrl: '/sub-app',
+          baseUrl: '/sub-app/id',
         }
         const resMock = {
           locals: {
-            CURRENT_PATH: '/sub-app/first',
+            CURRENT_PATH: '/sub-app/id/first',
             user: {
               permissions: [
                 'permission1',
@@ -95,13 +137,13 @@ describe('Apps middleware', () => {
           {
             path: 'first',
             label: 'First',
-            url: '/sub-app/first',
+            url: '/sub-app/id/first',
             isActive: true,
           },
           {
             path: 'second',
             label: 'Second',
-            url: '/sub-app/second',
+            url: '/sub-app/id/second',
             isActive: false,
           },
           {
@@ -110,9 +152,22 @@ describe('Apps middleware', () => {
             permissions: [
               'permission1',
             ],
-            url: '/sub-app/third',
+            url: '/sub-app/id/third',
             isActive: false,
-          }]
+          },
+          {
+            path: 'fourth',
+            label: 'Fourth',
+            url: '/sub-app/id/fourth',
+            isActive: false,
+          },
+          {
+            path: 'four',
+            label: 'Four',
+            url: '/sub-app/id/four',
+            isActive: false,
+          },
+        ]
         this.middleware.setLocalNav(NAV_ITEMS)(reqMock, resMock, this.nextSpy)
 
         expect(resMock.locals.localNavItems).to.deep.equal(expectedNavItems)
@@ -120,24 +175,36 @@ describe('Apps middleware', () => {
 
       it('should only include permitted items', () => {
         const reqMock = {
-          baseUrl: '/sub-app',
+          baseUrl: '/sub-app/id',
         }
         const resMock = {
           locals: {
-            CURRENT_PATH: '/sub-app/first',
+            CURRENT_PATH: '/sub-app/id/first',
           },
         }
         const expectedNavItems = [
           {
             path: 'first',
             label: 'First',
-            url: '/sub-app/first',
+            url: '/sub-app/id/first',
             isActive: true,
           },
           {
             path: 'second',
             label: 'Second',
-            url: '/sub-app/second',
+            url: '/sub-app/id/second',
+            isActive: false,
+          },
+          {
+            label: 'Fourth',
+            path: 'fourth',
+            url: '/sub-app/id/fourth',
+            isActive: false,
+          },
+          {
+            path: 'four',
+            label: 'Four',
+            url: '/sub-app/id/four',
             isActive: false,
           },
         ]
@@ -152,11 +219,11 @@ describe('Apps middleware', () => {
     const NAV_ITEMS = [{
       path: 'first',
       label: 'First',
-      url: '/base-url/first',
+      url: '/base-url/id/first',
     }, {
       path: 'second',
       label: 'Second',
-      url: '/base-url/second',
+      url: '/base-url/id/second',
     }]
 
     it('should redirect to the first item', () => {
@@ -170,7 +237,7 @@ describe('Apps middleware', () => {
 
       this.middleware.redirectToFirstNavItem({}, resMock)
 
-      expect(redirectMock).to.have.been.calledWith('/base-url/first')
+      expect(redirectMock).to.have.been.calledWith('/base-url/id/first')
     })
   })
 

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -4,6 +4,7 @@ module.exports = ({
   requestBody,
   requestParams = {},
   requestQuery = {},
+  CURRENT_PATH = '',
   breadcrumb = sinon.stub().returnsThis(),
   company,
   contact,
@@ -29,6 +30,7 @@ module.exports = ({
       render: sinon.spy(),
       redirect: sinon.spy(),
       locals: {
+        CURRENT_PATH,
         paths,
         company,
         contact,


### PR DESCRIPTION
Both companies and investments are mini-apps within the main app.
`/companies/id/investments/`

Nested apps within investments are defined as:
1. `/companies/id/investments/projects`
2. `/companies/id/investments/large-capital-profile`
3. `/companies/id/investments/growth-capital-profile`

When navigating to any of the above URLS the local navigation list item
is only selected for 1, where 2 & 3 are not selected.

This fix address both issues by selecting the relevant nav item
providing the current local path starts with the nav item url.

The current local path refers to the browsers URL.

For example:
'/companies/id/investments/projects'.startsWith('/companies/id/investments/')

Is true, so this selects the local investments nav item.

The same apples to both `/large-capital-profile` & `/growth-capital-profile`

https://uktrade.atlassian.net/browse/IPBETA-321
