### PR TITLE
Upgrade data-hub-components to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^0.4.0",
+    "data-hub-components": "^0.4.1",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,10 +3910,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-0.4.0.tgz#b7a61b934f2fa2cb29f5378002a20e83979cab15"
-  integrity sha512-ln1Vo4PRdN4s2uEbYUH5XTqr/GMez/0GpXWB4sLAg4/4TFZvUkJlfNJJnL7IejCZOW+YSu3WDM3CE+UjYmrUCw==
+data-hub-components@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-0.4.1.tgz#92db2b999640747279a8f59ba35e4dd81df7c6ab"
+  integrity sha512-JbamjUYrXSq8f+/2Ldl2ggR9ICtgi7CvR27tZmhJAwV34eagNOpbmtmambmDjU8Pizy1/4xCD704PyW8HtWwVQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/constants" "^0.7.1"


### PR DESCRIPTION
## Description of change

Version 0.4.1 of Data Hub components includes changes:
- presentation of `Contact` and `Adviser`
- inadvertently fixes contacts not showing in production

## Test instructions

Browse to any company and view the activity feed. `Contact` and `Adviser` should be presented differently.
 
## Screenshots
### Before
<img width="972" alt="Screenshot 2019-07-23 at 11 44 59" src="https://user-images.githubusercontent.com/1150417/61706416-f49d3880-ad3f-11e9-8f96-86caeffb9134.png">

### After 
<img width="977" alt="Screenshot 2019-07-23 at 11 45 09" src="https://user-images.githubusercontent.com/1150417/61706426-fb2bb000-ad3f-11e9-8754-a3dc90f8fb84.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
