### PR TITLE
Fix bug on conditional styles on typeaheads

### DIFF
--- a/assets/javascripts/vue/typeahead.vue
+++ b/assets/javascripts/vue/typeahead.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-bind:class="{classes, 'govuk-form-group--error': error}"
+  <div v-bind:class="[classes, {'govuk-form-group--error': error}]"
        v-bind:id="'group-field-' + name">
     <label class="c-form-group__label" :class="{ 'u-visually-hidden': hideLabel }" :for="id">
       <span class="c-form-group__label-text">{{ label }}</span>
@@ -15,9 +15,7 @@
     <span v-if="error" v-bind:id="name + '-error'" class="govuk-error-message">
       <span class="govuk-visually-hidden">Error:</span>
       <ul v-bind:id="name + '-error-messages'">
-        <li v-for="message in error" v-bind:key="message">
-          {{ message }}
-        </li>
+        <li>{{ error }}</li>
       </ul>
     </span>
 

--- a/src/apps/investments/controllers/create/create-profile.js
+++ b/src/apps/investments/controllers/create/create-profile.js
@@ -4,7 +4,7 @@ const { createCompanyProfile } = require('./../../../companies/apps/investments/
 
 const createProfile = async (req, res, next) => {
   if (!req.body.investor_company) {
-    set(res.locals, 'errors.messages.investor_company', ['Enter a company name'])
+    set(res.locals, 'errors.messages.investor_company', 'Enter a company name')
     return next()
   }
 

--- a/test/unit/apps/investment-projects/controllers/create/create-profile.test.js
+++ b/test/unit/apps/investment-projects/controllers/create/create-profile.test.js
@@ -114,7 +114,7 @@ describe('Investment create invenstor profile post call controller', () => {
         expect(this.createCompanyProfileSpy).not.to.be.called
         expect(this.middlewareParameters.resMock.redirect).not.to.be.called
         expect(this.middlewareParameters.resMock.locals.errors.messages.investor_company)
-          .an('array').that.includes('Enter a company name')
+          .to.be.a('string').that.equal('Enter a company name')
       })
     })
   })


### PR DESCRIPTION
**Implementation notes**
There was a bug on vue `v-bind:class` and as a result some styles could not be applied.
Also we thought with @ian-leggett that is better to pass just one error message so I ve dropped the multiple error messages logic
**Checklist**

**Before:**
<img width="331" alt="Screenshot 2019-05-16 at 16 01 13" src="https://user-images.githubusercontent.com/6704411/57864494-e1c43000-77f3-11e9-92ca-80a3f9c955f6.png">

**After**
<img width="339" alt="Screenshot 2019-05-16 at 16 00 52" src="https://user-images.githubusercontent.com/6704411/57864500-e4bf2080-77f3-11e9-944b-b9b7677cd54d.png">
- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
