### PR TITLE
Handle "No" when answering "Did the meeting happen?"

### DIFF
--- a/src/apps/constants.js
+++ b/src/apps/constants.js
@@ -1,0 +1,8 @@
+const ERROR = {
+  SELECT_AN_OPTION: 'You must select an option',
+  ENTER_A_DATE: 'You must enter a date',
+}
+
+module.exports = {
+  ERROR,
+}

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -85,6 +85,10 @@ const INTERACTION_STATUS = {
   COMPLETE: 'complete',
 }
 
+const ARCHIVED_REASON = {
+  RESCHEDULED: 'Rescheduled',
+}
+
 module.exports = {
   QUERY_FIELDS,
   QUERY_DATE_FIELDS,
@@ -95,4 +99,5 @@ module.exports = {
   IST_ONLY_SERVICES,
   SERVICE_DELIVERY_STATUS_COMPLETED,
   INTERACTION_STATUS,
+  ARCHIVED_REASON,
 }

--- a/src/apps/interactions/repos.js
+++ b/src/apps/interactions/repos.js
@@ -34,8 +34,18 @@ function getInteractionsForEntity ({ token, entityQuery, page = 1, sortby }) {
   })
 }
 
+function archiveInteraction (token, interactionId, reason) {
+  const options = {
+    body: { reason },
+    url: `${config.apiRoot}/v3/interaction/${interactionId}/archive`,
+    method: 'POST',
+  }
+  return authorisedRequest(token, options)
+}
+
 module.exports = {
   saveInteraction,
   fetchInteraction,
   getInteractionsForEntity,
+  archiveInteraction,
 }

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -4,7 +4,7 @@ const { DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS, QUERY_DATE_FIEL
 
 const { renderEditPage } = require('./controllers/edit')
 const { renderDetailsPage } = require('./controllers/details')
-const { renderCompletePage } = require('./controllers/complete')
+const { renderCompletePage, postComplete } = require('./controllers/complete')
 const { renderInteractionList } = require('./controllers/list')
 const { exportCollection } = require('../../modules/search/middleware/collection')
 const { getRequestBody } = require('../../middleware/collection')
@@ -47,6 +47,7 @@ router.get('/:interactionId', renderDetailsPage)
 
 router
   .route('/:interactionId/complete')
+  .post(detectUserAgent, postComplete, renderCompletePage)
   .get(detectUserAgent, renderCompletePage)
 
 module.exports = router

--- a/src/apps/interactions/router.sub-app.js
+++ b/src/apps/interactions/router.sub-app.js
@@ -2,7 +2,7 @@ const router = require('express').Router()
 
 const { renderEditPage } = require('./controllers/edit')
 const { renderDetailsPage } = require('./controllers/details')
-const { renderCompletePage } = require('./controllers/complete')
+const { renderCompletePage, postComplete } = require('./controllers/complete')
 const { postCreate, renderCreate } = require('./controllers/create')
 const { renderInteractionsForEntity } = require('./controllers/list')
 const { postDetails, getInteractionDetails } = require('./middleware/details')
@@ -40,6 +40,7 @@ router.get('/interactions/:interactionId', renderDetailsPage)
 
 router
   .route('/interactions/:interactionId/complete')
+  .post(detectUserAgent, postComplete, renderCompletePage)
   .get(detectUserAgent, renderCompletePage)
 
 module.exports = router

--- a/test/functional/cypress/selectors/interaction/complete.js
+++ b/test/functional/cypress/selectors/interaction/complete.js
@@ -2,13 +2,18 @@ module.exports = {
   meetingHappen: {
     yes: '[for="field-meeting_happen-1"]',
     no: '[for="field-meeting_happen-2"]',
+    error: '#group-field-meeting_happen .c-form-group__error-message',
   },
   archivedReason: {
     clientCancelled: '[for="field-archived_reason-1"]',
     ditCancelled: '[for="field-archived_reason-2"]',
     rescheduled: '[for="field-archived_reason-3"]',
+    error: '#group-field-archived_reason .c-form-group__error-message',
   },
-  rescheduledDate: '#group-field-date',
+  rescheduledDate: {
+    field: '#field-date',
+    error: '#group-field-date .c-form-group__error-message',
+  },
   actions: {
     continue: '.button',
     back: ({ companyId, interactionId }) => `[href="/companies/${companyId}/interactions/${interactionId}"]`,

--- a/test/functional/cypress/selectors/local-header.js
+++ b/test/functional/cypress/selectors/local-header.js
@@ -8,5 +8,6 @@ module.exports = () => {
       paragraph: (number) => `${localHeaderSelector} .c-local-header__description p:nth-child(${number})`,
     },
     viewFullBusinessDetailsLink: (companyId) => `${localHeaderSelector} [href="/companies/${companyId}/business-details"]`,
+    flash: '.c-message',
   }
 }

--- a/test/functional/cypress/specs/interaction/complete-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/complete-interaction-spec.js
@@ -2,61 +2,229 @@ const fixtures = require('../../fixtures')
 const selectors = require('../../selectors')
 
 describe('Complete interaction', () => {
-  let params = {}
+  context('Render form', () => {
+    let params = {}
 
-  before(() => {
-    params.companyId = fixtures.company.venusLtd.id
-    params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
+    before(() => {
+      params.companyId = fixtures.company.venusLtd.id
+      params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
 
-    cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
+      cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
 
-    cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+      cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+    })
+
+    it('should render breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.venusLtd.name)
+      cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.venusLtd.id}`)
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.text', 'Interactions')
+      cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.attr', 'href', `/companies/${fixtures.company.venusLtd.id}/interactions`)
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Interaction')
+    })
+
+    it('should render the heading', () => {
+      cy.get(selectors.localHeader().heading).should('have.text', 'Did the meeting take place?')
+    })
+
+    it('should render the form', () => {
+      cy.get(selectors.interaction.complete.meetingHappen.yes).should('be.visible')
+      cy.get(selectors.interaction.complete.meetingHappen.no).should('be.visible')
+      cy.get(selectors.interaction.complete.archivedReason.clientCancelled).should('not.be.visible')
+      cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should('not.be.visible')
+      cy.get(selectors.interaction.complete.archivedReason.rescheduled).should('not.be.visible')
+      cy.get(selectors.interaction.complete.rescheduledDate.field).should('not.be.visible')
+      cy.get(selectors.interaction.complete.actions.continue).should('be.visible')
+      cy.get(selectors.interaction.complete.actions.back(params)).should('be.visible')
+    })
+
+    it('should toggle field visibility in the form', () => {
+      cy.get(selectors.interaction.complete.meetingHappen.no).click()
+      cy.get(selectors.interaction.complete.archivedReason.clientCancelled).should('be.visible')
+      cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should('be.visible')
+      cy.get(selectors.interaction.complete.archivedReason.rescheduled).should('be.visible')
+      cy.get(selectors.interaction.complete.rescheduledDate.field).should('not.be.visible')
+
+      cy.get(selectors.interaction.complete.archivedReason.rescheduled).click()
+      cy.get(selectors.interaction.complete.rescheduledDate.field).should('be.visible')
+
+      cy.get(selectors.interaction.complete.archivedReason.clientCancelled).click()
+      cy.get(selectors.interaction.complete.rescheduledDate.field).should('not.be.visible')
+
+      cy.get(selectors.interaction.complete.meetingHappen.yes).click()
+      cy.get(selectors.interaction.complete.archivedReason.clientCancelled).should('not.be.visible')
+      cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should('not.be.visible')
+      cy.get(selectors.interaction.complete.archivedReason.rescheduled).should('not.be.visible')
+      cy.get(selectors.interaction.complete.rescheduledDate.field).should('not.be.visible')
+    })
   })
 
-  it('should render breadcrumbs', () => {
-    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
-    cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
-    cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
-    cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
-    cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.text', fixtures.company.venusLtd.name)
-    cy.get(selectors.breadcrumbs.item.byNumber(3)).should('have.attr', 'href', `/companies/${fixtures.company.venusLtd.id}`)
-    cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.text', 'Interactions')
-    cy.get(selectors.breadcrumbs.item.byNumber(4)).should('have.attr', 'href', `/companies/${fixtures.company.venusLtd.id}/interactions`)
-    cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Interaction')
-  })
+  context('Submit form', () => {
+    context('when no options are selected', () => {
+      let params = {}
 
-  it('should render the heading', () => {
-    cy.get(selectors.localHeader().heading).should('have.text', 'Did the meeting take place?')
-  })
+      before(() => {
+        params.companyId = fixtures.company.venusLtd.id
+        params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
 
-  it('should render the form', () => {
-    cy.get(selectors.interaction.complete.meetingHappen.yes).should('be.visible')
-    cy.get(selectors.interaction.complete.meetingHappen.no).should('be.visible')
-    cy.get(selectors.interaction.complete.archivedReason.clientCancelled).should('not.be.visible')
-    cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should('not.be.visible')
-    cy.get(selectors.interaction.complete.archivedReason.rescheduled).should('not.be.visible')
-    cy.get(selectors.interaction.complete.rescheduledDate).should('not.be.visible')
-    cy.get(selectors.interaction.complete.actions.continue).should('be.visible')
-    cy.get(selectors.interaction.complete.actions.back(params)).should('be.visible')
-  })
+        cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
 
-  it('should toggle field visibility in the form', () => {
-    cy.get(selectors.interaction.complete.meetingHappen.no).click()
-    cy.get(selectors.interaction.complete.archivedReason.clientCancelled).should('be.visible')
-    cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should('be.visible')
-    cy.get(selectors.interaction.complete.archivedReason.rescheduled).should('be.visible')
-    cy.get(selectors.interaction.complete.rescheduledDate).should('not.be.visible')
+        cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
 
-    cy.get(selectors.interaction.complete.archivedReason.rescheduled).click()
-    cy.get(selectors.interaction.complete.rescheduledDate).should('be.visible')
+        cy.get(selectors.interaction.complete.actions.continue).click()
+      })
 
-    cy.get(selectors.interaction.complete.archivedReason.clientCancelled).click()
-    cy.get(selectors.interaction.complete.rescheduledDate).should('not.be.visible')
+      it('should not redirect to the interaction list', () => {
+        cy.location('pathname').should('eq', `/companies/${params.companyId}/interactions/${params.interactionId}/complete`)
+      })
 
-    cy.get(selectors.interaction.complete.meetingHappen.yes).click()
-    cy.get(selectors.interaction.complete.archivedReason.clientCancelled).should('not.be.visible')
-    cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should('not.be.visible')
-    cy.get(selectors.interaction.complete.archivedReason.rescheduled).should('not.be.visible')
-    cy.get(selectors.interaction.complete.rescheduledDate).should('not.be.visible')
+      it('should show an error', () => {
+        cy.get(selectors.interaction.complete.meetingHappen.error).should('be.visible')
+        cy.get(selectors.interaction.complete.meetingHappen.error).should('have.text', 'You must select an option')
+      })
+    })
+
+    context('when the meeting did not happen', () => {
+      context('no reason selected', () => {
+        let params = {}
+
+        before(() => {
+          params.companyId = fixtures.company.venusLtd.id
+          params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
+
+          cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
+
+          cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+
+          cy.get(selectors.interaction.complete.meetingHappen.no).click()
+          cy.get(selectors.interaction.complete.actions.continue).click()
+        })
+
+        it('should not redirect to the interaction list', () => {
+          cy.location('pathname').should('eq', `/companies/${params.companyId}/interactions/${params.interactionId}/complete`)
+        })
+
+        it('should show an error', () => {
+          cy.get(selectors.interaction.complete.archivedReason.error).should('be.visible')
+          cy.get(selectors.interaction.complete.archivedReason.error).should('have.text', 'You must select an option')
+        })
+      })
+
+      context('and client cancelled', () => {
+        let params = {}
+
+        before(() => {
+          params.companyId = fixtures.company.venusLtd.id
+          params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
+
+          cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
+
+          cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+
+          cy.get(selectors.interaction.complete.meetingHappen.no).click()
+          cy.get(selectors.interaction.complete.archivedReason.clientCancelled).click()
+          cy.get(selectors.interaction.complete.actions.continue).click()
+        })
+
+        it('should redirect to the interaction list', () => {
+          cy.location('pathname').should('eq', `/companies/${params.companyId}/interactions`)
+        })
+
+        it('should show the success message', () => {
+          cy.get(selectors.localHeader().flash).should('contain', 'The interaction has been updated')
+          cy.get(selectors.localHeader().flash).should('have.class', 'c-message--success')
+        })
+
+        // todo assert interaction changed state
+      })
+
+      context('and DIT cancelled', () => {
+        let params = {}
+
+        before(() => {
+          params.companyId = fixtures.company.venusLtd.id
+          params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
+
+          cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
+
+          cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+
+          cy.get(selectors.interaction.complete.meetingHappen.no).click()
+          cy.get(selectors.interaction.complete.archivedReason.ditCancelled).click()
+          cy.get(selectors.interaction.complete.actions.continue).click()
+        })
+
+        it('should redirect to the interaction list', () => {
+          cy.location('pathname').should('eq', `/companies/${params.companyId}/interactions`)
+        })
+
+        it('should show the success message', () => {
+          cy.get(selectors.localHeader().flash).should('contain', 'The interaction has been updated')
+          cy.get(selectors.localHeader().flash).should('have.class', 'c-message--success')
+        })
+
+        // todo assert interaction changed state
+      })
+
+      context('and rescheduled', () => {
+        context('and a valid date is not entered', () => {
+          let params = {}
+
+          before(() => {
+            params.companyId = fixtures.company.venusLtd.id
+            params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
+
+            cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
+
+            cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+
+            cy.get(selectors.interaction.complete.meetingHappen.no).click()
+            cy.get(selectors.interaction.complete.archivedReason.rescheduled).click()
+            cy.get(selectors.interaction.complete.actions.continue).click()
+          })
+
+          it('should not redirect to the interaction list', () => {
+            cy.location('pathname').should('eq', `/companies/${params.companyId}/interactions/${params.interactionId}/complete`)
+          })
+
+          it('should show an error', () => {
+            cy.get(selectors.interaction.complete.rescheduledDate.error).should('be.visible')
+            cy.get(selectors.interaction.complete.rescheduledDate.error).should('have.text', 'You must enter a date')
+          })
+        })
+
+        context('and a valid date is entered', () => {
+          let params = {}
+
+          before(() => {
+            params.companyId = fixtures.company.venusLtd.id
+            params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
+
+            cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
+
+            cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+
+            cy.get(selectors.interaction.complete.meetingHappen.no).click()
+            cy.get(selectors.interaction.complete.archivedReason.rescheduled).click()
+            cy.get(selectors.interaction.complete.rescheduledDate.field).type('2030-01-01')
+            cy.get(selectors.interaction.complete.actions.continue).click()
+          })
+
+          it('should redirect to the interaction list', () => {
+            cy.location('pathname').should('eq', `/companies/${params.companyId}/interactions`)
+          })
+
+          it('should show the success message', () => {
+            cy.get(selectors.localHeader().flash).should('contain', 'The interaction has been updated')
+            cy.get(selectors.localHeader().flash).should('have.class', 'c-message--success')
+          })
+
+          // todo assert interaction changed state
+        })
+      })
+    })
   })
 })

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -22,7 +22,7 @@ describe('Interaction details', () => {
     })
 
     it('should render the heading', () => {
-      cy.get(selectors.localHeader().heading).should('not.be.empty')
+      cy.get(selectors.localHeader().heading).should('have.text', fixtures.interaction.interactionDraftPastMeeting.subject)
     })
 
     it('should render the details', () => {
@@ -74,7 +74,7 @@ describe('Interaction details', () => {
     })
 
     it('should render the heading', () => {
-      cy.get(selectors.localHeader().heading).should('not.be.empty')
+      cy.get(selectors.localHeader().heading).should('have.text', fixtures.interaction.interactionDraftFutureMeeting.subject)
     })
 
     it('should render the details', () => {
@@ -125,7 +125,7 @@ describe('Interaction details', () => {
     })
 
     it('should render the heading', () => {
-      cy.get(selectors.localHeader().heading).should('not.be.empty')
+      cy.get(selectors.localHeader().heading).should('have.text', fixtures.interaction.interactionWithLink.subject)
     })
 
     it('should render the details', () => {
@@ -187,7 +187,7 @@ describe('Interaction details', () => {
     })
 
     it('should render the heading', () => {
-      cy.get(selectors.localHeader().heading).should('not.be.empty')
+      cy.get(selectors.localHeader().heading).should('have.text', fixtures.interaction.interactionWithNoLink.subject)
     })
 
     it('should render the details', () => {

--- a/test/unit/apps/interactions/controllers/complete.test.js
+++ b/test/unit/apps/interactions/controllers/complete.test.js
@@ -2,6 +2,7 @@ const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parame
 const draftPastMeeting = require('~/test/unit/data/interactions/draft-past-meeting.json')
 
 const { completeController } = require('~/src/apps/interactions/controllers')
+const { ERROR } = require('~/src/apps/constants')
 
 describe('Interaction details controller', () => {
   describe('#renderCompletePage', () => {
@@ -41,6 +42,328 @@ describe('Interaction details controller', () => {
 
     it('should render the template with a form', () => {
       expect(this.middlewareParameters.resMock.render.firstCall.args[1].meetingHappenForm).to.exist
+    })
+  })
+
+  describe('#postComplete', () => {
+    context('when the user does not select a meeting happen option', () => {
+      beforeEach(() => {
+        this.saveInteractionStub = sinon.stub()
+        this.archiveInteractionStub = sinon.stub()
+
+        const controller = proxyquire('~/src/apps/interactions/controllers/complete', {
+          '../repos': {
+            saveInteraction: this.saveInteractionStub,
+            archiveInteraction: this.archiveInteractionStub,
+          },
+        })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {},
+          interaction: draftPastMeeting,
+        })
+
+        return controller.postComplete(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should not save the interaction', () => {
+        expect(this.saveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not archive the interaction', () => {
+        expect(this.archiveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not call flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.not.have.been.called
+      })
+
+      it('should not redirect to the entity', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.not.have.been.called
+      })
+
+      it('should set the errors', () => {
+        expect(this.middlewareParameters.resMock.locals.errors).to.deep.equal({
+          meeting_happen: [ ERROR.SELECT_AN_OPTION ],
+        })
+      })
+
+      it('should call next once', () => {
+        expect(this.middlewareParameters.nextSpy).calledOnceWithExactly()
+      })
+    })
+
+    context('when the user selects "No" and a valid archived reason', () => {
+      beforeEach(() => {
+        this.saveInteractionStub = sinon.stub()
+        this.archiveInteractionStub = sinon.stub()
+
+        const controller = proxyquire('~/src/apps/interactions/controllers/complete', {
+          '../repos': {
+            saveInteraction: this.saveInteractionStub,
+            archiveInteraction: this.archiveInteractionStub,
+          },
+        })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {
+            meeting_happen: 'false',
+            archived_reason: 'reason',
+          },
+          interaction: draftPastMeeting,
+        })
+
+        return controller.postComplete(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should not save the interaction', () => {
+        expect(this.saveInteractionStub).to.not.have.been.called
+      })
+
+      it('should archive the interaction', () => {
+        expect(this.archiveInteractionStub).calledOnceWithExactly('1234', draftPastMeeting.id, 'reason')
+      })
+
+      it('should call flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).calledOnceWithExactly('success', 'The interaction has been updated')
+      })
+
+      it('should redirect to the interactions', () => {
+        expect(this.middlewareParameters.resMock.redirect).calledOnceWithExactly('/interactions')
+      })
+
+      it('should not set the errors', () => {
+        expect(this.middlewareParameters.resMock.locals.errors).to.not.exist
+      })
+
+      it('should not call next', () => {
+        expect(this.middlewareParameters.nextSpy).to.not.have.been.called
+      })
+    })
+
+    context('when the user selects "No" and does not select an archived reason option', () => {
+      beforeEach(() => {
+        this.saveInteractionStub = sinon.stub()
+        this.archiveInteractionStub = sinon.stub()
+
+        const controller = proxyquire('~/src/apps/interactions/controllers/complete', {
+          '../repos': {
+            saveInteraction: this.saveInteractionStub,
+            archiveInteraction: this.archiveInteractionStub,
+          },
+        })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {
+            meeting_happen: 'false',
+          },
+          interaction: draftPastMeeting,
+        })
+
+        return controller.postComplete(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should not save the interaction', () => {
+        expect(this.saveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not archive the interaction', () => {
+        expect(this.archiveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not call flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.not.have.been.called
+      })
+
+      it('should not redirect to the entity', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.not.have.been.called
+      })
+
+      it('should set the errors', () => {
+        expect(this.middlewareParameters.resMock.locals.errors).to.deep.equal({
+          archived_reason: [ ERROR.SELECT_AN_OPTION ],
+        })
+      })
+
+      it('should call next once', () => {
+        expect(this.middlewareParameters.nextSpy).calledOnceWithExactly()
+      })
+    })
+
+    context('when the user selects "Rescheduled" and does not enter a date', () => {
+      beforeEach(() => {
+        this.saveInteractionStub = sinon.stub()
+        this.archiveInteractionStub = sinon.stub()
+
+        const controller = proxyquire('~/src/apps/interactions/controllers/complete', {
+          '../repos': {
+            saveInteraction: this.saveInteractionStub,
+            archiveInteraction: this.archiveInteractionStub,
+          },
+        })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {
+            meeting_happen: 'false',
+            archived_reason: 'Rescheduled',
+          },
+          interaction: draftPastMeeting,
+        })
+
+        return controller.postComplete(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should not save the interaction', () => {
+        expect(this.saveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not archive the interaction', () => {
+        expect(this.archiveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not call flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.not.have.been.called
+      })
+
+      it('should not redirect to the entity', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.not.have.been.called
+      })
+
+      it('should set the errors', () => {
+        expect(this.middlewareParameters.resMock.locals.errors).to.deep.equal({
+          date: [ ERROR.ENTER_A_DATE ],
+        })
+      })
+
+      it('should call next once', () => {
+        expect(this.middlewareParameters.nextSpy).calledOnceWithExactly()
+      })
+    })
+
+    context('when the user selects "Rescheduled" and does enter a date', () => {
+      beforeEach(() => {
+        this.saveInteractionStub = sinon.stub()
+        this.archiveInteractionStub = sinon.stub()
+
+        const controller = proxyquire('~/src/apps/interactions/controllers/complete', {
+          '../repos': {
+            saveInteraction: this.saveInteractionStub,
+            archiveInteraction: this.archiveInteractionStub,
+          },
+        })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {
+            meeting_happen: 'false',
+            archived_reason: 'Rescheduled',
+            date: 'date',
+          },
+          interaction: draftPastMeeting,
+        })
+
+        return controller.postComplete(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should save the interaction', () => {
+        expect(this.saveInteractionStub).calledOnceWithExactly('1234', {
+          date: 'date',
+          id: '888c12ee-91db-4964-908e-0f18ce823096',
+        })
+      })
+
+      it('should not archive the interaction', () => {
+        expect(this.archiveInteractionStub).to.not.have.been.called
+      })
+
+      it('should call flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).calledOnceWithExactly('success', 'The interaction has been updated')
+      })
+
+      it('should redirect to the interactions', () => {
+        expect(this.middlewareParameters.resMock.redirect).calledOnceWithExactly('/interactions')
+      })
+
+      it('should not set the errors', () => {
+        expect(this.middlewareParameters.resMock.locals.errors).to.not.exist
+      })
+
+      it('should not call next', () => {
+        expect(this.middlewareParameters.nextSpy).to.not.have.been.called
+      })
+    })
+
+    context('when saving responds with an error', () => {
+      beforeEach(() => {
+        this.saveInteractionStub = sinon.stub()
+        this.saveInteractionStub.rejects({ statusCode: 500, error: 'error' })
+        this.archiveInteractionStub = sinon.stub()
+
+        const controller = proxyquire('~/src/apps/interactions/controllers/complete', {
+          '../repos': {
+            saveInteraction: this.saveInteractionStub,
+            archiveInteraction: this.archiveInteractionStub,
+          },
+        })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {
+            meeting_happen: 'false',
+            archived_reason: 'Rescheduled',
+            date: 'date',
+          },
+          interaction: draftPastMeeting,
+        })
+
+        return controller.postComplete(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should attempt to save the interaction', () => {
+        expect(this.saveInteractionStub).to.be.calledOnce
+      })
+
+      it('should not archive the interaction', () => {
+        expect(this.archiveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not call flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.not.have.been.called
+      })
+
+      it('should not redirect to the entity', () => {
+        expect(this.middlewareParameters.resMock.redirect).to.not.have.been.called
+      })
+
+      it('should not set the errors', () => {
+        expect(this.middlewareParameters.resMock.locals.errors).to.not.exist
+      })
+
+      it('should call next once', () => {
+        expect(this.middlewareParameters.nextSpy).have.been.calledOnceWithExactly({ statusCode: 500, error: 'error' })
+      })
     })
   })
 })

--- a/test/unit/apps/interactions/repos.test.js
+++ b/test/unit/apps/interactions/repos.test.js
@@ -1,0 +1,22 @@
+const config = require('~/config')
+const draftPastMeeting = require('~/test/unit/data/interactions/draft-past-meeting.json')
+
+const {
+  archiveInteraction,
+} = require('~/src/apps/interactions/repos')
+
+describe('Interaction repository', () => {
+  describe('#archiveInteraction', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .post(`/v3/interaction/${draftPastMeeting.id}/archive`, { reason: 'reason' })
+        .reply(200, { id: draftPastMeeting.id })
+
+      this.interaction = await archiveInteraction('token', draftPastMeeting.id, 'reason')
+    })
+
+    it('should return an investment requirements object', () => {
+      expect(this.interaction).to.deep.equal({ id: draftPastMeeting.id })
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/a5PVnjeV/1199-patch-interaction-with-archived-and-archived-reason-when-clicking-no

## Change
Adds the functionality to `POST` a `No` when answering the question `Did the meeting happen?`.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
