### PR TITLE
Fix events to record organiser

### DIFF
--- a/src/apps/adviser/filters.js
+++ b/src/apps/adviser/filters.js
@@ -2,6 +2,7 @@ const { get } = require('lodash')
 
 function filterActiveAdvisers ({ advisers = [], includeAdviser }) {
   return advisers.filter((adviser) => {
+    // This returns all active users plus the include advisor (whether they are active or not)
     return get(adviser, 'is_active', true) || adviser.id === includeAdviser
   })
 }

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -36,8 +36,7 @@ async function renderEditPage (req, res, next) {
     const eventName = get(eventData, 'name')
     const lead_team = eventData.lead_team || get(req, 'session.user.dit_team.id')
     const mergedData = pickBy(merge({}, eventData, { lead_team }, res.locals.requestBody))
-
-    const currentAdviser = get(eventData, 'organiser.id')
+    const currentAdviser = get(eventData, 'organiser')
     const options = await getEditOptions(req.session.token, mergedData.created_on, currentAdviser)
 
     const eventForm =

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -101,7 +101,7 @@ const eventFormConfig = ({
       }),
       {
         macroName: 'Typeahead',
-        name: 'dit_adviser',
+        name: 'organiser',
         entity: 'adviser',
         label: 'Organiser',
         classes: 'c-form-group c-form-group--no-filter',

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -5,7 +5,6 @@ const { fetchEvent, saveEvent } = require('../repos')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformEventFormBodyToApiRequest(req.body)
-
   if (req.body.add_team || req.body.add_related_programme) {
     return next()
   }

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -181,6 +181,7 @@ function transformEventResponseToFormBody (props = {}) {
     teams: teams.map(team => get(team, 'id')),
     service: get(props.service, 'id'),
     event_shared: !!teams.length,
+    organiser: get(props.organiser, 'id'),
   })
 }
 
@@ -188,11 +189,13 @@ function transformEventFormBodyToApiRequest (props) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
   const teams = props.lead_team ? teamsArray.concat(props.lead_team) : teamsArray
+  const organiser = props.organiser
 
   return assign({}, props, {
     start_date: transformDateObjectToDateString('start_date')(props),
     end_date: transformDateObjectToDateString('end_date')(props),
     teams: uniq(teams),
+    organiser: organiser,
     related_programmes,
   })
 }

--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -168,7 +168,7 @@ describe('Event edit controller', () => {
           { label: 'Zac Smith', value: '3' },
         ]
 
-        const formOrganizerFieldOptions = getFormFieldOptions(this.res, 'dit_adviser')
+        const formOrganizerFieldOptions = getFormFieldOptions(this.res, 'organiser')
         expect(formOrganizerFieldOptions).to.deep.equal(expectedOptions)
       })
 
@@ -231,7 +231,6 @@ describe('Event edit controller', () => {
     context('when editing an event', () => {
       beforeEach(async () => {
         this.currentAdviser = this.activeInactiveAdviserData.results[3]
-
         this.res.locals.event = assign({}, eventData, {
           created_on: lastMonth,
           organiser: this.currentAdviser,

--- a/test/unit/apps/events/middleware/details.test.js
+++ b/test/unit/apps/events/middleware/details.test.js
@@ -24,7 +24,10 @@ const expectedBody = {
   uk_region: 'uk_region',
   notes: 'notes',
   lead_team: 'lead_team',
-  organiser: 'organiser',
+  organiser: {
+    'id': '1',
+    'name': 'abc',
+  },
   related_programmes: [ 'programme1', 'programme2' ],
   teams: [ 'team1', 'team2', 'lead_team' ],
   services: 'services',

--- a/test/unit/data/events/event.json
+++ b/test/unit/data/events/event.json
@@ -20,7 +20,10 @@
   "lead_team": "lead_team",
   "service": "1783ae93-b78f-e611-8c55-e4115bed50dc",
   "services": "services",
-  "organiser": "organiser",
+  "organiser": {
+    "id": "1",
+    "name": "abc"
+  },
   "teams": [ "team1", "team2" ],
   "related_programmes": [ "programme1", "programme2" ]
 }


### PR DESCRIPTION
## Problem
The organiser is not being recorded when adding an event.
![Screenshot 2019-04-04 at 11 03 23](https://user-images.githubusercontent.com/10154302/55552798-588aeb00-56d6-11e9-9705-200882fa084b.png)

## Solution
Update the events form so the organiser gets recorded.
![Screenshot 2019-04-04 at 11 05 21](https://user-images.githubusercontent.com/10154302/55552836-70626f00-56d6-11e9-9c39-c0a0ac73a4ba.png)

### How manually test
1. Add an event, on success you should see the organiser recorded.
2. Go to the event list page, you should see the organiser in the event card.
3. Try to edit the event and you should see the organiser updated.
