### PR TITLE
Add "I still cannot find the company" unhappy path form fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^1.5.1",
+    "data-hub-components": "^1.10.0",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -1,11 +1,18 @@
 /* eslint-disable camelcase */
 
 import React, { useState } from 'react'
-import { H3, LoadingBox } from 'govuk-react'
+import {
+  H3,
+  LoadingBox,
+  UnorderedList,
+  ListItem,
+  Details,
+} from 'govuk-react'
 import PropTypes from 'prop-types'
 import { compact, get } from 'lodash'
 import {
   FieldDnbCompany,
+  FieldInput,
   FieldRadios,
   FieldSelect,
   Form,
@@ -25,7 +32,7 @@ const COMPANY_LOCATION_OPTIONS = {
   },
 }
 
-function AddCompanyForm ({ host, csrfToken, foreignCountries }) {
+function AddCompanyForm ({ host, csrfToken, foreignCountries, regions, sectors }) {
   const [submitted, setSubmitted] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -118,20 +125,99 @@ function AddCompanyForm ({ host, csrfToken, foreignCountries }) {
             />
           </Step>
 
-          <Step name="companyDetails" forwardButtonText="Add company">
-            <H3>Confirm you want to add this company to Data Hub</H3>
+          {!form.values.cannotFind && (
+            <Step name="companyDetails" forwardButtonText="Add company">
+              <H3>Confirm you want to add this company to Data Hub</H3>
 
-            <DefinitionList header={getCompanyName(form.values)}>
-              <DefinitionList.Row
-                label="Companies House number"
-                description={getCompaniesHouseNumber(form.values)}
+              <DefinitionList header={getCompanyName(form.values)}>
+                <DefinitionList.Row
+                  label="Companies House number"
+                  description={getCompaniesHouseNumber(form.values)}
+                />
+                <DefinitionList.Row
+                  label="Address"
+                  description={getCompanyAddress(form.values)}
+                />
+              </DefinitionList>
+            </Step>
+          )}
+
+          {form.values.cannotFind && (
+            <Step name="unhappy" forwardButtonText="Add company">
+
+              <Details summary="Why am I seeing this?">
+                The company you want to add to Data Hub cannot be found in the external databases Data Hub checks.
+                You will need to provide information about the company, so the company can be added to Data Hub
+                while the Data Hub support team checks with the company the information you have provided.
+              </Details>
+
+              <FieldRadios
+                name="organisation_type"
+                label="Organisation type"
+                required="Select organisation"
+                options={[
+                  { label: 'Business', value: 'business' },
+                  { label: 'Charity', value: 'charity' },
+                  { label: 'Public body', value: 'publicbody' },
+                ]}
               />
-              <DefinitionList.Row
-                label="Address"
-                description={getCompanyAddress(form.values)}
+
+              <FieldInput
+                label="Name of company"
+                name="name"
+                required="Enter name"
+                type="text"
               />
-            </DefinitionList>
-          </Step>
+
+              <FieldInput
+                label="Company's website"
+                name="website"
+                required="Enter website"
+                type="text"
+              />
+
+              <FieldInput
+                label="Company's telephone number"
+                name="telephone"
+                type="text"
+              />
+
+              <FieldSelect
+                name="region"
+                label="DIT region"
+                emptyOption="-- Select DIT region --"
+                options={regions}
+                required="Select DIT region"
+              />
+
+              <FieldSelect
+                name="sector"
+                label="DIT sector"
+                emptyOption="-- Select DIT sector --"
+                options={sectors}
+                required="Select DIT sector"
+              />
+
+              <H3>What happens next</H3>
+              <p>
+                You are requesting a new company record to be added to Data Hub. This is what will happen next:
+                <UnorderedList>
+                  <ListItem>
+                    The information you have provided will be sent to the Data Hub support team and they will check this
+                    information with the company
+                  </ListItem>
+                  <ListItem>
+                    In the meantime, you can continue to record interactions with this company
+                  </ListItem>
+                  <ListItem>
+                    You will be sent an email with the outcome of the investigation
+                  </ListItem>
+                </UnorderedList>
+              </p>
+
+            </Step>
+          )}
+
         </LoadingBox>
       )}
     </Form>

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -1,18 +1,25 @@
 const { fetchForeignCountries } = require('./repos')
 const { searchDnbCompanies } = require('../../../../modules/search/services')
 const { saveDnbCompany } = require('../../repos')
+const { getOptions } = require('../../../../lib/options')
 
 async function renderAddCompanyForm (req, res, next) {
   try {
-    const foreignCountries = await fetchForeignCountries({ token: req.session.token })
+    const [foreignCountries, regions, sectors] = await Promise.all([
+      fetchForeignCountries({ token: req.session.token }),
+      getOptions(req.session.token, 'uk-region'),
+      getOptions(req.session.token, 'sector'),
+    ])
 
     res
       .breadcrumb('Add company')
       .render('companies/apps/add-company/views/client-container', {
         props: {
+          foreignCountries,
+          regions,
+          sectors,
           host: req.headers.host,
           csrfToken: res.locals.csrfToken,
-          foreignCountries,
         },
       })
   } catch (error) {

--- a/test/functional/cypress/selectors/company/add-company.js
+++ b/test/functional/cypress/selectors/company/add-company.js
@@ -11,6 +11,25 @@ module.exports = {
       someCompanyName: 'form ol li:nth-child(1)',
       someOtherCompany: 'form ol li:nth-child(2)',
     },
+    cannotFind: {
+      summary: 'details summary span',
+      stillCannotFind: 'a:contains("I still cannot find the company")',
+    },
+  },
+  newCompanyRecordForm: {
+    whyAmISeeingThis: {
+      summary: 'details summary span',
+    },
+    organisationType: {
+      business: 'input[type="radio"][value="business"]',
+      charity: 'input[type="radio"][value="charity"]',
+      publicBody: 'input[type="radio"][value="publicbody"]',
+    },
+    name: '#name input',
+    website: '#website input',
+    telephone: '#telephone input',
+    region: 'label[name="region"] select',
+    sector: 'label[name="sector"] select',
   },
   companyDetails: {
     subheader: 'form h2',

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -109,4 +109,50 @@ describe('Add company form', () => {
       })
     })
   })
