### PR TITLE
correct text in GVA messaging

### DIFF
--- a/src/apps/investments/middleware/forms/gross-value-added-message.js
+++ b/src/apps/investments/middleware/forms/gross-value-added-message.js
@@ -1,12 +1,12 @@
 /* eslint-disable camelcase */
 const { investmentTypes } = require('../../types')
 
-const foreignEquityInvestment = `<span class='govuk-body govuk-!-font-weight-bold'>Foreign equity investment value</span>`
 const primarySector = `<span class='govuk-body govuk-!-font-weight-bold'>Primary sector</span>`
+const capitalExpenditureValue = `<span class='govuk-body govuk-!-font-weight-bold'>capital expenditure value</span>`
 
 const gvaMessages = {
-  foreignEquityAndPrimarySector: `Add ${foreignEquityInvestment} and ${primarySector} (investment project summary) to calculate GVA`,
-  foreignEquityInvestment: `Add ${foreignEquityInvestment} and click "Save" to calculate GVA`,
+  capitalExpenditureAndPrimarySectorRequired: `Add ${capitalExpenditureValue} and ${primarySector} (investment project summary) to calculate GVA`,
+  capitalExpenditureRequired: `Add ${capitalExpenditureValue} and click "Save" to calculate GVA`,
   primarySector: `Add ${primarySector} (investment project summary) to calculate GVA`,
 }
 
@@ -24,11 +24,11 @@ const grossValueAddedMessage = ({
   }
 
   if (!foreign_equity_investment && !sector) {
-    return gvaMessages.foreignEquityAndPrimarySector
+    return gvaMessages.capitalExpenditureAndPrimarySectorRequired
   }
 
   if (!foreign_equity_investment) {
-    return gvaMessages.foreignEquityInvestment
+    return gvaMessages.capitalExpenditureRequired
   }
 
   if (!sector) {

--- a/test/unit/apps/investment-projects/middleware/forms/gross-value-added-message.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/gross-value-added-message.test.js
@@ -39,7 +39,7 @@ describe('Gross value added message', () => {
         investment_type: { name: investmentTypes.FDI },
         gross_value_added: null,
       }
-      expect(grossValueAddedMessage(investment)).to.eq(gvaMessages.foreignEquityInvestment)
+      expect(grossValueAddedMessage(investment)).to.eq(gvaMessages.capitalExpenditureRequired)
     })
   })
 
@@ -64,7 +64,7 @@ describe('Gross value added message', () => {
         investment_type: { name: investmentTypes.FDI },
         gross_value_added: null,
       }
-      expect(grossValueAddedMessage(investment)).to.eq(gvaMessages.foreignEquityAndPrimarySector)
+      expect(grossValueAddedMessage(investment)).to.eq(gvaMessages.capitalExpenditureAndPrimarySectorRequired)
     })
   })
 })

--- a/test/unit/apps/investment-projects/middleware/forms/value.test.js
+++ b/test/unit/apps/investment-projects/middleware/forms/value.test.js
@@ -6,7 +6,7 @@ const paths = require('~/src/apps/investments/paths')
 const config = require('~/config')
 const moment = require('moment')
 
-const gvaMessage = gvaMessages.foreignEquityAndPrimarySector
+const gvaMessage = gvaMessages.capitalExpenditureAndPrimarySectorRequired
 const yesterday = moment().subtract(1, 'days').toISOString()
 const lastMonth = moment().subtract(1, 'months').toISOString()
 


### PR DESCRIPTION
Corrects the wording in the value section of an Investment project from 'foreign equity' to 'capital expenditure'

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
