### PR TITLE
Upgrade to node 8.15.1, use latest buildpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ aliases:
 
   # Common steps
   - &restore_yarn_cache
-    restore_cache:
-      name: Restore yarn dependencies cache
-      steps:
-        - run: node --version > node_version
-        - run: yarn --version > yarn_version
-      key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
+    steps:
+      - run: node --version > node_version
+      - run: yarn --version > yarn_version
+      restore_cache:
+        name: Restore yarn dependencies cache
+        key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
 
   # Configuration shared between user_acceptance* jobs
   - &at_container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,7 @@ jobs:
     parallelism: 6
     steps:
       - checkout
+      - run: yarn install
       - *wait_for_backend
       - *wait_for_mock_sso
       - *store_versions
@@ -407,6 +408,7 @@ jobs:
       - *docker_data_hub_backend_celery
     steps:
       - checkout
+      - run: yarn install
       - *wait_for_backend
       - *wait_for_mock_sso
       - *store_versions
@@ -439,6 +441,7 @@ jobs:
       - *docker_data_hub_backend_celery
     steps:
       - checkout
+      - run: yarn install
       - *wait_for_backend
       - *wait_for_mock_sso
       - *store_versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 aliases:
-  - &node_version               node:8.11.3
+  - &node_version               node:8.15.1
   - &redis_version              redis:3.2.10
   - &postgres_version           postgres:10
   - &mi_postgres_version        postgres:9.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 aliases:
   - &node_version               node:8.15.1
+  - &yarn_version               node:1.15.1
   - &redis_version              redis:3.2.10
   - &postgres_version           postgres:10
   - &mi_postgres_version        postgres:9.6
@@ -11,12 +12,9 @@ aliases:
 
   # Common steps
   - &restore_yarn_cache
-    steps:
-      - run: node --version > node_version
-      - run: yarn --version > yarn_version
-      restore_cache:
-        name: Restore yarn dependencies cache
-        key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
+    restore_cache:
+      name: Restore yarn dependencies cache
+      key: yarn-dependency-{{ checksum "package.json" }}-{{ *node_version }}-{{ *yarn_version }}
 
   # Configuration shared between user_acceptance* jobs
   - &at_container_config
@@ -231,11 +229,9 @@ jobs:
       - *restore_yarn_cache
       - run: yarn install
       - run: yarn add wavy  # explicitly install wavy module
-      - run: node --version > node_version
-      - run: yarn --version > yarn_version
       - save_cache:
           name: Save yarn dependencies cache
-          key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
+          key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum *node_version }}-{{ checksum *yarn_version }}
           paths:
             - ~/data-hub-frontend/node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2
 aliases:
   - &node_version               node:8.15.1
-  - &yarn_version               node:1.15.1
   - &redis_version              redis:3.2.10
   - &postgres_version           postgres:10
   - &mi_postgres_version        postgres:9.6
@@ -14,7 +13,12 @@ aliases:
   - &restore_yarn_cache
     restore_cache:
       name: Restore yarn dependencies cache
-      key: yarn-dependency-{{ checksum "package.json" }}-{{ *node_version }}-{{ *yarn_version }}
+      key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
+
+  - &store_versions
+    run:
+      name: Temporarily store node/yarn versions on filesystem
+      command: node --version > node_version; yarn --version > yarn_version
 
   # Configuration shared between user_acceptance* jobs
   - &at_container_config
@@ -226,12 +230,13 @@ jobs:
     working_directory: ~/data-hub-frontend
     steps:
       - checkout
+      - *store_versions
       - *restore_yarn_cache
       - run: yarn install
       - run: yarn add wavy  # explicitly install wavy module
       - save_cache:
           name: Save yarn dependencies cache
-          key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum *node_version }}-{{ checksum *yarn_version }}
+          key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
           paths:
             - ~/data-hub-frontend/node_modules
 
@@ -242,6 +247,7 @@ jobs:
     working_directory: ~/data-hub-frontend
     steps:
       - checkout
+      - *store_versions
       - *restore_yarn_cache
       - run:
           name: Lint code
@@ -264,6 +270,7 @@ jobs:
     working_directory: ~/data-hub-frontend
     steps:
       - checkout
+      - *store_versions
       - *restore_yarn_cache
       - run:
           name: Run unit tests
@@ -292,6 +299,7 @@ jobs:
     working_directory: ~/data-hub-frontend
     steps:
       - checkout
+      - *store_versions
       - *restore_yarn_cache
       - run:
           name: Run vue tests
