### PR TITLE
Adding an "Investments projects" tab into Companies/Investment

### DIFF
--- a/src/apps/companies/apps/investments/projects/views/list-deprecated.njk
+++ b/src/apps/companies/apps/investments/projects/views/list-deprecated.njk
@@ -1,29 +1,5 @@
 {% extends "../../../../views/_deprecated/template.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">Investment projects</h2>
-
-  {% if company.archived %}
-    <details role="group">
-      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
-        <span class="details__summary">
-          Why can I not add an investment project?
-        </span>
-      </summary>
-      <div class="details__content" id="details-content-0" aria-hidden="false">
-        <p class="c-message c-message--muted">Investment projects cannot be added to an archived company.
-          <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
-        </p>
-      </div>
-    </details>
-  {% endif %}
-
-  {{
-    CollectionContent(results | assignCopy({
-      sort: sort,
-      countLabel: 'project',
-      query: QUERY,
-      actionButtons: actionButtons
-    }))
-  }}
+  {% include "./main.njk" %}
 {% endblock %}

--- a/src/apps/companies/apps/investments/projects/views/list.njk
+++ b/src/apps/companies/apps/investments/projects/views/list.njk
@@ -1,31 +1,5 @@
 {% extends "../../../../views/template.njk" %}
 
 {% block body_main_content %}
-
-  <h2 class="govuk-heading-m">Investment projects</h2>
-
-  {% if company.archived %}
-    <details role="group">
-      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
-        <span class="details__summary">
-          Why can I not add an investment project?
-        </span>
-      </summary>
-      <div class="details__content" id="details-content-0" aria-hidden="false">
-        <p class="c-message c-message--muted">Investment projects cannot be added to an archived company.
-          <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
-        </p>
-      </div>
-    </details>
-  {% endif %}
-
-  {{
-    CollectionContent(results | assignCopy({
-      sort: sort,
-      countLabel: 'project',
-      query: QUERY,
-      actionButtons: actionButtons
-    }))
-  }}
-
+  {% include "./main.njk" %}
 {% endblock %}

--- a/src/apps/companies/apps/investments/projects/views/main.njk
+++ b/src/apps/companies/apps/investments/projects/views/main.njk
@@ -1,0 +1,35 @@
+{% from "companies/apps/investments/macros/navigation.njk" import subnavigation %}
+
+{#
+    When Large captial growth has been implemented remove this comment
+    and expose the subnavigation for "Investments projects". This allows
+    the user to tab between the two.
+
+    {{ subnavigation(company, 'investment-projects') }}
+#}
+
+<h2 class="govuk-heading-m" data-cy="investment-subheading">Investment projects</h2>
+
+{% if company.archived %}
+  <details role="group">
+    <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+        <span class="details__summary">
+          Why can I not add an investment project?
+        </span>
+    </summary>
+    <div class="details__content" id="details-content-0" aria-hidden="false">
+      <p class="c-message c-message--muted">Investment projects cannot be added to an archived company.
+        <a href="/companies/{{company.id}}/unarchive">Click here to unarchive</a>
+      </p>
+    </div>
+  </details>
+{% endif %}
+
+  {{
+  CollectionContent(results | assignCopy({
+    sort: sort,
+    countLabel: 'project',
+    query: QUERY,
+    actionButtons: actionButtons
+  }))
+  }}

--- a/test/functional/cypress/specs/companies/investments/investment-projects-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-projects-spec.js
@@ -1,0 +1,16 @@
+const fixtures = require('../../../fixtures/index.js')
+const selectors = require('../../../selectors/index.js')
+
+const { oneListCorp } = fixtures.company
+
+describe('Company Investments and Investment projects', () => {
+  before(() => {
+    cy.visit(`/companies/${oneListCorp.id}/investments/projects`)
+  })
+
+  context('when viewing the company header', () => {
+    it('should display the "One List Corp" heading', () => {
+      cy.get(selectors.localHeader().heading).should('have.text', 'One List Corp')
+    })
+  })
+})


### PR DESCRIPTION
We cannot reveal the tab (hence it's commented out)  until the
"Large capital profile" functionality has been implemented allowing
the user to tab between the two. However, we can start to build out
the functional tests.

https://uktrade.atlassian.net/browse/IPBETA-374

**Not revealing any subtabs**

<img width="1273" alt="tab-not-reveal" src="https://user-images.githubusercontent.com/964268/54447728-0a6f7100-4742-11e9-8432-8a217f0026df.png">

**[Uncomment](https://github.com/uktrade/data-hub-frontend/blob/397bbcdd317a498930e6390cce990fa850415e87/src/apps/companies/apps/investments/projects/views/main.njk#L8) the code to see the tab**

<img width="1273" alt="Screenshot 2019-03-15 at 16 49 34" src="https://user-images.githubusercontent.com/964268/54448107-dfd1e800-4742-11e9-9e00-4b0ebe42df31.png">



