### PR TITLE
Bug missing company number

### DIFF
--- a/src/apps/companies/controllers/edit.js
+++ b/src/apps/companies/controllers/edit.js
@@ -18,14 +18,9 @@ async function getBusinessTypeOption (token, businessTypeId) {
   )
 }
 
-async function getBusinessTypeLabel (token, companiesHouseCategory, businessTypeId) {
-  if (companiesHouseCategory) {
-    return companiesHouseCategory
-  }
+async function getBusinessTypeLabel (token, businessTypeId) {
   const businessTypeOption = await getBusinessTypeOption(token, businessTypeId)
-  if (businessTypeOption) {
-    return businessTypeOption.label
-  }
+  return get(businessTypeOption, 'label')
 }
 
 function isForeignCompany (req, res) {
@@ -43,9 +38,7 @@ async function renderForm (req, res, next) {
     }
 
     const businessType = get(res.locals, 'formData.business_type')
-    const businessTypeLabel = await getBusinessTypeLabel(
-      req.session.token, res.locals.companiesHouseCategory, businessType
-    )
+    const businessTypeLabel = await getBusinessTypeLabel(req.session.token, businessType)
     const showTradingAddress = !isEmpty(get(res.locals, 'formData.trading_address_1'))
     const isForeign = isForeignCompany(req, res)
     const heading = `${res.locals.company ? 'Edit' : 'Add'} business details`

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -1,25 +1,8 @@
-const { get, isUndefined } = require('lodash')
-
-const { hqLabels } = require('../labels')
 const { getDitCompany, getCHCompany } = require('../repos')
 
 async function getCompany (req, res, next, id) {
   try {
-    const company = await getDitCompany(req.session.token, id)
-    const headquarterType = get(company, 'headquarter_type.name')
-
-    res.locals.company = company
-    res.locals.companiesHouseCategory = get(company, 'companies_house_data.company_category')
-    res.locals.metaItems = []
-
-    if (!isUndefined(headquarterType)) {
-      res.locals.metaItems.push({
-        type: 'badge',
-        label: 'Headquarter type',
-        value: hqLabels[headquarterType],
-      })
-    }
-
+    res.locals.company = await getDitCompany(req.session.token, id)
     next()
   } catch (error) {
     next(error)

--- a/src/apps/companies/transformers/company-to-about-view.js
+++ b/src/apps/companies/transformers/company-to-about-view.js
@@ -82,7 +82,7 @@ module.exports = ({
   duns_number,
   business_type,
   trading_names,
-  companies_house_data,
+  company_number,
   turnover,
   turnover_range,
   number_of_employees,
@@ -90,8 +90,6 @@ module.exports = ({
   website,
   description,
 }) => {
-  const company_number = get(companies_house_data, 'company_number')
-
   const viewRecord = {
     vat_number,
     description,

--- a/src/apps/companies/transformers/company-to-view.js
+++ b/src/apps/companies/transformers/company-to-view.js
@@ -50,7 +50,6 @@ module.exports = function transformCompanyToView ({
   trading_address_county,
   trading_address_postcode,
   trading_address_country,
-  companies_house_data,
   business_type,
   global_headquarters,
 }) {
@@ -91,7 +90,7 @@ module.exports = function transformCompanyToView ({
         country: trading_address_country,
       },
     } : null,
-    business_type: !companies_house_data ? get(business_type, 'name') : null,
+    business_type: get(business_type, 'name'),
   }
 
   if (get(headquarter_type, 'name') !== 'ghq') {

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -9,15 +9,17 @@
 
 {% block body_main_content %}
   <div class="section">
-    <h2 class="govuk-heading-s">Business type</h2>
-    {{ MetaList({
-        items: [
-          {
-            label: businessTypeLabel | default('(type of organisation not known)'),
-            value: ('&nbsp;' if company else '<a href="/companies/add-step-1">Change</a>') | safe
-          }
-        ]
-      }) }}
+    {% if businessTypeLabel %}
+      <h2 class="govuk-heading-s">Business type</h2>
+      {{ MetaList({
+          items: [
+            {
+              label: businessTypeLabel,
+              value: ('&nbsp;' if company else '<a href="/companies/add-step-1">Change</a>') | safe
+            }
+          ]
+        }) }}
+    {% endif %}
   </div>
 
 

--- a/test/unit/apps/companies/middleware/params.test.js
+++ b/test/unit/apps/companies/middleware/params.test.js
@@ -1,5 +1,4 @@
-const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
-const datahubOnlyCompany = require('~/test/unit/data/companies/datahub-only-company.json')
+const company = require('~/test/unit/data/companies/company-v4.json')
 const companiesHouseRecord = require('~/test/unit/data/companies/companies-house.json')
 
 describe('Companies form middleware', () => {
@@ -19,54 +18,13 @@ describe('Companies form middleware', () => {
   })
 
   describe('getCompany', () => {
-    context('when the API returns a company without companies house data', () => {
-      beforeEach(async () => {
-        this.getDitCompanyStub.resolves(datahubOnlyCompany)
-        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, 2)
-      })
-
-      it('should return the company', () => {
-        expect(this.resMock.locals).to.have.deep.property('company', datahubOnlyCompany)
-      })
-
-      it('should have a null companies house category', () => {
-        expect(this.resMock.locals).to.have.property('companiesHouseCategory', undefined)
-      })
-
-      it('should have a ehq metaItems', () => {
-        expect(this.resMock.locals).to.have.deep.property('metaItems', [
-          {
-            type: 'badge',
-            label: 'Headquarter type',
-            value: 'European HQ',
-          },
-        ])
-      })
+    beforeEach(async () => {
+      this.getDitCompanyStub.resolves(company)
+      await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, 2)
     })
 
-    context('when the API returns a company with companies house data', () => {
-      beforeEach(async () => {
-        this.getDitCompanyStub.resolves(companiesHouseCompany)
-        await this.middleware.getCompany(this.reqMock, this.resMock, this.nextSpy, 2)
-      })
-
-      it('should return the company', () => {
-        expect(this.resMock.locals).to.have.deep.property('company', companiesHouseCompany)
-      })
-
-      it('should have a null companies house category', () => {
-        expect(this.resMock.locals).to.have.property('companiesHouseCategory', 'Private Limited Company')
-      })
-
-      it('should have a ehq metaItems', () => {
-        expect(this.resMock.locals).to.have.deep.property('metaItems', [
-          {
-            type: 'badge',
-            label: 'Headquarter type',
-            value: 'European HQ',
-          },
-        ])
-      })
+    it('should return the company', () => {
+      expect(this.resMock.locals).to.have.deep.property('company', company)
     })
   })
 

--- a/test/unit/apps/companies/transformers/company-to-about-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-about-view.test.js
@@ -40,9 +40,7 @@ describe('#transformCompanyToKnownAsView', () => {
             'trading name 1',
             'trading name 2',
           ],
-          companies_house_data: {
-            company_number: '123456',
-          },
+          company_number: '123456',
           website: 'www.company.com',
           turnover: 100000,
           number_of_employees: 200,
@@ -157,9 +155,7 @@ describe('#transformCompanyToKnownAsView', () => {
             'trading name 1',
             'trading name 2',
           ],
-          companies_house_data: {
-            company_number: '123456',
-          },
+          company_number: '123456',
           vat_number: '0123456789',
           turnover_range: {
             name: '£33.5M+',

--- a/test/unit/apps/companies/transformers/company-to-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-view.test.js
@@ -1,6 +1,5 @@
 const datahubOnlyCompany = require('~/test/unit/data/companies/datahub-only-company.json')
 const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
-const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
 
 const transformCompanyToView = require('~/src/apps/companies/transformers/company-to-view')
 
@@ -139,28 +138,6 @@ describe('transformCompanyToView', () => {
 
     it('should supply sector', () => {
       expect(this.viewRecord.Sector).to.equal('Aerospace')
-    })
-  })
-
-  context('called with a datahub company with companies house data', () => {
-    beforeEach(() => {
-      this.viewRecord = transformCompanyToView(companiesHouseCompany)
-    })
-
-    it('should not include the business type', () => {
-      expect(this.viewRecord).to.have.ordered.keys([
-        'Primary address',
-        'Trading names',
-        'Trading address',
-        'UK region',
-        'Headquarter type',
-        'Sector',
-        'Website',
-        'Business description',
-        'VAT number',
-        'CDMS reference',
-        'Global HQ',
-      ])
     })
   })
 


### PR DESCRIPTION
https://trello.com/c/vMjd3B6t/1011-bug-fix-missing-company-number

👉 DEMO `~/companies/a73efeba-8499-11e6-ae22-56b6b6499611/business-details` (use Mercury Ltd in DEV)

## Problem
The `companies_house_category` object on the `v4/company/{id}` endpoint is redundant so the `Company number` (business details) and `Business type` fields are not being evaluated to display in the view.

## Solution
Remove references to `companies_house_category` and depend on `company_number` at the root of the `company` object.

## Before (business details)
![Screenshot 2019-04-03 at 21 53 26](https://user-images.githubusercontent.com/1150417/55514692-a5cc7580-5660-11e9-9543-4632585d4438.png)

## After (business details)
![Screenshot 2019-04-03 at 21 54 27](https://user-images.githubusercontent.com/1150417/55514699-ab29c000-5660-11e9-9c19-3b4691ded584.png)

## Before (edit company)
![Screenshot 2019-04-03 at 22 30 27](https://user-images.githubusercontent.com/1150417/55514708-afee7400-5660-11e9-8daf-251e294034ca.png)

## After (edit company)
![Screenshot 2019-04-03 at 22 30 13](https://user-images.githubusercontent.com/1150417/55514713-b67ceb80-5660-11e9-9dbd-c0f4d9b85048.png)