@@ -320,6 +328,7 @@ jobs:
       - checkout
       - run: yarn install
       - *wait_for_mock_sso
+      - *store_versions
       - *restore_yarn_cache
       - run: yarn build
       - *start_frontend
@@ -348,6 +357,7 @@ jobs:
       - checkout
       - *wait_for_backend
       - *wait_for_mock_sso
+      - *store_versions
       - *restore_yarn_cache
       - run: yarn build
       - *start_frontend
@@ -399,6 +409,7 @@ jobs:
       - checkout
       - *wait_for_backend
       - *wait_for_mock_sso
+      - *store_versions
       - *restore_yarn_cache
       - run: yarn build
       - *start_frontend
@@ -430,6 +441,7 @@ jobs:
       - checkout
       - *wait_for_backend
       - *wait_for_mock_sso
+      - *store_versions
       - *restore_yarn_cache
       - run: yarn build
       - *start_frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,10 @@ aliases:
   - &restore_yarn_cache
     restore_cache:
       name: Restore yarn dependencies cache
-      key: yarn-dependency-{{ checksum "package.json" }}
+      steps:
+        - run: node --version > node_version
+        - run: yarn --version > yarn_version
+      key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
 
   # Configuration shared between user_acceptance* jobs
   - &at_container_config
@@ -228,9 +231,11 @@ jobs:
       - *restore_yarn_cache
       - run: yarn install
       - run: yarn add wavy  # explicitly install wavy module
+      - run: node --version > node_version
+      - run: yarn --version > yarn_version
       - save_cache:
           name: Save yarn dependencies cache
-          key: yarn-dependency-{{ checksum "package.json" }}
+          key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}-{{ checksum "yarn_version" }}
           paths:
             - ~/data-hub-frontend/node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ukti/docker-datahub-fe-base:latest
 
-# **Notice that this base image is used on our deployments, so extra caution in modifying it.
-
 ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
@@ -15,7 +13,7 @@ WORKDIR /usr/src/app
 
 COPY package.json /usr/src/app/
 COPY yarn.lock /usr/src/app/
-RUN yarn --ignore-engines install
+RUN yarn install
 
 COPY . /usr/src/app
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ and be provided with a back end server to provide the API, data storage and sear
 
 ### Docker
 
-The project comes with docker compose files, this means if you have docker you can start
-the app with a single command.
+The project comes with docker compose files, this means if you have docker 
+you can start the app with a single command.
 
 There are 2 docker files.
 
@@ -157,14 +157,19 @@ in an environment file).
     docker-compose up
     ```
 
-    The server starts in developer mode, which means that when you make local changes it will auto-compile
-    sass or javavscript, and will restart nodejs when server side changes are made. A container with redis will also start, this is linked to the data hub container.
+    The server starts in developer mode, which means that when you make local 
+    changes it will auto-compile sass or javavscript, and will restart nodejs 
+    when server side changes are made. A container with redis will also start, 
+    this is linked to the data hub container.
     
-    You can access the server on port 3000, [http://localhost:3000](http://localhost:3000). You can also run
-    a remote debug session over port 5858 if using webstorm/Intellij or Visual Studio Code
+    You can access the server on port 3000, 
+    [http://localhost:3000](http://localhost:3000). You can also run a remote 
+    debug session over port 9229 if using webstorm/Intellij or Visual Studio Code
 
-4.  You will need to set up OAuth.  It is recommended to use the [uktrade/mock-sso](https://github.com/uktrade/mock-sso) 
-    backend as this is fully compatible with docker-compose projects - [see the OAuth section for more detail](#oauth).
+4.  You will need to set up OAuth.  It is recommended to use the 
+    [uktrade/mock-sso](https://github.com/uktrade/mock-sso) backend as this is 
+    fully compatible with docker-compose projects - 
+    [see the OAuth section for more detail](#oauth).
 
 ### Native install
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,3 +1,3 @@
 ---
 applications:
-  - buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.6.26
+  - buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.6.46

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": "8.11.3"
+    "node": "8.15.1"
   },
   "dependencies": {
     "autoprefixer": "^8.5.2",


### PR DESCRIPTION
It looks as if deployments via cloudfoundry are broken due to a missing linux dependency for the current node buildpack version.

This PR updates the buildpack to the latest version.  As a consequence we also need to bump node's version from 8.11.3 to 8.15.1 - there shouldn't be any backward incompatible changes or breakages.
