### PR TITLE
Redirect to company interactions on form submit

### DIFF
--- a/src/apps/interactions/controllers/complete.js
+++ b/src/apps/interactions/controllers/complete.js
@@ -51,7 +51,9 @@ async function postComplete (req, res, next) {
   }
 
   const { token } = req.session
-  const { interaction, interactions } = res.locals
+  const { interaction } = res.locals
+  const companyInteractionsPath = `/companies/${interaction.company.id}/interactions`
+
   if (req.body.meeting_happen === 'false') {
     try {
       if (req.body.archived_reason === ARCHIVED_REASON.RESCHEDULED) {
@@ -64,14 +66,14 @@ async function postComplete (req, res, next) {
       }
 
       req.flash('success', 'The interaction has been updated')
-      return res.redirect(getReturnLink(interactions))
+      return res.redirect(companyInteractionsPath)
     } catch (e) {
       return next(e)
     }
   }
 
   if (req.body.meeting_happen === 'true') {
-    const path = joinPaths([ `/companies/${interaction.company.id}/interactions`, interaction.id, 'create' ])
+    const path = joinPaths([ companyInteractionsPath, interaction.id, 'create' ])
     return res.redirect(path)
   }
 }

--- a/test/unit/apps/interactions/controllers/complete.test.js
+++ b/test/unit/apps/interactions/controllers/complete.test.js
@@ -137,7 +137,7 @@ describe('Interaction details controller', () => {
       })
 
       it('should redirect to the interactions', () => {
-        expect(this.middlewareParameters.resMock.redirect).calledOnceWithExactly('/interactions')
+        expect(this.middlewareParameters.resMock.redirect).calledOnceWithExactly(`/companies/${draftPastMeeting.company.id}/interactions`)
       })
 
       it('should not set the errors', () => {
@@ -300,7 +300,7 @@ describe('Interaction details controller', () => {
       })
 
       it('should redirect to the interactions', () => {
-        expect(this.middlewareParameters.resMock.redirect).calledOnceWithExactly('/interactions')
+        expect(this.middlewareParameters.resMock.redirect).calledOnceWithExactly(`/companies/${draftPastMeeting.company.id}/interactions`)
       })
 
       it('should not set the errors', () => {


### PR DESCRIPTION
## Change
When completing an interaction the user will be redirected to the company interactions view.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
