### PR TITLE
Add 3 new checkboxes that allow a user to add 'Desired deal roles'

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -52,6 +52,11 @@ const getConstructionRisks = async (token, profile) => {
   return transformCheckboxes(constructionRisks, profile.investorRequirements.constructionRisks)
 }
 
+const getDesiredDealRoles = async (token, profile) => {
+  const desiredDealRoles = await getOptions(token, 'capital-investment/desired-deal-role', { sorted: false })
+  return transformCheckboxes(desiredDealRoles, profile.investorRequirements.desiredDealRoles)
+}
+
 const getCompanyProfile = async (token, company, editing) => {
   const profiles = await getCompanyProfiles(token, company.id)
   const profile = profiles.results && profiles.results[0]
@@ -80,6 +85,7 @@ const renderProfile = async (req, res, next) => {
         getTimeHorizons(token, profile),
         getRestrictions(token, profile),
         getConstructionRisks(token, profile),
+        getDesiredDealRoles(token, profile),
       ]
 
       await Promise.all(promises).then(([
@@ -88,12 +94,14 @@ const renderProfile = async (req, res, next) => {
         timeHorizons,
         restrictions,
         constructionRisks,
+        desiredDealRoles,
       ]) => {
         profile.investorRequirements.dealTicketSizes.items = dealTicketSizes
         profile.investorRequirements.investmentTypes.items = investmentTypes
         profile.investorRequirements.timeHorizons.items = timeHorizons
         profile.investorRequirements.restrictions.items = restrictions
         profile.investorRequirements.constructionRisks.items = constructionRisks
+        profile.investorRequirements.desiredDealRoles.items = desiredDealRoles
       })
     }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
@@ -7,6 +7,7 @@ const transformInvestorRequirements = (body) => {
     time_horizons: sanitizeCheckboxes(body.timeHorizons),
     restrictions: sanitizeCheckboxes(body.restrictions),
     construction_risks: sanitizeCheckboxes(body.constructionRisks),
+    desired_deal_roles: sanitizeCheckboxes(body.desiredDealRoles),
   }
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -70,6 +70,9 @@ const transformProfile = (profile, editing) => {
       constructionRisks: {
         value: get(profile, 'construction_risks'),
       },
+      desiredDealRoles: {
+        value: get(profile, 'desired_deal_roles'),
+      },
     },
     location: {
       incompleteFields: get(profile, 'incomplete_location_fields.length'),

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
@@ -99,4 +99,24 @@
       items: profile.investorRequirements.constructionRisks.items
     })
   }}
+
+  <p>Minimum equity percentage</p>
+
+  {{
+    govukCheckboxes({
+      name: 'desiredDealRoles',
+      classes: 'construction-risk',
+      fieldset: {
+        attributes: {
+          'data-auto-id': 'desiredDealRoles'
+        },
+        legend: {
+          text: 'Desired deal role',
+          classes: 'govuk-fieldset__legend--s'
+        }
+      },
+      items: profile.investorRequirements.desiredDealRoles.items
+    })
+  }}
+
 {% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
@@ -7,7 +7,7 @@
   {{ taskListItem({ name: 'Restrictions / conditions', value: profile.investorRequirements.restrictions.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Construction risk', value: profile.investorRequirements.constructionRisks.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Minimum equity percentage' }) }}
-  {{ taskListItem({ name: 'Desired deal role' }) }}
+  {{ taskListItem({ name: 'Desired deal role', value: profile.investorRequirements.desiredDealRoles.value, key: 'name' }) }}
 </ul>
 
 {% call Form({

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -106,6 +106,12 @@ module.exports = {
       brownfield: '[data-auto-id=constructionRisks] #constructionRisks-2',
       operational: '[data-auto-id=constructionRisks] #constructionRisks-3',
     },
+    desiredDealRoles: {
+      name: '[data-auto-id=desiredDealRoles] legend',
+      leadManager: '[data-auto-id=desiredDealRoles] #desiredDealRoles-1',
+      coLeadManager: '[data-auto-id=desiredDealRoles] #desiredDealRoles-2',
+      coInvestor: '[data-auto-id=desiredDealRoles] #desiredDealRoles-3',
+    },
     taskList: {
       dealTicketSize: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(1) .task-list__item-name',
@@ -166,9 +172,12 @@ module.exports = {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(8) .task-list__item-name',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(8) .task-list__item-incomplete',
       },
-      desiredDealRole: {
+      desiredDealRoles: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(9) .task-list__item-name',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(9) .task-list__item-incomplete',
+        leadManager: '[data-auto-id=investorRequirements] ul > li:nth-child(9) span:nth-child(2)',
+        coLeadManager: '[data-auto-id=investorRequirements] ul > li:nth-child(9) span:nth-child(3)',
+        coInvestor: '[data-auto-id=investorRequirements] ul > li:nth-child(9) span:nth-child(4)',
       },
     },
   },

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -301,6 +301,14 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.constructionRisks.brownfield).should('be.checked')
         .get(investorRequirements.constructionRisks.operational).should('be.checked')
     })
