### PR TITLE
Change Abandoned Proposition details logic to distinguish urls from plain string and format accordingly

### DIFF
--- a/src/apps/propositions/transformers.js
+++ b/src/apps/propositions/transformers.js
@@ -87,7 +87,7 @@ function addLineBreaks (string) {
   } else {
     return {
       type: 'word',
-      string,
+      value: string,
     }
   }
 }
@@ -110,7 +110,7 @@ function addAnchorsToUrl (s) {
 
   return {
     type: 'link',
-    string: {
+    value: {
       url: string,
       name: string,
     },
@@ -150,7 +150,7 @@ function transformPropositionResponseToViewRecord ({
     adviser,
     details: formattedDetails ? {
       type: 'paragraph',
-      string: formattedDetails,
+      value: formattedDetails,
     } : null,
     ...transformFilesResultsToDetails(files.results, id, investment_project.id),
   }

--- a/src/apps/propositions/transformers.js
+++ b/src/apps/propositions/transformers.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { assign, capitalize, compact, get, mapKeys, pickBy } = require('lodash')
+const { assign, capitalize, get, mapKeys, pickBy } = require('lodash')
 const { format, isValid } = require('date-fns')
 
 const { transformDateObjectToDateString } = require('../transformers')
@@ -75,14 +75,21 @@ function transformPropositionToListItem ({
 
 function formatDetails (details = '') {
   if (details.length) {
-    const result = splitString(details).map(s => isUrl(s) ? addAnchorsToUrl(s) : addLineBreaks(s))
-
-    return compact(result).join(' ')
+    return splitString(details).map(s => isUrl(s) ? addAnchorsToUrl(s) : addLineBreaks(s))
   }
 }
 
 function addLineBreaks (string) {
-  return string.replace(/\n|\r/g, '<br>')
+  if (string.match(/\n|\r/g)) {
+    return {
+      type: 'linebreak',
+    }
+  } else {
+    return {
+      type: 'word',
+      string,
+    }
+  }
 }
 
 function isUrl (string) {
@@ -98,10 +105,16 @@ function splitString (string) {
   return string.split(new RegExp(separators.join('|'), 'g'))
 }
 
-function addAnchorsToUrl (string) {
-  const cleanString = string.replace(/\n|\r/g, '')
+function addAnchorsToUrl (s) {
+  const string = s.replace(/\n|\r/g, '')
 
-  return `<a href="${cleanString}">${cleanString}</a>`
+  return {
+    type: 'link',
+    string: {
+      url: string,
+      name: string,
+    },
+  }
 }
 
 function transformPropositionResponseToViewRecord ({
@@ -136,7 +149,7 @@ function transformPropositionResponseToViewRecord ({
     },
     adviser,
     details: formattedDetails ? {
-      type: 'html',
+      type: 'paragraph',
       string: formattedDetails,
     } : null,
     ...transformFilesResultsToDetails(files.results, id, investment_project.id),

--- a/src/apps/propositions/transformers.js
+++ b/src/apps/propositions/transformers.js
@@ -1,13 +1,11 @@
 /* eslint-disable camelcase */
-const { assign, capitalize, get, mapKeys, pickBy } = require('lodash')
+const { assign, capitalize, forEach, get, mapKeys, pickBy } = require('lodash')
 const { format, isValid } = require('date-fns')
 
 const { transformDateObjectToDateString } = require('../transformers')
 const { transformFilesResultsToDetails, transformLabelsToShowFiles } = require('../documents/transformers')
 const labels = require('./labels')
 const { PROPOSITION_STATE } = require('./constants')
-
-const isUrlRegex = '(http|https)://'
 
 function transformPropositionResponseToForm ({
   id,
@@ -75,46 +73,112 @@ function transformPropositionToListItem ({
 
 function formatDetails (details = '') {
   if (details.length) {
-    return splitString(details).map(s => isUrl(s) ? addAnchorsToUrl(s) : addLineBreaks(s))
+    return getParagraph(details)
   }
 }
 
-function addLineBreaks (string) {
-  if (string.match(/\n|\r/g)) {
-    return {
-      type: 'linebreak',
-    }
-  } else {
-    return {
-      type: 'word',
-      value: string,
-    }
-  }
-}
-
-function isUrl (string) {
-  return string.match(isUrlRegex)
-}
-
-function splitString (string) {
-  /**
-   * splits the string by space, and return caret
-   */
-  const separators = [' ', '\r']
-
+function getStringList (string) {
+  const separators = [' ', '\r', '\n']
   return string.split(new RegExp(separators.join('|'), 'g'))
 }
 
-function addAnchorsToUrl (s) {
-  const string = s.replace(/\n|\r/g, '')
+/**
+ * Returns a list of indexes where the string matches the url pattern (http, www, ftp)
+ * @param list
+ * @returns {Array}
+ */
+function getUrlListIndexes (list = []) {
+  const indexes = []
 
-  return {
-    type: 'link',
-    value: {
-      url: string,
-      name: string,
-    },
+  forEach(list,
+    (item, index) => {
+      const isUrl = item.startsWith('https://') ||
+        item.startsWith('http://') ||
+        item.startsWith('ftp://') ||
+        item.startsWith('www.')
+
+      if (isUrl) {
+        indexes.push(index)
+      }
+    })
+
+  return indexes
+}
+
+/**
+ * Returns a collection with two types of objects:
+ *  1. link - that matches the url pattern
+ *  2. paragraph - string resulting from the union of the list elements between the 'link' type objects
+ *
+ * if any urls found,
+ * concatenate the strings from the list in scope from next index
+ * after the url index (item + 1) upto the next url position (indexes[index + 1])
+ *
+ * @param string
+ * @returns {Array}
+ */
+function getParagraph (string) {
+  const paragraph = []
+  const stringList = getStringList(string)
+  const indexes = getUrlListIndexes(stringList)
+
+  /**
+
+   */
+  if (indexes.length) {
+    forEach(indexes, (item, index) => {
+      const sliceEnd = indexes[index + 1] ? indexes[index + 1] : stringList.length
+      const paragraphItem = getParagraphItem(getStringSlice(stringList, item + 1, sliceEnd))
+
+      /**
+       *  if text doesn't start with a link,
+       *  concatenate the strings from the list in scope from beginning to the `item` index position
+       */
+      if (indexes[0] !== 0 && index === 0) {
+        paragraph.push({
+          type: 'paragraph',
+          value: getStringSlice(stringList, 0, item),
+        })
+      }
+
+      paragraph.push({
+        type: 'link',
+        value:
+          {
+            url: stringList[item],
+            name: stringList[item],
+          },
+      })
+
+      if (paragraphItem) {
+        paragraph.push(paragraphItem)
+      }
+    })
+
+  /**
+   * else text has no urls
+   */
+  } else {
+    paragraph.push({
+      type: 'paragraph',
+      value: string,
+    })
   }
+
+  return paragraph
+}
+
+function getParagraphItem (value = '') {
+  if (value.length) {
+    return {
+      type: 'paragraph',
+      value,
+    }
+  }
+}
+
+function getStringSlice (string, start = 0, end = string.length) {
+  return string.slice(start, end).join(' ')
 }
 
 function transformPropositionResponseToViewRecord ({

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -60,6 +60,8 @@
     {{ data.address | formatAddress }}
   {% elif data.type === 'error' %}
     {{ error(data) }}
+  {% elif data.type === 'html' %}
+    {{ data.string | safe }}
   {% else %}
     {{ data.name or data | escapeHtml | safe }}
   {% endif %}

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -28,6 +28,18 @@
   {% endif  %}
 {% endmacro %}
 
+{% macro paragraph(data) %}
+  {%  for item in data.string %}
+    {% if item.type == 'link' %}
+      {{ link(item.string) }}
+    {% elseif item.type == 'linebreak' %}
+      <br>
+    {% else %}
+      {{ item.string }}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
 {% macro details(data) %}
   <div class="table__details">
     <span class="table__details-name">{{ data.name }}</span>
@@ -60,8 +72,8 @@
     {{ data.address | formatAddress }}
   {% elif data.type === 'error' %}
     {{ error(data) }}
-  {% elif data.type === 'html' %}
-    {{ data.string | safe }}
+  {% elif data.type === 'paragraph' %}
+    {{ paragraph(data) }}
   {% else %}
     {{ data.name or data | escapeHtml | safe }}
   {% endif %}

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -29,15 +29,11 @@
 {% endmacro %}
 
 {% macro paragraph(data) %}
-  {%  for item in data.string %}
-    {% if item.type == 'link' %}
-      {{ link(item.string) }}
-    {% elseif item.type == 'linebreak' %}
-      <br>
-    {% else %}
-      {{ item.string }}
-    {% endif %}
-  {% endfor %}
+  <p>
+    {% for item in data.value %}
+      {{ renderItem(item.value) }}
+    {% endfor %}
+  </p>
 {% endmacro %}
 
 {% macro details(data) %}

--- a/test/unit/apps/propositions/transformers.test.js
+++ b/test/unit/apps/propositions/transformers.test.js
@@ -113,11 +113,7 @@ describe('Proposition transformers', () => {
 
       it('should not transform it to a collection with only word objects', () => {
         expect(this.transformed.Details.value).to.deep.equal([
-          { type: 'word', value: 'the' },
-          { type: 'word', value: 'world' },
-          { type: 'word', value: 'is' },
-          { type: 'word', value: 'a' },
-          { type: 'word', value: 'stage' },
+          { type: 'paragraph', value: 'the world is a stage' },
         ])
       })
     })
@@ -175,7 +171,6 @@ describe('Proposition transformers', () => {
             { type: 'link',
               value: { url: 'http://bazzinga', name: 'http://bazzinga' },
             },
-            { type: 'word', value: '' },
           ]
         )
       })
@@ -218,11 +213,49 @@ describe('Proposition transformers', () => {
                 name: 'https://world-is-a-stage',
               },
           },
-          { type: 'word', value: 'and' },
-          { type: 'word', value: 'we' },
-          { type: 'word', value: 'are' },
-          { type: 'word', value: 'the' },
-          { type: 'word', value: 'actors' },
+          { type: 'paragraph', value: 'and we are the actors' },
+          ])
+      })
+    })
+
+    context('when provided an abandoned proposition and a text that starts has also some a urls as detail', () => {
+      beforeEach(() => {
+        mockProposition.status = 'Abandoned'
+        mockProposition.details = 'in this universe https://world-is-a-stage and we are the actors www.yahoo.com of the play http://third.link lorem ipsum'
+        this.transformed = transformPropositionResponseToViewRecord(mockProposition)
+      })
+
+      it('should transform it to a collection with a link object for the url and a word object for the rest of the words in the string', () => {
+        expect(this.transformed.Details.value).to.deep.equal(
+          [
+            { type: 'paragraph', value: 'in this universe' },
+            {
+              type: 'link',
+              value:
+                {
+                  url: 'https://world-is-a-stage',
+                  name: 'https://world-is-a-stage',
+                },
+            },
+            { type: 'paragraph', value: 'and we are the actors' },
+            {
+              type: 'link',
+              value:
+                {
+                  url: 'www.yahoo.com',
+                  name: 'www.yahoo.com',
+                },
+            },
+            { type: 'paragraph', value: 'of the play' },
+            {
+              type: 'link',
+              value:
+                {
+                  url: 'http://third.link',
+                  name: 'http://third.link',
+                },
+            },
+            { type: 'paragraph', value: 'lorem ipsum' },
           ])
       })
     })
@@ -236,17 +269,13 @@ describe('Proposition transformers', () => {
 
       it('should transform it to a collection with a link object for the url and a word object for the rest of the words in the string', () => {
         expect(this.transformed.Details.value).to.deep.equal([
-          { type: 'word', value: 'the' },
-          { type: 'word', value: 'world' },
+          { type: 'paragraph', value: 'the world' },
           {
             type: 'link',
             value: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
           },
-          { type: 'word', value: 'and' },
-          { type: 'word', value: 'we' },
-          { type: 'word', value: 'are' },
-          { type: 'word', value: 'the' },
-          { type: 'word', value: 'actors' }])
+          { type: 'paragraph', value: 'and we are the actors' },
+        ])
       })
     })
 
@@ -259,21 +288,12 @@ describe('Proposition transformers', () => {
 
       it('should transform it to a collection with two link objects for the urls and a word object for the rest of the words in the string', () => {
         expect(this.transformed.Details.value).to.deep.equal([
-          { type: 'word', value: 'the' },
-          { type: 'word', value: 'world' },
+          { type: 'paragraph', value: 'the world' },
           {
             type: 'link',
             value: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
           },
-          { type: 'word', value: 'and' },
-          { type: 'word', value: 'we' },
-          { type: 'word', value: 'are' },
-          { type: 'word', value: 'the' },
-          { type: 'word', value: 'actors,' },
-          { type: 'word', value: 'find' },
-          { type: 'word', value: 'more' },
-          { type: 'word', value: 'quotes' },
-          { type: 'word', value: 'at' },
+          { type: 'paragraph', value: 'and we are the actors, find more quotes at' },
           {
             type: 'link',
             value:
@@ -282,10 +302,7 @@ describe('Proposition transformers', () => {
                 name: 'http://padding-quotes#123',
               },
           },
-          { type: 'word', value: 'and' },
-          { type: 'word', value: 'put' },
-          { type: 'word', value: 'them' },
-          { type: 'word', value: 'here' }]
+          { type: 'paragraph', value: 'and put them here' }]
         )
       })
     })

--- a/test/unit/apps/propositions/transformers.test.js
+++ b/test/unit/apps/propositions/transformers.test.js
@@ -111,9 +111,14 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should not transform it to a url', () => {
-        expect(this.transformed.Details.string).to.equal('the world is a stage')
-        expect(this.transformed.Details.string).to.not.equal('<a href="http://the-world-is-a-stage">http://the-world-is-a-stage</a>')
+      it('should not transform it to a collection with only word objects', () => {
+        expect(this.transformed.Details.string).to.deep.equal([
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'world' },
+          { type: 'word', string: 'is' },
+          { type: 'word', string: 'a' },
+          { type: 'word', string: 'stage' },
+        ])
       })
     })
 
@@ -124,9 +129,16 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform it to a url', () => {
-        expect(this.transformed.Details.string).to.not.deep.equal('the world is a stage')
-        expect(this.transformed.Details.string).to.equal('<a href="http://the-world-is-a-stage">http://the-world-is-a-stage</a>')
+      it('should transform it to a collection with a single link object', () => {
+        expect(this.transformed.Details.string).to.not.equal('the world is a stage')
+        expect(this.transformed.Details.string).to.deep.equal(
+          [{ type: 'link',
+            string: {
+              url: 'http://the-world-is-a-stage',
+              name: 'http://the-world-is-a-stage',
+            },
+          }]
+        )
       })
     })
 
@@ -137,9 +149,16 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform it to a url', () => {
-        expect(this.transformed.Details.string).to.not.deep.equal('the world is a stage')
-        expect(this.transformed.Details.string).to.equal('<a href="http://the-world-is-a-stage">http://the-world-is-a-stage</a>')
+      it('should transform it to a collection with a single link object', () => {
+        expect(this.transformed.Details.string).to.deep.equal(
+          [{
+            type: 'link',
+            string: {
+              url: 'http://the-world-is-a-stage',
+              name: 'http://the-world-is-a-stage',
+            },
+          }]
+        )
       })
     })
 
@@ -150,9 +169,15 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform it to a url', () => {
-        expect(this.transformed.Details.string).to.not.deep.equal('the world is a stage')
-        expect(this.transformed.Details.string).to.equal('<a href="http://bazzinga">http://bazzinga</a>')
+      it('should transform it to a collection with a link object with http, and an empty word object', () => {
+        expect(this.transformed.Details.string).to.deep.equal(
+          [
+            { type: 'link',
+              string: { url: 'http://bazzinga', name: 'http://bazzinga' },
+            },
+            { type: 'word', string: '' },
+          ]
+        )
       })
     })
 
@@ -163,9 +188,16 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform it to a an anchor with the url as hyper-reference', () => {
-        expect(this.transformed.Details.string).to.not.equal('https://and-we-are-the-actors')
-        expect(this.transformed.Details.string).to.equal('<a href="https://and-we-are-the-actors">https://and-we-are-the-actors</a>')
+      it('should transform it to a collection with a link object with https', () => {
+        expect(this.transformed.Details.string).to.deep.equal(
+          [
+            { type: 'link',
+              string: {
+                url: 'https://and-we-are-the-actors',
+                name: 'https://and-we-are-the-actors',
+              },
+            }]
+        )
       })
     })
 
