### PR TITLE
Add endpoint to perform D&B company search

### DIFF
--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -1,3 +1,5 @@
+const { searchDnbCompanies } = require('../../../../modules/search/services')
+
 async function renderAddCompanyForm (req, res, next) {
   try {
     res
@@ -8,6 +10,20 @@ async function renderAddCompanyForm (req, res, next) {
   }
 }
 
+async function postSearchDnbCompanies (req, res, next) {
+  try {
+    const results = await searchDnbCompanies({
+      token: req.session.token,
+      requestBody: req.body,
+    })
+
+    res.json(results)
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
   renderAddCompanyForm,
+  postSearchDnbCompanies,
 }

--- a/src/apps/companies/apps/add-company/router.js
+++ b/src/apps/companies/apps/add-company/router.js
@@ -2,8 +2,10 @@ const router = require('express').Router()
 
 const {
   renderAddCompanyForm,
+  postSearchDnbCompanies,
 } = require('./controllers')
 
 router.get('/', renderAddCompanyForm)
+router.post('/', postSearchDnbCompanies)
 
 module.exports = router

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -22,7 +22,7 @@ const buildOptions = (
 
   return {
     body,
-    url: `${searchUrl}/${entity}`,
+    url: `${searchUrl}${entity ? `/${entity}` : ''}`,
     method: 'POST',
   }
 }
@@ -145,6 +145,16 @@ function searchAutocomplete ({ token, searchEntity, searchTerm = '', requestBody
     })
 }
 
+function searchDnbCompanies ({ token, requestBody = {} }) {
+  const url = `${config.apiRoot}/v4/dnb/company-search`
+  const options = buildOptions(false, url, {
+    ...requestBody,
+    page_size: 100,
+  })
+
+  return authorisedRequest(token, options)
+}
+
 module.exports = {
   search,
   searchCompanies,
@@ -153,4 +163,5 @@ module.exports = {
   searchInvestments,
   exportSearch,
   searchAutocomplete,
+  searchDnbCompanies,
 }

--- a/test/unit/apps/companies/apps/add-company/controllers.test.js
+++ b/test/unit/apps/companies/apps/add-company/controllers.test.js
@@ -14,10 +14,6 @@ describe('Add company form controllers', () => {
         )
       })
 
-      it('should render', () => {
-        expect(this.middlewareParameters.resMock.render).to.be.calledOnce
-      })
-
       it('should render the add company form template', () => {
         expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(
           'companies/apps/add-company/views/client-container'
@@ -28,7 +24,7 @@ describe('Add company form controllers', () => {
         expect(this.middlewareParameters.resMock.breadcrumb.firstCall).to.be.calledWith('Add company')
       })
 
-      it('should not call "next" with an error', async () => {
+      it('should not call next() with an error', () => {
         expect(this.middlewareParameters.nextSpy).to.not.have.been.called
       })
     })
@@ -51,8 +47,8 @@ describe('Add company form controllers', () => {
         )
       })
 
-      it('should call "next" with an error', async () => {
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledWith(this.error)
+      it('should call next() with an error', () => {
+        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnceWithExactly(this.error)
       })
     })
   })

--- a/test/unit/modules/search/services.test.js
+++ b/test/unit/modules/search/services.test.js
@@ -7,6 +7,7 @@ const {
   searchLimitedCompanies,
   exportSearch,
   searchAutocomplete,
+  searchDnbCompanies,
 } = require('~/src/modules/search/services')
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
@@ -326,6 +327,36 @@ describe('Search service', () => {
         token: '1234',
         searchEntity: 'company',
         searchTerm: 'search',
+      })
+    })
+
+    it('should return the response', () => {
+      expect(this.actual).to.deep.equal({
+        count: 0,
+        results: [],
+      })
+    })
+  })
+
+  describe('#searchDnbCompanies', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .post(`/v4/dnb/company-search`, {
+          search_term: 'company',
+          address_country: 'GB',
+          page_size: 100,
+        })
+        .reply(200, {
+          count: 0,
+          results: [],
+        })
+
+      this.actual = await searchDnbCompanies({
+        token: '1234',
+        requestBody: {
+          search_term: 'company',
+          address_country: 'GB',
+        },
       })
     })
 


### PR DESCRIPTION
## Description of change

The entity search component has a dependency on an endpoint to perform the search against the API. This is a preliminary change to add the endpoint.

## Test instructions
`POST` a request to `~/companies/create/dnb/companies-search` with request body:

```json
{
 "search_term": "company",
 "address_country": "GB",
 "page_size": 100
}
```

## Screenshots

There should be no visual difference.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
