### PR TITLE
Add filter to show only pre-approved activity types on the activity feed

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -110,6 +110,12 @@ const config = {
   },
   activityFeed: {
     paginationSize: 20,
+    supportedActivityTypes: [
+      'dit:Interaction',
+      'dit:ServiceDelivery',
+      'dit:InvestmentProject',
+      'dit:OMISOrder',
+    ],
   },
 }
 

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -17,6 +17,7 @@ function fetchActivityFeed ({
       bool: {
         filter: [
           { term: { 'object.attributedTo.id': `dit:DataHubCompany:${companyId}` } },
+          { terms: { 'object.type': config.activityFeed.supportedActivityTypes } },
         ],
       },
     },

--- a/test/unit/apps/companies/apps/activity-feed/repos.test.js
+++ b/test/unit/apps/companies/apps/activity-feed/repos.test.js
@@ -23,6 +23,12 @@ describe('Activity feed repos', () => {
             bool: {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:123' } },
+                { terms: { 'object.type': [
+                  'dit:Interaction',
+                  'dit:ServiceDelivery',
+                  'dit:InvestmentProject',
+                  'dit:OMISOrder',
+                ] } },
               ],
             },
           },
@@ -54,6 +60,12 @@ describe('Activity feed repos', () => {
             bool: {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:undefined' } },
+                { terms: { 'object.type': [
+                  'dit:Interaction',
+                  'dit:ServiceDelivery',
+                  'dit:InvestmentProject',
+                  'dit:OMISOrder',
+                ] } },
               ],
             },
           },
@@ -83,6 +95,12 @@ describe('Activity feed repos', () => {
             bool: {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:undefined' } },
+                { terms: { 'object.type': [
+                  'dit:Interaction',
+                  'dit:ServiceDelivery',
+                  'dit:InvestmentProject',
+                  'dit:OMISOrder',
+                ] } },
               ],
             },
           },


### PR DESCRIPTION
**Implementation notes**

https://trello.com/c/ZbBtWQTa/1323-show-only-pre-approved-activity-types-on-the-activity-feed

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
