### PR TITLE
Adding a reusable nunjucks details macro

### DIFF
--- a/src/apps/companies/apps/investments/macros/details/details.njk
+++ b/src/apps/companies/apps/investments/macros/details/details.njk
@@ -1,0 +1,18 @@
+{% macro details(summaryText, incompleteFields, open) %}
+  <details class="govuk-details govuk-details--dit {{ summaryText }}" {{ "open" if open }}>
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">{{ summaryText }}</span>
+      <div class="incomplete-fields">
+        {% if incompleteFields === 0 %}
+          <i class="fas fa-check"></i>
+          <span class="complete">Complete</span>
+        {% else  %}
+          <span>{{ incompleteFields }} {{ 'field' | pluralise(incompleteFields) }} incomplete</span>
+        {% endif %}
+      </div>
+    </summary>
+    <div class="govuk-details__text">
+      {{ caller() }}
+    </div>
+  </details>
+{% endmacro %}

--- a/src/apps/companies/apps/investments/macros/details/details.scss
+++ b/src/apps/companies/apps/investments/macros/details/details.scss
@@ -1,0 +1,70 @@
+.govuk-details--dit {
+  margin: 0;
+  padding-top: 8px;
+  border-top: 2px solid lightgray;
+
+  .govuk-details__summary:focus {
+    outline: none;
+    background: none;
+  }
+
+  .govuk-details__summary:before {
+    top: -31px;
+  }
+
+  .govuk-details__summary {
+    @include govuk-responsive-padding(8, "left");
+    display: flex;
+    flex-direction: column;
+  }
+
+  .govuk-details__summary-text {
+    font-size: 18px;
+    text-decoration: none;
+  }
+
+  .incomplete-fields {
+    font-size: 16px;
+    color: $dit-colour;
+  }
+
+  .govuk-details__text {
+    @include govuk-responsive-margin(4, "top");
+    padding: 0;
+    border-left: none;
+
+    select {
+      width: 100%;
+    }
+  }
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: 25px;
+    padding-bottom: 20px;
+
+    .govuk-details__summary-text {
+      font-size: 24px;
+    }
+
+    .incomplete-fields {
+      font-size: 18px;
+    }
+
+    .govuk-details__summary {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    .govuk-details__summary:before {
+      top: 0;
+    }
+
+    .govuk-details__summary:before {
+      border-width: 10px 0 10px 15px;
+    }
+
+    &[open] > .govuk-details__summary:before {
+      border-width: 15px 10px 0 10px;
+    }
+  }
+}


### PR DESCRIPTION
This component is a modification to the GOV.UK details component.

From this: https://design-system.service.gov.uk/components/details/
To this: https://8c3nz4.axshare.com/#g=1&p=ci_largecap_collapsed

It uses the same styles from GOV.UK with overrides to achieve the new
look-and-feel as per the design. The component adds an incomplete
field informing the user how many fields need to be completed before
expanding the section to reveal fields. Lastly, the component is fully
responsive: https://8c3nz4.axshare.com/#g=1&p=ci_largecap_mobile

https://uktrade.atlassian.net/browse/IPBETA-375

**Desktop**

![three-details-macros-desktop](https://user-images.githubusercontent.com/964268/54912197-0a146a00-4ee8-11e9-8c33-48eb6fe2543c.png)

**Mobile (iPhone 5)**

![three-details-macros-mobile](https://user-images.githubusercontent.com/964268/54912221-17315900-4ee8-11e9-9eb0-e7089f2a2f11.png)

