### PR TITLE
Add Nunjucks filter to format address

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -9,6 +9,7 @@ const { newlineToBr } = require('../../src/lib/text-formatting')
 const {
   assign,
   castArray,
+  compact,
   concat,
   escape,
   isArray,
@@ -185,6 +186,19 @@ const filters = {
     if (!dateFns.isValid(parsedDate)) { return value }
 
     return dateFns.format(parsedDate, format)
+  },
+
+  formatAddress: (address) => {
+    if (address) {
+      return compact([
+        address.line_1,
+        address.line_2,
+        address.town,
+        address.county,
+        address.postcode,
+        address.country.name,
+      ]).join(', ')
+    }
   },
 
   humanizeDuration: (value, measurement = 'minutes') => {

--- a/test/unit/config/nunjucks/filters.test.js
+++ b/test/unit/config/nunjucks/filters.test.js
@@ -308,6 +308,56 @@ describe('nunjucks filters', () => {
     })
   })
 
+  describe('#formatAddress', () => {
+    context('when all address fields are populated', () => {
+      beforeEach(() => {
+        this.actual = filters.formatAddress({
+          line_1: 'line 1',
+          line_2: 'line 2',
+          town: 'town',
+          county: 'county',
+          postcode: 'postcode',
+          country: {
+            name: 'country',
+          },
+        })
+      })
+
+      it('should format the address as a comma separated list', () => {
+        expect(this.actual).to.equal('line 1, line 2, town, county, postcode, country')
+      })
+    })
+
+    context('when minimal address fields are populated', () => {
+      beforeEach(() => {
+        this.actual = filters.formatAddress({
+          line_1: 'line 1',
+          line_2: '',
+          town: 'town',
+          county: '',
+          postcode: 'postcode',
+          country: {
+            name: 'country',
+          },
+        })
+      })
+
+      it('should format the address as a comma separated list', () => {
+        expect(this.actual).to.equal('line 1, town, postcode, country')
+      })
+    })
+
+    context('when the address does not exist', () => {
+      beforeEach(() => {
+        this.actual = filters.formatAddress(null)
+      })
+
+      it('should format the address as a comma separated list', () => {
+        expect(this.actual).to.not.exist
+      })
+    })
+  })
+
   describe('#collectionDefault', () => {
     const mockObjectWithEmpties = {
       a: true,


### PR DESCRIPTION
https://trello.com/c/urWUCYnD/884-consolidate-formatting-of-addresses

This change adds a Nunjucks filter to format addresses. This will ultimately consolidate current address formatting. It will also be consistent with other formatting on the FE - ie `formatCurrency`.