### PR TITLE
Fix running FE/BE together on docker - ensure everything works with mock SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ and be provided with a back end server to provide the API, data storage and sear
     ```bash
     API_ROOT=example.com docker-compose up frontend
     ```
+
+    If using the mock-sso instance specified in `docker-compose.yml`, you will 
+    also need to specify the `MOCK_SSO_USERNAME` environment variable in `.env`.
+    This should wire up with an Adviser in the data hub backend.
     
 ### Running project natively
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ and be provided with a back end server to provide the API, data storage and sear
 
     If using the mock-sso instance specified in `docker-compose.yml`, you will 
     also need to specify the `MOCK_SSO_USERNAME` environment variable in `.env`.
-    This should wire up with an Adviser in the data hub backend.
+    This value should correspond with an `Advisor.email` value in the Data Hub backend
     
 ### Running project natively
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       OAUTH2_CLIENT_ID: randomClientId
       OAUTH2_DEV_TOKEN: ditStaffToken
       CACHE_ASSETS: "true"
+      SESSION_SECRET: foobarbaz
     volumes:
       - ./assets:/usr/src/app/assets
       - ./common:/usr/src/app/common
@@ -58,7 +59,8 @@ services:
       - 8080:8080
     environment:
       MOCK_SSO_SCOPE: data-hub:internal-front-end
-      MOCK_SSO_TOKEN: 123
+      MOCK_SSO_TOKEN: ditStaffToken
+      MOCK_SSO_USERNAME: ${MOCK_SSO_USERNAME}
 
   mock-backend:
     image: ukti/data-hub-sandbox:1.0.0


### PR DESCRIPTION
## Description of change

This ensures that the frontend and backend can work together over docker.  This ensures that `SESSION_SECRET` has a default value, that mock-sso's token is a consistent value and that a username can be specified through an environment variable.