### PR TITLE
Show paragraph breaks in investor details section of large capital profiles

### DIFF
--- a/src/apps/companies/apps/investments/macros/tasklist/tasklist.njk
+++ b/src/apps/companies/apps/investments/macros/tasklist/tasklist.njk
@@ -21,7 +21,7 @@
           <span class="task-list__item-complete">{{ value }}</span>
         {% endfor %}
       {% else %}
-          <span class="task-list__item-complete">{{ props.value }}</span>
+          <span class="task-list__item-complete">{{ props.value | escapeHtml | safe }}</span>
       {% endif %}
     {% else %}
       <strong class="task-list__item-incomplete" id="{{ id | kebabCase }}-incomplete">INCOMPLETE</strong>


### PR DESCRIPTION
## Description of change

Show paragraph breaks in investor details section of large capital profiles to improve readability. 

This uses the same `| escapeHtml | safe` nunjucks filter as interactions does to show breaks in the notes field. 

## Test instructions

You should now be able to see the paragraph breaks in the investor details section of large capital profiles. 
 
## Screenshots
### Before

<img width="1050" alt="Screenshot 2019-08-06 at 09 45 26" src="https://user-images.githubusercontent.com/42253716/62525265-021dec80-b82f-11e9-9033-44e6fc4c39f3.png">

### After 

<img width="858" alt="Screenshot 2019-08-06 at 09 46 38" src="https://user-images.githubusercontent.com/42253716/62525310-1c57ca80-b82f-11e9-9bbf-d7060541bf69.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
