### PR TITLE
No theme being set when adding an event attendee

### DIFF
--- a/src/apps/events/attendees/controllers/create.js
+++ b/src/apps/events/attendees/controllers/create.js
@@ -32,6 +32,7 @@ async function createAttendee (req, res, next) {
       event: event.id,
       is_event: true,
       kind: 'service_delivery',
+      theme: 'other',
       service: get(event, 'service.id'),
       subject: `Attended ${event.name}`,
       was_policy_feedback_provided: false,

--- a/test/unit/apps/events/attendees/controllers/create.test.js
+++ b/test/unit/apps/events/attendees/controllers/create.test.js
@@ -49,6 +49,7 @@ describe('Create attendee controller', () => {
           event: '31a9f8bd-7796-4af4-8f8c-25450860e2d1',
           is_event: true,
           kind: 'service_delivery',
+          theme: 'other',
           service: '9484b82b-3499-e211-a939-e4115bead28a',
           subject: 'Attended A United Kingdom Get together',
           was_policy_feedback_provided: false,


### PR DESCRIPTION
## Problem
When adding an event attendee to an event you automatically create a service delivery. When posting this interaction to the API we are not setting the theme to `other` and as a result we are getting null values against recorded interactions.

```
<null>    263
investment    479
export    1884
other    672
```
![Screenshot 2019-05-14 at 12 38 38](https://user-images.githubusercontent.com/10154302/57698797-578e9700-764e-11e9-9241-87b7ceaf53b1.png)

## Solution
Set the theme value to `other` when creating an event attendee
![Screenshot 2019-05-14 at 12 40 16](https://user-images.githubusercontent.com/10154302/57698829-6a08d080-764e-11e9-97e1-05632104f3a0.png)


**Implementation notes**

_Add any additional information about the change that isn't captured in the Trello ticket._

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
