### PR TITLE
Integrate field dnb company

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^1.2.0",
+    "data-hub-components": "^1.4.0",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable */
 
 import React, { useState } from 'react'
-import { Details, LoadingBox } from 'govuk-react'
-import { Form, Step } from 'data-hub-components'
+import { Details, LoadingBox, H3 } from 'govuk-react'
+
+import { Form, Step, FieldDnbCompany } from 'data-hub-components'
 
 function AddCompanyForm(props) {
   const [submitted, setSubmitted] = useState(false)
@@ -32,8 +33,14 @@ function AddCompanyForm(props) {
           <p>Companies</p>
         </Step>
 
-        <Step name="companySearch">
-          <p>Add a Company</p>
+        <Step name="companySearch" hideForwardButton={true}>
+          <H3>Find the company</H3>
+
+          <FieldDnbCompany
+            apiEndpoint={`//${props.host}/companies/create/dnb/company-search?_csrf=${props.csrfToken}`}
+            country="UK"
+            name="dnb_company"
+          />
         </Step>
 
         <Step name="companyDetails" forwardButtonText={"Add company"}>

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -5,7 +5,12 @@ async function renderAddCompanyForm (req, res, next) {
   try {
     res
       .breadcrumb('Add company')
-      .render('companies/apps/add-company/views/client-container')
+      .render('companies/apps/add-company/views/client-container', {
+        props: {
+          host: req.headers.host,
+          csrfToken: res.locals.csrfToken,
+        },
+      })
   } catch (error) {
     next(error)
   }

--- a/src/server.js
+++ b/src/server.js
@@ -67,6 +67,7 @@ app.use(cookieParser())
 app.use(sessionStore)
 
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
+app.use(bodyParser.json())
 
 app.use(compression())
 app.use(i18n)

--- a/test/functional/cypress/selectors/company/add-company.js
+++ b/test/functional/cypress/selectors/company/add-company.js
@@ -3,4 +3,12 @@ module.exports = {
   submitButton: 'form button:contains("Add company")',
   backButton: 'form button:contains("Back")',
   subheader: 'form p',
+  h3: 'form h3',
+  entitySearch: {
+    searchButton: 'form button:contains("Search")',
+    results: {
+      someCompanyName: 'form ol li:nth-child(1)',
+      someOtherCompany: 'form ol li:nth-child(2)',
+    },
+  },
 }

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -6,6 +6,10 @@ describe('Add company form', () => {
       cy.visit('/companies/create')
     })
 
+    beforeEach(function () {
+      Cypress.Cookies.preserveOnce('datahub.sid')
+    })
+
     it('should render breadcrumbs', () => {
       cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
       cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
@@ -27,33 +31,44 @@ describe('Add company form', () => {
         cy.get(selectors.companyAdd.nextButton).click()
       })
 
-      it('should display "Add a Company" subheader', () => {
-        cy.get(selectors.companyAdd.subheader).should('have.text', 'Add a Company')
+      it('should display the "Find the company" heading', () => {
+        cy.get(selectors.companyAdd.h3).should('have.text', 'Find the company')
       })
 
       it('should display "Back" button', () => {
         cy.get(selectors.companyAdd.backButton).should('be.visible')
       })
 
-      it('should display "Next" button', () => {
-        cy.get(selectors.companyAdd.nextButton).should('be.visible')
+      it('should not display the "Next" button', () => {
+        cy.get(selectors.companyAdd.nextButton).should('not.be.visible')
       })
 
-      context('when I click the "Next" button', () => {
+      context('when I click the "Search" button', () => {
         before(() => {
-          cy.get(selectors.companyAdd.nextButton).click()
+          cy.get(selectors.companyAdd.entitySearch.searchButton).click()
         })
 
-        it('should display "Add company details" subheader', () => {
-          cy.get(selectors.companyAdd.subheader).should('have.text', 'Add company details')
+        it('should display the entity search results', () => {
+          cy.get(selectors.companyAdd.entitySearch.results.someCompanyName).should('be.visible')
+          cy.get(selectors.companyAdd.entitySearch.results.someOtherCompany).should('be.visible')
         })
 
-        it('should display "Back" button', () => {
-          cy.get(selectors.companyAdd.backButton).should('be.visible')
-        })
+        context('when I click the first company that does not exist on Data Hub', () => {
+          before(() => {
+            cy.get(selectors.companyAdd.entitySearch.results.someOtherCompany).click()
+          })
 
-        it('should display "Add company" button', () => {
-          cy.get(selectors.companyAdd.submitButton).should('be.visible')
+          it('should display "Add company details" subheader', () => {
+            cy.get(selectors.companyAdd.subheader).should('have.text', 'Add company details')
+          })
+
+          it('should display "Back" button', () => {
+            cy.get(selectors.companyAdd.backButton).should('be.visible')
+          })
+
+          it('should display "Add company" button', () => {
+            cy.get(selectors.companyAdd.submitButton).should('be.visible')
+          })
         })
       })
     })

--- a/test/unit/apps/companies/apps/add-company/controllers.test.js
+++ b/test/unit/apps/companies/apps/add-company/controllers.test.js
@@ -12,7 +12,7 @@ describe('Add company form controllers', () => {
   describe('#renderAddCompanyForm', () => {
     context('when the "Add company form" renders successfully', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({})
+        this.middlewareParameters = buildMiddlewareParameters()
         await renderAddCompanyForm(
           this.middlewareParameters.reqMock,
           this.middlewareParameters.resMock,
@@ -20,10 +20,14 @@ describe('Add company form controllers', () => {
         )
       })
 
-      it('should render the add company form template', () => {
-        expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(
-          'companies/apps/add-company/views/client-container'
-        )
+      it('should render the add company form template with fields', () => {
+        const expectedTemplate = 'companies/apps/add-company/views/client-container'
+        expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(expectedTemplate, {
+          props: {
+            host: 'localhost:3000',
+            csrfToken: 'csrf',
+          },
+        })
       })
 
       it('should add a breadcrumb', () => {
@@ -37,7 +41,7 @@ describe('Add company form controllers', () => {
 
     context('when the rendering fails', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({})
+        this.middlewareParameters = buildMiddlewareParameters()
 
         this.error = new Error('Could not render')
 

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -7,6 +7,7 @@ module.exports = ({
   requestParams = {},
   requestQuery = {},
   requestPath,
+  requestHeaders = { host: 'localhost:3000' },
   CURRENT_PATH = '',
   breadcrumb = sinon.stub().returnsThis(),
   title = sinon.stub().returnsThis(),
@@ -20,7 +21,7 @@ module.exports = ({
   features = {},
   userAgent = { isIE: false },
   user,
-}) => {
+} = {}) => {
   return {
     reqMock: {
       ...reqMock,
@@ -31,6 +32,7 @@ module.exports = ({
       params: requestParams,
       query: requestQuery,
       path: requestPath,
+      headers: requestHeaders,
       flash: sinon.spy(),
     },
     resMock: {
@@ -54,6 +56,7 @@ module.exports = ({
         features,
         userAgent,
         user,
+        csrfToken: 'csrf',
       },
     },
     nextSpy: sinon.spy(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,10 +4106,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-1.2.0.tgz#6547dfe29609650e692dcf5c0a1d3a7567925e03"
-  integrity sha512-D887jFyKLXwazgWcMm2dn37eV1WPDb1RGkKGn4BSwHomq4GQEDNu78+STpAewyUszR2BsCPogeaIElFHw0aiPA==
+data-hub-components@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-1.4.0.tgz#282cd5694515ef7ad1a93e4d29140463565920e5"
+  integrity sha512-Tv27S4sCluMLMDHf6n5Gar65beTaPS8gTzPpL5vqabw6lSs5pcwNgAABwARbekPMfAo09Q5iZRAJG1ci0uuC/w==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change
Change adds `FieldDnbCompany` to the new add company form steps. The `Search` click event integrates with the `POST` company search Express endpoint.

## Test instructions
1. Browse to `~/companies/create`
2. Click `Next`
3. Enter search criteria, ie `ralph`. Search results will be displayed

_What should I see?_
 
## Screenshots
### Before

TODO

### After 

TODO

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
