### PR TITLE
Integrate v4 company endpoint and formatAddress

### DIFF
--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -2,16 +2,13 @@ const { get, isUndefined } = require('lodash')
 
 const { hqLabels } = require('../labels')
 const { getDitCompany, getCHCompany } = require('../repos')
-const { getCompanyAddress } = require('../transformers/shared')
 
 async function getCompany (req, res, next, id) {
   try {
     const company = await getDitCompany(req.session.token, id)
-    const address = getCompanyAddress(company)
     const headquarterType = get(company, 'headquarter_type.name')
 
     res.locals.company = company
-    res.locals.headingAddress = get(address, 'value')
     res.locals.companiesHouseCategory = get(company, 'companies_house_data.company_category')
     res.locals.metaItems = []
 

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -1,10 +1,30 @@
 /* eslint camelcase: 0, prefer-promise-reject-errors: 0 */
+const { get } = require('lodash')
+
 const config = require('../../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
-// Get a company and then pad out the interactions with related data
+// TODO remove this when no dependencies on company.registered_address_* and company.trading_address_*
+const mapDeprecatedAddressFields = (companyAddress, deprecatedAddressPrefix) => {
+  return {
+    [`${deprecatedAddressPrefix}_address_1`]: get(companyAddress, 'line_1'),
+    [`${deprecatedAddressPrefix}_address_2`]: get(companyAddress, 'line_2'),
+    [`${deprecatedAddressPrefix}_address_town`]: get(companyAddress, 'town'),
+    [`${deprecatedAddressPrefix}_address_county`]: get(companyAddress, 'county'),
+    [`${deprecatedAddressPrefix}_address_postcode`]: get(companyAddress, 'postcode'),
+    [`${deprecatedAddressPrefix}_address_country`]: get(companyAddress, 'country'),
+  }
+}
+
 function getDitCompany (token, id) {
-  return authorisedRequest(token, `${config.apiRoot}/v3/company/${id}`)
+  return authorisedRequest(token, `${config.apiRoot}/v4/company/${id}`)
+    .then((company) => {
+      return {
+        ...company,
+        ...mapDeprecatedAddressFields(company.address, 'trading'),
+        ...mapDeprecatedAddressFields(company.registered_address, 'registered'),
+      }
+    })
 }
 
 function getCHCompany (token, id) {

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -2,7 +2,7 @@
 
 {% block local_header %}
   {% call LocalHeader({ heading: company.name, modifier: 'light-banner' }) %}
-    <p class="c-local-header__heading-after">{{ headingAddress }}</p>
+    <p class="c-local-header__heading-after">{{ company.address | formatAddress }}</p>
 
     {% if company.headquarter_type and company.headquarter_type.name == 'ghq' %}
       <div class="c-meta-list">

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -48,13 +48,19 @@ describe('Companies business details', () => {
     })
 
     it('should display the address', () => {
-      const addressSelector = selectors.companyBusinessDetails().address(1)
-      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
-      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
-      cy.get(addressSelector.line(1)).should('have.text', '12 St George\'s Road')
-      cy.get(addressSelector.line(2)).should('have.text', 'Paris')
-      cy.get(addressSelector.line(3)).should('have.text', '75001')
-      cy.get(addressSelector.line(4)).should('have.text', 'France')
+      const addressSelector1 = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector1.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector1.line(1)).should('have.text', '12 St George\'s Road')
+      cy.get(addressSelector1.line(2)).should('have.text', 'Paris')
+      cy.get(addressSelector1.line(3)).should('have.text', '75001')
+      cy.get(addressSelector1.line(4)).should('have.text', 'France')
+
+      const addressSelector2 = selectors.companyBusinessDetails().address(2)
+      cy.get(addressSelector2.badge(1)).should('have.text', 'Registered')
+      cy.get(addressSelector2.line(1)).should('have.text', '12 St George\'s Road')
+      cy.get(addressSelector2.line(2)).should('have.text', 'Paris')
+      cy.get(addressSelector2.line(3)).should('have.text', '75001')
+      cy.get(addressSelector2.line(4)).should('have.text', 'France')
     })
 
     it('should not display the "DIT region" details container', () => {
@@ -158,13 +164,19 @@ describe('Companies business details', () => {
     })
 
     it('should display the address', () => {
-      const addressSelector = selectors.companyBusinessDetails().address(1)
-      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
-      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
-      cy.get(addressSelector.line(1)).should('have.text', '66 Marcham Road')
-      cy.get(addressSelector.line(2)).should('have.text', 'Bordley')
-      cy.get(addressSelector.line(3)).should('have.text', 'BD23 8RZ')
-      cy.get(addressSelector.line(4)).should('have.text', 'United Kingdom')
+      const addressSelector1 = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector1.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector1.line(1)).should('have.text', '66 Marcham Road')
+      cy.get(addressSelector1.line(2)).should('have.text', 'Bordley')
+      cy.get(addressSelector1.line(3)).should('have.text', 'BD23 8RZ')
+      cy.get(addressSelector1.line(4)).should('have.text', 'United Kingdom')
+
+      const addressSelector2 = selectors.companyBusinessDetails().address(2)
+      cy.get(addressSelector2.badge(1)).should('have.text', 'Registered')
+      cy.get(addressSelector2.line(1)).should('have.text', '66 Marcham Road')
+      cy.get(addressSelector2.line(2)).should('have.text', 'Bordley')
+      cy.get(addressSelector2.line(3)).should('have.text', 'BD23 8RZ')
+      cy.get(addressSelector2.line(4)).should('have.text', 'United Kingdom')
     })
 
     it('should display the "DIT region" details container heading', () => {
@@ -282,13 +294,19 @@ describe('Companies business details', () => {
     })
 
     it('should display the address', () => {
-      const addressSelector = selectors.companyBusinessDetails().address(1)
-      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
-      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
-      cy.get(addressSelector.line(1)).should('have.text', '1 Main Road')
-      cy.get(addressSelector.line(2)).should('have.text', 'Rome')
-      cy.get(addressSelector.line(3)).should('have.text', '001122')
-      cy.get(addressSelector.line(4)).should('have.text', 'Italy')
+      const addressSelector1 = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector1.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector1.line(1)).should('have.text', '1 Main Road')
+      cy.get(addressSelector1.line(2)).should('have.text', 'Rome')
+      cy.get(addressSelector1.line(3)).should('have.text', '001122')
+      cy.get(addressSelector1.line(4)).should('have.text', 'Italy')
+
+      const addressSelector2 = selectors.companyBusinessDetails().address(2)
+      cy.get(addressSelector2.badge(1)).should('have.text', 'Registered')
+      cy.get(addressSelector2.line(1)).should('have.text', '1 Main Road')
+      cy.get(addressSelector2.line(2)).should('have.text', 'Rome')
+      cy.get(addressSelector2.line(3)).should('have.text', '001122')
+      cy.get(addressSelector2.line(4)).should('have.text', 'Italy')
     })
 
     it('should not display the "DIT region" details container', () => {
@@ -380,13 +398,19 @@ describe('Companies business details', () => {
     })
 
     it('should display the address', () => {
-      const addressSelector = selectors.companyBusinessDetails().address(1)
-      cy.get(addressSelector.badge(1)).should('have.text', 'Trading')
-      cy.get(addressSelector.badge(2)).should('have.text', 'Registered')
-      cy.get(addressSelector.line(1)).should('have.text', '16 Getabergsvagen')
-      cy.get(addressSelector.line(2)).should('have.text', 'Geta')
-      cy.get(addressSelector.line(3)).should('have.text', '22340')
-      cy.get(addressSelector.line(4)).should('have.text', 'Malta')
+      const addressSelector1 = selectors.companyBusinessDetails().address(1)
+      cy.get(addressSelector1.badge(1)).should('have.text', 'Trading')
+      cy.get(addressSelector1.line(1)).should('have.text', '16 Getabergsvagen')
+      cy.get(addressSelector1.line(2)).should('have.text', 'Geta')
+      cy.get(addressSelector1.line(3)).should('have.text', '22340')
+      cy.get(addressSelector1.line(4)).should('have.text', 'Malta')
+
+      const addressSelector2 = selectors.companyBusinessDetails().address(2)
+      cy.get(addressSelector2.badge(1)).should('have.text', 'Registered')
+      cy.get(addressSelector2.line(1)).should('have.text', '16 Getabergsvagen')
+      cy.get(addressSelector2.line(2)).should('have.text', 'Geta')
+      cy.get(addressSelector2.line(3)).should('have.text', '22340')
+      cy.get(addressSelector2.line(4)).should('have.text', 'Malta')
     })
 
     it('should not display the "DIT region" details container', () => {

--- a/test/unit/apps/companies/middleware/params.test.js
+++ b/test/unit/apps/companies/middleware/params.test.js
@@ -35,10 +35,6 @@ describe('Companies form middleware', () => {
         expect(this.resMock.locals).to.have.deep.property('company', datahubOnlyCompany)
       })
 
-      it('should return the company address', () => {
-        expect(this.resMock.locals).to.have.property('headingAddress', 'address')
-      })
-
       it('should have a null companies house category', () => {
         expect(this.resMock.locals).to.have.property('companiesHouseCategory', undefined)
       })
@@ -62,10 +58,6 @@ describe('Companies form middleware', () => {
 
       it('should return the company', () => {
         expect(this.resMock.locals).to.have.deep.property('company', companiesHouseCompany)
-      })
-
-      it('should return the company address', () => {
-        expect(this.resMock.locals).to.have.property('headingAddress', 'address')
       })
 
       it('should have a null companies house category', () => {

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -1,5 +1,10 @@
 /* eslint prefer-promise-reject-errors: 0 */
 const companyData = require('~/test/unit/data/company.json')
+const companyV4Data = require('~/test/unit/data/companies/company-v4.json')
+
+const config = require('~/config')
+
+const { getDitCompany } = require('~/src/apps/companies/repos.js')
 
 describe('Company repository', () => {
   describe('Save company', () => {
@@ -261,6 +266,40 @@ describe('Company repository', () => {
             },
           })
         })
+    })
+  })
+
+  describe('#getDitCompany', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v4/company/${companyV4Data.id}`)
+        .reply(200, companyV4Data)
+
+      this.company = await getDitCompany('1234', companyV4Data.id)
+    })
+
+    it('should return', () => {
+      expect(this.company).to.deep.equal({
+        ...companyV4Data,
+        registered_address_1: '82 Ramsgate Rd',
+        registered_address_2: '',
+        registered_address_town: 'Willington',
+        registered_address_county: '',
+        registered_address_postcode: 'NE28 5JB',
+        registered_address_country: {
+          name: 'United Kingdom',
+          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+        },
+        trading_address_1: '82 Ramsgate Rd',
+        trading_address_2: '',
+        trading_address_town: 'Willington',
+        trading_address_county: '',
+        trading_address_postcode: 'NE28 5JB',
+        trading_address_country: {
+          name: 'United Kingdom',
+          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+        },
+      })
     })
   })
 

--- a/test/unit/data/companies/company-v4.json
+++ b/test/unit/data/companies/company-v4.json
@@ -1,0 +1,91 @@
+{
+  "id": "a73efeba-8499-11e6-ae22-56b6b6499611",
+  "reference_code": "",
+  "name": "Mercury Ltd",
+  "trading_names": [],
+  "uk_based": true,
+  "company_number": "99919",
+  "vat_number": "",
+  "duns_number": null,
+  "created_on": "2016-06-05T12:00:00Z",
+  "modified_on": "2016-07-05T12:00:00Z",
+  "archived": false,
+  "archived_documents_url_path": "",
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "description": "This is a dummy company for testing",
+  "transferred_by": null,
+  "transferred_on": null,
+  "transferred_to": null,
+  "transfer_reason": "",
+  "website": null,
+  "business_type": {
+    "name": "Private limited company",
+    "id": "6f75408b-03e7-e611-bca1-e4115bead28a"
+  },
+  "one_list_group_tier": null,
+  "contacts": [],
+  "employee_range": {
+    "name": "500+",
+    "id": "41afd8d0-5d95-e211-a939-e4115bead28a"
+  },
+  "number_of_employees": null,
+  "is_number_of_employees_estimated": null,
+  "export_to_countries": [
+    {
+      "name": "Occupied Palestinian Territories",
+      "id": "35afd8d0-5d95-e211-a939-e4115bead28a"
+    },
+    {
+      "name": "Western Sahara",
+      "id": "36afd8d0-5d95-e211-a939-e4115bead28a"
+    }
+  ],
+  "future_interest_countries": [
+    {
+      "name": "Yemen",
+      "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+    }
+  ],
+  "headquarter_type": null,
+  "one_list_group_global_account_manager": null,
+  "global_headquarters": null,
+  "sector": {
+    "name": "Retail",
+    "id": "355f977b-8ac3-e211-a646-e4115bead28a"
+  },
+  "turnover_range": {
+    "name": "£33.5M+",
+    "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
+  },
+  "turnover": null,
+  "is_turnover_estimated": null,
+  "uk_region": {
+    "name": "North West",
+    "id": "824cd12a-6095-e211-a939-e4115bead28a"
+  },
+  "export_experience_category": null,
+  "address": {
+    "line_1": "82 Ramsgate Rd",
+    "line_2": "",
+    "town": "Willington",
+    "county": "",
+    "postcode": "NE28 5JB",
+    "country": {
+      "name": "United Kingdom",
+      "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
+  },
+  "registered_address": {
+    "line_1": "82 Ramsgate Rd",
+    "line_2": "",
+    "town": "Willington",
+    "county": "",
+    "postcode": "NE28 5JB",
+    "country": {
+      "name": "United Kingdom",
+      "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
+  }
+}


### PR DESCRIPTION
https://trello.com/c/urWUCYnD/884-consolidate-formatting-of-addresses

## Change
This change is to integrate the new `formatAddress` Nunjucks filter. As part of this change we will not be using the new `/v4/company/{id}` endpoint. I am temporarily adding the `registered_address_x` and `trading_address_x` fields to be backwards compatible with existing code. Once these fields are no longer depended on, I can remove the temporary addition.

There should be no difference in visual appearance.