### PR TITLE
Simplify the semantics of required checks within Large capital profile

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-form.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-form.js
@@ -34,28 +34,31 @@ const transformInvestorTypes = (investorTypes, { investorType }) => {
 const transformRequiredChecks = (requiredChecksMetaData, { requiredChecks }) => {
   const radioButtons = requiredChecksMetaData.map(transformObjectToOption)
 
-  if (requiredChecks.conducted) {
-    find(radioButtons, (item) => item.value === requiredChecks.conducted.id).checked = true
-  }
-
-  const retVal = {
-    ...requiredChecks,
+  const transformed = {
     cleared: find(radioButtons, item => item.text === types.CLEARED),
     issuesIdentified: find(radioButtons, item => item.text === types.ISSUES_IDENTIFIED),
     notYetChecked: find(radioButtons, item => item.text === types.NOT_YET_CHECKED),
     notRequired: find(radioButtons, item => item.text === types.CHECKS_NOT_REQUIRED),
   }
 
-  const selectedType = get(requiredChecks, 'conducted.name')
-  if (selectedType === types.CLEARED) {
-    retVal.cleared.adviser = requiredChecks.conductedBy
-    retVal.cleared.date = parseDate(requiredChecks.conductedOn)
-  } else if (selectedType === types.ISSUES_IDENTIFIED) {
-    retVal.issuesIdentified.adviser = requiredChecks.conductedBy
-    retVal.issuesIdentified.date = parseDate(requiredChecks.conductedOn)
+  const type = get(requiredChecks, 'type.name')
+
+  if (type === types.CLEARED) {
+    transformed.cleared.adviser = requiredChecks.adviser
+    transformed.cleared.date = parseDate(requiredChecks.date)
   }
 
-  return retVal
+  if (type === types.ISSUES_IDENTIFIED) {
+    transformed.issuesIdentified.adviser = requiredChecks.adviser
+    transformed.issuesIdentified.date = parseDate(requiredChecks.date)
+  }
+
+  const id = get(requiredChecks, 'type.id')
+  if (id) {
+    find(radioButtons, (item) => item.value === id).checked = true
+  }
+
+  return transformed
 }
 
 const transformAdvisers = (advisers) => {

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -1,5 +1,36 @@
 /* eslint-disable camelcase */
+const { formatDate } = require('../../../../../../../config/nunjucks/filters')
+const { CLEARED, ISSUES_IDENTIFIED } = require('../constants')
 const { get } = require('lodash')
+
+const getRequiredChecksDetails = (type, date, adviser) => {
+  const details = [ type.name ]
+
+  if (type.name === CLEARED || type.name === ISSUES_IDENTIFIED) {
+    details.push(`Date of most recent background checks: ${formatDate(date, 'DD MM YYYY')}`)
+    details.push(`Person responsible for most recent background checks: ${adviser.name}`)
+  }
+
+  return details
+}
+
+const transformRequiredChecks = (profile) => {
+  const type = get(profile, 'required_checks_conducted')
+  const date = get(profile, 'required_checks_conducted_on')
+  const adviser = get(profile, 'required_checks_conducted_by')
+
+  let value = null
+  if (type) {
+    value = getRequiredChecksDetails(type, date, adviser)
+  }
+
+  return {
+    type,
+    date,
+    adviser,
+    value,
+  }
+}
 
 const transformProfile = (profile, editing) => {
   return {
@@ -20,11 +51,7 @@ const transformProfile = (profile, editing) => {
       investorDescription: {
         value: get(profile, 'investor_description'),
       },
-      requiredChecks: {
-        conductedOn: get(profile, 'required_checks_conducted_on'),
-        conducted: get(profile, 'required_checks_conducted'),
-        conductedBy: get(profile, 'required_checks_conducted_by'),
-      },
+      requiredChecks: transformRequiredChecks(profile),
     },
     investorRequirements: {
       incompleteFields: get(profile, 'incomplete_requirements_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/details.njk
@@ -3,20 +3,7 @@
   {{ taskListItem({ name: 'Global assets under management', value: profile.investorDetails.globalAssetsUnderManagement.value }) }}
   {{ taskListItem({ name: 'Investable capital', value: profile.investorDetails.investableCapital.value }) }}
   {{ taskListItem({ name: 'Investor description', value: profile.investorDetails.investorDescription.value }) }}
-  {% call taskListItem({
-      name: 'Has this investor cleared the required checks within the last 12 months?',
-      value: profile.investorDetails.requiredChecks.conducted.name
-    })
-  %}
-    {% if profile.investorDetails.requiredChecks.conductedOn %}
-      <span class="task-list__item-complete">
-        Date of most recent background checks: {{ profile.investorDetails.requiredChecks.conductedOn | formatDate('DD MM YYYY') }}
-      </span>
-      <span class="task-list__item-complete">
-        Person responsible for most recent background checks: {{ profile.investorDetails.requiredChecks.conductedBy.name }}
-      </span>
-    {% endif %}
-  {%- endcall %}
+  {{ taskListItem({ name: 'Has this investor cleared the required checks within the last 12 months?', value: profile.investorDetails.requiredChecks.value }) }}
 </ul>
 
 {% call Form({

--- a/src/apps/companies/apps/investments/macros/tasklist/tasklist.njk
+++ b/src/apps/companies/apps/investments/macros/tasklist/tasklist.njk
@@ -7,8 +7,17 @@
       {{ props.name }}
     </span>
     {% if isComplete %}
-      <span class="task-list__item-complete">{{ props.value }}</span>
-      {{ caller() if caller }}
+      {% if props.value | isArray %}
+        {% for item in props.value %}
+          <span class="task-list__item-complete">{{ item }}</span>
+        {% endfor %}
+      {% elif props.value | isPlainObject %}
+        {% for key, value in props.value %}
+          <span class="task-list__item-complete">{{ value }}</span>
+        {% endfor %}
+      {% else %}
+          <span class="task-list__item-complete">{{ props.value }}</span>
+      {% endif %}
     {% else %}
       <strong class="task-list__item-incomplete" id="{{ id | kebabCase }}-incomplete">INCOMPLETE</strong>
     {% endif %}

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile.test.js
@@ -84,9 +84,10 @@ describe('Company Investments - large capital profile', () => {
             value: '',
           },
           requiredChecks: {
-            conducted: null,
-            conductedOn: null,
-            conductedBy: null,
+            adviser: null,
+            date: null,
+            type: null,
+            value: null,
           },
         },
         investorRequirements: {
@@ -113,7 +114,10 @@ describe('Company Investments - large capital profile', () => {
         profile.required_checks_conducted_on = '2019-05-02'
 
         //  Define the advisor.
-        profile.required_checks_conducted_by = 'a0dae366-1134-e411-985c-e4115bead28a'
+        profile.required_checks_conducted_by = {
+          name: 'Holly Collins',
+          id: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
+        }
 
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -159,16 +163,13 @@ describe('Company Investments - large capital profile', () => {
             value: '',
           },
           requiredChecks: {
-            conducted: {
-              id: '02d6fc9b-fbb9-4621-b247-d86f2487898e',
-              name: 'Cleared',
-            },
-            conductedOn: '2019-05-02',
-            conductedBy: 'a0dae366-1134-e411-985c-e4115bead28a',
             cleared: {
               checked: true,
               text: 'Cleared',
-              adviser: 'a0dae366-1134-e411-985c-e4115bead28a',
+              adviser: {
+                name: 'Holly Collins',
+                id: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
+              },
               advisers: [
                 {
                   label: 'Jeff Smith',
@@ -273,9 +274,15 @@ describe('Company Investments - large capital profile', () => {
         profile.global_assets_under_management = 1000
         profile.investable_capital = 2000
         profile.investor_description = 'Lorem ipsum dolor sit amet.'
-        profile.required_checks_conducted = '02d6fc9b-fbb9-4621-b247-d86f2487898e'
+        profile.required_checks_conducted = {
+          name: 'Cleared',
+          id: '02d6fc9b-fbb9-4621-b247-d86f2487898e',
+        }
+        profile.required_checks_conducted_by = {
+          name: 'Holly Collins',
+          id: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
+        }
         profile.required_checks_conducted_on = '2019-04-29'
-        profile.required_checks_conducted_by = 'a0dae366-1134-e411-985c-e4115bead28a'
 
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
@@ -311,9 +318,20 @@ describe('Company Investments - large capital profile', () => {
             value: 'Lorem ipsum dolor sit amet.',
           },
           requiredChecks: {
-            conducted: '02d6fc9b-fbb9-4621-b247-d86f2487898e',
-            conductedOn: '2019-04-29',
-            conductedBy: 'a0dae366-1134-e411-985c-e4115bead28a',
+            type: {
+              id: '02d6fc9b-fbb9-4621-b247-d86f2487898e',
+              name: 'Cleared',
+            },
+            date: '2019-04-29',
+            adviser: {
+              id: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
+              name: 'Holly Collins',
+            },
+            value: [
+              'Cleared',
+              'Date of most recent background checks: 29 04 2019',
+              'Person responsible for most recent background checks: Holly Collins',
+            ],
           },
         },
         investorRequirements: {

--- a/test/unit/apps/companies/controllers/investments/transformers/investor-details-to-form.test.js
+++ b/test/unit/apps/companies/controllers/investments/transformers/investor-details-to-form.test.js
@@ -59,29 +59,29 @@ describe('Large capital profile, Investor details API to form', () => {
     it('should transform the required checks when the user selects "Cleared"', () => {
       this.investorDetails = {
         requiredChecks: {
-          conducted: {
+          type: {
             name: 'Cleared',
             id: '1',
           },
-          conductedOn: '2019-05-01',
-          conductedBy: '123', // Adviser id.
+          date: '2019-05-01',
+          adviser: {
+            name: 'Holly',
+            id: '123',
+          },
         },
       }
 
       this.transformed = transformRequiredChecks(this.requiredChecks, this.investorDetails)
 
       expect(this.transformed).to.deep.equal({
-        conducted: {
-          name: 'Cleared',
-          id: '1',
-        },
-        conductedOn: '2019-05-01',
-        conductedBy: '123', // Adviser id.
         cleared: {
-          adviser: '123',
           checked: true,
           text: 'Cleared',
           value: '1',
+          adviser: {
+            name: 'Holly',
+            id: '123',
+          },
           date: {
             day: 1,
             month: 5,
@@ -106,38 +106,38 @@ describe('Large capital profile, Investor details API to form', () => {
     it('should transform the required checks when the user selects "Issues identified"', () => {
       this.investorDetails = {
         requiredChecks: {
-          conducted: {
+          type: {
             name: 'Issues identified',
             id: '2',
           },
-          conductedOn: '2019-05-02',
-          conductedBy: '123', // Adviser id.
+          date: '2019-05-02',
+          adviser: {
+            name: 'Holly',
+            id: '123',
+          },
         },
       }
 
       this.transformed = transformRequiredChecks(this.requiredChecks, this.investorDetails)
 
       expect(this.transformed).to.deep.equal({
-        conducted: {
-          name: 'Issues identified',
-          id: '2',
-        },
-        conductedOn: '2019-05-02',
-        conductedBy: '123', // Adviser id.
         cleared: {
           text: 'Cleared',
           value: '1',
         },
         issuesIdentified: {
-          adviser: '123',
           checked: true,
+          text: 'Issues identified',
+          value: '2',
+          adviser: {
+            id: '123',
+            name: 'Holly',
+          },
           date: {
             day: 2,
             month: 5,
             year: 2019,
           },
-          text: 'Issues identified',
-          value: '2',
         },
         notRequired: {
           text: 'Checks not required - See Investor Screening Report (ISR) guidance',
@@ -153,7 +153,7 @@ describe('Large capital profile, Investor details API to form', () => {
     it('should transform the required checks when the user selects "Checks not required..."', () => {
       this.investorDetails = {
         requiredChecks: {
-          conducted: {
+          type: {
             name: 'Checks not required - See Investor Screening Report (ISR) guidance',
             id: '3',
           },
@@ -163,10 +163,6 @@ describe('Large capital profile, Investor details API to form', () => {
       this.transformed = transformRequiredChecks(this.requiredChecks, this.investorDetails)
 
       expect(this.transformed).to.deep.equal({
-        conducted: {
-          name: 'Checks not required - See Investor Screening Report (ISR) guidance',
-          id: '3',
-        },
         cleared: {
           text: 'Cleared',
           value: '1',
@@ -190,7 +186,7 @@ describe('Large capital profile, Investor details API to form', () => {
     it('should transform the required checks when the user selects "Not yet checked"', () => {
       this.investorDetails = {
         requiredChecks: {
-          conducted: {
+          type: {
             name: 'Not yet checked',
             id: '4',
           },
@@ -200,10 +196,6 @@ describe('Large capital profile, Investor details API to form', () => {
       this.transformed = transformRequiredChecks(this.requiredChecks, this.investorDetails)
 
       expect(this.transformed).to.deep.equal({
-        conducted: {
-          name: 'Not yet checked',
-          id: '4',
-        },
         cleared: {
           text: 'Cleared',
           value: '1',


### PR DESCRIPTION
Moved away from the API notation of:
  - required_checks_conducted
  - required_checks_conducted_on
  - required_checks_conducted_by

  to:

   ` requiredChecks: {
        type: 'Cleared'
        date: '2019-05-12'
        adviser: 'id'
    }`


Improved the taskListItem macro so it has the ability to display an
array of strings or values defined within a plain object, previously
it could only handle strings. The required checks above now passes an
array of strings to display its details keeping the macro caller tidy
and easier to read. This change paves the way for future work around
a multitude of checkboxes.

https://uktrade.atlassian.net/browse/IPBETA-272

**Implementation notes**
There are no visual changes.

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
