### PR TITLE
Add "Link a subsidiary" link and "Business details" breadcrumb

### DIFF
--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -23,8 +23,13 @@ async function renderSubsidiaries (req, res, next) {
         transformCompanyToSubsidiaryListItem(res.locals.company),
       ))
 
+    res.breadcrumb(company.name, `/companies/${company.id}`)
+
+    if (features['companies-new-layout']) {
+      res.breadcrumb('Business details', `/companies/${company.id}/business-details`)
+    }
+
     return res
-      .breadcrumb(company.name, `/companies/${company.id}`)
       .breadcrumb(companyDetailsLabels.subsidiaries)
       .render(view, {
         heading: `Subsidiaries of ${company.name}`,

--- a/src/apps/companies/transformers/company-to-business-hierarchy-view.js
+++ b/src/apps/companies/transformers/company-to-business-hierarchy-view.js
@@ -12,12 +12,28 @@ const transformHeadquarterType = (headquarter_type) => {
   }
 }
 
-const transformSubsidiaries = (id, headquarter_type, subsidiariesCount) => {
+const transformSubsidiaries = (id, headquarter_type, subsidiariesCount, duns_number) => {
   if (headquarter_type) {
-    return subsidiariesCount ? {
-      url: `/companies/${id}/subsidiaries`,
-      name: `${subsidiariesCount} ${pluralise('subsidiary', subsidiariesCount)}`,
-    } : NONE_TEXT
+    if (subsidiariesCount) {
+      return {
+        url: `/companies/${id}/subsidiaries`,
+        name: `${subsidiariesCount} ${pluralise('subsidiary', subsidiariesCount)}`,
+      }
+    }
+
+    if (headquarter_type.name === 'ghq' && !duns_number) {
+      return {
+        name: NONE_TEXT,
+        actions: [
+          {
+            url: `/companies/${id}/subsidiaries/link`,
+            label: 'Link a subsidiary',
+          },
+        ],
+      }
+    }
+
+    return NONE_TEXT
   }
 }
 
@@ -51,7 +67,7 @@ const transformGlobalHq = (id, headquarter_type, global_headquarters, duns_numbe
 module.exports = ({ id, headquarter_type, global_headquarters, duns_number }, subsidiariesCount) => {
   const viewRecord = {
     headquarter_type: transformHeadquarterType(headquarter_type),
-    subsidiaries: transformSubsidiaries(id, headquarter_type, subsidiariesCount),
+    subsidiaries: transformSubsidiaries(id, headquarter_type, subsidiariesCount, duns_number),
     global_headquarters: transformGlobalHq(id, headquarter_type, global_headquarters, duns_number),
   }
 

--- a/test/unit/apps/companies/controllers/subsidiaries.test.js
+++ b/test/unit/apps/companies/controllers/subsidiaries.test.js
@@ -1,3 +1,5 @@
+const { forEach, isString } = require('lodash')
+
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
 const config = require('~/config')
@@ -8,19 +10,25 @@ const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
 const subsidiariesMock = require('~/test/unit/data/companies/subsidiaries.json')
 
 describe('company subsidiaries controller', () => {
-  const commonTests = ({ expectedBreadcrumb, expectedTemplate, expectedHeading, expectedCount }) => {
-    it('should add two breadcrumbs', () => {
-      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledTwice
+  const commonTests = ({
+    expectedBreadcrumbs,
+    expectedTemplate,
+    expectedHeading,
+    expectedCount,
+  }) => {
+    it(`should add ${expectedBreadcrumbs.length} breadcrumbs`, () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.callCount(expectedBreadcrumbs.length)
     })
 
-    it('should add a company breadcrumb', () => {
+    it('should add breadcrumbs', () => {
       const breadcrumbSpy = this.middlewareParameters.resMock.breadcrumb
-      expect(breadcrumbSpy).to.be.calledWith(expectedBreadcrumb)
-    })
-
-    it('should add a "Subsidiaries" breadcrumb', () => {
-      const breadcrumbSpy = this.middlewareParameters.resMock.breadcrumb
-      expect(breadcrumbSpy).to.be.calledWith('Subsidiaries')
+      forEach(expectedBreadcrumbs, (expectedBreadcrumb) => {
+        if (isString(expectedBreadcrumb)) {
+          expect(breadcrumbSpy).to.be.calledWith(expectedBreadcrumb)
+        } else {
+          expect(breadcrumbSpy).to.be.calledWith(expectedBreadcrumb.name, expectedBreadcrumb.url)
+        }
+      })
     })
 
     it('should render the correct template', () => {
@@ -59,7 +67,13 @@ describe('company subsidiaries controller', () => {
     })
 
     commonTests({
-      expectedBreadcrumb: 'SAMSUNG BIOEPIS UK LIMITED',
+      expectedBreadcrumbs: [
+        {
+          name: 'SAMSUNG BIOEPIS UK LIMITED',
+          url: `/companies/${companyMock.id}`,
+        },
+        'Subsidiaries',
+      ],
       expectedTemplate: 'companies/views/_deprecated/subsidiaries',
       expectedHeading: 'Subsidiaries of SAMSUNG BIOEPIS UK LIMITED',
       expectedCount: 1,
@@ -96,7 +110,13 @@ describe('company subsidiaries controller', () => {
     })
 
     commonTests({
-      expectedBreadcrumb: 'SAMSUNG BIOEPIS UK LIMITED',
+      expectedBreadcrumbs: [
+        {
+          name: 'SAMSUNG BIOEPIS UK LIMITED',
+          url: `/companies/${companyMock.id}`,
+        },
+        'Subsidiaries',
+      ],
       expectedTemplate: 'companies/views/_deprecated/subsidiaries',
       expectedHeading: 'Subsidiaries of SAMSUNG BIOEPIS UK LIMITED',
       expectedCount: 1,
@@ -134,7 +154,13 @@ describe('company subsidiaries controller', () => {
     })
 
     commonTests({
-      expectedBreadcrumb: 'SAMSUNG BIOEPIS UK LIMITED',
+      expectedBreadcrumbs: [
+        {
+          name: 'SAMSUNG BIOEPIS UK LIMITED',
+          url: `/companies/${companyMock.id}`,
+        },
+        'Subsidiaries',
+      ],
       expectedTemplate: 'companies/views/_deprecated/subsidiaries',
       expectedHeading: 'Subsidiaries of SAMSUNG BIOEPIS UK LIMITED',
       expectedCount: 0,
@@ -168,7 +194,13 @@ describe('company subsidiaries controller', () => {
     })
 
     commonTests({
-      expectedBreadcrumb: 'One List Corp',
+      expectedBreadcrumbs: [
+        {
+          name: 'One List Corp',
+          url: `/companies/${dnbCompanyMock.id}`,
+        },
+        'Subsidiaries',
+      ],
       expectedTemplate: 'companies/views/subsidiaries',
       expectedHeading: 'Subsidiaries of One List Corp',
       expectedCount: 1,
@@ -204,7 +236,17 @@ describe('company subsidiaries controller', () => {
     })
 
     commonTests({
-      expectedBreadcrumb: 'SAMSUNG BIOEPIS UK LIMITED',
+      expectedBreadcrumbs: [
+        {
+          name: 'SAMSUNG BIOEPIS UK LIMITED',
+          url: `/companies/${companyMock.id}`,
+        },
+        {
+          name: 'Business details',
+          url: `/companies/${companyMock.id}/business-details`,
+        },
+        'Subsidiaries',
+      ],
       expectedTemplate: 'companies/views/subsidiaries',
       expectedHeading: 'Subsidiaries of SAMSUNG BIOEPIS UK LIMITED',
       expectedCount: 1,

--- a/test/unit/apps/companies/transformers/company-to-business-hierarchy-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-business-hierarchy-view.test.js
@@ -30,6 +30,31 @@ describe('#transformCompanyToBusinessHierarchyView', () => {
       })
     })
 
+    context('when the company is a global ultimate without subsidiaries', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToBusinessHierarchyView({
+          id: '1',
+          headquarter_type: {
+            name: 'ghq',
+          },
+          global_headquarters: null,
+          duns_number: '123',
+        }, 0)
+      })
+
+      it('should set the headquarter type', () => {
+        expect(this.actual['Headquarter type']).to.deep.equal('Global HQ')
+      })
+
+      it('should set the subsidiaries to "None"', () => {
+        expect(this.actual.Subsidiaries).to.equal('None')
+      })
+
+      it('should not set the Global HQ', () => {
+        expect(this.actual['Global HQ']).to.not.exist
+      })
+    })
+
     context('when the company is a subsidiary', () => {
       beforeEach(() => {
         this.actual = transformCompanyToBusinessHierarchyView({
@@ -105,6 +130,38 @@ describe('#transformCompanyToBusinessHierarchyView', () => {
         expect(this.actual.Subsidiaries).to.deep.equal({
           url: `/companies/1/subsidiaries`,
           name: '2 subsidiaries',
+        })
+      })
+
+      it('should not set the Global HQ', () => {
+        expect(this.actual['Global HQ']).to.not.exist
+      })
+    })
+
+    context('when the company is a GHQ without subsidiaries', () => {
+      beforeEach(() => {
+        this.actual = transformCompanyToBusinessHierarchyView({
+          id: '1',
+          headquarter_type: {
+            name: 'ghq',
+          },
+          global_headquarters: null,
+        }, 0)
+      })
+
+      it('should set the headquarter type', () => {
+        expect(this.actual['Headquarter type']).to.deep.equal('Global HQ')
+      })
+
+      it('should set the subsidiaries to "None", with a "Link a subsidiary action"', () => {
+        expect(this.actual.Subsidiaries).to.deep.equal({
+          actions: [
+            {
+              label: 'Link a subsidiary',
+              url: '/companies/1/subsidiaries/link',
+            },
+          ],
+          name: 'None',
         })
       })
 


### PR DESCRIPTION
https://trello.com/c/4uGa5hfX/870-add-link-a-subsidiary-link-for-a-global-hq-without-subsidiaries

## Change
This change is for linking a subsidiary to a Data Hub company that is a GHQ.

It includes:
- `Link a subsidiary` link next to `Subsidiaries` in a `Business hierarchy` details of the `Business details` view
- `Business details` breadcrumb on the `Subsidiaries` view when the `companies-new-layout` flag is enabled

## Before (business details)
<img width="763" alt="Screenshot 2019-03-13 at 09 10 59" src="https://user-images.githubusercontent.com/1150417/54267087-8a45e180-4570-11e9-9497-214891365069.png">

## After (business details)
<img width="768" alt="Screenshot 2019-03-13 at 09 13 31" src="https://user-images.githubusercontent.com/1150417/54267102-916cef80-4570-11e9-8a28-d7d969d90ea1.png">

## Before (subsidiaries)
<img width="768" alt="Screenshot 2019-03-13 at 09 11 20" src="https://user-images.githubusercontent.com/1150417/54267118-992c9400-4570-11e9-86a8-5806c545b91e.png">

## After (subsidiaries)
<img width="792" alt="Screenshot 2019-03-13 at 09 13 52" src="https://user-images.githubusercontent.com/1150417/54267137-9f227500-4570-11e9-852f-a07efc0534c0.png">
