### PR TITLE
Add UK locations of interest field to location section of large capital profile

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -7,8 +7,8 @@ const {
   transformRequiredChecks,
 } = require('../transformers')
 
-const { getInvestorDetailsOptions, getInvestorRequirementsOptions } = require('../options')
-const { INVESTOR_DETAILS, INVESTOR_REQUIREMENTS } = require('../sections')
+const { getInvestorDetailsOptions, getInvestorRequirementsOptions, getLocationOptions } = require('../options')
+const { INVESTOR_DETAILS, INVESTOR_REQUIREMENTS, LOCATION } = require('../sections')
 const { assetClassSectors } = require('../constants')
 const { getCompanyProfiles } = require('../repos')
 const { get } = require('lodash')
@@ -82,6 +82,11 @@ const renderProfile = async (req, res, next) => {
           profile.investorRequirements.constructionRisks.items = transformCheckboxes(constructionRiskMD, constructionRisks)
           profile.investorRequirements.minimumEquityPercentage.items = transformRadioButtons(minimumEquityPercentageMD, minimumEquityPercentage)
           profile.investorRequirements.desiredDealRoles.items = transformCheckboxes(desiredDealRoleMD, desiredDealRoles)
+        })
+    } else if (editType === LOCATION) {
+      await getLocationOptions(token)
+        .then((result) => {
+          profile.location.uk_region_locations.items = result
         })
     }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/options.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/options.js
@@ -35,7 +35,12 @@ const getInvestorRequirementsOptions = (token) => {
   ]
 }
 
+const getLocationOptions = (token) => {
+  return getOptions(token, 'uk-region')
+}
+
 module.exports = {
   getInvestorDetailsOptions,
   getInvestorRequirementsOptions,
+  getLocationOptions,
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/styles.scss
+++ b/src/apps/companies/apps/investments/large-capital-profile/styles.scss
@@ -79,6 +79,12 @@ form {
     label {
       font-weight: bold;
     }
+    .c-form-fieldset__add-another {
+      margin-top: $default-spacing-unit;
+    }
+    .govuk-form-group {
+      margin-top: $default-spacing-unit;
+    }
   }
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/location-to-api.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/location-to-api.js
@@ -1,7 +1,10 @@
 /* eslint-disable camelcase */
-const transformLocation = ({ notes_on_locations }) => {
+const { sanitizeCheckboxes } = require('../../utils/transformers')
+
+const transformLocation = ({ notes_on_locations, uk_region_locations }) => {
   return {
     notes_on_locations,
+    uk_region_locations: sanitizeCheckboxes(uk_region_locations),
   }
 }
 

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -93,6 +93,9 @@ const transformProfile = (profile, editing) => {
     location: {
       incompleteFields: get(profile, 'incomplete_location_fields.length'),
       notes_on_locations: get(profile, 'notes_on_locations'),
+      uk_region_locations: {
+        value: get(profile, 'uk_region_locations', null),
+      },
     },
   }
 }

--- a/src/apps/companies/apps/investments/large-capital-profile/views/location-edit.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/location-edit.njk
@@ -11,7 +11,28 @@
   }
 }) %}
 
