### PR TITLE
Add service interaction sub headings

### DIFF
--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -37,7 +37,7 @@ async function buildForm (req, res, interactionId) {
     returnLink,
     returnText: interactionId ? 'Return without saving' : 'Cancel',
     buttonText: interactionId ? 'Save and return' : `Add ${lowerCase(req.params.kind)}`,
-    company: get(res.locals, 'company.id'),
+    company: get(res.locals, 'company.name'),
   }
 
   if (req.params.kind !== 'service-delivery' && req.params.kind !== 'interaction') {

--- a/src/apps/interactions/macros/service-delivery-form.js
+++ b/src/apps/interactions/macros/service-delivery-form.js
@@ -4,6 +4,10 @@ const labels = require('../labels')
 const {
   contact,
   service,
+  participantsHeading,
+  serviceHeading,
+  detailsHeading,
+  notesHeading,
   subject,
   notes,
   date,
@@ -29,6 +33,7 @@ module.exports = function ({
   hiddenFields,
   areas,
   types,
+  company,
 }) {
   return {
     returnLink,
@@ -36,38 +41,7 @@ module.exports = function ({
     buttonText,
     hiddenFields,
     children: [
-      date,
-      contact(contacts),
-      adviser(advisers),
-      // TODO this will be going once interactions are within events
-      {
-        macroName: 'MultipleChoiceField',
-        type: 'radio',
-        name: 'is_event',
-        optional: true,
-        modifier: 'inline',
-        options: [
-          {
-            label: 'Yes',
-            value: 'true',
-          },
-          {
-            label: 'No',
-            value: 'false',
-          },
-        ],
-      },
-      {
-        macroName: 'MultipleChoiceField',
-        name: 'event',
-        initialOption: '-- Select event --',
-        options: events,
-        modifier: 'subfield',
-        condition: {
-          name: 'is_event',
-          value: 'true',
-        },
-      },
+      serviceHeading,
       service(services),
       {
         macroName: 'MultipleChoiceField',
@@ -101,6 +75,41 @@ module.exports = function ({
           value: successfulServiceStatuses.join('||'),
         },
       },
+      participantsHeading(company),
+      contact(contacts),
+      adviser(advisers),
+      detailsHeading,
+      date,
+      // TODO this will be going once interactions are within events
+      {
+        macroName: 'MultipleChoiceField',
+        type: 'radio',
+        name: 'is_event',
+        optional: true,
+        modifier: 'inline',
+        options: [
+          {
+            label: 'Yes',
+            value: 'true',
+          },
+          {
+            label: 'No',
+            value: 'false',
+          },
+        ],
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        name: 'event',
+        initialOption: '-- Select event --',
+        options: events,
+        modifier: 'subfield',
+        condition: {
+          name: 'is_event',
+          value: 'true',
+        },
+      },
+      notesHeading,
       subject,
       notes,
       feedbackPolicyRequest,

--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -342,7 +342,7 @@ describe('Interaction edit controller (Interactions)', () => {
           label: undefined,
           macroName: 'FormSubHeading',
           heading: 'Interaction Participants',
-          secondaryHeading: '1',
+          secondaryHeading: 'Fred ltd.',
         },
         {
           name: 'contacts',
@@ -645,7 +645,7 @@ describe('Interaction edit controller (Interactions)', () => {
           macroName: 'FormSubHeading',
           value: undefined,
           heading: 'Interaction Participants',
-          secondaryHeading: '1',
+          secondaryHeading: 'Fred ltd.',
         },
         {
           name: 'contacts',
@@ -997,7 +997,7 @@ describe('Interaction edit controller (Interactions)', () => {
           macroName: 'FormSubHeading',
           value: undefined,
           heading: 'Interaction Participants',
-          secondaryHeading: '1',
+          secondaryHeading: 'Fred ltd.',
         },
         {
           name: 'contacts',

--- a/test/unit/apps/interactions/controllers/edit.service.test.js
+++ b/test/unit/apps/interactions/controllers/edit.service.test.js
@@ -216,19 +216,82 @@ describe('Interaction edit controller (Service delivery)', () => {
     })
 
     it('should generate a form with the required fields', () => {
-      const fields = this.interactionForm.children.map(field => pick(field, ['name', 'label', 'macroName', 'type']))
+      const fields = this.interactionForm.children.map(field => pick(field, ['name', 'label', 'macroName', 'type', 'heading', 'secondaryHeading']))
       expect(fields).to.deep.equal([
-        { name: 'date', label: 'Date of service delivery', macroName: 'DateFieldset' },
-        { name: 'contacts', label: 'Contact(s)', macroName: 'AddAnother' },
-        { name: 'dit_participants', label: 'Adviser(s)', macroName: 'AddAnother' },
-        { name: 'is_event', label: 'Is this an event?', macroName: 'MultipleChoiceField', type: 'radio' },
-        { name: 'event', label: 'Event', macroName: 'MultipleChoiceField' },
-        { name: 'service', label: 'Service', macroName: 'MultipleChoiceField' },
-        { name: 'service_delivery_status', label: 'Service status', macroName: 'MultipleChoiceField' },
-        { name: 'grant_amount_offered', label: 'Grant offered', macroName: 'TextField' },
-        { name: 'net_company_receipt', label: 'Net receipt', macroName: 'TextField' },
+        {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          heading: 'Service',
+        },
+        {
+          name: 'service',
+          label: 'Service',
+          macroName: 'MultipleChoiceField',
+        },
+        {
+          name: 'service_delivery_status',
+          label: 'Service status',
+          macroName: 'MultipleChoiceField',
+        },
+        {
+          name: 'grant_amount_offered',
+          label: 'Grant offered',
+          macroName: 'TextField',
+        },
+        {
+          name: 'net_company_receipt',
+          label: 'Net receipt',
+          macroName: 'TextField',
+        },
+        {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          heading: 'Interaction Participants',
+          secondaryHeading: 'Fred ltd.',
+        },
+        {
+          name: 'contacts',
+          label: 'Contact(s)',
+          macroName: 'AddAnother',
+        },
+        {
+          name: 'dit_participants',
+          label: 'Adviser(s)',
+          macroName: 'AddAnother',
+        },
+        {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          heading: 'Details',
+        },
+        {
+          name: 'date',
+          label: 'Date of service delivery',
+          macroName: 'DateFieldset',
+        },
+        {
+          name: 'is_event',
+          label: 'Is this an event?',
+          macroName: 'MultipleChoiceField',
+          type: 'radio',
+        },
+        {
+          name: 'event',
+          label: 'Event',
+          macroName: 'MultipleChoiceField',
+        },
+        {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          heading: 'Notes',
+        },
         { name: 'subject', label: 'Subject', macroName: 'TextField' },
-        { name: 'notes', label: 'Notes', macroName: 'TextField', type: 'textarea' },
+        {
+          name: 'notes',
+          label: 'Notes',
+          macroName: 'TextField',
+          type: 'textarea',
+        },
         {
           name: 'was_policy_feedback_provided',
           label: 'Did the contact give any feedback on government policy?',
@@ -241,9 +304,18 @@ describe('Interaction edit controller (Service delivery)', () => {
           macroName: 'MultipleChoiceField',
           type: 'checkbox',
         },
-        { name: 'policy_areas', label: 'Policy area', macroName: 'AddAnother' },
-        { name: 'policy_feedback_notes', label: 'Policy feedback notes', macroName: 'TextField', type: 'textarea' },
-      ])
+        {
+          name: 'policy_areas',
+          label: 'Policy area',
+          macroName: 'AddAnother',
+        },
+        {
+          name: 'policy_feedback_notes',
+          label: 'Policy feedback notes',
+          macroName: 'TextField',
+          type: 'textarea',
+        }]
+      )
     })
 
     it('should provide a list of contacts', () => {
@@ -444,14 +516,38 @@ describe('Interaction edit controller (Service delivery)', () => {
       const fields = this.interactionForm.children.map(field => pick(field, ['name', 'label', 'macroName', 'type', 'value']))
       expect(fields).to.deep.equal([
         {
-          name: 'date',
-          label: 'Date of service delivery',
-          macroName: 'DateFieldset',
-          value: {
-            day: '31',
-            month: '05',
-            year: '2017',
-          },
+          label: undefined,
+          macroName: 'FormSubHeading',
+          value: undefined,
+        },
+        {
+          name: 'service',
+          label: 'Service',
+          macroName: 'MultipleChoiceField',
+          value: '1231231231312',
+        },
+        {
+          name: 'service_delivery_status',
+          label: 'Service status',
+          macroName: 'MultipleChoiceField',
+          value: undefined,
+        },
+        {
+          name: 'grant_amount_offered',
+          label: 'Grant offered',
+          macroName: 'TextField',
+          value: undefined,
+        },
+        {
+          name: 'net_company_receipt',
+          label: 'Net receipt',
+          macroName: 'TextField',
+          value: undefined,
+        },
+        {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          value: undefined,
         },
         {
           name: 'contacts',
@@ -466,6 +562,17 @@ describe('Interaction edit controller (Service delivery)', () => {
           value: [1],
         },
         {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          value: undefined,
+        },
+        {
+          name: 'date',
+          label: 'Date of service delivery',
+          macroName: 'DateFieldset',
+          value: { day: '31', month: '05', year: '2017' },
+        },
+        {
           name: 'is_event',
           label: 'Is this an event?',
           macroName: 'MultipleChoiceField',
@@ -478,17 +585,24 @@ describe('Interaction edit controller (Service delivery)', () => {
           macroName: 'MultipleChoiceField',
           value: 'bac18331-ca4d-4501-960e-a1bd68b5d46e',
         },
-        { name: 'service', label: 'Service', macroName: 'MultipleChoiceField', value: '1231231231312' },
         {
-          name: 'service_delivery_status',
-          label: 'Service status',
-          macroName: 'MultipleChoiceField',
+          label: undefined,
+          macroName: 'FormSubHeading',
           value: undefined,
         },
-        { name: 'grant_amount_offered', label: 'Grant offered', macroName: 'TextField', value: undefined },
-        { name: 'net_company_receipt', label: 'Net receipt', macroName: 'TextField', value: undefined },
-        { name: 'subject', label: 'Subject', macroName: 'TextField', value: 'Test interactions' },
-        { name: 'notes', label: 'Notes', macroName: 'TextField', type: 'textarea', value: 'lorem ipsum' },
+        {
+          name: 'subject',
+          label: 'Subject',
+          macroName: 'TextField',
+          value: 'Test interactions',
+        },
+        {
+          name: 'notes',
+          label: 'Notes',
+          macroName: 'TextField',
+          type: 'textarea',
+          value: 'lorem ipsum',
+        },
         {
           name: 'was_policy_feedback_provided',
           label: 'Did the contact give any feedback on government policy?',
@@ -503,15 +617,19 @@ describe('Interaction edit controller (Service delivery)', () => {
           type: 'checkbox',
           value: [],
         },
-        { name: 'policy_areas', label: 'Policy area', macroName: 'AddAnother', value: [] },
+        {
+          name: 'policy_areas',
+          label: 'Policy area',
+          macroName: 'AddAnother',
+          value: [],
+        },
         {
           name: 'policy_feedback_notes',
           label: 'Policy feedback notes',
           macroName: 'TextField',
           type: 'textarea',
           value: undefined,
-        },
-      ])
+        }])
     })
 
     it('should provide a list of contacts', () => {
@@ -623,17 +741,44 @@ describe('Interaction edit controller (Service delivery)', () => {
     })
 
     it('should merge the changes on top of the original record', () => {
-      const fields = this.interactionForm.children.map(field => pick(field, ['name', 'label', 'macroName', 'type', 'value']))
+      const fields = this.interactionForm.children.map(field => pick(field, ['name', 'label', 'macroName', 'type', 'value', 'heading', 'secondaryHeading']))
       expect(fields).to.deep.equal([
         {
-          name: 'date',
-          label: 'Date of service delivery',
-          macroName: 'DateFieldset',
-          value: {
-            day: '31',
-            month: '05',
-            year: '2017',
-          },
+          label: undefined,
+          macroName: 'FormSubHeading',
+          value: undefined,
+          heading: 'Service',
+        },
+        {
+          name: 'service',
+          label: 'Service',
+          macroName: 'MultipleChoiceField',
+          value: '1231231231312',
+        },
+        {
+          name: 'service_delivery_status',
+          label: 'Service status',
+          macroName: 'MultipleChoiceField',
+          value: undefined,
+        },
+        {
+          name: 'grant_amount_offered',
+          label: 'Grant offered',
+          macroName: 'TextField',
+          value: undefined,
+        },
+        {
+          name: 'net_company_receipt',
+          label: 'Net receipt',
+          macroName: 'TextField',
+          value: undefined,
+        },
+        {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          value: undefined,
+          heading: 'Interaction Participants',
+          secondaryHeading: 'Fred ltd.',
         },
         {
           name: 'contacts',
@@ -648,6 +793,18 @@ describe('Interaction edit controller (Service delivery)', () => {
           value: [1],
         },
         {
+          label: undefined,
+          macroName: 'FormSubHeading',
+          value: undefined,
+          heading: 'Details',
+        },
+        {
+          name: 'date',
+          label: 'Date of service delivery',
+          macroName: 'DateFieldset',
+          value: { day: '31', month: '05', year: '2017' },
+        },
+        {
           name: 'is_event',
           label: 'Is this an event?',
           macroName: 'MultipleChoiceField',
@@ -660,17 +817,25 @@ describe('Interaction edit controller (Service delivery)', () => {
           macroName: 'MultipleChoiceField',
           value: 'bac18331-ca4d-4501-960e-a1bd68b5d46e',
         },
-        { name: 'service', label: 'Service', macroName: 'MultipleChoiceField', value: '1231231231312' },
         {
-          name: 'service_delivery_status',
-          label: 'Service status',
-          macroName: 'MultipleChoiceField',
+          label: undefined,
+          macroName: 'FormSubHeading',
           value: undefined,
+          heading: 'Notes',
         },
-        { name: 'grant_amount_offered', label: 'Grant offered', macroName: 'TextField', value: undefined },
-        { name: 'net_company_receipt', label: 'Net receipt', macroName: 'TextField', value: undefined },
-        { name: 'subject', label: 'Subject', macroName: 'TextField', value: 'a' },
-        { name: 'notes', label: 'Notes', macroName: 'TextField', type: 'textarea', value: 'lorem ipsum' },
+        {
+          name: 'subject',
+          label: 'Subject',
+          macroName: 'TextField',
+          value: 'a',
+        },
+        {
+          name: 'notes',
+          label: 'Notes',
+          macroName: 'TextField',
+          type: 'textarea',
+          value: 'lorem ipsum',
+        },
         {
           name: 'was_policy_feedback_provided',
           label: 'Did the contact give any feedback on government policy?',
@@ -685,15 +850,20 @@ describe('Interaction edit controller (Service delivery)', () => {
           type: 'checkbox',
           value: [],
         },
-        { name: 'policy_areas', label: 'Policy area', macroName: 'AddAnother', value: [] },
+        {
+          name: 'policy_areas',
+          label: 'Policy area',
+          macroName: 'AddAnother',
+          value: [],
+        },
         {
           name: 'policy_feedback_notes',
           label: 'Policy feedback notes',
           macroName: 'TextField',
           type: 'textarea',
           value: undefined,
-        },
-      ])
+        }]
+      )
     })
 
     it('should include the error in the form', () => {


### PR DESCRIPTION
## Problem
The service delivery interaction form should have the same layout as the interaction form #2010  and include the new sub-headings.

Trello - https://trello.com/c/EBxdYkD7/761-interactions-add-sub-headings-to-form

## Solution
Apply the same layout to the service delivery form.


**Implementation notes**

_Add any additional information about the change that isn't captured in the Trello ticket._

**Checklist**

- [ ] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