+
+  context('when the user clicks "I still cannot find the company"', () => {
+    before(() => {
+      cy.visit('/companies/create')
+
+      cy.get(selectors.companyAdd.form).find('[type="radio"]').check('uk')
+      cy.get(selectors.companyAdd.nextButton).click()
+
+      cy.get(selectors.companyAdd.entitySearch.searchButton).click()
+
+      cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
+      cy.get(selectors.companyAdd.entitySearch.cannotFind.stillCannotFind).click()
+    })
+
+    it('should display the form', () => {
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.business).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.publicBody).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.name).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.website).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.region).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.sector).should('be.visible')
+    })
+
+    context('when I complete the form', () => {
+      before(() => {
+        cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.business).click()
+        cy.get(selectors.companyAdd.newCompanyRecordForm.name).type('name')
+        cy.get(selectors.companyAdd.newCompanyRecordForm.website).type('website')
+        cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).type('0123456789')
+        cy.get(selectors.companyAdd.newCompanyRecordForm.region).select('London')
+        cy.get(selectors.companyAdd.newCompanyRecordForm.sector).select('Advanced Engineering')
+
+        cy.get(selectors.companyAdd.submitButton).click()
+      })
+
+      xit('should redirect to the new company activity', () => {
+        cy.location('pathname').should('eq', `/companies/5678/activity`)
+      })
+
+      xit('should display the flash message', () => {
+        cy.get(selectors.localHeader().flash).should('contain', 'Company added to Data Hub')
+      })
+    })
+  })
 })

--- a/test/unit/apps/companies/apps/add-company/controllers.test.js
+++ b/test/unit/apps/companies/apps/add-company/controllers.test.js
@@ -9,20 +9,37 @@ const countriesFixture = require('../../../../data/metadata/country')
 const { transformObjectToOption } = require('~/src/apps/transformers')
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder')
 
