### PR TITLE
Make "Edit" link on Business details consistent

### DIFF
--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -22,7 +22,7 @@
   display: block;
 
   @include media(tablet) {
-    font-size: 20px;
+    font-size: 19px;
     float: right;
 
     & + * {

--- a/src/templates/_macros/details-container/_details-container.scss
+++ b/src/templates/_macros/details-container/_details-container.scss
@@ -10,7 +10,7 @@
   }
 }
 
-.c-details-container__edit-link {
+.c-details-container__action {
   @include govuk-font($size: 19, $weight: bold);
 
   margin-left: auto;

--- a/src/templates/_macros/details-container/_details-container.scss
+++ b/src/templates/_macros/details-container/_details-container.scss
@@ -11,7 +11,7 @@
 }
 
 .c-details-container__edit-link {
-  @include govuk-font($size: 24);
+  @include govuk-font($size: 19, $weight: bold);
 
   margin-left: auto;
 }

--- a/src/templates/_macros/details-container/template.njk
+++ b/src/templates/_macros/details-container/template.njk
@@ -8,7 +8,7 @@
   {% endif %}
 
   {% if props.editUrl %}
-    <a href="{{ props.editUrl }}" class="c-details-container__edit-link">Edit</a>
+    <a href="{{ props.editUrl }}" class="c-details-container__action">Edit</a>
   {% endif %}
 
   {% if caller %}

--- a/test/functional/cypress/selectors/details-container.js
+++ b/test/functional/cypress/selectors/details-container.js
@@ -3,6 +3,6 @@ module.exports = (dataAutoId) => {
   return {
     container: containerSelector,
     heading: `${containerSelector} h2`,
-    editLink: `${containerSelector} a.c-details-container__edit-link`,
+    editLink: `${containerSelector} a.c-details-container__action`,
   }
 }


### PR DESCRIPTION
https://trello.com/c/gVcKL4jb/872-make-edit-links-consistent

## Change
`Edit` links on the `Business details` view are inconsistent with the rest of Data Hub. This change sets the size to 19 and the weight to bold.

## Before
![Screenshot 2019-03-15 at 13 40 05](https://user-images.githubusercontent.com/1150417/54436985-8ca06b00-472b-11e9-8c2c-801fd304da0d.png)

## After
![Screenshot 2019-03-15 at 13 40 21](https://user-images.githubusercontent.com/1150417/54436991-90cc8880-472b-11e9-8025-d3774f43581a.png)
