### PR TITLE
Switch export search to v4

### DIFF
--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -112,7 +112,8 @@ function searchLimitedCompanies ({ token, searchTerm, page = 1, limit = 10 }) {
 }
 
 function exportSearch ({ token, searchTerm = '', searchEntity, requestBody }) {
-  const searchUrl = `${config.apiRoot}/v3/search`
+  const apiVersion = searchEntity === 'company' ? 'v4' : 'v3'
+  const searchUrl = `${config.apiRoot}/${apiVersion}/search`
   const options = {
     url: `${searchUrl}/${searchEntity}/export`,
     method: 'POST',

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -1,6 +1,8 @@
 const paths = require('~/src/apps/investments/paths')
 
 module.exports = ({
+  reqMock = {},
+  resMock = {},
   requestBody,
   requestParams = {},
   requestQuery = {},
@@ -17,6 +19,7 @@ module.exports = ({
 }) => {
   return {
     reqMock: {
+      ...reqMock,
       session: {
         token: '1234',
       },
@@ -26,6 +29,7 @@ module.exports = ({
       flash: sinon.spy(),
     },
     resMock: {
+      ...resMock,
       breadcrumb,
       render: sinon.spy(),
       redirect: sinon.spy(),

--- a/test/unit/modules/search/services.test.js
+++ b/test/unit/modules/search/services.test.js
@@ -271,5 +271,44 @@ describe('Search service', () => {
         expect(this.middlewareParameters.resMock.on).to.be.called
       })
     })
+
+    context('when exporting records that are not company', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .post(`/v3/search/entity/export`, {
+            field: true,
+            term: 'search',
+          })
+          .reply(200, {
+            count: 0,
+            results: [],
+            aggregations: [],
+          })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          resMock: {
+            on: sinon.spy(),
+            emit: sinon.spy(),
+            end: sinon.spy(),
+            removeListener: sinon.spy(),
+          },
+        })
+
+        await exportSearch({
+          token: '1234',
+          searchTerm: 'search',
+          searchEntity: 'entity',
+          requestBody: {
+            field: true,
+          },
+        }).then((response) => {
+          response.pipe(this.middlewareParameters.resMock)
+        })
+      })
+
+      it('should return the response', () => {
+        expect(this.middlewareParameters.resMock.on).to.be.called
+      })
+    })
   })
 })

--- a/test/unit/modules/search/services.test.js
+++ b/test/unit/modules/search/services.test.js
@@ -5,7 +5,9 @@ const {
   searchInvestments,
   searchForeignCompanies,
   searchLimitedCompanies,
+  exportSearch,
 } = require('~/src/modules/search/services')
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
 describe('Search service', () => {
   describe('#search', () => {
@@ -226,6 +228,47 @@ describe('Search service', () => {
         count: 0,
         page: 1,
         results: [],
+      })
+    })
+  })
+
+  describe('#exportSearch', () => {
+    context('when exporting company records', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .post(`/v4/search/company/export`, {
+            field: true,
+            term: 'search',
+          })
+          .reply(200, {
+            count: 0,
+            results: [],
+            aggregations: [],
+          })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          resMock: {
+            on: sinon.spy(),
+            emit: sinon.spy(),
+            end: sinon.spy(),
+            removeListener: sinon.spy(),
+          },
+        })
+
+        await exportSearch({
+          token: '1234',
+          searchTerm: 'search',
+          searchEntity: 'company',
+          requestBody: {
+            field: true,
+          },
+        }).then((response) => {
+          response.pipe(this.middlewareParameters.resMock)
+        })
+      })
+
+      it('should return the response', () => {
+        expect(this.middlewareParameters.resMock.on).to.be.called
       })
     })
   })


### PR DESCRIPTION
**Implementation notes**

https://trello.com/c/9NgvNy5r/1119-use-v4-company-search-endpoint

This change introduces unit tests around export search functionality and switches the endpoint to `v4` is exporting `companies`.

Testing of CSV download is good.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