+
+    it('should display "Desired deal role" and all 3 checkboxes should be checked"', () => {
+      cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
+        .get(investorRequirements.desiredDealRoles.name).should('contain', 'Desired deal role')
+        .get(investorRequirements.desiredDealRoles.leadManager).should('be.checked')
+        .get(investorRequirements.desiredDealRoles.coLeadManager).should('be.checked')
+        .get(investorRequirements.desiredDealRoles.coInvestor).should('be.checked')
+    })
   })
 
   context('when viewing the "Investor requirements" details section', () => {
@@ -361,6 +369,15 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.taskList.constructionRisks.greenfield).should('contain', 'Greenfield (construction risk)')
         .get(investorRequirements.taskList.constructionRisks.brownfield).should('contain', 'Brownfield (some construction risk)')
         .get(investorRequirements.taskList.constructionRisks.operational).should('contain', 'Operational (no construction risk)')
+    })
+
+    it('should display "Desired deal role" and all 3 roles', () => {
+      cy.visit(largeCapitalProfile)
+        .get(selectors.investorRequirements.summary).click()
+        .get(investorRequirements.taskList.desiredDealRoles.name).should('contain', 'Desired deal role')
+        .get(investorRequirements.taskList.desiredDealRoles.leadManager).should('contain', 'Lead manager / deal structure')
+        .get(investorRequirements.taskList.desiredDealRoles.coLeadManager).should('contain', 'Co-lead manager')
+        .get(investorRequirements.taskList.desiredDealRoles.coInvestor).should('contain', 'Co-investor / syndicate member')
     })
   })
 })

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
@@ -1,33 +1,17 @@
 const investorTypeTransformed = require('~/test/unit/data/companies/investments/metadata/investor-type-transformed.json')
 const requiredChecksConducted = require('~/test/unit/data/companies/investments/metadata/required-checks-conducted.json')
