### PR TITLE
Add Gross Value Added (GVA)

### DIFF
--- a/src/apps/investments/labels.js
+++ b/src/apps/investments/labels.js
@@ -25,6 +25,7 @@ const labels = {
     view: {
       total_investment: 'Total investment',
       foreign_equity_investment: 'Foreign equity investment',
+      gross_value_added: 'Gross Value Added (GVA)',
       government_assistance: 'Government assistance',
       number_new_jobs: 'New jobs',
       average_salary: 'Average salary of new jobs',

--- a/src/apps/investments/middleware/forms/gross-value-added-message.js
+++ b/src/apps/investments/middleware/forms/gross-value-added-message.js
@@ -1,0 +1,44 @@
+/* eslint-disable camelcase */
+const { investmentTypes } = require('../../types')
+
+const foreignEquityInvestment = `<span class='govuk-body govuk-!-font-weight-bold'>Foreign equity investment value</span>`
+const primarySector = `<span class='govuk-body govuk-!-font-weight-bold'>Primary sector</span>`
+
+const gvaMessages = {
+  foreignEquityAndPrimarySector: `Add ${foreignEquityInvestment} and ${primarySector} (investment project summary) to calculate GVA`,
+  foreignEquityInvestment: `Add ${foreignEquityInvestment} and click "Save" to calculate GVA`,
+  primarySector: `Add ${primarySector} (investment project summary) to calculate GVA`,
+}
+
+const grossValueAddedMessage = ({
+  sector,
+  investment_type,
+  gross_value_added,
+  foreign_equity_investment }) => {
+  if (investment_type.name !== investmentTypes.FDI) {
+    return null
+  }
+
+  if (gross_value_added) {
+    return null
+  }
+
+  if (!foreign_equity_investment && !sector) {
+    return gvaMessages.foreignEquityAndPrimarySector
+  }
+
+  if (!foreign_equity_investment) {
+    return gvaMessages.foreignEquityInvestment
+  }
+
+  if (!sector) {
+    return gvaMessages.primarySector
+  }
+
+  return null
+}
+
+module.exports = {
+  grossValueAddedMessage,
+  gvaMessages,
+}

--- a/src/apps/investments/middleware/forms/value.js
+++ b/src/apps/investments/middleware/forms/value.js
@@ -1,9 +1,9 @@
-const { assign, get, merge } = require('lodash')
-
-const { updateInvestment } = require('../../repos')
-const { valueLabels } = require('../../labels')
 const { transformInvestmentValueFormBodyToApiRequest } = require('../../transformers/value')
+const { grossValueAddedMessage } = require('./gross-value-added-message')
 const { getOptions } = require('../../../../lib/options')
+const { updateInvestment } = require('../../repos')
+const { assign, get, merge } = require('lodash')
+const { valueLabels } = require('../../labels')
 
 async function populateForm (req, res, next) {
   const token = req.session.token
@@ -15,6 +15,7 @@ async function populateForm (req, res, next) {
     labels: valueLabels.edit,
     state: assign({}, investment, {
       average_salary: get(investment, 'average_salary.id'),
+      gross_value_added_message: grossValueAddedMessage(investment),
     }),
     options: {
       averageSalaryRange: await getOptions(token, 'salary-range', { createdOn }),

--- a/src/apps/investments/transformers/value.js
+++ b/src/apps/investments/transformers/value.js
@@ -17,11 +17,23 @@ function transformInvestmentAmount (clientCannotProvideInvestment, investmentAmo
   }
 }
 
+function transformGrossValueAdded (grossValueAdded) {
+  if (!grossValueAdded) {
+    return null
+  }
+
+  return {
+    type: 'currency',
+    name: grossValueAdded,
+  }
+}
+
 function transformInvestmentValueForView ({
   client_cannot_provide_total_investment,
   total_investment,
   client_cannot_provide_foreign_investment,
   foreign_equity_investment,
+  gross_value_added,
   number_new_jobs,
   number_safeguarded_jobs,
   government_assistance,
@@ -49,6 +61,7 @@ function transformInvestmentValueForView ({
   return {
     total_investment: transformInvestmentAmount(client_cannot_provide_total_investment, total_investment),
     foreign_equity_investment: transformInvestmentAmount(client_cannot_provide_foreign_investment, foreign_equity_investment),
+    gross_value_added: transformGrossValueAdded(gross_value_added),
     number_new_jobs: number_new_jobs && `${number_new_jobs} new jobs`,
     number_safeguarded_jobs: number_safeguarded_jobs && `${number_safeguarded_jobs} safeguarded jobs`,
     government_assistance: formatBoolean(government_assistance, {

--- a/src/apps/investments/views/value-edit.njk
+++ b/src/apps/investments/views/value-edit.njk
@@ -49,7 +49,7 @@
       })
     }}
 
-    {{ TextField({
+    {% call TextField({
       name: 'foreign_equity_investment',
       label: form.labels.foreign_equity_investment,
       value: form.state.foreign_equity_investment,
@@ -59,7 +59,18 @@
         name: 'client_cannot_provide_foreign_investment',
         value: 'false'
       }
-    }) }}
+      }) -%}
+      {% if form.state.investment_type.name === 'FDI' %}
+        <dl class="c-form-group">
+          <dt class="c-form-group__label-text">Gross value added (GVA)</dt>
+          {% if form.state.gross_value_added %}
+            <dd>{{ form.state.gross_value_added | formatCurrency }}</dd>
+          {% else %}
+            <dd>{{ form.state.gross_value_added_message | safe }}</dd>
+          {% endif %}
+        </dl>
+      {% endif %}
+    {%- endcall %}
 
     {{ TextField({
       name: 'number_new_jobs',

--- a/src/templates/_macros/form/text-field.njk
+++ b/src/templates/_macros/form/text-field.njk
@@ -28,5 +28,6 @@
     {% else %}
       {{ Input(props | assignCopy({ class: props.inputClass, data: props.inputData })) }}
     {% endif %}
+    {{ caller() if caller }}
   {% endcall %}
 {% endmacro %}

--- a/test/unit/apps/investment-projects/middleware/forms/gross-value-added-message.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/gross-value-added-message.test.js
@@ -1,0 +1,70 @@
+const { grossValueAddedMessage, gvaMessages } = require('~/src/apps/investments/middleware/forms/gross-value-added-message')
+const { investmentTypes } = require('~/src/apps/investments/types')
+
+describe('Gross value added message', () => {
+  context('when the investment type is not Foreign direct investment (FDI)', () => {
+    it('should be null when the investment type is Commitment to invest (CTI)', () => {
+      const investment = {
+        investment_type: {
+          name: investmentTypes.CTI,
+        },
+      }
+      expect(grossValueAddedMessage(investment)).to.be.null
+    })
+    it('should be null when the investment type is Non-FDI', () => {
+      const investment = {
+        investment_type: {
+          name: investmentTypes.NON_FDI,
+        },
+      }
+      expect(grossValueAddedMessage(investment)).to.be.null
+    })
+  })
+
+  context('when GVA is defined', () => {
+    it('should be null when the investment type is FDI', () => {
+      const investment = {
+        investment_type: { name: investmentTypes.FDI },
+        gross_value_added: 123,
+      }
+      expect(grossValueAddedMessage(investment)).to.be.null
+    })
+  })
+
+  context('when GVA is null and the user has not provided Foreign equity investment', () => {
+    it('should provide a message to the user', () => {
+      const investment = {
+        sector: {},
+        foreign_equity_investment: null,
+        investment_type: { name: investmentTypes.FDI },
+        gross_value_added: null,
+      }
+      expect(grossValueAddedMessage(investment)).to.eq(gvaMessages.foreignEquityInvestment)
+    })
+  })
+
+  context('when GVA is null and the user has not provided a Sector', () => {
+    it('should provide a message to the user', () => {
+      const investment = {
+        sector: null,
+        foreign_equity_investment: 250000,
+        investment_type: { name: investmentTypes.FDI },
+        gross_value_added: null,
+      }
+
+      expect(grossValueAddedMessage(investment)).to.eq(gvaMessages.primarySector)
+    })
+  })
+
+  context('when GVA is null and the user has not provided both Foreign equity investment and a Sector ', () => {
+    it('should provide a message to the user', () => {
+      const investment = {
+        sector: null,
+        foreign_equity_investment: null,
+        investment_type: { name: investmentTypes.FDI },
+        gross_value_added: null,
+      }
+      expect(grossValueAddedMessage(investment)).to.eq(gvaMessages.foreignEquityAndPrimarySector)
+    })
+  })
+})

--- a/test/unit/apps/investment-projects/middleware/forms/value.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/value.test.js
@@ -1,10 +1,12 @@
-const moment = require('moment')
-
-const config = require('~/config')
-const paths = require('~/src/apps/investments/paths')
+const { gvaMessages } = require('~/src/apps/investments/middleware/forms/gross-value-added-message')
 const adviserData = require('~/test/unit/data/investment/interaction/advisers')
 const controller = require('~/src/apps/investments/middleware/forms/value')
+const { investmentTypes } = require('~/src/apps/investments/types')
+const paths = require('~/src/apps/investments/paths')
+const config = require('~/config')
+const moment = require('moment')
 
+const gvaMessage = gvaMessages.foreignEquityAndPrimarySector
 const yesterday = moment().subtract(1, 'days').toISOString()
 const lastMonth = moment().subtract(1, 'months').toISOString()
 
@@ -61,6 +63,11 @@ describe('Investment form middleware - investment value', () => {
   describe('#populateForm', () => {
     context('when called for a new form', () => {
       beforeEach(async () => {
+        this.resMock.locals.investment = {
+          investment_type: {
+            name: investmentTypes.FDI,
+          },
+        }
         await controller.populateForm(this.reqMock, this.resMock, this.nextSpy)
       })
 
@@ -71,6 +78,8 @@ describe('Investment form middleware - investment value', () => {
       it('create an empty state object', () => {
         expect(this.resMock.locals.form.state).to.deep.equal({
           average_salary: undefined,
+          investment_type: { name: 'FDI' },
+          gross_value_added_message: gvaMessage,
         })
       })
 
@@ -98,6 +107,8 @@ describe('Investment form middleware - investment value', () => {
         this.resMock.locals.investment = {
           id: '1234',
           created_on: lastMonth,
+          investment_type: { name: 'FDI' },
+          gross_value_added_message: gvaMessage,
         }
 
         await controller.populateForm(this.reqMock, this.resMock, this.nextSpy)
@@ -112,6 +123,8 @@ describe('Investment form middleware - investment value', () => {
           id: '1234',
           created_on: lastMonth,
           average_salary: undefined,
+          investment_type: { name: 'FDI' },
+          gross_value_added_message: gvaMessage,
         })
       })
 
@@ -143,6 +156,8 @@ describe('Investment form middleware - investment value', () => {
             id: '1234',
             created_on: lastMonth,
             name: 'original name',
+            investment_type: { name: 'FDI' },
+            gross_value_added_message: gvaMessage,
           },
           form: {
             errors: ['an error'],
@@ -165,6 +180,8 @@ describe('Investment form middleware - investment value', () => {
           created_on: lastMonth,
           average_salary: undefined,
           name: 'modified name',
+          investment_type: { name: 'FDI' },
+          gross_value_added_message: gvaMessage,
         })
       })
 

--- a/test/unit/apps/investment-projects/transformers/value.test.js
+++ b/test/unit/apps/investment-projects/transformers/value.test.js
@@ -16,6 +16,7 @@ describe('Investment project transformers', () => {
           total_investment: null,
           client_cannot_provide_foreign_investment: true,
           foreign_equity_investment: null,
+          gross_value_added: null,
           number_new_jobs: null,
           number_safeguarded_jobs: null,
           government_assistance: false,
@@ -37,6 +38,7 @@ describe('Investment project transformers', () => {
         const expectedInvestmentValue = {
           total_investment: 'Client cannot provide this information',
           foreign_equity_investment: 'Client cannot provide this information',
+          gross_value_added: null,
           number_new_jobs: null,
           number_safeguarded_jobs: null,
           government_assistance: 'No government assistance',
@@ -62,6 +64,7 @@ describe('Investment project transformers', () => {
           total_investment: 100000,
           client_cannot_provide_foreign_investment: false,
           foreign_equity_investment: 200000,
+          gross_value_added: 16500,
           number_new_jobs: 100,
           number_safeguarded_jobs: 200,
           government_assistance: true,
@@ -108,6 +111,10 @@ describe('Investment project transformers', () => {
           foreign_equity_investment: {
             type: 'currency',
             name: 200000,
+          },
+          gross_value_added: {
+            name: 16500,
+            type: 'currency',
           },
           number_new_jobs: '100 new jobs',
           number_safeguarded_jobs: '200 safeguarded jobs',
@@ -190,6 +197,7 @@ describe('Investment project transformers', () => {
         const expectedInvestmentValue = {
           total_investment: null,
           foreign_equity_investment: null,
+          gross_value_added: null,
           number_new_jobs: '100 new jobs',
           number_safeguarded_jobs: '200 safeguarded jobs',
           government_assistance: 'Has government assistance',


### PR DESCRIPTION
Gross Value Added or GVA is a calculation performed via the API. The
value is calculated providing all of these conditions are true:
1. The investment is FDI.
2. The Foreign Equity Investment field has been defined by the user.
3. The Primary Sector field has been defined by the user.

The user is shown a helpful message when either or both 2 & 3 are false.

https://uktrade.atlassian.net/browse/IPBETA-329

**The user needs to complete both fields before GVA can be calculated**

![add-both-foreign-equity-value-and-primary-sector](https://user-images.githubusercontent.com/964268/56664596-4af6ce80-66a0-11e9-9901-ad517e6061e8.png)

**The user needs to complete "Foreign equity investment" before GVA can be calculated**

![add-foreign-equity-investment-value](https://user-images.githubusercontent.com/964268/56664609-4fbb8280-66a0-11e9-9c5e-9d28693e81a4.png)

**The user needs to complete the "Primary sector" before GVA can be calculated**
![add-primary-sector](https://user-images.githubusercontent.com/964268/56664616-534f0980-66a0-11e9-875e-cd7dbcf4d608.png)

**GVA has been calculated**
![gva](https://user-images.githubusercontent.com/964268/56664900-ed16b680-66a0-11e9-9e9b-c6e63e60b48a.png)

![gva-read-only](https://user-images.githubusercontent.com/964268/56665373-d4f36700-66a1-11e9-9284-3bd9fd5747f5.png)

**Checklist**
- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)