+const metadataMock = {
+  regionOptions: [
+    { id: '1', name: 'r1', disabled_on: null },
+    { id: '2', name: 'r2', disabled_on: null },
+    { id: '3', name: 'r3', disabled_on: null },
+  ],
+  sectorOptions: [
+    { id: '1', name: 's1', disabled_on: null },
+    { id: '2', name: 's2', disabled_on: null },
+    { id: '3', name: 's3', disabled_on: null },
+  ],
+}
+
 describe('Add company form controllers', () => {
   beforeEach(() => {
     nock(config.apiRoot)
       .get('/metadata/country/')
       .reply(200, countriesFixture)
+
+    nock(config.apiRoot)
+      .get('/metadata/sector/')
+      .reply(200, metadataMock.sectorOptions)
+
+    nock(config.apiRoot)
+      .get('/metadata/uk-region/')
+      .reply(200, metadataMock.regionOptions)
   })
 
   describe('#renderAddCompanyForm', () => {
     context('when the "Add company form" renders successfully', () => {
       beforeEach(async () => {
-        this.foreignCountriesFixture = countriesFixture
-          .filter(c => c.name !== 'United Kingdom')
-          .map(transformObjectToOption)
-
         this.middlewareParameters = buildMiddlewareParameters()
 
         await renderAddCompanyForm(
@@ -34,11 +51,19 @@ describe('Add company form controllers', () => {
 
       it('should render the add company form template with fields', () => {
         const expectedTemplate = 'companies/apps/add-company/views/client-container'
+        const expectedForeignCountries = countriesFixture
+          .filter(c => c.name !== 'United Kingdom')
+          .map(transformObjectToOption)
+        const expectedSectors = metadataMock.sectorOptions.map(transformObjectToOption)
+        const expectedRegions = metadataMock.regionOptions.map(transformObjectToOption)
+
         expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(expectedTemplate, {
           props: {
             host: 'localhost:3000',
             csrfToken: 'csrf',
-            foreignCountries: this.foreignCountriesFixture,
+            foreignCountries: expectedForeignCountries,
+            sectors: expectedSectors,
+            regions: expectedRegions,
           },
         })
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,10 +4092,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-1.5.1.tgz#a30b91d2ddbb96077a817af944e85af936702ebc"
-  integrity sha512-s1lKFt2rfX2icjRFj4rePZpyCcMwSTBW2O2C4dV2FfoZZBZZ+PuQCgUmdzV1XApgy4UcNktMDnlhrLVMa41CEg==
+data-hub-components@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-1.10.0.tgz#3b4d02dfcb9d064ae358c909f1f7eab156d47b3d"
+  integrity sha512-4OG4ENIW7R50DhIxsGJZoohMfbn9bVzX01bEBx03sNUo4HddDdCZtCGN2KUvtGQbdyqeSJgXjfFda/TbcDzgWw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"
@@ -4105,13 +4105,17 @@ data-hub-components@^1.5.1:
     "@govuk-react/error-text" "^0.7.1"
     "@govuk-react/form-group" "^0.7.1"
     "@govuk-react/input-field" "^0.7.1"
+    "@govuk-react/inset-text" "^0.7.1"
     "@govuk-react/label-text" "^0.7.1"
     "@govuk-react/lib" "^0.7.1"
     "@govuk-react/link" "^0.7.1"
+    "@govuk-react/list-item" "^0.7.1"
     "@govuk-react/multi-choice" "^0.7.1"
+    "@govuk-react/paragraph" "^0.7.1"
     "@govuk-react/radio" "^0.7.1"
     "@govuk-react/select" "^0.7.1"
     "@govuk-react/table" "^0.7.1"
+    "@govuk-react/unordered-list" "^0.7.1"
     axios "^0.19.0"
     constate "^1.2.0"
     govuk-colours "^1.0.3"


### PR DESCRIPTION
## Description of change
When the user clicks the `I still cannot find the company` link after searching for a company, they will be taken on an alternative route to manually enter details of the company. This change:
1. Integrates `data-hub-components` changes to handle `I still cannot find the company` click event
2. Presents the correct step
3. Adds a basic set of form fields to manually enter the company
4. Functional tests

## Test instructions
1. Browse to `~/companies/create`
2. Select `UK`
3. Click `Next`
4. Search for a company
5. Click `I cannot find the company I am looking for`
6. Click `I still cannot find the company`, you will be presented with a basic version of the form

## Known issues
- CSS needs ❤️ 
- Address component not included
- Not handling `Add company` button click at this stage

## Screenshots
![Screenshot 2019-09-12 at 16 43 16](https://user-images.githubusercontent.com/1150417/64799408-9260f700-d57c-11e9-9aa8-f5578c13291e.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
