### PR TITLE
Use D&B company data when displaying the confirmation step on the new "Add company form"

### DIFF
--- a/src/apps/companies/apps/add-company/client/DefinitionList.jsx
+++ b/src/apps/companies/apps/add-company/client/DefinitionList.jsx
@@ -35,25 +35,31 @@ const StyledDL = styled('dl')`
 
 const StyledDT = styled('dt')`
   padding-right: ${SPACING.SCALE_4};
-  min-width: 105px;
-`
-
-const StyledDD = styled('dd')`
+  width: 30%;
   font-weight: bold;
 `
 
 function Row ({ label, description }) {
+  if (!label || !description) {
+    return null
+  }
+
   return (
     <StyledInnerRow>
       <StyledDT>{ label }</StyledDT>
-      <StyledDD>{ description }</StyledDD>
+      <dd>{ description }</dd>
     </StyledInnerRow>
   )
 }
 
 Row.propTypes = {
-  label: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  description: PropTypes.string,
+}
+
+DefinitionList.defaultProps = {
+  label: null,
+  description: null,
 }
 
 function DefinitionList ({ header, children }) {

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -94,8 +94,8 @@ describe('Add company form', () => {
             cy.get(selectors.companyAdd.entitySearch.results.someOtherCompany).click()
           })
 
-          it('should display "Add this company to Data Hub" subheader', () => {
-            cy.get(selectors.companyAdd.stepHeader).should('have.text', 'Add this company to Data Hub')
+          it('should display "Confirm you want to add this company to Data Hub" subheader', () => {
+            cy.get(selectors.companyAdd.stepHeader).should('have.text', 'Confirm you want to add this company to Data Hub')
           })
 
           it('should display "Back" button', () => {


### PR DESCRIPTION
## Description of change

https://trello.com/c/Z4pQupwK/268-use-the-real-data-on-the-summary-view-within-the-new-add-company-form

Use D&B company data when displaying the confirmation step on the new "Add company form".

## Test instructions

Go to `http://localhost:3000/companies/create` and navigate to the last step and validate if the summary contains data from the entity search results.
 
## Screenshots
![image](https://user-images.githubusercontent.com/4199239/64545930-99d89400-d321-11e9-857b-de71693ca6fc.png)

## Checklist

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
