### PR TITLE
Reveal large capital profile to users

### DIFF
--- a/src/apps/companies/apps/investments/projects/views/main.njk
+++ b/src/apps/companies/apps/investments/projects/views/main.njk
@@ -1,12 +1,6 @@
 {% from "companies/apps/investments/macros/navigation.njk" import subnavigation %}
 
-{#
-    When Large captial growth has been implemented remove this comment
-    and expose the subnavigation for "Investments projects". This allows
-    the user to tab between the two.
-
-    {{ subnavigation(company, 'investment-projects') }}
-#}
+{{ subnavigation(company, 'investment-projects') }}
 
 <h2 class="govuk-heading-m">Investment projects</h2>
 


### PR DESCRIPTION
## Description of change

Reveal large capital profile to users by showing the new sub-navigation on the company investment projects page.

## Test instructions

When clicking on the investments tab of a company profile you should now see a new sub-navigation showing 'Invesments', 'Large capital profile' and (until my other PR is merged removing this) 'Growth capital profile'.

## Screenshots
### Before

![Screenshot 2019-09-10 at 16 18 06](https://user-images.githubusercontent.com/42253716/64626914-9824d400-d3e6-11e9-8c4c-0e781c41f3f0.png)

### After 

![Screenshot 2019-09-10 at 16 17 13](https://user-images.githubusercontent.com/42253716/64626862-788dab80-d3e6-11e9-882d-d891b7c0383b.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
