### PR TITLE
Hide details summary if company is D&B or archived

### DIFF
--- a/src/apps/companies/views/_deprecated/subsidiaries.njk
+++ b/src/apps/companies/views/_deprecated/subsidiaries.njk
@@ -2,25 +2,27 @@
 
 {% block main_grid_right_column %}
 
-  {% if company.archived or company.duns_number %}
-    <details role="group">
-      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
-        <span class="details__summary">
-          Why can I not link a subsidiary?
-        </span>
-      </summary>
-      <div class="details__content" id="details-content-0" aria-hidden="false">
-        {% if company.archived %}
-          <p class="c-message c-message--muted">Subsidiaries cannot be linked to an archived company.
-          <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
-        {% endif %}
-        {% if company.duns_number %}
-          <p class="c-message c-message--muted">Subsidiaries cannot be linked to a Dun & Bradstreet company.
-        {% endif %}
-        </p>
-      </div>
-    </details>
+  {% if company.duns_number %}
+    {{ govukDetails({
+      summaryText: 'Why can I not link a subsidiary?',
+      html: 'Subsidiaries cannot be linked to a Dun & Bradstreet company.',
+      attributes: {
+        'data-auto-id': 'subsidiariesWhyDunAndBradstreet'
+      }
+    }) }}
+  {% endif %}
+
+  {% if company.archived %}
+    {{ govukDetails({
+      summaryText: 'Why can I not link a subsidiary?',
+      html: 'Subsidiaries cannot be linked to an archived company.
+        <a href="/companies/' + company.id + '/unarchive">Click here to unarchive</a>',
+      attributes: {
+        'data-auto-id': 'subsidiariesWhyArchived'
+      }
+    }) }}
   {% endif %}
 
   {{ CollectionContent(subsidiaries) }}
+
 {% endblock %}

--- a/src/apps/companies/views/subsidiaries.njk
+++ b/src/apps/companies/views/subsidiaries.njk
@@ -6,21 +6,26 @@
 
 {% block body_main_content %}
 
-  <details role="group">
-    <summary role="button" aria-controls="details-content-0" aria-expanded="false">
-        <span class="details__summary">
-          Why can I not link a subsidiary?
-        </span>
-    </summary>
-    <div class="details__content" id="details-content-0" aria-hidden="false">
-      {% if company.archived %}
-        <p class="c-message c-message--muted">Subsidiaries cannot be linked to an archived company.
-        <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
-        {% endif %}
-        <p class="c-message c-message--muted">Subsidiaries cannot be linked to a Dun & Bradstreet company.
-      </p>
-    </div>
-  </details>
+  {% if company.duns_number %}
+    {{ govukDetails({
+      summaryText: 'Why can I not link a subsidiary?',
+      html: 'Subsidiaries cannot be linked to a Dun & Bradstreet company.',
+      attributes: {
+        'data-auto-id': 'subsidiariesWhyDunAndBradstreet'
+      }
+    }) }}
+  {% endif %}
+
+  {% if company.archived %}
+    {{ govukDetails({
+      summaryText: 'Why can I not link a subsidiary?',
+      html: 'Subsidiaries cannot be linked to an archived company.
+        <a href="/companies/' + company.id + '/unarchive">Click here to unarchive</a>',
+      attributes: {
+        'data-auto-id': 'subsidiariesWhyArchived'
+      }
+    }) }}
+  {% endif %}
 
   {{ CollectionContent(subsidiaries) }}
 

--- a/test/functional/cypress/selectors/company-subsidiaries.js
+++ b/test/functional/cypress/selectors/company-subsidiaries.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+  return {
+    whyDunAndBradstreet: '[data-auto-id="subsidiariesWhyDunAndBradstreet"]',
+    whyArchived: '[data-auto-id="subsidiariesWhyArchived"]',
+  }
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -1,4 +1,5 @@
 exports.companyBusinessDetails = require('./company-business-details')
+exports.companySubsidiaries = require('./company-subsidiaries')
 exports.companyInteraction = require('./company-interaction')
 exports.detailsContainer = require('./details-container')
 exports.interactionDetails = require('./interaction-details')

--- a/test/functional/cypress/specs/companies/subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-spec.js
@@ -1,0 +1,46 @@
+const fixtures = require('../../fixtures/index.js')
+const selectors = require('../../selectors/index.js')
+
+describe('Companies business details', () => {
+  context('when viewing subsidiaries for a Dun & Bradstreet company', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.oneListCorp.id}/subsidiaries`)
+    })
+
+    it('should display the "Why can I not link a subsidiary?" D&B details summary', () => {
+      cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('be.visible')
+    })
+
+    it('should not display the "Why can I not link a subsidiary?" archived details summary', () => {
+      cy.get(selectors.companySubsidiaries().whyArchived).should('not.exist')
+    })
+  })
+
+  context('when viewing subsidiaries for a Data Hub company', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.venusLtd.id}/subsidiaries`)
+    })
+
+    it('should not display the "Why can I not link a subsidiary?" D&B details summary', () => {
+      cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('not.exist')
+    })
+
+    it('should not display the "Why can I not link a subsidiary?" archived details summary', () => {
+      cy.get(selectors.companySubsidiaries().whyArchived).should('not.exist')
+    })
+  })
+
+  context('when viewing subsidiaries for an archived company', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.archivedLtd.id}/subsidiaries`)
+    })
+
+    it('should not display the "Why can I not link a subsidiary?" D&B details summary', () => {
+      cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('not.exist')
+    })
+
+    it('should display the "Why can I not link a subsidiary?" archived details summary', () => {
+      cy.get(selectors.companySubsidiaries().whyArchived).should('be.visible')
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/lSizcPfl/871-remove-why-can-i-not-link-a-subsidiary-details-for-data-hub-companies

## Change
Currently the `Why can I not link a subsidiary?` is showing for all companies. It should only be shown when a company is archived or when a company is from D&B data.

## Before
<img width="783" alt="Screenshot 2019-03-13 at 14 35 29" src="https://user-images.githubusercontent.com/1150417/54287358-677df200-459d-11e9-891f-359c0514aa10.png">

## After
<img width="769" alt="Screenshot 2019-03-13 at 14 35 05" src="https://user-images.githubusercontent.com/1150417/54287345-64830180-459d-11e9-8436-b587b38bf07c.png">