### PR TITLE
Update draft interaction to be complete

### DIFF
--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -1,4 +1,4 @@
-const { assign, get } = require('lodash')
+const { get, set } = require('lodash')
 const { sentence } = require('case')
 
 const { transformInteractionFormBodyToApiRequest } = require('../transformers')
@@ -17,16 +17,12 @@ async function postDetails (req, res, next) {
     req.flash('success', `${sentence(req.params.kind)} ${res.locals.interaction ? 'updated' : 'created'}`)
     res.redirect(joinPaths([ getReturnLink(res.locals.interactions), result.id ]))
   } catch (err) {
-    if (err.statusCode === 400) {
-      res.locals.form = assign({}, res.locals.form, {
-        errors: {
-          messages: err.error,
-        },
-      })
-      next()
-    } else {
-      next(err)
+    if (err.statusCode !== 400) {
+      return next(err)
     }
+
+    set(res.locals, 'form.errors.messages', err.error)
+    next()
   }
 }
 

--- a/src/apps/interactions/transformers/interaction-form-body-to-api.js
+++ b/src/apps/interactions/transformers/interaction-form-body-to-api.js
@@ -2,6 +2,7 @@ const { omit } = require('lodash')
 
 const castCompactArray = require('../../../lib/cast-compact-array')
 const { transformDateObjectToDateString } = require('../../transformers')
+const { INTERACTION_STATUS } = require('../constants')
 
 function transformInteractionFormBodyToApiRequest (props) {
   const policyAreasArray = castCompactArray(props.policy_areas)
@@ -18,6 +19,7 @@ function transformInteractionFormBodyToApiRequest (props) {
     dit_participants: advisersArray,
     policy_areas: policyAreasArray,
     policy_issue_types: policyIssueTypesArray,
+    status: INTERACTION_STATUS.COMPLETE,
   }, ['date_day', 'date_month', 'date_year'])
 }
 

--- a/test/unit/apps/interactions/middleware/details.test.js
+++ b/test/unit/apps/interactions/middleware/details.test.js
@@ -48,6 +48,7 @@ describe('Interaction details middleware', () => {
               policy_areas: [],
               policy_issue_types: [],
               service: '1783ae93-b78f-e611-8c55-e4115bed50dc',
+              status: 'complete',
               subject: 'subject',
             }
           )
@@ -108,6 +109,7 @@ describe('Interaction details middleware', () => {
               policy_areas: [],
               policy_issue_types: [],
               service: '1783ae93-b78f-e611-8c55-e4115bed50dc',
+              status: 'complete',
               subject: 'subject',
             }
           )


### PR DESCRIPTION
## Change
Sets the `status` of `interactions` to `complete` when saving an interaction. This is particularly useful when completing a `draft`.

## Test instructions
1. Browse to a `draft` interaction
2. Click `Complete interaction`
3. Select `Yes`
4. Complete the form
5. On the `details` view the `Complete interaction` button should not be visible

**Checklist**
- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
