### PR TITLE
Bug - Remove Vue class as it swallows click events

### DIFF
--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -13,7 +13,6 @@ const eventFormConfig = ({
   ukRegions,
 }) => {
   return {
-    class: 'js-vue-wrapper',
     method: 'post',
     buttonText: eventId ? 'Save and return' : 'Add event',
     returnText: eventId ? 'Return without saving' : 'Cancel',


### PR DESCRIPTION
## Problem
We still have a `js-vue-wrapper` class wrapping the events form which swallows any click event that should be added to the buttons of the 'add another' pattern. These classes should only be used to wrap Vue components and not the around a complete form.
![Screenshot 2019-03-26 at 09 48 12](https://user-images.githubusercontent.com/10154302/54988026-8624b580-4fad-11e9-9630-dbf7b7441f7a.png)

## Solution
Remove the class.
