### PR TITLE
Rework Dockerfile to be based on test base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,9 @@
-FROM ubuntu:16.04
+FROM ukti/docker-data-hub-base:latest
 
-ENV NODE_VERSION 8.11.3
-ENV YARN_VERSION 1.7.0
-ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-RUN apt-get update -qq
-RUN apt-get upgrade -y
-RUN apt-get install -y build-essential libpq-dev curl libpng-dev
-
-# Node js
-# gpg keys listed at https://github.com/nodejs/node#release-team
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
-  ; do \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
-  done
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
-  && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
-
-# Yarn
-RUN set -ex \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
-  done \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt/yarn \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/yarn --strip-components=1 \
-  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+RUN apt-get install -y psmisc
 
 # Setup app
 RUN mkdir -p /usr/src/app
@@ -58,11 +11,12 @@ WORKDIR /usr/src/app
 
 COPY package.json /usr/src/app/
 COPY yarn.lock /usr/src/app/
-RUN yarn install
+RUN yarn --ignore-engines install
 
 COPY . /usr/src/app
 RUN npm run build
 
 EXPOSE 3000
+EXPOSE 9229
 
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ukti/docker-data-hub-base:latest
 ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
+# Install package providing fuser command - necessary to run the app with code
+# watching and debugging under nodemon
 RUN apt-get install -y psmisc
 
 # Setup app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,10 @@ services:
       - ./config:/usr/src/app/config
       - ./src:/usr/src/app/src
       - ./test:/usr/src/app/test
-    command: ./node_modules/.bin/nodemon $NODE_DEBUG_OPTION --inspect -L
+    # Must explicitly kill the process running under port 9229 due to an 
+    # incompatibility between nodemon and docker detailed here:
+    # https://github.com/remy/nodemon/issues/1476
+    command: ./node_modules/.bin/nodemon $NODE_DEBUG_OPTION --delay 80ms --exec 'fuser -k 9229/tcp; sleep 0.1; node --inspect=0.0.0.0:9229 src/server.js' -L
     links:
       - redis
   webpack:

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "nightwatch-cucumber": "^9.0.0",
     "nightwatch-custom-commands-assertions": "^1.1.1",
     "nock": "^9.2.6",
-    "nodemon": "^1.17.5",
+    "nodemon": "^1.18.10",
     "npm-run-all": "^4.1.3",
     "nyc": "^11.8.0",
     "pre-commit": "^1.2.2",


### PR DESCRIPTION
The Dockerfile used for setting up local dev copies was quite outdated.  This lead to local `docker-compose build` commands to take over 30 minutes to complete.

This change cleans up the Dockerfile and makes it depend on our dockerhub-hosted frontend base image, which keeps things more DRY.
Also fixed an issue where the app would frequently crash when modifying source files - this was due to an incompatibility between nodemon and docker.  The fix is a little bit of a hack, but there's not really a more elegant alternative until a fix is made to nodemon directly.