@@ -176,9 +208,22 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform the url to an anchor thus ignoring the normal text', () => {
-        expect(this.transformed.Details.string).to.equal('<a href="https://world-is-a-stage">https://world-is-a-stage</a> and we are the actors')
-        expect(this.transformed.Details.string).to.not.equal('https://world-is-a-stage and we are the actors')
+      it('should transform it to a collection with a link object for the url and a word object for the rest of the words in the string', () => {
+        expect(this.transformed.Details.string).to.deep.equal(
+          [{
+            type: 'link',
+            string:
+              {
+                url: 'https://world-is-a-stage',
+                name: 'https://world-is-a-stage',
+              },
+          },
+          { type: 'word', string: 'and' },
+          { type: 'word', string: 'we' },
+          { type: 'word', string: 'are' },
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'actors' },
+          ])
       })
     })
 
@@ -189,9 +234,19 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform the url to an anchor thus ignoring the normal text', () => {
-        expect(this.transformed.Details.string).to.equal('the world <a href="https://is-a-stage">https://is-a-stage</a> and we are the actors')
-        expect(this.transformed.Details.string).to.not.equal('the world https://is-a-stage and we are the actors')
+      it('should transform it to a collection with a link object for the url and a word object for the rest of the words in the string', () => {
+        expect(this.transformed.Details.string).to.deep.equal([
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'world' },
+          {
+            type: 'link',
+            string: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
+          },
+          { type: 'word', string: 'and' },
+          { type: 'word', string: 'we' },
+          { type: 'word', string: 'are' },
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'actors' }])
       })
     })
 
