### PR TITLE
Modify getOptions metadata API call

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/options.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/options.js
@@ -1,26 +1,34 @@
 const { getOptions } = require('../../../../../lib/options')
 const { getAdvisers } = require('../../../../adviser/repos')
+const { transformObjectToGovUKOption } = require('../../../../../apps/transformers')
 
-const DO_NOT_SORT = { sorted: false }
+const OPTIONS = {
+  sorted: false,
+  transformer: transformObjectToGovUKOption,
+}
 
 const getInvestorDetailsOptions = (token) => {
   return [
-    getOptions(token, 'capital-investment/investor-type'),
-    getOptions(token, 'capital-investment/required-checks-conducted'),
+    getOptions(token, 'capital-investment/investor-type', OPTIONS),
+    getOptions(token, 'capital-investment/required-checks-conducted', OPTIONS),
     getAdvisers(token),
   ]
 }
 
 const getInvestorRequirementsOptions = (token) => {
   return [
-    getOptions(token, 'capital-investment/deal-ticket-size', DO_NOT_SORT),
-    getOptions(token, 'capital-investment/large-capital-investment-type'),
-    getOptions(token, 'capital-investment/return-rate', DO_NOT_SORT),
-    getOptions(token, 'capital-investment/time-horizon', DO_NOT_SORT),
-    getOptions(token, 'capital-investment/restriction', DO_NOT_SORT),
-    getOptions(token, 'capital-investment/construction-risk', DO_NOT_SORT),
-    getOptions(token, 'capital-investment/equity-percentage', DO_NOT_SORT),
-    getOptions(token, 'capital-investment/desired-deal-role', DO_NOT_SORT),
+    getOptions(token, 'capital-investment/deal-ticket-size', OPTIONS),
+    getOptions(token, 'capital-investment/large-capital-investment-type', {
+      sorted: true,
+      sortPropertyName: 'text',
+      transformer: transformObjectToGovUKOption,
+    }),
+    getOptions(token, 'capital-investment/return-rate', OPTIONS),
+    getOptions(token, 'capital-investment/time-horizon', OPTIONS),
+    getOptions(token, 'capital-investment/restriction', OPTIONS),
+    getOptions(token, 'capital-investment/construction-risk', OPTIONS),
+    getOptions(token, 'capital-investment/equity-percentage', OPTIONS),
+    getOptions(token, 'capital-investment/desired-deal-role', OPTIONS),
   ]
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-form.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-details-to-form.js
@@ -4,7 +4,6 @@ const moment = require('moment')
 const types = require('../constants')
 
 const { transformAdviserToOption } = require('../../../../../adviser/transformers')
-const transformObjectToOption = ({ value, label }) => ({ value, text: label })
 
 const parseDate = (dateStr) => {
   const date = moment(dateStr, 'YYYY-MM-DD', true)
@@ -15,30 +14,27 @@ const parseDate = (dateStr) => {
   }
 }
 
-const transformInvestorTypes = (investorTypes, { investorType }) => {
-  const options = investorTypes.map(transformObjectToOption)
+const transformInvestorTypes = (investorTypesMetadata, { investorType }) => {
   const { value } = investorType
 
   if (value) {
-    find(options, (item) => item.value === value).selected = true
+    find(investorTypesMetadata, (item) => item.value === value).selected = true
   }
 
-  options.unshift({
+  investorTypesMetadata.unshift({
     value: null,
     text: '-- Please select an investor type --',
   })
 
-  return options
+  return investorTypesMetadata
 }
 
-const transformRequiredChecks = (requiredChecksMetaData, { requiredChecks }) => {
-  const radioButtons = requiredChecksMetaData.map(transformObjectToOption)
-
+const transformRequiredChecks = (requiredChecksMetadata, { requiredChecks }) => {
   const transformed = {
-    cleared: find(radioButtons, item => item.text === types.CLEARED),
-    issuesIdentified: find(radioButtons, item => item.text === types.ISSUES_IDENTIFIED),
-    notYetChecked: find(radioButtons, item => item.text === types.NOT_YET_CHECKED),
-    notRequired: find(radioButtons, item => item.text === types.CHECKS_NOT_REQUIRED),
+    cleared: find(requiredChecksMetadata, item => item.text === types.CLEARED),
+    issuesIdentified: find(requiredChecksMetadata, item => item.text === types.ISSUES_IDENTIFIED),
+    notYetChecked: find(requiredChecksMetadata, item => item.text === types.NOT_YET_CHECKED),
+    notRequired: find(requiredChecksMetadata, item => item.text === types.CHECKS_NOT_REQUIRED),
   }
 
   const type = get(requiredChecks, 'type.name')
@@ -55,7 +51,7 @@ const transformRequiredChecks = (requiredChecksMetaData, { requiredChecks }) => 
 
   const id = get(requiredChecks, 'type.id')
   if (id) {
-    find(radioButtons, (item) => item.value === id).checked = true
+    find(requiredChecksMetadata, (item) => item.value === id).checked = true
   }
 
   return transformed

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-form.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/investor-requirements-to-form.js
@@ -1,20 +1,15 @@
 /* eslint-disable camelcase */
 const {
-  transformObjectToOption,
   checkOptionByMatchingId,
   checkOptionByFindingMatchingId,
 } = require('../../utils/transformers')
 
 const transformCheckboxes = (metadata, obj) => {
-  return metadata
-    .map(transformObjectToOption)
-    .map(checkOptionByFindingMatchingId(obj.value)) // Array
+  return metadata.map(checkOptionByFindingMatchingId(obj.value)) // Array
 }
 
 const transformRadioButtons = (metadata, obj) => {
-  return metadata
-    .map(transformObjectToOption)
-    .map(checkOptionByMatchingId(obj.value)) // String
+  return metadata.map(checkOptionByMatchingId(obj.value)) // String
 }
 
 module.exports = {

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -16,6 +16,13 @@ function transformObjectToOption ({ id, name }) {
   }
 }
 
+function transformObjectToGovUKOption ({ id, name }) {
+  return {
+    value: id,
+    text: name,
+  }
+}
+
 function transformHQCodeToLabelledOption ({ id, name }) {
   switch (name) {
     case 'ehq':
@@ -99,4 +106,5 @@ module.exports = {
   transformIdToObject,
   transformDateObjectToDateString,
   transformDateStringToDateObject,
+  transformObjectToGovUKOption,
 }

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -37,10 +37,12 @@ async function getOptions (
     currentValue,
     includeDisabled = false,
     sorted = true,
+    sortPropertyName = 'label',
     term,
     id,
     queryString = '',
     context,
+    transformer = transformObjectToOption,
   } = {}
 ) {
   if (id) {
@@ -75,9 +77,9 @@ async function getOptions (
     })
   }
 
-  const mappedOptions = options.map(transformObjectToOption)
+  const mappedOptions = options.map(transformer)
 
-  return sorted ? sortBy(mappedOptions, 'label') : mappedOptions
+  return sorted ? sortBy(mappedOptions, sortPropertyName) : mappedOptions
 }
 
 async function getOptionsForId (token, key, id) {

--- a/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-details-to-form.test.js
+++ b/test/unit/apps/companies/controllers/investments/large-capital-profile/transformers/investor-details-to-form.test.js
@@ -7,10 +7,10 @@ describe('Large capital profile, Investor details API to form', () => {
   context('when translating Investor types', () => {
     beforeEach(() => {
       const investorTypes = [ {
-        label: 'Angel syndicate',
+        text: 'Angel syndicate',
         value: '1',
       }, {
-        label: 'Asset manager',
+        text: 'Asset manager',
         value: '2',
       }]
 
@@ -42,16 +42,16 @@ describe('Large capital profile, Investor details API to form', () => {
   context('when translating required checks', () => {
     beforeEach(() => {
       this.requiredChecks = [ {
-        label: 'Cleared',
+        text: 'Cleared',
         value: '1',
       }, {
-        label: 'Issues identified',
+        text: 'Issues identified',
         value: '2',
       }, {
-        label: 'Not yet checked',
+        text: 'Not yet checked',
         value: '4',
       }, {
-        label: 'Checks not required - See Investor Screening Report (ISR) guidance',
+        text: 'Checks not required - See Investor Screening Report (ISR) guidance',
         value: '3',
       }]
     })

--- a/test/unit/lib/options.test.js
+++ b/test/unit/lib/options.test.js
@@ -74,45 +74,39 @@ describe('#options', () => {
     })
   })
 
-  context(
-    'when asking for options for an existing record using disabled value',
-    () => {
-      beforeEach(async () => {
-        this.options = await getOptions('1234', 'uk-region', {
-          currentValue: '2',
-          createdOn: today,
-        })
+  context('when asking for options for an existing record using disabled value', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', {
+        currentValue: '2',
+        createdOn: today,
       })
+    })
 
-      it('should return just active options', () => {
-        expect(this.options).to.deep.equal([
-          { label: 'r1', value: '1' },
-          { label: 'r2', value: '2' },
-          { label: 'r3', value: '3' },
-        ])
-      })
-    }
-  )
+    it('should return just active options', () => {
+      expect(this.options).to.deep.equal([
+        { label: 'r1', value: '1' },
+        { label: 'r2', value: '2' },
+        { label: 'r3', value: '3' },
+      ])
+    })
+  })
 
-  context(
-    'when asking for options for an existing record created before option disabled',
-    () => {
-      beforeEach(async () => {
-        this.options = await getOptions('1234', 'uk-region', {
-          currentValue: '1',
-          createdOn: lastWeek,
-        })
+  context('when asking for options for an existing record created before option disabled', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', {
+        currentValue: '1',
+        createdOn: lastWeek,
       })
+    })
 
-      it('should return just active options', () => {
-        expect(this.options).to.deep.equal([
-          { label: 'r1', value: '1' },
-          { label: 'r2', value: '2' },
-          { label: 'r3', value: '3' },
-        ])
-      })
-    }
-  )
+    it('should return just active options', () => {
+      expect(this.options).to.deep.equal([
+        { label: 'r1', value: '1' },
+        { label: 'r2', value: '2' },
+        { label: 'r3', value: '3' },
+      ])
+    })
+  })
 
   context('when asking for all options for a filter form', () => {
     beforeEach(async () => {
@@ -177,6 +171,52 @@ describe('#options', () => {
       it('should return options in that context', () => {
         expect(this.options).to.deep.equal([{ label: 'Advice', value: '1' }])
       })
+    })
+  })
+
+  context('when a transformer is provided', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', {
+        includeDisabled: true,
+        transformer: ({ id, name }) => {
+          return {
+            value: id,
+            text: name,
+          }
+        },
+      })
+    })
+
+    it('should transform the options', () => {
+      expect(this.options).to.deep.equal([
+        { text: 'r1', value: '1' },
+        { text: 'r3', value: '3' },
+        { text: 'r2', value: '2' },
+      ])
+    })
+  })
+
+  context('when the options are sorted', () => {
+    beforeEach(async () => {
+      this.options = await getOptions('1234', 'uk-region', {
+        sorted: true,
+        sortPropertyName: 'text',
+        includeDisabled: true,
+        transformer: ({ id, name }) => {
+          return {
+            value: id,
+            text: name,
+          }
+        },
+      })
+    })
+
+    it('should sort the options by the property name "text"', () => {
+      expect(this.options).to.deep.equal([
+        { text: 'r1', value: '1' },
+        { text: 'r2', value: '2' },
+        { text: 'r3', value: '3' },
+      ])
     })
   })
 })


### PR DESCRIPTION
Currently [getOptions()](https://github.com/uktrade/data-hub-frontend/blob/develop/src/lib/options.js#L32) makes an API call and transforms all metadata items into an options list that is consumed by all Data Hub components.

**Here is the current problem:**

```
  API metadata item
  {
    "id": "1",
    "name": "Angel syndicate",
  }

  The function getOptions() transforms the metadata item above into a new item that is consumed by Data Hub components. 
  {
    "value": "1",
    "label": "Angel syndicate"
  }
  
  Large capital profile then transforms the item above into a GOV.UK item
  {
    "value": "1",
    "text": "Angel syndicate"
  }
```

**Here is the solution:**
Add two new optional fields to the options object that's passed into getOptions()

1. `transformer` - allows custom metadata transformations. If this is not provided then the default transformer is used (i.e. the existing one)
2. `sortPropertyName` - allows the caller to sort the metadata options based on a property name. If this is not provided then the default property name is used `label` (i.e. the existing one)

These changes are necessary to accommodate GOV.UK components. 

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
