### PR TITLE
Enforce yarn version 1.15.2 and cleanup CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
-version: 2
+version: 2 # Do not upgrade to 2.1 until CircleCI CLI supports it
 aliases:
-  - &node_version               node:8.15.1
   - &redis_version              redis:3.2.10
   - &postgres_version           postgres:10
   - &mi_postgres_version        postgres:9.6
@@ -13,19 +12,11 @@ aliases:
   - &restore_yarn_cache
     restore_cache:
       name: Restore yarn dependencies cache
-      key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}
-
-  - &store_versions
-    run:
-      name: Temporarily store node/yarn versions on filesystem
-      command: node --version > node_version; yarn --version > yarn_version
+      key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
 
   # Configuration shared between user_acceptance* jobs
   - &at_container_config
     working_directory: ~/data-hub-frontend
-    environment:
-      BASH_ENV: "/usr/local/nvm/nvm.sh"  # make node, npm and yarn available
-      TZ: "/usr/share/zoneinfo/Europe/London"
 
   # Common steps for user_acceptance* jobs
   - &wait_for_backend
@@ -51,6 +42,12 @@ aliases:
     run:
       name: Wait for data hub frontend
       command: dockerize -wait ${QA_HOST}/healthcheck -timeout 120s
+
+  # Wait for api sandbox to report OK
+  - &wait_for_api_sandbox
+    run:
+      name: Wait for api sandbox
+      command: dockerize -wait ${API_ROOT}/ping.xml -timeout 120s
 
   # Create required cucumber directories
   - &create_cucumber_dirs
@@ -86,7 +83,6 @@ aliases:
     QA_SELENIUM_HOST: 127.0.0.1
     QA_SELENIUM_PORT: 4444
     REDIS_HOST: localhost
-    TZ: "/usr/share/zoneinfo/Europe/London"
     LOG_LEVEL: debug
     OAUTH2_TOKEN_FETCH_URL: http://localhost:8080/o/token
     OAUTH2_USER_PROFILE_URL: http://localhost:8080/api/v1/user/me
@@ -98,9 +94,8 @@ aliases:
     OAUTH2_DEV_TOKEN: *oauth2_dit_staff_token
 
   - &data_hub_functional_envs
-    API_ROOT: http://data-hub-sandbox.getsandbox.com
+    API_ROOT: http://localhost:8001
     QA_HOST: http://localhost:3000
-    TZ: "/usr/share/zoneinfo/Europe/London"
     LOG_LEVEL: debug
     REDIS_HOST: localhost
     MOCK_SSO_ROOT: http://localhost:8080
@@ -115,15 +110,9 @@ aliases:
 
   # Data hub base docker container
   - &docker_data_hub_base
-    image: ukti/docker-data-hub-base
+    image: ukti/data-hub-frontend-test:1.0.0
     environment:
       *data_hub_base_envs
-
-  # Cypress dependencies base docker container
-  - &docker_dit_cypress_dependencies
-    image: ukti/docker-dit-cypress
-    environment:
-      *data_hub_functional_envs
 
   # Data hub redis container
   - &docker_redis
@@ -139,7 +128,6 @@ aliases:
     name: postgres
     environment:
       POSTGRES_DB: datahub
-      TZ: "/usr/share/zoneinfo/Europe/London"
 
   # Data hub mi dashboard postgres container
   - &docker_mi_postgres
@@ -147,18 +135,20 @@ aliases:
     name: mi-postgres
     environment:
       POSTGRES_DB: mi
-      TZ: "/usr/share/zoneinfo/Europe/London"
 
   # Mock SSO container used by Data hub frontend
   - &docker_mock_sso
-    image: ukti/mock-sso
+    image: ukti/mock-sso:latest
     environment:
       - MOCK_SSO_SCOPE: 'data-hub:internal-front-end'
       - MOCK_SSO_TOKEN: 123
 
+  - &docker_data_api_sandbox
+    image: ukti/data-hub-sandbox:latest
+
   # Data hub backend
   - &docker_data_hub_backend_base
-    image: ukti/data-hub-leeloo
+    image: ukti/data-hub-leeloo:latest
     environment:
       AWS_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: foo
@@ -183,7 +173,6 @@ aliases:
       WEB_CONCURRENCY: 2
       ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
       ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
