### PR TITLE
Bug - missing contact adviser breaks interactions

### DIFF
--- a/src/apps/interactions/transformers/interaction-to-list-item.js
+++ b/src/apps/interactions/transformers/interaction-to-list-item.js
@@ -18,11 +18,13 @@ function transformInteractionToListItem (showCompany = true) {
   }) {
     const formatContacts = (contacts) => contacts.length > 1
       ? labels.interaction.multiple_contacts
-      : contacts.map(contact => contact.name)
+      : contacts.map(contact => getContactName(contact))
 
-    const formatParticipantName = (participant) => get(participant, 'team')
+    const getContactName = (contact) => get(contact, 'name') ? contact.name : 'Unknown contact'
+
+    const formatParticipantName = (participant) => (get(participant, 'adviser') && (get(participant, 'team')))
       ? `${participant.adviser.name}, ${participant.team.name}`
-      : participant.adviser.name
+      : get(participant, 'adviser') ? participant.adviser.name : 'Unknown adviser'
 
     const formatParticipants = (dit_participants) => dit_participants.length > 1
       ? labels.interaction.multiple_advisers
@@ -30,7 +32,11 @@ function transformInteractionToListItem (showCompany = true) {
 
     const metaItems = [
       { label: labels.metaItems.type, value: INTERACTION_NAMES[kind], type: 'badge' },
-      { label: labels.metaItems.type, value: was_policy_feedback_provided && INTERACTION_NAMES.policy_feedback, type: 'badge' },
+      {
+        label: labels.metaItems.type,
+        value: was_policy_feedback_provided && INTERACTION_NAMES.policy_feedback,
+        type: 'badge',
+      },
       { label: labels.metaItems.date, value: date, type: 'date' },
       { label: labels.metaItems.contacts, value: contacts && formatContacts(contacts) },
       { label: labels.metaItems.company, value: showCompany && company },

--- a/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-to-list-item.test.js
@@ -1,3 +1,4 @@
+const { find } = require('lodash')
 const transformInteractionToListItem = require('~/src/apps/interactions/transformers/interaction-to-list-item')
 const mockInteraction = require('~/test/unit/data/interactions/search-interaction.json')
 const mockInteractionWithFeedback = require('~/test/unit/data/interactions/search-interaction-with-feedback.json')
@@ -102,6 +103,87 @@ describe('#transformInteractionToListItem', () => {
 
     it('should transform data from interaction response to list item', () => {
       expect(this.transformed).have.property('name', 'No subject')
+    })
+  })
+
+  context('when the source is an interaction with adviser and team name', () => {
+    it('should return adviser name and team', () => {
+      this.transformed = transformInteractionToListItem()({
+        ...mockInteraction,
+        dit_participants: [
+          {
+            adviser: {
+              id: 1,
+              first_name: 'Bob',
+              last_name: 'Lawson',
+              name: 'Bob Lawson',
+            },
+            team: {
+              id: 1,
+              name: 'The test team',
+            },
+          }],
+      })
+      const metadata = this.transformed.meta
+      const adviserName = find(metadata, (item) => item.label === 'Adviser(s)')
+      expect(adviserName.value).to.deep.equal(['Bob Lawson, The test team'])
+    })
+  })
+
+  context('when the source is an interaction with a null team name', () => {
+    it('should return just an adviser name', () => {
+      this.transformed = transformInteractionToListItem()({
+        ...mockInteraction,
+        dit_participants: [
+          {
+            adviser: {
+              id: 1,
+              first_name: 'Bob',
+              last_name: 'Lawson',
+              name: 'Bob Lawson',
+            },
+            team: null,
+          }],
+      })
+      const metadata = this.transformed.meta
+      const adviserName = find(metadata, (item) => item.label === 'Adviser(s)')
+      expect(adviserName.value).to.deep.equal(['Bob Lawson'])
+    })
+  })
+
+  context('when the source is an interaction with a null adviser', () => {
+    it('should return unknown name', () => {
+      this.transformed = transformInteractionToListItem()({
+        ...mockInteraction,
+        dit_participants: [
+          {
+            adviser: null,
+            team: {
+              id: 1,
+              name: 'The test team',
+            },
+          }],
+      })
+      const metadata = this.transformed.meta
+      const adviserName = find(metadata, (item) => item.label === 'Adviser(s)')
+      expect(adviserName.value).to.deep.equal(['Unknown adviser'])
+    })
+  })
+
+  context('when the source is an interaction with a null contact name', () => {
+    it('should return unknown name', () => {
+      this.transformed = transformInteractionToListItem()({
+        ...mockInteraction,
+        contacts: [{
+          id: 'b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306',
+          first_name: 'Jackson',
+          last_name: 'Whitfield',
+          name: null,
+        }],
+      })
+      const metadata = this.transformed.meta
+      const contactName = find(metadata, (item) => item.label === 'Contact(s)')
+      expect(contactName.value).to.deep.equal(['Unknown contact'])
     })
   })
 


### PR DESCRIPTION
## Problem
Some old interactions do not have any advisers attached which is throwing up errors as the function cannot map a null value.

## Solution
Add a guard around this scenario, return a `Unknown name` string in an array so the function does not blow up.

**Implementation notes**

Trello - https://trello.com/c/TKDYrzOl/687-company-page-fails-if-an-interaction-is-missing-a-contact-or-an-adviser

**Checklist**

- [ ] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
