### PR TITLE
Reorder Business details sections

### DIFF
--- a/src/apps/companies/controllers/business-details.js
+++ b/src/apps/companies/controllers/business-details.js
@@ -23,11 +23,11 @@ async function renderBusinessDetails (req, res) {
     .render('companies/views/business-details', {
       heading: 'Business details',
       aboutDetails: transformCompanyToAboutView(company),
+      addressesDetails: transformCompanyToAddressesView(company),
+      regionDetails: transformCompanyToRegionView(company),
+      sectorDetails: transformCompanyToSectorView(company),
       oneListDetails: transformCompanyToOneListView(company),
       businessHierarchyDetails: transformCompanyToBusinessHierarchyView(company, subsidiaries.count),
-      sectorDetails: transformCompanyToSectorView(company),
-      regionDetails: transformCompanyToRegionView(company),
-      addressesDetails: transformCompanyToAddressesView(company),
       archivedDocumentPath: isEmpty(company.archived_documents_url_path) ? undefined : company.archived_documents_url_path,
     })
 }

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -54,28 +54,17 @@
     {% component 'key-value-table', items=aboutDetails, dataAutoId='aboutDetails' %}
   {% endcall %}
 
-  {% if oneListDetails %}
-    {% call DetailsContainer({ heading: 'Global Account Manager – One List', editUrl: editUrl, dataAutoId: 'oneListDetailsContainer' }) %}
-      {% component 'key-value-table', items=oneListDetails, dataAutoId='oneListDetails' %}
-
-      <p>
-        <a href="advisers">See all advisers on the core team</a>
-      </p>
-    {% endcall %}
-  {% endif %}
-
-  {% call DetailsContainer({ heading: 'Business hierarchy', editUrl: editUrl, dataAutoId: 'businessHierarchyDetailsContainer' }) %}
-    {% component 'key-value-table', items=businessHierarchyDetails, dataAutoId='businessHierarchyDetails' %}
-  {% endcall %}
-
-  {% call DetailsContainer({ heading: 'DIT sector', editUrl: editUrl, dataAutoId: 'sectorDetailsContainer' }) %}
-    <table class="table--key-value" data-auto-id="sectorDetails">
+  {% call DetailsContainer({ heading: 'Addresses', editUrl: editUrl, dataAutoId: 'addressesDetailsContainer' }) %}
+    <table class="table--key-value">
       <tbody>
-      {% for sector in sectorDetails %}
-        <tr>
-          <td>{{ sector }}</td>
+        <tr data-auto-id="businessDetailsAddress">
+          {% if addressesDetails.trading.address %}
+            {{ AddressCell(addressesDetails.trading.meta, addressesDetails.trading.address) }}
+          {% endif %}
+          {% if addressesDetails.registered.address %}
+            {{ AddressCell(addressesDetails.registered.meta, addressesDetails.registered.address) }}
+          {% endif %}
         </tr>
-      {% endfor %}
       </tbody>
     </table>
   {% endcall %}
@@ -92,19 +81,30 @@
     {% endcall %}
   {% endif %}
 
-  {% call DetailsContainer({ heading: 'Addresses', editUrl: editUrl, dataAutoId: 'addressesDetailsContainer' }) %}
-    <table class="table--key-value">
+  {% call DetailsContainer({ heading: 'DIT sector', editUrl: editUrl, dataAutoId: 'sectorDetailsContainer' }) %}
+    <table class="table--key-value" data-auto-id="sectorDetails">
       <tbody>
-        <tr data-auto-id="businessDetailsAddress">
-          {% if addressesDetails.trading.address %}
-            {{ AddressCell(addressesDetails.trading.meta, addressesDetails.trading.address) }}
-          {% endif %}
-          {% if addressesDetails.registered.address %}
-            {{ AddressCell(addressesDetails.registered.meta, addressesDetails.registered.address) }}
-          {% endif %}
+      {% for sector in sectorDetails %}
+        <tr>
+          <td>{{ sector }}</td>
         </tr>
+      {% endfor %}
       </tbody>
     </table>
+  {% endcall %}
+
+  {% if oneListDetails %}
+    {% call DetailsContainer({ heading: 'Global Account Manager – One List', editUrl: editUrl, dataAutoId: 'oneListDetailsContainer' }) %}
+      {% component 'key-value-table', items=oneListDetails, dataAutoId='oneListDetails' %}
+
+      <p>
+        <a href="advisers">See all advisers on the core team</a>
+      </p>
+    {% endcall %}
+  {% endif %}
+
+  {% call DetailsContainer({ heading: 'Business hierarchy', editUrl: editUrl, dataAutoId: 'businessHierarchyDetailsContainer' }) %}
+    {% component 'key-value-table', items=businessHierarchyDetails, dataAutoId='businessHierarchyDetails' %}
   {% endcall %}
 
   {% if archivedDocumentPath %}

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -39,6 +39,42 @@ describe('Companies business details', () => {
       })
     })
 
