### PR TITLE
Added 8 new checkboxes that allow a user to add the Investment type.

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -1,9 +1,9 @@
 const {
   transformProfile,
   transformAdvisers,
+  transformCheckboxes,
   transformInvestorTypes,
   transformRequiredChecks,
-  transformDealTicketSizes,
 } = require('../transformers')
 
 const { getOptions } = require('../../../../../../lib/options')
@@ -29,7 +29,12 @@ const getRequiredChecksAdvisers = async (token) => {
 
 const getDealTicketSizes = async (token, profile) => {
   const dealTicketSizes = await getOptions(token, 'capital-investment/deal-ticket-size', { sorted: false })
-  return transformDealTicketSizes(dealTicketSizes, profile.investorRequirements)
+  return transformCheckboxes(dealTicketSizes, profile.investorRequirements.dealTicketSizes)
+}
+
+const getInvestmentTypes = async (token, profile) => {
+  const investmentType = await getOptions(token, 'capital-investment/large-capital-investment-type')
+  return transformCheckboxes(investmentType, profile.investorRequirements.investmentTypes)
 }
 
 const getCompanyProfile = async (token, company, editing) => {
@@ -55,6 +60,7 @@ const renderProfile = async (req, res, next) => {
       profile.investorDetails.requiredChecks.issuesIdentified.advisers = advisers
     } else if (editType === INVESTOR_REQUIREMENTS) {
       profile.investorRequirements.dealTicketSizes.items = await getDealTicketSizes(token, profile)
+      profile.investorRequirements.investmentTypes.items = await getInvestmentTypes(token, profile)
     }
 
     res.render('companies/apps/investments/large-capital-profile/views/profile', { profile })

--- a/src/apps/companies/apps/investments/large-capital-profile/styles.scss
+++ b/src/apps/companies/apps/investments/large-capital-profile/styles.scss
@@ -1,3 +1,9 @@
+@mixin flexWrap() {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+
 nav.sub-navigation {
   border-bottom: 1px solid #c6c8c8;
   @include govuk-responsive-margin(4, "bottom");
@@ -43,12 +49,14 @@ nav.govuk-tabs {
     width: 75%;
   }
   form.investor-requirements-edit  {
-   .deal-ticket-sizes {
-     width: 660px;
-     height: 152px;
-     display: flex;
-     flex-direction: column;
-     flex-wrap: wrap;
-   }
+    .deal-ticket-sizes {
+      @include flexWrap;
+      width: 660px;
+      height: 152px;
+    }
+    .types-of-investment {
+      @include flexWrap;
+      height: 205px;
+    }
   }
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/index.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/index.js
@@ -1,5 +1,5 @@
 const { transformInvestorTypes, transformRequiredChecks, transformAdvisers } = require('./investor-details-to-form')
-const { transformDealTicketSizes } = require('./investor-requirements-to-form')
+const { transformCheckboxes } = require('./investor-requirements-to-form')
 const transformInvestorDetails = require('./investor-details-to-api')
 const transformInvestorRequirements = require('./investor-requirements-to-api')
 const transformProfile = require('./transform-profile')
@@ -7,9 +7,9 @@ const transformProfile = require('./transform-profile')
 module.exports = {
   transformProfile,
   transformAdvisers,
+  transformCheckboxes,
   transformInvestorTypes,
   transformRequiredChecks,
   transformInvestorDetails,
-  transformDealTicketSizes,
   transformInvestorRequirements,
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
@@ -3,6 +3,7 @@ const { sanitizeCheckboxes } = require('../../utils/transformers')
 const transformInvestorRequirements = (body) => {
   return {
     deal_ticket_sizes: sanitizeCheckboxes(body.dealTicketSizes),
+    investment_types: sanitizeCheckboxes(body.investmentTypes),
   }
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-form.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-form.js
@@ -1,15 +1,12 @@
 /* eslint-disable camelcase */
-const {
-  transformObjectToOption,
-  checkMatchingItemById,
-} = require('../../utils/transformers')
+const { transformObjectToOption, checkMatchingItemById } = require('../../utils/transformers')
 
-const transformDealTicketSizes = (dealTicketSizesMetaData, { dealTicketSizes }) => {
-  return dealTicketSizesMetaData
+const transformCheckboxes = (metaData, obj) => {
+  return metaData
     .map(transformObjectToOption)
-    .map(checkMatchingItemById(dealTicketSizes.value))
+    .map(checkMatchingItemById(obj.value))
 }
 
 module.exports = {
-  transformDealTicketSizes,
+  transformCheckboxes,
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -58,6 +58,9 @@ const transformProfile = (profile, editing) => {
       dealTicketSizes: {
         value: get(profile, 'deal_ticket_sizes'),
       },
+      investmentTypes: {
+        value: get(profile, 'investment_types'),
+      },
     },
     location: {
       incompleteFields: get(profile, 'incomplete_location_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
@@ -28,6 +28,23 @@
     })
   }}
 
-{% endcall %}
+  <p>Placeholder - Asset classes of interest</p>
 
-{#<pre>{{ profile.investorRequirements.dealTicketSizes.value | dump(2) }}</pre>#}
+  {{
+    govukCheckboxes({
+      name: "investmentTypes",
+      classes: 'types-of-investment',
+      fieldset: {
+        attributes: {
+          'data-auto-id': 'investmentTypes'
+        },
+        legend: {
+          text: "Types of investment",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: profile.investorRequirements.investmentTypes.items
+    })
+  }}
+
+{% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
@@ -1,7 +1,7 @@
 <ul class="task-list">
   {{ taskListItem({ name: 'Deal ticket size', value: profile.investorRequirements.dealTicketSizes.value, key: 'name'}) }}
   {{ taskListItem({ name: 'Asset classes of interest' }) }}
-  {{ taskListItem({ name: 'Types of investment' }) }}
+  {{ taskListItem({ name: 'Types of investment',  value: profile.investorRequirements.investmentTypes.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Minimum return rate' }) }}
   {{ taskListItem({ name: 'Time horizon / tenor' }) }}
   {{ taskListItem({ name: 'Restrictions / conditions' }) }}

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -65,12 +65,24 @@ module.exports = {
     edit: '[data-auto-id=investorRequirementsEdit]',
     save: '[data-auto-id=investorRequirementsSave]',
     dealTicketSize: {
+      name: '[data-auto-id=dealTicketSizes] legend',
       upTo49Million: '[data-auto-id=dealTicketSizes] #dealTicketSizes-1',
       fiftyTo99Million: '[data-auto-id=dealTicketSizes] #dealTicketSizes-2',
       oneHundredTo249Million: '[data-auto-id=dealTicketSizes] #dealTicketSizes-3',
       twoHundredFiftyTo499Million: '[data-auto-id=dealTicketSizes] #dealTicketSizes-4',
       fiveHundredTo999Million: '[data-auto-id=dealTicketSizes] #dealTicketSizes-5',
       oneBillionPlus: '[data-auto-id=dealTicketSizes] #dealTicketSizes-6',
+    },
+    investmentTypes: {
+      name: '[data-auto-id=investmentTypes] legend',
+      projectEquity: '[data-auto-id=investmentTypes] #investmentTypes-1',
+      projectDebt: '[data-auto-id=investmentTypes] #investmentTypes-2',
+      corporateEquity: '[data-auto-id=investmentTypes] #investmentTypes-3',
+      corporateDebt: '[data-auto-id=investmentTypes] #investmentTypes-4',
+      mezzanineDebt: '[data-auto-id=investmentTypes] #investmentTypes-5',
+      ventureCapitalFunds: '[data-auto-id=investmentTypes] #investmentTypes-6',
+      energyInfrastructure: '[data-auto-id=investmentTypes] #investmentTypes-7',
+      privateEquity: '[data-auto-id=investmentTypes] #investmentTypes-8',
     },
     taskList: {
       dealTicketSize: {
@@ -87,9 +99,17 @@ module.exports = {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(2) .task-list__item-name',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(2) .task-list__item-incomplete',
       },
-      typesOfInvestment: {
+      investmentTypes: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(3) .task-list__item-name',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(3) .task-list__item-incomplete',
+        projectEquity: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(2)',
+        projectDebt: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(3)',
+        corporateEquity: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(4)',
+        corporateDebt: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(5)',
+        mezzanineDebt: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(6)',
+        ventureCapitalFunds: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(7)',
+        energyInfrastructure: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(8)',
+        privateEquity: '[data-auto-id=investorRequirements] ul > li:nth-child(3) span:nth-child(9)',
       },
       minimumReturnRate: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(4) .task-list__item-name',

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -230,14 +230,28 @@ describe('Company Investments and Large capital profile', () => {
   context('when viewing the "Investor requirements" edit section', () => {
     const { investorRequirements } = selectors
 
-    it('should select all "Deal ticket sizes"', () => {
+    it('should display "Deal ticket size" and all checkboxes should be checked', () => {
       cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
+        .get(investorRequirements.dealTicketSize.name).should('contain', 'Deal ticket size')
         .get(investorRequirements.dealTicketSize.upTo49Million).should('be.checked')
         .get(investorRequirements.dealTicketSize.fiftyTo99Million).should('be.checked')
         .get(investorRequirements.dealTicketSize.oneHundredTo249Million).should('be.checked')
         .get(investorRequirements.dealTicketSize.twoHundredFiftyTo499Million).should('be.checked')
         .get(investorRequirements.dealTicketSize.fiveHundredTo999Million).should('be.checked')
         .get(investorRequirements.dealTicketSize.oneBillionPlus).should('be.checked')
+    })
+
+    it('should display "Types of investment" and all checkboxes should be checked"', () => {
+      cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
+        .get(investorRequirements.investmentTypes.name).should('contain', 'Types of investment')
+        .get(investorRequirements.investmentTypes.projectEquity).should('be.checked')
+        .get(investorRequirements.investmentTypes.projectDebt).should('be.checked')
+        .get(investorRequirements.investmentTypes.corporateEquity).should('be.checked')
+        .get(investorRequirements.investmentTypes.corporateDebt).should('be.checked')
+        .get(investorRequirements.investmentTypes.mezzanineDebt).should('be.checked')
+        .get(investorRequirements.investmentTypes.ventureCapitalFunds).should('be.checked')
+        .get(investorRequirements.investmentTypes.energyInfrastructure).should('be.checked')
+        .get(investorRequirements.investmentTypes.privateEquity).should('be.checked')
     })
   })
 
@@ -254,6 +268,20 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.taskList.dealTicketSize.twoHundredFiftyTo499Million).should('contain', '£250-499 million')
         .get(investorRequirements.taskList.dealTicketSize.fiveHundredTo999Million).should('contain', '£500-999 million')
         .get(investorRequirements.taskList.dealTicketSize.oneBillionPlus).should('contain', '£1 billion +')
+    })
+
+    it('should display "Types of investment" and all 8 investments', () => {
+      cy.visit(largeCapitalProfile)
+        .get(selectors.investorRequirements.summary).click()
+        .get(investorRequirements.taskList.investmentTypes.name).should('contain', 'Types of investment')
+        .get(investorRequirements.taskList.investmentTypes.projectEquity).should('contain', 'Direct Investment in Project Equity')
+        .get(investorRequirements.taskList.investmentTypes.projectDebt).should('contain', 'Direct Investment in Project Debt')
+        .get(investorRequirements.taskList.investmentTypes.corporateEquity).should('contain', 'Direct Investment in Corporate Equity')
+        .get(investorRequirements.taskList.investmentTypes.corporateDebt).should('contain', 'Direct Investment in Corporate Debt')
+        .get(investorRequirements.taskList.investmentTypes.mezzanineDebt).should('contain', 'Mezzanine Debt (incl. preferred shares, convertibles')
+        .get(investorRequirements.taskList.investmentTypes.ventureCapitalFunds).should('contain', 'Venture capital funds')
+        .get(investorRequirements.taskList.investmentTypes.energyInfrastructure).should('contain', 'Energy / Infrastructure / Real Estate Funds (UKEIREFs)')
+        .get(investorRequirements.taskList.investmentTypes.privateEquity).should('contain', 'Private Equity / Venture Capital')
     })
   })
 })

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
@@ -179,6 +179,9 @@ describe('Company Investments - Large capital profile - Investor details', () =>
           dealTicketSizes: {
             value: [],
           },
+          investmentTypes: {
+            value: [],
+          },
         },
         location: {
           incompleteFields: 3,

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile.test.js
@@ -91,6 +91,9 @@ describe('Company Investments - Large capital profile', () => {
           dealTicketSizes: {
             value: [],
           },
+          investmentTypes: {
+            value: [],
+          },
         },
         location: {
           incompleteFields: 3,
@@ -131,6 +134,11 @@ describe('Company Investments - Large capital profile', () => {
         profile.deal_ticket_sizes = [ {
           name: '£1 billion +',
           id: '5e7601b5-becd-42ea-b885-1bbd88b85e4b',
+        }]
+
+        profile.investment_types = [{
+          name: 'Direct Investment in Project Equity',
+          id: '4170d99a-02fc-46ee-8fd4-3fe786717708',
         }]
 
         nock(config.apiRoot)
@@ -189,6 +197,12 @@ describe('Company Investments - Large capital profile', () => {
             value: [ {
               name: '£1 billion +',
               id: '5e7601b5-becd-42ea-b885-1bbd88b85e4b',
+            }],
+          },
+          investmentTypes: {
+            value: [ {
+              name: 'Direct Investment in Project Equity',
+              id: '4170d99a-02fc-46ee-8fd4-3fe786717708',
             }],
           },
         },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
@@ -1,4 +1,5 @@
 const dealTicketSize = require('~/test/unit/data/companies/investments/metadata/deal-ticket-size.json')
+const investmentType = require('~/test/unit/data/companies/investments/metadata/investment-type.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile.json')
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
@@ -42,6 +43,8 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           .reply(200, clonedCompanyProfile)
           .get('/metadata/capital-investment/deal-ticket-size/')
           .reply(200, dealTicketSize)
+          .get('/metadata/capital-investment/large-capital-investment-type/')
+          .reply(200, investmentType)
 
         this.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
@@ -113,6 +116,34 @@ describe('Company Investments - Large capital profile - Investor requirements', 
               text: '£1 billion +',
               value: '5e7601b5-becd-42ea-b885-1bbd88b85e4b',
             }],
+          },
+          investmentTypes: {
+            items: [ {
+              text: 'Direct Investment in Corporate Debt',
+              value: 'f972c0d9-f480-4727-af39-dff10cf935a9',
+            }, {
+              text: 'Direct Investment in Corporate Equity',
+              value: '942726e3-1b3f-4218-b06e-7cf983754de0',
+            }, {
+              text: 'Direct Investment in Project Debt',
+              value: '06834da2-c9ac-4faf-b555-39762ce373ae',
+            }, {
+              text: 'Direct Investment in Project Equity',
+              value: '4170d99a-02fc-46ee-8fd4-3fe786717708',
+            }, {
+              text: 'Energy / Infrastructure / Real Estate Funds (UKEIREFs)',
+              value: '24826b7c-e3df-4a76-80d4-4fe2661b838e',
+            }, {
+              text: 'Mezzanine Debt (incl. preferred shares, convertibles)',
+              value: '703140ec-6990-4f36-8b22-52ebde63932c',
+            }, {
+              text: 'Private Equity / Venture Capital',
+              value: 'ef615dde-49d8-41dd-9ddd-a00c78004135',
+            }, {
+              text: 'Venture capital funds',
+              value: '8feb6087-d61c-43bd-9bf1-3d9e1129432b',
+            } ],
+            value: [],
           },
         },
         location: {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
@@ -1,0 +1,40 @@
+const {
+  transformInvestorRequirements,
+} = require('~/src/apps/companies/apps/investments/large-capital-profile/transformers')
+
+describe('Large capital profile, Investor requirements form to API', () => {
+  context('when translating Investor requirements', () => {
+    it('should transform undefined into an empty array', () => {
+      this.transformed = transformInvestorRequirements({
+        dealTicketSizes: undefined,
+        investmentTypes: undefined,
+      })
+      expect(this.transformed).to.deep.equal({
+        deal_ticket_sizes: [],
+        investment_types: [],
+      })
+    })
+
+    it('should transform a String by adding it to an empty array', () => {
+      this.transformed = transformInvestorRequirements({
+        dealTicketSizes: '123',
+        investmentTypes: '456',
+      })
+      expect(this.transformed).to.deep.equal({
+        deal_ticket_sizes: ['123'],
+        investment_types: ['456'],
+      })
+    })
+
+    it('should not transform String arrays', () => {
+      this.transformed = transformInvestorRequirements({
+        dealTicketSizes: ['1', '2', '3'],
+        investmentTypes: ['4', '5', '6'],
+      })
+      expect(this.transformed).to.deep.equal({
+        deal_ticket_sizes: ['1', '2', '3'],
+        investment_types: ['4', '5', '6'],
+      })
+    })
+  })
+})

--- a/test/unit/data/companies/investments/metadata/investment-type.json
+++ b/test/unit/data/companies/investments/metadata/investment-type.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "4170d99a-02fc-46ee-8fd4-3fe786717708",
+    "name": "Direct Investment in Project Equity",
+    "disabled_on": null
+  },
+  {
+    "id": "06834da2-c9ac-4faf-b555-39762ce373ae",
+    "name": "Direct Investment in Project Debt",
+    "disabled_on": null
+  },
+  {
+    "id": "942726e3-1b3f-4218-b06e-7cf983754de0",
+    "name": "Direct Investment in Corporate Equity",
+    "disabled_on": null
+  },
+  {
+    "id": "f972c0d9-f480-4727-af39-dff10cf935a9",
+    "name": "Direct Investment in Corporate Debt",
+    "disabled_on": null
+  },
+  {
+    "id": "703140ec-6990-4f36-8b22-52ebde63932c",
+    "name": "Mezzanine Debt (incl. preferred shares, convertibles)",
+    "disabled_on": null
+  },
+  {
+    "id": "8feb6087-d61c-43bd-9bf1-3d9e1129432b",
+    "name": "Venture capital funds",
+    "disabled_on": null
+  },
+  {
+    "id": "24826b7c-e3df-4a76-80d4-4fe2661b838e",
+    "name": "Energy / Infrastructure / Real Estate Funds (UKEIREFs)",
+    "disabled_on": null
+  },
+  {
+    "id": "ef615dde-49d8-41dd-9ddd-a00c78004135",
+    "name": "Private Equity / Venture Capital",
+    "disabled_on": null
+  }
+]


### PR DESCRIPTION
1. Direct Investment in Project Equity
2. Direct Investment in Project Debt
3. Direct Investment in Corporate Equity
4. Direct Investment in Corporate Debt
5. Mezzanine Debt (incl. preferred shares, convertibles)
6. Venture capital funds
7. Energy / Infrastructure / Real Estate Funds (UKEIREFs)
8. Private Equity / Venture Capital

Display what the user has selected within the profile read-only view.

https://uktrade.atlassian.net/browse/IPBETA-272

**Edit view**

<img width="1054" alt="investment-types-edit" src="https://user-images.githubusercontent.com/964268/57804632-0a481d80-7753-11e9-865f-cc2679e0f690.png">

**Read-only view**

<img width="1054" alt="investment-types" src="https://user-images.githubusercontent.com/964268/57804635-0d430e00-7753-11e9-8a59-5e5b86cc858d.png">

**Checklist**
- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
