### PR TITLE
Use new address objects when transforming address for edit company display

### DIFF
--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -1,9 +1,9 @@
 const companyDetailsLabels = {
   business_type: 'Business type',
   name: 'Name',
-  registered_address: 'Primary address',
+  registered_address: 'Registered address',
   trading_names: 'Trading names',
-  trading_address: 'Trading address',
+  address: 'Address',
   uk_region: 'UK region',
   headquarter_type: 'Headquarter type',
   global_headquarters: 'Global HQ',
@@ -49,8 +49,8 @@ const chDetailsLabels = {
 }
 
 const address = {
-  companyRegisteredAddress: 'Primary address',
-  companyTradingAddress: 'Trading address',
+  companyAddress: 'Address',
+  companyRegisteredAddress: 'Registered address',
   companiesHouseRegisteredAddress: 'Registered address',
 }
 

--- a/src/apps/companies/middleware/form.js
+++ b/src/apps/companies/middleware/form.js
@@ -1,4 +1,11 @@
-const { assign, get, filter, omit, pickBy } = require('lodash')
+const {
+  assign,
+  get,
+  filter,
+  isPlainObject,
+  omit,
+  pickBy,
+} = require('lodash')
 
 const { getOptions } = require('../../../lib/options')
 const { hqLabels } = require('../labels')
@@ -43,7 +50,8 @@ async function populateForm (req, res, next) {
     const createdOn = get(res.locals, 'company.created_on')
     const options = await getCompanyFormOptions(token, createdOn)
 
-    const defaultCompanyData = transformCompanyToForm(res.locals.companiesHouseRecord || res.locals.company)
+    const companyRecord = res.locals.companiesHouseRecord || res.locals.company
+    const defaultCompanyData = isPlainObject(companyRecord) ? transformCompanyToForm(companyRecord) : null
     const formData = assign({}, defaultCompanyData, req.body)
 
     if (get(req.query, 'business_type')) {

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -28,7 +28,7 @@ function getDitCompany (token, id) {
 }
 
 function getCHCompany (token, id) {
-  return authorisedRequest(token, `${config.apiRoot}/v3/ch-company/${id}`)
+  return authorisedRequest(token, `${config.apiRoot}/v4/ch-company/${id}`)
 }
 
 function saveCompany (token, company) {

--- a/src/apps/companies/transformers/companies-house-to-view.js
+++ b/src/apps/companies/transformers/companies-house-to-view.js
@@ -9,12 +9,7 @@ const { chDetailsLabels } = require('../labels')
 
 module.exports = function transformCompaniesHouseToView ({
   name,
-  registered_address_1,
-  registered_address_2,
-  registered_address_town,
-  registered_address_county,
-  registered_address_postcode,
-  registered_address_country,
+  registered_address,
   company_number,
   company_category,
   company_status,
@@ -31,14 +26,7 @@ module.exports = function transformCompaniesHouseToView ({
     business_type: company_category,
     registered_address: {
       type: 'address',
-      address: {
-        line_1: registered_address_1,
-        line_2: registered_address_2,
-        town: registered_address_town,
-        county: registered_address_county,
-        postcode: registered_address_postcode,
-        country: registered_address_country,
-      },
+      address: registered_address,
     },
     incorporation_date: formatLongDate(incorporation_date),
     sic_code: transformSicCodes({ sic_code_1, sic_code_2, sic_code_3, sic_code_4 }),

--- a/src/apps/companies/transformers/company-to-form.js
+++ b/src/apps/companies/transformers/company-to-form.js
@@ -1,46 +1,59 @@
 /* eslint-disable camelcase */
-const {
-  assign,
-  get,
-  isPlainObject,
-  mapValues,
-} = require('lodash')
+const { get } = require('lodash')
 
-// TODO: This is a temporary transformer to transform an API response into
-// a format needed for the form view
-//
-// Will be replaced with newer form builder transformers once the form view is
-// replaced with newer form macros
-module.exports = function transformCompanyToForm (company) {
-  if (!isPlainObject(company)) { return }
+const ADDRESS_TYPE = {
+  ADDRESS: 1,
+  REGISTERED: 2,
+}
 
-  const schema = {
-    registered_address_country: String,
-    trading_address_country: String,
-    business_type: String,
-    headquarter_type: Object,
-    uk_region: String,
-    sector: String,
-    employee_range: String,
-    turnover_range: String,
+const transformAddress = (address, addressType) => {
+  const prefix = addressType === ADDRESS_TYPE.ADDRESS ? '' : 'registered_'
+  return {
+    [`${prefix}address_1`]: get(address, 'line_1'),
+    [`${prefix}address_2`]: get(address, 'line_2'),
+    [`${prefix}address_town`]: get(address, 'town'),
+    [`${prefix}address_county`]: get(address, 'county'),
+    [`${prefix}address_postcode`]: get(address, 'postcode'),
+    [`${prefix}address_country`]: get(address, 'country.id'),
   }
+}
 
-  const formatted = mapValues(schema, (type, key) => {
-    if (type === Object) {
-      return get(company, key)
-    }
-    return get(company, `${key}.id`)
-  })
-
-  formatted.headquarter_type = get(formatted, 'headquarter_type.id', 'not_headquarters')
-  formatted.trading_names = company.trading_names && company.trading_names.length ? company.trading_names[0] : null
-
-  formatted.address_1 = get(company.address, 'line_1')
-  formatted.address_2 = get(company.address, 'line_2')
-  formatted.address_town = get(company.address, 'town')
-  formatted.address_county = get(company.address, 'county')
-  formatted.address_postcode = get(company.address, 'postcode')
-  formatted.address_country = get(company.address, 'country.id')
-
-  return assign({}, company, formatted)
+module.exports = function transformCompanyToForm ({
+  name,
+  uk_based,
+  uk_region,
+  sector,
+  description,
+  website,
+  employee_range,
+  turnover_range,
+  headquarter_type,
+  trading_names,
+  vat_number,
+  reference_code,
+  address,
+  registered_address,
+  business_type,
+  global_headquarters,
+  company_number,
+}) {
+  return {
+    name,
+    uk_based,
+    description,
+    website,
+    vat_number,
+    reference_code,
+    global_headquarters,
+    company_number,
+    ...transformAddress(address, ADDRESS_TYPE.ADDRESS),
+    ...transformAddress(registered_address, ADDRESS_TYPE.REGISTERED),
+    business_type: get(business_type, 'id'),
+    headquarter_type: get(headquarter_type, 'id', 'not_headquarters'),
+    uk_region: get(uk_region, 'id'),
+    sector: get(sector, 'id'),
+    employee_range: get(employee_range, 'id'),
+    turnover_range: get(turnover_range, 'id'),
+    trading_names: trading_names && !!trading_names.length ? trading_names[0] : null,
+  }
 }

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -20,7 +20,7 @@ function transformAddress ({
   if (trading_address_1 && trading_address_country) {
     return {
       type: 'address',
-      label: labels.address.companyTradingAddress,
+      label: labels.address.companyAddress,
       value: {
         line_1: trading_address_1,
         line_2: trading_address_2,

--- a/src/apps/companies/transformers/company-to-view.js
+++ b/src/apps/companies/transformers/company-to-view.js
@@ -1,103 +1,17 @@
 /* eslint-disable camelcase */
-const { get, pickBy, isNull } = require('lodash')
+const { get, pickBy } = require('lodash')
 
 const { getPrimarySectorName } = require('../../../../common/transform-sectors')
 const { getDataLabels } = require('../../../lib/controller-utils')
 const { companyDetailsLabels, hqLabels } = require('../labels')
 
-const setGlobalHQLink = ({ companyId, ghqDetail }) => {
-  const linkTheGlobalHQ = {
-    url: `/companies/${companyId}/hierarchies/ghq/search`,
-    name: 'Link the Global HQ',
-  }
-
-  const linkToTheGlobalHQ = {
-    url: `/companies/${get(ghqDetail, 'id')}`,
-    name: get(ghqDetail, 'name'),
-    actions: [
-      {
-        url: `/companies/${companyId}/hierarchies/ghq/remove`,
-        label: 'Remove link',
-      },
-    ],
-  }
-
-  return isNull(ghqDetail) ? linkTheGlobalHQ : linkToTheGlobalHQ
-}
-
 module.exports = function transformCompanyToView ({
-  id,
-  uk_based,
-  uk_region,
   sector,
-  description,
-  website,
-  employee_range,
-  turnover_range,
   headquarter_type,
-  trading_names,
-  vat_number,
-  reference_code,
-  registered_address_1,
-  registered_address_2,
-  registered_address_town,
-  registered_address_county,
-  registered_address_postcode,
-  registered_address_country,
-  trading_address_1,
-  trading_address_2,
-  trading_address_town,
-  trading_address_county,
-  trading_address_postcode,
-  trading_address_country,
-  business_type,
-  global_headquarters,
 }) {
   const viewRecord = {
-    trading_names: trading_names && trading_names.length ? trading_names : null,
-    vat_number,
-    reference_code,
-    description,
-    uk_region: get(uk_region, 'name'),
     sector: getPrimarySectorName(get(sector, 'name')),
-    website: (website && website.length > 0) ? {
-      name: website,
-      url: website,
-    } : null,
-    employee_range: get(employee_range, 'name'),
-    turnover_range: get(turnover_range, 'name'),
     headquarter_type: hqLabels[get(headquarter_type, 'name')] || 'Not a headquarters',
-    registered_address: registered_address_country ? {
-      type: 'address',
-      address: {
-        line_1: registered_address_1,
-        line_2: registered_address_2,
-        town: registered_address_town,
-        county: registered_address_county,
-        postcode: registered_address_postcode,
-        country: registered_address_country,
-      },
-    } : null,
-    country: !uk_based ? get(registered_address_country, 'name') : null,
-    trading_address: trading_address_country ? {
-      type: 'address',
-      address: {
-        line_1: trading_address_1,
-        line_2: trading_address_2,
-        town: trading_address_town,
-        county: trading_address_county,
-        postcode: trading_address_postcode,
-        country: trading_address_country,
-      },
-    } : null,
-    business_type: get(business_type, 'name'),
-  }
-
-  if (get(headquarter_type, 'name') !== 'ghq') {
-    viewRecord.global_headquarters = setGlobalHQLink({
-      companyId: id,
-      ghqDetail: global_headquarters,
-    })
   }
 
   return pickBy(getDataLabels(viewRecord, companyDetailsLabels))

--- a/test/acceptance/features/investment-projects/create.feature
+++ b/test/acceptance/features/investment-projects/create.feature
@@ -82,7 +82,7 @@ Feature: Create a new Investment project
     And I search for the foreign source of equity Mars Exports Ltd
     Then I can view the Equity Source in the collection
       | text               | expected                               |
-      | Primary address    | investmentProject.equitySource.address |
+      | Registered address | investmentProject.equitySource.address |
     And the Equity Source has badges
       | text               | expected                               |
       | Country            | investmentProject.equitySource.country |
@@ -139,7 +139,7 @@ Feature: Create a new Investment project
     And I search for the foreign source of equity Lambda plc
     Then I can view the Equity Source in the collection
       | text               | expected                               |
-      | Primary address    | investmentProject.equitySource.address |
+      | Registered address | investmentProject.equitySource.address |
     And the Equity Source has badges
       | text               | expected                               |
       | Country            | investmentProject.equitySource.country |

--- a/test/acceptance/pages/search/search.js
+++ b/test/acceptance/pages/search/search.js
@@ -85,7 +85,7 @@ module.exports = {
           selector: '.c-entity__header a',
         },
         sector: getSearchResultSelector('Sector'),
-        address: getSearchResultSelector('Trading address'),
+        address: getSearchResultSelector('Address'),
         tradingNames: getSearchResultSelector('Trading name'),
       },
     },

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -1,81 +1,39 @@
 /* eslint prefer-promise-reject-errors: 0 */
 const companyData = require('~/test/unit/data/company.json')
 const companyV4Data = require('~/test/unit/data/companies/company-v4.json')
+const companyCHData = require('~/test/unit/data/companies/companies-house-company.json')
 
 const config = require('~/config')
 
-const { getDitCompany } = require('~/src/apps/companies/repos.js')
+const { getDitCompany, getCHCompany } = require('~/src/apps/companies/repos.js')
 
 describe('Company repository', () => {
   describe('Save company', () => {
     describe('Make correct call to API', () => {
-      it('should call the API with a PATCH if an ID is provided.', (done) => {
-        const authorisedRequestStub = function (token, opts) {
-          expect(opts.method).to.eq('PATCH')
-          return new Promise((resolve) => {
-            resolve({ id: '1234', name: 'fred' })
-          })
-        }
-        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub)
-
-        companyRepository.saveCompany('1234', { id: '1234', name: 'fred' })
-          .then(() => {
-            done()
-          })
-          .catch((error) => {
-            throw Error(error)
-          })
+      beforeEach(() => {
+        this.authorisedRequestStub = sinon.stub().resolves({
+          id: 'TEST_TOKEN',
+          name: 'fred',
+        })
+        this.repo = makeRepositoryWithAuthRequest(this.authorisedRequestStub)
       })
-      it('should call the API at /v4/company/id if an ID is provided', (done) => {
-        const authorisedRequestStub = function (token, opts) {
-          expect(opts.url).to.include('/v4/company/1234')
-          return new Promise((resolve) => {
-            resolve({ id: '1234', name: 'fred' })
-          })
-        }
-        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub)
 
-        companyRepository.saveCompany('1234', { id: '1234', name: 'fred' })
-          .then(() => {
-            done()
-          })
-          .catch((error) => {
-            throw Error(error)
-          })
+      it('should call the API with a PATCH if an ID is provided.', async () => {
+        await this.repo.saveCompany('TEST_TOKEN', { id: 'TEST_TOKEN', name: 'fred' })
+        expect(this.authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+          body: { id: 'TEST_TOKEN', name: 'fred' },
+          method: 'PATCH',
+          url: 'http://localhost:8000/v4/company/TEST_TOKEN',
+        })
       })
-      it('should call the API with a POST if no ID is provided.', (done) => {
-        const authorisedRequestStub = function (token, opts) {
-          expect(opts.method).to.eq('POST')
-          return new Promise((resolve) => {
-            resolve({ id: '1234', name: 'fred' })
-          })
-        }
-        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub)
 
-        companyRepository.saveCompany('1234', { name: 'fred' })
-          .then(() => {
-            done()
-          })
-          .catch((error) => {
-            throw Error(error)
-          })
-      })
-      it('should call the API at /v4/company if no ID is provided', (done) => {
-        const authorisedRequestStub = function (token, opts) {
-          expect(opts.url).to.include('/v4/company')
-          return new Promise((resolve) => {
-            resolve({ id: '1234', name: 'fred' })
-          })
-        }
-        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub)
-
-        companyRepository.saveCompany('1234', { name: 'fred' })
-          .then(() => {
-            done()
-          })
-          .catch((error) => {
-            throw Error(error)
-          })
+      it('should call the API with a POST if no ID is provided.', async () => {
+        await this.repo.saveCompany('TEST_TOKEN', { name: 'fred' })
+        expect(this.authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+          body: { name: 'fred' },
+          method: 'POST',
+          url: 'http://localhost:8000/v4/company',
+        })
       })
     })
   })
@@ -83,58 +41,50 @@ describe('Company repository', () => {
   describe('Update company', () => {
     beforeEach(() => {
       this.authorisedRequestStub = sinon.stub().resolves(companyData)
-      this.repo = proxyquire('~/src/apps/companies/repos', {
-        '../../lib/authorised-request': { authorisedRequest: this.authorisedRequestStub },
-        '../../../config': {
-          apiRoot: 'http://test.com',
-        },
-      })
+      this.repo = makeRepositoryWithAuthRequest(this.authorisedRequestStub)
     })
 
-    it('should make the correct call to the API', () => {
-      return this.repo.updateCompany('1234', '999', { global_headquarters: '1' })
-        .then(() => {
-          expect(this.authorisedRequestStub).to.be.calledWith('1234', {
-            url: 'http://test.com/v4/company/999',
-            method: 'PATCH',
-            body: {
-              global_headquarters: '1',
-            },
-          })
-        })
+    it('should make the correct call to the API', async () => {
+      await this.repo.updateCompany('TEST_TOKEN', '999', { global_headquarters: '1' })
+      expect(this.authorisedRequestStub).to.be.calledOnceWithExactly('TEST_TOKEN', {
+        url: 'http://localhost:8000/v4/company/999',
+        method: 'PATCH',
+        body: {
+          global_headquarters: '1',
+        },
+      })
     })
   })
 
   describe('#getDitCompany', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       nock(config.apiRoot)
         .get(`/v4/company/${companyV4Data.id}`)
         .reply(200, companyV4Data)
-
-      this.company = await getDitCompany('1234', companyV4Data.id)
     })
 
-    it('should return', () => {
-      expect(this.company).to.deep.equal({
+    it('should return company', async () => {
+      const company = await getDitCompany('TEST_TOKEN', companyV4Data.id)
+      expect(company).to.deep.equal({
         ...companyV4Data,
-        registered_address_1: '82 Ramsgate Rd',
-        registered_address_2: '',
-        registered_address_town: 'Willington',
-        registered_address_county: '',
-        registered_address_postcode: 'NE28 5JB',
-        registered_address_country: {
-          name: 'United Kingdom',
-          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+        'registered_address_1': '82 Ramsgate Rd',
+        'registered_address_2': '',
+        'registered_address_country': {
+          'id': '80756b9a-5d95-e211-a939-e4115bead28a',
+          'name': 'United Kingdom',
         },
-        trading_address_1: '82 Ramsgate Rd',
-        trading_address_2: '',
-        trading_address_town: 'Willington',
-        trading_address_county: '',
-        trading_address_postcode: 'NE28 5JB',
-        trading_address_country: {
-          name: 'United Kingdom',
-          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+        'registered_address_county': '',
+        'registered_address_postcode': 'NE28 5JB',
+        'registered_address_town': 'Willington',
+        'trading_address_1': '82 Ramsgate Rd',
+        'trading_address_2': '',
+        'trading_address_country': {
+          'id': '80756b9a-5d95-e211-a939-e4115bead28a',
+          'name': 'United Kingdom',
         },
+        'trading_address_county': '',
+        'trading_address_postcode': 'NE28 5JB',
+        'trading_address_town': 'Willington',
       })
     })
   })

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -89,6 +89,19 @@ describe('Company repository', () => {
     })
   })
 
+  describe('#getCHCompany', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v4/ch-company/${companyCHData.id}`)
+        .reply(200, companyCHData)
+    })
+
+    it('should return company', async () => {
+      const company = await getCHCompany('TEST_TOKEN', companyCHData.id)
+      expect(company).to.deep.equal(companyCHData)
+    })
+  })
+
   function makeRepositoryWithAuthRequest (authorisedRequestStub) {
     return proxyquire('~/src/apps/companies/repos', {
       '../../lib/authorised-request': { authorisedRequest: authorisedRequestStub },

--- a/test/unit/apps/companies/transformers/companies-house-to-view.test.js
+++ b/test/unit/apps/companies/transformers/companies-house-to-view.test.js
@@ -1,10 +1,10 @@
-const companiesHouseCompany = require('~/test/unit/data/companies/companies-house-company.json')
+const companiesHouseCompany = require('~/test/unit/data/companies/companies-house.json')
 const transformCompaniesHouseToView = require('~/src/apps/companies/transformers/companies-house-to-view')
 
 describe('transformCompaniesHouseToView', () => {
   context('when companies data is provided', () => {
     beforeEach(() => {
-      this.viewRecord = transformCompaniesHouseToView(companiesHouseCompany.companies_house_data)
+      this.viewRecord = transformCompaniesHouseToView(companiesHouseCompany)
     })
 
     it('should return the fields expected in the correct order', () => {
@@ -20,11 +20,11 @@ describe('transformCompaniesHouseToView', () => {
     })
 
     it('should return the name', () => {
-      expect(this.viewRecord).to.have.property('Registered name', 'Samsung Bioepis Uk Limited')
+      expect(this.viewRecord).to.have.property('Registered name', 'Mercury Trading Ltd')
     })
 
     it('should return the company number', () => {
-      expect(this.viewRecord).to.have.property('Companies House No', '08840722')
+      expect(this.viewRecord).to.have.property('Companies House No', '99919')
     })
 
     it('should return the business type', () => {
@@ -39,11 +39,11 @@ describe('transformCompaniesHouseToView', () => {
       expect(this.viewRecord['Registered office address']).to.deep.equal({
         type: 'address',
         address: {
-          line_1: '5TH FLOOR, PROFILE WEST',
-          line_2: '950 GREAT WEST ROAD',
-          town: 'BRENTFORD',
-          county: 'MIDDLESEX',
-          postcode: 'TW8 9ES',
+          line_1: '64 Ermin Street',
+          line_2: '',
+          town: 'Y Ffor',
+          county: '',
+          postcode: 'LL53 5RN',
           country: {
             id: '80756b9a-5d95-e211-a939-e4115bead28a',
             name: 'United Kingdom',
@@ -53,7 +53,7 @@ describe('transformCompaniesHouseToView', () => {
     })
 
     it('should return the incorporation date', () => {
-      expect(this.viewRecord).to.have.property('Incorporated on', '10 January 2014')
+      expect(this.viewRecord).to.have.property('Incorporated on', '14 December 2000')
     })
 
     it('should return the formatted SIC codes', () => {

--- a/test/unit/apps/companies/transformers/company-to-form.test.js
+++ b/test/unit/apps/companies/transformers/company-to-form.test.js
@@ -1,0 +1,118 @@
+const datahubOnlyCompany = require('~/test/unit/data/companies/datahub-only-company.json')
+const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
+const companiesHouseCompany = require('~/test/unit/data/companies/companies-house.json')
+
+const transformCompanyToForm = require('~/src/apps/companies/transformers/company-to-form')
+
+describe('transformCompanyToForm', () => {
+  context('when called with a fully populated datahub only company', () => {
+    it('should return transformed values', () => {
+      const actual = transformCompanyToForm(datahubOnlyCompany)
+      const expected = {
+        business_type: '6f75408b-03e7-e611-bca1-e4115bead28a',
+        company_number: null,
+        description: 'description',
+        employee_range: undefined,
+        global_headquarters: undefined,
+        headquarter_type: '11322',
+        name: 'SAMSUNG BIOEPIS UK LIMITED',
+        reference_code: 'ORG-12345678',
+        sector: 'b622c9d2-5f95-e211-a939-e4115bead28a',
+        address_1: 'Business Innovation & Skills',
+        address_2: '1 Victoria Street',
+        address_town: 'London',
+        address_county: 'Greater London',
+        address_postcode: 'SW1H 0ET',
+        address_country: '80756b9a-5d95-e211-a939-e4115bead28a',
+        registered_address_1: '5TH FLOOR, PROFILE WEST',
+        registered_address_2: '950 GREAT WEST ROAD',
+        registered_address_country: '80756b9a-5d95-e211-a939-e4115bead28a',
+        registered_address_county: 'MIDDLESEX',
+        registered_address_postcode: 'TW8 9ES',
+        registered_address_town: 'BRENTFORD',
+        trading_names: 'Fred',
+        turnover_range: undefined,
+        uk_based: true,
+        uk_region: '814cd12a-6095-e211-a939-e4115bead28a',
+        vat_number: '123412341234',
+        website: 'http://www.test.com',
+      }
+
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+
+  context('when called with a minimally populated company', () => {
+    it('should return transformed values', () => {
+      const actual = transformCompanyToForm(minimalCompany)
+      const expected = {
+        business_type: undefined,
+        company_number: null,
+        description: null,
+        employee_range: undefined,
+        global_headquarters: undefined,
+        headquarter_type: 'not_headquarters',
+        name: 'SAMSUNG BIOEPIS UK LIMITED',
+        reference_code: '',
+        sector: 'b622c9d2-5f95-e211-a939-e4115bead28a',
+        address_1: '5TH FLOOR, PROFILE WEST',
+        address_2: '',
+        address_town: 'BRENTFORD',
+        address_county: 'MIDDLESEX',
+        address_postcode: 'TW8 9ES',
+        address_country: '80756b9a-5d95-e211-a939-e4115bead28a',
+        registered_address_1: undefined,
+        registered_address_2: undefined,
+        registered_address_town: undefined,
+        registered_address_county: undefined,
+        registered_address_postcode: undefined,
+        registered_address_country: undefined,
+        trading_names: null,
+        turnover_range: undefined,
+        uk_based: true,
+        uk_region: '814cd12a-6095-e211-a939-e4115bead28a',
+        vat_number: '',
+        website: null,
+      }
+
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+
+  context('when called with a Companies House company', () => {
+    it('should return transformed values', () => {
+      const actual = transformCompanyToForm(companiesHouseCompany)
+      const expected = {
+        business_type: '6f75408b-03e7-e611-bca1-e4115bead28a',
+        company_number: '99919',
+        description: undefined,
+        employee_range: undefined,
+        global_headquarters: undefined,
+        headquarter_type: 'not_headquarters',
+        name: 'Mercury Trading Ltd',
+        reference_code: undefined,
+        sector: undefined,
+        address_1: undefined,
+        address_2: undefined,
+        address_town: undefined,
+        address_county: undefined,
+        address_postcode: undefined,
+        address_country: undefined,
+        registered_address_1: '64 Ermin Street',
+        registered_address_2: '',
+        registered_address_town: 'Y Ffor',
+        registered_address_county: '',
+        registered_address_postcode: 'LL53 5RN',
+        registered_address_country: '80756b9a-5d95-e211-a939-e4115bead28a',
+        trading_names: null,
+        turnover_range: undefined,
+        uk_based: undefined,
+        uk_region: undefined,
+        vat_number: undefined,
+        website: undefined,
+      }
+
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+})

--- a/test/unit/apps/companies/transformers/company-to-list-item.test.js
+++ b/test/unit/apps/companies/transformers/company-to-list-item.test.js
@@ -139,7 +139,7 @@ describe('transformCompanyToListItem', () => {
 
     it('should include the trading address in the result', () => {
       expect(this.listItem.meta).to.containSubset([{
-        label: 'Trading address',
+        label: 'Address',
         type: 'address',
         value: {
           line_1: '100 Bolton Road',
@@ -157,7 +157,7 @@ describe('transformCompanyToListItem', () => {
 
     it('does not include the registered address', () => {
       expect(this.listItem.meta).to.not.containSubset([{
-        label: 'Primary address',
+        label: 'Registered address',
         value: 'Leeds City Centre, Leeds, EX1 2PM, United Kingdom',
       }])
     })
@@ -174,13 +174,13 @@ describe('transformCompanyToListItem', () => {
 
     it('should not include the trading address in the result', () => {
       expect(this.listItem.meta).to.not.containSubset([{
-        label: 'Trading address',
+        label: 'Address',
       }])
     })
 
     it('returns a formatted registered address', () => {
       expect(this.listItem.meta).to.containSubset([{
-        label: 'Primary address',
+        label: 'Registered address',
         type: 'address',
         value: {
           line_1: 'Leeds City Centre',

--- a/test/unit/apps/companies/transformers/company-to-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-view.test.js
@@ -1,5 +1,4 @@
 const datahubOnlyCompany = require('~/test/unit/data/companies/datahub-only-company.json')
-const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
 
 const transformCompanyToView = require('~/src/apps/companies/transformers/company-to-view')
 
@@ -11,180 +10,13 @@ describe('transformCompanyToView', () => {
 
     it('should contain just the fields expected', () => {
       expect(this.viewRecord).to.have.ordered.keys([
-        'Business type',
-        'Primary address',
-        'Trading names',
-        'Trading address',
-        'UK region',
         'Headquarter type',
         'Sector',
-        'Website',
-        'Business description',
-        'VAT number',
-        'CDMS reference',
-        'Global HQ',
       ])
-    })
-
-    it('should supply the business type', () => {
-      expect(this.viewRecord['Business type']).to.equal('Private limited company')
-    })
-
-    it('should supply the primary address', () => {
-      expect(this.viewRecord['Primary address']).to.deep.equal({
-        type: 'address',
-        address: {
-          line_1: '5TH FLOOR, PROFILE WEST',
-          line_2: '950 GREAT WEST ROAD',
-          town: 'BRENTFORD',
-          county: 'MIDDLESEX',
-          postcode: 'TW8 9ES',
-          country: {
-            id: '80756b9a-5d95-e211-a939-e4115bead28a',
-            name: 'United Kingdom',
-          },
-        },
-      })
-    })
-
-    it('should supply the trading name', () => {
-      expect(this.viewRecord['Trading names'][0]).to.equal('Fred')
-    })
-
-    it('should supply the trading address', () => {
-      expect(this.viewRecord['Primary address']).to.deep.equal({
-        type: 'address',
-        address: {
-          line_1: '5TH FLOOR, PROFILE WEST',
-          line_2: '950 GREAT WEST ROAD',
-          town: 'BRENTFORD',
-          county: 'MIDDLESEX',
-          postcode: 'TW8 9ES',
-          country: {
-            id: '80756b9a-5d95-e211-a939-e4115bead28a',
-            name: 'United Kingdom',
-          },
-        },
-      })
-    })
-
-    it('should supply the uk region', () => {
-      expect(this.viewRecord['UK region']).to.equal('North East')
     })
 
     it('should supply the headquarters', () => {
       expect(this.viewRecord['Headquarter type']).to.equal('European HQ')
-    })
-
-    it('should supply sector', () => {
-      expect(this.viewRecord.Sector).to.equal('Aerospace')
-    })
-
-    it('should convert website to link', () => {
-      expect(this.viewRecord.Website).to.deep.equal({
-        name: 'http://www.test.com',
-        url: 'http://www.test.com',
-      })
-    })
-
-    it('should supply description', () => {
-      expect(this.viewRecord['Business description']).to.equal('description')
-    })
-
-    it('should supply vat number', () => {
-      expect(this.viewRecord['VAT number']).to.equal('123412341234')
-    })
-
-    it('should supply the CDMS reference', () => {
-      expect(this.viewRecord['CDMS reference']).to.equal('ORG-12345678')
-    })
-  })
-
-  context('when called with a minimally populated company', () => {
-    beforeEach(() => {
-      this.viewRecord = transformCompanyToView(minimalCompany)
-    })
-
-    it('should contain just the fields expected', () => {
-      expect(this.viewRecord).to.have.ordered.keys([
-        'Primary address',
-        'UK region',
-        'Sector',
-        'Headquarter type',
-        'Global HQ',
-      ])
-    })
-
-    it('should supply the primary address', () => {
-      expect(this.viewRecord['Primary address']).to.deep.equal({
-        type: 'address',
-        address: {
-          line_1: '5TH FLOOR, PROFILE WEST',
-          line_2: '',
-          town: 'BRENTFORD',
-          county: 'MIDDLESEX',
-          postcode: 'TW8 9ES',
-          country: {
-            id: '80756b9a-5d95-e211-a939-e4115bead28a',
-            name: 'United Kingdom',
-          },
-        },
-      })
-    })
-
-    it('should supply the uk region', () => {
-      expect(this.viewRecord['UK region']).to.equal('North East')
-    })
-
-    it('should supply sector', () => {
-      expect(this.viewRecord.Sector).to.equal('Aerospace')
-    })
-  })
-
-  context('has a foreign datahub company', () => {
-    beforeEach(() => {
-      const foreignCompany = {
-        ...minimalCompany,
-        uk_based: false,
-        registered_address_country: {
-          id: '1234',
-          name: 'France',
-        },
-        uk_region: null,
-      }
-
-      this.viewRecord = transformCompanyToView(foreignCompany)
-    })
-
-    it('should contain just the fields expected', () => {
-      expect(this.viewRecord).to.have.ordered.keys([
-        'Primary address',
-        'Country',
-        'Sector',
-        'Headquarter type',
-        'Global HQ',
-      ])
-    })
-
-    it('should supply the primary address', () => {
-      expect(this.viewRecord['Primary address']).to.deep.equal({
-        type: 'address',
-        address: {
-          line_1: '5TH FLOOR, PROFILE WEST',
-          line_2: '',
-          town: 'BRENTFORD',
-          county: 'MIDDLESEX',
-          postcode: 'TW8 9ES',
-          country: {
-            id: '1234',
-            name: 'France',
-          },
-        },
-      })
-    })
-
-    it('should supply the country', () => {
-      expect(this.viewRecord.Country).to.equal('France')
     })
 
     it('should supply sector', () => {

--- a/test/unit/data/companies/companies-house.json
+++ b/test/unit/data/companies/companies-house.json
@@ -1,17 +1,12 @@
 {
   "id": 15387806,
   "name": "Mercury Trading Ltd",
-  "registered_address_1": "64 Ermin Street",
-  "registered_address_2": null,
-  "registered_address_town": "Y Ffor",
-  "registered_address_county": null,
-  "registered_address_postcode": "LL53 5RN",
   "company_number": "99919",
   "company_category": "Private Limited Company",
-  "company_status": "",
-  "sic_code_1": "",
+  "company_status": "Active",
+  "sic_code_1": "82990 - Other business support service activities n.e.c.",
   "sic_code_2": "",
-  "sic_code_3": "",
+  "sic_code_3": "more stuff",
   "sic_code_4": "",
   "uri": "",
   "incorporation_date": "2000-12-14",
@@ -19,8 +14,15 @@
     "id": "6f75408b-03e7-e611-bca1-e4115bead28a",
     "name": "Private limited company"
   },
-  "registered_address_country": {
-    "id": "80756b9a-5d95-e211-a939-e4115bead28a",
-    "name": "United Kingdom"
+  "registered_address": {
+    "line_1": "64 Ermin Street",
+    "line_2": "",
+    "town": "Y Ffor",
+    "county": "",
+    "postcode": "LL53 5RN",
+    "country": {
+      "name": "United Kingdom",
+      "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
   }
 }

--- a/test/unit/data/companies/datahub-only-company.json
+++ b/test/unit/data/companies/datahub-only-company.json
@@ -6,14 +6,27 @@
   "uk_based": true,
   "company_number": null,
   "vat_number": "123412341234",
-  "registered_address_1": "5TH FLOOR, PROFILE WEST",
-  "registered_address_2": "950 GREAT WEST ROAD",
-  "registered_address_town": "BRENTFORD",
-  "registered_address_county": "MIDDLESEX",
-  "registered_address_postcode": "TW8 9ES",
-  "registered_address_country": {
+  "address": {
+    "line_1": "Business Innovation & Skills",
+    "line_2": "1 Victoria Street",
+    "town": "London",
+    "county": "Greater London",
+    "postcode": "SW1H 0ET",
+    "country": {
       "name": "United Kingdom",
       "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
+  },
+  "registered_address": {
+    "line_1": "5TH FLOOR, PROFILE WEST",
+    "line_2": "950 GREAT WEST ROAD",
+    "town": "BRENTFORD",
+    "county": "MIDDLESEX",
+    "postcode": "TW8 9ES",
+    "country": {
+      "name": "United Kingdom",
+      "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
   },
   "created_on": "2017-11-13T13:09:29.008940Z",
   "modified_on": "2017-11-15T14:14:03.006642Z",
@@ -24,15 +37,6 @@
   "archived_by": null,
   "description": "description",
   "website": "http://www.test.com",
-  "trading_address_1": "Business Innovation & Skills",
-  "trading_address_2": "1 Victoria Street",
-  "trading_address_town": "London",
-  "trading_address_county": "Greater London",
-  "trading_address_postcode": "SW1H 0ET",
-  "trading_address_country": {
-    "id": "1234",
-    "name": "United Kingdom"
-  },
   "business_type": {
       "name": "Private limited company",
       "id": "6f75408b-03e7-e611-bca1-e4115bead28a"

--- a/test/unit/data/companies/ghq-company-transformed-results.json
+++ b/test/unit/data/companies/ghq-company-transformed-results.json
@@ -20,7 +20,7 @@
           "value": "Global HQ"
         },
         {
-          "label": "Primary address",
+          "label": "Registered address",
           "type": "address",
           "value": {
             "country": {
@@ -62,7 +62,7 @@
           "value": "Global HQ"
         },
         {
-          "label": "Primary address",
+          "label": "Registered address",
           "type": "address",
           "value": {
             "country": {

--- a/test/unit/data/companies/minimal-company.json
+++ b/test/unit/data/companies/minimal-company.json
@@ -6,15 +6,18 @@
   "uk_based": true,
   "company_number": null,
   "vat_number": "",
-  "registered_address_1": "5TH FLOOR, PROFILE WEST",
-  "registered_address_2": "",
-  "registered_address_town": "BRENTFORD",
-  "registered_address_county": "MIDDLESEX",
-  "registered_address_postcode": "TW8 9ES",
-  "registered_address_country": {
+  "address": {
+    "line_1": "5TH FLOOR, PROFILE WEST",
+    "line_2": "",
+    "town": "BRENTFORD",
+    "county": "MIDDLESEX",
+    "postcode": "TW8 9ES",
+    "country": {
       "name": "United Kingdom",
       "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
   },
+  "registered_address": null,
   "created_on": "2017-11-13T13:09:29.008940Z",
   "modified_on": "2017-11-15T14:14:03.006642Z",
   "archived": false,
@@ -24,12 +27,6 @@
   "archived_by": null,
   "description": null,
   "website": null,
-  "trading_address_1": null,
-  "trading_address_2": null,
-  "trading_address_town": null,
-  "trading_address_county": null,
-  "trading_address_postcode": null,
-  "trading_address_country": null,
   "business_type": null,
   "children": [],
   "one_list_group_tier": null,

--- a/test/unit/data/companies/subsidiary-company-transformed-results.json
+++ b/test/unit/data/companies/subsidiary-company-transformed-results.json
@@ -15,7 +15,7 @@
           "value": "United States"
         },
         {
-          "label": "Primary address",
+          "label": "Registered address",
           "type": "address",
           "value": {
             "country": {
@@ -56,7 +56,7 @@
           "value": "North West"
         },
         {
-          "label": "Primary address",
+          "label": "Registered address",
           "type": "address",
           "value": {
             "country": {


### PR DESCRIPTION
https://trello.com/c/jU3otZrf/1017-use-new-address-objects-when-transforming-address-for-edit-company-display

**Implementation notes**

This change is removing dependency on the old `trading_address` and `registered_address` fields from the company v3 endpoint. 

Note that adding and editing a company is affected with this change and therefore should be given special attention when manually testing.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
