### PR TITLE
Add activity feed endpoint to be used by the React components

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -108,6 +108,9 @@ const config = {
   currencyRate: {
     usdToGbp: 0.750148,
   },
+  activityFeed: {
+    paginationSize: 20,
+  },
 }
 
 module.exports = config

--- a/src/apps/activity-feed/controllers.js
+++ b/src/apps/activity-feed/controllers.js
@@ -1,0 +1,22 @@
+const { fetchActivityFeed } = require('./repos')
+const { transformActivityFeedSearchResults } = require('./transformers')
+
+async function getActivityFeedHandler (req, res, next) {
+  try {
+    const { from = 0, company_id: companyId } = req.query
+
+    const results = await fetchActivityFeed({
+      token: req.session.token,
+      from,
+      companyId,
+    })
+
+    res.json(transformActivityFeedSearchResults(results))
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  getActivityFeedHandler,
+}

--- a/src/apps/activity-feed/index.js
+++ b/src/apps/activity-feed/index.js
@@ -1,0 +1,5 @@
+const router = require('./router')
+
+module.exports = {
+  router,
+}

--- a/src/apps/activity-feed/repos.js
+++ b/src/apps/activity-feed/repos.js
@@ -1,0 +1,33 @@
+const { set } = require('lodash')
+const config = require('../../../config')
+const { authorisedRequest } = require('../../lib/authorised-request')
+
+async function fetchActivityFeed ({
+  token,
+  size = config.activityFeed.paginationSize,
+  from = 0,
+  companyId = null,
+}) {
+  const requestBody = {
+    size,
+    from,
+    sort: {
+      published: 'desc',
+    },
+  }
+
+  if (companyId) {
+    set(requestBody, 'query.bool.filter.term["object.attributedTo.id"]', `dit:DataHubCompany:${companyId}`)
+  }
+
+  const { hits } = await authorisedRequest(token, {
+    url: `${config.apiRoot}/v4/activity-feed`,
+    body: requestBody,
+  })
+
+  return hits
+}
+
+module.exports = {
+  fetchActivityFeed,
+}

--- a/src/apps/activity-feed/router.js
+++ b/src/apps/activity-feed/router.js
@@ -1,0 +1,6 @@
+const router = require('express').Router()
+const { getActivityFeedHandler } = require('./controllers')
+
+router.get('/api/activity-feed', getActivityFeedHandler)
+
+module.exports = router

--- a/src/apps/activity-feed/transformers.js
+++ b/src/apps/activity-feed/transformers.js
@@ -1,0 +1,17 @@
+/* eslint camelcase: 0 */
+
+function transformActivityFeedSearchResults ({
+  total,
+  hits,
+} = {}) {
+  return {
+    total,
+    activities: hits.map(transformActivity),
+  }
+}
+
+function transformActivity (hit) {
+  return hit._source
+}
+
+module.exports = { transformActivityFeedSearchResults }

--- a/test/unit/apps/activity-feed/controllers.test.js
+++ b/test/unit/apps/activity-feed/controllers.test.js
@@ -1,0 +1,90 @@
+const activityFeedRawFixture = require('../../data/activity-feed/activity-feed-from-es')
+const token = 'abcd'
+
+describe('Activity feed controllers', () => {
+  beforeEach(() => {
+    this.fetchActivityFeedStub = sinon.stub().resolves(activityFeedRawFixture.hits)
+    this.transformActivityFeedSearchResultsStub = sinon.stub().resolves()
+
+    this.controllers = proxyquire('../../src/apps/activity-feed/controllers', {
+      './repos': { fetchActivityFeed: this.fetchActivityFeedStub },
+      './transformers': { transformActivityFeedSearchResults: this.transformActivityFeedSearchResultsStub },
+    })
+
+    this.resMock = {
+      json: sinon.spy(),
+    }
+
+    this.nextSpy = sinon.spy()
+  })
+
+  describe('#getActivityFeedHandler', () => {
+    context('when called without query params', () => {
+      beforeEach(async () => {
+        const reqMock = {
+          query: {},
+          session: {
+            token: token,
+          },
+        }
+        await this.controllers.getActivityFeedHandler(reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call fetchActivityFeed with default params', async () => {
+        const expectedParams = { companyId: undefined, from: 0, token: token }
+
+        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(this.transformActivityFeedSearchResultsStub).to.be.calledOnce
+        expect(this.resMock.json).to.be.calledOnce
+      })
+    })
+
+    context('when called with company_id in the query', () => {
+      beforeEach(async () => {
+        const reqMock = {
+          query: {
+            company_id: 'com-123',
+          },
+          session: {
+            token: token,
+          },
+        }
+        await this.controllers.getActivityFeedHandler(reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call fetchActivityFeed with companyId', async () => {
+        const expectedParams = { companyId: 'com-123', from: 0, token: token }
+
+        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(this.transformActivityFeedSearchResultsStub).to.be.calledOnce
+        expect(this.resMock.json).to.be.calledOnce
+      })
+    })
+
+    context('when the endpoint returns error', () => {
+      beforeEach(async () => {
+        this.error = {
+          statusCode: 404,
+        }
+        this.fetchActivityFeedStub.rejects(this.error)
+
+        const reqMock = {
+          query: {},
+          session: {
+            token: token,
+          },
+        }
+        await this.controllers.getActivityFeedHandler(reqMock, this.resMock, this.nextSpy)
+      })
+
+      it('should call next with an error', async () => {
+        const expectedParams = { companyId: undefined, from: 0, token: token }
+
+        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(this.transformActivityFeedSearchResultsStub).to.not.have.been.called
+        expect(this.resMock.json).to.not.have.been.called
+        expect(this.nextSpy).to.have.been.calledWith(this.error)
+      })
+    })
+  })
+})

--- a/test/unit/apps/activity-feed/repos.test.js
+++ b/test/unit/apps/activity-feed/repos.test.js
@@ -1,0 +1,83 @@
+const config = require('../../../../config')
+const activityFeedRawFixture = require('../../data/activity-feed/activity-feed-from-es')
+const token = 'abcd'
+
+describe('Activity feed repos', () => {
+  beforeEach(() => {
+    this.authorisedRequestStub = sinon.stub().resolves(activityFeedRawFixture)
+    this.repos = proxyquire('../../src/apps/activity-feed/repos', {
+      '../../lib/authorised-request': { authorisedRequest: this.authorisedRequestStub },
+    })
+  })
+
+  describe('#fetchActivityFeed', () => {
+    context('when called with companyId', () => {
+      beforeEach(async () => {
+        this.results = await this.repos.fetchActivityFeed({ token, from: 1, size: 21, companyId: '123' })
+      })
+
+      it('should make a request without company ID in the request body', () => {
+        const expectedBody = {
+          from: 1,
+          query: {
+            bool: { filter: { term: { 'object.attributedTo.id': 'dit:DataHubCompany:123' } } },
+          },
+          size: 21,
+          sort: { published: 'desc' },
+        }
+        expect(this.authorisedRequestStub).to.be.calledOnceWith(token, {
+          body: expectedBody,
+          url: `${config.apiRoot}/v4/activity-feed`,
+        })
+      })
+
+      it('should return results', async () => {
+        expect(this.results).to.be.equal(activityFeedRawFixture.hits)
+      })
+    })
+
+    context('when called without companyId', () => {
+      beforeEach(async () => {
+        this.results = await this.repos.fetchActivityFeed({ token, from: 0, size: 20 })
+      })
+
+      it('should make a request without company ID in the request body', () => {
+        const expectedBody = {
+          from: 0,
+          size: 20,
+          sort: { published: 'desc' },
+        }
+        expect(this.authorisedRequestStub).to.be.calledOnceWith(token, {
+          body: expectedBody,
+          url: `${config.apiRoot}/v4/activity-feed`,
+        })
+      })
+
+      it('should return results', async () => {
+        expect(this.results).to.be.equal(activityFeedRawFixture.hits)
+      })
+    })
+
+    context('when called without any params', () => {
+      beforeEach(async () => {
+        this.results = await this.repos.fetchActivityFeed({})
+      })
+
+      it('should make a request with default params', async () => {
+        const expectedBody = {
+          from: 0,
+          size: 20,
+          sort: { published: 'desc' },
+        }
+        expect(this.authorisedRequestStub).to.be.calledOnceWith(undefined, {
+          body: expectedBody,
+          url: `${config.apiRoot}/v4/activity-feed`,
+        })
+      })
+
+      it('should return results', async () => {
+        expect(this.results).to.be.equal(activityFeedRawFixture.hits)
+      })
+    })
+  })
+})

--- a/test/unit/apps/activity-feed/router.test.js
+++ b/test/unit/apps/activity-feed/router.test.js
@@ -1,0 +1,8 @@
+const router = require('../../../../src/apps/activity-feed/router')
+
+describe('Activity feed routes', () => {
+  it('should define /api/activity-feed route', () => {
+    const paths = router.stack.filter(r => r.route).map(r => r.route.path)
+    expect(paths).to.contain('/api/activity-feed')
+  })
+})

--- a/test/unit/apps/activity-feed/transformers.test.js
+++ b/test/unit/apps/activity-feed/transformers.test.js
@@ -1,0 +1,10 @@
+const activityFeedRawFixture = require('../../data/activity-feed/activity-feed-from-es')
+const activityFeedTransformedFixture = require('../../data/activity-feed/activity-feed-transformed')
+const { transformActivityFeedSearchResults } = require('../../../../src/apps/activity-feed/transformers')
+
+describe('transformActivityFeedSearchResults', () => {
+  it('should transform ES results', () => {
+    const transformed = transformActivityFeedSearchResults(activityFeedRawFixture.hits)
+    expect(transformed).to.deep.equal(activityFeedTransformedFixture)
+  })
+})

--- a/test/unit/data/activity-feed/activity-feed-from-es.json
+++ b/test/unit/data/activity-feed/activity-feed-from-es.json
@@ -1,0 +1,386 @@
+{
+  "took": 1,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": 100,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "activity-feed",
+        "_type": "doc",
+        "_id": "99",
+        "_score": null,
+        "_source": {
+          "id": 99,
+          "type": "Announce",
+          "published": "2019-08-10T09:43:40.904+01:00",
+          "generator": {
+            "name": "dit:dataHub",
+            "type": "Application"
+          },
+          "object": {
+            "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+            "type": [
+              "dit:Event",
+              "dit:Interaction"
+            ],
+            "startTime": "2019-05-02T08:43:40.904649+00:00",
+            "dit:status": "complete",
+            "dit:archived": false,
+            "dit:communicationChannel": {
+              "name": "Email/Website"
+            },
+            "dit:subject": "Invited to Technology Roundtable 99",
+            "dit:service": {
+              "name": "Account Management"
+            },
+            "attributedTo": [
+              {
+                "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+                "dit:dunsNumber": "123456789",
+                "dit:companiesHouseNumber": "987654321",
+                "type": [
+                  "Organization",
+                  "dit:Company"
+                ],
+                "name": "Marco Test"
+              },
+              {
+                "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+                "type": [
+                  "Person",
+                  "dit:Contact"
+                ],
+                "dit:emailAddress": "john@example.com",
+                "name": "John Doe"
+              },
+              {
+                "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+                "type": [
+                  "Person",
+                  "dit:Adviser"
+                ],
+                "dit:emailAddress": "mariobros@dit.com",
+                "name": "Mario Bros",
+                "dit:team": {
+                  "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+                  "type": [
+                    "Group",
+                    "dit:Team"
+                  ],
+                  "name": "Digital Data Hub - Live Service"
+                }
+              }
+            ],
+            "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+          }
+        },
+        "sort": [
+          1565426620904
+        ]
+      },
+      {
+        "_index": "activity-feed",
+        "_type": "doc",
+        "_id": "98",
+        "_score": null,
+        "_source": {
+          "id": 98,
+          "type": "Announce",
+          "published": "2019-08-09T09:43:40.904+01:00",
+          "generator": {
+            "name": "dit:dataHub",
+            "type": "Application"
+          },
+          "object": {
+            "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+            "type": [
+              "dit:Event",
+              "dit:Interaction"
+            ],
+            "startTime": "2019-05-02T08:43:40.904649+00:00",
+            "dit:status": "complete",
+            "dit:archived": false,
+            "dit:communicationChannel": {
+              "name": "Email/Website"
+            },
+            "dit:subject": "Invited to Technology Roundtable 98",
+            "dit:service": {
+              "name": "Account Management"
+            },
+            "attributedTo": [
+              {
+                "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+                "dit:dunsNumber": "123456789",
+                "dit:companiesHouseNumber": "987654321",
+                "type": [
+                  "Organization",
+                  "dit:Company"
+                ],
+                "name": "Marco Test"
+              },
+              {
+                "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+                "type": [
+                  "Person",
+                  "dit:Contact"
+                ],
+                "dit:emailAddress": "john@example.com",
+                "name": "John Doe"
+              },
+              {
+                "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+                "type": [
+                  "Person",
+                  "dit:Adviser"
+                ],
+                "dit:emailAddress": "mariobros@dit.com",
+                "name": "Mario Bros",
+                "dit:team": {
+                  "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+                  "type": [
+                    "Group",
+                    "dit:Team"
+                  ],
+                  "name": "Digital Data Hub - Live Service"
+                }
+              }
+            ],
+            "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+          }
+        },
+        "sort": [
+          1565340220904
+        ]
+      },
+      {
+        "_index": "activity-feed",
+        "_type": "doc",
+        "_id": "97",
+        "_score": null,
+        "_source": {
+          "id": 97,
+          "type": "Announce",
+          "published": "2019-08-08T09:43:40.904+01:00",
+          "generator": {
+            "name": "dit:dataHub",
+            "type": "Application"
+          },
+          "object": {
+            "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+            "type": [
+              "dit:Event",
+              "dit:Interaction"
+            ],
+            "startTime": "2019-05-02T08:43:40.904649+00:00",
+            "dit:status": "complete",
+            "dit:archived": false,
+            "dit:communicationChannel": {
+              "name": "Email/Website"
+            },
+            "dit:subject": "Invited to Technology Roundtable 97",
+            "dit:service": {
+              "name": "Account Management"
+            },
+            "attributedTo": [
+              {
+                "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+                "dit:dunsNumber": "123456789",
+                "dit:companiesHouseNumber": "987654321",
+                "type": [
+                  "Organization",
+                  "dit:Company"
+                ],
+                "name": "Marco Test"
+              },
+              {
+                "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+                "type": [
+                  "Person",
+                  "dit:Contact"
+                ],
+                "dit:emailAddress": "john@example.com",
+                "name": "John Doe"
+              },
+              {
+                "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+                "type": [
+                  "Person",
+                  "dit:Adviser"
+                ],
+                "dit:emailAddress": "mariobros@dit.com",
+                "name": "Mario Bros",
+                "dit:team": {
+                  "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+                  "type": [
+                    "Group",
+                    "dit:Team"
+                  ],
+                  "name": "Digital Data Hub - Live Service"
+                }
+              }
+            ],
+            "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+          }
+        },
+        "sort": [
+          1565253820904
+        ]
+      },
+      {
+        "_index": "activity-feed",
+        "_type": "doc",
+        "_id": "96",
+        "_score": null,
+        "_source": {
+          "id": 96,
+          "type": "Announce",
+          "published": "2019-08-07T09:43:40.904+01:00",
+          "generator": {
+            "name": "dit:dataHub",
+            "type": "Application"
+          },
+          "object": {
+            "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+            "type": [
+              "dit:Event",
+              "dit:Interaction"
+            ],
+            "startTime": "2019-05-02T08:43:40.904649+00:00",
+            "dit:status": "complete",
+            "dit:archived": false,
+            "dit:communicationChannel": {
+              "name": "Email/Website"
+            },
+            "dit:subject": "Invited to Technology Roundtable 96",
+            "dit:service": {
+              "name": "Account Management"
+            },
+            "attributedTo": [
+              {
+                "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+                "dit:dunsNumber": "123456789",
+                "dit:companiesHouseNumber": "987654321",
+                "type": [
+                  "Organization",
+                  "dit:Company"
+                ],
+                "name": "Marco Test"
+              },
+              {
+                "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+                "type": [
+                  "Person",
+                  "dit:Contact"
+                ],
+                "dit:emailAddress": "john@example.com",
+                "name": "John Doe"
+              },
+              {
+                "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+                "type": [
+                  "Person",
+                  "dit:Adviser"
+                ],
+                "dit:emailAddress": "mariobros@dit.com",
+                "name": "Mario Bros",
+                "dit:team": {
+                  "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+                  "type": [
+                    "Group",
+                    "dit:Team"
+                  ],
+                  "name": "Digital Data Hub - Live Service"
+                }
+              }
+            ],
+            "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+          }
+        },
+        "sort": [
+          1565167420904
+        ]
+      },
+      {
+        "_index": "activity-feed",
+        "_type": "doc",
+        "_id": "95",
+        "_score": null,
+        "_source": {
+          "id": 95,
+          "type": "Announce",
+          "published": "2019-08-06T09:43:40.904+01:00",
+          "generator": {
+            "name": "dit:dataHub",
+            "type": "Application"
+          },
+          "object": {
+            "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+            "type": [
+              "dit:Event",
+              "dit:Interaction"
+            ],
+            "startTime": "2019-05-02T08:43:40.904649+00:00",
+            "dit:status": "complete",
+            "dit:archived": false,
+            "dit:communicationChannel": {
+              "name": "Email/Website"
+            },
+            "dit:subject": "Invited to Technology Roundtable 95",
+            "dit:service": {
+              "name": "Account Management"
+            },
+            "attributedTo": [
+              {
+                "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+                "dit:dunsNumber": "123456789",
+                "dit:companiesHouseNumber": "987654321",
+                "type": [
+                  "Organization",
+                  "dit:Company"
+                ],
+                "name": "Marco Test"
+              },
+              {
+                "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+                "type": [
+                  "Person",
+                  "dit:Contact"
+                ],
+                "dit:emailAddress": "john@example.com",
+                "name": "John Doe"
+              },
+              {
+                "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+                "type": [
+                  "Person",
+                  "dit:Adviser"
+                ],
+                "dit:emailAddress": "mariobros@dit.com",
+                "name": "Mario Bros",
+                "dit:team": {
+                  "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+                  "type": [
+                    "Group",
+                    "dit:Team"
+                  ],
+                  "name": "Digital Data Hub - Live Service"
+                }
+              }
+            ],
+            "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+          }
+        },
+        "sort": [
+          1565081020904
+        ]
+      }
+    ]
+  }
+}