-const investorType = require('~/test/unit/data/companies/investments/metadata/investor-type.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile-new.json')
-const advisersMock = require('~/test/unit/data/advisers/advisers.json')
-
-const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
-const companyMock = require('~/test/unit/data/companies/minimal-company.json')
+const investorType = require('~/test/unit/data/companies/investments/metadata/investor-type.json')
+const company = require('~/test/unit/data/companies/minimal-company.json')
+const advisers = require('~/test/unit/data/advisers/advisers.json')
 const { cloneDeep } = require('lodash')
 const config = require('~/config')
 
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 const controller = require('~/src/apps/companies/apps/investments/large-capital-profile/controllers')
 
 describe('Company Investments - Large capital profile - Investor details', () => {
   describe('renderProfile', () => {
-    const commonTests = (profile) => {
-      it('should call the render function once', () => {
-        expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
-      })
-
-      it('should call the render function and pass the view', () => {
-        const view = 'companies/apps/investments/large-capital-profile/views/profile'
-        expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal(view)
-      })
-
-      it('should call the render function and pass the profile', () => {
-        expect(this.middlewareParameters.resMock.render.args[0][1].profile).to.deep.equal(profile)
-      })
-    }
-
     context('when the user is editing the "Investor details" section', () => {
       beforeEach(async () => {
         const clonedCompanyProfile = cloneDeep(companyProfile)
@@ -39,27 +23,27 @@ describe('Company Investments - Large capital profile - Investor details', () =>
           id: '02d6fc9b-fbb9-4621-b247-d86f2487898e',
         }
 
-        // Define a date the advisor conducted the checks on.
+        // Define a date the Adviser conducted the checks on.
         profile.required_checks_conducted_on = '2019-05-02'
 
-        //  Define the advisor.
+        //  Define the adviser.
         profile.required_checks_conducted_by = {
           name: 'Holly Collins',
           id: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
         }
 
         nock(config.apiRoot)
-          .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
+          .get(`/v4/large-investor-profile?investor_company_id=${company.id}`)
           .reply(200, clonedCompanyProfile)
           .get('/metadata/capital-investment/investor-type/')
           .reply(200, investorType)
           .get('/metadata/capital-investment/required-checks-conducted/')
           .reply(200, requiredChecksConducted)
           .get('/adviser/?limit=100000&offset=0')
-          .reply(200, advisersMock)
+          .reply(200, advisers)
 
         this.middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
+          company,
           requestQuery: {
             editing: 'investor-details',
           },
@@ -72,7 +56,7 @@ describe('Company Investments - Large capital profile - Investor details', () =>
         )
       })
 
-      commonTests({
+      const profile = {
         editing: 'investor-details',
         id: companyProfile.results[0].id,
         investorDetails: {
@@ -185,10 +169,26 @@ describe('Company Investments - Large capital profile - Investor details', () =>
           constructionRisks: {
             value: [],
           },
+          desiredDealRoles: {
+            value: [],
+          },
         },
         location: {
           incompleteFields: 3,
         },
+      }
+
+      it('should call the render function once', () => {
+        expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
+      })
+
+      it('should call the render function and pass the view', () => {
+        const view = 'companies/apps/investments/large-capital-profile/views/profile'
+        expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal(view)
+      })
+
+      it('should call the render function and pass the profile', () => {
+        expect(this.middlewareParameters.resMock.render.args[0][1].profile).to.deep.equal(profile)
       })
     })
   })

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-complete.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-complete.test.js
@@ -91,6 +91,12 @@ describe('Company Investments - Large capital profile', () => {
               name: 'Brownfield (some construction risk)',
             }],
           },
+          desiredDealRoles: {
+            value: [ {
+              id: '48cace6e-ec14-467b-b1b5-19b318ab5c51',
+              name: 'Co-investor / syndicate member',
+            }],
+          },
         },
         location: {
           incompleteFields: 3,

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-new.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-new.test.js
@@ -66,6 +66,9 @@ describe('Company Investments - Large capital profile', () => {
           constructionRisks: {
             value: [],
           },
+          desiredDealRoles: {
+            value: [],
+          },
         },
         location: {
           incompleteFields: 3,

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
@@ -3,6 +3,7 @@ const investmentType = require('~/test/unit/data/companies/investments/metadata/
 const timeHorizons = require('~/test/unit/data/companies/investments/metadata/time-horizon.json')
 const restrictions = require('~/test/unit/data/companies/investments/metadata/restrictions.json')
 const constructionRisk = require('~/test/unit/data/companies/investments/metadata/construction-risk.json')
+const desiredDealRole = require('~/test/unit/data/companies/investments/metadata/desired-deal-role.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile-new.json')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
 const { cloneDeep } = require('lodash')
@@ -49,6 +50,8 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           .reply(200, restrictions)
           .get('/metadata/capital-investment/construction-risk/')
           .reply(200, constructionRisk)
+          .get('/metadata/capital-investment/desired-deal-role/')
+          .reply(200, desiredDealRole)
 
         this.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
@@ -210,6 +213,19 @@ describe('Company Investments - Large capital profile - Investor requirements', 
             }, {
               text: 'Operational (no construction risk)',
               value: '9f554b26-70f2-4cac-89ae-758c2ef71c70',
+            }],
+            value: [],
+          },
+          desiredDealRoles: {
+            items: [{
+              text: 'Lead manager / deal structure',
+              value: 'efadc6bb-2a73-4627-8ce3-9dc2c34c3f31',
+            }, {
+              text: 'Co-lead manager',
+              value: '29d930e6-de2f-403d-87dc-764bc418d33a',
+            }, {
+              text: 'Co-investor / syndicate member',
+              value: '48cace6e-ec14-467b-b1b5-19b318ab5c51',
             }],
             value: [],
           },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
@@ -11,6 +11,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         timeHorizons: undefined,
         restrictions: undefined,
         constructionRisks: undefined,
+        desiredDealsRoles: undefined,
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: [],
@@ -18,6 +19,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         time_horizons: [],
         restrictions: [],
         construction_risks: [],
+        desired_deal_roles: [],
       })
     })
 
@@ -28,6 +30,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         timeHorizons: 'id',
         restrictions: 'id',
         constructionRisks: 'id',
+        desiredDealRoles: 'id',
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: ['id'],
@@ -35,6 +38,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         time_horizons: ['id'],
         restrictions: ['id'],
         construction_risks: ['id'],
+        desired_deal_roles: ['id'],
       })
     })
 
