### PR TITLE
Bug - filter active inactive advisers

### DIFF
--- a/assets/javascripts/vue/typeahead.vue
+++ b/assets/javascripts/vue/typeahead.vue
@@ -143,6 +143,11 @@
         type: Boolean,
         required: false,
         default: true,
+      },
+      hideInactive: {
+        type: Boolean,
+        required: false,
+        default: true,
       }
     },
     created () {
@@ -169,9 +174,9 @@
         hiddenFormValue: this.selectedValue,
         setPlaceHolder: this.placeholder,
         isAsyncFunction: false,
-        isActive: true,
         hasLabel: this.hideLabel,
-        hasSubLabel: this.useSubLabel
+        hasSubLabel: this.useSubLabel,
+        filterInactive: this.hideInactive ? '&is_active=true' : ''
       }
     },
     methods: {
@@ -204,7 +209,7 @@
         if (query.length < 3) {return}
         this.isLoading = true
         this.isAsyncFunction = true
-        axios.get(`/api/options/${this.entity}?autocomplete=${query}&is_active=${this.isActive}`)
+        axios.get(`/api/options/${this.entity}?autocomplete=${query}${this.filterInactive}`)
           .then((response) => {
             this.options = response.data
             this.isLoading = false

--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -19,7 +19,8 @@ function getAdviser (token, id) {
 }
 
 async function fetchAdviserSearchResults (token, params) {
-  const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}`
+  const isActive = params.is_active ? '&is_active=true' : ''
+  const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}${isActive}`
   const adviserResults = await authorisedRequest(token, { url })
   return adviserResults.results
 }

--- a/src/apps/events/macros/event-filters-fields.js
+++ b/src/apps/events/macros/event-filters-fields.js
@@ -16,6 +16,7 @@ const eventFiltersFields = ({ advisers, userAgent }) => {
       classes: 'c-form-group c-form-group--smaller c-form-group--filter',
       placeholder: 'Search organiser',
       options: advisers.map(transformObjectToOption),
+      hideInactive: false,
     },
     {
       macroName: 'DateField',

--- a/src/apps/interactions/macros/collection-filter-fields.js
+++ b/src/apps/interactions/macros/collection-filter-fields.js
@@ -43,6 +43,7 @@ module.exports = function ({
       placeholder: 'Search adviser',
       useSubLabel: false,
       options: adviserOptions,
+      hideInactive: false,
     },
     {
       macroName: 'DateField',

--- a/src/apps/investments/macros.js
+++ b/src/apps/investments/macros.js
@@ -34,6 +34,7 @@ const investmentFiltersFields = function ({ currentAdviserId, sectorOptions, adv
       classes: 'c-form-group c-form-group--smaller c-form-group--filter',
       placeholder: 'Search adviser',
       options: adviserOptions,
+      hideInactive: false,
     },
     {
       macroName: 'MultipleChoiceField',

--- a/src/templates/_macros/form/typeahead.njk
+++ b/src/templates/_macros/form/typeahead.njk
@@ -30,6 +30,9 @@
         {% if props.useSubLabel === false %}
           {% raw %}:{% endraw %}use-sub-label="{{ props.useSubLabel }}"
         {% endif %}
+        {% if props.hideInactive === false %}
+          {% raw %}:{% endraw %}hide-inactive="{{ props.hideInactive }}"
+        {% endif %}
       >
       </typeahead>
     </div>

--- a/test/unit-client/assets/javascripts/vue/typeahead.test.js
+++ b/test/unit-client/assets/javascripts/vue/typeahead.test.js
@@ -191,9 +191,8 @@ describe('Typeahead', () => {
         instance = {
           name: 'adviser',
           entity: 'adviser',
-          multipleSelectOptions: false,
           options: [],
-          isActive: true,
+          filterInactive: '',
         }
         asyncSearch = Typeahead.methods.asyncSearch.bind(instance)
       })
@@ -214,7 +213,7 @@ describe('Typeahead', () => {
 
         it('should have fetched suggestions', () => {
           expect(axios.get).to.have.been.calledOnce
-          expect(axios.get).to.be.calledWith('/api/options/adviser?autocomplete=fred&is_active=true')
+          expect(axios.get).to.be.calledWith('/api/options/adviser?autocomplete=fred')
         })
 
         it('should store the return options', () => {
@@ -239,6 +238,33 @@ describe('Typeahead', () => {
 
         it('should clear the available options', () => {
           expect(instance.options).to.deep.equal([])
+        })
+      })
+
+      context('when choosing to not display inactive advisers', () => {
+        beforeEach((done) => {
+          instance = {
+            name: 'adviser',
+            entity: 'adviser',
+            options: [],
+            filterInactive: '&is_active=true',
+          }
+          asyncSearch = Typeahead.methods.asyncSearch.bind(instance)
+
+          axios.get = sinon.stub().resolves({
+            data: [{
+              value: '1',
+              label: 'Fred Smith',
+              subLabel: 'Dept of commerce',
+            }],
+          })
+
+          asyncSearch('fred')
+          setTimeout(done, 600)
+        })
+        it('should not fetch active users', () => {
+          expect(axios.get).to.have.been.calledOnce
+          expect(axios.get).to.be.calledWith('/api/options/adviser?autocomplete=fred&is_active=true')
         })
       })
     })

--- a/test/unit/apps/adviser/repos.test.js
+++ b/test/unit/apps/adviser/repos.test.js
@@ -53,7 +53,7 @@ describe('Adviser repository', () => {
     context('when searching for a term', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
-          .get('/adviser/?autocomplete=be')
+          .get('/adviser/?autocomplete=be&is_active=true')
           .reply(200, {
             results: [this.bertSmith],
           })

--- a/test/unit/apps/api/controllers/advisers.test.js
+++ b/test/unit/apps/api/controllers/advisers.test.js
@@ -40,7 +40,7 @@ describe('Adviser options API controller', () => {
   context('when called with a name for an adviser', () => {
     beforeEach(async () => {
       nock(config.apiRoot)
-        .get('/adviser/?autocomplete=be')
+        .get('/adviser/?autocomplete=be&is_active=true')
         .reply(200, {
           results: [this.bertSmith],
         })


### PR DESCRIPTION
![Screenshot 2019-05-02 at 09 37 47](https://user-images.githubusercontent.com/10154302/57302758-d0807280-70d3-11e9-9bd5-1a13929d961e.png)

## Problem
Only the adviser filters should return inactive advisers, currently this behaviour has been applied globally.

Trello - https://trello.com/c/vbEYJKwl/720-forms-should-only-search-active-advisers-when-adding-advisers

## Solution
Set a global option for the typeahead to only return active advisers then add the option to return inactive advisers for the filter only.

## Manual test
1. Open Django and find an adviser that is inactive
2. Go on the interactions page and search for this user and you should find him/her
3. Now go to a form page(add interaction) that uses the adviser search and you shouldn't be able to see the inactive adviser when you search.

