### PR TITLE
Fix object mutation during test run

### DIFF
--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -152,7 +152,9 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        interaction: interactionData,
+        interaction: {
+          ...interactionData,
+        },
         interactions: {
           returnLink: '/',
         },
@@ -200,7 +202,9 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        interaction: interactionData,
+        interaction: {
+          ...interactionData,
+        },
         interactions: {
           returnLink: '/',
         },
@@ -248,7 +252,9 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        interaction: interactionData,
+        interaction: {
+          ...interactionData,
+        },
         interactions: {
           returnLink: '/',
         },
@@ -487,7 +493,9 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        interaction: interactionData,
+        interaction: {
+          ...interactionData,
+        },
       }
 
       this.res.locals.interaction.date = now.format('YYYY-MM-DD')
@@ -733,7 +741,9 @@ describe('Interaction edit controller (Interactions)', () => {
         investment: {
           id: '3',
         },
-        interaction: interactionData,
+        interaction: {
+          ...interactionData,
+        },
       }
 
       nock(config.apiRoot)
@@ -778,7 +788,9 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        interaction: interactionData,
+        interaction: {
+          ...interactionData,
+        },
         form: {
           errors: {
             messages: {
@@ -897,7 +909,9 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        interaction: interactionData,
+        interaction: {
+          ...interactionData,
+        },
         form: {
           errors: {
             messages: {

--- a/test/unit/apps/interactions/transformers/interaction-response-to-view.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-response-to-view.test.js
@@ -1,6 +1,4 @@
 const config = require('~/config')
-const moment = require('moment')
-const now = moment()
 const transformInteractionResponseToViewRecord = require('~/src/apps/interactions/transformers/interaction-response-to-view')
 const mockInteraction = require('~/test/unit/data/interactions/interaction.json')
 const mockInteractionWithPolicyFeedback = require('~/test/unit/data/interactions/interaction-with-feedback.json')
@@ -41,7 +39,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         'Policy issue types': 'EU exit',
         'Date of interaction': {
           type: 'date',
-          name: now.format('YYYY-MM-DD'),
+          name: '2058-11-25',
         },
         'Documents': {
           hint: '(will open another website)',
@@ -102,7 +100,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         },
         'Date of interaction': {
           type: 'date',
-          name: now.format('YYYY-MM-DD'),
+          name: '2058-11-25',
         },
         'Adviser(s)': ['Bob Lawson, The test team'],
         'Investment project': {
@@ -142,7 +140,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         'Policy issue types': 'EU exit',
         'Date of interaction': {
           type: 'date',
-          name: now.format('YYYY-MM-DD'),
+          name: '2058-11-25',
         },
         'Communication channel': {
           id: '70c226d7-5d95-e211-a939-e4115bead28a',
@@ -188,7 +186,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         },
         'Date of interaction': {
           type: 'date',
-          name: now.format('YYYY-MM-DD'),
+          name: '2058-11-25',
         },
         'Adviser(s)': ['Bob Lawson, The test team'],
         'Communication channel': {
@@ -252,7 +250,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         'Policy issue types': 'EU exit',
         'Date of service delivery': {
           type: 'date',
-          name: now.format('YYYY-MM-DD'),
+          name: '2058-11-25',
         },
         'Adviser(s)': ['Bob Lawson, The test team'],
         'Documents': {
@@ -303,7 +301,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         'Policy issue types': 'EU exit',
         'Date of service delivery': {
           type: 'date',
-          name: now.format('YYYY-MM-DD'),
+          name: '2058-11-25',
         },
         'Adviser(s)': ['Bob Lawson, The test team'],
         'Event': 'No',
@@ -346,7 +344,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         },
         'Date of interaction': {
           type: 'date',
-          name: now.format('YYYY-MM-DD'),
+          name: '2058-11-25',
         },
         'Adviser(s)': ['Bob Lawson, The test team'],
         'Communication channel': {


### PR DESCRIPTION
This is prerequisite work for https://trello.com/c/tkNDxpne/1198-update-meeting-details-view-for-when-incomplete-interaction-is-clicked

A recent change was mutating the interaction mock so that subsequent tests were not able to assert correctly. Today's date is being hardcoded. This became a problem when running the tests in isolation as the mock had not been mutated.

This change copies the interaction mock to a new object so that mutation does not affect the mock.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
