### PR TITLE
Upgrade Data Hub components to 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^0.3.2",
+    "data-hub-components": "^0.3.5",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -77,7 +77,7 @@ describe('Company activity feed', () => {
       expectedHeading: fixtures.company.archivedLtd.name,
       expectedAddress: '16 Getabergsvagen, Geta, 22340, Malta',
       expectedCompanyId: fixtures.company.archivedLtd.id,
-      expectedActivitiesHeading: '1 activities',
+      expectedActivitiesHeading: '1 activity',
     })
 
     it('should display the badge', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,17 +3969,19 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-0.3.2.tgz#b4df633fb057520bd289723ec231807ddf0e6321"
-  integrity sha512-FnkS8e7t+ALgCmN6WDPb2u1LV5JROBPhFv0vFqrDKU7Kixy3Qlx9s2KaZ83SE2rkwRyDIAeMRVFTPopehlUXDg==
+data-hub-components@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-0.3.5.tgz#9d8b4c04cb36c8f91ca256acd47d45c0b91ca5b9"
+  integrity sha512-0ZUMfD1fwzJIhoYP0df/BNQZcoIyF5vw7jqF+ceJ6nc8gpHzM4REoi4PtTMXRnDlMBEyxWbBzjAAapaKbIjmHw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/constants" "^0.7.1"
     axios "^0.19.0"
+    govuk-colours "^1.0.3"
     govuk-react "^0.7.0"
     lodash "^4.17.11"
     moment "^2.24.0"
+    pluralise "^1.0.1"
     prop-types "^15.7.2"
     react-markdown "^4.0.8"
     styled-components "^4.2.0"
@@ -10467,6 +10469,11 @@ please-upgrade-node@^3.0.2:
   integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
   dependencies:
     semver-compare "^1.0.0"
+
+pluralise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pluralise/-/pluralise-1.0.1.tgz#c17a240ca8c6febb1439f7d2e78077defd128500"
+  integrity sha512-C2ddX33ihY6e3S7JYG8FspCf0o08D8tsXef2zcEx9geuX3vlOhkmUy6pXjRvmlVC60p7J5l3OxviKMFWLMs/0g==
 
 pluralize@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Description of change

Upgrades Data Hub components to 0.3.4 which includes:
- ability to show OMIS activity items
- activity feed contact links
- activity feed header update
- more specific service delivery activity item
- default activity card removed (blank items)
- activity feed responsive CSS

## Test instructions
Open a company page and view the activity feed.

*This should wait for #2040*

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
