### PR TITLE
Bug - Hold search term when choosing multiple options

### DIFF
--- a/assets/javascripts/vue/typeahead.vue
+++ b/assets/javascripts/vue/typeahead.vue
@@ -26,7 +26,7 @@
       v-model="selectedOptions"
       :placeholder="setPlaceHolder"
       :model="multiSelectModel"
-      :clear-on-select="true"
+      :clear-on-select="!multipleSelect"
       :close-on-select="isCloseOnSelect"
       :hide-selected="true"
       :internal-search="false"
@@ -200,7 +200,7 @@
     data () {
       return {
         selectedOptions: this.value ? JSON.parse(this.value) : [],
-        options: [],
+        options: !this.isAsync ? JSON.parse(this.model) : [],
         optionsData: this.model && JSON.parse(this.model),
         isLoading: false,
         id: uuid(),
@@ -220,6 +220,7 @@
       },
       clearInputField: function () {
         this.setPlaceHolder = this.placeholder
+        this.options = this.isAsync ? [] : this.options
       },
       getLabelFromValue: function (value, model) {
         if(!value){ return }


### PR DESCRIPTION
## Problem 
The team filter in interactions is not holding the search term whilst you select multiple options
Trello - https://trello.com/c/1gRdZGvu/754-bug-team-filter-in-interaction-view-not-holding-search-term
Below I searched for **"south"** clicked an option then lost the search term and then Aberdeen was showing at the top of the results.
![Screenshot 2019-05-28 at 15 38 53](https://user-images.githubusercontent.com/10154302/58487010-d0b5e000-815e-11e9-856d-0e7be723f0e0.png)


## Solution
The team filter should work like the adviser search, you should keep results in view even after selected 
multiple options
![Screenshot 2019-05-28 at 15 29 53](https://user-images.githubusercontent.com/10154302/58486535-f098d400-815d-11e9-95b8-7f0d7959e4f1.png)


**Checklist**

- [ ] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
