### PR TITLE
Add Adviser typeahead to investor details, Large capital profile

### DIFF
--- a/assets/javascripts/vue/typeahead.vue
+++ b/assets/javascripts/vue/typeahead.vue
@@ -221,7 +221,12 @@
     },
     watch: {
       selectedOptions: function (selectedOption) {
-        if (!selectedOption) {this.setPlaceHolder = this.placeholder}
+        if (selectedOption) {
+          this.hiddenFormValue = selectedOption.value
+        } else {
+          this.setPlaceHolder = this.placeholder
+        }
+
         if (!this.autoSubmit) { return }
 
         const form = this.formSelector ? document.querySelector(this.formSelector) : this.$el.closest('form')
@@ -230,9 +235,6 @@
         const query = pickBy(getFormData(form))
         delete query[this.id]
 
-        if (selectedOption) {
-          this.hiddenFormValue = selectedOption.value
-        }
         query[this.name] = Array.isArray(selectedOption) ? selectedOption.map(option => option.value) : [selectedOption]
 
         XHR.request(form.action, query)

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -1,34 +1,35 @@
 const {
   transformProfile,
+  transformAdvisers,
   transformInvestorTypes,
   transformRequiredChecks,
 } = require('../transformers')
 
 const { getOptions } = require('../../../../../../lib/options')
+const { getAdvisers } = require('../../../../../adviser/repos')
 const { getCompanyProfiles } = require('../repos')
 const { INVESTOR_DETAILS } = require('../sections')
 const { get } = require('lodash')
 
-const getInvestorTypes = (token, profile) => {
-  return getOptions(token, 'capital-investment/investor-type')
-    .then((investorTypes) => {
-      return transformInvestorTypes(investorTypes, profile.investorDetails)
-    })
+const getInvestorTypes = async (token, profile) => {
+  const investorTypes = await getOptions(token, 'capital-investment/investor-type')
+  return transformInvestorTypes(investorTypes, profile.investorDetails)
 }
 
-const getRequiredChecks = (token, profile) => {
-  return getOptions(token, 'capital-investment/required-checks-conducted')
-    .then((requiredChecks) => {
-      return transformRequiredChecks(requiredChecks, profile.investorDetails)
-    })
+const getRequiredChecks = async (token, profile) => {
+  const requiredChecks = await getOptions(token, 'capital-investment/required-checks-conducted')
+  return transformRequiredChecks(requiredChecks, profile.investorDetails)
 }
 
-const getCompanyProfile = (token, company, editing) => {
-  return getCompanyProfiles(token, company.id)
-    .then((profiles) => {
-      let profile = profiles.results && profiles.results[0]
-      return profile ? transformProfile(Object.freeze(profile), editing) : profile
-    })
+const getRequiredChecksAdvisers = async (token) => {
+  const advisers = await getAdvisers(token)
+  return transformAdvisers(advisers.results)
+}
+
+const getCompanyProfile = async (token, company, editing) => {
+  const profiles = await getCompanyProfiles(token, company.id)
+  const profile = profiles.results && profiles.results[0]
+  return profile ? transformProfile(Object.freeze(profile), editing) : profile
 }
 
 const renderProfile = async (req, res, next) => {
@@ -42,6 +43,10 @@ const renderProfile = async (req, res, next) => {
     if (get(profile, 'editing') === INVESTOR_DETAILS) {
       profile.investorDetails.investorType.items = await getInvestorTypes(token, profile)
       profile.investorDetails.requiredChecks = await getRequiredChecks(token, profile)
+
+      const advisers = await getRequiredChecksAdvisers(token)
+      profile.investorDetails.requiredChecks.cleared.advisers = advisers
+      profile.investorDetails.requiredChecks.issuesIdentified.advisers = advisers
     }
 
     res.render('companies/apps/investments/large-capital-profile/views/profile', { profile })

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/index.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/index.js
@@ -1,9 +1,10 @@
-const { transformInvestorTypes, transformRequiredChecks } = require('./investor-details-to-form')
+const { transformInvestorTypes, transformRequiredChecks, transformAdvisers } = require('./investor-details-to-form')
 const transformInvestorDetails = require('./investor-details-to-api')
 const transformProfile = require('./transform-profile')
 
 module.exports = {
   transformProfile,
+  transformAdvisers,
   transformInvestorTypes,
   transformRequiredChecks,
   transformInvestorDetails,

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-api.js
@@ -13,6 +13,18 @@ const nullifyIfEmptyString = (value) => {
   return value === '' ? null : value
 }
 
+const getAdviser = ({ conducted, clearedId, issuesIdentifiedId, adviser }) => {
+  if (conducted === clearedId) {
+    return adviser[0]
+  }
+
+  if (conducted === issuesIdentifiedId) {
+    return adviser[1]
+  }
+
+  return null
+}
+
 const transformInvestorDetails = (body) => {
   const {
     investorType,
@@ -28,11 +40,11 @@ const transformInvestorDetails = (body) => {
     investable_capital: nullifyIfEmptyString(investableCapital),
     investor_description: investorDescription,
     required_checks_conducted: conducted,
+  }
 
-    // Note: at present this work is completely hidden from all users.
-    // Temporarily hard-code the company adviser otherwise we are unable to POST into the API.
-    // The next piece of work will address this circumvention by allowing the user to select an adviser.
-    required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // adviser
+  const adviser = getAdviser(body)
+  if (adviser) {
+    investorDetails.required_checks_conducted_by = getAdviser(body)
   }
 
   const requiredChecksDate = getRequiredChecksDate(body, conducted)

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-form.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-form.js
@@ -4,6 +4,7 @@ const moment = require('moment')
 const types = require('../constants')
 
 const transformObjectToOption = ({ value, label }) => ({ value, text: label })
+const transformAdvisersToTypeahead = ({ name, dit_team, id }) => ({ label: name, subLabel: dit_team.name, value: id })
 
 const parseDate = (dateStr) => {
   const date = moment(dateStr, 'YYYY-MM-DD', true)
@@ -47,15 +48,22 @@ const transformRequiredChecks = (requiredChecksMetaData, { requiredChecks }) => 
 
   const selectedType = get(requiredChecks, 'conducted.name')
   if (selectedType === types.CLEARED) {
+    retVal.cleared.adviser = requiredChecks.conductedBy
     retVal.cleared.date = parseDate(requiredChecks.conductedOn)
   } else if (selectedType === types.ISSUES_IDENTIFIED) {
+    retVal.issuesIdentified.adviser = requiredChecks.conductedBy
     retVal.issuesIdentified.date = parseDate(requiredChecks.conductedOn)
   }
 
   return retVal
 }
 
+const transformAdvisers = (advisers) => {
+  return advisers.map(transformAdvisersToTypeahead)
+}
+
 module.exports = {
+  transformAdvisers,
   transformInvestorTypes,
   transformRequiredChecks,
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -23,6 +23,7 @@ const transformProfile = (profile, editing) => {
       requiredChecks: {
         conductedOn: get(profile, 'required_checks_conducted_on'),
         conducted: get(profile, 'required_checks_conducted'),
+        conductedBy: get(profile, 'required_checks_conducted_by'),
       },
     },
     investorRequirements: {

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details-edit.njk
@@ -9,7 +9,9 @@
   action: '/companies/' + company.id + '/investments/large-capital-profile/update',
   hiddenFields: {
     profileId: profile.id,
-    editing: profile.editing
+    editing: profile.editing,
+    clearedId: profile.investorDetails.requiredChecks.cleared.value,
+    issuesIdentifiedId: profile.investorDetails.requiredChecks.issuesIdentified.value
   }
 }) %}
 
@@ -79,6 +81,7 @@
 
   {% macro conditional(props) %}
     {% set date = props.date or {} %}
+
     {{
       govukDateInput({
         namePrefix: props.value,
@@ -111,6 +114,21 @@
             value: date.year
           }
         ]
+      })
+    }}
+
+    {{
+      Typeahead({
+        entity: 'adviser',
+        name: 'adviser',
+        label: 'Person responsible for most recent checks',
+        classes: 'c-form-group--no-filter',
+        autoSubmit: false,
+        isAsync: false,
+        useSubLabel: true,
+        multipleSelect: false,
+        value: props.adviser.id,
+        options: props.advisers
       })
     }}
   {% endmacro %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
@@ -12,6 +12,9 @@
       <span class="task-list__item-complete">
         Date of most recent background checks: {{ profile.investorDetails.requiredChecks.conductedOn | formatDate('DD MM YYYY') }}
       </span>
+      <span class="task-list__item-complete">
+        Person responsible for most recent background checks: {{ profile.investorDetails.requiredChecks.conductedBy.name }}
+      </span>
     {% endif %}
   {%- endcall %}
 </ul>

--- a/src/templates/_macros/form/typeahead.njk
+++ b/src/templates/_macros/form/typeahead.njk
@@ -27,6 +27,9 @@
         {% if props.isAsync === false %}
           {% raw %}:{% endraw %}is-async="{{ props.isAsync }}"
         {% endif %}
+        {% if props.autoSubmit === false %}
+          {% raw %}:{% endraw %}auto-submit="{{ props.autoSubmit }}"
+        {% endif %}
         {% if props.useSubLabel === false %}
           {% raw %}:{% endraw %}use-sub-label="{{ props.useSubLabel }}"
         {% endif %}

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -23,6 +23,11 @@ module.exports = {
       issuesIdentified: '[data-auto-id=requiredChecks] #conducted-2',
       notYetChecked: '[data-auto-id=requiredChecks] #conducted-3',
       notRequired: '[data-auto-id=requiredChecks] #conducted-4',
+      adviser: {
+        placeHolder: '#conditional-conducted-1 .multiselect__tags',
+        textInput: '#conditional-conducted-1 .multiselect__input',
+        selectedOption: '#conditional-conducted-1 .multiselect__single',
+      },
     },
     taskList: {
       investorType: {
@@ -49,6 +54,7 @@ module.exports = {
         name: '[data-auto-id="investorDetails"] ul > li:nth-child(5) .task-list__item-name',
         complete: '[data-auto-id="investorDetails"] ul > li:nth-child(5) .task-list__item-complete',
         completeDate: '[data-auto-id="investorDetails"] ul > li:nth-child(5) span:nth-child(3)',
+        adviser: '[data-auto-id="investorDetails"] ul > li:nth-child(5) span:nth-child(4)',
         incomplete: '[data-auto-id="investorDetails"] ul > li:nth-child(5) .task-list__item-incomplete',
       },
     },

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -177,6 +177,8 @@ describe('Company Investments and Large capital profile', () => {
 
   context('when viewing the "Investor details" section', () => {
     const { investorDetails } = selectors
+    const completeDate = 'Date of most recent background checks: 29 04 2019'
+    const adviser = 'Person responsible for most recent background checks: Aaron Chan'
 
     it('should display all the field values apart from "Investor Description"', () => {
       cy.visit(largeCapitalProfile).get(selectors.investorDetails.summary).click()
@@ -185,17 +187,17 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorDetails.taskList.investableCapital.complete).should('contain', 30000)
         .get(investorDetails.taskList.investorDescription.incomplete).should('contain', 'INCOMPLETE')
         .get(investorDetails.taskList.requiredChecks.complete).should('contain', 'Cleared')
-        .get(investorDetails.taskList.requiredChecks.completeDate).should('contain', 'Date of most recent background checks: 29 04 2019')
+        .get(investorDetails.taskList.requiredChecks.completeDate).should('contain', completeDate)
+        .get(investorDetails.taskList.requiredChecks.adviser).should('contain', adviser)
     })
   })
 
   context('when viewing the "Investor details" edit section', () => {
     const { investorDetails } = selectors
+    const adviser = 'Aaron Chan, British Embassy Manila Philippines'
 
     it('should display all the field values apart from "Investor Description"', () => {
-      cy.visit(largeCapitalProfile)
-        .get(investorDetails.summary).click()
-        .get(investorDetails.edit).click()
+      cy.visit(`${largeCapitalProfile}?editing=investor-details`)
         .get(investorDetails.investorType).should('contain', 'Asset manager')
         .get(investorDetails.globalAssetsUnderManagement).should('have.value', '1000000')
         .get(investorDetails.investableCapital).should('have.value', '30000')
@@ -204,6 +206,21 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorDetails.requiredChecks.clearedDay).should('have.value', '29')
         .get(investorDetails.requiredChecks.clearedMonth).should('have.value', '4')
         .get(investorDetails.requiredChecks.clearedYear).should('have.value', '2019')
+        .get(investorDetails.requiredChecks.adviser.placeHolder).should('contain', adviser)
+    })
+  })
+
+  context('When interacting with the Adviser typeahead', () => {
+    const { investorDetails } = selectors
+
+    it('should be able to select an Adviser', () => {
+      cy.visit(`${largeCapitalProfile}?editing=investor-details`)
+        .get(investorDetails.requiredChecks.adviser.placeHolder).click()
+        .get(investorDetails.requiredChecks.adviser.textInput).type('abby').wait(500)
+        .get(investorDetails.requiredChecks.adviser.textInput).type('{downarrow}')
+        .get(investorDetails.requiredChecks.adviser.textInput).type('{enter}')
+        .get(investorDetails.requiredChecks.adviser.selectedOption)
+        .should('contain', 'Abby Chan, British High Commission Singapore')
     })
   })
 })

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
@@ -4,6 +4,7 @@ const investorType = require('~/test/unit/data/companies/investments/metadata/in
 const requiredChecksConducted = require('~/test/unit/data/companies/investments/metadata/required-checks-conducted.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile.json')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
+const advisersMock = require('~/test/unit/data/advisers/advisers.json')
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 const { cloneDeep, pullAll } = require('lodash')
 const config = require('~/config')
@@ -85,6 +86,7 @@ describe('Company Investments - large capital profile', () => {
           requiredChecks: {
             conducted: null,
             conductedOn: null,
+            conductedBy: null,
           },
         },
         investorRequirements: {
@@ -110,6 +112,9 @@ describe('Company Investments - large capital profile', () => {
         // Define a date the advisor conducted the checks on.
         profile.required_checks_conducted_on = '2019-05-02'
 
+        //  Define the advisor.
+        profile.required_checks_conducted_by = 'a0dae366-1134-e411-985c-e4115bead28a'
+
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
           .reply(200, clonedCompanyProfile)
@@ -117,6 +122,8 @@ describe('Company Investments - large capital profile', () => {
           .reply(200, investorType)
           .get('/metadata/capital-investment/required-checks-conducted/')
           .reply(200, requiredChecksConducted)
+          .get('/adviser/?limit=100000&offset=0')
+          .reply(200, advisersMock)
 
         this.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
@@ -157,9 +164,38 @@ describe('Company Investments - large capital profile', () => {
               name: 'Cleared',
             },
             conductedOn: '2019-05-02',
+            conductedBy: 'a0dae366-1134-e411-985c-e4115bead28a',
             cleared: {
               checked: true,
               text: 'Cleared',
+              adviser: 'a0dae366-1134-e411-985c-e4115bead28a',
+              advisers: [
+                {
+                  label: 'Jeff Smith',
+                  subLabel: 'Team A',
+                  value: 'a0dae366-1134-e411-985c-e4115bead28a',
+                },
+                {
+                  label: 'Aaron Mr',
+                  subLabel: 'Team B',
+                  value: 'e13209b8-8d61-e311-8255-e4115bead28a',
+                },
+                {
+                  label: 'Mr Benjamin',
+                  subLabel: 'Team C',
+                  value: 'b9d6b3dc-7af4-e411-bcbe-e4115bead28a',
+                },
+                {
+                  label: 'George Chan',
+                  subLabel: 'Team D',
+                  value: '0119a99e-9798-e211-a939-e4115bead28a',
+                },
+                {
+                  label: 'Fred Rafters',
+                  subLabel: 'Team E',
+                  value: '0919a99e-9798-e211-a939-e4115bead28a',
+                },
+              ],
               date: {
                 day: 2,
                 month: 5,
@@ -170,6 +206,33 @@ describe('Company Investments - large capital profile', () => {
             issuesIdentified: {
               text: 'Issues identified',
               value: '9beab8fc-1094-49b4-97d0-37bc7a9de631',
+              advisers: [
+                {
+                  label: 'Jeff Smith',
+                  subLabel: 'Team A',
+                  value: 'a0dae366-1134-e411-985c-e4115bead28a',
+                },
+                {
+                  label: 'Aaron Mr',
+                  subLabel: 'Team B',
+                  value: 'e13209b8-8d61-e311-8255-e4115bead28a',
+                },
+                {
+                  label: 'Mr Benjamin',
+                  subLabel: 'Team C',
+                  value: 'b9d6b3dc-7af4-e411-bcbe-e4115bead28a',
+                },
+                {
+                  label: 'George Chan',
+                  subLabel: 'Team D',
+                  value: '0119a99e-9798-e211-a939-e4115bead28a',
+                },
+                {
+                  label: 'Fred Rafters',
+                  subLabel: 'Team E',
+                  value: '0919a99e-9798-e211-a939-e4115bead28a',
+                },
+              ],
             },
             notYetChecked: {
               text: 'Not yet checked',
@@ -212,6 +275,7 @@ describe('Company Investments - large capital profile', () => {
         profile.investor_description = 'Lorem ipsum dolor sit amet.'
         profile.required_checks_conducted = '02d6fc9b-fbb9-4621-b247-d86f2487898e'
         profile.required_checks_conducted_on = '2019-04-29'
+        profile.required_checks_conducted_by = 'a0dae366-1134-e411-985c-e4115bead28a'
 
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -249,6 +313,7 @@ describe('Company Investments - large capital profile', () => {
           requiredChecks: {
             conducted: '02d6fc9b-fbb9-4621-b247-d86f2487898e',
             conductedOn: '2019-04-29',
+            conductedBy: 'a0dae366-1134-e411-985c-e4115bead28a',
           },
         },
         investorRequirements: {

--- a/test/unit/apps/companies/controllers/investments/transformers/investor-details-to-api.test.js
+++ b/test/unit/apps/companies/controllers/investments/transformers/investor-details-to-api.test.js
@@ -11,6 +11,10 @@ describe('Large capital profile, Investor details form to API', () => {
         investableCapital: '',
         investorDescription: '',
         conducted: '',
+        adviser: [ '', '' ],
+        // Hidden fields
+        clearedId: '1',
+        issuesIdentifiedId: '2',
       })
       expect(this.transformed).to.deep.equal({
         investor_type: '',
@@ -18,7 +22,6 @@ describe('Large capital profile, Investor details form to API', () => {
         investable_capital: null,
         investor_description: '',
         required_checks_conducted: '',
-        required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // Hard-coded Adviser id.
       })
     })
 
@@ -29,9 +32,13 @@ describe('Large capital profile, Investor details form to API', () => {
         investableCapital: '100000',
         investorDescription: 'Lorem ipsum dolor sit amet',
         conducted: '1', // Cleared id
+        adviser: [ 'a80ff5fd-8904-4940-bf96-fe8047e34be5', '' ],
         '1-day': '02',
         '1-month': '05',
         '1-year': '2019',
+        // Hidden fields
+        clearedId: '1',
+        issuesIdentifiedId: '2',
       })
       expect(this.transformed).to.deep.equal({
         investor_type: 'assetManagerId',
@@ -39,8 +46,8 @@ describe('Large capital profile, Investor details form to API', () => {
         investable_capital: '100000',
         investor_description: 'Lorem ipsum dolor sit amet',
         required_checks_conducted: '1', // Cleared id
-        required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // Hard-coded Adviser id.
         required_checks_conducted_on: '2019-05-02', // Date the checks were conducted on
+        required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // Adviser id
       })
     })
 
@@ -51,9 +58,13 @@ describe('Large capital profile, Investor details form to API', () => {
         investableCapital: '100000',
         investorDescription: 'Lorem ipsum dolor sit amet',
         conducted: '2', // Issues identified id
+        adviser: [ '', 'a80ff5fd-8904-4940-bf96-fe8047e34be5' ],
         '2-day': '03',
         '2-month': '05',
         '2-year': '2019',
+        // Hidden fields
+        clearedId: '1',
+        issuesIdentifiedId: '2',
       })
       expect(this.transformed).to.deep.equal({
         investor_type: 'assetManagerId',
@@ -61,8 +72,8 @@ describe('Large capital profile, Investor details form to API', () => {
         investable_capital: '100000',
         investor_description: 'Lorem ipsum dolor sit amet',
         required_checks_conducted: '2', // Issues identified id
-        required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // Hard-coded Adviser id.
         required_checks_conducted_on: '2019-05-03', // Date the checks were conducted on
+        required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // Adviser id.
       })
     })
 
@@ -80,7 +91,6 @@ describe('Large capital profile, Investor details form to API', () => {
         investable_capital: '100000',
         investor_description: 'Lorem ipsum dolor sit amet',
         required_checks_conducted: '3', // Not yet checked id
-        required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // Hard-coded Adviser id.
       })
     })
 
@@ -98,7 +108,6 @@ describe('Large capital profile, Investor details form to API', () => {
         investable_capital: '100000',
         investor_description: 'Lorem ipsum dolor sit amet',
         required_checks_conducted: '4', // Checks not required id
-        required_checks_conducted_by: 'a80ff5fd-8904-4940-bf96-fe8047e34be5', // Hard-coded Adviser id.
       })
     })
   })

--- a/test/unit/apps/companies/controllers/investments/transformers/investor-details-to-form.test.js
+++ b/test/unit/apps/companies/controllers/investments/transformers/investor-details-to-form.test.js
@@ -64,6 +64,7 @@ describe('Large capital profile, Investor details API to form', () => {
             id: '1',
           },
           conductedOn: '2019-05-01',
+          conductedBy: '123', // Adviser id.
         },
       }
 
@@ -75,7 +76,9 @@ describe('Large capital profile, Investor details API to form', () => {
           id: '1',
         },
         conductedOn: '2019-05-01',
+        conductedBy: '123', // Adviser id.
         cleared: {
+          adviser: '123',
           checked: true,
           text: 'Cleared',
           value: '1',
@@ -108,6 +111,7 @@ describe('Large capital profile, Investor details API to form', () => {
             id: '2',
           },
           conductedOn: '2019-05-02',
+          conductedBy: '123', // Adviser id.
         },
       }
 
@@ -119,11 +123,13 @@ describe('Large capital profile, Investor details API to form', () => {
           id: '2',
         },
         conductedOn: '2019-05-02',
+        conductedBy: '123', // Adviser id.
         cleared: {
           text: 'Cleared',
           value: '1',
         },
         issuesIdentified: {
+          adviser: '123',
           checked: true,
           date: {
             day: 2,


### PR DESCRIPTION
**Testing url:** /companies/375094ac-f79a-43e5-9c88-059a7caa17f0/investments/large-capital-profile

* Edit section:
  Adding an Adviser typeahead allowing the user to select someone who has
  performed the required checks within the last 12 months. This field
  lives in Companies, Large capital profile, investor details.

* Read-only section:
  Adding a read-only label so the user knows who has performed the
  required checks.

https://uktrade.atlassian.net/browse/IPBETA-270

**Editing**

<img width="1154" alt="editing" src="https://user-images.githubusercontent.com/964268/57447267-9a1b3280-724e-11e9-831c-ba6c6b239d29.png">

**Edit selection**

<img width="1154" alt="adviser-edit" src="https://user-images.githubusercontent.com/964268/57446967-d4380480-724d-11e9-9591-ed2842e45a77.png">

**Read-only View**

<img width="1154" alt="adviser-read-only" src="https://user-images.githubusercontent.com/964268/57447046-05b0d000-724e-11e9-8347-e56c5fcf6410.png">

**Checklist**
- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