@@ -202,9 +257,36 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform the url to an anchor thus ignoring the normal text', () => {
-        expect(this.transformed.Details.string).to.equal('the world <a href="https://is-a-stage">https://is-a-stage</a> and we are the actors, find more quotes at <a href="http://padding-quotes#123">http://padding-quotes#123</a> and put them here')
-        expect(this.transformed.Details.string).to.not.equal('the world https://is-a-stage and we are the actors, find more quotes at http://padding-quotes#123 and put them here')
+      it('should transform it to a collection with two link objects for the urls and a word object for the rest of the words in the string', () => {
+        expect(this.transformed.Details.string).to.deep.equal([
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'world' },
+          {
+            type: 'link',
+            string: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
+          },
+          { type: 'word', string: 'and' },
+          { type: 'word', string: 'we' },
+          { type: 'word', string: 'are' },
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'actors,' },
+          { type: 'word', string: 'find' },
+          { type: 'word', string: 'more' },
+          { type: 'word', string: 'quotes' },
+          { type: 'word', string: 'at' },
+          {
+            type: 'link',
+            string:
+              {
+                url: 'http://padding-quotes#123',
+                name: 'http://padding-quotes#123',
+              },
+          },
+          { type: 'word', string: 'and' },
+          { type: 'word', string: 'put' },
+          { type: 'word', string: 'them' },
+          { type: 'word', string: 'here' }]
+        )
       })
     })
 
