### PR TITLE
Create company list

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -68,7 +68,7 @@
     @include media(tablet) {
       position: absolute;
       top: 0;
-      right: $default-spacing-unit;
+      right: 0;
     }
   }
 }

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -54,6 +54,7 @@ const matchingRouter = require('./apps/matching/router')
 const interactionsRouter = require('../interactions/router.sub-app')
 const activityFeedRouter = require('./apps/activity-feed/router')
 const addCompanyFormRouter = require('./apps/add-company/router')
+const addCreateListFormRouter = require('../company-lists/router')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
@@ -75,6 +76,7 @@ router.get('/export',
 )
 
 router.use('/create', addCompanyFormRouter)
+router.use('/:companyId/lists/create', addCreateListFormRouter)
 
 router
   .route('/add-step-1')
@@ -130,7 +132,6 @@ router.get('/:companyId/subsidiaries/link', renderLinkSubsidiary)
 router.get('/:companyId/orders', renderOrders)
 router.get('/:companyId/audit', renderAuditLog)
 router.get('/:companyId/documents', renderDocuments)
-
 router.use('/:companyId/investments', investmentsRouter)
 router.use('/:companyId/matching', matchingRouter)
 router.use('/:companyId', setInteractionsDetails, interactionsRouter)

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -17,6 +17,11 @@
       {% endif %}
     </form>
   {% endset %}
