### PR TITLE
Remove augmented legacy address fields when getting a DIT company

### DIFF
--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -1,30 +1,9 @@
 /* eslint camelcase: 0, prefer-promise-reject-errors: 0 */
-const { get } = require('lodash')
-
 const config = require('../../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
-// TODO remove this when no dependencies on company.registered_address_* and company.trading_address_*
-const mapDeprecatedAddressFields = (companyAddress, deprecatedAddressPrefix) => {
-  return {
-    [`${deprecatedAddressPrefix}_address_1`]: get(companyAddress, 'line_1'),
-    [`${deprecatedAddressPrefix}_address_2`]: get(companyAddress, 'line_2'),
-    [`${deprecatedAddressPrefix}_address_town`]: get(companyAddress, 'town'),
-    [`${deprecatedAddressPrefix}_address_county`]: get(companyAddress, 'county'),
-    [`${deprecatedAddressPrefix}_address_postcode`]: get(companyAddress, 'postcode'),
-    [`${deprecatedAddressPrefix}_address_country`]: get(companyAddress, 'country'),
-  }
-}
-
 function getDitCompany (token, id) {
   return authorisedRequest(token, `${config.apiRoot}/v4/company/${id}`)
-    .then((company) => {
-      return {
-        ...company,
-        ...mapDeprecatedAddressFields(company.address, 'trading'),
-        ...mapDeprecatedAddressFields(company.registered_address, 'registered'),
-      }
-    })
 }
 
 function getCHCompany (token, id) {

--- a/test/unit/apps/companies/repos.test.js
+++ b/test/unit/apps/companies/repos.test.js
@@ -65,27 +65,7 @@ describe('Company repository', () => {
 
     it('should return company', async () => {
       const company = await getDitCompany('TEST_TOKEN', companyV4Data.id)
-      expect(company).to.deep.equal({
-        ...companyV4Data,
-        'registered_address_1': '82 Ramsgate Rd',
-        'registered_address_2': '',
-        'registered_address_country': {
-          'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-          'name': 'United Kingdom',
-        },
-        'registered_address_county': '',
-        'registered_address_postcode': 'NE28 5JB',
-        'registered_address_town': 'Willington',
-        'trading_address_1': '82 Ramsgate Rd',
-        'trading_address_2': '',
-        'trading_address_country': {
-          'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-          'name': 'United Kingdom',
-        },
-        'trading_address_county': '',
-        'trading_address_postcode': 'NE28 5JB',
-        'trading_address_town': 'Willington',
-      })
+      expect(company).to.deep.equal(companyV4Data)
     })
   })
 


### PR DESCRIPTION
**Implementation notes**

https://trello.com/c/ImTjSMyT/1020-remove-augmentation-of-legacy-address-fields-in-getditcompany

Change removes augmentation of legacy address fields when `GET` `~/v4/company/{id}`. Fields are no longer depended on in the FE code.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
