### PR TITLE
Remove unused code that is causing lgtm warning

### DIFF
--- a/src/apps/investments/transformers/project.js
+++ b/src/apps/investments/transformers/project.js
@@ -48,8 +48,6 @@ function transformToApi (body) {
       }
 
       return [{ id: value }]
-    } else if (type === Boolean) {
-      return value === 'true' | false
     }
 
     return { id: value }


### PR DESCRIPTION
## Description of change

To fix the below lgtm warning regarding unclear precedent of nested operators I have removed code from the transformer that checked for booleans. There are no booleans sent back from the form. Even the one field that probably _should_ be a boolean, 'is_referral_source', comes back as the string 'false' or (in place of true) the user's id. 

https://lgtm.com/projects/g/uktrade/data-hub-frontend/snapshot/f6a29cdd09b6a3f4d3d813b9a7665de52e9a4117/files/src/apps/investments/transformers/project.js?sort=name&dir=ASC&mode=heatmap#x94a02476762900c1:1

Screenshot showing the absence of booleans in the body sent from the form to the function in question:

<img width="1634" alt="Screenshot 2019-08-02 at 17 06 13" src="https://user-images.githubusercontent.com/42253716/62383618-1076ba80-b548-11e9-882c-6c758df96616.png">

## Test instructions

Nothing should change

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
