### PR TITLE
Remove flag check when editing company information

### DIFF
--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -62,11 +62,7 @@ async function populateForm (req, res, next) {
 }
 
 function getDetailsUrl (features, currentCompany, savedCompany) {
-  const isEditingCompanyInNewLayout = features['companies-new-layout'] && currentCompany
-
-  return isEditingCompanyInNewLayout
-    ? `/companies/${savedCompany.id}/business-details`
-    : `/companies/${savedCompany.id}`
+  return currentCompany ? `/companies/${savedCompany.id}/business-details` : `/companies/${savedCompany.id}`
 }
 
 async function handleFormPost (req, res, next) {

--- a/src/apps/companies/middleware/hierarchies.js
+++ b/src/apps/companies/middleware/hierarchies.js
@@ -6,18 +6,12 @@ function transformErrorMessage (error) {
   return get(error, 'global_headquarters', ['There has been an error'])[0]
 }
 
-function getDetailsUrl (features, companyId) {
-  return features['companies-new-layout']
-    ? `/companies/${companyId}/business-details`
-    : `/companies/${companyId}/details`
-}
-
 async function setGlobalHQ (req, res, next) {
   const token = req.session.token
   const companyId = req.params.companyId
   const globalHqId = req.params.globalHqId
   const body = { global_headquarters: globalHqId }
-  const detailsUrl = getDetailsUrl(res.locals.features, companyId)
+  const detailsUrl = `/companies/${companyId}/business-details`
 
   try {
     await updateCompany(token, companyId, body)
@@ -37,7 +31,7 @@ async function removeGlobalHQ (req, res, next) {
   const token = req.session.token
   const companyId = req.params.companyId
   const body = { global_headquarters: null }
-  const detailsUrl = getDetailsUrl(res.locals.features, companyId)
+  const detailsUrl = `/companies/${companyId}/business-details`
 
   try {
     await updateCompany(token, companyId, body)

--- a/test/acceptance/features/companies/edit.feature
+++ b/test/acceptance/features/companies/edit.feature
@@ -4,27 +4,27 @@ Feature: Company details
   @companies-edit--headquarters
   Scenario: Update company headquarters
 
-    When I navigate to the `companies.details` page using `company` `Mars Exports Ltd` fixture
+    When I navigate to the `companies.business-details` page using `company` `Mars Exports Ltd` fixture
 
-    When I click the Company summary edit button
+    When I click the Business hierarchy edit button
     When I change "headquarter_type" radio button option to "Not a headquarters"
     And I submit the form
     Then I see the success message
-    And details view data for "Headquarter type" should contain "Not a headquarters"
+    And details view data for "Global HQ" should contain "None"
 
-    When I click the Company summary edit button
+    When I click the Business hierarchy edit button
     When I change "headquarter_type" radio button option to "European HQ"
     And I submit the form
     Then I see the success message
     And details view data for "Headquarter type" should contain "European HQ"
 
-    When I click the Company summary edit button
+    When I click the Business hierarchy edit button
     When I change "headquarter_type" radio button option to "UK HQ"
     And I submit the form
     Then I see the success message
     And details view data for "Headquarter type" should contain "UK HQ"
 
-    When I click the Company summary edit button
+    When I click the Business hierarchy edit button
     When I change "headquarter_type" radio button option to "Global HQ"
     And I submit the form
     Then I see the success message

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -122,7 +122,7 @@ function getLinkWithText (text, className) {
 const getSelectorForDetailsSectionEditButton = (sectionTitle, buttonText = 'Edit') => {
   return getSelectorForElementWithText(sectionTitle, {
     el: '//h2',
-    child: '/following-sibling::div/p[1]/a[contains(.,"Edit")]',
+    child: '/following-sibling::a[contains(.,"Edit")]',
   })
 }
 

--- a/test/unit/apps/companies/middleware/form.test.js
+++ b/test/unit/apps/companies/middleware/form.test.js
@@ -285,7 +285,7 @@ describe('Companies form middleware', () => {
 
   describe('#handleFormPost', () => {
     context('when saving is successful', () => {
-      const commonTests = (expectedCompanyToBeSaved) => {
+      const commonTests = (expectedCompanyToBeSaved, expectedRedirect) => {
         it('should call save company service', () => {
           expect(this.saveCompanyFormSpy).to.have.been.calledWith(
             this.middlewareParameters.reqMock.session.token,
@@ -299,7 +299,7 @@ describe('Companies form middleware', () => {
         })
 
         it('should redirect to the entity', () => {
-          expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(`/companies/${companyRecord.id}`)
+          expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(expectedRedirect)
         })
 
         it('should not call next', () => {
@@ -331,7 +331,7 @@ describe('Companies form middleware', () => {
         commonTests({
           name: 'Fred Bloggs Ltd',
           trading_names: [],
-        })
+        }, `/companies/${companyRecord.id}`)
       })
 
       context('when saving an existing company', () => {
@@ -339,6 +339,7 @@ describe('Companies form middleware', () => {
           this.saveCompanyFormSpy = sinon.spy(formService, 'saveCompanyForm')
 
           this.middlewareParameters = buildMiddlewareParameters({
+            company: companyRecord,
             requestBody: {
               id: companyRecord.id,
               name: 'Fred Bloggs Ltd',
@@ -360,7 +361,7 @@ describe('Companies form middleware', () => {
           id: companyRecord.id,
           name: 'Fred Bloggs Ltd',
           trading_names: [],
-        })
+        }, `/companies/${companyRecord.id}/business-details`)
       })
 
       context('when saving an existing company with a new trading name', () => {
@@ -368,6 +369,7 @@ describe('Companies form middleware', () => {
           this.saveCompanyFormSpy = sinon.spy(formService, 'saveCompanyForm')
 
           this.middlewareParameters = buildMiddlewareParameters({
+            company: companyRecord.id,
             requestBody: {
               id: companyRecord.id,
               name: 'Fred Bloggs Ltd',
@@ -390,7 +392,7 @@ describe('Companies form middleware', () => {
           id: companyRecord.id,
           name: 'Fred Bloggs Ltd',
           trading_names: [ 'trading name' ],
-        })
+        }, `/companies/${companyRecord.id}/business-details`)
       })
 
       context('when saving a uk company with just a registered address', () => {
@@ -425,7 +427,7 @@ describe('Companies form middleware', () => {
           registered_address_1: 'street',
           registered_address_country: '9999',
           trading_names: [],
-        })
+        }, `/companies/${companyRecord.id}`)
       })
 
       context('when saving a uk company with a trading and registered address', () => {
@@ -463,7 +465,7 @@ describe('Companies form middleware', () => {
           trading_address_1: 'another street',
           trading_address_country: '9999',
           trading_names: [],
-        })
+        }, `/companies/${companyRecord.id}`)
       })
 
       context('when the user indicates the company is not a headquarters', () => {
@@ -492,7 +494,7 @@ describe('Companies form middleware', () => {
           name: 'Fred Bloggs Ltd',
           headquarter_type: '',
           trading_names: [],
-        })
+        }, `/companies/${companyRecord.id}`)
       })
     })
 

--- a/test/unit/apps/companies/middleware/hierarchies.test.js
+++ b/test/unit/apps/companies/middleware/hierarchies.test.js
@@ -32,42 +32,6 @@ describe('Company hierarchies middleware', () => {
 
       it('should redirect', () => {
         expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
-        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
-      })
-
-      it('should call flash', () => {
-        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
-        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve linked the Global Headquarters')
-      })
-    })
-
-    context('when company update is successful and the companies new layout feature is enabled', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          requestParams: {
-            companyId: subsidiaryCompanyId,
-            globalHqId: globalHeadquartersId,
-          },
-          features: {
-            'companies-new-layout': true,
-          },
-        })
-
-        nock(config.apiRoot)
-          .patch(`/v3/company/${subsidiaryCompanyId}`, {
-            global_headquarters: globalHeadquartersId,
-          })
-          .reply(200, { id: subsidiaryCompanyId })
-
-        await setGlobalHQ(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      it('should redirect', () => {
-        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
         expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/business-details`)
       })
 
@@ -117,42 +81,6 @@ describe('Company hierarchies middleware', () => {
           requestParams: {
             companyId: subsidiaryCompanyId,
             globalHqId: globalHeadquartersId,
-          },
-        })
-
-        nock(config.apiRoot)
-          .patch(`/v3/company/${subsidiaryCompanyId}`, {
-            global_headquarters: globalHeadquartersId,
-          })
-          .reply(400, { error: 'Error message' })
-
-        await setGlobalHQ(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      it('should redirect', () => {
-        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
-        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
-      })
-
-      it('should call flash', () => {
-        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
-        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('error', 'There has been an error')
-      })
-    })
-
-    context('when company update fails with a validation error and the companies new layout feature is enabled', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          requestParams: {
-            companyId: subsidiaryCompanyId,
-            globalHqId: globalHeadquartersId,
-          },
-          features: {
-            'companies-new-layout': true,
           },
         })
 
@@ -205,41 +133,6 @@ describe('Company hierarchies middleware', () => {
 
       it('should redirect', () => {
         expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
-        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
-      })
-
-      it('should call flash', () => {
-        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
-        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve removed the link to Global Headquarters')
-      })
-    })
-
-    context('when company update is successful and the companies new layout feature is enabled', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          requestParams: {
-            companyId: subsidiaryCompanyId,
-          },
-          features: {
-            'companies-new-layout': true,
-          },
-        })
-
-        nock(config.apiRoot)
-          .patch(`/v3/company/${subsidiaryCompanyId}`, {
-            global_headquarters: null,
-          })
-          .reply(200, { id: subsidiaryCompanyId })
-
-        await removeGlobalHQ(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      it('should redirect', () => {
-        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
         expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/business-details`)
       })
 
@@ -287,41 +180,6 @@ describe('Company hierarchies middleware', () => {
         this.middlewareParameters = buildMiddlewareParameters({
           requestParams: {
             companyId: subsidiaryCompanyId,
-          },
-        })
-
-        nock(config.apiRoot)
-          .patch(`/v3/company/${subsidiaryCompanyId}`, {
-            global_headquarters: null,
-          })
-          .reply(400, { error: 'Error message' })
-
-        await removeGlobalHQ(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
-        )
-      })
-
-      it('should redirect', () => {
-        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
-        expect(this.middlewareParameters.resMock.redirect).to.be.calledWith(`/companies/${subsidiaryCompanyId}/details`)
-      })
-
-      it('should call flash', () => {
-        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
-        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('error', 'There has been an error')
-      })
-    })
-
-    context('when company update fails with a validation error and the companies new layout feature is enabled', () => {
-      beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          requestParams: {
-            companyId: subsidiaryCompanyId,
-          },
-          features: {
-            'companies-new-layout': true,
           },
         })
 


### PR DESCRIPTION
https://trello.com/c/Ap3nl8af/917-remove-companies-new-layout-flag

## Change
Removes the flag check so that after editing company information, the user is redirected to `Business details`. This is because the user will always start this action from `Business details`.