--- a/test/unit/data/activity-feed/activity-feed-transformed.json
+++ b/test/unit/data/activity-feed/activity-feed-transformed.json
@@ -1,0 +1,330 @@
+{
+  "total": 100,
+  "activities": [
+    {
+      "id": 99,
+      "type": "Announce",
+      "published": "2019-08-10T09:43:40.904+01:00",
+      "generator": {
+        "name": "dit:dataHub",
+        "type": "Application"
+      },
+      "object": {
+        "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+        "type": [
+          "dit:Event",
+          "dit:Interaction"
+        ],
+        "startTime": "2019-05-02T08:43:40.904649+00:00",
+        "dit:status": "complete",
+        "dit:archived": false,
+        "dit:communicationChannel": {
+          "name": "Email/Website"
+        },
+        "dit:subject": "Invited to Technology Roundtable 99",
+        "dit:service": {
+          "name": "Account Management"
+        },
+        "attributedTo": [
+          {
+            "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+            "dit:dunsNumber": "123456789",
+            "dit:companiesHouseNumber": "987654321",
+            "type": [
+              "Organization",
+              "dit:Company"
+            ],
+            "name": "Marco Test"
+          },
+          {
+            "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+            "type": [
+              "Person",
+              "dit:Contact"
+            ],
+            "dit:emailAddress": "john@example.com",
+            "name": "John Doe"
+          },
+          {
+            "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+            "type": [
+              "Person",
+              "dit:Adviser"
+            ],
+            "dit:emailAddress": "mariobros@dit.com",
+            "name": "Mario Bros",
+            "dit:team": {
+              "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+              "type": [
+                "Group",
+                "dit:Team"
+              ],
+              "name": "Digital Data Hub - Live Service"
+            }
+          }
+        ],
+        "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+      }
+    },
+    {
+      "id": 98,
+      "type": "Announce",
+      "published": "2019-08-09T09:43:40.904+01:00",
+      "generator": {
+        "name": "dit:dataHub",
+        "type": "Application"
+      },
+      "object": {
+        "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+        "type": [
+          "dit:Event",
+          "dit:Interaction"
+        ],
+        "startTime": "2019-05-02T08:43:40.904649+00:00",
+        "dit:status": "complete",
+        "dit:archived": false,
+        "dit:communicationChannel": {
+          "name": "Email/Website"
+        },
+        "dit:subject": "Invited to Technology Roundtable 98",
+        "dit:service": {
+          "name": "Account Management"
+        },
+        "attributedTo": [
+          {
+            "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+            "dit:dunsNumber": "123456789",
+            "dit:companiesHouseNumber": "987654321",
+            "type": [
+              "Organization",
+              "dit:Company"
+            ],
+            "name": "Marco Test"
+          },
+          {
+            "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+            "type": [
+              "Person",
+              "dit:Contact"
+            ],
+            "dit:emailAddress": "john@example.com",
+            "name": "John Doe"
+          },
+          {
+            "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+            "type": [
+              "Person",
+              "dit:Adviser"
+            ],
+            "dit:emailAddress": "mariobros@dit.com",
+            "name": "Mario Bros",
+            "dit:team": {
+              "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+              "type": [
+                "Group",
+                "dit:Team"
+              ],
+              "name": "Digital Data Hub - Live Service"
+            }
+          }
+        ],
+        "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+      }
+    },
+    {
+      "id": 97,
+      "type": "Announce",
+      "published": "2019-08-08T09:43:40.904+01:00",
+      "generator": {
+        "name": "dit:dataHub",
+        "type": "Application"
+      },
+      "object": {
+        "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+        "type": [
+          "dit:Event",
+          "dit:Interaction"
+        ],
+        "startTime": "2019-05-02T08:43:40.904649+00:00",
+        "dit:status": "complete",
+        "dit:archived": false,
+        "dit:communicationChannel": {
+          "name": "Email/Website"
+        },
+        "dit:subject": "Invited to Technology Roundtable 97",
+        "dit:service": {
+          "name": "Account Management"
+        },
+        "attributedTo": [
+          {
+            "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+            "dit:dunsNumber": "123456789",
+            "dit:companiesHouseNumber": "987654321",
+            "type": [
+              "Organization",
+              "dit:Company"
+            ],
+            "name": "Marco Test"
+          },
+          {
+            "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+            "type": [
+              "Person",
+              "dit:Contact"
+            ],
+            "dit:emailAddress": "john@example.com",
+            "name": "John Doe"
+          },
+          {
+            "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+            "type": [
+              "Person",
+              "dit:Adviser"
+            ],
+            "dit:emailAddress": "mariobros@dit.com",
+            "name": "Mario Bros",
+            "dit:team": {
+              "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+              "type": [
+                "Group",
+                "dit:Team"
+              ],
+              "name": "Digital Data Hub - Live Service"
+            }
+          }
+        ],
+        "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+      }
+    },
+    {
+      "id": 96,
+      "type": "Announce",
+      "published": "2019-08-07T09:43:40.904+01:00",
+      "generator": {
+        "name": "dit:dataHub",
+        "type": "Application"
+      },
+      "object": {
+        "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+        "type": [
+          "dit:Event",
+          "dit:Interaction"
+        ],
+        "startTime": "2019-05-02T08:43:40.904649+00:00",
+        "dit:status": "complete",
+        "dit:archived": false,
+        "dit:communicationChannel": {
+          "name": "Email/Website"
+        },
+        "dit:subject": "Invited to Technology Roundtable 96",
+        "dit:service": {
+          "name": "Account Management"
+        },
+        "attributedTo": [
+          {
+            "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+            "dit:dunsNumber": "123456789",
+            "dit:companiesHouseNumber": "987654321",
+            "type": [
+              "Organization",
+              "dit:Company"
+            ],
+            "name": "Marco Test"
+          },
+          {
+            "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+            "type": [
+              "Person",
+              "dit:Contact"
+            ],
+            "dit:emailAddress": "john@example.com",
+            "name": "John Doe"
+          },
+          {
+            "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+            "type": [
+              "Person",
+              "dit:Adviser"
+            ],
+            "dit:emailAddress": "mariobros@dit.com",
+            "name": "Mario Bros",
+            "dit:team": {
+              "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+              "type": [
+                "Group",
+                "dit:Team"
+              ],
+              "name": "Digital Data Hub - Live Service"
+            }
+          }
+        ],
+        "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+      }
+    },
+    {
+      "id": 95,
+      "type": "Announce",
+      "published": "2019-08-06T09:43:40.904+01:00",
+      "generator": {
+        "name": "dit:dataHub",
+        "type": "Application"
+      },
+      "object": {
+        "id": "dit:DataHubInteraction:a066cc49-b679-4cbe-93c5-3ceba2f067ec",
+        "type": [
+          "dit:Event",
+          "dit:Interaction"
+        ],
+        "startTime": "2019-05-02T08:43:40.904649+00:00",
+        "dit:status": "complete",
+        "dit:archived": false,
+        "dit:communicationChannel": {
+          "name": "Email/Website"
+        },
+        "dit:subject": "Invited to Technology Roundtable 95",
+        "dit:service": {
+          "name": "Account Management"
+        },
+        "attributedTo": [
+          {
+            "id": "dit:DataHubCompany:a4ead59f-dfc8-e511-a5e6-e4115bead28a",
+            "dit:dunsNumber": "123456789",
+            "dit:companiesHouseNumber": "987654321",
+            "type": [
+              "Organization",
+              "dit:Company"
+            ],
+            "name": "Marco Test"
+          },
+          {
+            "id": "dit:DataHubContact:04cadecd-2de4-4cda-9fda-59db93495dba",
+            "type": [
+              "Person",
+              "dit:Contact"
+            ],
+            "dit:emailAddress": "john@example.com",
+            "name": "John Doe"
+          },
+          {
+            "id": "dit:DataHubAdviser:2dc3c098-2f51-43c5-8767-752e8e5065b5",
+            "type": [
+              "Person",
+              "dit:Adviser"
+            ],
+            "dit:emailAddress": "mariobros@dit.com",
+            "name": "Mario Bros",
+            "dit:team": {
+              "id": "dit:DataHubTeam:3a48318c-9698-e211-a939-e4115bead28a",
+              "type": [
+                "Group",
+                "dit:Team"
+              ],
+              "name": "Digital Data Hub - Live Service"
+            }
+          }
+        ],
+        "url": "https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/a066cc49-b679-4cbe-93c5-3ceba2f067ec"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Implementation notes**

https://trello.com/c/QgJgM6jO/1184-add-function-in-frontend-to-fetch-activity-feed-from-leeloo

This is a new endpoint exposing activity feed from Leeloo and ES server, to be used by the new React components.

Dependencies: https://github.com/uktrade/data-hub-leeloo/pull/1721 and https://github.com/uktrade/data-hub-leeloo/pull/1734


**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
