### PR TITLE
Show "Why can I not complete this interaction?" details summary for future interactions

### DIFF
--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -26,4 +26,20 @@
 
     <a href="{{ returnLink }}">Back</a>
   </div>
+
+  {% if not canComplete and not canEdit %}
+    {{ govukDetails({
+      summaryText: 'Why can I not complete this interaction?',
+      html: '<p>
+          This is an upcoming interaction, once the meeting has taken place, you will see a button that will allow you to complete the interaction.</a>.
+        </p>
+        <p>
+          If you think the information is incomplete or incorrect, <a href="/support">get in touch using the support form</a>.
+        </p>',
+      attributes: {
+        'data-auto-id': 'interactionDetailsWhyCanINotComplete'
+      }
+    }) }}
+  {% endif %}
+
 {% endblock %}

--- a/test/functional/cypress/selectors/interaction/details.js
+++ b/test/functional/cypress/selectors/interaction/details.js
@@ -5,6 +5,7 @@ exports.interaction = {
     editInteraction: ({ companyId, interactionId }, theme, kind) => `[href="/companies/${companyId}/interactions/${interactionId}/edit/${theme}/${kind}"]`,
     back: ({ companyId }) => `[href="/companies/${companyId}/interactions/"]`,
   },
+  whyCanINotComplete: '[data-auto-id="interactionDetailsWhyCanINotComplete"]',
 }
 
 exports.serviceDelivery = {

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -53,6 +53,10 @@ describe('Interaction details', () => {
       cy.get(selectors.interaction.details.interaction.actions.back(params)).should('be.visible')
       cy.get(selectors.interaction.details.interaction.actions.back(params)).should('have.text', 'Back')
     })
+
+    it('should not render the "Why can I not complete this interaction?" details summary', () => {
+      cy.get(selectors.interaction.details.interaction.whyCanINotComplete).should('not.be.visible')
+    })
   })
 
   context('Future draft interaction', () => {
@@ -103,6 +107,10 @@ describe('Interaction details', () => {
     it('should render the "Back" link', () => {
       cy.get(selectors.interaction.details.interaction.actions.back(params)).should('be.visible')
       cy.get(selectors.interaction.details.interaction.actions.back(params)).should('have.text', 'Back')
+    })
+
+    it('should render the "Why can I not complete this interaction?" details summary', () => {
+      cy.get(selectors.interaction.details.interaction.whyCanINotComplete).should('be.visible')
     })
   })
 
@@ -166,6 +174,10 @@ describe('Interaction details', () => {
       cy.get(back).should('be.visible')
       cy.get(back).should('have.text', 'Back')
     })
+
+    it('should not render the "Why can I not complete this interaction?" details summary', () => {
+      cy.get(selectors.interaction.details.interaction.whyCanINotComplete).should('not.be.visible')
+    })
   })
 
   context('Complete investment project interaction without documents', () => {
@@ -228,6 +240,10 @@ describe('Interaction details', () => {
       const back = selectors.interaction.details.interaction.actions.back(params)
       cy.get(back).should('be.visible')
       cy.get(back).should('have.text', 'Back')
+    })
+
+    it('should not render the "Why can I not complete this interaction?" details summary', () => {
+      cy.get(selectors.interaction.details.interaction.whyCanINotComplete).should('not.be.visible')
     })
   })
 })


### PR DESCRIPTION
## Change
Adds a `Why can I not complete this interaction?` details summary to the interaction details screen. This will show for future applications only.

## Before
<img width="1019" alt="Screenshot 2019-06-05 at 15 24 51" src="https://user-images.githubusercontent.com/1150417/58964094-38df7400-87a6-11e9-8dcf-2f3209968a6f.png">

## After
<img width="1021" alt="Screenshot 2019-06-05 at 15 00 52" src="https://user-images.githubusercontent.com/1150417/58964109-40068200-87a6-11e9-8517-16a4069ace07.png">

## Steps to test
- Browse to a future interaction
- Click the details summary at the bottom
- Browse to a past interaction
- You should not see the details summary at the bottom

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