+    it('should display the "Addresses" details container heading', () => {
+      assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
+    })
+
+    it('should not display the "Addresses" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('addressesDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the address', () => {
+      const addressSelector = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
+      cy.get(addressSelector.line(1)).should('have.text', '12 St George\'s Road')
+      cy.get(addressSelector.line(2)).should('have.text', 'Paris')
+      cy.get(addressSelector.line(3)).should('have.text', '75001')
+      cy.get(addressSelector.line(4)).should('have.text', 'France')
+    })
+
+    it('should not display the "DIT region" details container', () => {
+      cy.get(selectors.detailsContainer('regionDetailsContainer').container).should('not.exist')
+    })
+
+    it('should display the "DIT sector" details container heading', () => {
+      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
+    })
+
+    it('should not display the "DIT sector" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "DIT sector" details', () => {
+      assertValueTable('sectorDetails', [
+        'Retail',
+      ])
+    })
+
     it('should display the "Global Account Manager - One List" details container heading', () => {
       assertDetailsContainerHeading('oneListDetailsContainer', 'Global Account Manager – One List')
     })
@@ -67,42 +103,6 @@ describe('Companies business details', () => {
         'Headquarter type': 'Global HQ',
         'Subsidiaries': 'None',
       })
-    })
-
-    it('should display the "DIT sector" details container heading', () => {
-      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
-    })
-
-    it('should not display the "DIT sector" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('not.exist')
-    })
-
-    it('should display the "DIT sector" details', () => {
-      assertValueTable('sectorDetails', [
-        'Retail',
-      ])
-    })
-
-    it('should not display the "DIT region" details container', () => {
-      cy.get(selectors.detailsContainer('regionDetailsContainer').container).should('not.exist')
-    })
-
-    it('should display the "Addresses" details container heading', () => {
-      assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
-    })
-
-    it('should not display the "Addresses" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('addressesDetailsContainer').editLink).should('not.exist')
-    })
-
-    it('should display the address', () => {
-      const addressSelector = selectors.companyBusinessDetails().address(1)
-      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
-      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
-      cy.get(addressSelector.line(1)).should('have.text', '12 St George\'s Road')
-      cy.get(addressSelector.line(2)).should('have.text', 'Paris')
-      cy.get(addressSelector.line(3)).should('have.text', '75001')
-      cy.get(addressSelector.line(4)).should('have.text', 'France')
     })
 
     it('should not display the "Documents from CDMS" details container', () => {
@@ -149,6 +149,52 @@ describe('Companies business details', () => {
       })
     })
 
+    it('should display the "Addresses" details container heading', () => {
+      assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
+    })
+
+    it('should display the "Addresses" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('addressesDetailsContainer').editLink).should('be.visible')
+    })
+
+    it('should display the address', () => {
+      const addressSelector = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
+      cy.get(addressSelector.line(1)).should('have.text', '66 Marcham Road')
+      cy.get(addressSelector.line(2)).should('have.text', 'Bordley')
+      cy.get(addressSelector.line(3)).should('have.text', 'BD23 8RZ')
+      cy.get(addressSelector.line(4)).should('have.text', 'United Kingdom')
+    })
+
+    it('should display the "DIT region" details container heading', () => {
+      assertDetailsContainerHeading('regionDetailsContainer', 'DIT region')
+    })
+
+    it('should display the "DIT region" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('regionDetailsContainer').editLink).should('be.visible')
+    })
+
+    it('should display the "DIT region" details', () => {
+      assertValueTable('regionDetails', [
+        'North West',
+      ])
+    })
+
+    it('should display the "DIT sector" details container heading', () => {
+      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
+    })
+
+    it('should display the "DIT sector" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('be.visible')
+    })
+
+    it('should display the "DIT sector" details', () => {
+      assertValueTable('sectorDetails', [
+        'Retail',
+      ])
+    })
+
     it('should display the "Global Account Manager - One List" details container heading', () => {
       assertDetailsContainerHeading('oneListDetailsContainer', 'Global Account Manager – One List')
     })
