### PR TITLE
Revert country of origin filter to previous

### DIFF
--- a/src/apps/investments/constants.js
+++ b/src/apps/investments/constants.js
@@ -84,7 +84,7 @@ const QUERY_FIELDS = [
   'status',
   'adviser',
   'sector_descends',
-  'country_investment_originates_from',
+  'investor_company_country',
   'uk_region_location',
   'stage',
   'investment_type',

--- a/src/apps/investments/labels.js
+++ b/src/apps/investments/labels.js
@@ -141,7 +141,7 @@ const labels = {
       level_of_involvement_simplified: 'Level of involvement specified',
       status: 'Status',
       uk_region_location: 'UK Region',
-      country_investment_originates_from: 'Country of origin',
+      investor_company_country: 'Country of origin',
       likelihood_to_land: 'Likelihood to land',
     },
   },

--- a/src/apps/investments/macros.js
+++ b/src/apps/investments/macros.js
@@ -45,7 +45,7 @@ const investmentFiltersFields = function ({ currentAdviserId, sectorOptions, adv
     },
     {
       macroName: 'MultipleChoiceField',
-      name: 'country_investment_originates_from',
+      name: 'investor_company_country',
       type: 'checkbox',
       modifier: 'option-select',
       options () {


### PR DESCRIPTION
**Implementation notes**
Previous applied changes with [1900](https://github.com/uktrade/data-hub-frontend/pull/1900) were ok but unfortunately changes were not communicate on time which led to errors on links in the FDI dashboard. We have to revert those changes asap and applied them back on later time

**Checklist**

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
