### PR TITLE
Remove i18n-future dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "history": "^4.7.2",
     "hmpo-form-wizard": "^9.9.0",
     "html5shiv": "^3.7.3",
-    "i18n-future": "^1.1.0",
     "image-webpack-loader": "^4.0.0",
     "lodash": "^4.17.13",
     "markdown-it": "^8.4.0",

--- a/src/apps/omis/apps/create/router.js
+++ b/src/apps/omis/apps/create/router.js
@@ -1,11 +1,6 @@
-const path = require('path')
 const router = require('express').Router()
 const wizard = require('hmpo-form-wizard')
-const i18nFuture = require('i18n-future')
 
-const i18n = i18nFuture({
-  path: path.resolve(__dirname, '../../locales/__lng__/__ns__.json'),
-})
 const steps = require('./steps')
 const fields = require('../../fields')
 const { CreateController } = require('../../controllers')
@@ -15,7 +10,6 @@ const config = {
   name: 'omis-create-order',
   journeyName: 'omis-create-order',
   template: '_layouts/form-wizard-step',
-  translate: i18n.translate.bind(i18n),
 }
 
 router.use(wizard(steps, fields, config))

--- a/src/apps/omis/apps/edit/controllers/edit-handler.js
+++ b/src/apps/omis/apps/edit/controllers/edit-handler.js
@@ -1,13 +1,8 @@
-const path = require('path')
-const i18nFuture = require('i18n-future')
 const { reduce } = require('lodash')
 
 const EditController = require('../../../controllers/edit')
 const steps = require('../steps')
 const fields = require('../fields')
