### PR TITLE
Format currency as GBP from USD for D&B companies

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -94,6 +94,9 @@ const config = {
   oneList: {
     email: process.env.ONE_LIST_EMAIL || 'one.list@example.com',
   },
+  currencyRate: {
+    usdToGbp: 0.750148,
+  },
 }
 
 module.exports = config

--- a/src/apps/companies/transformers/company-to-about-view.js
+++ b/src/apps/companies/transformers/company-to-about-view.js
@@ -4,11 +4,15 @@ const { get, pickBy, isEmpty } = require('lodash')
 const { aboutLabels } = require('../labels')
 const { getDataLabels } = require('../../../lib/controller-utils')
 const { NOT_SET_TEXT } = require('../constants')
+const { currencyRate } = require('../../../../config')
 
 function transformTurnover (turnover, turnover_range) {
   if (turnover) {
     return [
-      `USD ${turnover}`,
+      {
+        name: turnover * currencyRate.usdToGbp,
+        type: 'currency',
+      },
       {
         name: 'This is an estimated number',
         type: 'details',

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -267,7 +267,7 @@ describe('Companies business details', () => {
     it('should display the "About" details', () => {
       assertKeyValueTable('aboutDetails', {
         'Trading names': 'DnBD&B',
-        'Annual turnover': 'USD 1000000This is an estimated numberWhat does that mean?This is an estimated number',
+        'Annual turnover': '£750,148.00This is an estimated numberWhat does that mean?This is an estimated number',
         'Number of employees': '95This is an estimated numberWhat does that mean?This is an estimated number',
         'Website': 'Not set',
       })

--- a/test/unit/apps/companies/transformers/company-to-about-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-about-view.test.js
@@ -1,6 +1,13 @@
-const transformCompanyToAboutView = require('~/src/apps/companies/transformers/company-to-about-view')
 const { aboutLabels } = require('~/src/apps/companies/labels')
 const { NOT_SET_TEXT } = require('~/src/apps/companies/constants')
+
+const transformCompanyToAboutView = proxyquire('~/src/apps/companies/transformers/company-to-about-view', {
+  '../../../../config': {
+    currencyRate: {
+      usdToGbp: 0.75,
+    },
+  },
+})
 
 describe('#transformCompanyToKnownAsView', () => {
   const commonTests = (expectedTradingNames, expectedWebsite, expectedEmployees, expectedTurnover) => {
@@ -70,7 +77,10 @@ describe('#transformCompanyToKnownAsView', () => {
           },
         ],
         [
-          'USD 100000',
+          {
+            type: 'currency',
+            name: 75000,
+          },
           {
             details: {
               summaryText: 'What does that mean?',


### PR DESCRIPTION
https://trello.com/c/qqNKNRST/733-convert-annual-turnover-from-usd-to-gbp

## Change
Currently the `turnover` of Dun & Bradstreet companies is being presented in USD without formatting. This change converts the USD to GBP using the average rate from 2018. The currency is presented with formatting.

A further iteration will be to remove some of the zeros. As an example `£1,000,000.00` could be presented as `£1 million`

## Before
<img width="778" alt="Screenshot 2019-03-13 at 13 23 55" src="https://user-images.githubusercontent.com/1150417/54282593-41078900-4594-11e9-8e83-606361b76851.png">

## After
<img width="787" alt="Screenshot 2019-03-13 at 13 27 00" src="https://user-images.githubusercontent.com/1150417/54282610-4664d380-4594-11e9-89ff-4b358813d12f.png">
