### PR TITLE
Fix crashing homepage for users who do not have my-companies permissions 

### DIFF
--- a/src/apps/dashboard/controllers.js
+++ b/src/apps/dashboard/controllers.js
@@ -25,7 +25,15 @@ async function renderDashboard (req, res, next) {
         return []
       })
 
-    const companyList = JSON.stringify(transformCompanyList(await fetchCompanyList(req.session.token)))
+    const canViewCompanyList = userPermissions.includes(
+      'company_list.view_companylistitem'
+    )
+
+    const companyList = canViewCompanyList
+      ? JSON.stringify(
+        transformCompanyList(await fetchCompanyList(req.session.token))
+      )
+      : null
 
     res.title('Dashboard').render('dashboard/views/dashboard', {
       companyList,
@@ -37,6 +45,7 @@ async function renderDashboard (req, res, next) {
         GLOBAL_NAV_ITEMS,
         userPermissions
       ),
+      canViewCompanyList,
     })
   } catch (error) {
     next(error)

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -13,13 +13,14 @@
 
 {% block body_main_content %}
 <div class="grid-row dashboard">
+{% if canViewCompanyList %}   
     <div class="govuk-grid-column-two-thirds">
       {% component 'react-slot', {
         id: 'react-mount-my-companies',
         model: companyList
       } %}
     </div>
-
+{% endif %}   
     <div class="govuk-grid-column-one-third">
       {% component 'info-feed', {
         heading: 'Data Hub updates',
@@ -30,7 +31,6 @@
         outboundLinkText: 'View all updates'
       } %}
     </div>
-
-  </div>
+</div>
 
 {% endblock %}

--- a/test/unit/apps/dashboard/controllers.test.js
+++ b/test/unit/apps/dashboard/controllers.test.js
@@ -96,6 +96,39 @@ describe('dashboard controller', () => {
     })
   })
 
+  context('when the user has no permissions to view my-companies', () => {
+    beforeEach(async () => {
+      this.resMock = {
+        locals: {
+          user: {
+            permissions: [],
+          },
+        },
+        render: sinon.spy(),
+        title: sinon.stub().returnsThis(),
+      }
+
+      this.fetchHomepageDataStub.resolves(this.dashData)
+      this.fetchCompanyListStub.resolves(this.companyData)
+      await this.controllers.renderDashboard(
+        this.reqMock,
+        this.resMock,
+        this.nextSpy
+      )
+    })
+    it('canViewCompanyList should be false', () => {
+      const expected = {
+        companyList: null,
+        contacts: [{ id: '1234' }],
+        interactions: [{ id: '4321' }],
+        articleFeed: [],
+        interactionsPermitted: false,
+        canViewCompanyList: false,
+      }
+      expect(this.resMock.render.firstCall.args[1]).to.deep.equal(expected)
+    })
+  })
+
   context('when there is a problem calling the API', () => {
     beforeEach(async () => {
       this.error = { status: 500 }

--- a/test/unit/apps/dashboard/controllers.test.js
+++ b/test/unit/apps/dashboard/controllers.test.js
@@ -7,7 +7,11 @@ describe('dashboard controller', () => {
     })
 
     this.resMock = {
-      locals: {},
+      locals: {
+        user: {
+          permissions: ['company_list.view_companylistitem'],
+        },
+      },
       render: sinon.spy(),
       title: sinon.stub().returnsThis(),
     }
@@ -28,12 +32,16 @@ describe('dashboard controller', () => {
   context('when there are no errors calling the API', () => {
     beforeEach(async () => {
       this.dashData = {
-        contacts: [{
-          id: '1234',
-        }],
-        interactions: [{
-          id: '4321',
-        }],
+        contacts: [
+          {
+            id: '1234',
+          },
+        ],
+        interactions: [
+          {
+            id: '4321',
+          },
+        ],
       }
 
       this.companyData = {
@@ -56,7 +64,11 @@ describe('dashboard controller', () => {
 
       this.fetchHomepageDataStub.resolves(this.dashData)
       this.fetchCompanyListStub.resolves(this.companyData)
-      await this.controllers.renderDashboard(this.reqMock, this.resMock, this.nextSpy)
+      await this.controllers.renderDashboard(
+        this.reqMock,
+        this.resMock,
+        this.nextSpy
+      )
     })
 
     it('should render the dashboard template', () => {
@@ -70,7 +82,9 @@ describe('dashboard controller', () => {
 
     it('should render the page with interactions', () => {
       const renderOptions = this.resMock.render.firstCall.args[1]
-      expect(renderOptions.interactions).to.deep.equal(this.dashData.interactions)
+      expect(renderOptions.interactions).to.deep.equal(
+        this.dashData.interactions
+      )
     })
 
     it('should not call next', () => {
@@ -86,7 +100,11 @@ describe('dashboard controller', () => {
     beforeEach(async () => {
       this.error = { status: 500 }
       this.fetchHomepageDataStub.rejects(this.error)
-      await this.controllers.renderDashboard(this.reqMock, this.resMock, this.nextSpy)
+      await this.controllers.renderDashboard(
+        this.reqMock,
+        this.resMock,
+        this.nextSpy
+      )
     })
 
     it('should show an error', () => {


### PR DESCRIPTION
## Description of change
Homepage was crashing for Lep users as they do not have the right permissions to request my-companies data. A conditional was added around the template and request to fix this issue for them.

## Test instructions
Login as an lep user and browse to the homepage. You should only see only the  data hub updates component on the homepage.
 
## Screenshots
### Before
![image](https://user-images.githubusercontent.com/48679632/63940583-b93e0a00-ca61-11e9-8f38-60e274cfe097.png)

### After 
![image](https://user-images.githubusercontent.com/48679632/63940624-cce97080-ca61-11e9-9fd3-645bb8a1bbd5.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
