### PR TITLE
Include inactive advisers

### DIFF
--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -19,7 +19,7 @@ function getAdviser (token, id) {
 }
 
 async function fetchAdviserSearchResults (token, params) {
-  const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}&is_active=${params.is_active}`
+  const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}`
   const adviserResults = await authorisedRequest(token, { url })
   return adviserResults.results
 }

--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -53,7 +53,7 @@ describe('Adviser repository', () => {
     context('when searching for a term', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
-          .get('/adviser/?autocomplete=be&is_active=true')
+          .get('/adviser/?autocomplete=be')
           .reply(200, {
             results: [this.bertSmith],
           })

--- a/test/unit/apps/api/controllers/advisers.test.js
+++ b/test/unit/apps/api/controllers/advisers.test.js
@@ -40,7 +40,7 @@ describe('Adviser options API controller', () => {
   context('when called with a name for an adviser', () => {
     beforeEach(async () => {
       nock(config.apiRoot)
-        .get('/adviser/?autocomplete=be&is_active=true')
+        .get('/adviser/?autocomplete=be')
         .reply(200, {
           results: [this.bertSmith],
         })


### PR DESCRIPTION

![Screenshot 2019-05-02 at 09 37 47](https://user-images.githubusercontent.com/10154302/57064369-fa91f900-6cbd-11e9-9fe0-e7352b7524cd.png)


## Problem
Currently we are filtering out inactive advisers from the adviser search. We would still like to include these advisers and there interactions

## Solution
Remove the param value that goes out to the search API which filters out inactive advisers from the search results.

### Manual test
1. Go to the interaction collection page
2. Search for an adviser that is active in Django
3. In Django switch the adviser to inactive
4. Search again and you should still get the inactive adviser back


**Implementation notes**

_Add any additional information about the change that isn't captured in the Trello ticket._

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
