### PR TITLE
Bug adding company with Companies House address

### DIFF
--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -42,14 +42,14 @@
     }
   }) %}
     {% if companiesHouseRecord %}
-      <input type="hidden" name="name" value="{{ formData.name }}">
-      <input type="hidden" name="company_number" value="{{ formData.company_number }}">
-      <input type="hidden" name="registered_address_line_1" value="{{ formData.registered_address_1 }}">
-      <input type="hidden" name="registered_address_line_2" value="{{ formData.registered_address_2 }}">
-      <input type="hidden" name="registered_address_town" value="{{ formData.registered_address_town }}">
-      <input type="hidden" name="registered_address_county" value="{{ formData.registered_address_county }}">
-      <input type="hidden" name="registered_address_postcode" value="{{ formData.registered_address_postcode }}">
-      <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}">
+      <input type="hidden" name="name" value="{{ formData.name }}" data-auto-id="companiesHouseName">
+      <input type="hidden" name="company_number" value="{{ formData.company_number }}" data-auto-id="companiesHouseNumber">
+      <input type="hidden" name="registered_address_1" value="{{ formData.registered_address_1 }}" data-auto-id="companiesHouseAddress1">
+      <input type="hidden" name="registered_address_2" value="{{ formData.registered_address_2 }}" data-auto-id="companiesHouseAddress2">
+      <input type="hidden" name="registered_address_town" value="{{ formData.registered_address_town }}" data-auto-id="companiesHouseAddressTown">
+      <input type="hidden" name="registered_address_county" value="{{ formData.registered_address_county }}" data-auto-id="companiesHouseAddressCounty">
+      <input type="hidden" name="registered_address_postcode" value="{{ formData.registered_address_postcode }}" data-auto-id="companiesHouseAddressPostcode">
+      <input type="hidden" name="registered_address_country" value="{{ formData.registered_address_country }}" data-auto-id="companiesHouseAddressCountry">
     {% else %}
 
       {% if not isEditing %}

