### PR TITLE
Remove new layout flag check for investment apps

### DIFF
--- a/src/apps/companies/apps/investments/growth-capital-profile/controllers/list.js
+++ b/src/apps/companies/apps/investments/growth-capital-profile/controllers/list.js
@@ -1,11 +1,5 @@
-const list = 'companies/apps/investments/growth-capital-profile/views/list'
-
-const renderGrowthCapitalProfile = (req, res, next) => {
-  const { company, features } = res.locals
-
-  const view = (company.duns_number || features['companies-new-layout']) ? list : `${list}-deprecated`
-
-  res.render(view)
+const renderGrowthCapitalProfile = (req, res) => {
+  res.render('companies/apps/investments/growth-capital-profile/views/list')
 }
 
 module.exports = renderGrowthCapitalProfile

--- a/src/apps/companies/apps/investments/growth-capital-profile/views/list-deprecated.njk
+++ b/src/apps/companies/apps/investments/growth-capital-profile/views/list-deprecated.njk
@@ -1,5 +1,0 @@
-{% extends "../../../../views/_deprecated/template.njk" %}
-
-{% block main_grid_right_column %}
-  {% include "./main.njk" %}
-{% endblock %}

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/list.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/list.js
@@ -1,17 +1,14 @@
-const list = 'companies/apps/investments/large-capital-profile/views/list'
 const { getCompanyProfiles } = require('../repos')
 
 const renderLargeCapitalProfile = async (req, res, next) => {
   const token = req.session.token
-  const { company, features } = res.locals
-
-  const view = company.duns_number || features['companies-new-layout'] ? list : `${list}-deprecated`
+  const { company } = res.locals
 
   try {
     const companyProfiles = await getCompanyProfiles(token, company.id)
-    res.render(view, {
-      companyProfile: companyProfiles.results[0],
+    res.render('companies/apps/investments/large-capital-profile/views/list', {
       company,
+      companyProfile: companyProfiles.results[0],
     })
   } catch (error) {
     next(error)

--- a/src/apps/companies/apps/investments/large-capital-profile/views/list-deprecated.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/list-deprecated.njk
@@ -1,5 +1,0 @@
-{% extends "../../../../views/_deprecated/template.njk" %}
-
-{% block main_grid_right_column %}
-  {% include "./main.njk" %}
-{% endblock %}

--- a/src/apps/companies/apps/investments/projects/controllers/list.js
+++ b/src/apps/companies/apps/investments/projects/controllers/list.js
@@ -2,12 +2,9 @@ const { getCompanyInvestmentProjects } = require('../../../../../investments/rep
 const { transformInvestmentProjectToListItem } = require('../../../../../investments/transformers')
 const { transformApiResponseToCollection } = require('../../../../../../modules/api/transformers')
 
-const list = 'companies/apps/investments/projects/views/list'
-
 async function renderProjects (req, res, next) {
   const { token } = req.session
-  const { company, features } = res.locals
-  const view = (company.duns_number || features['companies-new-layout']) ? list : `${list}-deprecated`
+  const { company } = res.locals
   const actionButtons = company.archived ? undefined : [{
     label: 'Add investment project',
     url: `/investments/projects/create/${company.id}`,
@@ -23,7 +20,7 @@ async function renderProjects (req, res, next) {
     res
       .breadcrumb(company.name, `/companies/${company.id}`)
       .breadcrumb('Investment')
-      .render(view, {
+      .render('companies/apps/investments/projects/views/list', {
         results,
         actionButtons,
       })

--- a/src/apps/companies/apps/investments/projects/views/list-deprecated.njk
+++ b/src/apps/companies/apps/investments/projects/views/list-deprecated.njk
@@ -1,5 +1,0 @@
-{% extends "../../../../views/_deprecated/template.njk" %}
-
-{% block main_grid_right_column %}
-  {% include "./main.njk" %}
-{% endblock %}

--- a/test/unit/apps/companies/controllers/investments/growth-capital-profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/growth-capital-profile.test.js
@@ -2,69 +2,27 @@ const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parame
 
 const controller = require('~/src/apps/companies/apps/investments/growth-capital-profile/controllers')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
-const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
 
 describe('Company investments - growth capital profile', () => {
   describe('#renderInvestmentsGrowthCapitalProfile', () => {
-    const commonTests = (view) => {
-      it('should call the render function once', () => {
-        expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
+    beforeEach(() => {
+      this.middlewareParameters = buildMiddlewareParameters({
+        company: companyMock,
       })
 
-      it('should call the render function with the correct view', () => {
-        expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal(view)
-      })
-    }
-
-    context('when the company does not have a DUNS number', () => {
-      beforeEach(() => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
-        })
-
-        controller.renderGrowthCapitalProfile(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      commonTests('companies/apps/investments/growth-capital-profile/views/list-deprecated')
+      controller.renderGrowthCapitalProfile(
+        this.middlewareParameters.reqMock,
+        this.middlewareParameters.resMock,
+        this.middlewareParameters.nextSpy,
+      )
     })
 
-    context('when the company does has a DUNS number', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          company: dnbCompanyMock,
-        })
-
-        controller.renderGrowthCapitalProfile(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      commonTests('companies/apps/investments/growth-capital-profile/views/list')
+    it('should call the render function once', () => {
+      expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
     })
 
-    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
-          features: {
-            'companies-new-layout': true,
-          },
-        })
-
-        controller.renderGrowthCapitalProfile(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      commonTests('companies/apps/investments/growth-capital-profile/views/list')
+    it('should call the render function with the correct view', () => {
+      expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal('companies/apps/investments/growth-capital-profile/views/list')
     })
   })
 })

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
@@ -3,24 +3,23 @@ const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parame
 const noCompanyProfile = require('~/test/unit/data/companies/investments/large-capital-profile-empty.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile.json')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
-const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
 const config = require('~/config')
 
 const controller = require('~/src/apps/companies/apps/investments/large-capital-profile/controllers')
 
 describe('Company Investments - large capital profile', () => {
   describe('#renderInvestmentsLargeCapitalProfile', () => {
-    const commonTests = (view, company, companyProfile) => {
+    const commonTests = (companyProfile) => {
       it('should call the render function once', () => {
         expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
       })
 
       it('should call the render function and pass the view', () => {
-        expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal(view)
+        expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal('companies/apps/investments/large-capital-profile/views/list')
       })
 
       it('should call the render function and pass the company', () => {
-        expect(this.middlewareParameters.resMock.render.args[0][1].company).to.deep.equal(company)
+        expect(this.middlewareParameters.resMock.render.args[0][1].company).to.deep.equal(companyMock)
       })
 
       it('should call the render function and pass the company profile', () => {
@@ -28,7 +27,7 @@ describe('Company Investments - large capital profile', () => {
       })
     }
 
-    context('when the company does not have a DUNS number or a company profile', () => {
+    context('when the company does not have a company profile', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -45,30 +44,10 @@ describe('Company Investments - large capital profile', () => {
         )
       })
 
-      commonTests('companies/apps/investments/large-capital-profile/views/list-deprecated', companyMock, undefined)
+      commonTests(undefined)
     })
 
-    context('when the company has a DUNS number and a company profile', () => {
-      beforeEach(async () => {
-        nock(config.apiRoot)
-          .get(`/v4/large-investor-profile?investor_company_id=${dnbCompanyMock.id}`)
-          .reply(200, companyProfile)
-
-        this.middlewareParameters = buildMiddlewareParameters({
-          company: dnbCompanyMock,
-        })
-
-        await controller.renderLargeCapitalProfile(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      commonTests('companies/apps/investments/large-capital-profile/views/list', dnbCompanyMock, companyProfile.results[0])
-    })
-
-    context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
+    context('when the company has a company profile', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -76,9 +55,6 @@ describe('Company Investments - large capital profile', () => {
 
         this.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
-          features: {
-            'companies-new-layout': true,
-          },
         })
 
         await controller.renderLargeCapitalProfile(
@@ -88,7 +64,7 @@ describe('Company Investments - large capital profile', () => {
         )
       })
 
-      commonTests('companies/apps/investments/large-capital-profile/views/list', companyMock, companyProfile.results[0])
+      commonTests(companyProfile.results[0])
     })
   })
 })

--- a/test/unit/apps/companies/controllers/investments/projects.test.js
+++ b/test/unit/apps/companies/controllers/investments/projects.test.js
@@ -2,7 +2,6 @@ const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parame
 
 const investmentsMock = require('~/test/unit/data/investment/collection.json')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
-const dnbCompanyMock = require('~/test/unit/data/companies/dnb-company.json')
 
 describe('Company investments project controlle', () => {
   beforeEach(() => {
@@ -25,99 +24,48 @@ describe('Company investments project controlle', () => {
 
   describe('#renderInvestments', () => {
     context('when investments returns successfully', () => {
-      const commonTests = (expectedCompanyId, expectedTemplate) => {
-        it('should call audit log with correct arguments', () => {
-          expect(this.getCompanyInvestmentProjectsStub).to.have.been.calledWith('1234', expectedCompanyId, 1)
+      beforeEach(async () => {
+        this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {
+            page: 1,
+          },
+          company: companyMock,
         })
 
-        it('should call list item transformer', () => {
-          expect(this.transformApiResponseToCollectionSpy).to.have.been.calledOnce
-        })
-
-        it('should set the correct number of breadcrumbs', () => {
-          expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
-        })
-
-        it('should render the correct template', () => {
-          expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal(expectedTemplate)
-          expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
-        })
-
-        it('should send the correct template data', () => {
-          expect(this.middlewareParameters.resMock.render.args[0][1]).to.deep.equal({
-            results: investmentsMock.results,
-            actionButtons: [{
-              label: 'Add investment project',
-              url: `/investments/projects/create/${expectedCompanyId}`,
-            }],
-          })
-        })
-      }
-
-      context('when the company does not have a DUNS number', () => {
-        beforeEach(async () => {
-          this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)
-
-          this.middlewareParameters = buildMiddlewareParameters({
-            requestQuery: {
-              page: 1,
-            },
-            company: companyMock,
-          })
-
-          await this.controller(
-            this.middlewareParameters.reqMock,
-            this.middlewareParameters.resMock,
-            this.middlewareParameters.nextSpy,
-          )
-        })
-
-        commonTests(companyMock.id, 'companies/apps/investments/projects/views/list-deprecated')
+        await this.controller(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
       })
 
-      context('when the company does have a DUNS number', () => {
-        beforeEach(async () => {
-          this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)
-
-          this.middlewareParameters = buildMiddlewareParameters({
-            requestQuery: {
-              page: 1,
-            },
-            company: dnbCompanyMock,
-          })
-
-          await this.controller(
-            this.middlewareParameters.reqMock,
-            this.middlewareParameters.resMock,
-            this.middlewareParameters.nextSpy,
-          )
-        })
-
-        commonTests(dnbCompanyMock.id, 'companies/apps/investments/projects/views/list')
+      it('should call audit log with correct arguments', () => {
+        expect(this.getCompanyInvestmentProjectsStub).to.have.been.calledWith('1234', companyMock.id, 1)
       })
 
-      context('when the company does not have a DUNS number and the companies new layout feature is enabled', () => {
-        beforeEach(async () => {
-          this.getCompanyInvestmentProjectsStub.resolves(investmentsMock.results)
+      it('should call list item transformer', () => {
+        expect(this.transformApiResponseToCollectionSpy).to.have.been.calledOnce
+      })
 
-          this.middlewareParameters = buildMiddlewareParameters({
-            requestQuery: {
-              page: 1,
-            },
-            company: companyMock,
-            features: {
-              'companies-new-layout': true,
-            },
-          })
+      it('should set the correct number of breadcrumbs', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
+      })
 
-          await this.controller(
-            this.middlewareParameters.reqMock,
-            this.middlewareParameters.resMock,
-            this.middlewareParameters.nextSpy,
-          )
+      it('should render the correct template', () => {
+        expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal('companies/apps/investments/projects/views/list')
+        expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
+      })
+
+      it('should send the correct template data', () => {
+        expect(this.middlewareParameters.resMock.render.args[0][1]).to.deep.equal({
+          results: investmentsMock.results,
+          actionButtons: [{
+            label: 'Add investment project',
+            url: `/investments/projects/create/${companyMock.id}`,
+          }],
         })
-
-        commonTests(companyMock.id, 'companies/apps/investments/projects/views/list')
       })
     })
 


### PR DESCRIPTION
https://trello.com/c/Ap3nl8af/917-remove-companies-new-layout-flag

## Change
Removes the check for the `companies-new-layout` flag as it is now safe to display the new layout for all companies without checking the flag or `duns_number`.