### PR TITLE
Bug - Correct the state of the radio option for policy feedback

### DIFF
--- a/src/apps/interactions/transformers/interaction-response-to-form.js
+++ b/src/apps/interactions/transformers/interaction-response-to-form.js
@@ -44,7 +44,7 @@ function transformInteractionResponseToForm ({
     policy_areas: displayPolicyAreas,
     policy_issue_types: displayPolicyTypes,
     policy_feedback_notes,
-    was_policy_feedback_provided: isNil(was_policy_feedback_provided) ? 'false' : 'true',
+    was_policy_feedback_provided: was_policy_feedback_provided ? 'true' : 'false',
     date: {
       day: isValidDate ? format(date, 'DD') : '',
       month: isValidDate ? format(date, 'MM') : '',

--- a/test/unit/apps/interactions/transformers/interaction-response-to-form.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-response-to-form.test.js
@@ -1,5 +1,6 @@
 const transformInteractionResponseToForm = require('~/src/apps/interactions/transformers/interaction-response-to-form')
 const mockInteraction = require('~/test/unit/data/interactions/interaction-with-feedback.json')
+const mockInteractionNoFeedback = { ...mockInteraction }
 
 describe('#transformInteractionResponseToForm', () => {
   context('when the source is an interaction', () => {
@@ -102,6 +103,38 @@ describe('#transformInteractionResponseToForm', () => {
         policy_issue_types: ['4b9142df-0520-46bd-9da9-94147cdbae13'],
         policy_feedback_notes: 'Labore culpa quas cupiditate voluptatibus magni.',
         was_policy_feedback_provided: 'true',
+        notes: 'Labore culpa quas cupiditate voluptatibus magni.',
+        subject: 'ad',
+        policy_areas: [],
+      })
+    })
+  })
+
+  context('when the source is a service delivery and has no policy feedback', () => {
+    mockInteractionNoFeedback.was_policy_feedback_provided = false
+    mockInteractionNoFeedback.policy_issue_types = []
+    mockInteractionNoFeedback.policy_feedback_notes = ''
+    beforeEach(() => {
+      this.transformed = transformInteractionResponseToForm(mockInteractionNoFeedback)
+    })
+    it('should transform data from interaction response to form', () => {
+      expect(this.transformed).to.deep.equal({
+        company: '0f5216e0-849f-11e6-ae22-56b6b6499611',
+        contacts: ['7701587b-e88f-4f39-874f-0bd06321f7df'],
+        dit_adviser: '537df876-5062-e311-8255-e4115bead28a',
+        service: 'd320b92b-3499-e211-a939-e4115bead28a',
+        service_delivery_status: undefined,
+        grant_amount_offered: null,
+        net_company_receipt: null,
+        dit_team: '16362a92-9698-e211-a939-e4115bead28a',
+        communication_channel: '70c226d7-5d95-e211-a939-e4115bead28a',
+        date: { day: '25', month: '11', year: '2058' },
+        is_event: 'false',
+        event: undefined,
+        id: 'af4aac84-4d6a-47df-a733-5a54e3008c32',
+        policy_issue_types: [],
+        policy_feedback_notes: '',
+        was_policy_feedback_provided: 'false',
         notes: 'Labore culpa quas cupiditate voluptatibus magni.',
         subject: 'ad',
         policy_areas: [],


### PR DESCRIPTION
## Problem
When editing an interaction without policy feedback the state of the feedback option on the editable form is set to 'yes' when it should be 'no'
![Screenshot 2019-03-14 at 10 14 45](https://user-images.githubusercontent.com/10154302/54352164-e845f800-4648-11e9-8d67-306d242f4c5d.png)


## Solution
The state of the radio button for policy feedback should reflect what options you had previously choosen before editing the form.
![Screenshot 2019-03-14 at 10 57 32](https://user-images.githubusercontent.com/10154302/54352175-ed0aac00-4648-11e9-9ffc-51377cb14e40.png)