@@ -176,52 +222,6 @@ describe('Companies business details', () => {
       assertKeyValueTable('businessHierarchyDetails', {
         'Global HQ': 'Archived Ltd Remove link',
       })
-    })
-
-    it('should display the "DIT sector" details container heading', () => {
-      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
-    })
-
-    it('should display the "DIT sector" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('be.visible')
-    })
-
-    it('should display the "DIT sector" details', () => {
-      assertValueTable('sectorDetails', [
-        'Retail',
-      ])
-    })
-
-    it('should display the "DIT region" details container heading', () => {
-      assertDetailsContainerHeading('regionDetailsContainer', 'DIT region')
-    })
-
-    it('should display the "DIT region" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('regionDetailsContainer').editLink).should('be.visible')
-    })
-
-    it('should display the "DIT region" details', () => {
-      assertValueTable('regionDetails', [
-        'North West',
-      ])
-    })
-
-    it('should display the "Addresses" details container heading', () => {
-      assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
-    })
-
-    it('should display the "Addresses" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('addressesDetailsContainer').editLink).should('be.visible')
-    })
-
-    it('should display the address', () => {
-      const addressSelector = selectors.companyBusinessDetails().address(1)
-      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
-      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
-      cy.get(addressSelector.line(1)).should('have.text', '66 Marcham Road')
-      cy.get(addressSelector.line(2)).should('have.text', 'Bordley')
-      cy.get(addressSelector.line(3)).should('have.text', 'BD23 8RZ')
-      cy.get(addressSelector.line(4)).should('have.text', 'United Kingdom')
     })
 
     it('should display the "Documents from CDMS" details container heading', () => {
@@ -273,42 +273,6 @@ describe('Companies business details', () => {
       })
     })
 
-    it('should not display the "Global Account Manager - One List" details container', () => {
-      cy.get(selectors.detailsContainer('oneListDetailsContainer').container).should('not.exist')
-    })
-
-    it('should display the "Business hierarchy" details container heading', () => {
-      assertDetailsContainerHeading('businessHierarchyDetailsContainer', 'Business hierarchy')
-    })
-
-    it('should not display the "Business hierarchy" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('businessHierarchyDetailsContainer').editLink).should('not.exist')
-    })
-
-    it('should display the "Business hierarchy" details', () => {
-      assertKeyValueTable('businessHierarchyDetails', {
-        'Global HQ': 'None',
-      })
-    })
-
-    it('should display the "DIT sector" details container heading', () => {
-      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
-    })
-
-    it('should not display the "DIT sector" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('not.exist')
-    })
-
-    it('should display the "DIT sector" details', () => {
-      assertValueTable('sectorDetails', [
-        'Retail',
-      ])
-    })
-
-    it('should not display the "DIT region" details container', () => {
-      cy.get(selectors.detailsContainer('regionDetailsContainer').container).should('not.exist')
-    })
-
     it('should display the "Addresses" details container heading', () => {
       assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
     })
@@ -325,6 +289,42 @@ describe('Companies business details', () => {
       cy.get(addressSelector.line(2)).should('have.text', 'Rome')
       cy.get(addressSelector.line(3)).should('have.text', '001122')
       cy.get(addressSelector.line(4)).should('have.text', 'Italy')
+    })
+
+    it('should not display the "DIT region" details container', () => {
+      cy.get(selectors.detailsContainer('regionDetailsContainer').container).should('not.exist')
+    })
+
+    it('should display the "DIT sector" details container heading', () => {
+      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
+    })
+
+    it('should not display the "DIT sector" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "DIT sector" details', () => {
+      assertValueTable('sectorDetails', [
+        'Retail',
+      ])
+    })
+
+    it('should not display the "Global Account Manager - One List" details container', () => {
+      cy.get(selectors.detailsContainer('oneListDetailsContainer').container).should('not.exist')
+    })
+
+    it('should display the "Business hierarchy" details container heading', () => {
+      assertDetailsContainerHeading('businessHierarchyDetailsContainer', 'Business hierarchy')
+    })
+
+    it('should not display the "Business hierarchy" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('businessHierarchyDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "Business hierarchy" details', () => {
+      assertKeyValueTable('businessHierarchyDetails', {
+        'Global HQ': 'None',
+      })
     })
 
     it('should not display the "Documents from CDMS" details container', () => {
@@ -371,6 +371,42 @@ describe('Companies business details', () => {
       })
     })
 
