### PR TITLE
Adding a "Growth capital profile" tab into Companies/Investment

### DIFF
--- a/src/apps/companies/apps/investments/growth-capital-profile/views/list-deprecated.njk
+++ b/src/apps/companies/apps/investments/growth-capital-profile/views/list-deprecated.njk
@@ -1,5 +1,5 @@
 {% extends "../../../../views/_deprecated/template.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">Investments - Growth capital profile</h2>
+  {% include "./main.njk" %}
 {% endblock %}

--- a/src/apps/companies/apps/investments/growth-capital-profile/views/list.njk
+++ b/src/apps/companies/apps/investments/growth-capital-profile/views/list.njk
@@ -1,5 +1,5 @@
 {% extends "../../../../views/template.njk" %}
 
 {% block body_main_content %}
-  <h2 class="govuk-heading-m">Investments - Growth capital profile</h2>
+  {% include "./main.njk" %}
 {% endblock %}

--- a/src/apps/companies/apps/investments/growth-capital-profile/views/main.njk
+++ b/src/apps/companies/apps/investments/growth-capital-profile/views/main.njk
@@ -1,0 +1,11 @@
+{% from "companies/apps/investments/macros/navigation.njk" import subnavigation %}
+
+{{ subnavigation(company, 'growth-capital-profile') }}
+
+<h2 class="govuk-heading-m" data-auto-id="investment-subheading">Growth capital investor profile</h2>
+
+{% if companyProfile  %}
+  <pre>{{ companyProfile | dump(2) }}</pre>
+{% else %}
+  <button class="button" data-auto-id="create-a-profile">Create a profile</button>
+{% endif %}

--- a/test/functional/cypress/specs/companies/investments/growth-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/growth-capital-profile-spec.js
@@ -1,0 +1,61 @@
+const fixtures = require('../../../fixtures/index.js')
+const selectors = require('../../../selectors/index.js')
+
+const baseUrl = Cypress.config().baseUrl
+const { oneListCorp } = fixtures.company
+
+describe('Company Investments and Growth capital profile', () => {
+  before(() => {
+    cy.visit(`/companies/${oneListCorp.id}/investments/growth-capital-profile`)
+  })
+
+  context('when viewing the company header', () => {
+    it('should display the "One List Corp" heading', () => {
+      cy.get(selectors.localHeader().heading).should('have.text', 'One List Corp')
+    })
+  })
+
+  context('when viewing the 3 tabs', () => {
+    it('should display an "Investments projects" tab with the correct URL', () => {
+      cy.get(selectors.companyInvestment.investmentProjectsTab).find('a')
+        .should('have.prop', 'href')
+        .and('equal', `${baseUrl}/companies/${oneListCorp.id}/investments/projects`)
+    })
+
+    it('should display a "Large capital profile" tab with the correct URL', () => {
+      cy.get(selectors.companyInvestment.largeCapitalProfileTab).find('a')
+        .should('have.prop', 'href')
+        .and('equal', `${baseUrl}/companies/${oneListCorp.id}/investments/large-capital-profile`)
+    })
+
+    it('should display a "Growth capital profile" tab with the correct URL', () => {
+      cy.get(selectors.companyInvestment.growthCapitalProfileTab).find('a')
+        .should('have.prop', 'href')
+        .and('equal', `${baseUrl}/companies/${oneListCorp.id}/investments/growth-capital-profile`)
+    })
+  })
+
+  context('when the Growth capital profile tab is selected', () => {
+    it('should not have an "active" class on the "Investment projects" tab', () => {
+      cy.get(selectors.companyInvestment.investmentProjectsTab).should('not.have.class', 'active')
+    })
+
+    it('should not have an "active" class on the "Large capital profile" tab', () => {
+      cy.get(selectors.companyInvestment.largeCapitalProfileTab).should('not.have.class', 'active')
+    })
+
+    it('should have an "active" class on the "Growth capital profile" tab', () => {
+      cy.get(selectors.companyInvestment.growthCapitalProfileTab).should('have.class', 'active')
+    })
+  })
+
+  context('when viewing the tabbed area content', () => {
+    it('should display the "Growth capital investor profile" subheading', () => {
+      cy.get(selectors.companyInvestment.subHeading).should('have.text', 'Growth capital investor profile')
+    })
+
+    it('should display a "Create a profile" button when the company does not have a "Growth capital investor profile"', () => {
+      cy.get(selectors.companyInvestment.createAProfile).should('have.text', 'Create a profile')
+    })
+  })
+})


### PR DESCRIPTION
When a user selects the "Growth capital profile" tab we will make an
API call to a new endpoint although this is further down the line as
it's not a top priority at present.

For now we can just show the "Create a profile" button without any
API call or logic being applied and start to build out the functional
tests.

https://uktrade.atlassian.net/browse/IPBETA-373

<img width="1266" alt="Screenshot 2019-03-15 at 16 19 50" src="https://user-images.githubusercontent.com/964268/54446176-43a5e200-473e-11e9-8476-6b14656466b1.png">