### PR TITLE
Hide the company name within the list of company interactions

### DIFF
--- a/src/apps/companies/middleware/interactions.js
+++ b/src/apps/companies/middleware/interactions.js
@@ -7,6 +7,7 @@ function setInteractionsDetails (req, res, next) {
     entityName: company.name,
     query: { company_id: company.id },
     canAdd: !company.archived,
+    showCompany: false,
   }
 
   next()

--- a/src/apps/contacts/middleware/interactions.js
+++ b/src/apps/contacts/middleware/interactions.js
@@ -7,6 +7,7 @@ function setInteractionsDetails (req, res, next) {
     query: { contacts__id: req.params.contactId },
     view: 'contacts/views/interactions',
     canAdd: true,
+    showCompany: true,
   }
 
   next()

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -54,8 +54,19 @@ const filters = {
   policy_issue_types: 'Policy issue type',
 }
 
+const metaItems = {
+  type: 'Type',
+  date: 'Date',
+  contacts: 'Contact(s)',
+  company: 'Company',
+  dit_participants: 'Adviser(s)',
+  dit_team: 'Service provider',
+  service: 'Service',
+}
+
 module.exports = {
   interaction,
   serviceDelivery,
   filters,
+  metaItems,
 }

--- a/src/apps/interactions/macros/collection-sort-form.js
+++ b/src/apps/interactions/macros/collection-sort-form.js
@@ -1,28 +1,32 @@
-const options = [
-  { value: '-date', label: 'Newest' },
-  { value: 'company__name', label: 'Company: A-Z' },
-  { value: 'subject', label: 'Subject: A-Z' },
-]
-
-const interactionSortForm = {
-  method: 'get',
-  class: 'c-collection__sort-form js-AutoSubmit',
-  hideFormActions: true,
-  hiddenFields: { custom: true },
-  children: [
-    {
-      options,
-      macroName: 'MultipleChoiceField',
-      label: 'Sort by',
-      name: 'sortby',
-      modifier: ['small', 'inline', 'light'],
-    },
-  ],
+const getSortOptions = (showCompany = true) => {
+  return [
+    { value: '-date', label: 'Newest' },
+    { value: 'company__name', label: 'Company: A-Z' },
+    { value: 'subject', label: 'Subject: A-Z' },
+  ].filter(o => o.value !== 'company__name' || showCompany)
 }
 
-const defaultInteractionSort = options[0].value
+const buildInteractionSortForm = (showCompany = true) => {
+  return {
+    method: 'get',
+    class: 'c-collection__sort-form js-AutoSubmit',
+    hideFormActions: true,
+    hiddenFields: { custom: true },
+    children: [
+      {
+        options: getSortOptions(showCompany),
+        macroName: 'MultipleChoiceField',
+        label: 'Sort by',
+        name: 'sortby',
+        modifier: ['small', 'inline', 'light'],
+      },
+    ],
+  }
+}
+
+const getDefaultInteractionSort = (showCompany = true) => getSortOptions(showCompany)[0].value
 
 module.exports = {
-  interactionSortForm,
-  defaultInteractionSort,
+  buildInteractionSortForm,
+  getDefaultInteractionSort,
 }

--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -47,15 +47,14 @@ function transformInteractionResponseToViewRecord ({
 }) {
   const defaultEventText = kind === 'service_delivery' ? 'No' : null
   const kindLabels = labels[camelCase(kind)]
-  const displayPolicyAreas = (policy_areas || [])
-    .map(policy_area => policy_area.name)
-    .join(', ')
+  const formattedPolicyAreas = (policy_areas || []).map(policy_area => policy_area.name).join(', ')
+  const formattedPolicyTypes = (policy_issue_types || []).map(policy_type => policy_type.name).join(', ')
 
-  const displayPolicyTypes = (policy_issue_types || [])
-    .map(policy_type => policy_type.name)
-    .join(', ')
-  const hasTeam = (name) => get(name, 'team') ? `${name.adviser.name}, ${name.team.name}` : name.adviser.name
-  const displayDitParticipants = (dit_participants || []).map(ditParticipant => hasTeam(ditParticipant))
+  const formatParticipantName = (participant) => get(participant, 'team')
+    ? `${participant.adviser.name}, ${participant.team.name}`
+    : participant.adviser.name
+
+  const formattedParticipants = (dit_participants || []).map(participant => formatParticipantName(participant))
 
   const transformed = {
     company: transformEntityLink(company, 'companies'),
@@ -76,13 +75,13 @@ function transformInteractionResponseToViewRecord ({
       type: 'date',
       name: date,
     },
-    dit_participants: displayDitParticipants,
+    dit_participants: formattedParticipants,
     investment_project: transformEntityLink(investment_project, 'investments/projects'),
     event: transformEntityLink(event, 'events', defaultEventText),
     communication_channel: communication_channel,
     documents: transformDocumentsLink(archived_documents_url_path),
-    policy_issue_types: displayPolicyTypes,
-    policy_areas: displayPolicyAreas,
+    policy_issue_types: formattedPolicyTypes,
+    policy_areas: formattedPolicyAreas,
     policy_feedback_notes: policy_feedback_notes,
   }
 

--- a/src/apps/interactions/transformers/interaction-to-list-item.js
+++ b/src/apps/interactions/transformers/interaction-to-list-item.js
@@ -1,61 +1,50 @@
 /* eslint-disable camelcase */
-const { get } = require('lodash')
+const { compact, get } = require('lodash')
 
 const { INTERACTION_NAMES } = require('../constants')
-const { interaction } = require('../labels')
+const labels = require('../labels')
 
-function transformInteractionToListItem ({
-  id,
-  subject,
-  kind,
-  contacts,
-  company,
-  date,
-  dit_participants,
-  dit_team,
-  service,
-  was_policy_feedback_provided,
-}) {
-  const hasMultipleContacts = (contacts) => contacts.length > 1 ? interaction.multiple_contacts : contacts.map(contact => contact.name)
-  const hasTeam = (name) => get(name, 'team') ? `${name.adviser.name}, ${name.team.name}` : name.adviser.name
-  const hasMultipleAdvisers = (dit_participants) => dit_participants.length > 1 ? interaction.multiple_advisers : dit_participants.map(ditParticipant => hasTeam(ditParticipant))
-  return {
-    was_policy_feedback_provided,
+function transformInteractionToListItem (showCompany = true) {
+  return function ({
     id,
-    type: 'interaction',
-    name: subject || 'No subject',
-    meta: [
-      {
-        label: 'Type',
-        type: 'badge',
-        value: INTERACTION_NAMES[kind],
-      },
-      {
-        label: 'Date',
-        value: date,
-        type: 'date',
-      },
-      {
-        label: 'Contact(s)',
-        value: contacts && hasMultipleContacts(contacts),
-      },
-      {
-        label: 'Company',
-        value: company,
-      },
-      {
-        label: 'Adviser(s)',
-        value: dit_participants && hasMultipleAdvisers(dit_participants),
-      },
-      {
-        label: 'Service',
-        value: service,
-      },
-    ].concat(was_policy_feedback_provided ? {
-      label: 'Type',
-      type: 'badge',
-      value: INTERACTION_NAMES.policy_feedback,
-    } : null),
+    subject,
+    kind,
+    contacts,
+    company,
+    date,
+    dit_participants,
+    service,
+    was_policy_feedback_provided,
+  }) {
+    const formatContacts = (contacts) => contacts.length > 1
+      ? labels.interaction.multiple_contacts
+      : contacts.map(contact => contact.name)
+
+    const formatParticipantName = (participant) => get(participant, 'team')
+      ? `${participant.adviser.name}, ${participant.team.name}`
+      : participant.adviser.name
+
+    const formatParticipants = (dit_participants) => dit_participants.length > 1
+      ? labels.interaction.multiple_advisers
+      : dit_participants.map(participant => formatParticipantName(participant))
+
+    const metaItems = [
+      { label: labels.metaItems.type, value: INTERACTION_NAMES[kind], type: 'badge' },
+      { label: labels.metaItems.type, value: was_policy_feedback_provided && INTERACTION_NAMES.policy_feedback, type: 'badge' },
+      { label: labels.metaItems.date, value: date, type: 'date' },
+      { label: labels.metaItems.contacts, value: contacts && formatContacts(contacts) },
+      { label: labels.metaItems.company, value: showCompany && company },
+      { label: labels.metaItems.dit_participants, value: dit_participants && formatParticipants(dit_participants) },
+      { label: labels.metaItems.service, value: service },
+    ].filter(({ value }) => !!value)
+
+    return {
+      was_policy_feedback_provided,
+      id,
+      type: 'interaction',
+      name: subject || 'No subject',
+      meta: compact(metaItems),
+    }
   }
 }
 

--- a/src/apps/investments/middleware/interactions.js
+++ b/src/apps/investments/middleware/interactions.js
@@ -12,6 +12,7 @@ function setInteractionsDetails (req, res, next) {
     view: 'investments/views/interactions',
     createKind: 'interaction',
     canAdd: true,
+    showCompany: true,
   }
 
   next()

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -52,7 +52,7 @@ async function renderSearchResults (req, res) {
   }
 
   if (searchEntity === 'interaction') {
-    itemTransformers.push(transformInteractionToListItem)
+    itemTransformers.push(transformInteractionToListItem())
   }
 
   const results = await search({

--- a/test/functional/cypress/specs/companies/interactions-spec.js
+++ b/test/functional/cypress/specs/companies/interactions-spec.js
@@ -61,4 +61,31 @@ describe('Companies interactions', () => {
       cy.get(selector).should('have.text', 'View activity for this business on a timeline')
     })
   })
+
+  context('when viewing Venus Ltd which has multiple interactions', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.venusLtd.id}`)
+    })
+
+    it('should contain interaction details', () => {
+      cy.get(selectors.entityCollection.entity(1))
+        .should('contain', 'Date')
+        .and('contain', 'Contact(s)')
+        .and('contain', 'Service')
+    })
+
+    it('should not display the company name on the list of interactions', () => {
+      cy.get(selectors.entityCollection.entity(1))
+        .should('not.contain', 'Company')
+    })
+
+    it('should have default sorting option', () => {
+      cy.get(selectors.entityCollection.sort).should('have.value', '-date')
+    })
+
+    it('should contain interaction sorting options without the "Company: A-Z" filter', () => {
+      cy.get(selectors.entityCollection.sort)
+        .should('have.text', 'NewestSubject: A-Z')
+    })
+  })
 })

--- a/test/unit/apps/interactions/macros/collection-sort-form.test.js
+++ b/test/unit/apps/interactions/macros/collection-sort-form.test.js
@@ -1,0 +1,97 @@
+const { buildInteractionSortForm, getDefaultInteractionSort } = require('~/src/apps/interactions/macros/collection-sort-form.js')
+
+describe('interactions collection sort form', () => {
+  describe('#buildInteractionSortForm', () => {
+    it('should render form with all options', () => {
+      const actual = buildInteractionSortForm()
+      const expected = {
+        'method': 'get',
+        'class': 'c-collection__sort-form js-AutoSubmit',
+        'hideFormActions': true,
+        'hiddenFields': {
+          'custom': true,
+        },
+        'children': [
+          {
+            'options': [
+              {
+                'value': '-date',
+                'label': 'Newest',
+              },
+              {
+                'value': 'company__name',
+                'label': 'Company: A-Z',
+              },
+              {
+                'value': 'subject',
+                'label': 'Subject: A-Z',
+              },
+            ],
+            'macroName': 'MultipleChoiceField',
+            'label': 'Sort by',
+            'name': 'sortby',
+            'modifier': [
+              'small',
+              'inline',
+              'light',
+            ],
+          },
+        ],
+      }
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('should render form without company option', () => {
+      const actual = buildInteractionSortForm(false)
+      const expected = {
+        'method': 'get',
+        'class': 'c-collection__sort-form js-AutoSubmit',
+        'hideFormActions': true,
+        'hiddenFields': {
+          'custom': true,
+        },
+        'children': [
+          {
+            'options': [
+              {
+                'value': '-date',
+                'label': 'Newest',
+              },
+              {
+                'value': 'subject',
+                'label': 'Subject: A-Z',
+              },
+            ],
+            'macroName': 'MultipleChoiceField',
+            'label': 'Sort by',
+            'name': 'sortby',
+            'modifier': [
+              'small',
+              'inline',
+              'light',
+            ],
+          },
+        ],
+      }
+
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+
+  describe('#getDefaultInteractionSort', () => {
+    it('should get default option', () => {
+      const actual = getDefaultInteractionSort()
+      const expected = '-date'
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('should get default option when the company name is hidden', () => {
+      const actual = getDefaultInteractionSort(false)
+      const expected = '-date'
+
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+})

--- a/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
@@ -6,7 +6,7 @@ describe('#transformInteractionToListItem', () => {
   context('when the source is an interaction', () => {
     beforeEach(() => {
       mockInteraction.kind = 'interaction'
-      this.transformed = transformInteractionToListItem(mockInteraction)
+      this.transformed = transformInteractionToListItem()(mockInteraction)
     })
 
     it('should transform data from interaction response to list item', () => {
@@ -48,7 +48,6 @@ describe('#transformInteractionToListItem', () => {
               name: 'Test service',
             },
           },
-          null,
         ],
       })
     })
@@ -56,7 +55,7 @@ describe('#transformInteractionToListItem', () => {
 
   context('When the source is an interaction with multiple contacts', () => {
     beforeEach(() => {
-      this.transformed = transformInteractionToListItem({
+      this.transformed = transformInteractionToListItem()({
         ...mockInteraction,
         contacts: [{
           'id': 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
@@ -82,7 +81,7 @@ describe('#transformInteractionToListItem', () => {
 
   context('when the source is an interaction with an empty subject', () => {
     beforeEach(() => {
-      this.transformed = transformInteractionToListItem({
+      this.transformed = transformInteractionToListItem()({
         ...mockInteraction,
         subject: '',
       })
@@ -95,7 +94,7 @@ describe('#transformInteractionToListItem', () => {
 
   context('when the source is an interaction with a null subject', () => {
     beforeEach(() => {
-      this.transformed = transformInteractionToListItem({
+      this.transformed = transformInteractionToListItem()({
         ...mockInteraction,
         subject: null,
       })
@@ -108,7 +107,7 @@ describe('#transformInteractionToListItem', () => {
 
   context('when the source is a service delivery', () => {
     beforeEach(() => {
-      this.transformed = transformInteractionToListItem({
+      this.transformed = transformInteractionToListItem()({
         ...mockInteraction,
         kind: 'service_delivery',
       })
@@ -153,7 +152,6 @@ describe('#transformInteractionToListItem', () => {
               name: 'Test service',
             },
           },
-          null,
         ],
       })
     })
@@ -161,7 +159,7 @@ describe('#transformInteractionToListItem', () => {
 
   context('when the source is an interaction and has feedback', () => {
     beforeEach(() => {
-      this.transformed = transformInteractionToListItem(mockInteractionWithFeedback)
+      this.transformed = transformInteractionToListItem()(mockInteractionWithFeedback)
     })
     it('should transform data from interaction response to list item', () => {
       expect(this.transformed).to.deep.equal({
@@ -174,6 +172,11 @@ describe('#transformInteractionToListItem', () => {
             label: 'Type',
             type: 'badge',
             value: 'Interaction',
+          },
+          {
+            label: 'Type',
+            type: 'badge',
+            value: 'Policy feedback',
           },
           {
             label: 'Date',
@@ -202,11 +205,6 @@ describe('#transformInteractionToListItem', () => {
               name: 'Test service',
             },
           },
-          {
-            label: 'Type',
-            type: 'badge',
-            value: 'Policy feedback',
-          },
         ],
       })
     })
@@ -214,7 +212,7 @@ describe('#transformInteractionToListItem', () => {
 
   context('when the source is an service delivery and has feedback', () => {
     beforeEach(() => {
-      this.transformed = transformInteractionToListItem({
+      this.transformed = transformInteractionToListItem()({
         ...mockInteractionWithFeedback,
         kind: 'service_delivery',
       })
@@ -232,6 +230,11 @@ describe('#transformInteractionToListItem', () => {
             value: 'Service delivery',
           },
           {
+            label: 'Type',
+            type: 'badge',
+            value: 'Policy feedback',
+          },
+          {
             label: 'Date',
             type: 'date',
             value: '2017-05-31T00:00:00',
@@ -258,10 +261,58 @@ describe('#transformInteractionToListItem', () => {
               name: 'Test service',
             },
           },
+        ],
+      })
+    })
+  })
+
+  context('when the interactions are rendered within company context', () => {
+    beforeEach(() => {
+      this.transformed = transformInteractionToListItem(false)({
+        ...mockInteractionWithFeedback,
+        kind: 'service_delivery',
+      })
+    })
+    it('should transform data from interaction response to list item without company field included', () => {
+      expect(this.transformed).to.deep.equal({
+        was_policy_feedback_provided: true,
+        id: '7265dc3c-e89d-45ee-8106-d1e370c1c73d',
+        type: 'interaction',
+        name: 'Test interactions',
+        meta: [
           {
-            label: 'Type',
+            value: 'Service delivery',
             type: 'badge',
+            label: 'Type',
+          },
+          {
             value: 'Policy feedback',
+            type: 'badge',
+            label: 'Type',
+          },
+          {
+            value: '2017-05-31T00:00:00',
+            type: 'date',
+            label: 'Date',
+          },
+          {
+            value: [
+              'Jackson Whitfield',
+            ],
+            label: 'Contact(s)',
+          },
+          {
+            value: [
+              'Bob Lawson, The test team',
+            ],
+            label: 'Adviser(s)',
+          },
+          {
+            value: {
+              id: '1231231231312',
+              name: 'Test service',
+            },
+            label: 'Service',
           },
         ],
       })


### PR DESCRIPTION
## Motive

https://trello.com/c/7cporIpn/691-do-not-show-company-on-interactions-page

> Company meta item should not show for interactions collection when browsing from a company. When browsing to Interactions from the global navigation Company should show as it's a list of interactions across all companies.

## Solution

This PR is removing the **Company** field and the sorting option from the list of interactions on the company page.

It is done by introducing a new boolean parameter `showCompany` passed to `res.locals.interactions`.

<img width="524" alt="Interactions - Companies - DIT Data Hub 2019-04-08 14-07-23" src="https://user-images.githubusercontent.com/4199239/55726659-3e1f7d00-5a08-11e9-876f-f73c54eaf921.png">

<img width="530" alt="Interactions - Companies - DIT Data Hub 2019-04-08 14-08-55" src="https://user-images.githubusercontent.com/4199239/55726812-95bde880-5a08-11e9-875e-e94ced73b885.png">


