### PR TITLE
Bug: Filter is still applied when unselecting it while a filter request is still being loaded.

### DIFF
--- a/assets/javascripts/modules/auto-submit.js
+++ b/assets/javascripts/modules/auto-submit.js
@@ -11,15 +11,35 @@ const AutoSubmit = {
     this.bindEvents()
   },
 
+  isCheckboxSynced (evt) {
+    // This is needed because checkboxes can go out of sync with posted values. We prevent
+    // this by reverting the checkbox to it's previous state if there is already a submit in progress.
+    // This intentionally affects all checkboxes that trigger form submits site-wide.
+
+    if (this.isSubmitting && evt.target.type === 'checkbox') {
+      evt.target.checked = !evt.target.checked
+      return
+    }
+    return true
+  },
+
   handleFormSubmit (evt) {
+    if (!this.isCheckboxSynced(evt)) return
+
     if (evt.target.classList.contains('ie-date-field')) {
-      if (!checkDateFormat(evt.target.value)) { return }
+      if (!checkDateFormat(evt.target.value)) {
+        return
+      }
     }
     const targetForm = evt.target.closest('form')
 
-    if (!targetForm) { return }
+    if (!targetForm) {
+      return
+    }
 
-    const shouldSubmit = targetForm.classList.contains(this.selector.substring(1))
+    const shouldSubmit = targetForm.classList.contains(
+      this.selector.substring(1)
+    )
 
     if (shouldSubmit) {
       evt.preventDefault()
@@ -33,14 +53,18 @@ const AutoSubmit = {
   },
 
   submitForm (form) {
-    if (this.isSubmitting) { return }
+    if (this.isSubmitting) {
+      return
+    }
     this.isSubmitting = true
 
     const query = pickBy(getFormData(form))
 
     XHR.request(form.action, query)
-      .then(() => { this.isSubmitting = false })
-      .catch((error) => {
+      .then(() => {
+        this.isSubmitting = false
+      })
+      .catch(error => {
         this.isSubmitting = false
         console.error(`Could not fetch data: ${error}`)
       })

--- a/test/unit-client/assets/javascripts/lib/auto-submit.test.js
+++ b/test/unit-client/assets/javascripts/lib/auto-submit.test.js
@@ -1,0 +1,43 @@
+const {
+  isCheckboxSynced,
+} = require('../../../../../assets/javascripts/modules/auto-submit')
+
+describe('#Auto-submit', function () {
+  describe('isCheckboxSynced()', function () {
+    context('can submit form', function () {
+      beforeEach(function () {
+        this.evt = {
+          target: {
+            checked: false,
+            type: 'checkbox',
+          },
+        }
+
+        this.isSubmitting = false
+      })
+
+      it('return true and not change checkbox value', function () {
+        expect(isCheckboxSynced.call(this, this.evt)).to.equal(true)
+        expect(this.evt.target.checked).to.equal(false)
+      })
+    })
+
+    context('can not submit form', function () {
+      beforeEach(function () {
+        this.evt = {
+          target: {
+            checked: true,
+            type: 'checkbox',
+          },
+        }
+
+        this.isSubmitting = true
+      })
+
+      it('return false and change checkbox value', function () {
+        expect(isCheckboxSynced.call(this, this.evt)).to.equal(undefined)
+        expect(this.evt.target.checked).to.equal(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixed a bug that caused filter checkboxes to showing incorrect tick values when rapidly clicked 2 or more times.

Controversy: This section of code is all client side and had no unit tests prior. Adding them would require quite a bit of work for such a small change as all the previous code would need to be tested and the DOM structure set up.

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
