### PR TITLE
Evaluate company.address to get company address when creating investment project

### DIFF
--- a/src/apps/investments/views/create/equity-source.njk
+++ b/src/apps/investments/views/create/equity-source.njk
@@ -13,7 +13,7 @@
         <td>{{ company.name }}</td>
       </tr>
       <tr>
-        <td>{{ company.registered_address_country.name }}</td>
+        <td>{{ company.address.country.name }}</td>
       </tr>
       <tr>
         <td>{{ companyInvestments.count|default('No', true) }} investment {{ 'project' | pluralise(companyInvestments.count) }} in the UK</td>

--- a/src/apps/investments/views/create/investment-type.njk
+++ b/src/apps/investments/views/create/investment-type.njk
@@ -12,7 +12,7 @@
       <td>{{ company.name }}</td>
     </tr>
     <tr>
-      <td>{{ company.registered_address_country.name }}</td>
+      <td>{{ company.address.country.name }}</td>
     </tr>
     <tr>
       <td>{{ companyInvestments.count|default('No', true) }} investment {{ 'project' | pluralise(companyInvestments.count) }} in the UK</td>

--- a/src/apps/investments/views/create/project.njk
+++ b/src/apps/investments/views/create/project.njk
@@ -14,7 +14,7 @@
           <td>{{ equityCompany.name }}</td>
         </tr>
         <tr>
-          <td>{{ equityCompany.registered_address_country.name }}</td>
+          <td>{{ equityCompany.address.country.name }}</td>
         </tr>
         <tr>
           <td>{{ equityCompanyInvestments.count|default('No', true) }} investment {{ 'project' | pluralise(equityCompanyInvestments.count) }} in the UK</td>

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -22,8 +22,12 @@ Feature: Create a new Investment project
       | France                           |
       | No investment projects in the UK |
     When I select FDI as the Investment project type
-    And I choose Yes for "Will this company be the source of foreign equity investment?"
-    And I populate the create Investment Project form
+    Then the Client company values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | No investment projects in the UK |
+    When I choose Yes for "Will this company be the source of foreign equity investment?"
     Then I see the success message
     And the investment project local header is displayed
       | key           | value            | formatter              |
@@ -58,7 +62,17 @@ Feature: Create a new Investment project
       | France                           |
       | No investment projects in the UK |
     When I select FDI as the Investment project type
+    Then the Client company values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | 1 investment project in the UK   |
     And I choose No for "Will this company be the source of foreign equity investment?"
+    Then the Client company values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | 1 investment project in the UK   |
     And I search for the foreign source of equity Mars Exports Ltd
     Then I can view the Equity Source in the collection
       | text               | expected                               |
@@ -104,6 +118,13 @@ Feature: Create a new Investment project
       | Tier A - Strategic Account          |
       | Relationship manager: Travis Greene |
     When I select Non-FDI as the Investment project type
+    And the Client company values are displayed
+      | value                               |
+      | Venus Ltd                           |
+      | United Kingdom                      |
+      | 9 investment projects in the UK     |
+      | Tier A - Strategic Account          |
+      | Relationship manager: Travis Greene |
     And I search for the foreign source of equity Lambda plc
     Then I can view the Equity Source in the collection
       | text               | expected                               |
@@ -147,6 +168,11 @@ Feature: Create a new Investment project
       | France                           |
       | No investment projects in the UK |
     When I select Commitment to invest as the Investment project type
+    Then the Client company values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | 2 investment projects in the UK  |
     And I choose Yes for "Will this company be the source of foreign equity investment?"
     And I populate the create Investment Project form
     Then I see the success message

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -28,6 +28,12 @@ Feature: Create a new Investment project
       | France                           |
       | No investment projects in the UK |
     When I choose Yes for "Will this company be the source of foreign equity investment?"
+    Then the Source of foreign equity investment values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | No investment projects in the UK |
+    When I populate the create Investment Project form
     Then I see the success message
     And the investment project local header is displayed
       | key           | value            | formatter              |
@@ -81,6 +87,11 @@ Feature: Create a new Investment project
       | text               | expected                               |
       | Country            | investmentProject.equitySource.country |
     Then I choose the first item in the collection
