### PR TITLE
Fix two bugs when going through add company flow

### DIFF
--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -73,8 +73,10 @@ function postAddStepOne (req, res, next) {
   return res.redirect(`/companies/add-step-2?${queryString.stringify(params)}`)
 }
 
-function renderAddStepTwo (req, res, next) {
-  res.render('companies/views/add-step-2.njk')
+function renderAddStepTwo (req, res) {
+  res.render('companies/views/add-step-2', {
+    heading: 'Add company',
+  })
 }
 
 module.exports = {

--- a/src/apps/companies/views/add-step-2.njk
+++ b/src/apps/companies/views/add-step-2.njk
@@ -1,4 +1,4 @@
-{% extends "./template.njk" %}
+{% extends "_layouts/template.njk" %}
 
 {% block body_main_content %}
   <div class="key-value key-value--vertical">

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -5,6 +5,7 @@
 {% endset %}
 
 {% set isEditing = true if company.id else false %}
+{% set returnLink = '/companies/' + company.id + '/business-details' if isEditing else '/companies/add-step-1' %}
 
 {% block body_main_content %}
   <div class="section">
@@ -30,7 +31,7 @@
 
   {% call Form({
     buttonText: 'Save and return' if isEditing else 'Add company',
-    returnLink: '/companies/' + company.id + '/business-details',
+    returnLink: returnLink,
     returnText: 'Return without saving' if isEditing else 'Back',
     actionExtension: {
         country : 'non-uk' if isForeign else 'uk'

--- a/test/unit/apps/companies/controllers/add.test.js
+++ b/test/unit/apps/companies/controllers/add.test.js
@@ -1,5 +1,6 @@
 const { sortBy } = require('lodash')
 
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 const companiesHouseAndLtdCompanies = require('~/test/unit/data/search/companiesHouseAndLtdCompanies')
 const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company')
 const config = require('~/config')
@@ -212,6 +213,28 @@ describe('Company add controller', () => {
           expect(res.locals.errors.messages).to.have.property('business_type_for_other')
           done()
         })
+      })
+    })
+  })
+
+  describe('#renderAddStepTwo', () => {
+    beforeEach(() => {
+      this.middlewareParameters = buildMiddlewareParameters({})
+
+      companyAddController.renderAddStepTwo(this.middlewareParameters.reqMock, this.middlewareParameters.resMock)
+    })
+
+    it('should render once', () => {
+      expect(this.middlewareParameters.resMock.render).to.be.calledOnce
+    })
+
+    it('should render the correct template', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[0]).to.equal('companies/views/add-step-2')
+    })
+
+    it('should render a heading', () => {
+      expect(this.middlewareParameters.resMock.render.firstCall.args[1]).to.deep.equal({
+        heading: 'Add company',
       })
     })
   })


### PR DESCRIPTION
## Bug 1
https://trello.com/c/ChoXL69y/929-bug-referencing-incorrect-template-for-company-add-step-2

![image](https://user-images.githubusercontent.com/1150417/55169586-f62d6a00-516c-11e9-9a28-63997cd26325.png)

The `View full business details` link is visible on step 2 of adding a company.

### Solution 1
The incorrect template was being referenced so the view was being treated as if the user is within the context of an existing company.

## Bug 2
https://trello.com/c/rev8JLb4/930-bug-wrong-url-for-back-link-when-adding-a-company

![image (1)](https://user-images.githubusercontent.com/1150417/55169606-fd547800-516c-11e9-8f94-b6aeca00876e.png)

The `Back` link when adding a company is broken.

### Solution 2
Link was referencing `company.id` as if an existing company was being edited. It needs to redirect back to step 1.