### PR TITLE
Bug - remove TAP from interaction form and sort service options

### DIFF
--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -1,4 +1,4 @@
-const { assign } = require('lodash')
+const { assign, sortBy } = require('lodash')
 const { globalFields } = require('../../macros')
 
 const eventFormConfig = ({
@@ -97,7 +97,7 @@ const eventFormConfig = ({
         options: teams,
       }),
       assign({}, globalFields.serviceDeliveryServices, {
-        options: services,
+        options: sortBy(services, (option) => option.label),
       }),
       {
         macroName: 'Typeahead',

--- a/src/apps/interactions/macros/interaction-form.js
+++ b/src/apps/interactions/macros/interaction-form.js
@@ -32,8 +32,6 @@ module.exports = function ({
   areas,
   types,
   company,
-  tapServices = [],
-  statuses = [],
 }) {
   return {
     returnLink,
@@ -43,28 +41,6 @@ module.exports = function ({
     children: [
       serviceHeading,
       ...service(services),
-      {
-        macroName: 'MultipleChoiceField',
-        name: 'service_delivery_status',
-        initialOption: '-- Select service status --',
-        options: statuses,
-        optional: true,
-        modifier: ['subfield', 'medium'],
-        condition: {
-          name: 'subService',
-          value: tapServices.length && tapServices.join('||'),
-        },
-      },
-      {
-        macroName: 'TextField',
-        name: 'grant_amount_offered',
-        optional: true,
-        modifier: ['subfield', 'medium'],
-        condition: {
-          name: 'subService',
-          value: tapServices.length && tapServices.join('||'),
-        },
-      },
       participantsHeading(company),
       contact(contacts),
       adviser(advisers),

--- a/src/apps/interactions/services/interaction-options.js
+++ b/src/apps/interactions/services/interaction-options.js
@@ -88,7 +88,7 @@ async function getInteractionFormOptions (token, createdOn, req, res) {
         []
       )
       .filter(service => includes(service.label, '(TAP)'))
-      .map(service => service.value),
+      .map(service => service.value) || [],
     statuses: await getOptions(token, 'service-delivery-status', {
       createdOn,
       sorted: false,

--- a/src/apps/interactions/transformers/interaction-to-options.js
+++ b/src/apps/interactions/transformers/interaction-to-options.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { uniqBy } = require('lodash')
+const { uniqBy, sortBy } = require('lodash')
 
 function transformServicesOptions (services) {
   const deliminator = ' : '
@@ -11,11 +11,11 @@ function transformServicesOptions (services) {
           value: q.id,
           label: q.name,
           options:
-              q.answer_options &&
-              q.answer_options.map(o => ({
-                label: o.name,
-                value: o.id,
-              })),
+            q.answer_options &&
+            q.answer_options.map(o => ({
+              label: o.name,
+              value: o.id,
+            })),
         }
       })
       : []
@@ -79,7 +79,7 @@ function transformServicesOptions (services) {
     return {
       ...service,
       interactionQuestions,
-      secondaryOptions,
+      secondaryOptions: sortBy(secondaryOptions, (option) => option.label),
     }
   })
 

--- a/test/unit/apps/interactions/controllers/edit.interaction.test.js
+++ b/test/unit/apps/interactions/controllers/edit.interaction.test.js
@@ -324,16 +324,6 @@ describe('Interaction edit controller (Interactions)', () => {
           type: 'radio',
         },
         {
-          label: 'Service status',
-          macroName: 'MultipleChoiceField',
-          name: 'service_delivery_status',
-        },
-        {
-          label: 'Grant offered',
-          macroName: 'TextField',
-          name: 'grant_amount_offered',
-        },
-        {
           label: undefined,
           macroName: 'FormSubHeading',
           heading: 'Interaction Participants',
@@ -682,18 +672,6 @@ describe('Interaction edit controller (Interactions)', () => {
           macroName: 'MultipleChoiceField',
           type: 'radio',
           value: undefined,
-        },
-        {
-          label: 'Service status',
-          macroName: 'MultipleChoiceField',
-          name: 'service_delivery_status',
-          value: undefined,
-        },
-        {
-          label: 'Grant offered',
-          macroName: 'TextField',
-          name: 'grant_amount_offered',
-          value: null,
         },
         {
           label: undefined,
@@ -1095,18 +1073,6 @@ describe('Interaction edit controller (Interactions)', () => {
           macroName: 'MultipleChoiceField',
           type: 'radio',
           value: undefined,
-        },
-        {
-          name: 'service_delivery_status',
-          label: 'Service status',
-          macroName: 'MultipleChoiceField',
-          value: undefined,
-        },
-        {
-          name: 'grant_amount_offered',
-          label: 'Grant offered',
-          macroName: 'TextField',
-          value: null,
         },
         {
           label: undefined,


### PR DESCRIPTION
## Description of change
1. We need to remove the additional TAP options when choosing an interaction.
2. We need to sort the secondary service options in alphabetical order.

## Test instructions
1. Go to add a new interaction via contacts/companies
2. Choose export > interaction
3. In the service dropdown list choose a TAP option
 
## Screenshots
### Before
![Screenshot 2019-07-17 at 11 33 43](https://user-images.githubusercontent.com/10154302/61368921-d7232700-a886-11e9-8ad7-77a4c31e26ff.png)


### After

![Screenshot 2019-07-17 at 11 29 23](https://user-images.githubusercontent.com/10154302/61368854-b78bfe80-a886-11e9-9add-fbf1ed8a6856.png)

2. Do the steps above and you should see the following in alphabetical order
### Before
![Screenshot 2019-07-17 at 11 36 36](https://user-images.githubusercontent.com/10154302/61369069-2d906580-a887-11e9-8597-b21dbc1c0deb.png)

### After
![Screenshot 2019-07-17 at 11 29 30](https://user-images.githubusercontent.com/10154302/61369084-3719cd80-a887-11e9-8b0e-383e456f267c.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
