### PR TITLE
Use lodash get for nullable country on address

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -12,6 +12,7 @@ const {
   compact,
   concat,
   escape,
+  get,
   isArray,
   isFunction,
   isPlainObject,
@@ -196,7 +197,7 @@ const filters = {
         address.town,
         address.county,
         address.postcode,
-        address.country.name,
+        get(address, 'country.name'),
       ]).join(', ')
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub-frontend",
-  "version": "5.15.0",
+  "version": "5.15.1",
   "description": "Data Hub Frontend",
   "main": "src/server.js",
   "repository": {

--- a/test/unit/config/nunjucks/filters.test.js
+++ b/test/unit/config/nunjucks/filters.test.js
@@ -356,6 +356,23 @@ describe('nunjucks filters', () => {
         expect(this.actual).to.not.exist
       })
     })
+
+    context('when the country is null', () => {
+      beforeEach(() => {
+        this.actual = filters.formatAddress({
+          line_1: 'line 1',
+          line_2: 'line 2',
+          town: 'town',
+          county: 'county',
+          postcode: 'postcode',
+          country: null,
+        })
+      })
+
+      it('should format the address as a comma separated list', () => {
+        expect(this.actual).to.equal('line 1, line 2, town, county, postcode')
+      })
+    })
   })
 
   describe('#collectionDefault', () => {


### PR DESCRIPTION
https://trello.com/c/pUVVgjT9/1003-bug-fix-formataddress-as-country-is-nullable

## Problem
It is possible for the country to be `null` on the `address` object. As a result, there are template render errors when searching or filtering companies.

e.g. https://sentry.ci.uktrade.io/dit/front-end/issues/8572

## Solution
Use `lodash` `get` to retrieve the company name. If there is no value then the company address will be presented without a country.