### PR TITLE
FEX-171 Enable external data sources into activity feed

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -109,6 +109,9 @@ const config = {
   activityFeed: {
     paginationSize: 20,
     supportedActivityTypes: [
+      'dit:Accounts',
+      'dit:Company',
+      'dit:Export',
       'dit:Interaction',
       'dit:ServiceDelivery',
       'dit:InvestmentProject',

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^0.4.1",
+    "data-hub-components": "^0.9.0",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/test/unit/apps/companies/apps/activity-feed/repos.test.js
+++ b/test/unit/apps/companies/apps/activity-feed/repos.test.js
@@ -24,6 +24,9 @@ describe('Activity feed repos', () => {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:123' } },
                 { terms: { 'object.type': [
+                  'dit:Accounts',
+                  'dit:Company',
+                  'dit:Export',
                   'dit:Interaction',
                   'dit:ServiceDelivery',
                   'dit:InvestmentProject',
@@ -61,6 +64,9 @@ describe('Activity feed repos', () => {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:undefined' } },
                 { terms: { 'object.type': [
+                  'dit:Accounts',
+                  'dit:Company',
+                  'dit:Export',
                   'dit:Interaction',
                   'dit:ServiceDelivery',
                   'dit:InvestmentProject',
@@ -96,6 +102,9 @@ describe('Activity feed repos', () => {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:undefined' } },
                 { terms: { 'object.type': [
+                  'dit:Accounts',
+                  'dit:Company',
+                  'dit:Export',
                   'dit:Interaction',
                   'dit:ServiceDelivery',
                   'dit:InvestmentProject',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2170,6 +2170,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios-mock-adapter@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.17.0.tgz#0dbee43c606d4aaba5a43d88d96d6661a7cc3c04"
+  integrity sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@0.19.0, axios@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
@@ -3602,6 +3609,11 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
+constate@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/constate/-/constate-1.2.0.tgz#2e1e608a8ecb91381fb850810ace712f1e45a504"
+  integrity sha512-cdcCg5MFSIU1sq091lpqi7RhY0KB6zYuSFtYOF9fLQRaudZVybRo7IahFxi7vvtfsuAysrTPAMmv5FDHLJ6K8Q==
+
 contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
@@ -4107,20 +4119,23 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-0.4.1.tgz#92db2b999640747279a8f59ba35e4dd81df7c6ab"
-  integrity sha512-JbamjUYrXSq8f+/2Ldl2ggR9ICtgi7CvR27tZmhJAwV34eagNOpbmtmambmDjU8Pizy1/4xCD704PyW8HtWwVQ==
+data-hub-components@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-0.9.0.tgz#818b714b5e21d5329da8e9776f40594b3bb0c5e3"
+  integrity sha512-GCgWUYmX5pxJR88IsRHzbGbs2TAROmT+4mDvCyMsm9wfZOr+kJbNSgYWSXHe279ffAo0a/Wde761iV24ZE8imA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/constants" "^0.7.1"
     axios "^0.19.0"
+    axios-mock-adapter "^1.17.0"
+    constate "^1.2.0"
     govuk-colours "^1.0.3"
     govuk-react "^0.7.0"
     lodash "^4.17.11"
     moment "^2.24.0"
     pluralise "^1.0.1"
     prop-types "^15.7.2"
+    query-string "^6.8.2"
     react-markdown "^4.0.8"
     styled-components "^4.2.0"
 
@@ -4304,7 +4319,7 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@^1.0.0:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
@@ -10983,6 +10998,15 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.2.tgz#36cb7e452ae11a4b5e9efee83375e0954407b2f6"
+  integrity sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -12491,6 +12515,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -12671,6 +12700,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@0.0.2, string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
## Description of change

This PR enables users to see in the activity feed events which come from external sources as Companies House Incorporation, Accounts Due and HMRC Exporters.

The external sources go through a matching process and then are feed into the Activity Stream from where we get them from.

## Test instructions

In the Company Activity Feed Tab there should be visible cards that carry the 'Companies House' and HMRC labels.

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
