### PR TITLE
Refactor flash assertion to reuse common selector

### DIFF
--- a/test/functional/cypress/selectors/company/subsidiaries.js
+++ b/test/functional/cypress/selectors/company/subsidiaries.js
@@ -2,8 +2,5 @@ module.exports = () => {
   return {
     whyArchived: '[data-auto-id="subsidiariesWhyArchived"]',
     linkASubsidiary: '[data-auto-id="Link a subsidiary"]',
-    flash: {
-      success: '.c-message--success',
-    },
   }
 }

--- a/test/functional/cypress/selectors/interaction/details.js
+++ b/test/functional/cypress/selectors/interaction/details.js
@@ -1,5 +1,4 @@
 exports.interaction = {
-  successMsg: '.c-message--success',
   actions: {
     completeInteraction: ({ companyId, interactionId }) => `[href="/companies/${companyId}/interactions/${interactionId}/complete"]`,
     editInteraction: ({ companyId, interactionId }, theme, kind) => `[href="/companies/${companyId}/interactions/${interactionId}/edit/${theme}/${kind}"]`,
@@ -9,7 +8,6 @@ exports.interaction = {
 }
 
 exports.serviceDelivery = {
-  successMsg: '.c-message--success',
   company: 'tr:nth-child(1)',
   contacts: 'tr:nth-child(2)',
   service: 'tr:nth-child(3)',

--- a/test/functional/cypress/specs/companies/subsidiaries-link-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-link-spec.js
@@ -13,6 +13,6 @@ describe('Companies link a subsidiary', () => {
     cy.get(selectors.companySubsidiariesLink().search.button).click()
     cy.get(selectors.companySubsidiariesLink().search.result(1).title).click()
 
-    cy.get(selectors.companySubsidiaries().flash.success).should('contain', 'You’ve linked the subsidiary')
+    cy.get(selectors.localHeader().flash).should('contain', 'You’ve linked the subsidiary')
   })
 })

--- a/test/functional/cypress/specs/interaction/add-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/add-interaction-spec.js
@@ -295,7 +295,7 @@ const assertDetails = ({
   communicationChannel = 'Social Media',
   documents = 'There are no files or documents',
 }) => {
-  cy.get(serviceDeliveryDetails.successMsg).should('contain', flashMessage)
+  cy.get(selectors.localHeader().flash).should('contain', flashMessage)
   cy.get(serviceDeliveryDetails.company).should('contain', company)
   cy.get(serviceDeliveryDetails.contacts).should('contain', contact)
   cy.get(serviceDeliveryDetails.service).should('contain', service)


### PR DESCRIPTION
## Change
This is a quick refactor so that we reuse the local header selector to reference the `flash` rather than specifying a `flash` for each view and therefore in all selectors.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