@@ -215,9 +297,33 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform the url to an anchor thus ignoring the normal text', () => {
-        expect(this.transformed.Details.string).to.equal('the world <a href="https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D">https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D</a> <br> The World is a stage and Susan from Accounts piloted the revolving bacon')
-        expect(this.transformed.Details.string).to.not.equal('the world https://is-a-stage and we are the actors, find more quotes at http://padding-quotes#123 and put them here')
+      it('should transform it to a collection with a link object for the complete url and a word object for the rest of the words in the string', () => {
+        expect(this.transformed.Details.string).to.deep.equal([
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'world' },
+          {
+            type: 'link',
+            string:
+              {
+                url: 'https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D',
+                name: 'https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D',
+              },
+          },
+          { type: 'linebreak' },
+          { type: 'word', string: 'The' },
+          { type: 'word', string: 'World' },
+          { type: 'word', string: 'is' },
+          { type: 'word', string: 'a' },
+          { type: 'word', string: 'stage' },
+          { type: 'word', string: 'and' },
+          { type: 'word', string: 'Susan' },
+          { type: 'word', string: 'from' },
+          { type: 'word', string: 'Accounts' },
+          { type: 'word', string: 'piloted' },
+          { type: 'word', string: 'the' },
+          { type: 'word', string: 'revolving' },
+          { type: 'word', string: 'bacon' },
+        ])
       })
     })
   })

