### PR TITLE
Refactor table assertion to reusable helper

### DIFF
--- a/test/functional/cypress/helpers/key-value-table.js
+++ b/test/functional/cypress/helpers/key-value-table.js
@@ -1,0 +1,29 @@
+const { keys, forEach } = require('lodash')
+
+const selectors = require('../selectors')
+
+const assertKeyValueTable = (dataAutoId, expected) => {
+  forEach(keys(expected), (key, i) => {
+    const rowNumber = i + 1
+    cy.get(selectors.keyValueTable(dataAutoId).keyCell(rowNumber)).should('have.text', key)
+
+    if (expected[key].href) {
+      cy.get(selectors.keyValueTable(dataAutoId).valueCellLink(rowNumber)).should('have.attr', 'href', expected[key].href)
+      cy.get(selectors.keyValueTable(dataAutoId).valueCellLink(rowNumber)).should('have.text', expected[key].name)
+    } else {
+      cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expected[key])
+    }
+  })
+}
+
+const assertValueTable = (dataAutoId, expected) => {
+  forEach(expected, (expectedValue, i) => {
+    const rowNumber = i + 1
+    cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expectedValue)
+  })
+}
+
+module.exports = {
+  assertKeyValueTable,
+  assertValueTable,
+}

--- a/test/functional/cypress/selectors/key-value-table.js
+++ b/test/functional/cypress/selectors/key-value-table.js
@@ -7,5 +7,8 @@ module.exports = (dataAutoId) => {
     valueCell: (rowNumber) => {
       return `${tableSelector} tr:nth-child(${rowNumber}) td`
     },
+    valueCellLink: (rowNumber) => {
+      return `${tableSelector} tr:nth-child(${rowNumber}) td a`
+    },
   }
 }

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -1,5 +1,4 @@
-const { keys, forEach } = require('lodash')
-
+const { assertKeyValueTable, assertValueTable } = require('../../helpers/key-value-table')
 const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 
@@ -633,20 +632,5 @@ describe('Companies business details', () => {
 
   const assertDetailsContainerHeading = (dataAutoId, expected) => {
     cy.get(selectors.detailsContainer(dataAutoId).heading).should('have.text', expected)
-  }
-
-  const assertKeyValueTable = (dataAutoId, expected) => {
-    forEach(keys(expected), (key, i) => {
-      const rowNumber = i + 1
-      cy.get(selectors.keyValueTable(dataAutoId).keyCell(rowNumber)).should('have.text', key)
-      cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expected[key])
-    })
-  }
-
-  const assertValueTable = (dataAutoId, expected) => {
-    forEach(expected, (expectedValue, i) => {
-      const rowNumber = i + 1
-      cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expectedValue)
-    })
   }
 })


### PR DESCRIPTION
This is prerequisite work for https://trello.com/c/tkNDxpne/1198-update-meeting-details-view-for-when-incomplete-interaction-is-clicked

Moving the functional test key value table assertion to a reusable helper.

Change also introduces the ability to assert links.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
