### PR TITLE
Bug - Update table styles to accommodate long urls

### DIFF
--- a/assets/stylesheets/_deprecated/components/_table.scss
+++ b/assets/stylesheets/_deprecated/components/_table.scss
@@ -3,8 +3,12 @@
 .table--key-value {
 
   margin: 20px 0;
+  table-layout: fixed;
 
   tbody {
+    th, td {
+      word-wrap: break-word;
+    }
     th {
       vertical-align: top;
       width: 40%;


### PR DESCRIPTION
## Problem
Trello - https://trello.com/c/MjttLC7i/550-super-long-urls-break-the-table-layout

If you add a long url in the table data cell the table layout overflows its parent container
![Screenshot 2019-05-23 at 10 31 51](https://user-images.githubusercontent.com/10154302/58244803-4844d300-7d4b-11e9-960c-715f38c6c633.png)

## Solution
Wrap long urls using CSS rules
![Screenshot 2019-05-23 at 10 32 08](https://user-images.githubusercontent.com/10154302/58244841-585cb280-7d4b-11e9-98de-b8036173c9f4.png)

**Implementation notes**

_Add any additional information about the change that isn't captured in the Trello ticket._

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
