### PR TITLE
Replace dit_adviser references

### DIFF
--- a/src/apps/adviser/filters.js
+++ b/src/apps/adviser/filters.js
@@ -1,9 +1,13 @@
-const { get } = require('lodash')
+const { get, includes } = require('lodash')
 
 function filterActiveAdvisers ({ advisers = [], includeAdviser }) {
-  return advisers.filter((adviser) => {
+  return advisers.filter(adviser => {
     // This returns all active users plus the include advisor (whether they are active or not)
-    return get(adviser, 'is_active', true) || adviser.id === includeAdviser
+    return (
+      get(adviser, 'is_active', true) ||
+      adviser.id === includeAdviser ||
+      includes(includeAdviser, adviser.id)
+    )
   })
 }
 module.exports = {

--- a/src/apps/adviser/filters.js
+++ b/src/apps/adviser/filters.js
@@ -1,11 +1,11 @@
 const { get, includes } = require('lodash')
 
-function filterActiveAdvisers ({ advisers = [], includeAdviser }) {
+function filterActiveAdvisers ({ advisers = [], includeAdviser = [] }) {
+  includeAdviser = [...includeAdviser]
   return advisers.filter(adviser => {
     // This returns all active users plus the include advisor (whether they are active or not)
     return (
       get(adviser, 'is_active', true) ||
-      adviser.id === includeAdviser ||
       includes(includeAdviser, adviser.id)
     )
   })

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -38,11 +38,17 @@ async function getInteractionOptions (token, req, res) {
 
   const areas = await getOptions(token, 'policy-area')
 
-  const currentAdviser = get(res.locals, 'interaction.dit_adviser.id')
+  const currentAdvisers =
+    get(res.locals, 'interaction.dit_participants') &&
+    res.locals.interaction.dit_participants.map(
+      participant => participant.adviser && participant.adviser.id
+    )
+
   const advisers = await getAdvisers(token)
+
   const activeAdvisers = filterActiveAdvisers({
     advisers: advisers.results,
-    includeAdviser: currentAdviser,
+    includeAdviser: currentAdvisers,
   })
 
   const adviserOptions = activeAdvisers.map(transformAdviserToOption)
@@ -106,12 +112,20 @@ async function renderInteractionList (req, res, next) {
 
 function renderInteractionsForEntity (req, res, next) {
   try {
-    const { view, returnLink, createKind, canAdd, theme = '' } = res.locals.interactions
+    const {
+      view,
+      returnLink,
+      createKind,
+      canAdd,
+      theme = '',
+    } = res.locals.interactions
     const actionButtons = canAdd
       ? [
         {
           label: 'Add interaction',
-          url: `${returnLink}create${createKind ? `/${theme}/${createKind}` : ''}`,
+          url: `${returnLink}create${
+            createKind ? `/${theme}/${createKind}` : ''
+          }`,
         },
       ]
       : undefined

--- a/src/apps/interactions/services/form.js
+++ b/src/apps/interactions/services/form.js
@@ -1,4 +1,7 @@
-const { getPropertyId, nullEmptyFields } = require('../../../lib/property-helpers')
+const {
+  getPropertyId,
+  nullEmptyFields,
+} = require('../../../lib/property-helpers')
 
 /**
  * Accepts an API interaction object and converts it into a format compatible with a HTML form
@@ -17,9 +20,6 @@ function getInteractionAsFormData (interaction) {
     subject: interaction.subject || null,
     notes: interaction.notes || null,
     date: interaction.date || null,
-    dit_adviser: getPropertyId(interaction, 'dit_adviser'),
-    service: getPropertyId(interaction, 'service'),
-    dit_team: getPropertyId(interaction, 'dit_team'),
   }
 
   result = nullEmptyFields(result)

--- a/test/unit/apps/interactions/services/form.service.test.js
+++ b/test/unit/apps/interactions/services/form.service.test.js
@@ -4,20 +4,20 @@ describe('interaction form service', () => {
   let saveInteractionStub
   let company
   let contact
-  let dit_adviser
   let communication_channel
   let interaction
-  let service
-  let dit_team
   let interactionFormService
 
   beforeEach(() => {
     company = { id: '1234', name: 'Fred ltd' }
-    contact = { id: '3321', name: 'Fred Smith', first_name: 'Fred', last_name: 'Smith', company }
-    dit_adviser = { id: '4455', name: 'Fred Jones', first_name: 'Fred', last_name: 'Jones' }
+    contact = {
+      id: '3321',
+      name: 'Fred Smith',
+      first_name: 'Fred',
+      last_name: 'Smith',
+      company,
+    }
     communication_channel = { id: '1234', name: 'Email' }
-    service = { id: '6654', name: 'Significant Assist' }
-    dit_team = { id: '90934', name: 'North East' }
     interaction = {
       id: '999',
       company,
@@ -26,9 +26,6 @@ describe('interaction form service', () => {
       subject: 'Test subject',
       notes: 'Test notes',
       date: '2017-01-02:T00:00:00.00Z',
-      dit_adviser,
-      service,
-      dit_team,
     }
 
     saveInteractionStub = sinon.stub().resolves({
@@ -38,11 +35,14 @@ describe('interaction form service', () => {
       contact: contact.id,
     })
 
-    interactionFormService = proxyquire('~/src/apps/interactions/services/form', {
-      '../repos': {
-        saveInteraction: saveInteractionStub,
-      },
-    })
+    interactionFormService = proxyquire(
+      '~/src/apps/interactions/services/form',
+      {
+        '../repos': {
+          saveInteraction: saveInteractionStub,
+        },
+      }
+    )
   })
 
   describe('Convert API to Form', () => {
@@ -55,27 +55,17 @@ describe('interaction form service', () => {
         subject: 'Test subject',
         notes: 'Test notes',
         date: '2017-01-02:T00:00:00.00Z',
-        dit_adviser: dit_adviser.id,
-        service: service.id,
-        dit_team: dit_team.id,
       }
-      expect(interactionFormService.getInteractionAsFormData(interaction)).to.deep.equal(expected)
+      expect(
+        interactionFormService.getInteractionAsFormData(interaction)
+      ).to.deep.equal(expected)
     })
     it('should handle new blank interactions being editing for the first time', () => {
       const freshInteraction = {
         company,
         contact: null,
         communication_channel: communication_channel,
-        dit_adviser,
         date: '2017-01-02:T00:00:00.00Z',
-        service: {
-          id: null,
-          name: null,
-        },
-        dit_team: {
-          id: null,
-          name: null,
-        },
       }
       const expected = {
         id: null,
@@ -85,11 +75,10 @@ describe('interaction form service', () => {
         subject: null,
         notes: null,
         date: '2017-01-02:T00:00:00.00Z',
-        dit_adviser: dit_adviser.id,
-        service: null,
-        dit_team: null,
       }
-      expect(interactionFormService.getInteractionAsFormData(freshInteraction)).to.deep.equal(expected)
+      expect(
+        interactionFormService.getInteractionAsFormData(freshInteraction)
+      ).to.deep.equal(expected)
     })
   })
 })


### PR DESCRIPTION
There are still some references to `interaction.dit_adviser` and `interaction.dit_team` in the FE that needed to be updated to use the `dit_participants` array.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
