### PR TITLE
Filter service option names on events

### DIFF
--- a/test/unit/apps/events/controllers/edit.test.js
+++ b/test/unit/apps/events/controllers/edit.test.js
@@ -5,6 +5,7 @@ const config = require('~/config')
 const eventData = require('~/test/unit/data/events/event.json')
 const adviserFilters = require('~/src/apps/adviser/filters')
 const serviceOptionData = require('~/test/unit/data/interactions/service-options-data.json')
+const { filterServiceNames } = require('../../../../../src/apps/events/controllers/edit')
 
 const yesterday = moment().subtract(1, 'days').toISOString()
 const lastMonth = moment().subtract(1, 'months').toISOString()
@@ -362,6 +363,23 @@ describe('Event edit controller', () => {
 
         expect(actualErrors).to.deep.equal(expectedErrors)
       })
+    })
+  })
+
+  describe('#filterServiceNames', () => {
+    this.testData = [
+      { label: 'A Specific DIT Export Service or Funding : label with excluded strings' },
+      { label: 'A Specific Service : label with excluded strings2' },
+      { label: 'label without excluded strings' },
+    ]
+
+    this.expected = [
+      { label: 'label with excluded strings' },
+      { label: 'label with excluded strings2' },
+      { label: 'label without excluded strings' },
+    ]
+    it('should transform labels excluding strings in exlusion list', async () => {
+      expect(filterServiceNames(this.testData)).to.deep.equal(this.expected)
     })
   })
 })


### PR DESCRIPTION
## Description of change
Temporary change to filter service names on event's page. Will be removed in 4 weeks.

Removes following strings from displaying in the service options dropdown within events: 
`'A Specific DIT Export Service or Funding', 'A Specific Service',`

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
