### PR TITLE
Introduce breadcrumb tests across specs

### DIFF
--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -21,7 +21,12 @@
     <header class="c-local-header {{ modifier }}" aria-label="local header" data-auto-id="localHeader">
       <div class="govuk-width-container">
         {% if breadcrumbs|length > 1 %}
-          {{ govukBreadcrumbs({ items: breadcrumbs }) }}
+          {{ govukBreadcrumbs({
+            items: breadcrumbs,
+            attributes: {
+              'data-auto-id': 'breadcrumbs'
+            }
+          }) }}
         {% endif %}
 
         {% if messages|length %}

--- a/test/functional/cypress/selectors/breadcrumbs.js
+++ b/test/functional/cypress/selectors/breadcrumbs.js
@@ -1,0 +1,6 @@
+module.exports = {
+  item: {
+    byNumber: (number) => `.govuk-breadcrumbs__list li:nth-child(${number}) .govuk-breadcrumbs__link`,
+    last: () => '.govuk-breadcrumbs__list li:last-child',
+  },
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -2,6 +2,8 @@ exports.companyBusinessDetails = require('./company/business-details')
 exports.companyInteraction = require('./company/interaction')
 exports.companyInvestment = require('./company/investment')
 exports.companySubsidiaries = require('./company/subsidiaries')
+
+exports.breadcrumbs = require('./breadcrumbs')
 exports.detailsContainer = require('./details-container')
 exports.document = require('./document')
 exports.entityCollection = require('./entity-collection')

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -9,6 +9,16 @@ describe('Companies business details', () => {
       cy.visit(`/companies/${fixtures.company.oneListCorp.id}/business-details`)
     })
 
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.oneListCorp.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.oneListCorp.id}`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Business details')
+    })
+
     it('should display the "Business details" heading', () => {
       cy.get(selectors.localHeader().heading).should('have.text', 'Business details')
     })
@@ -123,6 +133,16 @@ describe('Companies business details', () => {
   context('when viewing business details for a Data Hub company in the UK', () => {
     before(() => {
       cy.visit(`/companies/${fixtures.company.venusLtd.id}/business-details`)
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.venusLtd.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.venusLtd.id}`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Business details')
     })
 
     it('should display the "Business details" heading', () => {
@@ -257,6 +277,16 @@ describe('Companies business details', () => {
       cy.visit(`/companies/${fixtures.company.dnbCorp.id}/business-details`)
     })
 
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.dnbCorp.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.dnbCorp.id}`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Business details')
+    })
+
     it('should display the "Business details" heading', () => {
       cy.get(selectors.localHeader().heading).should('have.text', 'Business details')
     })
@@ -358,6 +388,16 @@ describe('Companies business details', () => {
   context('when viewing business details for an archived Data Hub company', () => {
     before(() => {
       cy.visit(`/companies/${fixtures.company.archivedLtd.id}/business-details`)
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.archivedLtd.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.archivedLtd.id}`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Business details')
     })
 
     it('should display the "Business details" heading', () => {
@@ -474,6 +514,16 @@ describe('Companies business details', () => {
   context('when viewing business details for a company with minimal data', () => {
     before(() => {
       cy.visit(`/companies/${fixtures.company.minimallyMinimalLtd.id}/business-details`)
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.minimallyMinimalLtd.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.minimallyMinimalLtd.id}`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Business details')
     })
 
     it('should display the "Business details" heading', () => {

--- a/test/functional/cypress/specs/companies/collection-spec.js
+++ b/test/functional/cypress/specs/companies/collection-spec.js
@@ -5,6 +5,12 @@ describe('Company Collections', () => {
     cy.visit('/companies?sortby=collectionTest')
   })
 
+  it('should render breadcrumbs', () => {
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+    cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Companies')
+  })
+
   it('should display a list of companies', () => {
     cy.get(selectors.entityCollection.entities).children().should('have.length', 9)
   })

--- a/test/functional/cypress/specs/companies/interactions-spec.js
+++ b/test/functional/cypress/specs/companies/interactions-spec.js
@@ -7,6 +7,14 @@ describe('Companies interactions', () => {
     expectedAddress,
     expectedCompanyId,
   }) => {
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Interactions')
+    })
+
     it('should display the heading', () => {
       cy.get(selectors.localHeader().heading).should('have.text', expectedHeading)
     })

--- a/test/functional/cypress/specs/companies/matching/select-spec.js
+++ b/test/functional/cypress/specs/companies/matching/select-spec.js
@@ -7,6 +7,16 @@ describe('Companies matching select', () => {
       cy.visit(`/companies/${fixtures.company.oneListCorp.id}/matching/select`)
     })
 
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.oneListCorp.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.oneListCorp.id}`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Select the match')
+    })
+
     it('should display the heading', () => {
       cy.get(selectors.localHeader().heading).should('have.text', `Select the match for ${fixtures.company.oneListCorp.name}`)
     })

--- a/test/functional/cypress/specs/companies/subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-spec.js
@@ -7,6 +7,18 @@ describe('Companies business details', () => {
       cy.visit(`/companies/${fixtures.company.oneListCorp.id}/subsidiaries`)
     })
 
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.oneListCorp.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.oneListCorp.id}`)
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.text', 'Business details')
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.attr', 'href', `/companies/${fixtures.company.oneListCorp.id}/business-details`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Subsidiaries')
+    })
+
     it('should display the "Why can I not link a subsidiary?" D&B details summary', () => {
       cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('be.visible')
     })
@@ -21,6 +33,18 @@ describe('Companies business details', () => {
       cy.visit(`/companies/${fixtures.company.venusLtd.id}/subsidiaries`)
     })
 
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.venusLtd.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.venusLtd.id}`)
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.text', 'Business details')
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.attr', 'href', `/companies/${fixtures.company.venusLtd.id}/business-details`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Subsidiaries')
+    })
+
     it('should not display the "Why can I not link a subsidiary?" D&B details summary', () => {
       cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('not.exist')
     })
