### PR TITLE
Add 'Minimum equity percentage' radio buttons for Large capital profile  

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -2,6 +2,7 @@ const {
   transformProfile,
   transformAdvisers,
   transformCheckboxes,
+  transformRadioButtons,
   transformInvestorTypes,
   transformRequiredChecks,
 } = require('../transformers')
@@ -45,6 +46,7 @@ const renderProfile = async (req, res, next) => {
           timeHorizonMD,
           restrictionMD,
           constructionRiskMD,
+          minimumEquityPercentageMD,
           desiredDealRoleMD,
         ]) => {
           const {
@@ -53,6 +55,7 @@ const renderProfile = async (req, res, next) => {
             timeHorizons,
             restrictions,
             constructionRisks,
+            minimumEquityPercentage,
             desiredDealRoles,
           } = profile.investorRequirements
 
@@ -61,6 +64,7 @@ const renderProfile = async (req, res, next) => {
           profile.investorRequirements.timeHorizons.items = transformCheckboxes(timeHorizonMD, timeHorizons)
           profile.investorRequirements.restrictions.items = transformCheckboxes(restrictionMD, restrictions)
           profile.investorRequirements.constructionRisks.items = transformCheckboxes(constructionRiskMD, constructionRisks)
+          profile.investorRequirements.minimumEquityPercentage.items = transformRadioButtons(minimumEquityPercentageMD, minimumEquityPercentage)
           profile.investorRequirements.desiredDealRoles.items = transformCheckboxes(desiredDealRoleMD, desiredDealRoles)
         })
     }

--- a/src/apps/companies/apps/investments/large-capital-profile/options.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/options.js
@@ -1,6 +1,8 @@
 const { getOptions } = require('../../../../../lib/options')
 const { getAdvisers } = require('../../../../adviser/repos')
 
