### PR TITLE
Use prod environment var when building client-side code on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
       - checkout
       - *restore_yarn_cache
       - run: yarn install --pure-lockfile
-      - run: yarn build
+      - run: yarn build:prod
       - run:
           name: Run client-side unit tests
           command: |
@@ -324,7 +324,7 @@ jobs:
       - *restore_yarn_cache
       - *wait_for_api_sandbox
       - run: yarn install --pure-lockfile
-      - run: yarn build
+      - run: yarn build:prod
       - *start_frontend
       - *wait_for_frontend
       - run:
@@ -349,7 +349,7 @@ jobs:
       - *restore_yarn_cache
       - *wait_for_api_sandbox
       - run: yarn install --pure-lockfile
-      - run: yarn build
+      - run: yarn build:prod
       - *start_frontend
       - *wait_for_frontend
       - run:
@@ -380,7 +380,7 @@ jobs:
       - *wait_for_mock_sso
       - *restore_yarn_cache
       - run: yarn install --pure-lockfile
-      - run: yarn build
+      - run: yarn build:prod
       - *start_frontend
       - *wait_for_frontend
       - run:
@@ -432,7 +432,7 @@ jobs:
       - *wait_for_mock_sso
       - *restore_yarn_cache
       - run: yarn install --pure-lockfile
-      - run: yarn build
+      - run: yarn build:prod
       - *start_frontend
       - *wait_for_frontend
       - *create_cucumber_dirs
@@ -464,7 +464,7 @@ jobs:
       - *wait_for_mock_sso
       - *restore_yarn_cache
       - run: yarn install --pure-lockfile
-      - run: yarn build
+      - run: yarn build:prod
       - *start_frontend
       - *wait_for_frontend
       - *create_cucumber_dirs
@@ -496,7 +496,7 @@ jobs:
       - *wait_for_mock_sso
       - *restore_yarn_cache
       - run: yarn install --pure-lockfile
-      - run: yarn build
+      - run: yarn build:prod
       - *start_frontend
       - *wait_for_frontend
       - *create_cucumber_dirs

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ and be provided with a back end server to provide the API, data storage and sear
     **In production mode:**
     
     ```bash
+    export NODE_ENV=production
     yarn run build && yarn start
     ```
     

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "del .build",
     "start": "node --use-strict src/server.js",
     "build": "npm run clean && webpack",
+    "build:prod": "NODE_ENV=production npm run build",
     "develop": "run-p watch:js:*",
     "watch:test": "npm run test:unit -- -w",
     "watch:js:client": "webpack --watch --progress",
@@ -33,7 +34,6 @@
     "circle:acceptance:dit-staff": "yarn circle:acceptance --skiptags ignore,da,lep",
     "circle:acceptance:da-staff": "yarn circle:acceptance --tag da --skiptags ignore",
     "circle:acceptance:lep-staff": "yarn circle:acceptance --tag lep --skiptags ignore",
-    "heroku-postbuild": "yarn cache clean && npm rebuild && npm run build",
     "lint-staged": "lint-staged"
   },
   "pre-commit": "lint-staged",


### PR DESCRIPTION
## Description of change

CircleCI will now run tests using code compiled same way as on prod.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
