### PR TITLE
Bugfix/remove duplicate operand companyName in the interactions fields macro

### DIFF
--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -28,7 +28,7 @@ async function getHiddenFields (req, res, interactionId) {
 
 async function buildForm (req, res, interactionId, validatedKind) {
   const options = await getInteractionOptions(req, res)
-  const hiddenFields = await getHiddenFields(req, res, interactionId, validatedKind)
+  const hiddenFields = await getHiddenFields(req, res, interactionId)
   const returnLink = joinPaths([ getReturnLink(res.locals.interactions), interactionId ])
 
   const formProperties = {

--- a/src/apps/interactions/macros/fields.js
+++ b/src/apps/interactions/macros/fields.js
@@ -130,7 +130,7 @@ module.exports = {
     return {
       macroName: 'FormSubHeading',
       heading: 'Interaction Participants',
-      secondaryHeading: companyName && companyName,
+      secondaryHeading: companyName,
     }
   },
   detailsHeading: {

--- a/src/apps/interactions/transformers/interaction-response-to-form.js
+++ b/src/apps/interactions/transformers/interaction-response-to-form.js
@@ -20,6 +20,7 @@ function transformInteractionResponseToForm ({
   date,
   company,
   communication_channel,
+  kind,
 } = {}) {
   if (!id) return null
   const isValidDate = isValid(new Date(date))
@@ -50,6 +51,7 @@ function transformInteractionResponseToForm ({
     },
     company: get(company, 'id'),
     communication_channel: get(communication_channel, 'id'),
+    kind,
   }
 }
 

--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -507,7 +507,7 @@ describe('Interaction edit controller (Interactions)', () => {
   context('When adding an interaction from a company', () => {
     beforeEach(async () => {
       this.req.params = {
-        ...this.req.parms,
+        ...this.req.params,
         theme: 'export',
         kind: 'interaction',
       }
@@ -1087,13 +1087,12 @@ describe('Interaction edit controller (Interactions)', () => {
     })
   })
 
-  context('when an interaction has no kind', () => {
+  context('when a new interaction has no kind', () => {
     beforeEach(async () => {
       this.req.params = {
         ...this.req.parms,
         theme: 'export',
         kind: '',
-        interactionId: 'af4aac84-4d6a-47df-a733-5a54e3008c32',
       }
 
       this.res.locals = {
@@ -1101,8 +1100,56 @@ describe('Interaction edit controller (Interactions)', () => {
           id: '1',
           name: 'Fred ltd.',
         },
-        interaction: {
-          ...interactionData,
+        form: {
+          errors: {
+            messages: {
+              subject: ['Error message'],
+            },
+          },
+        },
+        requestBody: {
+          subject: 'a',
+        },
+      }
+
+      nock(config.apiRoot)
+        .get('/v3/contact?company_id=1&limit=500')
+        .reply(200, { results: this.contactsData })
+        .get('/metadata/team/')
+        .reply(200, this.metadataMock.teamOptions)
+        .get('/metadata/service/?contexts__has_any=export_service_delivery')
+        .reply(200, this.metadataMock.serviceOptions)
+        .get('/adviser/?limit=100000&offset=0')
+        .reply(200, { results: this.activeInactiveAdviserData })
+        .get('/metadata/communication-channel/')
+        .reply(200, this.metadataMock.channelOptions)
+        .get('/metadata/service-delivery-status/')
+        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .get('/metadata/policy-area/')
+        .reply(200, this.metadataMock.policyAreaOptions)
+        .get('/metadata/policy-issue-type/')
+        .reply(200, this.metadataMock.policyIssueType)
+
+      await controller.renderEditPage(this.req, this.res, this.nextStub)
+    })
+    it('should redirect to a 404', () => {
+      expect(this.res.redirect).to.have.been.called
+      expect(this.res.redirect).to.have.been.calledWith('/404')
+    })
+  })
+
+  context('when a new interaction has a kind that does not match service-delivery or interaction', () => {
+    beforeEach(async () => {
+      this.req.params = {
+        ...this.req.parms,
+        theme: 'export',
+        kind: 'not-really-an-interaction',
+      }
+
+      this.res.locals = {
+        company: {
+          id: '1',
+          name: 'Fred ltd.',
         },
         form: {
           errors: {

--- a/test/unit/apps/interactions/transformers/interaction-response-to-form.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-response-to-form.test.js
@@ -28,6 +28,7 @@ describe('#transformInteractionResponseToForm', () => {
         notes: 'Labore culpa quas cupiditate voluptatibus magni.',
         subject: 'ad',
         policy_areas: [],
+        kind: 'interaction',
       })
     })
   })
@@ -67,6 +68,7 @@ describe('#transformInteractionResponseToForm', () => {
         notes: 'Labore culpa quas cupiditate voluptatibus magni.',
         subject: 'ad',
         policy_areas: [],
+        kind: 'interaction',
       })
     })
   })
@@ -103,6 +105,7 @@ describe('#transformInteractionResponseToForm', () => {
         notes: 'Labore culpa quas cupiditate voluptatibus magni.',
         subject: 'ad',
         policy_areas: [],
+        kind: 'interaction',
       })
     })
   })
@@ -134,6 +137,7 @@ describe('#transformInteractionResponseToForm', () => {
         notes: 'Labore culpa quas cupiditate voluptatibus magni.',
         subject: 'ad',
         policy_areas: [],
+        kind: 'interaction',
       })
     })
   })


### PR DESCRIPTION
## Description of change

Remove duplicate operand companyName in the interactions fields macro

There is a duplicate operand `companyName && companyName`. There doesn't seem to be any reason for this operator and so I have simply replaced it with the variable `companyName`. 

## Test instructions

No visible changes.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