--- a/test/functional/cypress/fixtures/ch-company/mercury-trading-ltd.json
+++ b/test/functional/cypress/fixtures/ch-company/mercury-trading-ltd.json
@@ -1,0 +1,4 @@
+{
+  "company_number": "99919",
+  "name": "Mercury Trading Ltd",
+}

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -1,4 +1,7 @@
 module.exports = {
+  chCompany: {
+    mercuryTradingLtd: require('./ch-company/mercury-trading-ltd'),
+  },
   company: {
     archivedLtd: require('./company/archived-ltd.json'),
     dnbCorp: require('./company/dnb-corp.json'),

--- a/test/functional/cypress/selectors/company/add-step-2.js
+++ b/test/functional/cypress/selectors/company/add-step-2.js
@@ -1,0 +1,14 @@
+module.exports = {
+  hiddenFields: {
+    companiesHouse: {
+      name: '[data-auto-id="companiesHouseName"]',
+      number: '[data-auto-id="companiesHouseNumber"]',
+      address1: '[data-auto-id="companiesHouseAddress1"]',
+      address2: '[data-auto-id="companiesHouseAddress2"]',
+      town: '[data-auto-id="companiesHouseAddressTown"]',
+      county: '[data-auto-id="companiesHouseAddressCounty"]',
+      postcode: '[data-auto-id="companiesHouseAddressPostcode"]',
+      country: '[data-auto-id="companiesHouseAddressCountry"]',
+    },
+  },
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -1,4 +1,5 @@
 exports.companyBusinessDetails = require('./company/business-details')
+exports.companyAddStep2 = require('./company/add-step-2')
 exports.companyEdit = require('./company/edit')
 exports.companyInteraction = require('./company/interaction')
 exports.companyInvestment = require('./company/investment')

--- a/test/functional/cypress/specs/companies/add-step-2-spec.js
+++ b/test/functional/cypress/specs/companies/add-step-2-spec.js
@@ -1,0 +1,114 @@
+const fixtures = require('../../fixtures')
+const selectors = require('../../selectors')
+
+describe('Company edit', () => {
+  const commonTests = () => {
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Add business details')
+    })
+
+    it('should render the trading name text field', () => {
+      cy.get(selectors.companyEdit.tradingName).should('be.visible')
+    })
+
+    it('should render the annual turnover radio buttons', () => {
+      cy.get(selectors.companyEdit.annualTurnover[0]).should('be.visible')
+      cy.get(selectors.companyEdit.annualTurnover[1]).should('be.visible')
+      cy.get(selectors.companyEdit.annualTurnover[2]).should('be.visible')
+      cy.get(selectors.companyEdit.annualTurnover[3]).should('be.visible')
+    })
+
+    it('should render the number of employees radio buttons', () => {
+      cy.get(selectors.companyEdit.numberOfEmployees[0]).should('be.visible')
+      cy.get(selectors.companyEdit.numberOfEmployees[1]).should('be.visible')
+      cy.get(selectors.companyEdit.numberOfEmployees[2]).should('be.visible')
+      cy.get(selectors.companyEdit.numberOfEmployees[3]).should('be.visible')
+      cy.get(selectors.companyEdit.numberOfEmployees[4]).should('be.visible')
+    })
+
+    it('should render the website text field', () => {
+      cy.get(selectors.companyEdit.website).should('be.visible')
+    })
+
+    it('should render the business description text field', () => {
+      cy.get(selectors.companyEdit.businessDescription)
+        .should('be.visible')
+    })
+
+    it('should render a save button', () => {
+      cy.get(selectors.companyEdit.saveButton).should('have.text', 'Add company')
+    })
+
+    it('should render a back link', () => {
+      cy.get(selectors.companyEdit.backLink).should('have.text', 'Back')
+      cy.get(selectors.companyEdit.backLink).should('have.attr', 'href', `/companies/add-step-1`)
+    })
+  }
+
+  context('when editing a legacy UK company on the One List', () => {
+    before(() => {
+      cy.visit(`/companies/add/${fixtures.chCompany.mercuryTradingLtd.company_number}`)
+    })
+
+    commonTests()
+
+    it('should render the Companies House number uneditable field', () => {
+      cy.get(selectors.uneditableField('group-field-selected_company_number')).should('have.text', '99919')
+    })
+
+    it('should render the VAT number text field', () => {
+      cy.get(selectors.companyEdit.vatNumber).should('be.visible')
+    })
+
+    it('should render the address fields', () => {
+      cy.get(selectors.companyEdit.address.postcodeLookup)
+        .should('be.visible')
+        .and('have.value', 'LL53 5RN')
+
+      cy.get(selectors.companyEdit.address.line1)
+        .should('be.visible')
+        .and('have.value', '64 Ermin Street')
+
+      cy.get(selectors.companyEdit.address.line2)
+        .should('be.visible')
+        .and('have.value', '')
+
+      cy.get(selectors.companyEdit.address.town)
+        .should('be.visible')
+        .and('have.value', 'Y Ffor')
+
+      cy.get(selectors.companyEdit.address.county)
+        .should('be.visible')
+        .and('have.value', '')
+
+      cy.get(selectors.companyEdit.address.postcode)
+        .should('not.be.visible')
+
+      cy.get(selectors.companyEdit.address.country)
+        .should('not.exist')
+
+      cy.get(selectors.uneditableField('group-field-selected_address_country'))
+        .should('have.text', 'United Kingdom')
+    })
+
+    it('should render the region list', () => {
+      cy.get(selectors.companyEdit.region)
+        .should('be.visible')
+    })
+
+    it('should render the sector list', () => {
+      cy.get(selectors.companyEdit.sector).should('be.visible')
+    })
+
+    it('should render the business hierarchy radio buttons', () => {
+      cy.get(selectors.companyEdit.businessHierarchy[0]).should('be.visible')
+      cy.get(selectors.companyEdit.businessHierarchy[1]).should('be.visible')
+      cy.get(selectors.companyEdit.businessHierarchy[2]).should('be.visible')
+      cy.get(selectors.companyEdit.businessHierarchy[3]).should('be.visible')
+    })
+  })
+})

--- a/test/functional/cypress/specs/companies/add-step-2-spec.js
+++ b/test/functional/cypress/specs/companies/add-step-2-spec.js
@@ -56,6 +56,40 @@ describe('Company edit', () => {
 
     commonTests()
 
+    it('should render the Companies House hidden fields', () => {
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.name)
+        .should('exist')
+        .and('have.value', 'Mercury Trading Ltd')
+
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.number)
+        .should('exist')
+        .and('have.value', '99919')
+
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.address1)
+        .should('exist')
+        .and('have.value', '64 Ermin Street')
+
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.address2)
+        .should('exist')
+        .and('have.value', '')
+
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.town)
+        .should('exist')
+        .and('have.value', 'Y Ffor')
+
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.county)
+        .should('exist')
+        .and('have.value', '')
+
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.postcode)
+        .should('exist')
+        .and('have.value', 'LL53 5RN')
+
+      cy.get(selectors.companyAddStep2.hiddenFields.companiesHouse.country)
+        .should('exist')
+        .and('have.value', '80756b9a-5d95-e211-a939-e4115bead28a')
+    })
+
     it('should render the Companies House number uneditable field', () => {
       cy.get(selectors.uneditableField('group-field-selected_company_number')).should('have.text', '99919')
     })


### PR DESCRIPTION
**Implementation notes**

https://trello.com/c/KEqatPXN/1100-bug-companies-house-address-not-being-added-as-registered-address

This is a regression from a #1888 

## Problem
When adding a company using Companies House data, the registered address is not being added to the company.

## Solution
The hidden address fields were incorrectly named for line 1 and 2.

In addition I have introduced functional tests around company add step 2.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