+  {% if features.companies_create_list %}
+    {% set action %}
+      <a href="/companies/{{ company.id }}/lists/create" class="govuk-button govuk-button--secondary">Add to my lists</a>
+    {% endset %}
+  {% endif %}
 
   {% call LocalHeader({
     heading: company.name,

--- a/src/apps/company-lists/client/CreateListFormSection.jsx
+++ b/src/apps/company-lists/client/CreateListFormSection.jsx
@@ -1,0 +1,49 @@
+/* eslint-disable */
+
+import React from 'react'
+import axios from 'axios'
+import { CreateListForm } from 'data-hub-components'
+
+const CreateListFormSection = (
+  {
+    id,
+    token,
+    name,
+    hint,
+    label,
+    cancelUrl,
+    maxLength
+  }) => {
+
+  async function onCreateList (id, name, token, cancelUrl, listName) {
+    try {
+      await axios({
+        method: 'POST',
+        url: `/companies/${id}/lists/create?_csrf=${token}`,
+        headers: {
+          'accept': 'application/json',
+          'content-type': 'application/json',
+        },
+        data: {
+          name: listName,
+        },
+      })
+      window.location.href = cancelUrl
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  return (
+    <CreateListForm
+      name={name}
+      hint={hint}
+      label={label}
+      cancelUrl={cancelUrl}
+      maxLength={maxLength}
+      onSubmitHandler={({ listName }) => onCreateList(id, name, token, cancelUrl, listName)}
+    />
+  )
+}
+
+export default CreateListFormSection

--- a/src/apps/company-lists/controllers/create.js
+++ b/src/apps/company-lists/controllers/create.js
@@ -1,0 +1,41 @@
+const { createUserCompanyList } = require('../repos')
+
+async function createCompanyList (req, res, next) {
+  const { id, name } = req.body
+  try {
+    await createUserCompanyList(req.session.token, id, name)
+    req.flash('success', 'Company list created')
+    res.send()
+  } catch (error) {
+    req.flash('error', 'Could not create list')
+    next(error)
+  }
+}
+
+async function renderCreateListForm (req, res, next) {
+  const { company } = res.locals
+  try {
+    res
+      .breadcrumb(company.name)
+      .breadcrumb('lists')
+      .breadcrumb('Create a list')
+      .render('company-lists/views/create-list-container', {
+        props: {
+          id: company.id,
+          token: res.locals.csrfToken,
+          name: 'listName',
+          label: 'List name',
+          hint: 'This is a name only you see, and can be up to 30 characters',
+          cancelUrl: `/companies/${company.id}`,
+          maxLength: 30,
+        },
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderCreateListForm,
+  createCompanyList,
+}

--- a/src/apps/company-lists/repos.js
+++ b/src/apps/company-lists/repos.js
@@ -1,6 +1,17 @@
 const config = require('../../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
+function createUserCompanyList (token, id, name) {
+  return authorisedRequest(token, {
+    method: 'POST',
+    url: `${config.apiRoot}/v4/company-list`,
+    body: {
+      id,
+      name,
+    },
+  })
+}
+
 async function getCompanyList (token, id) {
   return authorisedRequest(token, `${config.apiRoot}/v4/company-list/${id}`)
 }
@@ -15,4 +26,5 @@ async function deleteCompanyList (token, id) {
 module.exports = {
   deleteCompanyList,
   getCompanyList,
+  createUserCompanyList,
 }

--- a/src/apps/company-lists/router.js
+++ b/src/apps/company-lists/router.js
@@ -6,6 +6,14 @@ const { handleRoutePermissions } = require('../middleware')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
+const {
+  renderCreateListForm,
+  createCompanyList,
+} = require('./controllers/create')
+
+router.post('/', createCompanyList)
+router.get('/', renderCreateListForm)
+
 router.get('/:listId/delete', fetchCompanyList, renderDeleteCompanyListPage)
 router.post('/:listId/delete', handleDeleteCompanyList)
 

--- a/src/apps/company-lists/views/create-list-container.njk
+++ b/src/apps/company-lists/views/create-list-container.njk
@@ -1,0 +1,12 @@
+{% extends "_layouts/template.njk" %}
+
+{% block body_main_content %}
+
+  {% set props = props or {} %}
+
+  {% component 'react-slot', {
+    id: 'create-company-list-form',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -5,6 +5,7 @@ import { ActivityFeedApp } from 'data-hub-components'
 import AddCompanyForm from './apps/companies/apps/add-company/client/AddCompanyForm'
 import DeleteCompanyList from './apps/company-lists/client/DeleteCompanyList'
 import MyCompanies from './apps/dashboard/client/MyCompanies.jsx'
+import CreateListFormSection from './apps/company-lists/client/CreateListFormSection'
 
 function Mount ({ selector, children }) {
   return [...document.querySelectorAll(selector)].map(domNode => {
@@ -31,6 +32,9 @@ function App () {
       </Mount>
       <Mount selector="#delete-company-list">
         {props => <DeleteCompanyList {...props} />}
+      </Mount>
+      <Mount selector="#create-company-list-form">
+        {props => <CreateListFormSection {...props} />}
       </Mount>
     </>
   )

--- a/test/functional/cypress/selectors/company-lists/create.js
+++ b/test/functional/cypress/selectors/company-lists/create.js
@@ -1,0 +1,8 @@
+module.exports = {
+  label: 'form label',
+  hint: 'form span',
+  errorLabel: 'form label span:nth-child(2)',
+  input: 'form label input',
+  submit: 'form button',
+  cancel: 'form a',
+}

--- a/test/functional/cypress/selectors/company/index.js
+++ b/test/functional/cypress/selectors/company/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  button: `.c-local-header__actions a`,
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -8,9 +8,11 @@ exports.companyInvestment = require('./company/investment')
 exports.companySubsidiariesLink = require('./company/subsidiaries-link')
 exports.companySubsidiaries = require('./company/subsidiaries')
 exports.companyAddToListButton = require('./company/add-to-list')
+exports.companyCreateListButton = require('./company')
 
 exports.companyList = {
   delete: require('./company-lists/delete'),
+  create: require('./company-lists/create'),
 }
 
 exports.contactCreate = require('./contact/create')

--- a/test/functional/cypress/specs/company-lists/create-spec.js
+++ b/test/functional/cypress/specs/company-lists/create-spec.js
@@ -42,7 +42,7 @@ describe('Create a company list', () => {
 
   context('when submitting with no input', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create-list`)
+      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create`)
     })
     it('should display an error', () => {
       cy.get(selectors.companyList.create.submit).click()
@@ -52,7 +52,7 @@ describe('Create a company list', () => {
 
   context('when submitting over 30 characters', () => {
     before(() => {
-      cy.visit('/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018/lists/create-list')
+      cy.visit('/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018/lists/create')
     })
     it('should display an error', () => {
       cy.get(selectors.companyList.create.input).type('loooooooooooooonnnnnnnnnnnnnggggggggg text!')
@@ -63,7 +63,7 @@ describe('Create a company list', () => {
 
   context('when submitting a valid list name', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create-list`)
+      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create`)
     })
     it('should display a success message', () => {
       cy.get(selectors.companyList.create.input).type('New list name')
@@ -74,7 +74,7 @@ describe('Create a company list', () => {
 
   context('when cancelling the form', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create-list`)
+      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create`)
     })
     it('should return to the company page', () => {
       cy.get(selectors.companyList.create.cancel).click()

--- a/test/functional/cypress/specs/company-lists/create-spec.js
+++ b/test/functional/cypress/specs/company-lists/create-spec.js
@@ -1,0 +1,84 @@
+const selectors = require('../../selectors')
+const fixtures = require('../../fixtures')
+
+describe('Create a company list', () => {
+  context('when viewing a Create list form', () => {
+    before(() => {
+      cy.visit('/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018/lists/create')
+    })
+
+    it('displays breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Companies')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/companies')
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Create a list')
+    })
+
+    it('displays the "Create list" heading', () => {
+      cy.get(selectors.localHeader().heading).should('have.text', 'Create a list')
+    })
+
+    it('displays the list name', () => {
+      cy.get(selectors.companyList.create.label).should('have.text', 'List name')
+    })
+
+    it('displays the hint', () => {
+      cy.get(selectors.companyList.create.hint).should('have.text', 'This is a name only you see, and can be up to 30 characters')
+    })
+
+    it('displays an input', () => {
+      cy.get(selectors.companyList.create.input).should('exist')
+    })
+
+    it('displays an button', () => {
+      cy.get(selectors.companyList.create.submit).should('have.text', 'Create list')
+    })
+
+    it('displays a cancel link', () => {
+      cy.get(selectors.companyList.create.cancel).should('have.text', 'Cancel')
+    })
+  })
+
+  context('when submitting with no input', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create-list`)
+    })
+    it('should display an error', () => {
+      cy.get(selectors.companyList.create.submit).click()
+      cy.get(selectors.companyList.create.errorLabel).should('have.text', 'Enter a name for your list')
+    })
+  })
+
+  context('when submitting over 30 characters', () => {
+    before(() => {
+      cy.visit('/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018/lists/create-list')
+    })
+    it('should display an error', () => {
+      cy.get(selectors.companyList.create.input).type('loooooooooooooonnnnnnnnnnnnnggggggggg text!')
+      cy.get(selectors.companyList.create.submit).click()
+      cy.get(selectors.companyList.create.errorLabel).should('have.text', 'Enter list name which is no longer than 30 characters')
+    })
+  })
+
+  context('when submitting a valid list name', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create-list`)
+    })
+    it('should display a success message', () => {
+      cy.get(selectors.companyList.create.input).type('New list name')
+      cy.get(selectors.companyList.create.submit).click()
+      cy.get(selectors.localHeader().flash).should('contain.text', 'Company list created')
+    })
+  })
+
+  context('when cancelling the form', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/lists/create-list`)
+    })
+    it('should return to the company page', () => {
+      cy.get(selectors.companyList.create.cancel).click()
+      cy.get(selectors.localHeader().heading).should('contain.text', fixtures.company.lambdaPlc.name)
+    })
+  })
+})

--- a/test/unit/apps/company-lists/controllers/create.test.js
+++ b/test/unit/apps/company-lists/controllers/create.test.js
@@ -1,0 +1,122 @@
+const config = require('~/config')
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder')
+const { createCompanyList, renderCreateListForm } = require('~/src/apps/company-lists/controllers/create')
+
+describe('Creating company lists', () => {
+  describe('#createCompanyList', () => {
+    context('when a company has been successfully added to a list', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters()
+        this.middlewareParameters.reqMock.body = { id: '1', name: 'listName' }
+        this.middlewareParameters.resMock.send = sinon.stub()
+
+        nock(config.apiRoot)
+          .post('/v4/company-list', {
+            id: '1',
+            name: 'listName',
+          })
+          .reply(200, { id: '1', name: 'listName', created_on: '2019' })
+
+        await createCompanyList(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should send a success message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledWith('success', 'Company list created')
+      })
+
+      it('should then send the response', () => {
+        expect(this.middlewareParameters.resMock.send).to.have.been.called
+      })
+    })
+
+    context('when a company has failed to be added to a list', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters()
+        this.middlewareParameters.reqMock.body = { id: '1', name: 'listName' }
+        this.middlewareParameters.resMock.send = sinon.stub()
+
+        nock(config.apiRoot)
+          .post('/v4/company-list', {
+            id: '1',
+            name: 'listName',
+          })
+          .reply(400)
+
+        await createCompanyList(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should send a error message', () => {
+        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledWith('error', 'Could not create list')
+      })
+
+      it('should then send the response', () => {
+        expect(this.middlewareParameters.nextSpy).to.have.been.called
+      })
+    })
+  })
+
+  describe('#renderCreateListForm', () => {
+    beforeEach(async () => {
+      this.middlewareParameters = buildMiddlewareParameters()
+      this.middlewareParameters.resMock.locals = {
+        csrfToken: 'token',
+        company: {
+          name: 'Company',
+          id: '1',
+        },
+      }
+
+      await renderCreateListForm(
+        this.middlewareParameters.reqMock,
+        this.middlewareParameters.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should render a breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('Company')
+      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('lists')
+      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('Create a list')
+    })
+
+    it('should render to the view with props', () => {
+      expect(this.middlewareParameters.resMock.render).to.have.been.calledWith('company-lists/views/create-list-container',
+        {
+          props: {
+            id: '1',
+            token: 'token',
+            name: 'listName',
+            label: 'List name',
+            hint: 'This is a name only you see, and can be up to 30 characters',
+            cancelUrl: `/companies/1`,
+            maxLength: 30,
+          },
+        })
+    })
+
+    context('when there is an error in the render', () => {
+      beforeEach(async () => {
+        this.middlewareParameters.resMock.render.throws()
+
+        await renderCreateListForm(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should call next with errors', () => {
+        expect(this.middlewareParameters.nextSpy).to.be.called
+        expect(this.middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(Error)
+      })
+    })
+  })
+})

--- a/test/unit/apps/company-lists/controllers/create.test.js
+++ b/test/unit/apps/company-lists/controllers/create.test.js
@@ -6,9 +6,9 @@ describe('Creating company lists', () => {
   describe('#createCompanyList', () => {
     context('when a company has been successfully added to a list', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters()
-        this.middlewareParameters.reqMock.body = { id: '1', name: 'listName' }
-        this.middlewareParameters.resMock.send = sinon.stub()
+        global.middlewareParameters = buildMiddlewareParameters()
+        global.middlewareParameters.reqMock.body = { id: '1', name: 'listName' }
+        global.middlewareParameters.resMock.send = sinon.stub()
 
         nock(config.apiRoot)
           .post('/v4/company-list', {
@@ -18,26 +18,26 @@ describe('Creating company lists', () => {
           .reply(200, { id: '1', name: 'listName', created_on: '2019' })
 
         await createCompanyList(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
       it('should send a success message', () => {
-        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledWith('success', 'Company list created')
+        expect(global.middlewareParameters.reqMock.flash).to.have.been.calledWith('success', 'Company list created')
       })
 
       it('should then send the response', () => {
-        expect(this.middlewareParameters.resMock.send).to.have.been.called
+        expect(global.middlewareParameters.resMock.send).to.have.been.called
       })
     })
 
     context('when a company has failed to be added to a list', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters()
-        this.middlewareParameters.reqMock.body = { id: '1', name: 'listName' }
-        this.middlewareParameters.resMock.send = sinon.stub()
+        global.middlewareParameters = buildMiddlewareParameters()
+        global.middlewareParameters.reqMock.body = { id: '1', name: 'listName' }
+        global.middlewareParameters.resMock.send = sinon.stub()
 
         nock(config.apiRoot)
           .post('/v4/company-list', {
@@ -47,26 +47,26 @@ describe('Creating company lists', () => {
           .reply(400)
 
         await createCompanyList(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
       it('should send a error message', () => {
-        expect(this.middlewareParameters.reqMock.flash).to.have.been.calledWith('error', 'Could not create list')
+        expect(global.middlewareParameters.reqMock.flash).to.have.been.calledWith('error', 'Could not create list')
       })
 
       it('should then send the response', () => {
-        expect(this.middlewareParameters.nextSpy).to.have.been.called
+        expect(global.middlewareParameters.nextSpy).to.have.been.called
       })
     })
   })
 
   describe('#renderCreateListForm', () => {
     beforeEach(async () => {
-      this.middlewareParameters = buildMiddlewareParameters()
-      this.middlewareParameters.resMock.locals = {
+      global.middlewareParameters = buildMiddlewareParameters()
+      global.middlewareParameters.resMock.locals = {
         csrfToken: 'token',
         company: {
           name: 'Company',
@@ -75,20 +75,20 @@ describe('Creating company lists', () => {
       }
 
       await renderCreateListForm(
-        this.middlewareParameters.reqMock,
-        this.middlewareParameters.resMock,
-        this.middlewareParameters.nextSpy,
+        global.middlewareParameters.reqMock,
+        global.middlewareParameters.resMock,
+        global.middlewareParameters.nextSpy,
       )
     })
 
     it('should render a breadcrumb', () => {
-      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('Company')
-      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('lists')
-      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('Create a list')
+      expect(global.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('Company')
+      expect(global.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('lists')
+      expect(global.middlewareParameters.resMock.breadcrumb).to.have.been.calledWith('Create a list')
     })
 
     it('should render to the view with props', () => {
-      expect(this.middlewareParameters.resMock.render).to.have.been.calledWith('company-lists/views/create-list-container',
+      expect(global.middlewareParameters.resMock.render).to.have.been.calledWith('company-lists/views/create-list-container',
         {
           props: {
             id: '1',
@@ -104,18 +104,18 @@ describe('Creating company lists', () => {
 
     context('when there is an error in the render', () => {
       beforeEach(async () => {
-        this.middlewareParameters.resMock.render.throws()
+        global.middlewareParameters.resMock.render.throws()
 
         await renderCreateListForm(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
       it('should call next with errors', () => {
-        expect(this.middlewareParameters.nextSpy).to.be.called
-        expect(this.middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(Error)
+        expect(global.middlewareParameters.nextSpy).to.be.called
+        expect(global.middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(Error)
       })
     })
   })

--- a/test/unit/apps/company-lists/repos.test.js
+++ b/test/unit/apps/company-lists/repos.test.js
@@ -3,6 +3,7 @@ const config = require('~/config')
 const {
   getCompanyList,
   deleteCompanyList,
+  createUserCompanyList,
 } = require('~/src/apps/company-lists/repos')
 
 const companyListFixture = require('~/test/unit/data/company-lists/list-with-multiple-items.json')
@@ -10,6 +11,22 @@ const companyListFixture = require('~/test/unit/data/company-lists/list-with-mul
 const companyListId = companyListFixture.id
 
 describe('Company list repository', () => {
+  describe('#createUserCompanyList', () => {
+    beforeEach(() => {
+      nock(config.apiRoot)
+        .post('/v4/company-list', {
+          id: '1',
+          name: 'listName',
+        })
+        .reply(200, { id: '1', name: 'listName', created_on: '2019' })
+    })
+
+    it('should return company', async () => {
+      const companyList = await createUserCompanyList('TEST_TOKEN', '1', 'listName')
+      expect(companyList).to.deep.equal({ id: '1', name: 'listName', created_on: '2019' })
+    })
+  })
+
   describe('#getCompanyList', () => {
     beforeEach(async () => {
       nock(config.apiRoot)


### PR DESCRIPTION
## Description of change
Previously the user could only add companies to one list which displayed on the homepage, this enables the user to create a multiple lists.

## Test instructions
The action that creates a new list is hidden under a feature flag called `companies_create_list` so you need to activate this. One the feature flag is in place you need to:
- Visit a company
- Click the "Add to list" button
- Create a new list via the form
- You should then see a success page

_What should I see?_
 
## Screenshots
![Screenshot 2019-09-11 at 10 27 28](https://user-images.githubusercontent.com/10154302/64685414-e1c0fd80-d47e-11e9-968e-557e81e009da.png)
![Screenshot 2019-09-11 at 10 27 36](https://user-images.githubusercontent.com/10154302/64685426-e685b180-d47e-11e9-854c-ee9ec97d5ff0.png)
![Screenshot 2019-09-11 at 10 27 53](https://user-images.githubusercontent.com/10154302/64685430-ea193880-d47e-11e9-90f3-cef1ffe21196.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