-    {{
+  {{
+    AddAnother({
+      buttonName: 'uk_region_locations',
+      name: 'uk_region_locations',
+      label: 'UK locations of interest',
+      attributes: {
+        'data-auto-id': 'ukRegionLocations'
+      },
+      value: profile.location.uk_region_locations.value,
+      children: [{
+        macroName: 'MultipleChoiceField',
+        name: 'uk_region_locations',
+        label: 'UK locations of interest',
+        isLabelHidden: true,
+        optional: true,
+        initialOption: '-- Select region --',
+        options: profile.location.uk_region_locations.items
+      }]
+    })
+  }}
+
+  {{
     govukTextarea({
       name: 'notes_on_locations',
       label: {
@@ -23,5 +44,6 @@
       value: profile.location.notes_on_locations
     })
   }}
+
 
 {% endcall %}

--- a/src/apps/companies/apps/investments/large-capital-profile/views/location.njk
+++ b/src/apps/companies/apps/investments/large-capital-profile/views/location.njk
@@ -1,5 +1,5 @@
 <ul class="task-list">
-  {{ taskListItem({ name: 'UK locations of interest' }) }}
+  {{ taskListItem({ name: 'UK locations of interest', value: profile.location.uk_region_locations.value, key: 'name'}) }}
   {{ taskListItem({ name: 'Other countries the investor is considering' }) }}
   {{ taskListItem({ name: "Notes on investor's location preferences", value: profile.location.notes_on_locations }) }}
 </ul>

--- a/test/functional/cypress/selectors/company/investment.js
+++ b/test/functional/cypress/selectors/company/investment.js
@@ -247,6 +247,8 @@ module.exports = {
       ukLocationsOfInterest: {
         name: '[data-auto-id=location] ul > li:nth-child(1) .task-list__item-name',
         incomplete: '[data-auto-id=location] ul > li:nth-child(1) .task-list__item-incomplete',
+        locationOne: '[data-auto-id="location"] > .govuk-details__text > .task-list > :nth-child(1) > :nth-child(2)',
+        locationTwo: '[data-auto-id="location"] > .govuk-details__text > .task-list > :nth-child(1) > :nth-child(3)',
       },
       otherCountriesTheInvestorIsConsidering: {
         name: '[data-auto-id=location] ul > li:nth-child(2) .task-list__item-name',

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -495,6 +495,14 @@ describe('Company Investments and Large capital profile', () => {
         .get(location.taskList.notesOnInvestorsLocationPreferences.name).should('contain', "Notes on investor's location preferences")
         .get(location.taskList.notesOnInvestorsLocationPreferences.complete).should('contain', 'Notes go here please')
     })
+
+    it("should display 'UK locations of interest' and London and the West Midlands", () => {
+      cy.visit(largeCapitalProfile)
+        .get(location.summary).click()
+        .get(location.taskList.ukLocationsOfInterest.name).should('contain', 'UK locations of interest')
+        .get(location.taskList.ukLocationsOfInterest.locationOne).should('contain', 'London')
+        .get(location.taskList.ukLocationsOfInterest.locationTwo).should('contain', 'West Midlands')
+    })
   })
 })
 

--- a/test/unit/apps/companies/apps/investments/large-capital-profile/details-edit.test.js
+++ b/test/unit/apps/companies/apps/investments/large-capital-profile/details-edit.test.js
@@ -192,6 +192,9 @@ describe('Company Investments - Large capital profile - Investor details', () =>
         location: {
           incompleteFields: 3,
           notes_on_locations: '',
+          uk_region_locations: {
+            value: [],
+          },
         },
       }
 

--- a/test/unit/apps/companies/apps/investments/large-capital-profile/location-edit.test.js
+++ b/test/unit/apps/companies/apps/investments/large-capital-profile/location-edit.test.js
@@ -1,0 +1,180 @@
+const companyProfile = require('~/test/unit/data/companies/investments/large-capital-profile-new.json')
+const company = require('~/test/unit/data/companies/minimal-company.json')
+const ukRegion = require('~/test/unit/data/companies/investments/metadata/uk-region.json')
+
+const { cloneDeep } = require('lodash')
+const config = require('~/config')
+
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const controller = require('~/src/apps/companies/apps/investments/large-capital-profile/controllers')
+
+describe('Company Investments - Large capital profile - Investor details', () => {
+  describe('renderProfile', () => {
+    context('when the user is editing the "Location" section', () => {
+      beforeEach(async () => {
+        const clonedCompanyProfile = cloneDeep(companyProfile)
+
+        nock(config.apiRoot)
+          .get(`/v4/large-investor-profile?investor_company_id=${company.id}`)
+          .reply(200, clonedCompanyProfile)
+          .get('/metadata/uk-region/')
+          .reply(200, ukRegion)
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          company,
+          requestQuery: {
+            editing: 'location',
+          },
+        })
+
+        await controller.renderProfile(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      const profile = {
+        editing: 'location',
+        id: companyProfile.results[0].id,
+        investorDetails: {
+          incompleteFields: 5,
+          investorType: {
+            text: null,
+            value: null,
+          },
+          globalAssetsUnderManagement: {
+            value: null,
+          },
+          investableCapital: {
+            value: null,
+          },
+          investorDescription: {
+            value: '',
+          },
+          requiredChecks: {
+            adviser: null,
+            date: null,
+            type: null,
+            value: null,
+          },
+        },
+        investorRequirements: {
+          incompleteFields: 9,
+          dealTicketSizes: {
+            value: [],
+          },
+          assetClasses: {
+            energyAndInfrastructure: {
+              value: [],
+            },
+            realEstate: {
+              value: [],
+            },
+          },
+          investmentTypes: {
+            value: [],
+          },
+          minimumReturnRate: {
+            text: null,
+            value: null,
+          },
+          timeHorizons: {
+            value: [],
+          },
+          restrictions: {
+            value: [],
+          },
+          constructionRisks: {
+            value: [],
+          },
+          minimumEquityPercentage: {
+            text: null,
+            value: null,
+          },
+          desiredDealRoles: {
+            value: [],
+          },
+        },
+        location: {
+          incompleteFields: 3,
+          notes_on_locations: '',
+          uk_region_locations: {
+            items: [
+              {
+                label: 'All',
+                value: '1718e330-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'East Midlands',
+                value: '844cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'East of England',
+                value: '864cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'London',
+                value: '874cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'North East',
+                value: '814cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'North West',
+                value: '824cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'Northern Ireland',
+                value: '8e4cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'Scotland',
+                value: '8c4cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'South East',
+                value: '884cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'South West',
+                value: '894cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'UKTI Dubai Hub',
+                value: 'e1dd40e9-3dfd-e311-8a2b-e4115bead28a',
+              },
+              {
+                label: 'Wales',
+                value: '8d4cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'West Midlands',
+                value: '854cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                label: 'Yorkshire and The Humber',
+                value: '834cd12a-6095-e211-a939-e4115bead28a',
+              },
+            ],
+            value: [],
+          },
+        },
+      }
+
+      it('should call the render function once', () => {
+        expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce
+      })
+
+      it('should call the render function and pass the view', () => {
+        const view = 'companies/apps/investments/large-capital-profile/views/profile'
+        expect(this.middlewareParameters.resMock.render.args[0][0]).to.equal(view)
+      })
+
+      it('should call the render function and pass the profile', () => {
+        expect(this.middlewareParameters.resMock.render.args[0][1].profile).to.deep.equal(profile)
+      })
+    })
+  })
+})

--- a/test/unit/apps/companies/apps/investments/large-capital-profile/profile/profile-complete.test.js
+++ b/test/unit/apps/companies/apps/investments/large-capital-profile/profile/profile-complete.test.js
@@ -139,10 +139,21 @@ describe('Company Investments - Large capital profile', () => {
           },
         },
         location: {
-          incompleteFields: 2,
+          incompleteFields: 1,
           notes_on_locations: 'They are super keen on the Midlands Engine',
-        },
-      }
+          uk_region_locations: {
+            value: [
+              {
+                name: 'East of England',
+                id: '864cd12a-6095-e211-a939-e4115bead28a',
+              },
+              {
+                name: 'London',
+                id: '874cd12a-6095-e211-a939-e4115bead28a',
+              },
+            ],
+          },
+        } }
 
       it('should call the render function once', () => {
         expect(this.middlewareParameters.resMock.render).to.have.been.calledOnce

--- a/test/unit/apps/companies/apps/investments/large-capital-profile/profile/profile-new.test.js
+++ b/test/unit/apps/companies/apps/investments/large-capital-profile/profile/profile-new.test.js
@@ -89,6 +89,9 @@ describe('Company Investments - Large capital profile', () => {
         location: {
           incompleteFields: 3,
           notes_on_locations: '',
+          uk_region_locations: {
+            value: [],
+          },
         },
       }
 

--- a/test/unit/apps/companies/apps/investments/large-capital-profile/requirements-edit.test.js
+++ b/test/unit/apps/companies/apps/investments/large-capital-profile/requirements-edit.test.js
@@ -420,6 +420,9 @@ describe('Company Investments - Large capital profile - Investor requirements', 
         location: {
           incompleteFields: 3,
           notes_on_locations: '',
+          uk_region_locations: {
+            'value': [],
+          },
         },
       }
 

--- a/test/unit/apps/companies/apps/investments/large-capital-profile/transformers/location-to-api.test.js
+++ b/test/unit/apps/companies/apps/investments/large-capital-profile/transformers/location-to-api.test.js
@@ -7,12 +7,32 @@ describe('Large capital profile, location form to API', () => {
     beforeEach(() => {
       this.transformed = transformLocation({
         notes_on_locations: 'They love Birmingham',
+        uk_region_locations: [
+          {
+            'name': 'East of England',
+            'id': '864cd12a-6095-e211-a939-e4115bead28a',
+          },
+          {
+            'name': 'London',
+            'id': '874cd12a-6095-e211-a939-e4115bead28a',
+          },
+        ],
       })
     })
 
     it('should transform the POST', () => {
       expect(this.transformed).to.deep.equal({
         notes_on_locations: 'They love Birmingham',
+        uk_region_locations: [
+          {
+            'name': 'East of England',
+            'id': '864cd12a-6095-e211-a939-e4115bead28a',
+          },
+          {
+            'name': 'London',
+            'id': '874cd12a-6095-e211-a939-e4115bead28a',
+          },
+        ],
       })
     })
   })

--- a/test/unit/data/companies/investments/large-capital-profile-completed.json
+++ b/test/unit/data/companies/investments/large-capital-profile-completed.json
@@ -19,7 +19,6 @@
         "desired_deal_roles"
       ],
       "incomplete_location_fields": [
-        "uk_region_locations",
         "other_countries_being_considered"
       ],
       "investor_type": {
@@ -100,7 +99,16 @@
           "name": "Commerical led"
         }
       ],
-      "uk_region_locations": [],
+      "uk_region_locations": [
+        {
+          "name": "East of England",
+          "id": "864cd12a-6095-e211-a939-e4115bead28a"
+        },
+        {
+          "name": "London",
+          "id": "874cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
       "notes_on_locations": "They are super keen on the Midlands Engine",
       "other_countries_being_considered": []
     }

--- a/test/unit/data/companies/investments/metadata/uk-region.json
+++ b/test/unit/data/companies/investments/metadata/uk-region.json
@@ -1,0 +1,112 @@
+[
+    {
+        "id": "934cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Alderney",
+        "disabled_on": "2013-03-25T14:25:00Z"
+    },
+    {
+        "id": "1718e330-6095-e211-a939-e4115bead28a",
+        "name": "All",
+        "disabled_on": null
+    },
+    {
+        "id": "8b4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Channel Islands",
+        "disabled_on": "2013-03-25T14:25:00Z"
+    },
+    {
+        "id": "844cd12a-6095-e211-a939-e4115bead28a",
+        "name": "East Midlands",
+        "disabled_on": null
+    },
+    {
+        "id": "864cd12a-6095-e211-a939-e4115bead28a",
+        "name": "East of England",
+        "disabled_on": null
+    },
+    {
+        "id": "8a4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "England",
+        "disabled_on": "2013-03-25T14:25:00Z"
+    },
+    {
+        "id": "804cd12a-6095-e211-a939-e4115bead28a",
+        "name": "FDI Hub",
+        "disabled_on": "2014-10-20T09:44:00Z"
+    },
+    {
+        "id": "904cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Guernsey",
+        "disabled_on": "2013-03-25T14:25:00Z"
+    },
+    {
+        "id": "8f4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Isle of Man",
+        "disabled_on": "2013-03-25T14:25:00Z"
+    },
+    {
+        "id": "924cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Jersey",
+        "disabled_on": "2013-03-25T14:25:00Z"
+    },
+    {
+        "id": "874cd12a-6095-e211-a939-e4115bead28a",
+        "name": "London",
+        "disabled_on": null
+    },
+    {
+        "id": "814cd12a-6095-e211-a939-e4115bead28a",
+        "name": "North East",
+        "disabled_on": null
+    },
+    {
+        "id": "8e4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Northern Ireland",
+        "disabled_on": null
+    },
+    {
+        "id": "824cd12a-6095-e211-a939-e4115bead28a",
+        "name": "North West",
+        "disabled_on": null
+    },
+    {
+        "id": "914cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Sark",
+        "disabled_on": "2013-03-25T14:25:00Z"
+    },
+    {
+        "id": "8c4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Scotland",
+        "disabled_on": null
+    },
+    {
+        "id": "884cd12a-6095-e211-a939-e4115bead28a",
+        "name": "South East",
+        "disabled_on": null
+    },
+    {
+        "id": "894cd12a-6095-e211-a939-e4115bead28a",
+        "name": "South West",
+        "disabled_on": null
+    },
+    {
+        "id": "e1dd40e9-3dfd-e311-8a2b-e4115bead28a",
+        "name": "UKTI Dubai Hub",
+        "disabled_on": null
+    },
+    {
+        "id": "8d4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Wales",
+        "disabled_on": null
+    },
+    {
+        "id": "854cd12a-6095-e211-a939-e4115bead28a",
+        "name": "West Midlands",
+        "disabled_on": null
+    },
+    {
+        "id": "834cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Yorkshire and The Humber",
+        "disabled_on": null
+    }
+]


### PR DESCRIPTION
## Description of change

Add `UK locations of interest` field to location section of large capital profiles. 

## Test instructions

After clicking edit on the location section you should see an `Add another` select field displaying active UK Region metadata. You should be able to select multiple regions and save them to the profile. The profile should then display the regions saved. 
 
## Screenshots
### Before

![Screenshot 2019-09-02 at 17 16 53](https://user-images.githubusercontent.com/42253716/64126421-93886c00-cda5-11e9-95d6-1fe2b233a65a.png)
![Screenshot 2019-09-02 at 17 17 03](https://user-images.githubusercontent.com/42253716/64126422-93886c00-cda5-11e9-9086-de6092e18c5e.png)

### After 

![Screenshot 2019-09-02 at 17 18 01](https://user-images.githubusercontent.com/42253716/64126518-f1b54f00-cda5-11e9-87e9-5919dd40ca73.png)
![Screenshot 2019-09-02 at 17 20 02](https://user-images.githubusercontent.com/42253716/64126519-f24de580-cda5-11e9-8a78-1404f81ab556.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