--- a/test/unit/apps/propositions/transformers.test.js
+++ b/test/unit/apps/propositions/transformers.test.js
@@ -112,12 +112,12 @@ describe('Proposition transformers', () => {
       })
 
       it('should not transform it to a collection with only word objects', () => {
-        expect(this.transformed.Details.string).to.deep.equal([
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'world' },
-          { type: 'word', string: 'is' },
-          { type: 'word', string: 'a' },
-          { type: 'word', string: 'stage' },
+        expect(this.transformed.Details.value).to.deep.equal([
+          { type: 'word', value: 'the' },
+          { type: 'word', value: 'world' },
+          { type: 'word', value: 'is' },
+          { type: 'word', value: 'a' },
+          { type: 'word', value: 'stage' },
         ])
       })
     })
@@ -130,10 +130,10 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a collection with a single link object', () => {
-        expect(this.transformed.Details.string).to.not.equal('the world is a stage')
-        expect(this.transformed.Details.string).to.deep.equal(
+        expect(this.transformed.Details.value).to.not.equal('the world is a stage')
+        expect(this.transformed.Details.value).to.deep.equal(
           [{ type: 'link',
-            string: {
+            value: {
               url: 'http://the-world-is-a-stage',
               name: 'http://the-world-is-a-stage',
             },
@@ -150,10 +150,10 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a collection with a single link object', () => {
-        expect(this.transformed.Details.string).to.deep.equal(
+        expect(this.transformed.Details.value).to.deep.equal(
           [{
             type: 'link',
-            string: {
+            value: {
               url: 'http://the-world-is-a-stage',
               name: 'http://the-world-is-a-stage',
             },
@@ -170,12 +170,12 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a collection with a link object with http, and an empty word object', () => {
-        expect(this.transformed.Details.string).to.deep.equal(
+        expect(this.transformed.Details.value).to.deep.equal(
           [
             { type: 'link',
-              string: { url: 'http://bazzinga', name: 'http://bazzinga' },
+              value: { url: 'http://bazzinga', name: 'http://bazzinga' },
             },
-            { type: 'word', string: '' },
+            { type: 'word', value: '' },
           ]
         )
       })
@@ -189,10 +189,10 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a collection with a link object with https', () => {
-        expect(this.transformed.Details.string).to.deep.equal(
+        expect(this.transformed.Details.value).to.deep.equal(
           [
             { type: 'link',
-              string: {
+              value: {
                 url: 'https://and-we-are-the-actors',
                 name: 'https://and-we-are-the-actors',
               },
@@ -209,20 +209,20 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a collection with a link object for the url and a word object for the rest of the words in the string', () => {
-        expect(this.transformed.Details.string).to.deep.equal(
+        expect(this.transformed.Details.value).to.deep.equal(
           [{
             type: 'link',
-            string:
+            value:
               {
                 url: 'https://world-is-a-stage',
                 name: 'https://world-is-a-stage',
               },
           },
-          { type: 'word', string: 'and' },
-          { type: 'word', string: 'we' },
-          { type: 'word', string: 'are' },
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'actors' },
+          { type: 'word', value: 'and' },
+          { type: 'word', value: 'we' },
+          { type: 'word', value: 'are' },
+          { type: 'word', value: 'the' },
+          { type: 'word', value: 'actors' },
           ])
       })
     })
@@ -235,18 +235,18 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a collection with a link object for the url and a word object for the rest of the words in the string', () => {
-        expect(this.transformed.Details.string).to.deep.equal([
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'world' },
+        expect(this.transformed.Details.value).to.deep.equal([
+          { type: 'word', value: 'the' },
+          { type: 'word', value: 'world' },
           {
             type: 'link',
-            string: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
+            value: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
           },
-          { type: 'word', string: 'and' },
-          { type: 'word', string: 'we' },
-          { type: 'word', string: 'are' },
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'actors' }])
+          { type: 'word', value: 'and' },
+          { type: 'word', value: 'we' },
+          { type: 'word', value: 'are' },
+          { type: 'word', value: 'the' },
+          { type: 'word', value: 'actors' }])
       })
     })
 
@@ -258,72 +258,35 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a collection with two link objects for the urls and a word object for the rest of the words in the string', () => {
-        expect(this.transformed.Details.string).to.deep.equal([
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'world' },
+        expect(this.transformed.Details.value).to.deep.equal([
+          { type: 'word', value: 'the' },
+          { type: 'word', value: 'world' },
           {
             type: 'link',
-            string: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
+            value: { url: 'https://is-a-stage', name: 'https://is-a-stage' },
           },
-          { type: 'word', string: 'and' },
-          { type: 'word', string: 'we' },
-          { type: 'word', string: 'are' },
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'actors,' },
-          { type: 'word', string: 'find' },
-          { type: 'word', string: 'more' },
-          { type: 'word', string: 'quotes' },
-          { type: 'word', string: 'at' },
+          { type: 'word', value: 'and' },
+          { type: 'word', value: 'we' },
+          { type: 'word', value: 'are' },
+          { type: 'word', value: 'the' },
+          { type: 'word', value: 'actors,' },
+          { type: 'word', value: 'find' },
+          { type: 'word', value: 'more' },
+          { type: 'word', value: 'quotes' },
+          { type: 'word', value: 'at' },
           {
             type: 'link',
-            string:
+            value:
               {
                 url: 'http://padding-quotes#123',
                 name: 'http://padding-quotes#123',
               },
           },
-          { type: 'word', string: 'and' },
-          { type: 'word', string: 'put' },
-          { type: 'word', string: 'them' },
-          { type: 'word', string: 'here' }]
+          { type: 'word', value: 'and' },
+          { type: 'word', value: 'put' },
+          { type: 'word', value: 'them' },
+          { type: 'word', value: 'here' }]
         )
-      })
-    })
-
-    context('when provided an abandoned proposition and a text including a complex url and a new line as detail', () => {
-      beforeEach(() => {
-        mockProposition.status = 'Abandoned'
-        mockProposition.details = 'the world https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D \n The World is a stage and Susan from Accounts piloted the revolving bacon'
-        this.transformed = transformPropositionResponseToViewRecord(mockProposition)
-      })
-
-      it('should transform it to a collection with a link object for the complete url and a word object for the rest of the words in the string', () => {
-        expect(this.transformed.Details.string).to.deep.equal([
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'world' },
-          {
-            type: 'link',
-            string:
-              {
-                url: 'https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D',
-                name: 'https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D',
-              },
-          },
-          { type: 'linebreak' },
-          { type: 'word', string: 'The' },
-          { type: 'word', string: 'World' },
-          { type: 'word', string: 'is' },
-          { type: 'word', string: 'a' },
-          { type: 'word', string: 'stage' },
-          { type: 'word', string: 'and' },
-          { type: 'word', string: 'Susan' },
-          { type: 'word', string: 'from' },
-          { type: 'word', string: 'Accounts' },
-          { type: 'word', string: 'piloted' },
-          { type: 'word', string: 'the' },
-          { type: 'word', string: 'revolving' },
-          { type: 'word', string: 'bacon' },
-        ])
       })
     })
   })

