### PR TITLE
Guard against no service being submitted

### DIFF
--- a/src/apps/interactions/transformers/interaction-form-body-to-api.js
+++ b/src/apps/interactions/transformers/interaction-form-body-to-api.js
@@ -14,28 +14,30 @@ function transformInteractionFormBodyToApiRequest (props, services) {
   const selectedServiceOption = services.find(
     service => service.value === props.service
   )
+
   const serviceAnswers = {}
+  let service = null
+  if (selectedServiceOption) {
+    const serviceHasSecondaryOptions = !!selectedServiceOption.secondaryOptions.length
 
-  const serviceHasSecondaryOptions = !!selectedServiceOption.secondaryOptions
-    .length
+    service = serviceHasSecondaryOptions
+      ? props.subService.find(id => id.length)
+      : selectedServiceOption.value
 
-  const service = serviceHasSecondaryOptions
-    ? props.subService.find(id => id.length)
-    : selectedServiceOption.value
+    const serviceOptionStore = serviceHasSecondaryOptions
+      ? selectedServiceOption.secondaryOptions[0]
+      : selectedServiceOption
 
-  const serviceOptionStore = serviceHasSecondaryOptions
-    ? selectedServiceOption.secondaryOptions[0]
-    : selectedServiceOption
-
-  serviceOptionStore.interactionQuestions.map(interactionQuestion => {
-    for (const [key, value] of Object.entries(props)) {
-      if (key === interactionQuestion.value) {
-        serviceAnswers[key] = {
-          [value]: {},
+    serviceOptionStore.interactionQuestions.map(interactionQuestion => {
+      for (const [key, value] of Object.entries(props)) {
+        if (key === interactionQuestion.value) {
+          serviceAnswers[key] = {
+            [value]: {},
+          }
         }
       }
-    }
-  })
+    })
+  }
 
   return omit(
     {

--- a/test/unit/apps/interactions/transformers/interaction-form-body-to-api.test.js
+++ b/test/unit/apps/interactions/transformers/interaction-form-body-to-api.test.js
@@ -141,4 +141,26 @@ describe('#transformInteractionFormBodyToApiRequest', () => {
       })
     }
   )
+
+  context(
+    'when no selected service can be found',
+    () => {
+      beforeEach(() => {
+        this.transformed = transformInteractionFormBodyToApiRequest(
+          {
+            service: undefined,
+          },
+          transformedServices
+        )
+      })
+
+      it('should post a null as service value', () => {
+        expect(this.transformed.service).to.equal(null)
+      })
+
+      it('should return service answers as an empty object', () => {
+        expect(this.transformed.service_answers).to.deep.equal({})
+      })
+    }
+  )
 })


### PR DESCRIPTION
## Description of change

When submitting a interaction with no service the form errors

## Test instructions
Add interaction without a service selected.
 
## Screenshots
### Before 
![Screenshot 2019-07-19 at 11 09 24](https://user-images.githubusercontent.com/10154302/61529492-5c3e4580-aa19-11e9-8350-f1bac2bb5c2d.png)

### After 
![Screenshot 2019-07-19 at 11 37 57](https://user-images.githubusercontent.com/10154302/61529604-ade6d000-aa19-11e9-8b0b-105f137edc92.png)

