### PR TITLE
Set the node/yarn version in the development Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 
 FROM ubuntu:16.04
 
-ENV NODE_VERSION  8.15.1
-ENV YARN_VERSION  1.15.2
+ENV NODE_VERSION  10.16.0
+ENV YARN_VERSION  1.16.0
 ENV NVM_DIR       /usr/local/nvm
 ENV NODE_PATH     $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
 ENV PATH          $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH


### PR DESCRIPTION
**Implementation notes**

This adjusts `Dockerfile` to set the correct node/yarn version now we are using node10.  The dockerfile is only used in local development.

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
