### PR TITLE
Evaluate UK company address for landing address

### DIFF
--- a/src/apps/investments/transformers/landing.js
+++ b/src/apps/investments/transformers/landing.js
@@ -1,26 +1,27 @@
 /* eslint-disable camelcase */
-const { get, isPlainObject } = require('lodash')
+const { get, compact } = require('lodash')
 
 const { formatLongDate } = require('../../../../common/date')
 
-function transformInvestmentLandingForView (data) {
-  if (!isPlainObject(data)) {
-    return
-  }
-
+function transformInvestmentLandingForView ({ uk_company, actual_land_date }) {
   return {
-    uk_company: data.uk_company ? { name: data.uk_company.name, url: `/companies/${data.uk_company.id}` } : null,
-    company_number: get(data, 'uk_company.company_number'),
-    registered_address: data.uk_company ? [
-      data.uk_company.registered_address_1,
-      data.uk_company.registered_address_2,
-      data.uk_company.registered_address_town,
-      data.uk_company.registered_address_country.name,
-      data.uk_company.registered_address_county,
-      data.uk_company.registered_address_postcode,
-    ].filter((address) => address) : null,
-    actual_land_date: data.actual_land_date ? formatLongDate(data.actual_land_date) : null,
+    uk_company: uk_company ? {
+      name: uk_company.name,
+      url: `/companies/${uk_company.id}`,
+    } : null,
+    company_number: get(uk_company, 'company_number'),
+    registered_address: uk_company ? compact([
+      uk_company.address.line_1,
+      uk_company.address.line_2,
+      uk_company.address.town,
+      uk_company.address.county,
+      uk_company.address.postcode,
+      uk_company.address.country.name,
+    ]) : null,
+    actual_land_date: actual_land_date ? formatLongDate(actual_land_date) : null,
   }
 }
 
-module.exports = { transformInvestmentLandingForView }
+module.exports = {
+  transformInvestmentLandingForView,
+}

--- a/test/unit/apps/investment-projects/controllers/evaluation.test.js
+++ b/test/unit/apps/investment-projects/controllers/evaluation.test.js
@@ -151,9 +151,9 @@ describe('Investment evaluation controller', () => {
         'FIRST FLOOR ACHME HOUSE',
         'KIRKDALE ROAD',
         'LEYTONSTONE',
-        'United Kingdom',
         'LONDON',
         'E134 1HP',
+        'United Kingdom',
       ],
       'Actual land date': '21 July 2018',
     }

--- a/test/unit/apps/investment-projects/transformers/landing.test.js
+++ b/test/unit/apps/investment-projects/transformers/landing.test.js
@@ -1,0 +1,76 @@
+const { transformInvestmentLandingForView } = require('~/src/apps/investments/transformers/landing')
+
+describe('Investment landing transformer', () => {
+  describe('#transformInvestmentLandingForView', () => {
+    context('when the investment has a UK company and actual land date', () => {
+      beforeEach(() => {
+        this.transformed = transformInvestmentLandingForView({
+          uk_company: {
+            id: '24f8df2c-a22e-4058-bda9-b5b96853ccd7',
+            name: 'UK company',
+            company_number: '123456',
+            address: {
+              line_1: 'line 1',
+              line_2: 'line 2',
+              town: 'town',
+              county: 'county',
+              postcode: 'postcode',
+              country: {
+                name: 'country',
+              },
+            },
+          },
+          actual_land_date: '2019-04-09',
+        })
+      })
+
+      it('should set the UK company', () => {
+        expect(this.transformed.uk_company).to.deep.equal({
+          name: 'UK company',
+          url: `/companies/24f8df2c-a22e-4058-bda9-b5b96853ccd7`,
+        })
+      })
+
+      it('should set the company number', () => {
+        expect(this.transformed.company_number).to.equal('123456')
+      })
+
+      it('should set the address', () => {
+        expect(this.transformed.registered_address).to.deep.equal([
+          'line 1',
+          'line 2',
+          'town',
+          'county',
+          'postcode',
+          'country',
+        ])
+      })
+
+      it('should set the actual land date', () => {
+        expect(this.transformed.actual_land_date).to.equal('9 April 2019')
+      })
+    })
+
+    context('when the investment UK company and actual land date are not known', () => {
+      beforeEach(() => {
+        this.transformed = transformInvestmentLandingForView({})
+      })
+
+      it('should not set the UK company', () => {
+        expect(this.transformed.uk_company).to.not.exist
+      })
+
+      it('should not set the company number', () => {
+        expect(this.transformed.company_number).to.not.exist
+      })
+
+      it('should not set the address', () => {
+        expect(this.transformed.registered_address).to.not.exist
+      })
+
+      it('should not set the actual land date', () => {
+        expect(this.transformed.actual_land_date).to.not.exist
+      })
+    })
+  })
+})

--- a/test/unit/data/investment/investment-data-uk-company.json
+++ b/test/unit/data/investment/investment-data-uk-company.json
@@ -224,15 +224,18 @@
     "export_to_countries": [],
     "future_interest_countries": [],
     "uk_based": true,
-    "registered_address_1": "FIRST FLOOR ACHME HOUSE",
-    "registered_address_2": "KIRKDALE ROAD",
-    "registered_address_town": "LEYTONSTONE",
-    "registered_address_country": {
-      "id": "80756b9a-5d95-e211-a939-e4115bead28a",
-      "name": "United Kingdom"
+    "address": {
+      "line_1": "FIRST FLOOR ACHME HOUSE",
+      "line_2": "KIRKDALE ROAD",
+      "town": "LEYTONSTONE",
+      "country": {
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+        "name": "United Kingdom"
+      },
+      "county": "LONDON",
+      "postcode": "E134 1HP"
     },
-    "registered_address_county": "LONDON",
-    "registered_address_postcode": "E134 1HP",
+    "registered_address": null,
     "created_on": "2017-05-04T15:26:21.437150",
     "modified_on": "2017-05-04T15:26:21.437150",
     "archived": false,
@@ -241,11 +244,6 @@
     "company_number": "08311441",
     "description": "test\r\n\r\ntest\r\n\r\ntest",
     "website": "http://moo.com",
-    "trading_address_1": null,
-    "trading_address_2": null,
-    "trading_address_town": null,
-    "trading_address_county": null,
-    "trading_address_postcode": null,
     "archived_by": null,
     "business_type": {
       "id": "6f75408b-03e7-e611-bca1-e4115bead28a",
@@ -269,7 +267,6 @@
       "id": "924cd12a-6095-e211-a939-e4115bead28a",
       "name": "Jersey"
     },
-    "trading_address_country": null,
     "headquarter_type": null,
     "one_list_group_tier": {
       "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",


### PR DESCRIPTION
https://trello.com/c/xizxCgLG/1014-use-new-address-object-for-project-landing-section-in-investment

## Change
Removes the dependency on `registered_address_*` fields for presenting the investor company address. Now using the `company.address` fields from the `v4` `company` endpoint.

There should be no visual change on the FE.