### PR TITLE
restore missing heroku build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "circle:acceptance:dit-staff": "yarn circle:acceptance --skiptags ignore,da,lep",
     "circle:acceptance:da-staff": "yarn circle:acceptance --tag da --skiptags ignore",
     "circle:acceptance:lep-staff": "yarn circle:acceptance --tag lep --skiptags ignore",
+    "heroku-postbuild": "yarn cache clean && npm rebuild && npm run build",
     "lint-staged": "lint-staged"
   },
   "pre-commit": "lint-staged",


### PR DESCRIPTION
Gov PaaS uses the `heroku-postbuild` script to run webpack and compile assets. This was removed in an earlier PR, which meant that although the build succeeded it was missing CSS & JS.

This simply restores that script.

Historical note: it's called `heroku-postbuild` because Gov PaaS is based on Cloud Foundry which in turn is a fork of heroku

Before:
<img width="665" alt="Screenshot 2019-08-09 at 13 45 24" src="https://user-images.githubusercontent.com/161962/62779896-4b2ea480-baac-11e9-8e20-d8c356af0133.png">
After:
<img width="1044" alt="Screenshot 2019-08-09 at 13 45 39" src="https://user-images.githubusercontent.com/161962/62779899-4e299500-baac-11e9-8c0a-18ffa2a1a6de.png">

😄 