### PR TITLE
Bugfix/prevet unvalidated redirect from omis controller edit lead assignee

### DIFF
--- a/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
+++ b/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
@@ -6,7 +6,9 @@ async function editLeadAssignee (req, res, next) {
   const adviserId = req.body.adviserId
   const orderId = req.body.orderId
 
-  if (!adviserId || !orderId) { return res.redirect(res.locals.ORIGINAL_URL) }
+  if (!adviserId || !orderId) {
+    return res.redirect(res.locals.ORIGINAL_URL)
+  }
 
   try {
     const allAssignees = await Order.getAssignees(req.session.token, orderId)

--- a/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
+++ b/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
@@ -5,10 +5,9 @@ const { Order } = require('../../../models')
 async function editLeadAssignee (req, res, next) {
   const adviserId = req.body.adviserId
   const orderId = req.body.orderId
-  const returnUrl = req.body.returnUrl || req.header('Referer')
 
-  if (!adviserId || !orderId) {
-    return res.redirect(returnUrl)
+  if (!adviserId || !orderId)
+    return res.redirect(res.locals.ORIGINAL_URL)
   }
 
   try {
@@ -23,7 +22,7 @@ async function editLeadAssignee (req, res, next) {
     await Order.saveAssignees(req.session.token, orderId, assignees)
 
     req.flash('success', `Lead adviser in the market set to ${get(leadAdviser, 'adviser.name')}`)
-    res.redirect(returnUrl)
+    res.redirect(res.locals.ORIGINAL_URL)
   } catch (error) {
     next(error)
   }

--- a/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
+++ b/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
@@ -6,9 +6,7 @@ async function editLeadAssignee (req, res, next) {
   const adviserId = req.body.adviserId
   const orderId = req.body.orderId
 
-  if (!adviserId || !orderId)
-    return res.redirect(res.locals.ORIGINAL_URL)
-  }
+  if (!adviserId || !orderId) { return res.redirect(res.locals.ORIGINAL_URL) }
 
   try {
     const allAssignees = await Order.getAssignees(req.session.token, orderId)


### PR DESCRIPTION
## Description of change

Replace `returnUrl` with `res.locals.ORIGINAL_URL` in documents upload middleware in order to prevent unvalidated redirect as per this lgtm alert (https://lgtm.com/projects/g/uktrade/data-hub-frontend/snapshot/450ce6fc03cea40cac751f5a7ba955bd7579341d/files/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js?sort=name&dir=ASC&mode=heatmap)

Using res.locals.ORIGINAL_URL sanitises the url as the middleware takes the baseUrl and checks if it has the https prefix and then adds the host path. This prevents the route redirecting the user off of the site. It then appends the baseUrl with the req.originalUrl.

This is existing middleware and so there is no new code required.

This is slightly different to the other two fixes to similar alerts as this controller had a variable `returnUrl`. However, `res.locals.ORIGINAL_URL` should do the same job with less code. 

## Test instructions

The user should still be redirected back to where they came from if there is no advisor or no order, and when the user has been successful in updating the lead adviser in the market.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
