### PR TITLE
prevent unvalidated redirect from '/:companyId/investments/'

### DIFF
--- a/src/apps/companies/apps/investments/router.js
+++ b/src/apps/companies/apps/investments/router.js
@@ -4,7 +4,7 @@ const growthCapitalProfileRouter = require('./growth-capital-profile/router')
 
 const router = require('express').Router()
 
-router.get('/', (req, res, next) => res.redirect(`${req.originalUrl}/projects`))
+router.get('/', (req, res, next) => res.redirect(`${res.locals.ORIGINAL_URL}/projects`))
 router.use('/projects', projectsRouter)
 router.use('/large-capital-profile', largeCapitalProfileRouter)
 router.use('/growth-capital-profile', growthCapitalProfileRouter)


### PR DESCRIPTION
## Description of change

Replace `req.originalURL` with `res.locals.ORIGINAL_URL` in company investment router in order to prevent unvalidated redirect as per this lgtm alert (https://lgtm.com/projects/g/uktrade/data-hub-frontend/snapshot/450ce6fc03cea40cac751f5a7ba955bd7579341d/files/src/apps/companies/apps/investments/router.js?sort=name&dir=ASC&mode=heatmap#x83b401f56979a58d:1)

Using `res.locals.ORIGINAL_URL` sanitises the url as the middleware takes the `baseUrl` and checks if it has the https prefix and then adds the host path. This prevents the route redirecting the user off of the site. It then appends the `baseUrl` with the `req.originalUrl`. 

This is existing middleware and so there is no new code required.

## Test instructions

When you click the investment tab on the company page the url should successfully redirect from '/:companyId/investments/' to '/:companyId/investments/projects'
 
## Screenshots

No visible changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
