### PR TITLE
Improved autocomplete advisor selection performance

### DIFF
--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -1,7 +1,10 @@
 const qs = require('querystring')
 const { get } = require('lodash')
 const { collectionFilterFields } = require('../macros')
-const { buildSelectedFiltersSummary, buildFieldsWithSelectedEntities } = require('../../builders')
+const {
+  buildSelectedFiltersSummary,
+  buildFieldsWithSelectedEntities,
+} = require('../../builders')
 const { getOptions } = require('../../../lib/options')
 const { buildExportAction } = require('../../../lib/export-helper')
 const { getAdvisers } = require('../../adviser/repos')
@@ -21,13 +24,17 @@ const exportOptions = {
 
 async function getInteractionOptions (token, req, res) {
   const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
-  const sectorOptions = await getOptions(token, SECTOR, { queryString: QUERY_STRING })
-  const serviceOptions = await getOptions(token, 'service', { includeDisabled: true })
+  const sectorOptions = await getOptions(token, SECTOR, {
+    queryString: QUERY_STRING,
+  })
+  const serviceOptions = await getOptions(token, 'service', {
+    includeDisabled: true,
+  })
   const teamOptions = await getOptions(token, 'team', { includeDisabled: true })
   const types = await getOptions(token, 'policy-issue-type')
-  const advisers = await getAdvisers(token)
   const areas = await getOptions(token, 'policy-area')
 
+  const advisers = await getAdvisers(token)
   const activeAdvisers = filterActiveAdvisers({
     advisers: advisers.results,
     includeAdviser: currentAdviser,
@@ -60,9 +67,20 @@ async function renderInteractionList (req, res, next) {
       userAgent: res.locals.userAgent,
     })
 
-    const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(token, filtersFields, query)
-    const selectedFilters = await buildSelectedFiltersSummary(filtersFieldsWithSelectedOptions, query)
-    const exportAction = await buildExportAction(qs.stringify(req.query), user.permissions, exportOptions)
+    const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
+      token,
+      filtersFields,
+      query
+    )
+    const selectedFilters = await buildSelectedFiltersSummary(
+      filtersFieldsWithSelectedOptions,
+      query
+    )
+    const exportAction = await buildExportAction(
+      qs.stringify(req.query),
+      user.permissions,
+      exportOptions
+    )
 
     res.render('_layouts/collection', {
       selectedFilters,
@@ -79,16 +97,18 @@ async function renderInteractionList (req, res, next) {
 function renderInteractionsForEntity (req, res, next) {
   try {
     const { view, returnLink, createKind, canAdd } = res.locals.interactions
-    const actionButtons = canAdd ? [{
-      label: 'Add interaction',
-      url: `${returnLink}create${createKind ? `/${createKind}` : ''}`,
-    }] : undefined
+    const actionButtons = canAdd
+      ? [
+        {
+          label: 'Add interaction',
+          url: `${returnLink}create${createKind ? `/${createKind}` : ''}`,
+        },
+      ]
+      : undefined
 
-    res
-      .breadcrumb('Interactions')
-      .render(view, {
-        actionButtons,
-      })
+    res.breadcrumb('Interactions').render(view, {
+      actionButtons,
+    })
   } catch (error) {
     next(error)
   }

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -23,7 +23,7 @@ const exportOptions = {
 }
 
 async function getInteractionOptions (token, req, res) {
-  const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
+  if (get(req, 'xhr')) return
   const sectorOptions = await getOptions(token, SECTOR, {
     queryString: QUERY_STRING,
   })
@@ -32,8 +32,10 @@ async function getInteractionOptions (token, req, res) {
   })
   const teamOptions = await getOptions(token, 'team', { includeDisabled: true })
   const types = await getOptions(token, 'policy-issue-type')
+
   const areas = await getOptions(token, 'policy-area')
 
+  const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
   const advisers = await getAdvisers(token)
   const activeAdvisers = filterActiveAdvisers({
     advisers: advisers.results,
@@ -117,4 +119,5 @@ function renderInteractionsForEntity (req, res, next) {
 module.exports = {
   renderInteractionList,
   renderInteractionsForEntity,
+  getInteractionOptions,
 }


### PR DESCRIPTION

[616](https://trello.com/c/OhMVI2uW/616)

Autocomplete triggers a load of all metadata on advisor selection in the interactions section.

This has been refactored and tests have been added reducing the time it takes every request to be completed 

**Checklist**

- [x] Does PR title include the Trello ticket id and short description of the change?
- [x] Has the branch been rebased to develop?
- [x] Has the code be properly tested? (unit/functional/integration/E2E)
- [x] Is the implementation of this change clear and simple?