### PR TITLE
Update images used for data-hub-leeloo in CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ aliases:
   - &redis_version              redis:3.2.10
   - &postgres_version           postgres:10
   - &mi_postgres_version        postgres:9.6
-  - &elasticsearch_version      docker.elastic.co/elasticsearch/elasticsearch:6.4.3
+  - &elasticsearch_version      docker.elastic.co/elasticsearch/elasticsearch:6.7.1
   - &oauth2_dit_staff_token     ditStaffToken
   - &oauth2_da_staff_token      daStaffToken
   - &oauth2_lep_staff_token     lepStaffToken

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ aliases:
   - &oauth2_dit_staff_token     ditStaffToken
   - &oauth2_da_staff_token      daStaffToken
   - &oauth2_lep_staff_token     lepStaffToken
+  - &leeloo_develop_image       quay.io/uktrade/data-hub-leeloo:develop
+  - &leeloo_master_image        quay.io/uktrade/data-hub-leeloo:master
 
   # Common steps
   - &restore_yarn_cache
@@ -152,7 +154,7 @@ aliases:
 
   # Data hub backend
   - &docker_data_hub_backend_base
-    image: ukti/data-hub-leeloo:latest
+    image: *leeloo_develop_image
     environment:
       AWS_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: foo
@@ -520,9 +522,9 @@ jobs:
       - *docker_mi_postgres
       - *docker_mock_sso
       - <<: *docker_data_hub_backend_api
-        image: ukti/data-hub-leeloo:master
+        image: *leeloo_master_image
       - <<: *docker_data_hub_backend_celery
-        image: ukti/data-hub-leeloo:master
+        image: *leeloo_master_image
 
   # Run acceptance tests for LEP staff using the master version of the backend
   master-lep_staff_at:
@@ -538,9 +540,9 @@ jobs:
       - *docker_mi_postgres
       - *docker_mock_sso
       - <<: *docker_data_hub_backend_api
-        image: ukti/data-hub-leeloo:master
+        image: *leeloo_master_image
       - <<: *docker_data_hub_backend_celery
-        image: ukti/data-hub-leeloo:master
+        image: *leeloo_master_image
 
   # Run acceptance tests for DA staff using the master version of the backend
   master-da_staff_at:
@@ -556,9 +558,9 @@ jobs:
       - *docker_mi_postgres
       - *docker_mock_sso
       - <<: *docker_data_hub_backend_api
-        image: ukti/data-hub-leeloo:master
+        image: *leeloo_master_image
       - <<: *docker_data_hub_backend_celery
-        image: ukti/data-hub-leeloo:master
+        image: *leeloo_master_image
 
 # CircleCI workflows
 workflows:


### PR DESCRIPTION
## Description of change

This:

- uses the new data-hub-leeloo images on Quay during CircleCI builds
  
  (This is as `data-hub-leeloo` builds are being migrated from Docker Hub to Quay. See https://quay.io/repository/uktrade/data-hub-leeloo for details of the new images.)

- updates the Elasticsearch image used during CircleCI builds to match what is currently used in data-hub-leeloo


## Test instructions

Have a look at the CircleCI build log.

_What should I see?_
 
- it should be pulling data-hub-leeloo images from quay.io
- it should be pulling the Elasticsearch 6.7.1 image
- the build should pass

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
