### PR TITLE
Measure tests coverage with Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,9 @@ jobs:
           path: coverage
       - store_artifacts:
           path: coverage
+      - run:
+          name: Publish coverage to Codecov
+          command: bash <(curl -s https://codecov.io/bash)
 
   # Run unit client tests and store results
   unit_client_tests:


### PR DESCRIPTION
## Description of change

This PR add a step to CircleCI which will publish coverage of our unit tests to Codecov. It will allow us to monitor how well our code is covered.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
