### PR TITLE
Add 6 new checkboxes that allow a user to add the Restrictions / conditions

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -42,6 +42,11 @@ const getTimeHorizons = async (token, profile) => {
   return transformCheckboxes(timeHorizons, profile.investorRequirements.timeHorizons)
 }
 
+const getRestrictions = async (token, profile) => {
+  const restriction = await getOptions(token, 'capital-investment/restriction', { sorted: false })
+  return transformCheckboxes(restriction, profile.investorRequirements.restrictions)
+}
+
 const getCompanyProfile = async (token, company, editing) => {
   const profiles = await getCompanyProfiles(token, company.id)
   const profile = profiles.results && profiles.results[0]
@@ -67,6 +72,7 @@ const renderProfile = async (req, res, next) => {
       profile.investorRequirements.dealTicketSizes.items = await getDealTicketSizes(token, profile)
       profile.investorRequirements.investmentTypes.items = await getInvestmentTypes(token, profile)
       profile.investorRequirements.timeHorizons.items = await getTimeHorizons(token, profile)
+      profile.investorRequirements.restrictions.items = await getRestrictions(token, profile)
     }
 
     res.render('companies/apps/investments/large-capital-profile/views/profile', { profile })

--- a/src/apps/companies/apps/investments/large-capital-profile/styles.scss
+++ b/src/apps/companies/apps/investments/large-capital-profile/styles.scss
@@ -49,6 +49,7 @@ nav.govuk-tabs {
     width: 75%;
   }
   form.investor-requirements-edit  {
+    .restrictions,
     .deal-ticket-sizes {
       @include flexWrap;
       width: 660px;

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
@@ -5,6 +5,7 @@ const transformInvestorRequirements = (body) => {
     deal_ticket_sizes: sanitizeCheckboxes(body.dealTicketSizes),
     investment_types: sanitizeCheckboxes(body.investmentTypes),
     time_horizons: sanitizeCheckboxes(body.timeHorizons),
+    restrictions: sanitizeCheckboxes(body.restrictions),
   }
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -64,6 +64,9 @@ const transformProfile = (profile, editing) => {
       timeHorizons: {
         value: get(profile, 'time_horizons'),
       },
+      restrictions: {
+        value: get(profile, 'restrictions'),
+      },
     },
     location: {
       incompleteFields: get(profile, 'incomplete_location_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
@@ -66,4 +66,21 @@
     })
   }}
 
+  {{
+    govukCheckboxes({
+      name: 'restrictions',
+      classes: 'restrictions',
+      fieldset: {
+        attributes: {
+          'data-auto-id': 'restrictions'
+        },
+        legend: {
+          text: 'Restrictions / conditions',
+          classes: 'govuk-fieldset__legend--s'
+        }
+      },
+      items: profile.investorRequirements.restrictions.items
+    })
+  }}
+
 {% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
@@ -4,7 +4,7 @@
   {{ taskListItem({ name: 'Types of investment',  value: profile.investorRequirements.investmentTypes.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Minimum return rate' }) }}
   {{ taskListItem({ name: 'Time horizon / tenor', value: profile.investorRequirements.timeHorizons.value, key: 'name' }) }}
-  {{ taskListItem({ name: 'Restrictions / conditions' }) }}
+  {{ taskListItem({ name: 'Restrictions / conditions', value: profile.investorRequirements.restrictions.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Construction risk' }) }}
   {{ taskListItem({ name: 'Minimum equity percentage' }) }}
   {{ taskListItem({ name: 'Desired deal role' }) }}

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -91,6 +91,15 @@ module.exports = {
       tenTo14Years: '[data-auto-id=timeHorizons] #timeHorizons-3',
       fifteenYearsPlus: '[data-auto-id=timeHorizons] #timeHorizons-4',
     },
+    restrictions: {
+      name: '[data-auto-id=restrictions] legend',
+      liquidity: '[data-auto-id=restrictions] #restrictions-1',
+      inflationAdjustment: '[data-auto-id=restrictions] #restrictions-2',
+      requireFXHedge: '[data-auto-id=restrictions] #restrictions-3',
+      requireBoardSeat: '[data-auto-id=restrictions] #restrictions-4',
+      requireLinkedTech: '[data-auto-id=restrictions] #restrictions-5',
+      willParticipateInCompBids: '[data-auto-id=restrictions] #restrictions-6',
+    },
     taskList: {
       dealTicketSize: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(1) .task-list__item-name',
@@ -130,9 +139,16 @@ module.exports = {
         tenTo14Years: '[data-auto-id=investorRequirements]  ul > li:nth-child(5) span:nth-child(4)',
         fifteenYearsPlus: '[data-auto-id=investorRequirements]  ul > li:nth-child(5) span:nth-child(5)',
       },
-      restrictionsConditions: {
+      restrictions: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(6) .task-list__item-name',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(6) .task-list__item-incomplete',
+        liquidity: '[data-auto-id=investorRequirements] ul > li:nth-child(6) span:nth-child(2)',
+        inflationAdjustment: '[data-auto-id=investorRequirements] ul > li:nth-child(6) span:nth-child(3)',
+        requireFXHedge: '[data-auto-id=investorRequirements] ul > li:nth-child(6) span:nth-child(4)',
+        requireBoardSeat: '[data-auto-id=investorRequirements] ul > li:nth-child(6) span:nth-child(5)',
+        requireLinkedTech: '[data-auto-id=investorRequirements] ul > li:nth-child(6) span:nth-child(6)',
+        willParticipateInCompBids: '[data-auto-id=investorRequirements] ul > li:nth-child(6) span:nth-child(7)',
+
       },
       constructionRisk: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(7) .task-list__item-name',

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -282,6 +282,17 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.timeHorizons.tenTo14Years).should('be.checked')
         .get(investorRequirements.timeHorizons.fifteenYearsPlus).should('be.checked')
     })
+
+    it('should display "Restrictions / conditions" and all checkboxes should be checked"', () => {
+      cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
+        .get(investorRequirements.restrictions.name).should('contain', 'Restrictions / conditions')
+        .get(investorRequirements.restrictions.liquidity).should('be.checked')
+        .get(investorRequirements.restrictions.inflationAdjustment).should('be.checked')
+        .get(investorRequirements.restrictions.requireFXHedge).should('be.checked')
+        .get(investorRequirements.restrictions.requireBoardSeat).should('be.checked')
+        .get(investorRequirements.restrictions.requireLinkedTech).should('be.checked')
+        .get(investorRequirements.restrictions.willParticipateInCompBids).should('be.checked')
+    })
   })
 
   context('when viewing the "Investor requirements" details section', () => {
@@ -321,6 +332,18 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.taskList.timeHorizon.fiveTo9Years).should('contain', '5-9 years')
         .get(investorRequirements.taskList.timeHorizon.tenTo14Years).should('contain', '10-14 years')
         .get(investorRequirements.taskList.timeHorizon.fifteenYearsPlus).should('contain', '15 years +')
+    })
+
+    it('should display "Restrictions / conditions" and all 6 restrictions', () => {
+      cy.visit(largeCapitalProfile)
+        .get(selectors.investorRequirements.summary).click()
+        .get(investorRequirements.taskList.restrictions.name).should('contain', 'Restrictions / conditions')
+        .get(investorRequirements.taskList.restrictions.liquidity).should('contain', 'Liquidity / exchange listing')
+        .get(investorRequirements.taskList.restrictions.inflationAdjustment).should('contain', 'Inflation adjustment')
+        .get(investorRequirements.taskList.restrictions.requireFXHedge).should('contain', 'Require FX hedge')
+        .get(investorRequirements.taskList.restrictions.requireBoardSeat).should('contain', 'Require board seat')
+        .get(investorRequirements.taskList.restrictions.requireLinkedTech).should('contain', 'Require linked technology / knowledge transfer')
+        .get(investorRequirements.taskList.restrictions.willParticipateInCompBids).should('contain', 'Will participate in competitive bids / auctions')
     })
   })
 })

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
@@ -99,33 +99,27 @@ describe('Company Investments - Large capital profile - Investor details', () =>
                 name: 'Holly Collins',
                 id: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
               },
-              advisers: [
-                {
-                  label: 'Jeff Smith',
-                  subLabel: 'Team A',
-                  value: 'a0dae366-1134-e411-985c-e4115bead28a',
-                },
-                {
-                  label: 'Aaron Mr',
-                  subLabel: 'Team B',
-                  value: 'e13209b8-8d61-e311-8255-e4115bead28a',
-                },
-                {
-                  label: 'Mr Benjamin',
-                  subLabel: 'Team C',
-                  value: 'b9d6b3dc-7af4-e411-bcbe-e4115bead28a',
-                },
-                {
-                  label: 'George Chan',
-                  subLabel: 'Team D',
-                  value: '0119a99e-9798-e211-a939-e4115bead28a',
-                },
-                {
-                  label: 'Fred Rafters',
-                  subLabel: 'Team E',
-                  value: '0919a99e-9798-e211-a939-e4115bead28a',
-                },
-              ],
+              advisers: [{
+                label: 'Jeff Smith',
+                subLabel: 'Team A',
+                value: 'a0dae366-1134-e411-985c-e4115bead28a',
+              }, {
+                label: 'Aaron Mr',
+                subLabel: 'Team B',
+                value: 'e13209b8-8d61-e311-8255-e4115bead28a',
+              }, {
+                label: 'Mr Benjamin',
+                subLabel: 'Team C',
+                value: 'b9d6b3dc-7af4-e411-bcbe-e4115bead28a',
+              }, {
+                label: 'George Chan',
+                subLabel: 'Team D',
+                value: '0119a99e-9798-e211-a939-e4115bead28a',
+              }, {
+                label: 'Fred Rafters',
+                subLabel: 'Team E',
+                value: '0919a99e-9798-e211-a939-e4115bead28a',
+              }],
               date: {
                 day: 2,
                 month: 5,
@@ -183,6 +177,9 @@ describe('Company Investments - Large capital profile - Investor details', () =>
             value: [],
           },
           timeHorizons: {
+            value: [],
+          },
+          restrictions: {
             value: [],
           },
         },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile.test.js
@@ -97,6 +97,9 @@ describe('Company Investments - Large capital profile', () => {
           timeHorizons: {
             value: [],
           },
+          restrictions: {
+            value: [],
+          },
         },
         location: {
           incompleteFields: 3,
@@ -147,6 +150,11 @@ describe('Company Investments - Large capital profile', () => {
         profile.time_horizons = [{
           id: '29a0a8e9-1c21-432a-bb4f-b9363b46a6aa',
           name: '10-14 years',
+        }]
+
+        profile.restrictions = [{
+          id: '24d90807-91de-4814-92f6-0a5ee43406d1',
+          name: 'Require FX hedge',
         }]
 
         nock(config.apiRoot)
@@ -217,6 +225,12 @@ describe('Company Investments - Large capital profile', () => {
             value: [ {
               id: '29a0a8e9-1c21-432a-bb4f-b9363b46a6aa',
               name: '10-14 years',
+            }],
+          },
+          restrictions: {
+            value: [ {
+              id: '24d90807-91de-4814-92f6-0a5ee43406d1',
+              name: 'Require FX hedge',
             }],
           },
         },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
@@ -1,6 +1,7 @@
 const dealTicketSize = require('~/test/unit/data/companies/investments/metadata/deal-ticket-size.json')
 const investmentType = require('~/test/unit/data/companies/investments/metadata/investment-type.json')
 const timeHorizons = require('~/test/unit/data/companies/investments/metadata/time-horizon.json')
+const restrictions = require('~/test/unit/data/companies/investments/metadata/restrictions.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile.json')
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
@@ -58,6 +59,8 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           .reply(200, investmentType)
           .get('/metadata/capital-investment/time-horizon/')
           .reply(200, timeHorizons)
+          .get('/metadata/capital-investment/restriction/')
+          .reply(200, restrictions)
 
         this.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
@@ -186,6 +189,28 @@ describe('Company Investments - Large capital profile - Investor requirements', 
               name: 'Up to 5 years',
               id: 'd2d1bdbb-c42a-459c-adaa-fce45ce08cc9',
             }],
+          },
+          restrictions: {
+            items: [{
+              text: 'Liquidity / exchange listing',
+              value: '5b4f5dc5-c836-4572-afd2-013776ed00c5',
+            }, {
+              text: 'Inflation adjustment',
+              value: 'daa293d4-e18e-44af-b139-bd1b4c4a9067',
+            }, {
+              text: 'Require FX hedge',
+              value: '24d90807-91de-4814-92f6-0a5ee43406d1',
+            }, {
+              text: 'Require board seat',
+              value: '7dad0891-9174-437d-bb30-b610ac1ecd0a',
+            }, {
+              text: 'Require linked technology / knowledge transfer',
+              value: 'bfa167ab-f98a-4c73-b34d-c34ba7bdf93b',
+            }, {
+              text: 'Will participate in competitive bids / auctions',
+              value: 'dbc0cdf0-5365-4cbf-8d55-7516b6ebc383',
+            }],
+            value: [],
           },
         },
         location: {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
@@ -14,6 +14,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         deal_ticket_sizes: [],
         investment_types: [],
         time_horizons: [],
+        restrictions: [],
       })
     })
 
