### PR TITLE
Use Chrome 74 for functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
     steps:
       - checkout
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - save_cache:
           name: Save yarn dependencies cache
           key: yarn-dependency-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
@@ -237,7 +237,7 @@ jobs:
     steps:
       - checkout
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run:
           name: Lint code
           command: |
@@ -258,7 +258,7 @@ jobs:
     steps:
       - checkout
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run:
           name: Run unit tests
           command: |
@@ -284,7 +284,7 @@ jobs:
     steps:
       - checkout
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run: yarn build
       - run:
           name: Run client-side unit tests
@@ -318,7 +318,7 @@ jobs:
       - *wait_for_mock_sso
       - *restore_yarn_cache
       - *wait_for_api_sandbox
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -347,7 +347,7 @@ jobs:
       - *wait_for_backend
       - *wait_for_mock_sso
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -399,7 +399,7 @@ jobs:
       - *wait_for_backend
       - *wait_for_mock_sso
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -431,7 +431,7 @@ jobs:
       - *wait_for_backend
       - *wait_for_mock_sso
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
@@ -463,7 +463,7 @@ jobs:
       - *wait_for_backend
       - *wait_for_mock_sso
       - *restore_yarn_cache
-      - run: yarn install
+      - run: yarn install --pure-lockfile
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,14 +317,14 @@ jobs:
       - checkout
       - *wait_for_mock_sso
       - *restore_yarn_cache
+      - *wait_for_api_sandbox
       - run: yarn install
       - run: yarn build
       - *start_frontend
       - *wait_for_frontend
-      - *wait_for_api_sandbox
       - run:
           name: Run Cypress tests
-          command: yarn test:functional --browser chrome --parallel --record --key $CYPRESS_DASHBOARD_KEY
+          command: yarn test:functional --parallel --record --key $CYPRESS_DASHBOARD_KEY
           when: always
       - store_artifacts:
           path: cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ aliases:
 
   # Data hub base docker container
   - &docker_data_hub_base
-    image: ukti/data-hub-frontend-test:1.0.0
+    image: ukti/data-hub-frontend-test:1.1.0
     environment:
       *data_hub_base_envs
 
@@ -324,7 +324,7 @@ jobs:
       - *wait_for_frontend
       - run:
           name: Run Cypress tests
-          command: yarn test:functional --parallel --record --key $CYPRESS_DASHBOARD_KEY
+          command: yarn test:functional --browser chrome --parallel --record --key $CYPRESS_DASHBOARD_KEY
           when: always
       - store_artifacts:
           path: cypress/screenshots

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,9 +3,6 @@
 
 FROM node:8.15.1
 
-# Increment this version each time when you edit Dockerfile.
-ENV VERSION                1.0.0
-
 ENV DOCKERIZE_VERSION      v0.3.0
 ENV YARN_VERSION           1.15.2
 ENV NPM_CONFIG_LOGLEVEL    warn
@@ -51,11 +48,13 @@ RUN apt-get install -y \
   libasound2 \
   xvfb
 
-# Install Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
-  && apt-get update \
-  && apt-get install -y dbus-x11 google-chrome-stable
+# Install Chrome (73)
+# We decided to lock on Chrome 73 for now until we solve random error when running functional tests: "Error: There has been an OAuth stateId mismatch"
+# See related CircleCI build: https://circleci.com/gh/uktrade/data-hub-frontend/48022#tests/containers/3
+RUN apt-get install -y xdg-utils libgtk-3-0 lsb-release libappindicator3-1 fonts-liberation \
+  && curl https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_74.0.3729.169-1_amd64.deb -O \
+  && dpkg -i google-chrome-stable_74.0.3729.169-1_amd64.deb \
+  && rm google-chrome-stable_74.0.3729.169-1_amd64.deb
 
 # Install dependencies for acceptance tests
 RUN apt-get install -y openjdk-8-jre
@@ -66,3 +65,4 @@ RUN npm -v
 RUN yarn -v
 RUN google-chrome --version
 RUN git --version
+RUN java -version

--- a/test/README.md
+++ b/test/README.md
@@ -3,7 +3,7 @@
 ## Creating Docker container for CircleCI
 
 ```bash
-export VERSION=1.0.0 # Increment this version each time when you edit Dockerfile.
+export VERSION=1.1.0 # Increment this version each time when you edit Dockerfile.
 
 docker login # Ask webops for Docker Hub access to the ukti group.
 docker build -f test/Dockerfile -t data-hub-frontend-test .


### PR DESCRIPTION
**Implementation notes**

Use Chrome 74 for functional tests as the version 75 returns random error.
At some point this issue needs to be investigated closer.

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
