### PR TITLE
Add subsidiary/Global HQ linking for D&B companies

### DIFF
--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -8,7 +8,7 @@ async function renderSubsidiaries (req, res, next) {
   try {
     const token = req.session.token
     const { company } = res.locals
-    const actionButtons = company.archived || company.duns_number ? undefined : [{
+    const actionButtons = company.archived ? undefined : [{
       label: companyDetailsLabels.link_a_subsidiary,
       url: `/companies/${company.id}/subsidiaries/link`,
     }]

--- a/src/apps/companies/middleware/hierarchies.js
+++ b/src/apps/companies/middleware/hierarchies.js
@@ -54,7 +54,7 @@ async function addSubsidiary (req, res, next) {
 
   try {
     await updateCompany(token, subsidiaryCompanyId, body)
-    req.flash('success', 'You’ve linked the Subsidiary')
+    req.flash('success', 'You’ve linked the subsidiary')
   } catch (error) {
     if (error.statusCode !== 400) {
       return next(error)

--- a/src/apps/companies/transformers/company-to-business-hierarchy-view.js
+++ b/src/apps/companies/transformers/company-to-business-hierarchy-view.js
@@ -12,7 +12,7 @@ const transformHeadquarterType = (headquarter_type) => {
   }
 }
 
-const transformSubsidiaries = (id, headquarter_type, subsidiariesCount, duns_number) => {
+const transformSubsidiaries = (id, headquarter_type, subsidiariesCount) => {
   if (headquarter_type) {
     if (subsidiariesCount) {
       return {
@@ -21,7 +21,7 @@ const transformSubsidiaries = (id, headquarter_type, subsidiariesCount, duns_num
       }
     }
 
-    if (headquarter_type.name === 'ghq' && !duns_number) {
+    if (headquarter_type.name === 'ghq') {
       return {
         name: NONE_TEXT,
         actions: [
@@ -37,11 +37,11 @@ const transformSubsidiaries = (id, headquarter_type, subsidiariesCount, duns_num
   }
 }
 
-const transformGlobalHq = (id, headquarter_type, global_headquarters, duns_number) => {
+const transformGlobalHq = (id, headquarter_type, global_headquarters) => {
   if (!headquarter_type && !global_headquarters) {
     return pickBy({
       name: NONE_TEXT,
-      actions: duns_number ? null : [
+      actions: [
         {
           url: `/companies/${id}/hierarchies/ghq/search`,
           label: 'Link to the Global HQ',
@@ -54,7 +54,7 @@ const transformGlobalHq = (id, headquarter_type, global_headquarters, duns_numbe
     return pickBy({
       url: `/companies/${global_headquarters.id}`,
       name: global_headquarters.name,
-      actions: duns_number ? null : [
+      actions: [
         {
           url: `/companies/${id}/hierarchies/ghq/remove`,
           label: 'Remove link',
@@ -64,11 +64,11 @@ const transformGlobalHq = (id, headquarter_type, global_headquarters, duns_numbe
   }
 }
 
-module.exports = ({ id, headquarter_type, global_headquarters, duns_number }, subsidiariesCount) => {
+module.exports = ({ id, headquarter_type, global_headquarters }, subsidiariesCount) => {
   const viewRecord = {
     headquarter_type: transformHeadquarterType(headquarter_type),
-    subsidiaries: transformSubsidiaries(id, headquarter_type, subsidiariesCount, duns_number),
-    global_headquarters: transformGlobalHq(id, headquarter_type, global_headquarters, duns_number),
+    subsidiaries: transformSubsidiaries(id, headquarter_type, subsidiariesCount),
+    global_headquarters: transformGlobalHq(id, headquarter_type, global_headquarters),
   }
 
   return pickBy(getDataLabels(viewRecord, businessHierarchyLabels))

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -14,8 +14,6 @@ module.exports = function transformCompanyToListItem ({
   modified_on,
   headquarter_type,
   global_headquarters,
-  global_headquarters_archived,
-  global_headquarters_duns_number,
 } = {}) {
   if (!id) { return }
 
@@ -65,14 +63,6 @@ module.exports = function transformCompanyToListItem ({
       value: ghqName,
       url: `/companies/${ghqId}`,
     })
-
-    if (!global_headquarters_archived && !global_headquarters_duns_number) {
-      meta.push({
-        label: '',
-        value: 'Remove subsidiary',
-        url: `/companies/${id}/hierarchies/ghq/remove`,
-      })
-    }
   }
 
   meta.push({

--- a/src/apps/companies/transformers/company-to-subsidiary-list-item.js
+++ b/src/apps/companies/transformers/company-to-subsidiary-list-item.js
@@ -1,13 +1,16 @@
 const transformCompanyToListItem = require('./company-to-list-item')
 
-module.exports = function transformCompanyToSubsidiaryListItem ({ archived: globalHeadquartersArchived, duns_number: globalHeadquartersDunsNumber }) {
+module.exports = function transformCompanyToSubsidiaryListItem ({ archived: globalHeadquartersArchived }) {
   return (company) => {
-    const listItem = transformCompanyToListItem({
-      ...company,
-      global_headquarters_archived: globalHeadquartersArchived,
-      global_headquarters_duns_number: globalHeadquartersDunsNumber,
-    })
-    listItem.meta = listItem.meta.filter(metaItem => metaItem.label !== 'Global HQ')
+    const listItem = transformCompanyToListItem(company)
+
+    if (!globalHeadquartersArchived) {
+      listItem.meta.push({
+        value: 'Remove subsidiary',
+        url: `/companies/${company.id}/hierarchies/ghq/remove`,
+      })
+    }
+
     return listItem
   }
 }

--- a/src/apps/companies/views/subsidiaries.njk
+++ b/src/apps/companies/views/subsidiaries.njk
@@ -6,16 +6,6 @@
 
 {% block body_main_content %}
 
-  {% if company.duns_number %}
-    {{ govukDetails({
-      summaryText: 'Why can I not link a subsidiary?',
-      html: 'Subsidiaries cannot be linked to a Dun & Bradstreet company.',
-      attributes: {
-        'data-auto-id': 'subsidiariesWhyDunAndBradstreet'
-      }
-    }) }}
-  {% endif %}
-
   {% if company.archived %}
     {{ govukDetails({
       summaryText: 'Why can I not link a subsidiary?',

--- a/test/acceptance/features/companies/subsidiaries.feature
+++ b/test/acceptance/features/companies/subsidiaries.feature
@@ -48,9 +48,8 @@ Feature: Company subsidiaries
     And the page should contain text "Why can I not link a subsidiary"
 
   @companies-subsidiaries--dnb-company
-  Scenario: DnB company cannot link to a subsidiary
+  Scenario: DnB company can link to a subsidiary
     When I navigate to the `companies.subsidiaries` page using `company` `One List Corp` fixture
-    And I should not see the "Link a subsidiary" button
+    And I should see the "Link a subsidiary" button
     And I can view the collection
-    And the page should contain text "Why can I not link a subsidiary"
     And I should not see the "Remove subsidiary" link

--- a/test/acceptance/features/companies/subsidiaries.feature
+++ b/test/acceptance/features/companies/subsidiaries.feature
@@ -52,4 +52,4 @@ Feature: Company subsidiaries
     When I navigate to the `companies.subsidiaries` page using `company` `One List Corp` fixture
     And I should see the "Link a subsidiary" button
     And I can view the collection
-    And I should not see the "Remove subsidiary" link
+    And I should see the "Remove subsidiary" link

--- a/test/functional/cypress/selectors/company/subsidiaries-link.js
+++ b/test/functional/cypress/selectors/company/subsidiaries-link.js
@@ -1,0 +1,13 @@
+module.exports = () => {
+  return {
+    search: {
+      term: '.c-entity-search__input',
+      button: '.c-entity-search__button',
+      result (number) {
+        return {
+          title: `.c-entity-list__item:nth-child(${number}) h3 a`,
+        }
+      },
+    },
+  }
+}

--- a/test/functional/cypress/selectors/company/subsidiaries.js
+++ b/test/functional/cypress/selectors/company/subsidiaries.js
@@ -1,6 +1,5 @@
 module.exports = () => {
   return {
-    whyDunAndBradstreet: '[data-auto-id="subsidiariesWhyDunAndBradstreet"]',
     whyArchived: '[data-auto-id="subsidiariesWhyArchived"]',
   }
 }

--- a/test/functional/cypress/selectors/company/subsidiaries.js
+++ b/test/functional/cypress/selectors/company/subsidiaries.js
@@ -1,5 +1,9 @@
 module.exports = () => {
   return {
     whyArchived: '[data-auto-id="subsidiariesWhyArchived"]',
+    linkASubsidiary: '[data-auto-id="Link a subsidiary"]',
+    flash: {
+      success: '.c-message--success',
+    },
   }
 }

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -3,6 +3,7 @@ exports.companyAddStep2 = require('./company/add-step-2')
 exports.companyEdit = require('./company/edit')
 exports.companyCollection = require('./company/company-collection')
 exports.companyInvestment = require('./company/investment')
+exports.companySubsidiariesLink = require('./company/subsidiaries-link')
 exports.companySubsidiaries = require('./company/subsidiaries')
 
 exports.contactCreate = require('./contact/create')

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -1,7 +1,7 @@
 const { keys, forEach } = require('lodash')
 
-const fixtures = require('../../fixtures/index.js')
-const selectors = require('../../selectors/index.js')
+const fixtures = require('../../fixtures')
+const selectors = require('../../selectors')
 
 describe('Companies business details', () => {
   context('when viewing business details for a Dun & Bradstreet GHQ company on the One List not in the UK', () => {

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -117,7 +117,7 @@ describe('Companies business details', () => {
     it('should display the "Business hierarchy" details', () => {
       assertKeyValueTable('businessHierarchyDetails', {
         'Headquarter type': 'Global HQ',
-        'Subsidiaries': 'None',
+        'Subsidiaries': 'None Link a subsidiary',
       })
     })
 
@@ -372,7 +372,7 @@ describe('Companies business details', () => {
 
     it('should display the "Business hierarchy" details', () => {
       assertKeyValueTable('businessHierarchyDetails', {
-        'Global HQ': 'None',
+        'Global HQ': 'None Link to the Global HQ',
       })
     })
 

--- a/test/functional/cypress/specs/companies/contact-spec.js
+++ b/test/functional/cypress/specs/companies/contact-spec.js
@@ -1,5 +1,5 @@
-const fixtures = require('../../fixtures/index.js')
-const selectors = require('../../selectors/index.js')
+const fixtures = require('../../fixtures')
+const selectors = require('../../selectors')
 
 describe('Companies Contact', () => {
   context('when viewing contacts for an archived company', () => {

--- a/test/functional/cypress/specs/companies/interactions-spec.js
+++ b/test/functional/cypress/specs/companies/interactions-spec.js
@@ -1,5 +1,5 @@
-const fixtures = require('../../fixtures/index.js')
-const selectors = require('../../selectors/index.js')
+const fixtures = require('../../fixtures')
+const selectors = require('../../selectors')
 
 describe('Companies interactions', () => {
   const commonTests = ({

--- a/test/functional/cypress/specs/companies/investments/growth-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/growth-capital-profile-spec.js
@@ -1,5 +1,5 @@
-const { localHeader, companyInvestment: selectors } = require('../../../selectors/index.js')
-const fixtures = require('../../../fixtures/index.js')
+const { localHeader, companyInvestment: selectors } = require('../../../selectors')
+const fixtures = require('../../../fixtures')
 const baseUrl = Cypress.config().baseUrl
 const { oneListCorp } = fixtures.company
 

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -1,5 +1,5 @@
 const { localHeader, companyInvestment: selectors } = require('../../../selectors')
-const fixtures = require('../../../fixtures/index.js')
+const fixtures = require('../../../fixtures')
 const baseUrl = Cypress.config().baseUrl
 const { oneListCorp, lambdaPlc } = fixtures.company
 const largeCapitalProfile = `/companies/${oneListCorp.id}/investments/large-capital-profile`

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -1,4 +1,4 @@
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 
 describe('Company OMIS Collections', () => {

--- a/test/functional/cypress/specs/companies/subsidiaries-link-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-link-spec.js
@@ -1,0 +1,18 @@
+const fixtures = require('../../fixtures/index.js')
+const selectors = require('../../selectors/index.js')
+
+describe('Companies link a subsidiary', () => {
+  before(() => {
+    cy.visit(`/companies/${fixtures.company.oneListCorp.id}/subsidiaries`)
+  })
+
+  it('should link a subsidiary', () => {
+    cy.get(selectors.companySubsidiaries().linkASubsidiary).click()
+
+    cy.get(selectors.companySubsidiariesLink().search.term).type('lambda')
+    cy.get(selectors.companySubsidiariesLink().search.button).click()
+    cy.get(selectors.companySubsidiariesLink().search.result(1).title).click()
+
+    cy.get(selectors.companySubsidiaries().flash.success).should('contain', 'You’ve linked the subsidiary')
+  })
+})

--- a/test/functional/cypress/specs/companies/subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-spec.js
@@ -19,10 +19,6 @@ describe('Companies business details', () => {
       cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Subsidiaries')
     })
 
-    it('should display the "Why can I not link a subsidiary?" D&B details summary', () => {
-      cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('be.visible')
-    })
-
     it('should not display the "Why can I not link a subsidiary?" archived details summary', () => {
       cy.get(selectors.companySubsidiaries().whyArchived).should('not.exist')
     })
@@ -45,10 +41,6 @@ describe('Companies business details', () => {
       cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Subsidiaries')
     })
 
-    it('should not display the "Why can I not link a subsidiary?" D&B details summary', () => {
-      cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('not.exist')
-    })
-
     it('should not display the "Why can I not link a subsidiary?" archived details summary', () => {
       cy.get(selectors.companySubsidiaries().whyArchived).should('not.exist')
     })
@@ -69,10 +61,6 @@ describe('Companies business details', () => {
       cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.text', 'Business details')
       cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.attr', 'href', `/companies/${fixtures.company.archivedLtd.id}/business-details`)
       cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Subsidiaries')
-    })
-
-    it('should not display the "Why can I not link a subsidiary?" D&B details summary', () => {
-      cy.get(selectors.companySubsidiaries().whyDunAndBradstreet).should('not.exist')
     })
 
     it('should display the "Why can I not link a subsidiary?" archived details summary', () => {

--- a/test/functional/cypress/specs/companies/subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-spec.js
@@ -1,7 +1,7 @@
 const fixtures = require('../../fixtures/index.js')
 const selectors = require('../../selectors/index.js')
 
-describe('Companies business details', () => {
+describe('Companies subsidiaries', () => {
   context('when viewing subsidiaries for a Dun & Bradstreet company', () => {
     before(() => {
       cy.visit(`/companies/${fixtures.company.oneListCorp.id}/subsidiaries`)

--- a/test/functional/cypress/specs/companies/subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-spec.js
@@ -1,5 +1,5 @@
-const fixtures = require('../../fixtures/index.js')
-const selectors = require('../../selectors/index.js')
+const fixtures = require('../../fixtures')
+const selectors = require('../../selectors')
 
 describe('Companies subsidiaries', () => {
   context('when viewing subsidiaries for a Dun & Bradstreet company', () => {

--- a/test/functional/cypress/specs/contacts/collection-spec.js
+++ b/test/functional/cypress/specs/contacts/collection-spec.js
@@ -1,5 +1,5 @@
 const selectors = require('../../selectors')
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 
 describe('Contacts Collections', () => {
   before(() => {

--- a/test/functional/cypress/specs/contacts/sort-spec.js
+++ b/test/functional/cypress/specs/contacts/sort-spec.js
@@ -1,5 +1,5 @@
 const selectors = require('../../selectors')
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 
 describe('Contact Collections Sort', () => {
   beforeEach(() => {

--- a/test/functional/cypress/specs/interaction/add-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/add-interaction-spec.js
@@ -1,4 +1,4 @@
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 const utils = require('../../support/utils')
 

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -1,4 +1,4 @@
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 
 describe('Interaction details', () => {

--- a/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
+++ b/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
@@ -1,4 +1,4 @@
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 
 describe('Service delivery form', () => {

--- a/test/functional/cypress/specs/investment-project/investment-project-document-spec.js
+++ b/test/functional/cypress/specs/investment-project/investment-project-document-spec.js
@@ -1,4 +1,4 @@
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 
 describe('Investment Project Documents', () => {

--- a/test/functional/cypress/specs/omis/create.js
+++ b/test/functional/cypress/specs/omis/create.js
@@ -1,5 +1,5 @@
-const fixtures = require('../../fixtures/index.js')
-const selectors = require('../../selectors/index.js')
+const fixtures = require('../../fixtures')
+const selectors = require('../../selectors')
 
 describe('Omis Create Required Fields', () => {
   before(() => {

--- a/test/functional/cypress/specs/omis/edit-draft-spec.js
+++ b/test/functional/cypress/specs/omis/edit-draft-spec.js
@@ -1,4 +1,4 @@
-const fixtures = require('../../fixtures/index.js')
+const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 
 describe('Omis Edit Draft', () => {

--- a/test/unit/apps/companies/middleware/hierarchies.test.js
+++ b/test/unit/apps/companies/middleware/hierarchies.test.js
@@ -238,7 +238,7 @@ describe('Company hierarchies middleware', () => {
 
       it('should call flash', () => {
         expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
-        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve linked the Subsidiary')
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledWith('success', 'You’ve linked the subsidiary')
       })
     })
 

--- a/test/unit/apps/companies/transformers/company-to-business-hierarchy-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-business-hierarchy-view.test.js
@@ -46,8 +46,16 @@ describe('#transformCompanyToBusinessHierarchyView', () => {
         expect(this.actual['Headquarter type']).to.deep.equal('Global HQ')
       })
 
-      it('should set the subsidiaries to "None"', () => {
-        expect(this.actual.Subsidiaries).to.equal('None')
+      it('should set the subsidiaries to "None", with a "Link a subsidiary action"', () => {
+        expect(this.actual.Subsidiaries).to.deep.equal({
+          actions: [
+            {
+              label: 'Link a subsidiary',
+              url: '/companies/1/subsidiaries/link',
+            },
+          ],
+          name: 'None',
+        })
       })
 
       it('should not set the Global HQ', () => {
@@ -76,8 +84,14 @@ describe('#transformCompanyToBusinessHierarchyView', () => {
         expect(this.actual.Subsidiaries).to.not.exist
       })
 
-      it('should set the Global HQ without a "Remove link" action', () => {
+      it('should set the Global HQ with a "Remove link" action', () => {
         expect(this.actual['Global HQ']).to.deep.equal({
+          actions: [
+            {
+              label: 'Remove link',
+              url: '/companies/1/hierarchies/ghq/remove',
+            },
+          ],
           name: 'Parent Ltd',
           url: '/companies/2',
         })
@@ -102,8 +116,14 @@ describe('#transformCompanyToBusinessHierarchyView', () => {
         expect(this.actual.Subsidiaries).to.not.exist
       })
 
-      it('should set the Global HQ without a "Link to the Global HQ" action', () => {
+      it('should set the Global HQ with a "Link to the Global HQ" action', () => {
         expect(this.actual['Global HQ']).to.deep.equal({
+          actions: [
+            {
+              label: 'Link to the Global HQ',
+              url: `/companies/1/hierarchies/ghq/search`,
+            },
+          ],
           name: 'None',
         })
       })

--- a/test/unit/apps/companies/transformers/company-to-list-item.test.js
+++ b/test/unit/apps/companies/transformers/company-to-list-item.test.js
@@ -195,51 +195,16 @@ describe('transformCompanyToListItem', () => {
 
   context('global headquarters information', () => {
     context('contains the global headquarters information', () => {
-      context('and its global headquarters is not archived', () => {
-        beforeEach(() => {
-          this.listItem = transformCompanyToListItem(companyData)
-        })
-
-        it('should include the headquarter info in the result', () => {
-          expect(this.listItem.meta).to.containSubset([{
-            label: 'Global HQ',
-            value: 'Mars Exports Ltd',
-            url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
-          }])
-        })
-
-        it('should include the "Remove subsidiary" link in the result', () => {
-          expect(this.listItem.meta).to.containSubset([{
-            label: '',
-            value: 'Remove subsidiary',
-            url: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/hierarchies/ghq/remove',
-          }])
-        })
+      beforeEach(() => {
+        this.listItem = transformCompanyToListItem(companyData)
       })
 
-      context('and its global headquarters is archived', () => {
-        beforeEach(() => {
-          this.listItem = transformCompanyToListItem({
-            ...companyData,
-            global_headquarters_archived: true,
-          })
-        })
-
-        it('should include the headquarter info in the result', () => {
-          expect(this.listItem.meta).to.containSubset([{
-            label: 'Global HQ',
-            value: 'Mars Exports Ltd',
-            url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
-          }])
-        })
-
-        it('should not include the "Remove subsidiary" link in the result', () => {
-          expect(this.listItem.meta).to.not.containSubset([{
-            label: '',
-            value: 'Remove subsidiary',
-            url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd/hierarchies/ghq/remove',
-          }])
-        })
+      it('should include the headquarter info in the result', () => {
+        expect(this.listItem.meta).to.containSubset([{
+          label: 'Global HQ',
+          value: 'Mars Exports Ltd',
+          url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+        }])
       })
     })
 

--- a/test/unit/apps/companies/transformers/company-to-subsidiary-list-item.test.js
+++ b/test/unit/apps/companies/transformers/company-to-subsidiary-list-item.test.js
@@ -1,0 +1,39 @@
+const transformCompanyToSubsidiaryListItem = require('~/src/apps/companies/transformers/company-to-subsidiary-list-item')
+
+const companyMock = require('~/test/unit/data/companies/company-v4.json')
+
+describe('#transformCompanyToSubsidiaryListItem', () => {
+  context('when the global headquarters is not archived', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToSubsidiaryListItem({
+        archived: false,
+      })(companyMock)
+    })
+
+    it('should add the "Remove subsidiary" link', () => {
+      expect(this.actual.meta).to.containSubset([
+        {
+          value: 'Remove subsidiary',
+          url: `/companies/${companyMock.id}/hierarchies/ghq/remove`,
+        },
+      ])
+    })
+  })
+
+  context('when the global headquarters is archived', () => {
+    beforeEach(() => {
+      this.actual = transformCompanyToSubsidiaryListItem({
+        archived: true,
+      })(companyMock)
+    })
+
+    it('should not add the "Remove subsidiary" link', () => {
+      expect(this.actual.meta).to.not.containSubset([
+        {
+          value: 'Remove subsidiary',
+          url: `/companies/${companyMock.id}/hierarchies/ghq/remove`,
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## Change
Currently Global HQ and subsidiary companies populated from D&B data cannot be linked. This change removes the flag so that companies can now be linked.

## Test
Attention should be giving to the following areas:
- adding a subsidiary to a Global HQ
- linking a subsidiary to a Global HQ
- removing subsidiary/Global HQ links

## Before
### No ability to link a subsidiary
<img width="804" alt="Screenshot 2019-05-21 at 10 59 24" src="https://user-images.githubusercontent.com/1150417/58087404-6928ef00-7bb8-11e9-9d3a-47c4d9fc720e.png">

### No action to start linking a subsidiary
<img width="771" alt="Screenshot 2019-05-21 at 10 58 17" src="https://user-images.githubusercontent.com/1150417/58087405-6928ef00-7bb8-11e9-88c1-9b37df00b034.png">

### No ability to remove a subsidiary
<img width="767" alt="Screenshot 2019-05-21 at 10 51 20" src="https://user-images.githubusercontent.com/1150417/58087406-69c18580-7bb8-11e9-9dfe-f9b1eaaf56a8.png">

## After
### Ability to search for a company and link a subsidiary
<img width="808" alt="Screenshot 2019-05-21 at 10 59 16" src="https://user-images.githubusercontent.com/1150417/58087432-72b25700-7bb8-11e9-91d8-e1314389b0c1.png">

### Action to start linking
<img width="779" alt="Screenshot 2019-05-21 at 10 58 27" src="https://user-images.githubusercontent.com/1150417/58087434-72b25700-7bb8-11e9-9022-829bbc728fd3.png">

### Ability to remove a subsidiary
<img width="762" alt="Screenshot 2019-05-21 at 10 50 57" src="https://user-images.githubusercontent.com/1150417/58087436-72b25700-7bb8-11e9-945e-5952dc0c9fae.png">


**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