@@ -22,11 +23,13 @@ describe('Large capital profile, Investor requirements form to API', () => {
         dealTicketSizes: 'id',
         investmentTypes: 'id',
         timeHorizons: 'id',
+        restrictions: 'id',
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: ['id'],
         investment_types: ['id'],
         time_horizons: ['id'],
+        restrictions: ['id'],
       })
     })
 
@@ -35,11 +38,13 @@ describe('Large capital profile, Investor requirements form to API', () => {
         dealTicketSizes: ['id'],
         investmentTypes: ['id'],
         timeHorizons: ['id'],
+        restrictions: ['id'],
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: ['id'],
         investment_types: ['id'],
         time_horizons: ['id'],
+        restrictions: ['id'],
       })
     })
   })

--- a/test/unit/data/companies/investments/metadata/restrictions.json
+++ b/test/unit/data/companies/investments/metadata/restrictions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "5b4f5dc5-c836-4572-afd2-013776ed00c5",
+    "name": "Liquidity / exchange listing"
+  },
+  {
+    "id": "daa293d4-e18e-44af-b139-bd1b4c4a9067",
+    "name": "Inflation adjustment"
+  },
+  {
+    "id": "24d90807-91de-4814-92f6-0a5ee43406d1",
+    "name": "Require FX hedge"
+  },
+  {
+    "id": "7dad0891-9174-437d-bb30-b610ac1ecd0a",
+    "name": "Require board seat"
+  },
+  {
+    "id": "bfa167ab-f98a-4c73-b34d-c34ba7bdf93b",
+    "name": "Require linked technology / knowledge transfer"
+  },
+  {
+    "id": "dbc0cdf0-5365-4cbf-8d55-7516b6ebc383",
+    "name": "Will participate in competitive bids / auctions"
+  }
+]


### PR DESCRIPTION
1. Liquidity / exchange listing
2. Inflation adjustment
3. Require FX hedge
4. Require board seat
5. Require linked technology / knowledge transfer
6. Will participate in competitive bids / auctions

Display what the user has selected within the profile read-only view.

https://uktrade.atlassian.net/browse/IPBETA-272

**Edit restrictions**

![edit-restrictions](https://user-images.githubusercontent.com/964268/58035338-72ff1380-7b20-11e9-8a22-9f46184dc285.png)

**View restrictions**

![view-restrictions](https://user-images.githubusercontent.com/964268/58035731-4f889880-7b21-11e9-8428-3b06e79fb97d.png)

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
