### PR TITLE
Redirect to business details after archive

### DIFF
--- a/src/apps/companies/controllers/archive.js
+++ b/src/apps/companies/controllers/archive.js
@@ -2,15 +2,11 @@
 const { archiveCompany: archive, unarchiveCompany: unarchive } = require('../repos')
 const logger = require('../../../../config/logger')
 
-function getDetailsUrl (features, company) {
-  return features['companies-new-layout'] ? `/companies/${company.id}/business-details` : `/companies/${company.id}`
-}
-
 async function archiveCompany (req, res) {
-  const { company, features } = res.locals
+  const { company } = res.locals
   const { archived_reason, archived_reason_other } = req.body
   const reason = archived_reason_other || archived_reason
-  const detailsUrl = getDetailsUrl(features, company)
+  const detailsUrl = `/companies/${company.id}/business-details`
 
   if (!reason) {
     req.flash('error', 'A reason must be supplied to archive a company')
@@ -31,8 +27,8 @@ async function archiveCompany (req, res) {
 }
 
 async function unarchiveCompany (req, res) {
-  const { company, features } = res.locals
-  const detailsUrl = getDetailsUrl(features, company)
+  const { company } = res.locals
+  const detailsUrl = `/companies/${company.id}/business-details`
 
   try {
     await unarchive(req.session.token, company.id)

--- a/test/unit/apps/companies/controllers/archive.test.js
+++ b/test/unit/apps/companies/controllers/archive.test.js
@@ -43,7 +43,7 @@ describe('Company controller, archive', () => {
     })
 
     it('should redirect back to company', () => {
-      expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(expectedPath)
+      expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(`/companies/${companyMock.id}/business-details`)
       expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
     })
   }
@@ -61,7 +61,6 @@ describe('Company controller, archive', () => {
 
       commonTests({
         expectedFlash: 'error',
-        expectedPath: `/companies/${companyMock.id}`,
       })
 
       it('should not attempt to archive company', () => {
@@ -89,7 +88,6 @@ describe('Company controller, archive', () => {
             stubName: 'archiveCompany',
             expectedReason: 'Archived reason',
             expectedFlash: 'success',
-            expectedPath: `/companies/${companyMock.id}`,
           })
         })
 
@@ -145,30 +143,6 @@ describe('Company controller, archive', () => {
         })
       })
     })
-
-    context('when the companies new layout feature is enabled', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          requestBody: {
-            archived_reason: 'Archived reason',
-          },
-          company: companyMock,
-          features: {
-            'companies-new-layout': true,
-          },
-        })
-
-        this.stub.unarchiveCompany.resolves(companyMock)
-
-        await this.controller.archiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
-      })
-
-      commonTests({
-        stubName: 'archiveCompany',
-        expectedFlash: 'success',
-        expectedPath: `/companies/${companyMock.id}/business-details`,
-      })
-    })
   })
 
   describe('#unarchiveCompany', () => {
@@ -187,31 +161,6 @@ describe('Company controller, archive', () => {
         commonTests({
           stubName: 'unarchiveCompany',
           expectedFlash: 'success',
-          expectedPath: `/companies/${companyMock.id}`,
-        })
-      })
-
-      context('when the companies new layout feature is enabled', () => {
-        beforeEach(async () => {
-          this.middlewareParameters = buildMiddlewareParameters({
-            requestQuery: {
-              redirect: '/redirect/here',
-            },
-            company: companyMock,
-            features: {
-              'companies-new-layout': true,
-            },
-          })
-
-          this.stub.unarchiveCompany.resolves(companyMock)
-
-          await this.controller.unarchiveCompany(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
-        })
-
-        commonTests({
-          stubName: 'unarchiveCompany',
-          expectedFlash: 'success',
-          expectedPath: `/companies/${companyMock.id}/business-details`,
         })
       })
     })
@@ -230,7 +179,6 @@ describe('Company controller, archive', () => {
       commonTests({
         stubName: 'unarchiveCompany',
         expectedFlash: 'error',
-        expectedPath: `/companies/${companyMock.id}`,
       })
 
       it('should send error to logger', () => {


### PR DESCRIPTION
https://trello.com/c/Ap3nl8af/917-remove-companies-new-layout-flag

## Change
When archiving or unarchiving a company, the user should be redirect to the `Business details` view as that is where the flow originated from.