### PR TITLE
Add skeleton company list app

### DIFF
--- a/src/apps/company-lists/constants.js
+++ b/src/apps/company-lists/constants.js
@@ -1,0 +1,5 @@
+const APP_PERMISSIONS = []
+
+module.exports = {
+  APP_PERMISSIONS,
+}

--- a/src/apps/company-lists/index.js
+++ b/src/apps/company-lists/index.js
@@ -1,0 +1,7 @@
+const router = require('./router')
+
+module.exports = {
+  displayName: 'My company lists',
+  mountpath: '/company-lists',
+  router,
+}

--- a/src/apps/company-lists/repos.js
+++ b/src/apps/company-lists/repos.js
@@ -1,0 +1,18 @@
+const config = require('../../../config')
+const { authorisedRequest } = require('../../lib/authorised-request')
+
+async function getCompanyList (token, id) {
+  return authorisedRequest(token, `${config.apiRoot}/v4/company-list/${id}`)
+}
+
+async function deleteCompanyList (token, id) {
+  return authorisedRequest(token, {
+    url: `${config.apiRoot}/v4/company-list/${id}`,
+    method: 'DELETE',
+  })
+}
+
+module.exports = {
+  deleteCompanyList,
+  getCompanyList,
+}

--- a/src/apps/company-lists/router.js
+++ b/src/apps/company-lists/router.js
@@ -1,0 +1,8 @@
+const router = require('express').Router()
+
+const { APP_PERMISSIONS } = require('./constants')
+const { handleRoutePermissions } = require('../middleware')
+
+router.use(handleRoutePermissions(APP_PERMISSIONS))
+
+module.exports = router

--- a/test/unit/apps/company-lists/repos.test.js
+++ b/test/unit/apps/company-lists/repos.test.js
@@ -1,0 +1,39 @@
+const config = require('~/config')
+
+const {
+  getCompanyList,
+  deleteCompanyList,
+} = require('~/src/apps/company-lists/repos')
+
+const companyListFixture = require('~/test/unit/data/company-lists/list-with-multiple-items.json')
+
+const companyListId = companyListFixture.id
+
+describe('Company list repository', () => {
+  describe('#getCompanyList', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get(`/v4/company-list/${companyListId}`)
+        .reply(200, companyListFixture)
+    })
+
+    it('returns a company list', async () => {
+      let companyList = await getCompanyList('token', companyListId)
+      expect(companyList).to.deep.equal(companyListFixture)
+    })
+  })
+
+  describe('#deleteCompanyList', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .delete(`/v4/company-list/${companyListId}`)
+        .reply(204)
+    })
+
+    it('deletes a company list', async () => {
+      expect(
+        async () => deleteCompanyList('token', companyListId)
+      ).to.not.throw()
+    })
+  })
+})

--- a/test/unit/data/company-lists/list-with-multiple-items.json
+++ b/test/unit/data/company-lists/list-with-multiple-items.json
@@ -1,0 +1,6 @@
+{
+  "id": "2a8fb06f-2099-44d6-b404-e0fae0b9ea59",
+  "name": "A list with multiple items",
+  "item_count": 13,
+  "created_on": "2018-01-01T15:20:23Z"
+}


### PR DESCRIPTION
## Description of change

This adds a skeleton app for company lists for future PRs for company list functionality to build on.

It currently includes a couple of functions for getting and deleting a company list from the API.

The app is otherwise deliberately mostly empty as future PRs will add to it.

## Test instructions

Nothing to test in the interface.
 
## Screenshots

No visible changes.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
