### PR TITLE
Unify the way React apps are mounted

### DIFF
--- a/src/apps/companies/apps/activity-feed/views/client-container.njk
+++ b/src/apps/companies/apps/activity-feed/views/client-container.njk
@@ -2,10 +2,9 @@
 
 {% block body_main_content %}
 
-  {% set props = props or {} %}
-
-  <div id="activity-feed-app" data-props="{{ props | dump }}">
-    <noscript>Please enable JavaScript in your browser to see the activity feed.</noscript>
-  </div>
+  {% component 'react-slot', {
+    id: 'activity-feed-app',
+    props: props
+  } %}
 
 {% endblock %}

--- a/src/apps/companies/apps/add-company/views/client-container.njk
+++ b/src/apps/companies/apps/add-company/views/client-container.njk
@@ -2,10 +2,9 @@
 
 {% block body_main_content %}
 
-  {% set props = props or {} %}
-
-  <div id="add-company-form" data-props="{{ props | dump }}">
-    <noscript>Please enable JavaScript in your browser to see the content.</noscript>
-  </div>
+  {% component 'react-slot', {
+    id: 'add-company-form',
+    props: props
+  } %}
 
 {% endblock %}

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -24,10 +24,9 @@
     </div>
 {% if canViewCompanyList %}
     <div class="govuk-grid-column-full">
-      {% component 'react-slot', {
-        id: 'react-mount-my-companies',
-        model: companyList
-      } %}
+      <div id="react-mount-my-companies" data-model="{{ companyList }}">
+        <noscript>Please enable JavaScript in your browser to see the content.</noscript>
+      </div>
     </div>
 {% endif %}
 </div>

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import React from 'react'
 import ReactDOM from 'react-dom'
 
@@ -7,7 +5,7 @@ import { ActivityFeedApp } from 'data-hub-components'
 import AddCompanyForm from './apps/companies/apps/add-company/client/AddCompanyForm'
 import MyCompanies from './apps/dashboard/client/MyCompanies.jsx'
 
-function Mount({ selector, children }) {
+function Mount ({ selector, children }) {
   return [...document.querySelectorAll(selector)].map(domNode => {
     const props =
       'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}
@@ -18,7 +16,7 @@ function Mount({ selector, children }) {
   })
 }
 
-function App() {
+function App () {
   return (
     <>
       <Mount selector="#add-company-form">

--- a/src/templates/_components/react-slot.njk
+++ b/src/templates/_components/react-slot.njk
@@ -1,15 +1,19 @@
 {##
- # @param {string}    id         The react slot element ID to mount the component to
- # @param {string[]}  classes    Classes for the wrapping div
+ # @param {string} id - The react slot element ID to mount the component to
+ # @param {string[]} classes - Classes for the wrapping div
+ # @param {object} props - Props which will be passed to the React component
  #
  # @example
  # {% component 'react-slot', {
  #    id: 'react-mount-my-companies',
  #    classes: 'gov-uk-column-one-third',
-      model: data
+ #    props: data
  #  } %}
  #
-##}
-<div id="{{id}}" class="{{classes}}" data-model="{{ model }}">
-  <noscript> Please enable Javascript in your browser to view this section. <noscript>
+ #}
+
+{% set props = props or {} %}
+
+<div id="{{id}}" class="{{classes}}" data-props="{{ props | dump }}">
+  <noscript>Please enable JavaScript in your browser to see the content.</noscript>
 </div>


### PR DESCRIPTION
## Description of change

This PR is refactoring the `react-slot` template and the way we are currently mounting React apps.

There is no visual change.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