+const DO_NOT_SORT = { sorted: false }
+
 const getInvestorDetailsOptions = (token) => {
   return [
     getOptions(token, 'capital-investment/investor-type'),
@@ -10,14 +12,14 @@ const getInvestorDetailsOptions = (token) => {
 }
 
 const getInvestorRequirementsOptions = (token) => {
-  const doNotSort = { sorted: false }
   return [
-    getOptions(token, 'capital-investment/deal-ticket-size', doNotSort),
+    getOptions(token, 'capital-investment/deal-ticket-size', DO_NOT_SORT),
     getOptions(token, 'capital-investment/large-capital-investment-type'),
-    getOptions(token, 'capital-investment/time-horizon', doNotSort),
-    getOptions(token, 'capital-investment/restriction', doNotSort),
-    getOptions(token, 'capital-investment/construction-risk', doNotSort),
-    getOptions(token, 'capital-investment/desired-deal-role', doNotSort),
+    getOptions(token, 'capital-investment/time-horizon', DO_NOT_SORT),
+    getOptions(token, 'capital-investment/restriction', DO_NOT_SORT),
+    getOptions(token, 'capital-investment/construction-risk', DO_NOT_SORT),
+    getOptions(token, 'capital-investment/equity-percentage', DO_NOT_SORT),
+    getOptions(token, 'capital-investment/desired-deal-role', DO_NOT_SORT),
   ]
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/index.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/index.js
@@ -1,5 +1,5 @@
 const { transformInvestorTypes, transformRequiredChecks, transformAdvisers } = require('./investor-details-to-form')
-const { transformCheckboxes } = require('./investor-requirements-to-form')
+const { transformCheckboxes, transformRadioButtons } = require('./investor-requirements-to-form')
 const transformInvestorDetails = require('./investor-details-to-api')
 const transformInvestorRequirements = require('./investor-requirements-to-api')
 const transformProfile = require('./transform-profile')
@@ -8,6 +8,7 @@ module.exports = {
   transformProfile,
   transformAdvisers,
   transformCheckboxes,
+  transformRadioButtons,
   transformInvestorTypes,
   transformRequiredChecks,
   transformInvestorDetails,

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
@@ -7,6 +7,7 @@ const transformInvestorRequirements = (body) => {
     time_horizons: sanitizeCheckboxes(body.timeHorizons),
     restrictions: sanitizeCheckboxes(body.restrictions),
     construction_risks: sanitizeCheckboxes(body.constructionRisks),
+    minimum_equity_percentage: body.minimumEquityPercentage,
     desired_deal_roles: sanitizeCheckboxes(body.desiredDealRoles),
   }
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-form.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-form.js
@@ -1,12 +1,23 @@
 /* eslint-disable camelcase */
-const { transformObjectToOption, checkMatchingItemById } = require('../../utils/transformers')
+const {
+  transformObjectToOption,
+  checkOptionByMatchingId,
+  checkOptionByFindingMatchingId,
+} = require('../../utils/transformers')
 
-const transformCheckboxes = (metaData, obj) => {
-  return metaData
+const transformCheckboxes = (metadata, obj) => {
+  return metadata
     .map(transformObjectToOption)
-    .map(checkMatchingItemById(obj.value))
+    .map(checkOptionByFindingMatchingId(obj.value)) // Array
+}
+
+const transformRadioButtons = (metadata, obj) => {
+  return metadata
+    .map(transformObjectToOption)
+    .map(checkOptionByMatchingId(obj.value)) // String
 }
 
 module.exports = {
   transformCheckboxes,
+  transformRadioButtons,
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -70,6 +70,10 @@ const transformProfile = (profile, editing) => {
       constructionRisks: {
         value: get(profile, 'construction_risks'),
       },
+      minimumEquityPercentage: {
+        text: get(profile, 'minimum_equity_percentage.name', null),
+        value: get(profile, 'minimum_equity_percentage.id', null),
+      },
       desiredDealRoles: {
         value: get(profile, 'desired_deal_roles'),
       },

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
@@ -100,7 +100,21 @@
     })
   }}
 
-  <p>Minimum equity percentage</p>
+  {{
+    govukRadios({
+      name: 'minimumEquityPercentage',
+      fieldset: {
+        attributes: {
+          'data-auto-id': 'minimumEquityPercentage'
+        },
+        legend: {
+          text: 'Minimum equity percentage',
+          classes: 'govuk-fieldset__legend--s'
+        }
+      },
+      items: profile.investorRequirements.minimumEquityPercentage.items
+    })
+  }}
 
   {{
     govukCheckboxes({

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
@@ -6,7 +6,7 @@
   {{ taskListItem({ name: 'Time horizon / tenor', value: profile.investorRequirements.timeHorizons.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Restrictions / conditions', value: profile.investorRequirements.restrictions.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Construction risk', value: profile.investorRequirements.constructionRisks.value, key: 'name' }) }}
-  {{ taskListItem({ name: 'Minimum equity percentage' }) }}
+  {{ taskListItem({ name: 'Minimum equity percentage', value: profile.investorRequirements.minimumEquityPercentage.text }) }}
   {{ taskListItem({ name: 'Desired deal role', value: profile.investorRequirements.desiredDealRoles.value, key: 'name' }) }}
 </ul>
 

--- a/src/apps/companies/apps/investments/utils/transformers.js
+++ b/src/apps/companies/apps/investments/utils/transformers.js
@@ -2,13 +2,23 @@ const { find, isString, castArray, compact } = require('lodash')
 
 const transformObjectToOption = ({ value, label }) => ({ value, text: label })
 
-const checkMatchingItemById = (items) => {
-  return obj => {
-    if (find(items, (item) => item.id === obj.value)) {
-      obj.checked = true
+const checkOptionByFindingMatchingId = (items) => {
+  return option => {
+    if (find(items, (item) => item.id === option.value)) {
+      option.checked = true
     }
 
-    return obj
+    return option
+  }
+}
+
+const checkOptionByMatchingId = (id) => {
+  return option => {
+    if (option.value === id) {
+      option.checked = true
+    }
+
+    return option
   }
 }
 
@@ -17,7 +27,8 @@ const sanitizeCheckboxes = (selection) => {
 }
 
 module.exports = {
-  checkMatchingItemById,
-  transformObjectToOption,
   sanitizeCheckboxes,
+  transformObjectToOption,
+  checkOptionByMatchingId,
+  checkOptionByFindingMatchingId,
 }

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -106,6 +106,13 @@ module.exports = {
       brownfield: '[data-auto-id=constructionRisks] #constructionRisks-2',
       operational: '[data-auto-id=constructionRisks] #constructionRisks-3',
     },
+    minimumEquityPercentage: {
+      name: '[data-auto-id=minimumEquityPercentage] legend',
+      zeroPercent: '[data-auto-id=minimumEquityPercentage] #minimumEquityPercentage-1',
+      oneTo19Percent: '[data-auto-id=minimumEquityPercentage] #minimumEquityPercentage-2',
+      twentyTo49Percent: '[data-auto-id=minimumEquityPercentage] #minimumEquityPercentage-3',
+      fiftyPercentPlus: '[data-auto-id=minimumEquityPercentage] #minimumEquityPercentage-4',
+    },
     desiredDealRoles: {
       name: '[data-auto-id=desiredDealRoles] legend',
       leadManager: '[data-auto-id=desiredDealRoles] #desiredDealRoles-1',
@@ -170,6 +177,7 @@ module.exports = {
       },
       minimumEquityPercentage: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(8) .task-list__item-name',
+        complete: '[data-auto-id=investorRequirements] ul > li:nth-child(8) .task-list__item-complete',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(8) .task-list__item-incomplete',
       },
       desiredDealRoles: {

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -302,6 +302,12 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.constructionRisks.operational).should('be.checked')
     })
 
+    it('should display "Minimum equity percentage" and the radio button "20-49%"" should be checked"', () => {
+      cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
+        .get(investorRequirements.minimumEquityPercentage.name).should('contain', 'Minimum equity percentage')
+        .get(investorRequirements.minimumEquityPercentage.twentyTo49Percent).should('be.checked')
+    })
+
     it('should display "Desired deal role" and all 3 checkboxes should be checked"', () => {
       cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
         .get(investorRequirements.desiredDealRoles.name).should('contain', 'Desired deal role')
@@ -369,6 +375,13 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.taskList.constructionRisks.greenfield).should('contain', 'Greenfield (construction risk)')
         .get(investorRequirements.taskList.constructionRisks.brownfield).should('contain', 'Brownfield (some construction risk)')
         .get(investorRequirements.taskList.constructionRisks.operational).should('contain', 'Operational (no construction risk)')
+    })
+
+    it('should display "Minimum equity percentage" and "20-49%"', () => {
+      cy.visit(largeCapitalProfile)
+        .get(selectors.investorRequirements.summary).click()
+        .get(investorRequirements.taskList.minimumEquityPercentage.name).should('contain', 'Minimum equity percentage')
+        .get(investorRequirements.taskList.minimumEquityPercentage.complete).should('contain', '20-49%')
     })
 
     it('should display "Desired deal role" and all 3 roles', () => {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
@@ -169,6 +169,10 @@ describe('Company Investments - Large capital profile - Investor details', () =>
           constructionRisks: {
             value: [],
           },
+          minimumEquityPercentage: {
+            text: null,
+            value: null,
+          },
           desiredDealRoles: {
             value: [],
           },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-complete.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-complete.test.js
@@ -91,6 +91,10 @@ describe('Company Investments - Large capital profile', () => {
               name: 'Brownfield (some construction risk)',
             }],
           },
+          minimumEquityPercentage: {
+            text: '20-49%',
+            value: 'ec061f70-b287-41cf-aaf4-620aec79616b',
+          },
           desiredDealRoles: {
             value: [ {
               id: '48cace6e-ec14-467b-b1b5-19b318ab5c51',

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-new.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-new.test.js
@@ -66,6 +66,10 @@ describe('Company Investments - Large capital profile', () => {
           constructionRisks: {
             value: [],
           },
+          minimumEquityPercentage: {
+            text: null,
+            value: null,
+          },
           desiredDealRoles: {
             value: [],
           },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
@@ -3,6 +3,7 @@ const investmentType = require('~/test/unit/data/companies/investments/metadata/
 const timeHorizons = require('~/test/unit/data/companies/investments/metadata/time-horizon.json')
 const restrictions = require('~/test/unit/data/companies/investments/metadata/restrictions.json')
 const constructionRisk = require('~/test/unit/data/companies/investments/metadata/construction-risk.json')
+const minimumEquityPercentage = require('~/test/unit/data/companies/investments/metadata/minimum-equity-percentage.json')
 const desiredDealRole = require('~/test/unit/data/companies/investments/metadata/desired-deal-role.json')
 const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile-new.json')
 const companyMock = require('~/test/unit/data/companies/minimal-company.json')
@@ -37,6 +38,11 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           name: 'Up to 5 years',
         }]
 
+        profile.minimum_equity_percentage = {
+          id: 'f7b72f8b-399e-43b2-b7ef-f42a154ef916',
+          name: '1-19%',
+        }
+
         nock(config.apiRoot)
           .get(`/v4/large-investor-profile?investor_company_id=${companyMock.id}`)
           .reply(200, clonedCompanyProfile)
@@ -50,6 +56,8 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           .reply(200, restrictions)
           .get('/metadata/capital-investment/construction-risk/')
           .reply(200, constructionRisk)
+          .get('/metadata/capital-investment/equity-percentage/')
+          .reply(200, minimumEquityPercentage)
           .get('/metadata/capital-investment/desired-deal-role/')
           .reply(200, desiredDealRole)
 
@@ -215,6 +223,24 @@ describe('Company Investments - Large capital profile - Investor requirements', 
               value: '9f554b26-70f2-4cac-89ae-758c2ef71c70',
             }],
             value: [],
+          },
+          minimumEquityPercentage: {
+            items: [{
+              text: '0% - Not required',
+              value: '414a13f7-1b6f-4071-a6d3-d22ed64f4612',
+            }, {
+              checked: true,
+              text: '1-19%',
+              value: 'f7b72f8b-399e-43b2-b7ef-f42a154ef916',
+            }, {
+              text: '20-49%',
+              value: 'ec061f70-b287-41cf-aaf4-620aec79616b',
+            }, {
+              text: '50% +',
+              value: '488bf5ad-4c8e-4e6b-b339-182f291dcd76',
+            }],
+            text: '1-19%',
+            value: 'f7b72f8b-399e-43b2-b7ef-f42a154ef916',
           },
           desiredDealRoles: {
             items: [{

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
@@ -4,7 +4,7 @@ const {
 
 describe('Large capital profile, Investor requirements form to API', () => {
   context('when translating Investor requirements', () => {
-    it('should transform undefined into an empty array', () => {
+    it('should transform all undefined fields', () => {
       this.transformed = transformInvestorRequirements({
         dealTicketSizes: undefined,
         investmentTypes: undefined,
@@ -12,6 +12,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         restrictions: undefined,
         constructionRisks: undefined,
         desiredDealsRoles: undefined,
+        minimumEquityPercentage: undefined,
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: [],
@@ -20,16 +21,18 @@ describe('Large capital profile, Investor requirements form to API', () => {
         restrictions: [],
         construction_risks: [],
         desired_deal_roles: [],
+        minimum_equity_percentage: undefined,
       })
     })
 
-    it('should transform a String by adding it to an empty array', () => {
+    it('should transform all String fields', () => {
       this.transformed = transformInvestorRequirements({
         dealTicketSizes: 'id',
         investmentTypes: 'id',
         timeHorizons: 'id',
         restrictions: 'id',
         constructionRisks: 'id',
+        minimumEquityPercentage: 'id',
         desiredDealRoles: 'id',
       })
       expect(this.transformed).to.deep.equal({
@@ -38,6 +41,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         time_horizons: ['id'],
         restrictions: ['id'],
         construction_risks: ['id'],
+        minimum_equity_percentage: 'id',
         desired_deal_roles: ['id'],
       })
     })
@@ -49,7 +53,8 @@ describe('Large capital profile, Investor requirements form to API', () => {
         timeHorizons: ['id'],
         restrictions: ['id'],
         constructionRisks: ['id'],
-        desiredDealRoles: 'id',
+        minimumEquityPercentage: 'id',
+        desiredDealRoles: ['id'],
       })
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: ['id'],
@@ -57,6 +62,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
         time_horizons: ['id'],
         restrictions: ['id'],
         construction_risks: ['id'],
+        minimum_equity_percentage: 'id',
         desired_deal_roles: ['id'],
       })
     })

--- a/test/unit/data/companies/investments/large-capital-profile-completed.json
+++ b/test/unit/data/companies/investments/large-capital-profile-completed.json
@@ -56,7 +56,10 @@
         "id": "884deaf6-cb0c-4036-b78c-efd92cb10098",
         "name": "Brownfield (some construction risk)"
       }],
-      "minimum_equity_percentage": null,
+      "minimum_equity_percentage": {
+        "id": "ec061f70-b287-41cf-aaf4-620aec79616b",
+        "name": "20-49%"
+      },
       "desired_deal_roles": [{
         "id": "48cace6e-ec14-467b-b1b5-19b318ab5c51",
         "name": "Co-investor / syndicate member"

--- a/test/unit/data/companies/investments/metadata/minimum-equity-percentage.json
+++ b/test/unit/data/companies/investments/metadata/minimum-equity-percentage.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "414a13f7-1b6f-4071-a6d3-d22ed64f4612",
+    "name": "0% - Not required",
+    "disabled_on": null
+  },
+  {
+    "id": "f7b72f8b-399e-43b2-b7ef-f42a154ef916",
+    "name": "1-19%",
+    "disabled_on": null
+  },
+  {
+    "id": "ec061f70-b287-41cf-aaf4-620aec79616b",
+    "name": "20-49%",
+    "disabled_on": null
+  },
+  {
+    "id": "488bf5ad-4c8e-4e6b-b339-182f291dcd76",
+    "name": "50% +",
+    "disabled_on": null
+  }
+]


### PR DESCRIPTION
Add 4 new radio buttons for 'Minimum equity percentage'

1. 0% - Not required
2. 1-19%
3. 20-49%
4. 50% +

Add a single label within the read-only view showing the users selection

https://uktrade.atlassian.net/browse/IPBETA-272

** Minimum equity percentage - edit**

<img width="1029" alt="equity-percentage-edit" src="https://user-images.githubusercontent.com/964268/58311276-7c2e0000-7e00-11e9-9d55-47812e84375f.png">

** Minimum equity percentage - read-only**

<img width="1029" alt="equity-percentage-read-only" src="https://user-images.githubusercontent.com/964268/58311290-851ed180-7e00-11e9-8c57-572d42131769.png">

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
