### PR TITLE
Replace req.originalUrl with res.locals.ORIGINAL_URL in documents upload middleware

### DIFF
--- a/src/apps/documents/middleware/upload.js
+++ b/src/apps/documents/middleware/upload.js
@@ -25,7 +25,7 @@ function parseForm (req, res) {
         })
       } catch (e) {
         req.flash('error', e.message)
-        res.redirect(req.originalUrl)
+        res.redirect(res.locals.ORIGINAL_URL)
       }
 
       if (collection.length === index + 1) {


### PR DESCRIPTION
## Description of change

Replace `req.originalURL` with `res.locals.ORIGINAL_URL` in documents upload middleware in order to prevent unvalidated redirect as per this lgtm alert (https://lgtm.com/projects/g/uktrade/data-hub-frontend/snapshot/450ce6fc03cea40cac751f5a7ba955bd7579341d/files/src/apps/documents/middleware/upload.js?sort=name&dir=ASC&mode=heatmap#x1d69251715af46dc:1)

Using res.locals.ORIGINAL_URL sanitises the url as the middleware takes the baseUrl and checks if it has the https prefix and then adds the host path. This prevents the route redirecting the user off of the site. It then appends the baseUrl with the req.originalUrl.

This is existing middleware and so there is no new code required.

## Test instructions

The user should still be redirected back to where they came from when there is an error uploading a file.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
