### PR TITLE
Add "Time horizon / tenor" to Large capital profile, Investor requirements 

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -37,6 +37,11 @@ const getInvestmentTypes = async (token, profile) => {
   return transformCheckboxes(investmentType, profile.investorRequirements.investmentTypes)
 }
 
+const getTimeHorizons = async (token, profile) => {
+  const timeHorizons = await getOptions(token, 'capital-investment/time-horizon', { sorted: false })
+  return transformCheckboxes(timeHorizons, profile.investorRequirements.timeHorizons)
+}
+
 const getCompanyProfile = async (token, company, editing) => {
   const profiles = await getCompanyProfiles(token, company.id)
   const profile = profiles.results && profiles.results[0]
@@ -61,6 +66,7 @@ const renderProfile = async (req, res, next) => {
     } else if (editType === INVESTOR_REQUIREMENTS) {
       profile.investorRequirements.dealTicketSizes.items = await getDealTicketSizes(token, profile)
       profile.investorRequirements.investmentTypes.items = await getInvestmentTypes(token, profile)
+      profile.investorRequirements.timeHorizons.items = await getTimeHorizons(token, profile)
     }
 
     res.render('companies/apps/investments/large-capital-profile/views/profile', { profile })

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
@@ -2,15 +2,15 @@ const { transformInvestorDetails, transformInvestorRequirements } = require('../
 const { updateCompanyProfile } = require('../repos')
 const { INVESTOR_DETAILS, INVESTOR_REQUIREMENTS } = require('../sections')
 
+const transformer = {
+  [INVESTOR_DETAILS]: transformInvestorDetails,
+  [INVESTOR_REQUIREMENTS]: transformInvestorRequirements,
+}
+
 const updateProfile = async (req, res, next) => {
   const { profileId, editing } = req.body
   const { company } = res.locals
   const { token } = req.session
-
-  const transformer = {
-    [INVESTOR_DETAILS]: transformInvestorDetails,
-    [INVESTOR_REQUIREMENTS]: transformInvestorRequirements,
-  }
 
   try {
     const body = transformer[editing](req.body)

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
@@ -4,6 +4,7 @@ const transformInvestorRequirements = (body) => {
   return {
     deal_ticket_sizes: sanitizeCheckboxes(body.dealTicketSizes),
     investment_types: sanitizeCheckboxes(body.investmentTypes),
+    time_horizons: sanitizeCheckboxes(body.timeHorizons),
   }
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -61,6 +61,9 @@ const transformProfile = (profile, editing) => {
       investmentTypes: {
         value: get(profile, 'investment_types'),
       },
+      timeHorizons: {
+        value: get(profile, 'time_horizons'),
+      },
     },
     location: {
       incompleteFields: get(profile, 'incomplete_location_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
@@ -47,4 +47,23 @@
     })
   }}
 
+  <p>Placeholder - Minimum return rate</p>
+
+  {{
+    govukCheckboxes({
+      name: "timeHorizons",
+      classes: 'time-horizon',
+      fieldset: {
+        attributes: {
+          'data-auto-id': 'timeHorizons'
+        },
+        legend: {
+          text: "Time horizon / tenor",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: profile.investorRequirements.timeHorizons.items
+    })
+  }}
+
 {% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
@@ -1,9 +1,9 @@
 <ul class="task-list">
-  {{ taskListItem({ name: 'Deal ticket size', value: profile.investorRequirements.dealTicketSizes.value, key: 'name'}) }}
+  {{ taskListItem({ name: 'Deal ticket size', value: profile.investorRequirements.dealTicketSizes.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Asset classes of interest' }) }}
   {{ taskListItem({ name: 'Types of investment',  value: profile.investorRequirements.investmentTypes.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Minimum return rate' }) }}
-  {{ taskListItem({ name: 'Time horizon / tenor' }) }}
+  {{ taskListItem({ name: 'Time horizon / tenor', value: profile.investorRequirements.timeHorizons.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Restrictions / conditions' }) }}
   {{ taskListItem({ name: 'Construction risk' }) }}
   {{ taskListItem({ name: 'Minimum equity percentage' }) }}

--- a/src/apps/companies/apps/investments/utils/transformers.js
+++ b/src/apps/companies/apps/investments/utils/transformers.js
@@ -1,4 +1,4 @@
-const { find, isString } = require('lodash')
+const { find, isString, castArray, compact } = require('lodash')
 
 const transformObjectToOption = ({ value, label }) => ({ value, text: label })
 
@@ -12,12 +12,8 @@ const checkMatchingItemById = (items) => {
   }
 }
 
-const ifStringAddToEmtpyArray = (obj) => {
-  return isString(obj) ? [obj] : obj
-}
-
 const sanitizeCheckboxes = (selection) => {
-  return selection === undefined ? [] : ifStringAddToEmtpyArray(selection)
+  return isString(selection) ? castArray(selection) : compact(selection)
 }
 
 module.exports = {

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -84,6 +84,13 @@ module.exports = {
       energyInfrastructure: '[data-auto-id=investmentTypes] #investmentTypes-7',
       privateEquity: '[data-auto-id=investmentTypes] #investmentTypes-8',
     },
+    timeHorizons: {
+      name: '[data-auto-id=timeHorizons] legend',
+      upToFiveYears: '[data-auto-id=timeHorizons] #timeHorizons-1',
+      fiveTo9Years: '[data-auto-id=timeHorizons] #timeHorizons-2',
+      tenTo14Years: '[data-auto-id=timeHorizons] #timeHorizons-3',
+      fifteenYearsPlus: '[data-auto-id=timeHorizons] #timeHorizons-4',
+    },
     taskList: {
       dealTicketSize: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(1) .task-list__item-name',
@@ -115,9 +122,13 @@ module.exports = {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(4) .task-list__item-name',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(4) .task-list__item-incomplete',
       },
-      timeHorizonTenor: {
+      timeHorizon: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(5) .task-list__item-name',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(5) .task-list__item-incomplete',
+        upToFiveYears: '[data-auto-id=investorRequirements] ul > li:nth-child(5) span:nth-child(2)',
+        fiveTo9Years: '[data-auto-id=investorRequirements]  ul > li:nth-child(5) span:nth-child(3)',
+        tenTo14Years: '[data-auto-id=investorRequirements]  ul > li:nth-child(5) span:nth-child(4)',
+        fifteenYearsPlus: '[data-auto-id=investorRequirements]  ul > li:nth-child(5) span:nth-child(5)',
       },
       restrictionsConditions: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(6) .task-list__item-name',

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -253,6 +253,15 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.investmentTypes.energyInfrastructure).should('be.checked')
         .get(investorRequirements.investmentTypes.privateEquity).should('be.checked')
     })
+
+    it('should display "Time Horizon / tenor" and all checkboxes should be checked"', () => {
+      cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
+        .get(investorRequirements.timeHorizons.name).should('contain', 'Time horizon / tenor')
+        .get(investorRequirements.timeHorizons.upToFiveYears).should('be.checked')
+        .get(investorRequirements.timeHorizons.fiveTo9Years).should('be.checked')
+        .get(investorRequirements.timeHorizons.tenTo14Years).should('be.checked')
+        .get(investorRequirements.timeHorizons.fifteenYearsPlus).should('be.checked')
+    })
   })
 
   context('when viewing the "Investor requirements" details section', () => {
@@ -282,6 +291,16 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.taskList.investmentTypes.ventureCapitalFunds).should('contain', 'Venture capital funds')
         .get(investorRequirements.taskList.investmentTypes.energyInfrastructure).should('contain', 'Energy / Infrastructure / Real Estate Funds (UKEIREFs)')
         .get(investorRequirements.taskList.investmentTypes.privateEquity).should('contain', 'Private Equity / Venture Capital')
+    })
+
+    it('should display "Time horizon / tenor" and all 4 times', () => {
+      cy.visit(largeCapitalProfile)
+        .get(selectors.investorRequirements.summary).click()
+        .get(investorRequirements.taskList.timeHorizon.name).should('contain', 'Time horizon / tenor')
+        .get(investorRequirements.taskList.timeHorizon.upToFiveYears).should('contain', 'Up to 5 years')
+        .get(investorRequirements.taskList.timeHorizon.fiveTo9Years).should('contain', '5-9 years')
+        .get(investorRequirements.taskList.timeHorizon.tenTo14Years).should('contain', '10-14 years')
+        .get(investorRequirements.taskList.timeHorizon.fifteenYearsPlus).should('contain', '15 years +')
     })
   })
 })

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
@@ -182,6 +182,9 @@ describe('Company Investments - Large capital profile - Investor details', () =>
           investmentTypes: {
             value: [],
           },
+          timeHorizons: {
+            value: [],
+          },
         },
         location: {
           incompleteFields: 3,

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile.test.js
@@ -94,6 +94,9 @@ describe('Company Investments - Large capital profile', () => {
           investmentTypes: {
             value: [],
           },
+          timeHorizons: {
+            value: [],
+          },
         },
         location: {
           incompleteFields: 3,
@@ -139,6 +142,11 @@ describe('Company Investments - Large capital profile', () => {
         profile.investment_types = [{
           name: 'Direct Investment in Project Equity',
           id: '4170d99a-02fc-46ee-8fd4-3fe786717708',
+        }]
+
+        profile.time_horizons = [{
+          id: '29a0a8e9-1c21-432a-bb4f-b9363b46a6aa',
+          name: '10-14 years',
         }]
 
         nock(config.apiRoot)
@@ -203,6 +211,12 @@ describe('Company Investments - Large capital profile', () => {
             value: [ {
               name: 'Direct Investment in Project Equity',
               id: '4170d99a-02fc-46ee-8fd4-3fe786717708',
+            }],
+          },
+          timeHorizons: {
+            value: [ {
+              id: '29a0a8e9-1c21-432a-bb4f-b9363b46a6aa',
+              name: '10-14 years',
             }],
           },
         },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
@@ -1,5 +1,6 @@
 const dealTicketSize = require('~/test/unit/data/companies/investments/metadata/deal-ticket-size.json')
 const investmentType = require('~/test/unit/data/companies/investments/metadata/investment-type.json')
+const timeHorizons = require('~/test/unit/data/companies/investments/metadata/time-horizon.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile.json')
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
@@ -38,6 +39,16 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           id: '5e7601b5-becd-42ea-b885-1bbd88b85e4b',
         }]
 
+        profile.investment_types = [{
+          id: '06834da2-c9ac-4faf-b555-39762ce373ae',
+          name: 'Direct Investment in Project Debt',
+        }]
+
+        profile.time_horizons = [{
+          id: 'd2d1bdbb-c42a-459c-adaa-fce45ce08cc9',
+          name: 'Up to 5 years',
+        }]
+
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
           .reply(200, clonedCompanyProfile)
@@ -45,6 +56,8 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           .reply(200, dealTicketSize)
           .get('/metadata/capital-investment/large-capital-investment-type/')
           .reply(200, investmentType)
+          .get('/metadata/capital-investment/time-horizon/')
+          .reply(200, timeHorizons)
 
         this.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
@@ -125,6 +138,7 @@ describe('Company Investments - Large capital profile - Investor requirements', 
               text: 'Direct Investment in Corporate Equity',
               value: '942726e3-1b3f-4218-b06e-7cf983754de0',
             }, {
+              checked: true,
               text: 'Direct Investment in Project Debt',
               value: '06834da2-c9ac-4faf-b555-39762ce373ae',
             }, {
@@ -143,7 +157,35 @@ describe('Company Investments - Large capital profile - Investor requirements', 
               text: 'Venture capital funds',
               value: '8feb6087-d61c-43bd-9bf1-3d9e1129432b',
             } ],
-            value: [],
+            value: [{
+              id: '06834da2-c9ac-4faf-b555-39762ce373ae',
+              name: 'Direct Investment in Project Debt',
+            }],
+          },
+          timeHorizons: {
+            items: [
+              {
+                checked: true,
+                text: 'Up to 5 years',
+                value: 'd2d1bdbb-c42a-459c-adaa-fce45ce08cc9',
+              },
+              {
+                text: '5-9 years',
+                value: 'd186343f-ed66-47e4-9ab0-258f583ff3cb',
+              },
+              {
+                text: '10-14 years',
+                value: '29a0a8e9-1c21-432a-bb4f-b9363b46a6aa',
+              },
+              {
+                text: '15 years +',
+                value: 'c4579a5e-4588-4952-a974-e03475a3f559',
+              },
+            ],
+            value: [{
+              name: 'Up to 5 years',
+              id: 'd2d1bdbb-c42a-459c-adaa-fce45ce08cc9',
+            }],
           },
         },
         location: {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
@@ -8,32 +8,38 @@ describe('Large capital profile, Investor requirements form to API', () => {
       this.transformed = transformInvestorRequirements({
         dealTicketSizes: undefined,
         investmentTypes: undefined,
+        timeHorizons: undefined,
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: [],
         investment_types: [],
+        time_horizons: [],
       })
     })
 
     it('should transform a String by adding it to an empty array', () => {
       this.transformed = transformInvestorRequirements({
-        dealTicketSizes: '123',
-        investmentTypes: '456',
+        dealTicketSizes: 'id',
+        investmentTypes: 'id',
+        timeHorizons: 'id',
       })
       expect(this.transformed).to.deep.equal({
-        deal_ticket_sizes: ['123'],
-        investment_types: ['456'],
+        deal_ticket_sizes: ['id'],
+        investment_types: ['id'],
+        time_horizons: ['id'],
       })
     })
 
     it('should not transform String arrays', () => {
       this.transformed = transformInvestorRequirements({
-        dealTicketSizes: ['1', '2', '3'],
-        investmentTypes: ['4', '5', '6'],
+        dealTicketSizes: ['id'],
+        investmentTypes: ['id'],
+        timeHorizons: ['id'],
       })
       expect(this.transformed).to.deep.equal({
-        deal_ticket_sizes: ['1', '2', '3'],
-        investment_types: ['4', '5', '6'],
+        deal_ticket_sizes: ['id'],
+        investment_types: ['id'],
+        time_horizons: ['id'],
       })
     })
   })

--- a/test/unit/data/companies/investments/metadata/time-horizon.json
+++ b/test/unit/data/companies/investments/metadata/time-horizon.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "d2d1bdbb-c42a-459c-adaa-fce45ce08cc9",
+    "name": "Up to 5 years"
+  },
+  {
+    "id": "d186343f-ed66-47e4-9ab0-258f583ff3cb",
+    "name": "5-9 years"
+  },
+  {
+    "id": "29a0a8e9-1c21-432a-bb4f-b9363b46a6aa",
+    "name": "10-14 years"
+  },
+  {
+    "id": "c4579a5e-4588-4952-a974-e03475a3f559",
+    "name": "15 years +"
+  }
+]


### PR DESCRIPTION
Added 4 new checkboxes that allow a user to add the Time horizon / tenor

1. Up to 5 years
2. 5-9 years
3. 10-14 years
4. 15 years +

Display what the user has selected within the profile read-only view.

https://uktrade.atlassian.net/browse/IPBETA-272

**Edit view**

<img width="1078" alt="time-horizon-edit" src="https://user-images.githubusercontent.com/964268/57854505-4c6b7080-77e0-11e9-87de-09692481e145.png">

**Read-only view**

<img width="1106" alt="time-horizon-read-only" src="https://user-images.githubusercontent.com/964268/57854513-52f9e800-77e0-11e9-9dcc-5e18ba0e3a32.png">

**Checklist**
- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
