### PR TITLE
Adding three new fields into Investor details, Large capital profile

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
@@ -11,10 +11,12 @@ const updateProfile = async (req, res, next) => {
     const {
       investorType,
       globalAssetsUnderManagement,
+      investableCapital,
     } = req.body
 
     body.investor_type = investorType
     body.global_assets_under_management = globalAssetsUnderManagement
+    body.investable_capital = investableCapital
   }
 
   try {

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
@@ -8,8 +8,13 @@ const updateProfile = async (req, res, next) => {
 
   const body = {}
   if (editing === INVESTOR_DETAILS) {
-    const { investorType } = req.body
+    const {
+      investorType,
+      globalAssetsUnderManagement,
+    } = req.body
+
     body.investor_type = investorType
+    body.global_assets_under_management = globalAssetsUnderManagement
   }
 
   try {

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
@@ -12,11 +12,13 @@ const updateProfile = async (req, res, next) => {
       investorType,
       globalAssetsUnderManagement,
       investableCapital,
+      investorDescription,
     } = req.body
 
     body.investor_type = investorType
     body.global_assets_under_management = globalAssetsUnderManagement
     body.investable_capital = investableCapital
+    body.investor_description = investorDescription
   }
 
   try {

--- a/src/apps/companies/apps/investments/large-capital-profile/styles.scss
+++ b/src/apps/companies/apps/investments/large-capital-profile/styles.scss
@@ -25,6 +25,12 @@ nav.govuk-tabs {
   details:last-child {
     border-bottom: 2px solid lightgray;
   }
+
+  form.investor-details-edit {
+    label {
+      font-weight: bold;
+    }
+  }
 }
 
 @include govuk-media-query($from: tablet) {

--- a/src/apps/companies/apps/investments/large-capital-profile/styles.scss
+++ b/src/apps/companies/apps/investments/large-capital-profile/styles.scss
@@ -30,6 +30,11 @@ nav.govuk-tabs {
     label {
       font-weight: bold;
     }
+    .investor-description {
+      span {
+        display: block;
+      }
+    }
   }
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -11,6 +11,9 @@ const transformProfile = (profile, editing) => {
         text: get(profile, 'investor_type.name'),
         value: get(profile, 'investor_type.id'),
       },
+      globalAssetsUnderManagement: {
+        value: get(profile, 'global_assets_under_management'),
+      },
     },
     investorRequirements: {
       incompleteFields: get(profile, 'incomplete_requirements_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -14,6 +14,9 @@ const transformProfile = (profile, editing) => {
       globalAssetsUnderManagement: {
         value: get(profile, 'global_assets_under_management'),
       },
+      investableCapital: {
+        value: get(profile, 'investable_capital'),
+      },
     },
     investorRequirements: {
       incompleteFields: get(profile, 'incomplete_requirements_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -17,6 +17,9 @@ const transformProfile = (profile, editing) => {
       investableCapital: {
         value: get(profile, 'investable_capital'),
       },
+      investorDescription: {
+        value: get(profile, 'investor_description'),
+      },
     },
     investorRequirements: {
       incompleteFields: get(profile, 'incomplete_requirements_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
@@ -43,4 +43,21 @@
     })
   }}
 
+  {{
+    govukInput({
+      type: 'number',
+      name: 'investableCapital',
+      label: {
+        text: 'Investable capital'
+      },
+      hint: {
+        text: 'Enter value in US dollars'
+      },
+      attributes: {
+        'data-auto-id': 'investableCapital'
+      },
+      value: profile.investorDetails.investableCapital.value
+    })
+  }}
+
 {% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
@@ -60,4 +60,21 @@
     })
   }}
 
+  {{
+    govukTextarea({
+      name: 'investorDescription',
+      label: {
+        text: 'Investor description'
+      },
+      hint: {
+        html: '<span>Enter any additional relevant information.</span>For instance when founded, ownership, purpose and strategy.',
+        classes: 'investor-description'
+      },
+      attributes: {
+        'data-auto-id': 'investorDescription'
+      },
+      value: profile.investorDetails.investorDescription.value
+    })
+  }}
+
 {% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
@@ -26,4 +26,21 @@
     })
   }}
 
