### PR TITLE
Add "Business details" breadcrumb to audit view

### DIFF
--- a/src/apps/companies/controllers/audit.js
+++ b/src/apps/companies/controllers/audit.js
@@ -16,6 +16,7 @@ async function renderAuditLog (req, res, next) {
 
     res
       .breadcrumb(company.name, `/companies/${company.id}`)
+      .breadcrumb('Business details', `/companies/${company.id}/business-details`)
       .breadcrumb('Audit history')
       .render('companies/views/audit', {
         auditLog,

--- a/test/unit/apps/companies/controllers/audit.test.js
+++ b/test/unit/apps/companies/controllers/audit.test.js
@@ -49,8 +49,20 @@ describe('Company audit controller', () => {
       expect(this.transformAuditLogToListItemSpy).to.have.been.calledOnce
     })
 
-    it('should set the correct number of breadcrumbs', () => {
-      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
+    it('should set three breadcrumbs', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledThrice
+    })
+
+    it('should set the company breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWithExactly(companyMock.name, `/companies/${companyMock.id}`)
+    })
+
+    it('should set the business details breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWithExactly('Business details', `/companies/${companyMock.id}/business-details`)
+    })
+
+    it('should set the audit breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWithExactly('Audit history')
     })
 
     it('should render the correct template', () => {


### PR DESCRIPTION
https://trello.com/c/KpSozXAa/902-add-audit-trail-link-with-text-to-business-details-view

## Change
Adds the `Business details` breadcrumb to the `/audit` companies view.

## Before
![Screenshot 2019-03-28 at 18 13 31](https://user-images.githubusercontent.com/1150417/55182343-60ea9f80-5185-11e9-8750-066a3b693aea.png)

## After
![Screenshot 2019-03-28 at 18 13 03](https://user-images.githubusercontent.com/1150417/55182358-67791700-5185-11e9-94ac-cc152cd94527.png)