+    it('should display the "Addresses" details container heading', () => {
+      assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
+    })
+
+    it('should not display the "Addresses" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('addressesDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the address', () => {
+      const addressSelector = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
+      cy.get(addressSelector.line(1)).should('have.text', '16 Getabergsvagen')
+      cy.get(addressSelector.line(2)).should('have.text', 'Geta')
+      cy.get(addressSelector.line(3)).should('have.text', '22340')
+      cy.get(addressSelector.line(4)).should('have.text', 'Malta')
+    })
+
+    it('should not display the "DIT region" details container', () => {
+      cy.get(selectors.detailsContainer('regionDetailsContainer').container).should('not.exist')
+    })
+
+    it('should display the "DIT sector" details container heading', () => {
+      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
+    })
+
+    it('should not display the "DIT sector" details container "Edit" link', () => {
+      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('not.exist')
+    })
+
+    it('should display the "DIT sector" details', () => {
+      assertValueTable('sectorDetails', [
+        'Retail',
+      ])
+    })
+
     it('should display the "Global Account Manager - One List" details container heading', () => {
       assertDetailsContainerHeading('oneListDetailsContainer', 'Global Account Manager – One List')
     })
@@ -399,42 +435,6 @@ describe('Companies business details', () => {
         'Headquarter type': 'Global HQ',
         'Subsidiaries': '1 subsidiary',
       })
-    })
-
-    it('should display the "DIT sector" details container heading', () => {
-      assertDetailsContainerHeading('sectorDetailsContainer', 'DIT sector')
-    })
-
-    it('should not display the "DIT sector" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('sectorDetailsContainer').editLink).should('not.exist')
-    })
-
-    it('should display the "DIT sector" details', () => {
-      assertValueTable('sectorDetails', [
-        'Retail',
-      ])
-    })
-
-    it('should not display the "DIT region" details container', () => {
-      cy.get(selectors.detailsContainer('regionDetailsContainer').container).should('not.exist')
-    })
-
-    it('should display the "Addresses" details container heading', () => {
-      assertDetailsContainerHeading('addressesDetailsContainer', 'Addresses')
-    })
-
-    it('should not display the "Addresses" details container "Edit" link', () => {
-      cy.get(selectors.detailsContainer('addressesDetailsContainer').editLink).should('not.exist')
-    })
-
-    it('should display the address', () => {
-      const addressSelector = selectors.companyBusinessDetails().address(1)
-      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
-      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
-      cy.get(addressSelector.line(1)).should('have.text', '16 Getabergsvagen')
-      cy.get(addressSelector.line(2)).should('have.text', 'Geta')
-      cy.get(addressSelector.line(3)).should('have.text', '22340')
-      cy.get(addressSelector.line(4)).should('have.text', 'Malta')
     })
 
     it('should not display the "Documents from CDMS" details container', () => {

--- a/test/unit/apps/companies/controllers/business-details.test.js
+++ b/test/unit/apps/companies/controllers/business-details.test.js
@@ -1,3 +1,4 @@
+
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
 const config = require('~/config')
@@ -32,24 +33,24 @@ describe('#renderBusinessDetails', () => {
         expect(this.middlewareParameters.resMock.render.firstCall.args[1].aboutDetails).to.exist
       })
 
-      it('should set the One List details', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].oneListDetails).to.exist
-      })
-
-      it('should set the business hierarchy details', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].businessHierarchyDetails).to.exist
-      })
-
-      it('should set the sector details', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].sectorDetails).to.exist
+      it('should set the addresses details', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].addressesDetails).to.exist
       })
 
       it('should set the region details', () => {
         expect(this.middlewareParameters.resMock.render.firstCall.args[1].regionDetails).to.exist
       })
 
-      it('should set the addresses details', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].addressesDetails).to.exist
+      it('should set the sector details', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].sectorDetails).to.exist
+      })
+
+      it('should set the One List details', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].oneListDetails).to.exist
+      })
+
+      it('should set the business hierarchy details', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].businessHierarchyDetails).to.exist
       })
     }
 


### PR DESCRIPTION
https://trello.com/c/3NeEiyIu/727-reorder-business-details-sections

## Change
Sections in the `Business details` view need to be in a more logical order. This is a straight forward move of code and the test steps have also been moved for consistency.

## Before
<img width="361" alt="Screenshot 2019-03-18 at 16 43 47" src="https://user-images.githubusercontent.com/1150417/54590202-6f1b1c00-4a1f-11e9-8ef8-c0b4c4cba134.png">

## After
<img width="363" alt="Screenshot 2019-03-18 at 16 46 51" src="https://user-images.githubusercontent.com/1150417/54590212-7510fd00-4a1f-11e9-925a-31c28c21159c.png">