+  {{
+    govukInput({
+      type: 'number',
+      name: 'globalAssetsUnderManagement',
+      label: {
+        text: 'Global assets under management'
+      },
+      hint: {
+        text: 'Enter value in US dollars'
+      },
+      attributes: {
+        'data-auto-id': 'globalAssetsUnderManagement'
+      },
+      value: profile.investorDetails.globalAssetsUnderManagement.value
+    })
+  }}
+
 {% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
@@ -1,7 +1,7 @@
 <ul class="task-list">
   {{ taskListItem({ name: 'Investor type', value: profile.investorDetails.investorType.text }) }}
   {{ taskListItem({ name: 'Global assets under management', value: profile.investorDetails.globalAssetsUnderManagement.value }) }}
-  {{ taskListItem({ name: 'Investable capital' }) }}
+  {{ taskListItem({ name: 'Investable capital', value: profile.investorDetails.investableCapital.value }) }}
   {{ taskListItem({ name: 'Investor description' }) }}
   {{ taskListItem({
        id: 'investor-checks',

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
@@ -1,6 +1,6 @@
 <ul class="task-list">
   {{ taskListItem({ name: 'Investor type', value: profile.investorDetails.investorType.text }) }}
-  {{ taskListItem({ name: 'Global assets under management' }) }}
+  {{ taskListItem({ name: 'Global assets under management', value: profile.investorDetails.globalAssetsUnderManagement.value }) }}
   {{ taskListItem({ name: 'Investable capital' }) }}
   {{ taskListItem({ name: 'Investor description' }) }}
   {{ taskListItem({

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
@@ -2,7 +2,7 @@
   {{ taskListItem({ name: 'Investor type', value: profile.investorDetails.investorType.text }) }}
   {{ taskListItem({ name: 'Global assets under management', value: profile.investorDetails.globalAssetsUnderManagement.value }) }}
   {{ taskListItem({ name: 'Investable capital', value: profile.investorDetails.investableCapital.value }) }}
-  {{ taskListItem({ name: 'Investor description' }) }}
+  {{ taskListItem({ name: 'Investor description', value: profile.investorDetails.investorDescription.value }) }}
   {{ taskListItem({
        id: 'investor-checks',
        name: 'Has this investor cleared the required checks within the last 12 months?'

--- a/src/apps/companies/apps/investments/large-capital-profile/views/profile.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/profile.njk
@@ -1,6 +1,8 @@
 {% from "companies/apps/investments/macros/navigation.njk" import subnavigation %}
 {% from "companies/apps/investments/macros/details/details.njk" import details %}
 {% from "companies/apps/investments/macros/tasklist/tasklist.njk" import taskListItem %}
+{% from "input/macro.njk" import govukInput %}
+
 {% extends "../../../../views/template.njk" %}
 
 {% block body_main_content %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/profile.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/profile.njk
@@ -1,6 +1,7 @@
 {% from "companies/apps/investments/macros/navigation.njk" import subnavigation %}
 {% from "companies/apps/investments/macros/details/details.njk" import details %}
 {% from "companies/apps/investments/macros/tasklist/tasklist.njk" import taskListItem %}
+{% from "textarea/macro.njk" import govukTextarea %}
 {% from "input/macro.njk" import govukInput %}
 
 {% extends "../../../../views/template.njk" %}

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -13,6 +13,7 @@ module.exports = {
     save: '[data-auto-id=investorDetailsSave]',
     investorType: '[data-auto-id=investorType]',
     globalAssetsUnderManagement: '[data-auto-id=globalAssetsUnderManagement]',
+    investableCapital: '[data-auto-id=investableCapital]',
     taskList: {
       investorType: {
         name: '[data-auto-id="investorDetails"] ul > li:nth-child(1) .task-list__item-name',

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -12,6 +12,7 @@ module.exports = {
     edit: '[data-auto-id=investorDetailsEdit]',
     save: '[data-auto-id=investorDetailsSave]',
     investorType: '[data-auto-id=investorType]',
+    globalAssetsUnderManagement: '[data-auto-id=globalAssetsUnderManagement]',
     taskList: {
       investorType: {
         name: '[data-auto-id="investorDetails"] ul > li:nth-child(1) .task-list__item-name',

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -14,6 +14,7 @@ module.exports = {
     investorType: '[data-auto-id=investorType]',
     globalAssetsUnderManagement: '[data-auto-id=globalAssetsUnderManagement]',
     investableCapital: '[data-auto-id=investableCapital]',
+    investorDescription: '[data-auto-id=investorDescription]',
     taskList: {
       investorType: {
         name: '[data-auto-id="investorDetails"] ul > li:nth-child(1) .task-list__item-name',

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -195,6 +195,7 @@ describe('Company Investments and Large capital profile', () => {
         .get(selectors.investorDetails.investorType).select('Angel syndicate')
         .get(selectors.investorDetails.globalAssetsUnderManagement).type(1000)
         .get(selectors.investorDetails.investableCapital).type(2000)
+        .get(selectors.investorDetails.investorDescription).type('Lorem ipsum dolor sit amet.')
         .get(selectors.investorDetails.save).click()
         .url().should('contain', largeCapitalProfile)
     })

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -194,6 +194,7 @@ describe('Company Investments and Large capital profile', () => {
         .url().should('contain', `?editing=investor-details`)
         .get(selectors.investorDetails.investorType).select('Angel syndicate')
         .get(selectors.investorDetails.globalAssetsUnderManagement).type(1000)
+        .get(selectors.investorDetails.investableCapital).type(2000)
         .get(selectors.investorDetails.save).click()
         .url().should('contain', largeCapitalProfile)
     })

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -2,10 +2,11 @@ const { localHeader, companyInvestment: selectors } = require('../../../selector
 const fixtures = require('../../../fixtures/index.js')
 const baseUrl = Cypress.config().baseUrl
 const { oneListCorp } = fixtures.company
+const largeCapitalProfile = `/companies/${oneListCorp.id}/investments/large-capital-profile`
 
 describe('Company Investments and Large capital profile', () => {
   context('when viewing the company header', () => {
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     it('should display the "One List Corp" heading', () => {
       cy.get(localHeader().heading).should('have.text', 'One List Corp')
@@ -13,7 +14,7 @@ describe('Company Investments and Large capital profile', () => {
   })
 
   context('when viewing the 3 tabs', () => {
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     it('should display an "Investments projects" tab with the correct URL', () => {
       cy.get(selectors.tabs.investmentProjects).find('a')
@@ -35,7 +36,7 @@ describe('Company Investments and Large capital profile', () => {
   })
 
   context('when the Large capital profile tab is selected', () => {
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     it('should not have an "active" class on the "Investment projects" tab', () => {
       cy.get(selectors.tabs.investmentProjects).should('not.have.class', 'active')
@@ -51,7 +52,7 @@ describe('Company Investments and Large capital profile', () => {
   })
 
   context('when viewing the tabbed area content', () => {
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     it('should display the "Large capital investor profile" subheading', () => {
       cy.get(selectors.subHeading).should('have.text', 'Large capital investor profile')
@@ -59,7 +60,7 @@ describe('Company Investments and Large capital profile', () => {
   })
 
   context('when clicking on a profile summary', () => {
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     it('should expand the "Investor details" summary and have an enabled edit button', () => {
       cy.get(selectors.investorDetails.summary).click()
@@ -108,7 +109,7 @@ describe('Company Investments and Large capital profile', () => {
   })
 
   context('when viewing the incomplete fields on each summary', () => {
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     it('should display "5 fields incomplete"', () => {
       cy.get(selectors.investorDetails.incompleteFields).should('contain', '5 fields incomplete')
@@ -133,7 +134,7 @@ describe('Company Investments and Large capital profile', () => {
       'Has this investor cleared the required checks within the last 12 months?',
     ]
 
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     Object.keys(taskList).forEach((key, index) => {
       it(`should display both ${labels[index]} and INCOMPLETE`, () => {
@@ -157,7 +158,7 @@ describe('Company Investments and Large capital profile', () => {
       'Desired deal role',
     ]
 
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     Object.keys(taskList).forEach((key, index) => {
       it(`should display both ${labels[index]} and INCOMPLETE`, () => {
@@ -175,7 +176,7 @@ describe('Company Investments and Large capital profile', () => {
       'Notes on investor\'s location preferences',
     ]
 
-    before(() => cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`))
+    before(() => cy.visit(largeCapitalProfile))
 
     Object.keys(taskList).forEach((key, index) => {
       it(`should display both ${labels[index]} and INCOMPLETE`, () => {
@@ -185,22 +186,22 @@ describe('Company Investments and Large capital profile', () => {
     })
   })
 
-  context('when saving an "Investor type" within "Investor details"', () => {
-    it('should select the "Angel syndicate" and save the change', () => {
-      const largeCapitalProfile = `${baseUrl}/companies/${oneListCorp.id}/investments/large-capital-profile`
-      cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`)
+  context('when completing the entire "Investor details" form', () => {
+    it('should fill in all fields and save', () => {
+      cy.visit(largeCapitalProfile)
         .get(selectors.investorDetails.summary).click()
         .get(selectors.investorDetails.edit).click()
-        .url().should('eq', `${largeCapitalProfile}?editing=investor-details`)
+        .url().should('contain', `?editing=investor-details`)
         .get(selectors.investorDetails.investorType).select('Angel syndicate')
+        .get(selectors.investorDetails.globalAssetsUnderManagement).type(1000)
         .get(selectors.investorDetails.save).click()
-        .url().should('eq', largeCapitalProfile)
+        .url().should('contain', largeCapitalProfile)
     })
   })
 })
 
 const visitLargeCapitalProfileAndExpandAllSections = () => {
-  cy.visit(`/companies/${oneListCorp.id}/investments/large-capital-profile`)
+  cy.visit(largeCapitalProfile)
     .get(selectors.investorDetails.summary).click()
     .get(selectors.investorRequirements.summary).click()
     .get(selectors.location.summary).click()

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
@@ -75,6 +75,9 @@ describe('Company Investments - large capital profile', () => {
           globalAssetsUnderManagement: {
             value: null,
           },
+          investableCapital: {
+            value: null,
+          },
         },
         investorRequirements: {
           incompleteFields: 9,
@@ -120,6 +123,9 @@ describe('Company Investments - large capital profile', () => {
           globalAssetsUnderManagement: {
             value: null,
           },
+          investableCapital: {
+            value: null,
+          },
         },
         investorRequirements: {
           incompleteFields: 9,
@@ -138,6 +144,7 @@ describe('Company Investments - large capital profile', () => {
         pullAll(profile.incomplete_details_fields, [
           'investor_type',
           'global_assets_under_management',
+          'investable_capital',
         ])
 
         profile.investor_type = {
@@ -146,6 +153,7 @@ describe('Company Investments - large capital profile', () => {
         }
 
         profile.global_assets_under_management = 1000
+        profile.investable_capital = 2000
 
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -166,13 +174,16 @@ describe('Company Investments - large capital profile', () => {
         editing: undefined,
         id: 'a9e7afa4-1079-422a-b24e-a77f3ba80375',
         investorDetails: {
-          incompleteFields: 3,
+          incompleteFields: 2,
           investorType: {
             text: 'Asset manager',
             value: '80168d31-fa91-494e-9ad5-b9255e01b5da',
           },
           globalAssetsUnderManagement: {
             value: 1000,
+          },
+          investableCapital: {
+            value: 2000,
           },
         },
         investorRequirements: {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
@@ -1,11 +1,11 @@
-const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const investorTypeTransformed = require('~/test/unit/data/companies/investments/metadata/investor-type-transformed.json')
 const noCompanyProfile = require('~/test/unit/data/companies/investments/large-capital-profile-empty.json')
 const investorType = require('~/test/unit/data/companies/investments/metadata/investor-type.json')
-const investorTypeTransformed = require('~/test/unit/data/companies/investments/metadata/investor-type-transformed.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile.json')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const { cloneDeep, pullAll } = require('lodash')
 const config = require('~/config')
-const { cloneDeep } = require('lodash')
 
 const controller = require('~/src/apps/companies/apps/investments/large-capital-profile/controllers')
 
@@ -72,6 +72,9 @@ describe('Company Investments - large capital profile', () => {
             text: undefined,
             value: undefined,
           },
+          globalAssetsUnderManagement: {
+            value: null,
+          },
         },
         investorRequirements: {
           incompleteFields: 9,
@@ -114,6 +117,9 @@ describe('Company Investments - large capital profile', () => {
             value: undefined,
             items: investorTypeTransformed,
           },
+          globalAssetsUnderManagement: {
+            value: null,
+          },
         },
         investorRequirements: {
           incompleteFields: 9,
@@ -124,19 +130,22 @@ describe('Company Investments - large capital profile', () => {
       })
     })
 
-    context('when the user has previously saved the "Investor type" within "Investor details"', () => {
+    context('when the user has previously saved all fields within "Investor details"', () => {
       beforeEach(async () => {
         const clonedCompanyProfile = cloneDeep(companyProfile)
         const profile = clonedCompanyProfile.results[0]
 
-        // Remove investor-type from the incomplete details fields array.
-        profile.incomplete_details_fields.shift()
+        pullAll(profile.incomplete_details_fields, [
+          'investor_type',
+          'global_assets_under_management',
+        ])
 
-        // User has previously saved 'Asset manager'.
         profile.investor_type = {
           id: '80168d31-fa91-494e-9ad5-b9255e01b5da',
           name: 'Asset manager',
         }
+
+        profile.global_assets_under_management = 1000
 
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -157,10 +166,13 @@ describe('Company Investments - large capital profile', () => {
         editing: undefined,
         id: 'a9e7afa4-1079-422a-b24e-a77f3ba80375',
         investorDetails: {
-          incompleteFields: 4,
+          incompleteFields: 3,
           investorType: {
             text: 'Asset manager',
             value: '80168d31-fa91-494e-9ad5-b9255e01b5da',
+          },
+          globalAssetsUnderManagement: {
+            value: 1000,
           },
         },
         investorRequirements: {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
@@ -78,6 +78,9 @@ describe('Company Investments - large capital profile', () => {
           investableCapital: {
             value: null,
           },
+          investorDescription: {
+            value: '',
+          },
         },
         investorRequirements: {
           incompleteFields: 9,
@@ -126,6 +129,9 @@ describe('Company Investments - large capital profile', () => {
           investableCapital: {
             value: null,
           },
+          investorDescription: {
+            value: '',
+          },
         },
         investorRequirements: {
           incompleteFields: 9,
@@ -145,6 +151,7 @@ describe('Company Investments - large capital profile', () => {
           'investor_type',
           'global_assets_under_management',
           'investable_capital',
+          'investor_description',
         ])
 
         profile.investor_type = {
@@ -154,6 +161,7 @@ describe('Company Investments - large capital profile', () => {
 
         profile.global_assets_under_management = 1000
         profile.investable_capital = 2000
+        profile.investor_description = 'Lorem ipsum dolor sit amet.'
 
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -174,7 +182,7 @@ describe('Company Investments - large capital profile', () => {
         editing: undefined,
         id: 'a9e7afa4-1079-422a-b24e-a77f3ba80375',
         investorDetails: {
-          incompleteFields: 2,
+          incompleteFields: 1,
           investorType: {
             text: 'Asset manager',
             value: '80168d31-fa91-494e-9ad5-b9255e01b5da',
@@ -184,6 +192,9 @@ describe('Company Investments - large capital profile', () => {
           },
           investableCapital: {
             value: 2000,
+          },
+          investorDescription: {
+            value: 'Lorem ipsum dolor sit amet.',
           },
         },
         investorRequirements: {


### PR DESCRIPTION
The three new fields are:

1. Global assets under management
2. Investable capital
3. Investor description

https://uktrade.atlassian.net/browse/IPBETA-270

### Three new fields

![three-new-fields](https://user-images.githubusercontent.com/964268/55855505-a03ec600-5b5f-11e9-8584-a757b8ce2ebe.png)

### Three new labels

![three-new-labels](https://user-images.githubusercontent.com/964268/55855535-b056a580-5b5f-11e9-8a1f-e3d7c16e074a.png)