--- a/test/unit/apps/propositions/transformers.test.js
+++ b/test/unit/apps/propositions/transformers.test.js
@@ -112,11 +112,8 @@ describe('Proposition transformers', () => {
       })
 
       it('should not transform it to a url', () => {
-        expect(this.transformed.Details).to.deep.equal('the world is a stage')
-        expect(this.transformed.Details).to.not.deep.equal({
-          name: 'http://the-world-is-a-stage',
-          url: 'http://the-world-is-a-stage',
-        })
+        expect(this.transformed.Details.string).to.equal('the world is a stage')
+        expect(this.transformed.Details.string).to.not.equal('<a href="http://the-world-is-a-stage">http://the-world-is-a-stage</a>')
       })
     })
 
@@ -128,11 +125,34 @@ describe('Proposition transformers', () => {
       })
 
       it('should transform it to a url', () => {
-        expect(this.transformed.Details).to.not.deep.equal('the world is a stage')
-        expect(this.transformed.Details).to.deep.equal({
-          name: 'http://the-world-is-a-stage',
-          url: 'http://the-world-is-a-stage',
-        })
+        expect(this.transformed.Details.string).to.not.deep.equal('the world is a stage')
+        expect(this.transformed.Details.string).to.equal('<a href="http://the-world-is-a-stage">http://the-world-is-a-stage</a>')
+      })
+    })
+
+    context('when provided an abandoned proposition and a url with http as detail ending with a new line', () => {
+      beforeEach(() => {
+        mockProposition.status = 'Abandoned'
+        mockProposition.details = 'http://the-world-is-a-stage\n'
+        this.transformed = transformPropositionResponseToViewRecord(mockProposition)
+      })
+
+      it('should transform it to a url', () => {
+        expect(this.transformed.Details.string).to.not.deep.equal('the world is a stage')
+        expect(this.transformed.Details.string).to.equal('<a href="http://the-world-is-a-stage">http://the-world-is-a-stage</a>')
+      })
+    })
+
+    context('when provided an abandoned proposition and a url with http as detail ending with a carriage return', () => {
+      beforeEach(() => {
+        mockProposition.status = 'Abandoned'
+        mockProposition.details = 'http://bazzinga\r'
+        this.transformed = transformPropositionResponseToViewRecord(mockProposition)
+      })
+
+      it('should transform it to a url', () => {
+        expect(this.transformed.Details.string).to.not.deep.equal('the world is a stage')
+        expect(this.transformed.Details.string).to.equal('<a href="http://bazzinga">http://bazzinga</a>')
       })
     })
 
