### PR TITLE
Hide "Complete interaction" button when archived

### DIFF
--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -14,7 +14,8 @@ function renderDetailsPage (req, res, next) {
     const interactionViewRecord = transformInteractionResponseToViewRecord(interaction, isComplete)
     const canComplete = features['interactions-complete-drafts'] === true &&
       interaction.status === INTERACTION_STATUS.DRAFT &&
-      new Date(interaction.date) < new Date()
+      new Date(interaction.date) < new Date() &&
+      !interaction.archived
 
     return res
       .breadcrumb(breadcrumb)

--- a/test/unit/apps/interactions/controllers/details.test.js
+++ b/test/unit/apps/interactions/controllers/details.test.js
@@ -249,5 +249,57 @@ describe('Interaction details controller', () => {
         expect(this.middlewareParameters.resMock.render.firstCall.args[1].canEdit).to.be.false
       })
     })
+
+    context('when rendering a draft archived meeting', () => {
+      beforeEach(() => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          interaction: {
+            ...draftPastMeeting,
+            archived: true,
+          },
+          requestParams: {
+            id: '1234',
+          },
+          features: {
+            'interactions-complete-drafts': true,
+          },
+        })
+
+        detailsController.renderDetailsPage(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should set the breadcrumb', () => {
+        expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWithExactly('Interaction')
+        expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledOnce
+      })
+
+      it('should set the title', () => {
+        expect(this.middlewareParameters.resMock.title).to.be.calledWith('Past meeting between Brendan and Theodore')
+      })
+
+      it('should render the interaction details template', () => {
+        expect(this.middlewareParameters.resMock.render).to.be.calledWith('interactions/views/details')
+      })
+
+      it('should render the template without Document details', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].interactionViewRecord.Documents).to.not.exist
+      })
+
+      it('should render the template with interaction data', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].interactionViewRecord).to.exist
+      })
+
+      it('should render the template with canComplete as false', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].canComplete).to.be.false
+      })
+
+      it('should render the template with canEdit as false', () => {
+        expect(this.middlewareParameters.resMock.render.firstCall.args[1].canEdit).to.be.false
+      })
+    })
   })
 })


### PR DESCRIPTION
## Change
Hides the `Complete interaction` button when the `interaction` is `archived`. This is useful for `draft` interactions which are cancelled and therefore `archived`.

## Test instructions
1. Browse to a `draft` interaction that is `archived`
2. There should be no `Complete interaction` button

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
