### PR TITLE
Increase options limit so all lists can be scrolled to the end

### DIFF
--- a/assets/javascripts/vue/typeahead.vue
+++ b/assets/javascripts/vue/typeahead.vue
@@ -33,7 +33,7 @@
       :loading="isLoading"
       :multiple="multipleSelect"
       :options="options"
-      :options-limit="500"
+      :options-limit="1500"
       :show-no-results="false"
       :showLabels="false"
       :searchable="true"


### PR DESCRIPTION
## Problem
Within the typeahead there is a limit set to 500 options so if a drop down list has options greater than 500 you cannot scroll to the end.

## Solution
Increase the limit to 1500

## Test instructions
Go to interactions and choose "teams" you should be able to scroll all options
 
## Screenshots
### Before
![Screenshot 2019-06-27 at 13 05 15](https://user-images.githubusercontent.com/10154302/60264914-3cb17280-98dc-11e9-86d3-61682c3d9d10.png)

### After
![Screenshot 2019-06-27 at 13 05 39](https://user-images.githubusercontent.com/10154302/60264943-4fc44280-98dc-11e9-8594-8862fce1954d.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