@@ -45,6 +49,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         timeHorizons: ['id'],
         restrictions: ['id'],
         constructionRisks: ['id'],
+        desiredDealRoles: 'id',
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: ['id'],
@@ -52,6 +57,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         time_horizons: ['id'],
         restrictions: ['id'],
         construction_risks: ['id'],
+        desired_deal_roles: ['id'],
       })
     })
   })

--- a/test/unit/data/companies/investments/large-capital-profile-completed.json
+++ b/test/unit/data/companies/investments/large-capital-profile-completed.json
@@ -57,7 +57,10 @@
         "name": "Brownfield (some construction risk)"
       }],
       "minimum_equity_percentage": null,
-      "desired_deal_roles": [],
+      "desired_deal_roles": [{
+        "id": "48cace6e-ec14-467b-b1b5-19b318ab5c51",
+        "name": "Co-investor / syndicate member"
+      }],
       "restrictions": [{
         "id": "24d90807-91de-4814-92f6-0a5ee43406d1",
         "name": "Require FX hedge"

--- a/test/unit/data/companies/investments/metadata/desired-deal-role.json
+++ b/test/unit/data/companies/investments/metadata/desired-deal-role.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "efadc6bb-2a73-4627-8ce3-9dc2c34c3f31",
+    "name": "Lead manager / deal structure",
+    "disabled_on": null
+  },
+  {
+    "id": "29d930e6-de2f-403d-87dc-764bc418d33a",
+    "name": "Co-lead manager",
+    "disabled_on": null
+  },
+  {
+    "id": "48cace6e-ec14-467b-b1b5-19b318ab5c51",
+    "name": "Co-investor / syndicate member",
+    "disabled_on": null
+  }
+]


### PR DESCRIPTION
1. Lead manager / deal structure
2. Co-lead manager
3. Co-investor / syndicate member

Display what the user has selected within the profile read-only view.

https://uktrade.atlassian.net/browse/IPBETA-272

**Edit Desired deal role**

<img width="1161" alt="desired-deal-role-edit" src="https://user-images.githubusercontent.com/964268/58186772-75db3f00-7cad-11e9-941d-5410f9db5034.png">

**View Desired deal role**

<img width="1161" alt="desired-deal-role-read" src="https://user-images.githubusercontent.com/964268/58186786-796ec600-7cad-11e9-9fd8-54d1c56a7931.png">


**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
