### PR TITLE
Change all buttons to match GOV.UK Design System

### DIFF
--- a/assets/javascripts/modules/add-items.js
+++ b/assets/javascripts/modules/add-items.js
@@ -136,7 +136,7 @@ const AddItems = {
     }
 
     const addButtonElement = this.document.createElement('button')
-    addButtonElement.className = `button button--secondary ${addButtonClass}`
+    addButtonElement.className = `govuk-button govuk-button--secondary ${addButtonClass}`
 
     const addButtonWrapper = this.document.createElement('p')
     addButtonWrapper.className = 'c-form-group c-form-group--compact'
@@ -153,7 +153,7 @@ const AddItems = {
         }
 
         const removeButtonElement = this.document.createElement('button')
-        removeButtonElement.className = `button button--link ${removeButtonClass}`
+        removeButtonElement.className = `govuk-button button--link ${removeButtonClass}`
 
         item.appendChild(removeButtonElement)
       })

--- a/assets/javascripts/modules/archive-form.js
+++ b/assets/javascripts/modules/archive-form.js
@@ -59,7 +59,7 @@ const ArchiveForm = {
 
   createShowButton () {
     const showArchiveFormButton = this.document.createElement('a')
-    showArchiveFormButton.classList.add('button', 'button--secondary')
+    showArchiveFormButton.classList.add('govuk-button', 'govuk-button--secondary')
     showArchiveFormButton.href = '#'
     showArchiveFormButton.textContent = 'Archive'
     return showArchiveFormButton

--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -80,7 +80,7 @@
     text-align: right;
   }
 
-  .button--secondary {
+  .govuk-button--secondary {
     @include core-font(16);
     margin-bottom: $default-spacing-unit / 2;
 

--- a/assets/stylesheets/components/_button.scss
+++ b/assets/stylesheets/components/_button.scss
@@ -1,42 +1,10 @@
-@import "~govuk_frontend_toolkit/stylesheets/design-patterns/buttons";
 @import "../settings/colours";
 
 // Buttons
 // ==========================================================================
 
-.button {
-  @include button ($button-colour);
-  padding-bottom: .526315em;
-
-  @include media (mobile) {
-    width: 100%;
-    text-align: center;
-  }
-}
-
-// Fix unwanted button padding in Firefox
-.button::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-
-.button:focus {
-  outline: 3px solid $focus-colour;
-}
-
-.button[disabled="disabled"]:focus {
-  outline: none;
-}
-
-// modifiers
-.button--secondary {
-  @include button ($grey-2);
-  padding-bottom: .526315em;
-}
-
-.button--destructive {
-  @include button($red);
-  padding-bottom: .526315em;
+.govuk-button {
+  margin-bottom: 0;
 }
 
 .button--link {

--- a/assets/stylesheets/components/_collection-filters.scss
+++ b/assets/stylesheets/components/_collection-filters.scss
@@ -1,7 +1,7 @@
 @import "../settings";
 
 .c-collection-filters {
-  .button {
+  .govuk-button {
     width: 100%;
   }
 

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -102,7 +102,7 @@
   a {
     text-decoration: none;
 
-    &:not(.button):hover {
+    &:not(.govuk-button):hover {
       text-decoration: underline;
     }
   }

--- a/assets/stylesheets/components/form/_form-control.scss
+++ b/assets/stylesheets/components/form/_form-control.scss
@@ -1,4 +1,6 @@
+@import "~govuk_frontend_toolkit/stylesheets/design-patterns/buttons";
 @import "../../settings";
+@import "../../settings/colours";
 
 .c-form-control {
   appearance: none;
@@ -34,7 +36,7 @@
     }
 
     &::before {
-      @include button ($grey-2);
+      @include button ($grey-3);
       padding-bottom: .526315em;
       content: 'Choose a file';
       display: inline-block;

--- a/src/apps/addresses/macros/postcode-lookup-form.js
+++ b/src/apps/addresses/macros/postcode-lookup-form.js
@@ -10,7 +10,7 @@ module.exports = ({
         name: 'postcode',
         label: 'Postcode',
         modifier: 'short',
-        innerHTML: '<button class="button">Find address</button>',
+        innerHTML: '<button class="govuk-button">Find address</button>',
         validations: [
           {
             type: 'required',

--- a/src/apps/companies/apps/investments/growth-capital-profile/views/main.njk
+++ b/src/apps/companies/apps/investments/growth-capital-profile/views/main.njk
@@ -7,5 +7,5 @@
 {% if companyProfile  %}
   <pre>{{ companyProfile | dump(2) }}</pre>
 {% else %}
-  <button class="button">Create a profile</button>
+  <button class="govuk-button">Create a profile</button>
 {% endif %}

--- a/src/apps/companies/views/edit.njk
+++ b/src/apps/companies/views/edit.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/template.njk" %}
 
 {% set lookupButton %}
-  <button class="button button--secondary postcode-lookup-button" type="button">Find UK address</button>
+  <button class="govuk-button govuk-button--secondary postcode-lookup-button" type="button">Find UK address</button>
 {% endset %}
 
 {% set isEditing = true if company.id else false %}

--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -7,7 +7,7 @@
 
     {% if not company.archived %}
       <p class="actions">
-        <a href="/companies/{{company.id}}/exports/edit" class="button button--secondary">Edit export markets</a>
+        <a href="/companies/{{company.id}}/exports/edit" class="govuk-button govuk-button--secondary">Edit export markets</a>
       </p>
     {% endif %}
   {% endcall %}

--- a/src/apps/companies/views/link-subsidiary.njk
+++ b/src/apps/companies/views/link-subsidiary.njk
@@ -7,7 +7,7 @@
 {% block body_main_content %}
 
   {% set summaryActionsHTML %}
-    <a id="return-to-subsidiaries-list" class="button button--secondary" href="{{'/companies/' + company.id + '/subsidiaries'}}">Back</a>
+    <a id="return-to-subsidiaries-list" class="govuk-button govuk-button--secondary" href="{{'/companies/' + company.id + '/subsidiaries'}}">Back</a>
   {% endset %}
 
   {{ EntitySearchForm({

--- a/src/apps/components/views/form.njk
+++ b/src/apps/components/views/form.njk
@@ -4,18 +4,29 @@
   <h2 class="heading-large">Buttons</h2>
 
   {% call Example('Primary button') %}
-    <button class="button">Primary button</button>
-    <button class="button" disabled="disabled">Disabled primary button</button>
+    <button class="govuk-button">Primary button</button>
+    <button class="govuk-button" disabled="disabled">Disabled primary button</button>
   {% endcall %}
 
   {% call Example('Secondary button') %}
-    <button class="button button--secondary">Secondary button</button>
-    <button class="button button--secondary" disabled="disabled">Disabled secondary button</button>
+    <button class="govuk-button govuk-button--secondary">Secondary button</button>
   {% endcall %}
 
-  {% call Example('Destructive button') %}
-    <button class="button button--destructive">Destructive button</button>
-    <button class="button button--destructive" disabled="disabled">Disabled destructive button</button>
+  {% call Example('Warning button') %}
+    <button class="govuk-button govuk-button--warning">Warning button</button>
+  {% endcall %}
+
+  {% call Example('Link button') %}
+    <button class="govuk-button button--link">Link button</button>
+  {% endcall %}
+
+  {% call Example('File upload') %}
+  {{ TextField({
+    type: 'file',
+    label: 'File',
+    name: 'original_filename',
+    isLabelHidden: true
+  }) }}
   {% endcall %}
 
   <h2 class="heading-large">Entity search</h2>
@@ -217,7 +228,7 @@
 
   {% call Example('Fields with actions') %}
     {% set removeButton %}
-      <button class="button button--link c-form-group__action">Remove</button>
+      <button class="govuk-button button--link c-form-group__action">Remove</button>
     {% endset %}
 
     {% call Form(form) %}
@@ -263,7 +274,7 @@
 
   {% call Example('Add another (custom actions)') %}
     {% set removeButton %}
-      <button class="button button--link c-form-group__action js-AddItems__remove">Remove</button>
+      <button class="govuk-button button--link c-form-group__action js-AddItems__remove">Remove</button>
     {% endset %}
 
     {% call Form(form) %}
@@ -280,7 +291,7 @@
         </div>
 
         <p class="c-form-group c-form-group--compact">
-          <button class="button button--secondary js-AddItems__add" name="add-item">
+          <button class="govuk-button govuk-button--secondary js-AddItems__add" name="add-item">
             Add item
           </button>
         </p>

--- a/src/apps/components/views/messages.njk
+++ b/src/apps/components/views/messages.njk
@@ -7,7 +7,7 @@
       element: 'div'
     }) %}
       <p>A message with <a href="">a link</a> and <strong>strong text</strong>.</p>
-      <p><button class="button">button</button></p>
+      <p><button class="govuk-button">button</button></p>
     {% endcall %}
 
     {% call Message({
@@ -16,7 +16,7 @@
     }) %}
       <p>A message with <strong>strong text</strong>.</p>
       <p><a href="">A link</a></p>
-      <p><button class="button">button</button></p>
+      <p><button class="govuk-button">button</button></p>
     {% endcall %}
   {% endcall %}
 

--- a/src/apps/contacts/views/details.njk
+++ b/src/apps/contacts/views/details.njk
@@ -7,7 +7,7 @@
 
     {% if not contact.archived %}
       <p>
-        <a href="/contacts/{{id}}/edit" class="button button--secondary">Edit contact</a>
+        <a href="/contacts/{{id}}/edit" class="govuk-button govuk-button--secondary">Edit contact</a>
       </p>
     {% endif %}
   {% endcall %}

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -131,7 +131,7 @@
             <span class="c-form-group__label-text">Postcode look up</span>
           </label>
           <input id="field-postcode-lookup" class="c-form-control c-form-control--PostcodeLookup" autoComplete="off">
-          <button class="button button--secondary postcode-lookup-button" type="button">Find UK address</button>
+          <button class="govuk-button govuk-button--secondary postcode-lookup-button" type="button">Find UK address</button>
         </div>
 
         <div class="c-form-group form-group--address-suggestions">

--- a/src/apps/events/views/details.njk
+++ b/src/apps/events/views/details.njk
@@ -3,6 +3,6 @@
 {% block main_grid_right_column %}
   {% component 'key-value-table', variant='striped', items=eventViewRecord %}
   {% if event.disabled_on == null %}
-    <a class="button button--secondary" href="/events/{{ event.id }}/edit">Edit event</a>
+    <a class="govuk-button govuk-button--secondary" href="/events/{{ event.id }}/edit">Edit event</a>
   {% endif %}
 {% endblock %}

--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -20,7 +20,7 @@
       {{ govukButton({
         text: 'Edit ' + kindWord,
         href: [ returnLink, interaction.id, 'edit', themePath, kindPath ] | joinPaths,
-        classes: 'govuk-button--secondary'
+        classes: 'govuk-button govuk-button--secondary'
       }) }}
     {% endif %}
 

--- a/src/apps/investments/apps/evidence/views/list.njk
+++ b/src/apps/investments/apps/evidence/views/list.njk
@@ -57,5 +57,5 @@
   </table>
 
   <br>
-  <a href="evidence/add-new" class="button">Add new evidence</a>
+  <a href="evidence/add-new" class="govuk-button">Add new evidence</a>
 {% endblock %}

--- a/src/apps/investments/views/_details-form.njk
+++ b/src/apps/investments/views/_details-form.njk
@@ -125,7 +125,7 @@
       {% endfor %}
 
       <p class="c-form-fieldset__add-another">
-        <button class="button button--secondary js-AddItems__add" type="submit" name="add-item" value="business_activities" data-persist-values="true">Add another activity</button>
+        <button class="govuk-button govuk-button--secondary js-AddItems__add" type="submit" name="add-item" value="business_activities" data-persist-values="true">Add another activity</button>
       </p>
     </div>
 
@@ -162,7 +162,7 @@
 
 
       <p class="c-form-fieldset__add-another">
-        <button class="button button--secondary js-AddItems__add" type="submit" name="add-item" value="client_contacts" data-persist-values="true">Add another contact</button>
+        <button class="govuk-button govuk-button--secondary js-AddItems__add" type="submit" name="add-item" value="client_contacts" data-persist-values="true">Add another contact</button>
       </p>
     </div>
   {% endcall %}

--- a/src/apps/investments/views/details.njk
+++ b/src/apps/investments/views/details.njk
@@ -2,7 +2,7 @@
 
 {% macro renderButton(endpoint, label, isSecondary) %}
   <p>
-    <a href="edit-{{ endpoint }}" class="button{{ '--secondary' if isSecondary }}">
+    <a href="edit-{{ endpoint }}" class="govuk-button{{ ' govuk-button--secondary' if isSecondary }}">
       {{ label }}
     </a>
   </p>

--- a/src/apps/investments/views/team/details.njk
+++ b/src/apps/investments/views/team/details.njk
@@ -7,7 +7,7 @@
       columns: clientRelationshipManagementLabels.view,
       data: clientRelationshipManagementData
     } %}
-    <a href="edit-client-relationship-management" class="button button--secondary">Change</a>
+    <a href="edit-client-relationship-management" class="govuk-button govuk-button--secondary">Change</a>
   {% endcall %}
 
   {% call DetailsContainer({ heading: 'Project management' }) %}
@@ -21,13 +21,13 @@
         columns: projectManagementLabels.view,
         data: projectManagementData
       } %}
-      <p><a href="edit-project-management" class="button button--secondary">Change</a></p>
+      <p><a href="edit-project-management" class="govuk-button govuk-button--secondary">Change</a></p>
     {% else %}
       {{ Message({
         type: 'muted',
         text: 'Once both a Project Manager and a Project Assurance have been assigned, the project will move to "Active" stage.'
       }) }}
-      <p><a href="edit-project-management" class="button">Assign</a></p>
+      <p><a href="edit-project-management" class="govuk-button">Assign</a></p>
     {% endif %}
   {% endcall %}
 
@@ -37,7 +37,7 @@
       data: teamMembersData
     } %}
 
-    <a href="edit-team-members" class="button button--secondary">Change</a>
+    <a href="edit-team-members" class="govuk-button govuk-button--secondary">Change</a>
   {% endcall %}
 
   {% call DetailsContainer({ heading: 'Success verifier' }) %}

--- a/src/apps/omis/apps/create/views/timeout.njk
+++ b/src/apps/omis/apps/create/views/timeout.njk
@@ -3,6 +3,6 @@
 {% block form %}
   <p>Your session has timed out due to a long period of inactivity.</p>
   <p>
-    <a href="{{ baseUrl }}" class="button">Restart</a>
+    <a href="{{ baseUrl }}" class="govuk-button">Restart</a>
   </p>
 {% endblock %}

--- a/src/apps/omis/apps/edit/controllers/cancel-order.js
+++ b/src/apps/omis/apps/edit/controllers/cancel-order.js
@@ -21,7 +21,7 @@ class CancelOrderController extends EditController {
       disableFormAction: false,
       returnText: 'Return without cancelling',
       buttonText: 'Cancel order',
-      buttonModifiers: 'button--destructive',
+      buttonModifiers: 'govuk-button--warning',
       fields: {
         cancellation_reason: {
           options: filteredReasons.map(transformObjectToOption),

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -38,9 +38,7 @@ async function setContact (req, res, next) {
   }
 
   try {
-    const contact = await getContact(req.session.token, contactId)
-
-    res.locals.order.contact = contact
+    res.locals.order.contact = await getContact(req.session.token, contactId)
     next()
   } catch (error) {
     next(error)
@@ -52,9 +50,7 @@ async function setAssignees (req, res, next) {
 
   if (orderId) {
     try {
-      const assignees = await Order.getAssignees(req.session.token, orderId)
-
-      res.locals.assignees = assignees
+      res.locals.assignees = await Order.getAssignees(req.session.token, orderId)
     } catch (error) {
       return next(error)
     }
@@ -67,9 +63,7 @@ async function setSubscribers (req, res, next) {
 
   if (orderId) {
     try {
-      const subscribers = await Order.getSubscribers(req.session.token, orderId)
-
-      res.locals.subscribers = subscribers
+      res.locals.subscribers = await Order.getSubscribers(req.session.token, orderId)
     } catch (error) {
       return next(error)
     }
@@ -252,7 +246,7 @@ function setQuoteForm (req, res, next) {
   if (get(quote, 'created_on') && !get(quote, 'cancelled_on')) {
     form.action = `/omis/${orderId}/quote/cancel`
     form.buttonText = 'Withdraw quote'
-    form.buttonModifiers = 'button--destructive'
+    form.buttonModifiers = 'govuk-button--warning'
     res.locals.destructive = true
 
     if (quote.accepted_on) {

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -3,7 +3,7 @@
 {% set actions %}
   {% if order.status in ['paid'] %}
     <p class="c-local-header__action">
-      <a href="edit/complete-order" class="button">Complete order</a>
+      <a href="edit/complete-order" class="govuk-button">Complete order</a>
     </p>
   {% endif %}
 
@@ -22,7 +22,7 @@
   {% else %}
     <p class="c-local-header__action">
       {% if order.status == 'draft' %}
-        <a href="quote" class="button">Preview quote</a>
+        <a href="quote" class="govuk-button">Preview quote</a>
       {% elif order.status not in ['cancelled']  %}
         <a href="quote">View quote</a>
       {% endif %}

--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -109,7 +109,7 @@
                   orderId: order.id
                 }
               }) %}
-                <button type="submit" class="button button--link button--compact">Set as lead adviser</button>
+                <button type="submit" class="govuk-button button--link button--compact">Set as lead adviser</button>
               {% endcall %}
             {% endif %}
           </td>

--- a/src/apps/propositions/macros/abandon-form.js
+++ b/src/apps/propositions/macros/abandon-form.js
@@ -24,6 +24,6 @@ module.exports = function ({
         label: labels.abandonProposition[field.name],
       })
     }),
-    buttonModifiers: 'button--destructive',
+    buttonModifiers: 'govuk-button--warning',
   }
 }

--- a/src/apps/propositions/views/details.njk
+++ b/src/apps/propositions/views/details.njk
@@ -7,7 +7,7 @@
     <ul class="list-links">
       {% if proposition.files.results.length == 0 %}
         <li class="list-links-item">
-          <a class="button" href="{{proposition.id}}/document">
+          <a class="govuk-button" href="{{proposition.id}}/document">
             Upload Files
           </a>
         </li>
@@ -18,7 +18,7 @@
           </a>
         </li>
         <li class="list-links-item">
-          <a class="button" href="{{proposition.id}}/complete">
+          <a class="govuk-button" href="{{proposition.id}}/complete">
             Complete proposition
           </a>
         </li>

--- a/src/templates/_components/archive-form.njk
+++ b/src/templates/_components/archive-form.njk
@@ -47,6 +47,6 @@
   }) }}
 
   <div class="c-form-actions">
-    <button class="button button--save" type="submit">Archive</button>
+    <button class="govuk--button" type="submit">Archive</button>
   </div>
 </form>

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -48,7 +48,7 @@
                 })) %}
                   {% for value in fieldValues %}
                     {% set removeButton %}
-                      <button class="button button--link c-form-group__action js-AddItems__remove" name="remove-item" value="{{ key }}::{{ loop.index0 }}">
+                      <button class="govuk-button button--link c-form-group__action js-AddItems__remove" name="remove-item" value="{{ key }}::{{ loop.index0 }}">
                         {{ translate(removeButtonText) }}
                       </button>
                     {% endset %}
@@ -67,7 +67,7 @@
                 {% endcall %}
 
                 <p class="c-form-group c-form-group--compact">
-                  <button class="button button--secondary js-AddItems__add" name="add-item" value="{{ key }}">
+                  <button class="govuk-button govuk-button--secondary js-AddItems__add" name="add-item" value="{{ key }}">
                     {{ translate(addButtonText) }}
                   </button>
                 </p>

--- a/src/templates/_macros/collection-header/_collection-header.scss
+++ b/src/templates/_macros/collection-header/_collection-header.scss
@@ -128,7 +128,7 @@
     float: right;
   }
 
-  .button {
+  .govuk-button {
     margin-left: $default-spacing-unit / 2;
     margin-bottom: 2px;
   }

--- a/src/templates/_macros/collection-header/template.njk
+++ b/src/templates/_macros/collection-header/template.njk
@@ -33,7 +33,7 @@
         {% endif %}
 
         {% for actionButton in actionButtons %}
-          <a class="button button--secondary" href="{{ actionButton.url }}" data-auto-id="{{ actionButton.label }}">{{ actionButton.label }}</a>
+          <a class="govuk-button govuk-button--secondary" href="{{ actionButton.url }}" data-auto-id="{{ actionButton.label }}">{{ actionButton.label }}</a>
         {% endfor %}
       </div>
     {% endif %}
@@ -81,7 +81,7 @@
       </span>
       <span class="c-collection__header-actions">
         {% if not props.exportAction.invalidNumberOfItems(count, props.exportAction.maxItems) %}
-          <a class="button" download href="{{ props.exportAction.url }}">Download</a>
+          <a class="govuk-button" download href="{{ props.exportAction.url }}">Download</a>
         {% endif %}
       </span>
     </div>

--- a/src/templates/_macros/entity/cta-list.njk
+++ b/src/templates/_macros/entity/cta-list.njk
@@ -10,8 +10,8 @@
   {% if props.items | length %}
     {% if props.items[0].value === 'Ongoing' or props.items[0].value === 'Late' %}
       <div class="{{ 'c-entity__cta-list' | applyClassModifiers(props.modifier) }}">
-        <a href="{{ props.url }}/abandon" class="button button--secondary">Abandon</a>
-        <a href="{{ props.url }}/document" class="button">Complete</a>
+        <a href="{{ props.url }}/abandon" class="govuk-button govuk-button--secondary">Abandon</a>
+        <a href="{{ props.url }}/document" class="govuk-button">Complete</a>
       </div>
     {% endif %}
   {% endif %}

--- a/src/templates/_macros/form/add-another.njk
+++ b/src/templates/_macros/form/add-another.njk
@@ -34,7 +34,7 @@
 
       <p class="c-form-fieldset__add-another">
         <input
-          class="button button--secondary js-AddItems__add{{ typeaheadClassModifier }}"
+          class="govuk-button govuk-button--secondary js-AddItems__add{{ typeaheadClassModifier }}"
           type="submit"
           name="{{ props.buttonName }}"
           value="Add another"

--- a/src/templates/_macros/form/form.njk
+++ b/src/templates/_macros/form/form.njk
@@ -65,7 +65,7 @@
       <div class="c-form-actions {{ props.actionsClass }}">
         {% if not props.hidePrimaryFormAction %}
           <button
-            class="button js-prevent-multiple-submits {{ buttonModifiers }}"
+            class="govuk-button js-prevent-multiple-submits {{ buttonModifiers }}"
             {{ 'disabled="disabled"' if props.disableFormAction }}
             {% if buttonDataAttr %}data-auto-id="{{ buttonDataAttr }}"{% endif %}
           >

--- a/test/acceptance/helpers/selectors.js
+++ b/test/acceptance/helpers/selectors.js
@@ -22,7 +22,7 @@ function getSelectorForElementWithText (text, { el = '//*', className, child, ha
  * @returns {{selector: string, locateStrategy: string}}
  */
 function getButtonWithText (text) {
-  return getSelectorForElementWithText(text, { el: '//*', className: 'button' })
+  return getSelectorForElementWithText(text, { el: '//*', className: 'govuk-button' })
 }
 
 /**

--- a/test/functional/cypress/selectors/contact/create.js
+++ b/test/functional/cypress/selectors/contact/create.js
@@ -1,7 +1,7 @@
 const msgCls = '.c-form-group__error-message'
 
 module.exports = {
-  addContact: '.c-form-actions .button',
+  addContact: '.c-form-actions .govuk-button',
   validationHeader: '.c-error-summary__heading',
   validationFieldMsg: {
     name: `[for="field-first_name"] ${msgCls}`,

--- a/test/functional/cypress/selectors/interaction/complete.js
+++ b/test/functional/cypress/selectors/interaction/complete.js
@@ -15,7 +15,7 @@ module.exports = {
     error: '#group-field-date .c-form-group__error-message',
   },
   actions: {
-    continue: '.button',
+    continue: '.govuk-button',
     back: ({ companyId, interactionId }) => `[href="/companies/${companyId}/interactions/${interactionId}"]`,
   },
 }

--- a/test/functional/cypress/selectors/omis/create.js
+++ b/test/functional/cypress/selectors/omis/create.js
@@ -4,7 +4,7 @@ module.exports = {
   sectorYes: '[for="field-use_sector_from_company-1"]',
   sectorNo: '[for="field-use_sector_from_company-2"]',
   sector: '#field-sector',
-  continue: '.button',
+  continue: '.govuk-button',
   validationMsg: '.c-error-summary__error-text',
   suggestedSectorMsg: '.c-message--muted',
   archivedMsg: '.c-message',

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -1074,7 +1074,7 @@ describe('OMIS View middleware', () => {
           try {
             expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
             expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Withdraw quote')
-            expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button--destructive')
+            expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'govuk-button--warning')
 
             done()
           } catch (error) {
@@ -1103,7 +1103,7 @@ describe('OMIS View middleware', () => {
               try {
                 expect(this.resMock.locals.quoteForm).to.have.property('action', '/omis/123456789/quote/cancel')
                 expect(this.resMock.locals.quoteForm).to.have.property('buttonText', 'Withdraw quote')
-                expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'button--destructive')
+                expect(this.resMock.locals.quoteForm).to.have.property('buttonModifiers', 'govuk-button--warning')
 
                 done()
               } catch (error) {

--- a/test/unit/components/archive-form.test.js
+++ b/test/unit/components/archive-form.test.js
@@ -23,7 +23,7 @@ const HTML = `
       </div>
     </fieldset>
     <div class="save-bar">
-      <button class="button button--save" type="submit">Archive</button>
+      <button class="govuk-button" type="submit">Archive</button>
     </div>
   </form>
 `
@@ -53,7 +53,7 @@ describe('archive form control', () => {
 
   it('it should add a button to reveal the form', () => {
     const prev = this.form.previousSibling
-    expect(domTokenToArray(prev.classList)).to.include('button')
+    expect(domTokenToArray(prev.classList)).to.include('govuk-button')
     expect(prev.textContent).to.include('Archive')
   })
 

--- a/test/unit/macros/collection/collection-content.test.js
+++ b/test/unit/macros/collection/collection-content.test.js
@@ -58,7 +58,7 @@ describe('Collection macro', () => {
 
     it('should render an action button header', () => {
       const actionHeader = this.component.querySelectorAll('.c-collection__header-actions')
-      const actionButton = this.component.querySelectorAll('.button--secondary')
+      const actionButton = this.component.querySelectorAll('.govuk-button--secondary')
 
       expect(actionHeader).to.exist
       expect(actionButton).to.exist

--- a/test/unit/macros/form/form.test.js
+++ b/test/unit/macros/form/form.test.js
@@ -22,7 +22,7 @@ describe('Form component', () => {
         macros.renderToDom('TextField'),
       )
       expect(component.querySelector('.c-form-actions')).to.exist
-      expect(component.querySelector('button.button').textContent).to.equal('Submit')
+      expect(component.querySelector('button.govuk-button').textContent).to.equal('Submit')
     })
 
     it('should render form with custom props', () => {
@@ -50,7 +50,7 @@ describe('Form component', () => {
       const component = macros.renderWithCallerToDom('Form', formProps)(
         macros.renderToDom('TextField'),
       )
-      expect(component.querySelector('button.button').textContent).to.equal('Save')
+      expect(component.querySelector('button.govuk-button').textContent).to.equal('Save')
     })
 
     it('should render form without form actions', () => {
@@ -74,7 +74,7 @@ describe('Form component', () => {
       const returnLink = component.querySelector('[href="/previous-page"]')
       expect(returnLink).to.exist
       expect(returnLink.textContent).to.equal('Back')
-      expect(component.querySelector('.c-form-actions .button')).to.not.exist
+      expect(component.querySelector('.c-form-actions .govuk-button')).to.not.exist
     })
 
     it('should render form with button modifier as string', () => {
@@ -84,7 +84,7 @@ describe('Form component', () => {
       const component = macros.renderWithCallerToDom('Form', formProps)(
         macros.renderToDom('TextField'),
       )
-      expect(component.querySelector('button.button').classList.contains('modifier')).to.be.true
+      expect(component.querySelector('button.govuk-button').classList.contains('modifier')).to.be.true
     })
 
     it('should render form with button modifier as array', () => {
@@ -94,7 +94,7 @@ describe('Form component', () => {
       const component = macros.renderWithCallerToDom('Form', formProps)(
         macros.renderToDom('TextField'),
       )
-      const classList = component.querySelector('button.button').classList
+      const classList = component.querySelector('button.govuk-button').classList
 
       expect(classList.contains('modifier-1')).to.be.true
       expect(classList.contains('modifier-2')).to.be.true


### PR DESCRIPTION
**Implementation notes**

Currently our buttons doesn't match the GOV.UK design system:
https://design-system.service.gov.uk/components/button/

This PR is meant to fix this.

https://trello.com/c/coevqkWf/1245-change-all-buttons-to-match-govuk-design-system

## Before

![image](https://user-images.githubusercontent.com/4199239/59281019-76d51000-8c5e-11e9-994a-6a53e4eda11a.png)

## After

![image](https://user-images.githubusercontent.com/4199239/59280929-4ee5ac80-8c5e-11e9-92b9-984eca677ec4.png)

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