@@ -33,6 +57,18 @@ describe('Companies business details', () => {
   context('when viewing subsidiaries for an archived company', () => {
     before(() => {
       cy.visit(`/companies/${fixtures.company.archivedLtd.id}/subsidiaries`)
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.archivedLtd.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.archivedLtd.id}`)
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.text', 'Business details')
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.attr', 'href', `/companies/${fixtures.company.archivedLtd.id}/business-details`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Subsidiaries')
     })
 
     it('should not display the "Why can I not link a subsidiary?" D&B details summary', () => {

--- a/test/functional/cypress/specs/contacts/collection-spec.js
+++ b/test/functional/cypress/specs/contacts/collection-spec.js
@@ -5,6 +5,12 @@ describe('Contacts Collections', () => {
     cy.visit('/contacts/?sortby=dummy')
   })
 
+  it('should render breadcrumbs', () => {
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+    cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Contacts')
+  })
+
   it('should display a list of contacts', () => {
     cy.get(selectors.entityCollection.entities).children().should('have.length', 100)
   })

--- a/test/functional/cypress/specs/contacts/documents-spec.js
+++ b/test/functional/cypress/specs/contacts/documents-spec.js
@@ -1,18 +1,46 @@
 const selectors = require('../../selectors')
 
 describe('Contact Documents', () => {
-  it('should display appropriate message when there is a link to a document', () => {
-    cy.visit('/contacts/default-contact-with-document/documents')
+  context('when there is a document link', () => {
+    before(() => {
+      cy.visit('/contacts/default-contact-with-document/documents')
+    })
 
-    cy.get(selectors.document.documentHeader).should('contain', 'Document')
-    cy.get(selectors.document.documentContent).should('contain', 'View files and documents')
-    cy.get(selectors.document.documentContent).should('contain', '(will open another website)')
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Contacts')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/contacts')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', 'Joseph Woof')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/contacts/5e75d636-1d24-416a-aaf0-3fb220d594ce`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Documents')
+    })
+
+    it('should display appropriate message when there is a link to a document', () => {
+      cy.get(selectors.document.documentHeader).should('contain', 'Document')
+      cy.get(selectors.document.documentContent).should('contain', 'View files and documents')
+      cy.get(selectors.document.documentContent).should('contain', '(will open another website)')
+    })
   })
 
-  it('should display appropriate message when there is not a link to a document', () => {
-    cy.visit('/contacts/5555d636-1d24-416a-aaf0-3fb220d59aaa/documents')
-    cy.get(selectors.document.documentHeader).should('contain', 'Document')
-    cy.get(selectors.document.documentContent).should(
-      'contain', 'There are no files or documents')
+  context('when there is not a document link', () => {
+    before(() => {
+      cy.visit('/contacts/5555d636-1d24-416a-aaf0-3fb220d59aaa/documents')
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Contacts')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/contacts')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', 'Joseph Woof')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/contacts/5555d636-1d24-416a-aaf0-3fb220d59aaa`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Documents')
+    })
+
+    it('should display appropriate message when there is not a link to a document', () => {
+      cy.get(selectors.document.documentHeader).should('contain', 'Document')
+      cy.get(selectors.document.documentContent).should('contain', 'There are no files or documents')
+    })
   })
 })