-const i18n = i18nFuture({
-  path: path.resolve(__dirname, '../../../locales/__lng__/__ns__.json'),
-})
 
 function editHandler (req, res, next) {
   const step = steps[`/${req.params.step}`]
@@ -27,7 +22,6 @@ function editHandler (req, res, next) {
     next: nextUrl,
     backLink: nextUrl,
     controller: EditController,
-    translate: i18n.translate.bind(i18n),
     successMessage: 'Changes saved',
   }
   const overrides = {

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -1,6 +1,4 @@
 const { assign, get, filter, mapValues, pickBy } = require('lodash')
-const path = require('path')
-const i18nFuture = require('i18n-future')
 
 const logger = require('../../../../../config/logger')
 const { Order } = require('../../models')
@@ -8,17 +6,6 @@ const { setCompany: setCompanyMW } = require('../../middleware')
 const { getContact } = require('../../../contacts/repos')
 const { transformPaymentToView } = require('../../transformers')
 const editSteps = require('../edit/steps')
-
-const i18n = i18nFuture({
-  path: path.resolve(__dirname, '../../locales/__lng__/__ns__.json'),
-})
-
-function setTranslation (req, res, next) {
-  res.locals.translate = (key) => {
-    return i18n.translate(key)
-  }
-  next()
-}
 
 function setCompany (req, res, next) {
   const orderId = get(res.locals, 'order.company.id')
@@ -259,7 +246,6 @@ function setQuoteForm (req, res, next) {
 }
 
 module.exports = {
-  setTranslation,
   setCompany,
   setContact,
   setAssignees,

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -8,7 +8,6 @@ const {
   renderPaymentReceipt,
 } = require('./controllers')
 const {
-  setTranslation,
   setCompany,
   setContact,
   setAssignees,
@@ -31,7 +30,6 @@ const LOCAL_NAV = [
 ]
 
 router.use(setLocalNav(LOCAL_NAV))
-router.use(setTranslation)
 router.use(setCompany)
 router.use(setOrderBreadcrumb)
 router.use(setQuoteSummary)

--- a/src/apps/omis/controllers/form.js
+++ b/src/apps/omis/controllers/form.js
@@ -1,5 +1,6 @@
 const { get, filter, flatten, forEach, mapValues } = require('lodash')
 const { Controller } = require('hmpo-form-wizard')
+const labels = require('../locales/en/default')
 
 class FormController extends Controller {
   render (req, res, next) {
@@ -16,7 +17,15 @@ class FormController extends Controller {
     const errors = super.getErrors(req, res)
 
     errors.messages = mapValues(errors, (item) => {
-      return `${req.translate(`fields.${item.key}.label`)} ${item.message}`
+      /*
+      In order to remove the i18n-future dependency this
+      function has been introduced to replace code which was
+      calling the translation library. Translations are not
+      required at this stage.
+      */
+      const label = get(labels, `fields.${item.key}.label`)
+      const error = get(labels, `validation.${item.type}`)
+      return `${label} ${error}`
     })
 
     return errors

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -1,8 +1,9 @@
-const { assign, get } = require('lodash')
+const { assign, get, set } = require('lodash')
 
 const { getDitCompany } = require('../companies/repos')
 const { setHomeBreadcrumb } = require('../middleware')
 const { Order } = require('./models')
+const labels = require('./locales/en/default')
 
 async function setCompany (req, res, next, companyId) {
   try {
@@ -48,8 +49,20 @@ function setOrderBreadcrumb (req, res, next) {
   return setHomeBreadcrumb(reference)(req, res, next)
 }
 
+/*
+In order to remove the i18n-future dependency this
+function has been introduced to replace code which was
+calling the translation library. Translations are not
+required at this stage.
+*/
+function translate (req, res, next) {
+  set(res.locals, 'translate', (key) => get(labels, key))
+  next()
+}
+
 module.exports = {
   setCompany,
   setOrder,
   setOrderBreadcrumb,
+  translate,
 }

--- a/src/apps/omis/router.js
+++ b/src/apps/omis/router.js
@@ -3,13 +3,15 @@ const router = require('express').Router()
 const { APP_PERMISSIONS } = require('./constants')
 
 const { setHomeBreadcrumb, removeBreadcrumb, handleRoutePermissions } = require('../middleware')
-const { setOrder, setOrderBreadcrumb } = require('./middleware')
+const { setOrder, setOrderBreadcrumb, translate } = require('./middleware')
 
 const viewApp = require('./apps/view')
 const editApp = require('./apps/edit')
 const createApp = require('./apps/create')
 const listApp = require('./apps/list')
 const reconciliationApp = require('./apps/reconciliation')
+
+router.use(translate)
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -97,10 +97,6 @@ module.exports = function locals (req, res, next) {
     getLocal (key) {
       return res.locals[key]
     },
-
-    translate (key) {
-      return req.translate(key)
-    },
   })
   next()
 }

--- a/src/server.js
+++ b/src/server.js
@@ -13,7 +13,6 @@ const enforce = require('express-sslify')
 const favicon = require('serve-favicon')
 const cookieParser = require('cookie-parser')
 const minifyHTML = require('express-minify-html')
-const i18n = require('i18n-future').middleware()
 
 const title = require('./middleware/title')
 const breadcrumbs = require('./middleware/breadcrumbs')
@@ -70,7 +69,6 @@ app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
 app.use(bodyParser.json())
 
 app.use(compression())
-app.use(i18n)
 
 app.set('view engine', 'njk')
 nunjucks(app, config)

--- a/src/templates/_layouts/form-wizard-step.njk
+++ b/src/templates/_layouts/form-wizard-step.njk
@@ -76,12 +76,6 @@
               {{ callAsMacro(props.fieldType)(props) }}
             {% endif %}
 
-            {% if props.supportingContent %}
-              {# TODO: Replace with a details/summary element using the question a user may be asking as the summary #}
-              {% call Message({ type: 'muted' }) %}
-                {{ translate(props.supportingContent) }}
-              {% endcall %}
-            {% endif %}
           {% endif %}
         {% endfor %}
       {% endblock %}

--- a/test/unit/apps/omis/apps/view/middleware.test.js
+++ b/test/unit/apps/omis/apps/view/middleware.test.js
@@ -97,18 +97,6 @@ describe('OMIS View middleware', () => {
     })
   })
 
-  describe('setTranslation()', () => {
-    it('should set a translate method on locals', () => {
-      this.middleware.setTranslation({}, this.resMock, this.nextSpy)
-
-      expect(this.resMock.locals).to.have.property('translate')
-      expect(this.resMock.locals.translate).to.be.a('function')
-      expect(this.nextSpy).to.have.been.calledOnce
-
-      expect(this.resMock.locals.translate('translation.key')).to.equal('translation.key')
-    })
-  })
-
   describe('setCompany()', () => {
     context('when no order exists', () => {
       beforeEach(() => {

--- a/test/unit/apps/omis/controllers/form.test.js
+++ b/test/unit/apps/omis/controllers/form.test.js
@@ -224,16 +224,16 @@ describe('OMIS FormController', () => {
     context('when parent returns an errors object', () => {
       beforeEach(() => {
         this.getErrorsStub = this.getErrorsStub.returns({
-          fieldOne: {
-            key: 'fieldOne',
+          assignee_time: {
+            key: 'assignee_time',
             type: 'required',
-            message: 'cannot not be blank',
+            message: 'cannot be blank',
             url: '/step-url',
           },
-          fieldTwo: {
-            key: 'fieldTwo',
+          assignee_actual_time: {
+            key: 'assignee_actual_time',
             type: 'required',
-            message: 'cannot not be blank',
+            message: 'cannot be blank',
             url: '/step-url',
           },
         })
@@ -248,21 +248,21 @@ describe('OMIS FormController', () => {
         const errors = this.controller.getErrors(this.reqMock, globalRes)
 
         expect(errors).to.deep.equal({
-          fieldOne: {
-            key: 'fieldOne',
+          assignee_time: {
+            key: 'assignee_time',
             type: 'required',
-            message: 'cannot not be blank',
+            message: 'cannot be blank',
             url: '/step-url',
           },
-          fieldTwo: {
-            key: 'fieldTwo',
+          assignee_actual_time: {
+            key: 'assignee_actual_time',
             type: 'required',
-            message: 'cannot not be blank',
+            message: 'cannot be blank',
             url: '/step-url',
           },
           messages: {
-            fieldOne: 'fields.fieldOne.label cannot not be blank',
-            fieldTwo: 'fields.fieldTwo.label cannot not be blank',
+            assignee_time: 'Estimated hours cannot be blank',
+            assignee_actual_time: 'Actual hours worked cannot be blank',
           },
         })
       })

--- a/test/unit/apps/omis/middleware.test.js
+++ b/test/unit/apps/omis/middleware.test.js
@@ -1,3 +1,4 @@
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 const companyData = require('~/test/unit/data/company.json')
 const orderData = require('~/test/unit/data/omis/simple-order.json')
 
@@ -265,6 +266,27 @@ describe('OMIS middleware', () => {
 
       expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledOnce
       expect(this.setHomeBreadcrumbReturnSpy).to.have.been.calledWith({}, this.resMock, this.nextSpy)
+    })
+  })
+
+  describe('translate()', () => {
+    beforeEach(() => {
+      this.middlewareParameters = buildMiddlewareParameters({})
+
+      this.middleware.translate(
+        this.middlewareParameters.reqMock,
+        this.middlewareParameters.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should set the translate function', () => {
+      const actual = this.middlewareParameters.resMock.locals.translate('fields.contact.label')
+      expect(actual).to.equal('Contact responsible for the order')
+    })
+
+    it('should call next()', () => {
+      expect(this.middlewareParameters.nextSpy).to.have.been.calledOnceWithExactly()
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,11 +2897,6 @@ callsites@^0.2.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
   integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
 
-callsites@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-1.0.1.tgz#c14c24188ce8e1d6a030b4c3c942e6ba895b6a1a"
-  integrity sha1-wUwkGIzo4dagMLTDyULmuolbaho=
-
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
@@ -3397,11 +3392,6 @@ colors@^1.0.3, colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
-colors@~0.6.0-1:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
-  integrity sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=
-
 combine-errors@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/combine-errors/-/combine-errors-3.0.3.tgz#f4df6740083e5703a3181110c2b10551f003da86"
@@ -3438,11 +3428,6 @@ commander@^2.14.1, commander@^2.19.0, commander@^2.2.0, commander@^2.8.1, comman
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
-
-commander@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
-  integrity sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=
 
 commander@~2.8.1:
   version "2.8.1"
@@ -5856,14 +5841,6 @@ find@^0.2.7:
   dependencies:
     traverse-chain "~0.1.0"
 
-findup@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/findup/-/findup-0.1.5.tgz#8ad929a3393bac627957a7e5de4623b06b0e2ceb"
-  integrity sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=
-  dependencies:
-    colors "~0.6.0-1"
-    commander "~2.1.0"
-
 flat-cache@^1.2.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
@@ -6288,7 +6265,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.15, glob@^5.0.5:
+glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
@@ -6919,16 +6896,6 @@ https-proxy-agent@^2.2.1:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
-
-i18n-future@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/i18n-future/-/i18n-future-1.1.0.tgz#aa64d5fd3b9d740ff60ef5e22d764afff1a2a71c"
-  integrity sha1-qmTV/TuddA/2DvXiLXZK//Gipxw=
-  dependencies:
-    callsites "^1.0.0"
-    findup "^0.1.5"
-    glob "^5.0.5"
-    lodash "^3.7.0"
 
 i18n-lookup@^1.0.0:
   version "1.0.0"
@@ -8744,11 +8711,6 @@ lodash@4.17.15, lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, loda
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^3.7.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
 log-symbols@2.2.0, log-symbols@^2.0.0, log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description of change

i18n-future is dependent on Lodash 3.7.0. A security vulnerability has been highlighted with the Lodash dependency.

The i18n-future package has not been released for over three years and is no longer maintained.

As a result it is best this dependency is removed.

## Test instructions
The following areas will need special attention:
- OMIS order complete
- OMIS order assignee time
- OMIS order work order view
- OMIS order quote view

Based on the above views error messages and labels will need to be checked.
 
## Screenshots
There should be no visual difference.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
