### PR TITLE
Continue with create interaction journey when selecting "Yes" for "Did the meeting happen?"

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -6,6 +6,7 @@ const Case = require('case')
 const numeral = require('numeral')
 const queryString = require('qs')
 const { newlineToBr } = require('../../src/lib/text-formatting')
+const { joinPaths } = require('../../src/lib/path')
 const {
   assign,
   castArray,
@@ -82,6 +83,7 @@ const filters = {
   isPlainObject,
   isString,
   pluralise,
+  joinPaths,
   sentenceCase: Case.sentence,
 
   escapeHtml (contents) {

--- a/src/apps/interactions/controllers/complete.js
+++ b/src/apps/interactions/controllers/complete.js
@@ -70,7 +70,10 @@ async function postComplete (req, res, next) {
     }
   }
 
-  // todo meeting_happen true
+  if (req.body.meeting_happen === 'true') {
+    const path = joinPaths([ `/companies/${interaction.company.id}/interactions`, interaction.id, 'create' ])
+    return res.redirect(path)
+  }
 }
 
 module.exports = {

--- a/src/apps/interactions/controllers/complete.js
+++ b/src/apps/interactions/controllers/complete.js
@@ -6,12 +6,8 @@ const { saveInteraction, archiveInteraction } = require('../repos')
 const { buildFormWithStateAndErrors } = require('../../builders')
 const { ERROR } = require('../../constants')
 const { ARCHIVED_REASON } = require('../constants')
-
-function getReturnLink (interactions, interactionId) {
-  const prefix = get(interactions, 'returnLink', 'interactions/')
-
-  return `${prefix}${interactionId}`
-}
+const { joinPaths } = require('../../../lib/path')
+const { getReturnLink } = require('../helpers')
 
 function renderCompletePage (req, res) {
   const {
@@ -26,7 +22,7 @@ function renderCompletePage (req, res) {
 
   const form = meetingHappenForm({
     userAgent,
-    returnLink: getReturnLink(interactions, interaction.id),
+    returnLink: joinPaths([ getReturnLink(interactions), interaction.id ]),
   })
 
   return res
@@ -56,7 +52,6 @@ async function postComplete (req, res, next) {
 
   const { token } = req.session
   const { interaction, interactions } = res.locals
-
   if (req.body.meeting_happen === 'false') {
     try {
       if (req.body.archived_reason === ARCHIVED_REASON.RESCHEDULED) {
@@ -69,7 +64,7 @@ async function postComplete (req, res, next) {
       }
 
       req.flash('success', 'The interaction has been updated')
-      return res.redirect(get(interactions, 'returnLink', '/interactions'))
+      return res.redirect(getReturnLink(interactions))
     } catch (e) {
       return next(e)
     }

--- a/src/apps/interactions/controllers/create.js
+++ b/src/apps/interactions/controllers/create.js
@@ -1,5 +1,6 @@
 const { get, kebabCase } = require('lodash')
 const { kindForm } = require('../macros')
+const { joinPaths } = require('../../../lib/path')
 
 const kindLookup = {
   export_interaction: {
@@ -46,8 +47,16 @@ function postCreate (req, res, next) {
   }
 
   const { kind, theme } = kindLookup[kindType] || kindLookup.other
+  const path = joinPaths(
+    [
+      res.locals.interactions.returnLink,
+      'create',
+      kebabCase(theme),
+      kebabCase(kind),
+    ]
+  )
 
-  return res.redirect(`${res.locals.interactions.returnLink}create/${kebabCase(theme)}/${kebabCase(kind)}`)
+  return res.redirect(path)
 }
 
 function renderCreate (req, res) {

--- a/src/apps/interactions/controllers/create.js
+++ b/src/apps/interactions/controllers/create.js
@@ -50,7 +50,8 @@ function postCreate (req, res, next) {
   const path = joinPaths(
     [
       res.locals.interactions.returnLink,
-      'create',
+      req.params.interactionId,
+      req.params.interactionId ? 'edit' : 'create',
       kebabCase(theme),
       kebabCase(kind),
     ]

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -6,6 +6,8 @@ const { transformDateStringToDateObject } = require('../../transformers')
 const { interactionForm, serviceDeliveryForm } = require('../macros')
 const { buildFormWithStateAndErrors } = require('../../builders')
 const { getInteractionOptions } = require('../services/interaction-options')
+const { getReturnLink } = require('../helpers')
+const { joinPaths } = require('../../../lib/path')
 
 const formConfigs = {
   'interaction': interactionForm,
@@ -24,15 +26,10 @@ async function getHiddenFields (req, res, interactionId) {
   return hiddenFields
 }
 
-const getReturnLink = (res, interactionId) => {
-  const urlPrefix = (res.locals.interactions && res.locals.interactions.returnLink) || '/interactions/'
-  return interactionId ? `${urlPrefix}${interactionId}` : urlPrefix
-}
-
 async function buildForm (req, res, interactionId) {
   const options = await getInteractionOptions(req, res)
   const hiddenFields = await getHiddenFields(req, res, interactionId)
-  const returnLink = getReturnLink(res, interactionId)
+  const returnLink = joinPaths([ getReturnLink(res.locals.interactions), interactionId ])
 
   const formProperties = {
     ...options,

--- a/src/apps/interactions/helpers.js
+++ b/src/apps/interactions/helpers.js
@@ -1,0 +1,9 @@
+const { get } = require('lodash')
+
+const getReturnLink = (interactions) => {
+  return get(interactions, 'returnLink', '/interactions')
+}
+
+module.exports = {
+  getReturnLink,
+}

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -5,6 +5,8 @@ const { transformInteractionFormBodyToApiRequest } = require('../transformers')
 const { fetchInteraction, saveInteraction } = require('../repos')
 const { getContact } = require('../../contacts/repos')
 const { getDitCompany } = require('../../companies/repos')
+const { joinPaths } = require('../../../lib/path')
+const { getReturnLink } = require('../helpers')
 
 async function postDetails (req, res, next) {
   res.locals.requestBody = transformInteractionFormBodyToApiRequest(req.body)
@@ -13,12 +15,7 @@ async function postDetails (req, res, next) {
     const result = await saveInteraction(req.session.token, res.locals.requestBody)
 
     req.flash('success', `${sentence(req.params.kind)} ${res.locals.interaction ? 'updated' : 'created'}`)
-
-    if (res.locals.interactions && res.locals.interactions.returnLink) {
-      return res.redirect(res.locals.interactions.returnLink + result.id)
-    }
-
-    return res.redirect(`/interactions/${result.id}`)
+    res.redirect(joinPaths([ getReturnLink(res.locals.interactions), result.id ]))
   } catch (err) {
     if (err.statusCode === 400) {
       res.locals.form = assign({}, res.locals.form, {

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -39,7 +39,7 @@ router.get('/export',
 )
 
 router
-  .route('/:interactionId/:theme/:kind/edit')
+  .route('/:interactionId/edit/:theme/:kind')
   .post(postDetails, renderEditPage)
   .get(renderEditPage)
 

--- a/src/apps/interactions/router.sub-app.js
+++ b/src/apps/interactions/router.sub-app.js
@@ -32,7 +32,7 @@ router.route('/interactions/create/:theme/:kind')
   .post(postDetails, renderEditPage)
   .get(renderEditPage)
 
-router.route('/interactions/:interactionId/:theme/:kind/edit')
+router.route('/interactions/:interactionId/edit/:theme/:kind')
   .post(postDetails, renderEditPage)
   .get(renderEditPage)
 

--- a/src/apps/interactions/router.sub-app.js
+++ b/src/apps/interactions/router.sub-app.js
@@ -19,7 +19,7 @@ router.get('/interactions',
 )
 
 router
-  .route('/interactions/create')
+  .route([ '/interactions/create', '/interactions/:interactionId/create' ])
   .post(
     postCreate,
     renderCreate,

--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% set kindWord = interaction.kind | lowerCase %}
-{% set returnLink = interactions.returnLink if interactions else '' %}
+{% set returnLink = interactions.returnLink if interactions else '/interactions' %}
 {% set themePath = interaction.theme | kebabCase if interaction.theme else 'other' %}
 {% set kindPath = interaction.kind | kebabCase %}
 
@@ -12,14 +12,14 @@
     {% if canComplete %}
       {{ govukButton({
         text: 'Complete ' + kindWord,
-        href: returnLink + interaction.id + '/complete'
+        href: [ returnLink, interaction.id, 'complete' ] | joinPaths
       }) }}
     {% endif %}
 
     {% if canEdit %}
       {{ govukButton({
         text: 'Edit ' + kindWord,
-        href: returnLink + interaction.id + '/' + themePath + '/' + kindPath + '/edit',
+        href: [ returnLink, interaction.id, 'edit', themePath, kindPath ] | joinPaths,
         classes: 'govuk-button--secondary'
       }) }}
     {% endif %}

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -1,0 +1,21 @@
+const { trimEnd, trimStart, map, join, compact } = require('lodash')
+
+const joinPaths = (paths) => {
+  const cleanPaths = compact(map(paths, (path, index) => {
+    if (index === 0) {
+      return trimEnd(path, '/')
+    }
+
+    if (index === paths.length - 1) {
+      return trimStart(path, '/')
+    }
+
+    return trimStart(trimEnd(path, '/'), '/')
+  }))
+
+  return join(cleanPaths, '/')
+}
+
+module.exports = {
+  joinPaths,
+}

--- a/src/modules/form/helpers.js
+++ b/src/modules/form/helpers.js
@@ -1,20 +1,4 @@
-const { isString, trimEnd, trimStart, map, join } = require('lodash')
-
-const joinPaths = (paths) => {
-  const cleanPaths = map(paths, (path, index) => {
-    if (index === 0) {
-      return trimEnd(path, '/')
-    }
-
-    if (index === paths.length - 1) {
-      return trimStart(path, '/')
-    }
-
-    return trimStart(trimEnd(path, '/'), '/')
-  })
-
-  return join(cleanPaths, '/')
-}
+const { isString } = require('lodash')
 
 const getNextPath = (step, requestBody) => {
   if (step.nextPath) {
@@ -24,5 +8,4 @@ const getNextPath = (step, requestBody) => {
 
 module.exports = {
   getNextPath,
-  joinPaths,
 }

--- a/src/modules/form/middleware.js
+++ b/src/modules/form/middleware.js
@@ -1,6 +1,7 @@
 const { isEmpty, set, forEach, get } = require('lodash')
 
-const { getNextPath, joinPaths } = require('./helpers')
+const { getNextPath } = require('./helpers')
+const { joinPaths } = require('../../lib/path')
 const state = require('./state/current')
 const { getErrors } = require('./errors')
 

--- a/src/modules/form/state/middleware.js
+++ b/src/modules/form/state/middleware.js
@@ -13,7 +13,8 @@ const {
 } = require('lodash')
 
 const state = require('../state/current')
-const { joinPaths, getNextPath } = require('../helpers')
+const { getNextPath } = require('../helpers')
+const { joinPaths } = require('../../../lib/path')
 
 const mapStepsWithState = (steps, currentState) => {
   return compact(map(steps, (step, stepId) => {

--- a/test/functional/cypress/selectors/interaction/details.js
+++ b/test/functional/cypress/selectors/interaction/details.js
@@ -2,7 +2,7 @@ exports.interaction = {
   successMsg: '.c-message--success',
   actions: {
     completeInteraction: ({ companyId, interactionId }) => `[href="/companies/${companyId}/interactions/${interactionId}/complete"]`,
-    editInteraction: ({ companyId, interactionId }, theme, kind) => `[href="/companies/${companyId}/interactions/${interactionId}/${theme}/${kind}/edit"]`,
+    editInteraction: ({ companyId, interactionId }, theme, kind) => `[href="/companies/${companyId}/interactions/${interactionId}/edit/${theme}/${kind}"]`,
     back: ({ companyId }) => `[href="/companies/${companyId}/interactions/"]`,
   },
 }

--- a/test/functional/cypress/specs/interaction/complete-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/complete-interaction-spec.js
@@ -226,5 +226,25 @@ describe('Complete interaction', () => {
         })
       })
     })
+
+    context('when the meeting did happen', () => {
+      let params = {}
+
+      before(() => {
+        params.companyId = fixtures.company.venusLtd.id
+        params.interactionId = fixtures.interaction.interactionDraftPastMeeting.id
+
+        cy.visit(`/companies/${params.companyId}/interactions/${params.interactionId}`)
+
+        cy.get(selectors.interaction.details.interaction.actions.completeInteraction(params)).click()
+
+        cy.get(selectors.interaction.complete.meetingHappen.yes).click()
+        cy.get(selectors.interaction.complete.actions.continue).click()
+      })
+
+      it('should redirect to the interaction create form', () => {
+        cy.location('pathname').should('eq', `/companies/${params.companyId}/interactions/${[params.interactionId]}/create`)
+      })
+    })
   })
 })

--- a/test/unit/apps/interactions/controllers/complete.test.js
+++ b/test/unit/apps/interactions/controllers/complete.test.js
@@ -202,7 +202,7 @@ describe('Interaction details controller', () => {
       })
     })
 
-    context('when the user selects "Rescheduled" and does not enter a date', () => {
+    context('when the user selects "No" and "Rescheduled" and does not enter a date', () => {
       beforeEach(() => {
         this.saveInteractionStub = sinon.stub()
         this.archiveInteractionStub = sinon.stub()
@@ -256,7 +256,7 @@ describe('Interaction details controller', () => {
       })
     })
 
-    context('when the user selects "Rescheduled" and does enter a date', () => {
+    context('when the user selects "No" and "Rescheduled" and does enter a date', () => {
       beforeEach(() => {
         this.saveInteractionStub = sinon.stub()
         this.archiveInteractionStub = sinon.stub()
@@ -363,6 +363,58 @@ describe('Interaction details controller', () => {
 
       it('should call next once', () => {
         expect(this.middlewareParameters.nextSpy).have.been.calledOnceWithExactly({ statusCode: 500, error: 'error' })
+      })
+    })
+
+    context('when the user selects "Yes"', () => {
+      beforeEach(() => {
+        this.saveInteractionStub = sinon.stub()
+        this.archiveInteractionStub = sinon.stub()
+
+        const controller = proxyquire('~/src/apps/interactions/controllers/complete', {
+          '../repos': {
+            saveInteraction: this.saveInteractionStub,
+            archiveInteraction: this.archiveInteractionStub,
+          },
+        })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          requestBody: {
+            meeting_happen: 'true',
+          },
+          interaction: draftPastMeeting,
+        })
+
+        return controller.postComplete(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should not save the interaction', () => {
+        expect(this.saveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not archive the interaction', () => {
+        expect(this.archiveInteractionStub).to.not.have.been.called
+      })
+
+      it('should not call flash message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.not.have.been.called
+      })
+
+      it('should redirect to the interaction create journey', () => {
+        const expectedPath = `/companies/${draftPastMeeting.company.id}/interactions/${draftPastMeeting.id}/create`
+        expect(this.middlewareParameters.resMock.redirect).calledOnceWithExactly(expectedPath)
+      })
+
+      it('should not set the errors', () => {
+        expect(this.middlewareParameters.resMock.locals.errors).to.not.exist
+      })
+
+      it('should not call next', () => {
+        expect(this.middlewareParameters.nextSpy).to.not.have.been.called
       })
     })
   })

--- a/test/unit/apps/interactions/controllers/create.test.js
+++ b/test/unit/apps/interactions/controllers/create.test.js
@@ -19,6 +19,7 @@ describe('Create interaction, step 1', () => {
         },
       },
       body: {},
+      params: {},
     }
 
     this.res = {
@@ -210,6 +211,31 @@ describe('Create interaction, step 1', () => {
 
       it('should continue onto the render form controller', () => {
         expect(this.next).to.be.calledOnce
+      })
+    })
+
+    context('when a request is made for an existing interaction', () => {
+      beforeEach(() => {
+        this.req = assign({}, this.req, {
+          body: {
+            theme: 'interaction',
+            kind_export: 'export_interaction',
+          },
+          query: {
+            company: '1234',
+            contact: '4321',
+          },
+          params: {
+            interactionId: '1',
+          },
+        })
+
+        this.create.postCreate(this.req, this.res, this.next)
+      })
+
+      it('should forward the user to the edit interaction page', () => {
+        const redirectUrl = this.res.redirect.firstCall.args[0]
+        expect(redirectUrl).to.equal('/return/1/edit/export/interaction')
       })
     })
   })

--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -156,7 +156,7 @@ describe('Interaction edit controller (Interactions)', () => {
           ...interactionData,
         },
         interactions: {
-          returnLink: '/',
+          returnLink: '/return',
         },
         entityName: 'Fred Bloggs',
       }
@@ -206,7 +206,7 @@ describe('Interaction edit controller (Interactions)', () => {
           ...interactionData,
         },
         interactions: {
-          returnLink: '/',
+          returnLink: '/return',
         },
         entityName: 'Fred Bloggs',
       }
@@ -256,7 +256,7 @@ describe('Interaction edit controller (Interactions)', () => {
           ...interactionData,
         },
         interactions: {
-          returnLink: '/',
+          returnLink: '/return',
         },
         entityName: 'Fred Bloggs',
       }
@@ -417,7 +417,7 @@ describe('Interaction edit controller (Interactions)', () => {
     })
 
     it('should set the return link source of the add action', () => {
-      expect(this.interactionForm.returnLink).to.equal('/')
+      expect(this.interactionForm.returnLink).to.equal('/return')
     })
 
     it('should set the appropriate return text', () => {
@@ -442,7 +442,6 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        returnLink: '/',
         entityName: 'Fred ltd.',
       }
 
@@ -682,7 +681,6 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '3',
           name: 'Invest in things',
         },
-        returnLink: '/',
         entityName: 'Invest in things',
       }
 

--- a/test/unit/apps/interactions/controllers/edit.service.test.js
+++ b/test/unit/apps/interactions/controllers/edit.service.test.js
@@ -169,7 +169,7 @@ describe('Interaction edit controller (Service delivery)', () => {
           }],
         },
         interactions: {
-          returnLink: '/',
+          returnLink: '/return',
         },
         entityName: 'Fred Bloggs',
       }
@@ -322,7 +322,7 @@ describe('Interaction edit controller (Service delivery)', () => {
     })
 
     it('should set the return link source of the add action', () => {
-      expect(this.interactionForm.returnLink).to.equal('/')
+      expect(this.interactionForm.returnLink).to.equal('/return')
     })
 
     it('should set the appropriate return text', () => {

--- a/test/unit/apps/interactions/helpers.test.js
+++ b/test/unit/apps/interactions/helpers.test.js
@@ -1,0 +1,25 @@
+const { getReturnLink } = require('~/src/apps/interactions/helpers')
+
+describe('Interaction helpers', () => {
+  describe('#getReturnLink', () => {
+    context('when the return link exists', () => {
+      beforeEach(() => {
+        this.actual = getReturnLink({ returnLink: '/return' })
+      })
+
+      it('should return the link', () => {
+        expect(this.actual).to.equal('/return')
+      })
+    })
+
+    context('when the return link does not exist', () => {
+      beforeEach(() => {
+        this.actual = getReturnLink(null)
+      })
+
+      it('should return the link', () => {
+        expect(this.actual).to.equal('/interactions')
+      })
+    })
+  })
+})

--- a/test/unit/apps/interactions/middleware/collection.test.js
+++ b/test/unit/apps/interactions/middleware/collection.test.js
@@ -17,7 +17,6 @@ describe('interaction collection middleware', () => {
 
     this.res = {
       locals: {
-        returnLink: '/return',
         userAgent: {
           isIE: false,
         },

--- a/test/unit/lib/path.test.js
+++ b/test/unit/lib/path.test.js
@@ -1,4 +1,4 @@
-const { joinPaths } = require('~/src/modules/form/helpers.js')
+const { joinPaths } = require('~/src/lib/path.js')
 
 describe('#joinPaths', () => {
   context('when the first path has an extra forward slash at the end', () => {

--- a/test/unit/modules/form/journey-builder.test.js
+++ b/test/unit/modules/form/journey-builder.test.js
@@ -415,11 +415,11 @@ describe('#build', () => {
 
       it('should redirect to the finish', () => {
         expect(this.response.statusCode).to.equal(302)
-        expect(this.response.headers.location).to.equal('/base/entities/1')
+        expect(this.response.headers.location).to.equal('base/entities/1')
       })
 
       it('should not render a template', () => {
-        expect(this.response.res.text).to.equal('Found. Redirecting to /base/entities/1')
+        expect(this.response.res.text).to.equal('Found. Redirecting to base/entities/1')
       })
     })
 

--- a/test/unit/modules/form/middleware.test.js
+++ b/test/unit/modules/form/middleware.test.js
@@ -246,7 +246,7 @@ describe('#postDetails', () => {
     })
 
     it('should redirect', () => {
-      expect(this.redirectSpy).to.be.calledWithExactly('/base/1')
+      expect(this.redirectSpy).to.be.calledWithExactly('base/1')
       expect(this.redirectSpy).to.have.been.calledOnce
     })
   })


### PR DESCRIPTION
https://trello.com/c/8rj2EuuB/1201-continue-with-rest-of-interaction-journey-when-clicking-yes

## Change
When selecting `Yes` for `Did the meeting happen?` then the user will continue with the rest of the journey to create the interaction.

## Demo
![yes-journey-demo](https://user-images.githubusercontent.com/1150417/58885003-509cf680-86d9-11e9-8d1b-4bec9d757486.gif)

## Steps to test
- Set API config to DEV
- Browse to `~/interactions/7d04e661-3660-4ea7-8c13-376e0fd192de`
- Click `Complete interaction`
- Click `Yes` and `Continue`

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
