### PR TITLE
In interactions sort the contacts in alphabetical order

### DIFF
--- a/src/apps/contacts/repos.js
+++ b/src/apps/contacts/repos.js
@@ -1,3 +1,4 @@
+const { sortBy } = require('lodash')
 const { authorisedRequest } = require('../../lib/authorised-request')
 const config = require('../../../config')
 
@@ -46,7 +47,7 @@ async function getContactsForCompany (token, companyId) {
       limit: 500,
     },
   })
-  return response.results
+  return sortBy(response.results, [(name) => name.first_name])
 }
 
 function getContactAuditLog (token, contactId, page = 1) {

--- a/src/apps/interactions/services/interaction-options.js
+++ b/src/apps/interactions/services/interaction-options.js
@@ -34,7 +34,9 @@ async function getCommonOptions (token, createdOn, req, res) {
   const companyId = get(res.locals, 'company.id')
   const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
 
-  const contacts = await getContactsForCompany(token, companyId)
+  const companyContacts = await getContactsForCompany(token, companyId)
+  const contacts = companyContacts.filter(contact => !contact.archived).map(transformContactToOption)
+
   const advisers = await getAdvisers(token)
 
   const activeAdvisers = filterActiveAdvisers({
@@ -44,7 +46,7 @@ async function getCommonOptions (token, createdOn, req, res) {
 
   const commonOptions = {
     advisers: activeAdvisers.map(transformAdviserToOption),
-    contacts: contacts.filter(contact => !contact.archived).map(transformContactToOption),
+    contacts: contacts,
     teams: await getOptions(token, 'team', { createdOn }),
   }
 

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -3,6 +3,7 @@ const {
   filter,
   keyBy,
   snakeCase,
+  upperFirst,
 } = require('lodash')
 const { isValid, format, parse } = require('date-fns')
 
@@ -45,7 +46,7 @@ function transformStringToOption (string) {
 function transformContactToOption ({ id, first_name, last_name, job_title, email }) {
   return {
     value: id,
-    label: filter([`${first_name} ${last_name}`, job_title]).join(', '),
+    label: upperFirst(filter([`${first_name} ${last_name}`, job_title]).join(', ')),
   }
 }
 

--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -360,8 +360,8 @@ describe('Interaction edit controller (Interactions)', () => {
       const contactField = find(this.interactionForm.children, ({ name }) => name === 'contacts')
       const contact = contactField.children[0].options
       expect(contact).to.deep.equal([
-        { value: '999', label: 'Fred Smith, Manager' },
         { value: '998', label: 'Emily Brown, Director' },
+        { value: '999', label: 'Fred Smith, Manager' },
       ])
     })
 
@@ -393,8 +393,8 @@ describe('Interaction edit controller (Interactions)', () => {
       const contactField = find(this.interactionForm.children, ({ name }) => name === 'contacts')
       const contact = contactField.children[0].options
       expect(contact).to.deep.equal([
-        { value: '999', label: 'Fred Smith, Manager' },
         { value: '998', label: 'Emily Brown, Director' },
+        { value: '999', label: 'Fred Smith, Manager' },
       ])
     })
 
@@ -612,8 +612,8 @@ describe('Interaction edit controller (Interactions)', () => {
       const contactField = find(this.interactionForm.children, ({ name }) => name === 'contacts')
       const contacts = contactField.children[0]
       expect(contacts.options).to.deep.equal([
-        { value: '999', label: 'Fred Smith, Manager' },
         { value: '998', label: 'Emily Brown, Director' },
+        { value: '999', label: 'Fred Smith, Manager' },
       ])
     })
 

--- a/test/unit/apps/interactions/controllers/edit.service.test.js
+++ b/test/unit/apps/interactions/controllers/edit.service.test.js
@@ -250,8 +250,8 @@ describe('Interaction edit controller (Service delivery)', () => {
       const contactField = find(this.interactionForm.children, ({ name }) => name === 'contacts')
       const contacts = contactField.children[0].options
       expect(contacts).to.deep.equal([
-        { value: '999', label: 'Fred Smith, Manager' },
         { value: '998', label: 'Emily Brown, Director' },
+        { value: '999', label: 'Fred Smith, Manager' },
       ])
     })
 
@@ -518,8 +518,8 @@ describe('Interaction edit controller (Service delivery)', () => {
       const contactField = find(this.interactionForm.children, ({ name }) => name === 'contacts')
       const contact = contactField.children[0]
       expect(contact.options).to.deep.equal([
-        { value: '999', label: 'Fred Smith, Manager' },
         { value: '998', label: 'Emily Brown, Director' },
+        { value: '999', label: 'Fred Smith, Manager' },
       ])
     })
 


### PR DESCRIPTION
## Problem
Trello - https://trello.com/c/vdHzKb2E/739-alphabetical-sort-for-interactions-contacts-list

When editing an interaction the contacts options are not in order making it confusing for the user to find the contact they wish to select.
![Screenshot 2019-05-23 at 13 58 33](https://user-images.githubusercontent.com/10154302/58254658-1e97a600-7d63-11e9-8a39-034df9d51332.png)

## Solution
Sort the contacts in alphabetical order. If any contact starts with a lowercase letter then capitalise this character first.
![Screenshot 2019-05-23 at 13 58 41](https://user-images.githubusercontent.com/10154302/58254726-4850cd00-7d63-11e9-86f4-6c298129755b.png)

### Manual test
1. Edit an interaction
2. Select a different contact to the one pre-selected

**Implementation notes**

_Add any additional information about the change that isn't captured in the Trello ticket._

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