@@ -143,28 +163,61 @@ describe('Proposition transformers', () => {
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should transform it to a url', () => {
-        expect(this.transformed.Details).to.not.deep.equal('https://and-we-are-the-actors')
-        expect(this.transformed.Details).to.deep.equal({
-          name: 'https://and-we-are-the-actors',
-          url: 'https://and-we-are-the-actors',
-        })
+      it('should transform it to a an anchor with the url as hyper-reference', () => {
+        expect(this.transformed.Details.string).to.not.equal('https://and-we-are-the-actors')
+        expect(this.transformed.Details.string).to.equal('<a href="https://and-we-are-the-actors">https://and-we-are-the-actors</a>')
       })
     })
 
-    context('when provided an abandoned proposition and a text including a url with https as detail', () => {
+    context('when provided an abandoned proposition and a text that starts with a https url as detail', () => {
       beforeEach(() => {
         mockProposition.status = 'Abandoned'
-        mockProposition.details = 'the world is a stage, https://and-we-are-the-actors'
+        mockProposition.details = 'https://world-is-a-stage and we are the actors'
         this.transformed = transformPropositionResponseToViewRecord(mockProposition)
       })
 
-      it('should not transform it to a url', () => {
-        expect(this.transformed.Details).to.deep.equal('the world is a stage, https://and-we-are-the-actors')
-        expect(this.transformed.Details).to.not.deep.equal({
-          name: 'https://and-we-are-the-actors',
-          url: 'https://and-we-are-the-actors',
-        })
+      it('should transform the url to an anchor thus ignoring the normal text', () => {
+        expect(this.transformed.Details.string).to.equal('<a href="https://world-is-a-stage">https://world-is-a-stage</a> and we are the actors')
+        expect(this.transformed.Details.string).to.not.equal('https://world-is-a-stage and we are the actors')
+      })
+    })
+
+    context('when provided an abandoned proposition and a text including an url with https as detail', () => {
+      beforeEach(() => {
+        mockProposition.status = 'Abandoned'
+        mockProposition.details = 'the world https://is-a-stage and we are the actors'
+        this.transformed = transformPropositionResponseToViewRecord(mockProposition)
+      })
+
+      it('should transform the url to an anchor thus ignoring the normal text', () => {
+        expect(this.transformed.Details.string).to.equal('the world <a href="https://is-a-stage">https://is-a-stage</a> and we are the actors')
+        expect(this.transformed.Details.string).to.not.equal('the world https://is-a-stage and we are the actors')
+      })
+    })
+
+    context('when provided an abandoned proposition and a text including multiple urls as detail', () => {
+      beforeEach(() => {
+        mockProposition.status = 'Abandoned'
+        mockProposition.details = 'the world https://is-a-stage and we are the actors, find more quotes at http://padding-quotes#123 and put them here'
+        this.transformed = transformPropositionResponseToViewRecord(mockProposition)
+      })
+
+      it('should transform the url to an anchor thus ignoring the normal text', () => {
+        expect(this.transformed.Details.string).to.equal('the world <a href="https://is-a-stage">https://is-a-stage</a> and we are the actors, find more quotes at <a href="http://padding-quotes#123">http://padding-quotes#123</a> and put them here')
+        expect(this.transformed.Details.string).to.not.equal('the world https://is-a-stage and we are the actors, find more quotes at http://padding-quotes#123 and put them here')
+      })
+    })
+
+    context('when provided an abandoned proposition and a text including a complex url and a new line as detail', () => {
+      beforeEach(() => {
+        mockProposition.status = 'Abandoned'
+        mockProposition.details = 'the world https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D \n The World is a stage and Susan from Accounts piloted the revolving bacon'
+        this.transformed = transformPropositionResponseToViewRecord(mockProposition)
+      })
+
+      it('should transform the url to an anchor thus ignoring the normal text', () => {
+        expect(this.transformed.Details.string).to.equal('the world <a href="https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D">https://not.your.business.com/in-oui/Tower/BMI-slender/Heroes/Alpacas/AllTheThings.bruv?CarrotFruit=%2Bounce-ti%2Tennis%2FWD-atlethics%2BStuff%2Travel%2More%2L3ss%tim3ws6erz%20-%20Blah%2Cu8cumb34&Rap_Music=0x012000D998E6715Fr0GPF4881B0002C5764B8EF&EyeEye=%7B08EEDE07-DOOH-4B91-ASIA-BOYBAND48766CE%7D</a> <br> The World is a stage and Susan from Accounts piloted the revolving bacon')
+        expect(this.transformed.Details.string).to.not.equal('the world https://is-a-stage and we are the actors, find more quotes at http://padding-quotes#123 and put them here')
       })
     })
   })

--- a/test/unit/components/key-value-table.test.js
+++ b/test/unit/components/key-value-table.test.js
@@ -229,6 +229,47 @@ describe('Key/value table component', () => {
     })
   })
 
