### PR TITLE
Use address.country for investor country

### DIFF
--- a/src/apps/investments/transformers/fdi.js
+++ b/src/apps/investments/transformers/fdi.js
@@ -1,6 +1,4 @@
 /* eslint-disable camelcase */
-const { get } = require('lodash')
-
 const { getInvestmentTypeDetails } = require('./shared')
 
 function transformInvestmentFDIForView ({
@@ -15,7 +13,7 @@ function transformInvestmentFDIForView ({
       name: investor_company.name,
       url: `/companies/${investor_company.id}`,
     },
-    foreign_country: get(investor_company, 'registered_address_country.name'),
+    foreign_country: investor_company.address.country.name,
     uk_company: uk_company ? {
       name: uk_company.name,
       url: `/companies/${uk_company.id}`,

--- a/test/unit/apps/investment-projects/transformers/fdi.test.js
+++ b/test/unit/apps/investment-projects/transformers/fdi.test.js
@@ -1,0 +1,89 @@
+const { transformInvestmentFDIForView } = require('~/src/apps/investments/transformers/fdi')
+
+const investment = {
+  investment_type: {
+    id: '3e143372-496c-4d1e-8278-6fdd3da9b48b',
+    name: 'FDI',
+  },
+  fdi_type: {
+    name: 'Creation of new site or activity',
+    id: 'f8447013-cfdc-4f35-a146-6619665388b3',
+  },
+  investor_company: {
+    id: 'fc58888b-a098-e211-a939-e4115bead28a',
+    name: 'Investor company',
+    address: {
+      country: {
+        name: 'France',
+      },
+    },
+  },
+}
+
+describe('Investment FDI transformer', () => {
+  describe('#transformInvestmentFDIForView', () => {
+    const commonTests = ({ expectedInvestorRetainingVotingPower }) => {
+      it('should contain only the expected fields', () => {
+        expect(this.transformed).to.have.ordered.keys([
+          'foreign_country',
+          'foreign_investor',
+          'investor_retain_voting_power',
+          'type_of_investment',
+          'uk_company',
+        ])
+      })
+
+      it('should set the foreign country', () => {
+        expect(this.transformed.foreign_country).to.equal('France')
+      })
+
+      it('should set the foreign investor', () => {
+        expect(this.transformed.foreign_investor).to.deep.equal({
+          name: 'Investor company',
+          url: '/companies/fc58888b-a098-e211-a939-e4115bead28a',
+        })
+      })
+
+      it('should set investor retaining voting power', () => {
+        expect(this.transformed.investor_retain_voting_power).to.equal(expectedInvestorRetainingVotingPower)
+      })
+
+      it('should set type of investment', () => {
+        expect(this.transformed.type_of_investment).to.equal('FDI, Creation of new site or activity')
+      })
+    }
+
+    context('when the investment has a UK company', () => {
+      beforeEach(() => {
+        this.transformed = transformInvestmentFDIForView({
+          ...investment,
+          uk_company: {
+            id: '24f8df2c-a22e-4058-bda9-b5b96853ccd7',
+            name: 'UK company',
+          },
+        })
+      })
+
+      commonTests({ expectedInvestorRetainingVotingPower: 'Yes' })
+
+      it('should set the UK company', () => {
+        expect(this.transformed.uk_company).to.deep.equal({
+          name: 'UK company',
+          url: '/companies/24f8df2c-a22e-4058-bda9-b5b96853ccd7',
+        })
+      })
+    })
+
+    context('when the investment UK company is not known', () => {
+      beforeEach(() => {
+        this.transformed = transformInvestmentFDIForView(investment)
+      })
+
+      commonTests({ expectedInvestorRetainingVotingPower: 'No' })
+
+      it('should not set the UK company', () => {
+        expect(this.transformed.uk_company).to.not.exist
+      })
+    })
+  })
+})

--- a/test/unit/data/investment/investment-data-uk-company.json
+++ b/test/unit/data/investment/investment-data-uk-company.json
@@ -36,15 +36,18 @@
     "export_to_countries": [],
     "future_interest_countries": [],
     "uk_based": false,
-    "registered_address_1": "The octagon",
-    "registered_address_2": "13A, A.J ACHME Drive,",
-    "registered_address_town": "Victoria island",
-    "registered_address_country": {
-      "id": "4561b8be-5d95-e211-a939-e4115bead28a",
-      "name": "Nigeria"
+    "address": {
+      "line_1": "The octagon",
+      "line_2": "13A, A.J ACHME Drive,",
+      "town": "Victoria island",
+      "country": {
+        "id": "4561b8be-5d95-e211-a939-e4115bead28a",
+        "name": "Nigeria"
+      },
+      "county": "lagos,Nigeria",
+      "postcode": null
     },
-    "registered_address_county": "lagos,Nigeria",
-    "registered_address_postcode": null,
+    "registered_address": null,
     "created_on": "2008-03-18T09:10:03",
     "modified_on": "2017-07-14T10:33:06.406791",
     "archived": false,
@@ -53,11 +56,6 @@
     "company_number": null,
     "description": "",
     "website": "www.achme.com/africa/",
-    "trading_address_1": null,
-    "trading_address_2": null,
-    "trading_address_town": null,
-    "trading_address_county": null,
-    "trading_address_postcode": null,
     "archived_by": null,
     "business_type": {
       "id": "98d14e94-5d95-e211-a939-e4115bead28a",
@@ -73,7 +71,6 @@
       "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",
       "name": "Undefined"
     },
-    "trading_address_country": null,
     "headquarter_type": null,
     "one_list_group_tier": {
       "id": "b91bf800-8d53-e311-aef3-441ea13961e2",

--- a/test/unit/data/investment/investment-data.json
+++ b/test/unit/data/investment/investment-data.json
@@ -36,15 +36,18 @@
     "export_to_countries": [],
     "future_interest_countries": [],
     "uk_based": false,
-    "registered_address_1": "707-19 Yoksam2 dong",
-    "registered_address_2": "Gangnam-gu",
-    "registered_address_town": "Seoul",
-    "registered_address_country": {
-      "id": "7c6a9ab2-5d95-e211-a939-e4115bead28a",
-      "name": "Korea (South)"
+    "address": {
+      "line_1": "707-19 Yoksam2 dong",
+      "line_2": "Gangnam-gu",
+      "town": "Seoul",
+      "country": {
+        "id": "7c6a9ab2-5d95-e211-a939-e4115bead28a",
+        "name": "Korea (South)"
+      },
+      "county": "",
+      "postcode": "135-918"
     },
-    "registered_address_county": "",
-    "registered_address_postcode": "135-918",
+    "registered_address": null,
     "created_on": "2008-04-02T06:00:34",
     "modified_on": "2015-11-12T15:50:58",
     "archived": false,
@@ -53,11 +56,6 @@
     "company_number": null,
     "description": "IT",
     "website": null,
-    "trading_address_1": "",
-    "trading_address_2": "",
-    "trading_address_town": "",
-    "trading_address_county": "",
-    "trading_address_postcode": "",
     "archived_by": null,
     "business_type": {
       "id": "98d14e94-5d95-e211-a939-e4115bead28a",
@@ -73,7 +71,6 @@
       "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",
       "name": "Undefined"
     },
-    "trading_address_country": null,
     "headquarter_type": null,
     "one_list_group_tier": null,
     "one_list_group_global_account_manager": null


### PR DESCRIPTION
https://trello.com/c/vvkBwowP/1013-use-new-address-object-when-presenting-investor-country-for-investment

## Change
The `registered_address_*` and `trading_address_*` fields are deprecated. To get the `country` for a `company` the `company.address.country.name` field should be evaluated.

This change adds missing unit tests for the transformer and users the new `address` object.