+    Then the Source of foreign equity investment values are displayed
+      | value                            |
+      | Mars Exports Ltd                 |
+      | United States                    |
+      | No investment projects in the UK |
     When I populate the create Investment Project form
     Then I see the success message
     And the investment project local header is displayed
@@ -133,6 +144,11 @@ Feature: Create a new Investment project
       | text               | expected                               |
       | Country            | investmentProject.equitySource.country |
     Then I choose the first item in the collection
+    Then the Source of foreign equity investment values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | No investment projects in the UK |
     When I populate the create Investment Project form
     Then I see the success message
     And the investment project local header is displayed
@@ -174,6 +190,11 @@ Feature: Create a new Investment project
       | France                           |
       | 2 investment projects in the UK  |
     And I choose Yes for "Will this company be the source of foreign equity investment?"
+    Then the Source of foreign equity investment values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | No investment projects in the UK |
     And I populate the create Investment Project form
     Then I see the success message
     And the investment project local header is displayed

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -16,6 +16,11 @@ Feature: Create a new Investment project
     When I navigate to the `companies.investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
+    And the Client company values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | No investment projects in the UK |
     When I select FDI as the Investment project type
     And I choose Yes for "Will this company be the source of foreign equity investment?"
     And I populate the create Investment Project form
@@ -47,6 +52,11 @@ Feature: Create a new Investment project
     When I navigate to the `companies.investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
+    And the Client company values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | No investment projects in the UK |
     When I select FDI as the Investment project type
     And I choose No for "Will this company be the source of foreign equity investment?"
     And I search for the foreign source of equity Mars Exports Ltd
@@ -86,6 +96,13 @@ Feature: Create a new Investment project
     When I navigate to the `companies.investments` page using `company` `Venus Ltd` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
+    And the Client company values are displayed
+      | value                               |
+      | Venus Ltd                           |
+      | United Kingdom                      |
+      | No investment projects in the UK    |
+      | Tier A - Strategic Account          |
+      | Relationship manager: Travis Greene |
     When I select Non-FDI as the Investment project type
     And I search for the foreign source of equity Lambda plc
     Then I can view the Equity Source in the collection
@@ -124,6 +141,11 @@ Feature: Create a new Investment project
     When I navigate to the `companies.investments` page using `company` `Lambda plc` fixture
     And I click the "Add investment project" link
     Then I am taken to the "Add investment project" page
+    And the Client company values are displayed
+      | value                            |
+      | Lambda plc                       |
+      | France                           |
+      | No investment projects in the UK |
     When I select Commitment to invest as the Investment project type
     And I choose Yes for "Will this company be the source of foreign equity investment?"
     And I populate the create Investment Project form

--- a/test/acceptance/features/step_definitions/details.js
+++ b/test/acceptance/features/step_definitions/details.js
@@ -112,7 +112,7 @@ Then(/^details view data for "(.+)" should contain "(.+)"$/, async (detailsItemN
 
 Then(/^the (.+) values are displayed$/, async function (tableTitle, dataTable) {
   const expectedKeyValues = removeFalsey(dataTable.hashes(), this.state)
-  const tableSelector = Details.getSelectorForKeyValueTable(tableTitle)
+  const tableSelector = Details.getSelectorForValueTable(tableTitle)
 
   await assertTableRowCount(tableSelector, expectedKeyValues)
   await assertTableContent.bind(this)(tableSelector, expectedKeyValues, TABLE_TYPE.VALUE)

--- a/test/acceptance/pages/details.js
+++ b/test/acceptance/pages/details.js
@@ -29,6 +29,12 @@ module.exports = {
       getSelectorForKeyValueTable (title) {
         return getSelectorForTable(title, 'table--key-value')
       },
+      getSelectorForValueTable (title) {
+        return getSelectorForElementWithText(title, {
+          el: '//h2',
+          child: '//following-sibling::table[1]',
+        })
+      },
       getSelectorForDataTable (title) {
         return getSelectorForTable(title, 'data-table')
       },


### PR DESCRIPTION
https://trello.com/c/X9ob0P2O/1015-use-new-address-object-when-creating-investment

## Change
Removes dependency on `registered_address_*` when creating an investment project to display company information.

There should be no visual change on the FE.