--- a/test/functional/cypress/specs/interaction/add-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/add-interaction-spec.js
@@ -11,6 +11,14 @@ describe('Add Interaction', () => {
         cy.visit(`/companies/${fixtures.default.id}/interactions/create/interaction`)
       })
 
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add interaction')
+      })
+
       it('should add the interaction', () => {
         const subject = utils.randomString()
 
@@ -27,6 +35,14 @@ describe('Add Interaction', () => {
         cy.visit(`/contacts/${fixtures.default.id}/interactions/create/interaction`)
       })
 
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Contacts')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/contacts')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add interaction')
+      })
+
       it('should add the interaction', () => {
         const subject = utils.randomString()
 
@@ -41,6 +57,16 @@ describe('Add Interaction', () => {
     context('when in the context of an investment project', () => {
       beforeEach(() => {
         cy.visit(`/investments/projects/${fixtures.default.id}/interactions/create/interaction`)
+      })
+
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Investments')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/investments')
+        cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', 'New hotel (commitment to invest)')
+        cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', '/investments/projects/fb5b5006-56af-40e0-8615-7aba53e0e4bf')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add interaction')
       })
 
       it('should add the interaction', () => {
@@ -61,6 +87,14 @@ describe('Add Interaction', () => {
         cy.visit(`/companies/${fixtures.default.id}/interactions/create/service-delivery`)
       })
 
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add service delivery')
+      })
+
       it('should add the service delivery', () => {
         const subject = utils.randomString()
 
@@ -75,6 +109,14 @@ describe('Add Interaction', () => {
     context('when in the context of a contact', () => {
       beforeEach(() => {
         cy.visit(`/contacts/${fixtures.default.id}/interactions/create/service-delivery`)
+      })
+
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Contacts')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/contacts')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add service delivery')
       })
 
       it('should add the service delivery', () => {
@@ -93,6 +135,16 @@ describe('Add Interaction', () => {
         cy.visit(`/investments/projects/${fixtures.default.id}/interactions/create/service-delivery`)
       })
 
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Investments')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/investments')
+        cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', 'New hotel (commitment to invest)')
+        cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', '/investments/projects/fb5b5006-56af-40e0-8615-7aba53e0e4bf')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add service delivery')
+      })
+
       it('should add the service delivery', () => {
         const subject = utils.randomString()
 
@@ -107,6 +159,14 @@ describe('Add Interaction', () => {
     context('when TAP service fields are empty', () => {
       beforeEach(() => {
         cy.visit(`/companies/${fixtures.default.id}/interactions/create/service-delivery`)
+      })
+
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add service delivery')
       })
 
       it('should add the service delivery', () => {
@@ -128,6 +188,14 @@ describe('Add Interaction', () => {
     context('when TAP service fields are populated', () => {
       beforeEach(() => {
         cy.visit(`/companies/${fixtures.default.id}/interactions/create/service-delivery`)
+      })
+
+      it('should render breadcrumbs', () => {
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+        cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+        cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+        cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add service delivery')
       })
 
       it('should add the service delivery', () => {

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -3,9 +3,19 @@ const selectors = require('../../selectors')
 
 describe('Interaction details', () => {
   describe('Service Delivery', () => {
-    it('should display appropriate message when there is a link to a document', () => {
+    before(() => {
       cy.visit(`/interactions/${fixtures.interaction.interactionWithLink.id}`)
+    })
 
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Interactions')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/interactions')
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Service delivery')
+    })
+
+    it('should display appropriate message when there is a link to a document', () => {
       cy.get(selectors.nav.localNav).should('not.be.visible')
       cy.get(selectors.interactionDetails.serviceDelivery.documents).should(
         'contain', 'View files and documents (will open another website)')
@@ -15,6 +25,14 @@ describe('Interaction details', () => {
   describe('Interaction', () => {
     before(() => {
       cy.visit(`/interactions/${fixtures.interaction.interactionWithNoLink.id}`)
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Interactions')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/interactions')
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Interaction')
     })
 
     it('should display appropriate message when there is not a link to a document', () => {

--- a/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
+++ b/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
@@ -8,6 +8,14 @@ describe('Service delivery form', () => {
     cy.visit(`/companies/${fixtures.default.id}/interactions/create/service-delivery`)
   })
 
+  it('should render breadcrumbs', () => {
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+    cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+    cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+    cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add service delivery')
+  })
+
   it('should display all service delivery fields', () => {
     cy.get(selectors.interactionForm.contact).should('be.visible')
     cy.get(selectors.interactionForm.ditAdviserTypeahead.fieldset).should('to.exist')

--- a/test/functional/cypress/specs/investment-project/collection-spec.js
+++ b/test/functional/cypress/specs/investment-project/collection-spec.js
@@ -5,6 +5,12 @@ describe('Investment Project Collections', () => {
     cy.visit('/investments/projects')
   })
 
+  it('should render breadcrumbs', () => {
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+    cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Investments')
+  })
+
   it('should display a list of investments', () => {
     cy.get(selectors.entityCollection.entities).children().should('have.length', 10)
   })

--- a/test/functional/cypress/specs/investment-project/investment-project-document-spec.js
+++ b/test/functional/cypress/specs/investment-project/investment-project-document-spec.js
@@ -2,18 +2,46 @@ const fixtures = require('../../fixtures/index.js')
 const selectors = require('../../selectors')
 
 describe('Investment Project Documents', () => {
-  it('should display appropriate message when there is a link to a document', () => {
-    cy.visit(`/investments/projects/${fixtures.investment.investmentWithLink.id}/documents`)
+  context('when there is a document link', () => {
+    before(() => {
+      cy.visit(`/investments/projects/${fixtures.investment.investmentWithLink.id}/documents`)
+    })
 
-    cy.get(selectors.document.documentHeader).should('contain', 'Document')
-    cy.get(selectors.document.documentContent).should('contain', 'View files and documents')
-    cy.get(selectors.document.documentContent).should('contain', '(will open another website)')
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Investments')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/investments')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', 'New hotel (commitment to invest)')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/investments/projects/fb5b5006-56af-40e0-8615-7aba53e0e4bf`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Documents')
+    })
+
+    it('should display appropriate message when there is a link to a document', () => {
+      cy.get(selectors.document.documentHeader).should('contain', 'Document')
+      cy.get(selectors.document.documentContent).should('contain', 'View files and documents')
+      cy.get(selectors.document.documentContent).should('contain', '(will open another website)')
+    })
   })
 
-  it('should display appropriate message when there is not a link to a document', () => {
-    cy.visit(`/investments/projects/${fixtures.investment.investmentWithNoLink.id}/documents`)
-    cy.get(selectors.document.documentHeader).should('contain', 'Document')
-    cy.get(selectors.document.documentContent).should(
-      'contain', 'There are no files or documents')
+  context('when there is not a document link', () => {
+    before(() => {
+      cy.visit(`/investments/projects/${fixtures.investment.investmentWithNoLink.id}/documents`)
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Investments')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/investments')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', 'Green tea plantation')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/investments/projects/addca042-5a00-412c-9d7c-acc04552756c`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Documents')
+    })
+
+    it('should display appropriate message when there is not a link to a document', () => {
+      cy.get(selectors.document.documentHeader).should('contain', 'Document')
+      cy.get(selectors.document.documentContent).should('contain', 'There are no files or documents')
+    })
   })
 })


### PR DESCRIPTION
## Change
Introduces functional tests around breadcrumbs. These are a critical component for user navigation. The breadcrumb tests have been applied to all functional tests except for the company investment tests.

This change should not affect the appearance of the FE.