### PR TITLE
Delete duplicate operand companyName in interaction fields macro

### DIFF
--- a/src/apps/interactions/macros/fields.js
+++ b/src/apps/interactions/macros/fields.js
@@ -207,7 +207,7 @@ module.exports = {
     return {
       macroName: 'FormSubHeading',
       heading: 'Interaction Participants',
-      secondaryHeading: companyName && companyName,
+      secondaryHeading: companyName,
     }
   },
   detailsHeading: {


### PR DESCRIPTION
## Description of change

Remove duplicate operand `companyName` in the interactions fields macro

There is a duplicate operand `companyName && companyName`. There doesn't seem to be any reason for this operator and so I have simply replaced it with the variable `companyName`.
 
## Screenshots

No visible changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