-      TZ: "/usr/share/zoneinfo/Europe/London"
 
   - &docker_data_hub_backend_api
     <<: *docker_data_hub_backend_base
@@ -226,30 +215,29 @@ aliases:
 jobs:
   # Save yarn dependencies to cache
   dependencies:
+    <<: *at_container_config
     docker:
-      - image: *node_version
-    working_directory: ~/data-hub-frontend
+      - <<: *docker_data_hub_base
     steps:
       - checkout
-      - *store_versions
       - *restore_yarn_cache
       - run: yarn install
       - save_cache:
           name: Save yarn dependencies cache
-          key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "node_version" }}
+          key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/data-hub-frontend/node_modules
             - /root/.cache/Cypress
 
   # Run linting jobs
   lint_code:
+    <<: *at_container_config
     docker:
-      - image: *node_version
-    working_directory: ~/data-hub-frontend
+      - <<: *docker_data_hub_base
     steps:
       - checkout
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
       - run:
           name: Lint code
           command: |
@@ -264,20 +252,17 @@ jobs:
 
   # Run unit tests and store results
   unit_tests:
+    <<: *at_container_config
     docker:
-      - image: *node_version
-        environment:
-          TZ: "/usr/share/zoneinfo/Europe/London"
-    working_directory: ~/data-hub-frontend
+      - *docker_data_hub_base
     steps:
       - checkout
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
       - run:
           name: Run unit tests
           command: |
             mkdir junit
-            yarn build
             yarn circle:unit
           environment:
             MOCHA_FILE: junit/test-results.xml
@@ -293,20 +278,18 @@ jobs:
 
   # Run unit client tests and store results
   unit_client_tests:
+    <<: *at_container_config
     docker:
-      - image: *node_version
-        environment:
-          TZ: "/usr/share/zoneinfo/Europe/London"
-    working_directory: ~/data-hub-frontend
+      - <<: *docker_data_hub_base
     steps:
       - checkout
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
+      - run: yarn build
       - run:
-          name: Run unit tests
+          name: Run client-side unit tests
           command: |
             mkdir junit
-            yarn build
             yarn circle:unit-client
           environment:
             MOCHA_FILE: junit/test-results.xml
@@ -324,22 +307,23 @@ jobs:
   functional_tests:
     <<: *at_container_config
     docker:
-      - *docker_dit_cypress_dependencies
-      - *docker_data_hub_base
+      - <<: *docker_data_hub_base
+        environment: *data_hub_functional_envs
       - *docker_redis
       - *docker_mock_sso
-    parallelism: 6
-    working_directory: ~/data-hub-frontend
+      - *docker_data_api_sandbox
+    parallelism: 9
     steps:
       - checkout
       - *wait_for_mock_sso
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
+      - *wait_for_api_sandbox
       - run:
-          name: Cypress tests
+          name: Run Cypress tests
           command: yarn test:functional --browser chrome --parallel --record --key $CYPRESS_DASHBOARD_KEY
           when: always
       - store_artifacts:
@@ -362,8 +346,8 @@ jobs:
       - checkout
       - *wait_for_backend
       - *wait_for_mock_sso
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -414,8 +398,8 @@ jobs:
       - checkout
       - *wait_for_backend
       - *wait_for_mock_sso
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -446,8 +430,8 @@ jobs:
       - checkout
       - *wait_for_backend
       - *wait_for_mock_sso
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -478,8 +462,8 @@ jobs:
       - checkout
       - *wait_for_backend
       - *wait_for_mock_sso
-      - *store_versions
       - *restore_yarn_cache
+      - run: yarn install
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -542,7 +526,7 @@ jobs:
       - <<: *docker_data_hub_backend_celery
         image: ukti/data-hub-leeloo:master
 
-# CircleCi workflows
+# CircleCI workflows
 workflows:
   version: 2
   datahub:
@@ -575,8 +559,3 @@ workflows:
       - master-dit_staff_at: *master_common_at_workflow_config
       - master-da_staff_at: *master_common_at_workflow_config
       - master-lep_staff_at: *master_common_at_workflow_config
-
-# Webhook for geckoboard heroku app
-notify:
-  webhooks:
-    - url: https://data-hub-circleci-geckoboard.herokuapp.com/parse-payload

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ scripts/trello-story-description.txt
 
 # BrowserStack local log
 local.log