+  context('when there is one item and the data is a paragraph', () => {
+    beforeEach(() => {
+      const component = renderComponentToDom('key-value-table', {
+        items: {
+          'Label 1': {
+            name: 'Paragraph',
+            type: 'paragraph',
+            string: [{
+              type: 'link',
+              string:
+                {
+                  url: 'https://world-is-a-stage',
+                  name: 'https://world-is-a-stage',
+                },
+            },
+            { type: 'word', string: 'and' },
+            { type: 'word', string: 'we' },
+            { type: 'word', string: 'are' },
+            { type: 'word', string: 'the' },
+            { type: 'word', string: 'actors' },
+            ],
+          },
+        },
+      })
+
+      this.rows = component.querySelectorAll('tr')
+    })
+
+    it('should render one row', () => {
+      expect(this.rows.length).to.equal(1)
+    })
+
+    it('should render a label', () => {
+      expect(this.rows[0].querySelector('th').textContent).to.equal('Label 1')
+    })
+
+    it('should render the paragraph', () => {
+      expect(this.rows[0].querySelector('td').textContent).to.equal(' https://world-is-a-stage and we\n        are the actors')
+    })
+  })
+
   context('when there is one item and the data is an object with a name', () => {
     beforeEach(() => {
       const component = renderComponentToDom('key-value-table', {

--- a/test/unit/components/key-value-table.test.js
+++ b/test/unit/components/key-value-table.test.js
@@ -236,19 +236,15 @@ describe('Key/value table component', () => {
           'Label 1': {
             name: 'Paragraph',
             type: 'paragraph',
-            string: [{
+            value: [{
               type: 'link',
-              string:
+              value:
                 {
                   url: 'https://world-is-a-stage',
                   name: 'https://world-is-a-stage',
                 },
             },
-            { type: 'word', string: 'and' },
-            { type: 'word', string: 'we' },
-            { type: 'word', string: 'are' },
-            { type: 'word', string: 'the' },
-            { type: 'word', string: 'actors' },
+            { type: 'paragraph', value: 'and we are the actors' },
             ],
           },
         },
@@ -266,7 +262,7 @@ describe('Key/value table component', () => {
     })
 
     it('should render the paragraph', () => {
-      expect(this.rows[0].querySelector('td').textContent).to.equal(' https://world-is-a-stage and we\n        are the actors')
+      expect(this.rows[0].querySelector('td').textContent).to.equal('\n         https://world-is-a-stage and we\n          are the actors\n      ')
     })
   })
 


### PR DESCRIPTION
Users seem to add both urls and explanatory text to the details section when abandoning a proposition and they expect to see the formatting accordingly.

Create an html type for key-value-table template for rendering html strings

![Screenshot 2019-04-04 at 15 33 59](https://user-images.githubusercontent.com/1295319/55564245-6305ae80-56ef-11e9-8dd6-37afbe193740.png)

<!--- Add Jira ticket number this work relates to at the beginning of the Title -->
