### PR TITLE
Replace V3 registered address with the new address object from api V4 for OMIS

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -190,7 +190,7 @@ const filters = {
     return dateFns.format(parsedDate, format)
   },
 
-  formatAddress: (address) => {
+  formatAddress: (address, join = ', ') => {
     if (address) {
       return compact([
         address.line_1,
@@ -199,7 +199,7 @@ const filters = {
         address.county,
         address.postcode,
         address.country.name,
-      ]).join(', ')
+      ]).join(join)
     }
   },
 

--- a/src/apps/omis/apps/create/views/company--edit.njk
+++ b/src/apps/omis/apps/create/views/company--edit.njk
@@ -4,13 +4,9 @@
   {% call Message({ type: 'muted' }) %}
     {{ company.name }}
     <br>
-    {{ [
-      company.registered_address_1,
-      company.registered_address_2,
-      company.registered_address_county,
-      company.registered_address_town,
-      company.registered_address_postcode
-    ] | removeNilAndEmpty | join(', ') }}
+    {% set address = company.registered_address if company.registered_address else company.address %}
+
+    {{ address | formatAddress }}
     <br>
     <a href="?search=true">Change company</a>
   {% endcall %}

--- a/src/apps/omis/apps/create/views/summary.njk
+++ b/src/apps/omis/apps/create/views/summary.njk
@@ -10,16 +10,12 @@
     {{ values.contact.email | escape }}
   {% endset %}
 
+  {% set address = company.registered_address if company.registered_address else company.address %}
+
   {% set companyValue %}
     {{ values.company.name | escape }}
     <br>
-    {{ [
-      values.company.registered_address_1,
-      values.company.registered_address_2,
-      values.company.registered_address_county,
-      values.company.registered_address_town,
-      values.company.registered_address_postcode
-    ] | removeNilAndEmpty | join(", ") | escape }}
+    {{ address | formatAddress }}
   {% endset %}
 
   {% call MultiStepForm({

--- a/src/apps/omis/apps/edit/views/invoice-details.njk
+++ b/src/apps/omis/apps/edit/views/invoice-details.njk
@@ -10,14 +10,7 @@
     order.billing_address_country.name | escape
   ] | removeNilAndEmpty %}
 
-  {% set registeredAddress = [
-    company.registered_address_1 | escape,
-    company.registered_address_2 | escape,
-    company.registered_address_town | escape,
-    company.registered_address_county | escape,
-    company.registered_address_postcode | escape,
-    company.registered_address_country.name | escape
-  ] | removeNilAndEmpty %}
+  {% set address = company.registered_address if company.registered_address else company.address %}
 
   <div class="c-form-group">
     <p class="c-form-group__label">
@@ -32,9 +25,9 @@
         <br>
         <a href="billing-address?returnUrl={{ CURRENT_PATH }}">Change address</a>
       {% else %}
-        {{ registeredAddress | join('<br>') | safe }}
+        {{ address | formatAddress('<br />') | safe }}
         {% call Message({ type: 'muted' }) %}
-          The company’s registered address is currently being used for the invoice.
+          The company’s address is currently being used for the invoice.
           <br>
           <a href="billing-address?returnUrl={{ CURRENT_PATH }}">Add a different billing address</a>
         {% endcall %}

--- a/src/apps/omis/apps/edit/views/payment-reconciliation.njk
+++ b/src/apps/omis/apps/edit/views/payment-reconciliation.njk
@@ -17,19 +17,15 @@
     {% endcall %}
   {% endif %}
 
+  {% set address = company.registered_address if company.registered_address else company.address %}
+
   {% if order.status === 'quote_accepted' %}
     <h2 class="heading-medium">Company details</h2>
 
     <div>
       {{ company.name }}
       <br>
-      {{ [
-        company.registered_address_1,
-        company.registered_address_2,
-        company.registered_address_county,
-        company.registered_address_town,
-        company.registered_address_postcode
-        ] | removeNilAndEmpty | join(", ") }}
+      {{ address | formatAddress }}
     </div>
 
     <h2 class="heading-medium">Invoice details</h2>

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -213,23 +213,16 @@
     values.billing_address_country.name
   ] | removeNilAndEmpty %}
 
-  {% set registeredAddress = [
-    company.registered_address_1,
-    company.registered_address_2,
-    company.registered_address_town,
-    company.registered_address_county,
-    company.registered_address_postcode,
-    company.registered_address_country.name
-  ] | removeNilAndEmpty %}
+  {% set address = company.registered_address if company.registered_address else company.address %}
 
   {% set addressValue %}
     {% if billingAddress | length %}
       {{ billingAddress | join(', ') }}
     {% else %}
-      <p>{{ registeredAddress | join(', ') }}</p>
+      <p>{{ address | formatAddress }}</p>
 
       {% call Message({ type: 'muted' }) %}
-        The company’s registered address is currently being used for the invoice.
+        The company’s address is currently being used for the invoice.
       {% endcall %}
     {% endif %}
   {% endset %}

--- a/test/unit/config/nunjucks/filters.test.js
+++ b/test/unit/config/nunjucks/filters.test.js
@@ -356,6 +356,25 @@ describe('nunjucks filters', () => {
         expect(this.actual).to.not.exist
       })
     })
+
+    context('when specifying a custom join', () => {
+      beforeEach(() => {
+        this.actual = filters.formatAddress({
+          line_1: 'line 1',
+          line_2: '',
+          town: 'town',
+          county: '',
+          postcode: 'postcode',
+          country: {
+            name: 'country',
+          },
+        }, '<br />')
+      })
+
+      it('should format the address as a comma separated list', () => {
+        expect(this.actual).to.equal('line 1<br />town<br />postcode<br />country')
+      })
+    })
   })
 
   describe('#collectionDefault', () => {


### PR DESCRIPTION
**Implementation notes**

https://trello.com/c/gtRA9Om2/1061-remove-dependency-on-registeredaddress-in-omis-invoice-details

We can no longer depend on `registered_address_*` and we should use the `company.address` instead.

There are no visual changes.

**Please note:** Functional and acceptance tests are very limited for OMIS, this should be changed as a part of this ticket.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
