### PR TITLE
Fix sorting on the Activity Feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ local.log
 # Yarn version policy
 .yarnrc
 .yarn/
+
+# NVM version
+.nvmrc

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -11,7 +11,14 @@ function fetchActivityFeed ({
     size,
     from,
     sort: {
-      'object.startTime': 'desc',
+      _script: {
+        type: 'string',
+        script: {
+          lang: 'painless',
+          source: "return !doc['object.startTime'].empty ? doc['object.startTime'].value : doc['published'].value",
+        },
+        order: 'desc',
+      },
     },
     query: {
       bool: {

--- a/test/unit/apps/companies/apps/activity-feed/repos.test.js
+++ b/test/unit/apps/companies/apps/activity-feed/repos.test.js
@@ -1,6 +1,17 @@
 const config = require('~/config')
 const activityFeedRawFixture = require('~/test/unit/data/activity-feed/activity-feed-from-es')
+
 const token = 'abcd'
+const sortQuery = {
+  _script: {
+    type: 'string',
+    script: {
+      lang: 'painless',
+      source: "return !doc['object.startTime'].empty ? doc['object.startTime'].value : doc['published'].value",
+    },
+    order: 'desc',
+  },
+}
 
 describe('Activity feed repos', () => {
   beforeEach(() => {
@@ -33,7 +44,7 @@ describe('Activity feed repos', () => {
             },
           },
           size: 21,
-          sort: { 'object.startTime': 'desc' },
+          sort: sortQuery,
         }
         expect(this.authorisedRequestStub).to.be.calledOnceWith(token, {
           body: expectedBody,
@@ -55,7 +66,7 @@ describe('Activity feed repos', () => {
         const expectedBody = {
           from: 0,
           size: 20,
-          sort: { 'object.startTime': 'desc' },
+          sort: sortQuery,
           query: {
             bool: {
               filter: [
@@ -90,7 +101,7 @@ describe('Activity feed repos', () => {
         const expectedBody = {
           from: 0,
           size: 20,
-          sort: { 'object.startTime': 'desc' },
+          sort: sortQuery,
           query: {
             bool: {
               filter: [


### PR DESCRIPTION
## Description of change

https://trello.com/c/5rX6Jygn/1372-fix-sorting-of-the-activities

Current sorting on the activity feed is only using `object.startDate` field which doesn't exists on some of the activities.

This PR is introducing a dynamic sorting which uses `object.startDate` as the default sorting field and `published` as a secondary field in case if the `startDate` doesn't exists in the document.

## Test instructions

Check if activities are correctly sorted, a good example can be found on the DEV environment:
https://www.datahub.dev.uktrade.io/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd/activity/data

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
