### PR TITLE
Fix unvalidated dynamic method call in interactions and use 'kind' of interaction from the database where possible. Edit existing and add new tests.

### DIFF
--- a/src/apps/interactions/transformers/interaction-response-to-form.js
+++ b/src/apps/interactions/transformers/interaction-response-to-form.js
@@ -21,6 +21,7 @@ function transformInteractionResponseToForm ({
   date,
   company,
   communication_channel,
+  kind,
 } = {}) {
   if (!id) return null
   const isValidDate = isValid(new Date(date))
@@ -62,6 +63,7 @@ function transformInteractionResponseToForm ({
     },
     company: get(company, 'id'),
     communication_channel: get(communication_channel, 'id'),
+    kind,
   }
 }
 

--- a/test/unit/apps/interactions/transformers/interaction-response-to-form.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-response-to-form.test.js
@@ -1,5 +1,6 @@
 const transformInteractionResponseToForm = require('~/src/apps/interactions/transformers/interaction-response-to-form')
 const mockInteraction = require('~/test/unit/data/interactions/interaction-with-feedback.json')
+
 const mockInteractionNoFeedback = { ...mockInteraction }
 
 describe('#transformInteractionResponseToForm', () => {
@@ -29,6 +30,7 @@ describe('#transformInteractionResponseToForm', () => {
           date: { day: '25', month: '11', year: '2058' },
           company: '0f5216e0-849f-11e6-ae22-56b6b6499611',
           communication_channel: '70c226d7-5d95-e211-a939-e4115bead28a',
+          kind: 'interaction',
         }
       )
     })
@@ -70,6 +72,7 @@ describe('#transformInteractionResponseToForm', () => {
           date: { day: '25', month: '11', year: '2058' },
           company: '0f5216e0-849f-11e6-ae22-56b6b6499611',
           communication_channel: '70c226d7-5d95-e211-a939-e4115bead28a',
+          kind: 'interaction',
         })
     })
   })
@@ -107,6 +110,7 @@ describe('#transformInteractionResponseToForm', () => {
           date: { day: '25', month: '11', year: '2058' },
           company: '0f5216e0-849f-11e6-ae22-56b6b6499611',
           communication_channel: '70c226d7-5d95-e211-a939-e4115bead28a',
+          kind: 'interaction',
         }
       )
     })
@@ -140,6 +144,7 @@ describe('#transformInteractionResponseToForm', () => {
           date: { day: '25', month: '11', year: '2058' },
           company: '0f5216e0-849f-11e6-ae22-56b6b6499611',
           communication_channel: '70c226d7-5d95-e211-a939-e4115bead28a',
+          kind: 'interaction',
         }
       )
     })


### PR DESCRIPTION
Fix `unvalidated dynamic method call` in interactions and use `kind` of interaction from the database where possible. Edit existing and add new tests.

## Description of change

This is a fix for the `unvalidated dynamic method call `causing the lgtm alert here - https://lgtm.com/projects/g/uktrade/data-hub-frontend/snapshot/5a4537e7dfc6cd5d9b44e3571688ab2cc11bfc62/files/src/apps/interactions/controllers/edit.js?sort=name&dir=ASC&mode=heatmap#xf6399df9ec561b58:1

The `unvalidated dynamic method call` is fixed by using `.hasOwnProperty` object method to make sure the variable passed to `formConfigs` is either `interaction` or `service-delivery`.

The only functional change is that for existing interactions and service deliveries the type of form displayed - service delivery or interaction - is determined by the `kind` stored in the database and is not drawn from the `URL params`. This is to make the code more robust by not allowing a user to erroneously change the `URL params` to be able to submit incorrect data to the database with the incorrect form. This will become more important in the future as the interaction forms increasingly diverge to provide a more bespoke user experience depending on the type of interaction. 

When creating new interactions the `kind` continues to be drawn from the `URL params` as there is not yet any data in the database.

## Test instructions

_What should I see?_

Interactions should function exactly the same as before. 
 
## Screenshots

No visible changes to the user

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
