### PR TITLE
Display CDMS reference code on the company details page

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -92,6 +92,7 @@ const aboutLabels = {
   trading_names: 'Trading names',
   company_number: 'Companies House number',
   vat_number: 'VAT number',
+  reference_code: 'CDMS reference',
   turnover: 'Annual turnover',
   number_of_employees: 'Number of employees',
   website: 'Website',

--- a/src/apps/companies/transformers/company-to-about-view.js
+++ b/src/apps/companies/transformers/company-to-about-view.js
@@ -79,6 +79,7 @@ function transformWebsite (website) {
 
 module.exports = ({
   vat_number,
+  reference_code,
   duns_number,
   business_type,
   trading_names,
@@ -92,6 +93,7 @@ module.exports = ({
 }) => {
   const viewRecord = {
     vat_number,
+    reference_code,
     description,
     business_type: duns_number ? null : get(business_type, 'name'),
     trading_names: isEmpty(trading_names) ? NOT_SET_TEXT : trading_names,

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -149,6 +149,7 @@ describe('Companies business details', () => {
       assertKeyValueTable('aboutDetails', {
         'Business type': 'Company',
         'Trading names': 'Not set',
+        'CDMS reference': 'ORG-10096257',
         'Annual turnover': 'Not set',
         'Number of employees': 'Not set',
         'Website': 'Not set',

--- a/test/unit/apps/companies/transformers/company-to-about-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-about-view.test.js
@@ -157,6 +157,7 @@ describe('#transformCompanyToKnownAsView', () => {
           ],
           company_number: '123456',
           vat_number: '0123456789',
+          reference_code: 'ORG-12345678',
           turnover_range: {
             name: '£33.5M+',
           },
@@ -206,6 +207,10 @@ describe('#transformCompanyToKnownAsView', () => {
         expect(this.actual['VAT number']).to.equal('0123456789')
       })
 
+      it('should set the CDMS reference', () => {
+        expect(this.actual['CDMS reference']).to.equal('ORG-12345678')
+      })
+
       it('should set the description', () => {
         expect(this.actual.Description).to.equal('description')
       })
@@ -233,6 +238,10 @@ describe('#transformCompanyToKnownAsView', () => {
 
       it('should set the business type', () => {
         expect(this.actual['Business type']).to.equal('Company')
+      })
+
+      it('should not set the CDMS reference', () => {
+        expect(this.actual['CDMS reference']).to.not.exist
       })
 
       it('should not set the VAT number', () => {


### PR DESCRIPTION
https://trello.com/c/Q24IPbyk/997-add-cdms-id-to-company-record

Display CDMS ID (known as CDMS reference) on the company details page.

![image](https://user-images.githubusercontent.com/4199239/55492251-d398c680-562e-11e9-848a-bf0d23892e4e.png)

![image](https://user-images.githubusercontent.com/4199239/55491937-4ce3e980-562e-11e9-8f83-1aaaa540b286.png)
