### PR TITLE
Use new base docker image for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ukti/docker-datahub-fe-base:latest
 
+# **Notice that this base image is used on our deployments, so extra caution in modifying it.
+
 ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ukti/docker-data-hub-base:latest
+FROM ukti/docker-datahub-fe-base:latest
 
 ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH


### PR DESCRIPTION
This changes the Dockerfile to use a new purpose-built base docker image, instead of the base image for testing.

It transpired that this Dockerfile is in use for deployments - and the changes that were made to inherit from the test base lead to breakages on jenkins.  The new base image aims to be as minimal as possible and locks node to 8.11.3.