+
+# Yarn version policy
+.yarnrc
+.yarn/

--- a/README.md
+++ b/README.md
@@ -191,20 +191,26 @@ The project is using ES6 async/await therefore Node 8 is required.
    git clone https://github.com/UKTradeInvestment/data-hub-frontend && cd data-hub-frontend
    ```
 
-2. Install node dependencies:
+2. Ensure correct version of yarn is used:
+
+   ```
+   yarn policies set-version 1.15.2
+   ```
+   
+3. Install node dependencies:
 
    ```
    yarn install
    ```
 
-3. Create a copy of the sample .env file and add values for the keys
+4. Create a copy of the sample .env file and add values for the keys
    (a current member of the project team can give you these):
 
    ```
    cp sample.env .env
    ```
 
-4. Run an instance of Redis and change `REDIS_HOST` and `REDIS_PORT` in your
+5. Run an instance of Redis and change `REDIS_HOST` and `REDIS_PORT` in your
    .env file if necessary
 
 #### Run in production mode

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": "8.15.1"
+    "node": "8.15.1",
+    "yarn": "1.15.2"
   },
   "dependencies": {
     "axios": "^0.18.0",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,68 @@
+# This docker image is used ONLY with CircleCI to run tests.
+# For local development image see Dockerfile in the root directory of this project.
+
+FROM node:8.15.1
+
+# Increment this version each time when you edit Dockerfile.
+ENV VERSION                1.0.0
+
+ENV DOCKERIZE_VERSION      v0.3.0
+ENV YARN_VERSION           1.15.2
+ENV NPM_CONFIG_LOGLEVEL    warn
+ENV NPM_CONFIG_UNSAFE_PERM true
+ENV TZ                     Europe/London
+ENV TERM xterm
+
+RUN apt-get update
+
+# Install common dependencies
+RUN apt-get install -y \
+  tzdata \
+  wget \
+  curl \
+  make \
+  git
+
+# Fix error when libpng cannot be found after CircleCI restores cache for pngquant-bin.
+# See https://github.com/tcoopman/image-webpack-loader/issues/95
+RUN wget -q -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb \
+  && dpkg -i /tmp/libpng12.deb \
+  && rm /tmp/libpng12.deb
+
+# Use specific yarn version
+RUN npm install -g yarn@$YARN_VERSION
+
+# Set timezone
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+  && echo "Timezone: $(date +%z)"
+
+# Install dockerize
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# Install Cypress dependencies
+RUN apt-get install -y \
+  libgtk2.0-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  xvfb
+
+# Install Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
+  && apt-get update \
+  && apt-get install -y dbus-x11 google-chrome-stable
+
+# Install dependencies for acceptance tests
+RUN apt-get install -y openjdk-8-jre
+
+# Versions of local tools
+RUN node -v
+RUN npm -v
+RUN yarn -v
+RUN google-chrome --version
+RUN git --version

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,28 @@
+# Testing
+
+## Creating Docker container for CircleCI
+
+```bash
+export VERSION=1.0.0 # Increment this version each time when you edit Dockerfile.
+
+docker login # Ask webops for Docker Hub access to the ukti group.
+docker build -f test/Dockerfile -t data-hub-frontend-test .
+
+docker tag data-hub-frontend-test:latest ukti/data-hub-frontend-test:${VERSION}
+docker tag data-hub-frontend-test:latest ukti/data-hub-frontend-test:latest
+
+docker push ukti/data-hub-frontend-test:${VERSION}
+docker push ukti/data-hub-frontend-test:latest
+```
+
+You image should be now listed at [Docker Hub](https://cloud.docker.com/u/ukti/repository/docker/ukti/data-hub-frontend-test/tags).
+
+## Executing CircleCI jobs locally
+
+Not all the jobs currently can be executed locally.
+
+```bash
+curl -fLSs https://circle.ci/cli | bash
+circleci local execute --job unit_tests
+circleci local execute --job unit_client_tests
+```


### PR DESCRIPTION
**Implementation notes**

This PR will enforce using a specific version of Yarn, same as we currently do for node version.

For more info see https://yarnpkg.com/lang/en/docs/cli/policies/#toc-policies-set-version

**Dependencies**

- [x] https://github.com/uktrade/docker-datahub-fe-base/pull/1

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
