### PR TITLE
Remove dead branch from company-to-list-item.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CircleCI](https://circleci.com/gh/uktrade/data-hub-frontend.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-frontend)
 [![Known Vulnerabilities](https://snyk.io/test/github/uktrade/data-hub-frontend/badge.svg)](https://snyk.io/test/github/uktrade/data-hub-frontend) 
 
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/uktrade/data-hub-frontend.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/uktrade/data-hub-frontend/alerts/)
+
 An express application that fetches data from a back end JSON based api and renders it to the screen.
 This front end layer is primarily turning requests from the browser into back end API calls and then
 rendering them using Nunjucks template language.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![CircleCI](https://circleci.com/gh/uktrade/data-hub-frontend.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-frontend)
 [![Known Vulnerabilities](https://snyk.io/test/github/uktrade/data-hub-frontend/badge.svg)](https://snyk.io/test/github/uktrade/data-hub-frontend) 
 
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/uktrade/data-hub-frontend.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/uktrade/data-hub-frontend/alerts/)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/uktrade/data-hub-frontend.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/uktrade/data-hub-frontend/alerts/) 
+[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/uktrade/data-hub-frontend.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/uktrade/data-hub-frontend/context:javascript)
 
 An express application that fetches data from a back end JSON based api and renders it to the screen.
 This front end layer is primarily turning requests from the browser into back end API calls and then

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Data Hub frontend
 
 [![CircleCI](https://circleci.com/gh/uktrade/data-hub-frontend.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-frontend)
-[![Known Vulnerabilities](https://snyk.io/test/github/uktrade/data-hub-frontend/badge.svg)](https://snyk.io/test/github/uktrade/data-hub-frontend) 
-
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/uktrade/data-hub-frontend.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/uktrade/data-hub-frontend/alerts/) 
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/uktrade/data-hub-frontend.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/uktrade/data-hub-frontend/context:javascript)
 

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -149,7 +149,7 @@ module.exports = function transformCompanyToListItem ({
     registered_address_2,
   }))
 
-  const url = id ? `/companies/${id}` : `/companies/view/ch/${companies_house_data.company_number}`
+  const url = `/companies/${id}`
 
   return {
     id,


### PR DESCRIPTION
LGTM pointed out that the id this line: 

```
const url = id ? `/companies/${id}` : `/companies/view/ch/${companies_house_data.company_number}`
```
will never evaluate to false as there's an early return before that that bails out of the function if id is falsy

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
