### PR TITLE
Fix Activity Feed on IE 10

### DIFF
--- a/src/apps/companies/apps/activity-feed/client.jsx
+++ b/src/apps/companies/apps/activity-feed/client.jsx
@@ -7,7 +7,7 @@ const { ActivityFeedApp } = require('data-hub-components')
 const element = document.querySelector('#activity-feed-app')
 
 if (element) {
-  const params = JSON.parse(element.dataset.params)
+  const params = JSON.parse(element.getAttribute('data-params'))
 
   render(
     <ActivityFeedApp {...params} />,


### PR DESCRIPTION
## Description of change

Use `element.getAttribute` instead of `element.dataset` to support IE 10 on Activity Feed.

## Test instructions

Working Activity Feed on IE 10.
 
## Screenshots

### Before

![image](https://user-images.githubusercontent.com/4199239/62690826-5955c580-b9c5-11e9-81ba-8c739e5578f5.png)


### After 

![image](https://user-images.githubusercontent.com/4199239/62689638-1d216580-b9c3-11e9-89db-b6bbe15fe31a.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
