### PR TITLE
Add 'Minimum return rate' radio buttons (x4) to Large capital profile

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -43,6 +43,7 @@ const renderProfile = async (req, res, next) => {
         .then(([
           dealTicketSizeMD,
           investmentTypeMD,
+          minimumReturnRateMD,
           timeHorizonMD,
           restrictionMD,
           constructionRiskMD,
@@ -52,6 +53,7 @@ const renderProfile = async (req, res, next) => {
           const {
             dealTicketSizes,
             investmentTypes,
+            minimumReturnRate,
             timeHorizons,
             restrictions,
             constructionRisks,
@@ -61,6 +63,7 @@ const renderProfile = async (req, res, next) => {
 
           profile.investorRequirements.dealTicketSizes.items = transformCheckboxes(dealTicketSizeMD, dealTicketSizes)
           profile.investorRequirements.investmentTypes.items = transformCheckboxes(investmentTypeMD, investmentTypes)
+          profile.investorRequirements.minimumReturnRate.items = transformRadioButtons(minimumReturnRateMD, minimumReturnRate)
           profile.investorRequirements.timeHorizons.items = transformCheckboxes(timeHorizonMD, timeHorizons)
           profile.investorRequirements.restrictions.items = transformCheckboxes(restrictionMD, restrictions)
           profile.investorRequirements.constructionRisks.items = transformCheckboxes(constructionRiskMD, constructionRisks)

--- a/src/apps/companies/apps/investments/large-capital-profile/options.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/options.js
@@ -15,6 +15,7 @@ const getInvestorRequirementsOptions = (token) => {
   return [
     getOptions(token, 'capital-investment/deal-ticket-size', DO_NOT_SORT),
     getOptions(token, 'capital-investment/large-capital-investment-type'),
+    getOptions(token, 'capital-investment/return-rate', DO_NOT_SORT),
     getOptions(token, 'capital-investment/time-horizon', DO_NOT_SORT),
     getOptions(token, 'capital-investment/restriction', DO_NOT_SORT),
     getOptions(token, 'capital-investment/construction-risk', DO_NOT_SORT),

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-api.js
@@ -4,6 +4,7 @@ const transformInvestorRequirements = (body) => {
   return {
     deal_ticket_sizes: sanitizeCheckboxes(body.dealTicketSizes),
     investment_types: sanitizeCheckboxes(body.investmentTypes),
+    minimum_return_rate: body.minimumReturnRate,
     time_horizons: sanitizeCheckboxes(body.timeHorizons),
     restrictions: sanitizeCheckboxes(body.restrictions),
     construction_risks: sanitizeCheckboxes(body.constructionRisks),

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -61,6 +61,10 @@ const transformProfile = (profile, editing) => {
       investmentTypes: {
         value: get(profile, 'investment_types'),
       },
+      minimumReturnRate: {
+        text: get(profile, 'minimum_return_rate.name', null),
+        value: get(profile, 'minimum_return_rate.id', null),
+      },
       timeHorizons: {
         value: get(profile, 'time_horizons'),
       },

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements-edit.njk
@@ -47,7 +47,21 @@
     })
   }}
 
-  <p>Placeholder - Minimum return rate</p>
+  {{
+    govukRadios({
+      name: 'minimumReturnRate',
+      fieldset: {
+        attributes: {
+          'data-auto-id': 'minimumReturnRate'
+        },
+        legend: {
+          text: 'Minimum return rate',
+          classes: 'govuk-fieldset__legend--s'
+        }
+      },
+      items: profile.investorRequirements.minimumReturnRate.items
+    })
+  }}
 
   {{
     govukCheckboxes({

--- a/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/requirements.njk
@@ -2,7 +2,7 @@
   {{ taskListItem({ name: 'Deal ticket size', value: profile.investorRequirements.dealTicketSizes.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Asset classes of interest' }) }}
   {{ taskListItem({ name: 'Types of investment',  value: profile.investorRequirements.investmentTypes.value, key: 'name' }) }}
-  {{ taskListItem({ name: 'Minimum return rate' }) }}
+  {{ taskListItem({ name: 'Minimum return rate', value: profile.investorRequirements.minimumReturnRate.text }) }}
   {{ taskListItem({ name: 'Time horizon / tenor', value: profile.investorRequirements.timeHorizons.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Restrictions / conditions', value: profile.investorRequirements.restrictions.value, key: 'name' }) }}
   {{ taskListItem({ name: 'Construction risk', value: profile.investorRequirements.constructionRisks.value, key: 'name' }) }}

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -84,6 +84,13 @@ module.exports = {
       energyInfrastructure: '[data-auto-id=investmentTypes] #investmentTypes-7',
       privateEquity: '[data-auto-id=investmentTypes] #investmentTypes-8',
     },
+    minimumReturnRate: {
+      name: '[data-auto-id=minimumReturnRate] legend',
+      zeroTo5Percent: '[data-auto-id=minimumReturnRate] #minimumReturnRate-1',
+      fiveTo10Percent: '[data-auto-id=minimumReturnRate] #minimumReturnRate-2',
+      tenTo15Percent: '[data-auto-id=minimumReturnRate] #minimumReturnRate-3',
+      fifteenPercent: '[data-auto-id=minimumReturnRate] #minimumReturnRate-4',
+    },
     timeHorizons: {
       name: '[data-auto-id=timeHorizons] legend',
       upToFiveYears: '[data-auto-id=timeHorizons] #timeHorizons-1',
@@ -148,6 +155,7 @@ module.exports = {
       },
       minimumReturnRate: {
         name: '[data-auto-id=investorRequirements] ul > li:nth-child(4) .task-list__item-name',
+        complete: '[data-auto-id=investorRequirements] ul > li:nth-child(4) .task-list__item-complete',
         incomplete: '[data-auto-id=investorRequirements] ul > li:nth-child(4) .task-list__item-incomplete',
       },
       timeHorizon: {

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -274,6 +274,12 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.investmentTypes.privateEquity).should('be.checked')
     })
 
+    it('should display "Minimum return rate" and the radio button "10-15%" should be checked"', () => {
+      cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
+        .get(investorRequirements.minimumReturnRate.name).should('contain', 'Minimum return rate')
+        .get(investorRequirements.minimumReturnRate.tenTo15Percent).should('be.checked')
+    })
+
     it('should display "Time Horizon / tenor" and all 4 checkboxes should be checked"', () => {
       cy.visit(`${largeCapitalProfile}?editing=investor-requirements`)
         .get(investorRequirements.timeHorizons.name).should('contain', 'Time horizon / tenor')
@@ -344,6 +350,13 @@ describe('Company Investments and Large capital profile', () => {
         .get(investorRequirements.taskList.investmentTypes.ventureCapitalFunds).should('contain', 'Venture capital funds')
         .get(investorRequirements.taskList.investmentTypes.energyInfrastructure).should('contain', 'Energy / Infrastructure / Real Estate Funds (UKEIREFs)')
         .get(investorRequirements.taskList.investmentTypes.privateEquity).should('contain', 'Private Equity / Venture Capital')
+    })
+
+    it('should display "Minimum return rate" and "10-15%"', () => {
+      cy.visit(largeCapitalProfile)
+        .get(selectors.investorRequirements.summary).click()
+        .get(investorRequirements.taskList.minimumReturnRate.name).should('contain', 'Minimum return rate')
+        .get(investorRequirements.taskList.minimumReturnRate.complete).should('contain', '10-15%')
     })
 
     it('should display "Time horizon / tenor" and all 4 times', () => {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/details-edit.test.js
@@ -160,6 +160,10 @@ describe('Company Investments - Large capital profile - Investor details', () =>
           investmentTypes: {
             value: [],
           },
+          minimumReturnRate: {
+            text: null,
+            value: null,
+          },
           timeHorizons: {
             value: [],
           },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-complete.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-complete.test.js
@@ -73,6 +73,10 @@ describe('Company Investments - Large capital profile', () => {
               id: '4170d99a-02fc-46ee-8fd4-3fe786717708',
             }],
           },
+          minimumReturnRate: {
+            text: '5-10%',
+            value: '65c9bc7a-af68-4549-a9c9-70cd73109617',
+          },
           timeHorizons: {
             value: [ {
               id: '29a0a8e9-1c21-432a-bb4f-b9363b46a6aa',

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-new.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/profile/profile-new.test.js
@@ -57,6 +57,10 @@ describe('Company Investments - Large capital profile', () => {
           investmentTypes: {
             value: [],
           },
+          minimumReturnRate: {
+            text: null,
+            value: null,
+          },
           timeHorizons: {
             value: [],
           },

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/requirements-edit.test.js
@@ -1,5 +1,6 @@
 const dealTicketSize = require('~/test/unit/data/companies/investments/metadata/deal-ticket-size.json')
 const investmentType = require('~/test/unit/data/companies/investments/metadata/investment-type.json')
+const minimumReturnRate = require('~/test/unit/data/companies/investments/metadata/minimum-return-rate.json')
 const timeHorizons = require('~/test/unit/data/companies/investments/metadata/time-horizon.json')
 const restrictions = require('~/test/unit/data/companies/investments/metadata/restrictions.json')
 const constructionRisk = require('~/test/unit/data/companies/investments/metadata/construction-risk.json')
@@ -50,6 +51,8 @@ describe('Company Investments - Large capital profile - Investor requirements', 
           .reply(200, dealTicketSize)
           .get('/metadata/capital-investment/large-capital-investment-type/')
           .reply(200, investmentType)
+          .get('/metadata/capital-investment/return-rate/')
+          .reply(200, minimumReturnRate)
           .get('/metadata/capital-investment/time-horizon/')
           .reply(200, timeHorizons)
           .get('/metadata/capital-investment/restriction/')
@@ -163,6 +166,23 @@ describe('Company Investments - Large capital profile - Investor requirements', 
               id: '06834da2-c9ac-4faf-b555-39762ce373ae',
               name: 'Direct Investment in Project Debt',
             }],
+          },
+          minimumReturnRate: {
+            items: [{
+              text: 'Up to 5% IRR',
+              value: '6fec56ba-0be9-4931-bd76-16e11924ec55',
+            }, {
+              text: '5-10%',
+              value: '65c9bc7a-af68-4549-a9c9-70cd73109617',
+            }, {
+              text: '10-15%',
+              value: '6ecbd7d2-e16a-4bfd-a4b9-8c9bca947302',
+            }, {
+              text: '15%',
+              value: '0c55bd5c-82ea-4400-b7fc-7344958ee3a5',
+            }],
+            text: null,
+            value: null,
           },
           timeHorizons: {
             items: [

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-requirements-to-api.test.js
@@ -8,6 +8,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
       this.transformed = transformInvestorRequirements({
         dealTicketSizes: undefined,
         investmentTypes: undefined,
+        minimumReturnRate: undefined,
         timeHorizons: undefined,
         restrictions: undefined,
         constructionRisks: undefined,
@@ -17,6 +18,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: [],
         investment_types: [],
+        minimum_return_rate: undefined,
         time_horizons: [],
         restrictions: [],
         construction_risks: [],
@@ -29,6 +31,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
       this.transformed = transformInvestorRequirements({
         dealTicketSizes: 'id',
         investmentTypes: 'id',
+        minimumReturnRate: 'id',
         timeHorizons: 'id',
         restrictions: 'id',
         constructionRisks: 'id',
@@ -38,6 +41,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: ['id'],
         investment_types: ['id'],
+        minimum_return_rate: 'id',
         time_horizons: ['id'],
         restrictions: ['id'],
         construction_risks: ['id'],
@@ -50,6 +54,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
       this.transformed = transformInvestorRequirements({
         dealTicketSizes: ['id'],
         investmentTypes: ['id'],
+        minimumReturnRate: 'id',
         timeHorizons: ['id'],
         restrictions: ['id'],
         constructionRisks: ['id'],
@@ -59,6 +64,7 @@ describe('Large capital profile, Investor requirements form to API', () => {
       expect(this.transformed).to.deep.equal({
         deal_ticket_sizes: ['id'],
         investment_types: ['id'],
+        minimum_return_rate: 'id',
         time_horizons: ['id'],
         restrictions: ['id'],
         construction_risks: ['id'],

--- a/test/unit/data/companies/investments/large-capital-profile-completed.json
+++ b/test/unit/data/companies/investments/large-capital-profile-completed.json
@@ -47,7 +47,10 @@
         "name": "Direct Investment in Project Equity",
         "id": "4170d99a-02fc-46ee-8fd4-3fe786717708"
       }],
-      "minimum_return_rate": null,
+      "minimum_return_rate": {
+        "id": "65c9bc7a-af68-4549-a9c9-70cd73109617",
+        "name": "5-10%"
+      },
       "time_horizons": [{
         "id": "29a0a8e9-1c21-432a-bb4f-b9363b46a6aa",
         "name": "10-14 years"

--- a/test/unit/data/companies/investments/metadata/minimum-return-rate.json
+++ b/test/unit/data/companies/investments/metadata/minimum-return-rate.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "6fec56ba-0be9-4931-bd76-16e11924ec55",
+    "name": "Up to 5% IRR",
+    "disabled_on": null
+  },
+  {
+    "id": "65c9bc7a-af68-4549-a9c9-70cd73109617",
+    "name": "5-10%",
+    "disabled_on": null
+  },
+  {
+    "id": "6ecbd7d2-e16a-4bfd-a4b9-8c9bca947302",
+    "name": "10-15%",
+    "disabled_on": null
+  },
+  {
+    "id": "0c55bd5c-82ea-4400-b7fc-7344958ee3a5",
+    "name": "15%",
+    "disabled_on": null
+  }
+]


### PR DESCRIPTION
Added 4 new radio buttons for 'Minimum return rate'

1. Up to 5% IRR
2. 5-10%
3. 10-15%
4. 15%

Display what the user has selected within the profile read-only view.

**Minimum return rate - edit**

<img width="1053" alt="minimum-return-rate-edit" src="https://user-images.githubusercontent.com/964268/58321535-4ac02f00-7e16-11e9-8bda-4ca74782d5f7.png">

**Minimum return rate - read-only**

<img width="1084" alt="minimum-return-rate-read-only" src="https://user-images.githubusercontent.com/964268/58321529-485dd500-7e16-11e9-85b1-1d9aa415a3ea.png">

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
