### PR TITLE
Ensure activity feed content loads

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -14,7 +14,7 @@ async function renderActivityFeed (req, res, next) {
       .render('companies/apps/activity-feed/views/container', {
         params: {
           ...addContentParams,
-          apiEndpoint: `/companies/${company.id}/activity-feed/data`,
+          apiEndpoint: `/companies/${company.id}/activity/data`,
         },
       })
   } catch (error) {

--- a/test/functional/cypress/selectors/company/activity.js
+++ b/test/functional/cypress/selectors/company/activity.js
@@ -1,0 +1,8 @@
+module.exports = {
+  activityFeed: {
+    item: (number) => {
+      return `#activity-feed-app > div > ol > li:nth-child(${number})`
+    },
+    noActivites: '#activity-feed-app > div > div:nth-child(3)',
+  },
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -1,3 +1,4 @@
+exports.companyActivity = require('./company/activity')
 exports.companyBusinessDetails = require('./company/business-details')
 exports.companyAddStep2 = require('./company/add-step-2')
 exports.companyEdit = require('./company/edit')

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -6,6 +6,7 @@ describe('Company activity feed', () => {
     expectedHeading,
     expectedAddress,
     expectedCompanyId,
+    expectedActivitiesHeading,
   }) => {
     it('should render breadcrumbs', () => {
       cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
@@ -38,7 +39,7 @@ describe('Company activity feed', () => {
     })
 
     it('should display the "Activities" heading', () => {
-      cy.get(selectors.companyCollection().heading).should('have.text', 'Activities')
+      cy.get(selectors.companyCollection().heading).should('have.text', expectedActivitiesHeading)
     })
   }
 
@@ -51,10 +52,19 @@ describe('Company activity feed', () => {
       expectedHeading: fixtures.company.venusLtd.name,
       expectedAddress: '66 Marcham Road, Bordley, BD23 8RZ, United Kingdom',
       expectedCompanyId: fixtures.company.venusLtd.id,
+      expectedActivitiesHeading: 'Activities',
     })
 
     it('should display "Add interaction" button', () => {
       cy.get(selectors.companyCollection().interaction.addButton(fixtures.company.venusLtd.id)).should('have.text', 'Add interaction')
+    })
+
+    it('should not display the activity feed', () => {
+      cy.get(selectors.companyActivity.activityFeed.item(1)).should('not.be.visible')
+    })
+
+    it('should display the "There are no activities to show." message', () => {
+      cy.get(selectors.companyActivity.activityFeed.noActivites).should('be.visible')
     })
   })
 
@@ -67,6 +77,7 @@ describe('Company activity feed', () => {
       expectedHeading: fixtures.company.archivedLtd.name,
       expectedAddress: '16 Getabergsvagen, Geta, 22340, Malta',
       expectedCompanyId: fixtures.company.archivedLtd.id,
+      expectedActivitiesHeading: '1 activities',
     })
 
     it('should display the badge', () => {
@@ -85,6 +96,14 @@ describe('Company activity feed', () => {
 
     it('should not display the "Add interaction" button', () => {
       cy.get(selectors.companyCollection().interaction.addButton(fixtures.company.archivedLtd.id)).should('not.exist')
+    })
+
+    it('should display the activity feed', () => {
+      cy.get(selectors.companyActivity.activityFeed.item(1)).should('be.visible')
+    })
+
+    it('should not display the "There are no activities to show." message', () => {
+      cy.get(selectors.companyActivity.activityFeed.noActivites).should('not.be.visible')
     })
   })
 })

--- a/test/unit/apps/companies/apps/activity-feed/controllers.test.js
+++ b/test/unit/apps/companies/apps/activity-feed/controllers.test.js
@@ -85,7 +85,7 @@ describe('Activity feed controllers', () => {
           params: {
             addContentLink: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/interactions/create',
             addContentText: 'Add interaction',
-            apiEndpoint: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/activity-feed/data',
+            apiEndpoint: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/activity/data',
           },
         })
       })
@@ -122,7 +122,7 @@ describe('Activity feed controllers', () => {
       it('should render the template without the "Add interaction" button', () => {
         expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly('companies/apps/activity-feed/views/container', {
           params: {
-            apiEndpoint: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/activity-feed/data',
+            apiEndpoint: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/activity/data',
           },
         })
       })


### PR DESCRIPTION
## Change
A bug was introduced so that activity feed content was not loading. This change fixes that and adds test to ensure the activity feed loads.

## Screenshot
Broken in `DEV`

![Screenshot 2019-06-20 at 14 52 26](https://user-images.githubusercontent.com/1150417/59854586-200cbc00-936b-11e9-9271-fdc48982fd34.png)

## Steps to test
Browse to any company.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
