### PR TITLE
Remove external sources activities until activities filter is enabled

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -109,9 +109,6 @@ const config = {
   activityFeed: {
     paginationSize: 20,
     supportedActivityTypes: [
-      'dit:Accounts',
-      'dit:Company',
-      'dit:Export',
       'dit:Interaction',
       'dit:ServiceDelivery',
       'dit:InvestmentProject',

--- a/test/unit/apps/companies/apps/activity-feed/repos.test.js
+++ b/test/unit/apps/companies/apps/activity-feed/repos.test.js
@@ -24,9 +24,6 @@ describe('Activity feed repos', () => {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:123' } },
                 { terms: { 'object.type': [
-                  'dit:Accounts',
-                  'dit:Company',
-                  'dit:Export',
                   'dit:Interaction',
                   'dit:ServiceDelivery',
                   'dit:InvestmentProject',
@@ -64,9 +61,6 @@ describe('Activity feed repos', () => {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:undefined' } },
                 { terms: { 'object.type': [
-                  'dit:Accounts',
-                  'dit:Company',
-                  'dit:Export',
                   'dit:Interaction',
                   'dit:ServiceDelivery',
                   'dit:InvestmentProject',
@@ -102,9 +96,6 @@ describe('Activity feed repos', () => {
               filter: [
                 { term: { 'object.attributedTo.id': 'dit:DataHubCompany:undefined' } },
                 { terms: { 'object.type': [
-                  'dit:Accounts',
-                  'dit:Company',
-                  'dit:Export',
                   'dit:Interaction',
                   'dit:ServiceDelivery',
                   'dit:InvestmentProject',


### PR DESCRIPTION
## Description of change

In some cases the activity feed feels cluttered because of the amount of external activity data and no filtering feature available, so we decided to remove it momentarily, due to popular demand.

## Test instructions

Activity feed with no external activities
 
## Screenshots
### Before

_Add a screenshot_

### After 

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
