### PR TITLE
Add dependabot to keep `data-hub-components` updated

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,24 @@
+# Documentation: https://dependabot.com/docs/config-file
+
+version: 1
+update_configs:
+  - package_manager: javascript
+    directory: "/"
+    update_schedule: live
+    target_branch: develop
+    default_reviewers:
+      - datahub-fed
+    allowed_updates:
+      - match:
+          update_type: "security"
+
+  - package_manager: javascript
+    directory: "/"
+    update_schedule: weekly
+    target_branch: develop
+    version_requirement_updates: increase_versions
+    default_reviewers:
+      - datahub-fed
+    allowed_updates:
+      - match:
+          dependency_name: "data-hub-components"


### PR DESCRIPTION
## Description of change

Use dependabot to keep https://github.com/uktrade/data-hub-components updated.

## Test instructions

Opens a PR every week (Monday) with updates to the https://github.com/uktrade/data-hub-components package, so we don't have to do this manually.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
