### PR TITLE
Hook up POST of company when creating from D&B search result

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -58,15 +58,13 @@ function AddCompanyForm ({ host, csrfToken, countries, organisationTypes, region
   async function onSubmit (values) {
     setIsSubmitting(true)
 
-    if (values.cannotFind) {
-      try {
-        const { data } = await axios.post(`//${host}/companies/create/dnb/company-investigation?_csrf=${csrfToken}`, values)
-        window.location.href = `//${host}/companies/${data.id}`
-      } catch (error) {
-        // TODO: handle error
-      }
-    } else {
-      // TODO: handle can find
+    const path = values.cannotFind ? 'company-investigation' : 'company-create'
+
+    try {
+      const { data } = await axios.post(`//${host}/companies/create/dnb/${path}?_csrf=${csrfToken}`, values)
+      window.location.href = `//${host}/companies/${data.id}`
+    } catch (error) {
+      // todo handle error
     }
 
     setIsSubmitting(false)

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -51,10 +51,11 @@ async function postSearchDnbCompanies (req, res, next) {
 
 async function postAddDnbCompany (req, res, next) {
   try {
-    const company = await saveDnbCompany(req.session.token, req.body.duns_number)
-    req.flash('success', 'Company created')
-
-    res.json(company)
+    await saveDnbCompany(req.session.token, req.body.duns_number)
+      .then((result) => {
+        req.flash('success', 'Company added to Data Hub')
+        res.json(result)
+      })
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/apps/add-company/router.js
+++ b/src/apps/companies/apps/add-company/router.js
@@ -7,13 +7,9 @@ const {
   postAddDnbCompanyInvestigation,
 } = require('./controllers')
 
-router
-  .route('/')
-  .get(renderAddCompanyForm)
-  .post(postAddDnbCompany)
-
+router.get('/', renderAddCompanyForm)
+router.post('/dnb/company-create', postAddDnbCompany)
 router.post('/dnb/company-search', postSearchDnbCompanies)
-
 router.post('/dnb/company-investigation', postAddDnbCompanyInvestigation)
 
 module.exports = router

--- a/test/functional/cypress/fixtures/company/some-other-company.json
+++ b/test/functional/cypress/fixtures/company/some-other-company.json
@@ -1,0 +1,4 @@
+{
+  "id": "ca8fae21-2895-47cf-90ba-9273c94dab92",
+  "name": "Some other company",
+}

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -10,6 +10,7 @@ module.exports = {
     marsExportsLtd: require('./company/mars-exports-ltd'),
     minimallyMinimalLtd: require('./company/minimally-minimal-ltd'),
     oneListCorp: require('./company/one-list-corp.json'),
+    someOtherCompany: require('./company/some-other-company.json'),
     venusLtd: require('./company/venus-ltd.json'),
     withContacts: require('./company/with-contacts.json'),
   },

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -130,6 +130,20 @@ describe('Add company form', () => {
           it('should display "Add company" button', () => {
             cy.get(selectors.companyAdd.submitButton).should('be.visible')
           })
+
+          context('when the "Add company" button is clicked', () => {
+            before(() => {
+              cy.get(selectors.companyAdd.submitButton).click()
+            })
+
+            it('should redirect to the new company activity', () => {
+              cy.location('pathname').should('eq', `/companies/${fixtures.company.someOtherCompany.id}/activity`)
+            })
+
+            it('should display the flash message', () => {
+              cy.get(selectors.localHeader().flash).should('contain', 'Company added to Data Hub')
+            })
+          })
         })
       })
     })

--- a/test/unit/apps/companies/apps/add-company/controllers.test.js
+++ b/test/unit/apps/companies/apps/add-company/controllers.test.js
@@ -234,7 +234,7 @@ describe('Add company form controllers', () => {
       })
 
       it('should flash a created message', () => {
-        expect(this.middlewareParameters.reqMock.flash).to.be.calledOnceWithExactly('success', 'Company created')
+        expect(this.middlewareParameters.reqMock.flash).to.be.calledOnceWithExactly('success', 'Company added to Data Hub')
       })
 
       it('should respond with the created company', () => {

--- a/test/unit/apps/companies/apps/add-company/router.test.js
+++ b/test/unit/apps/companies/apps/add-company/router.test.js
@@ -10,7 +10,8 @@ describe('Add company form routes', () => {
     })
 
     expect(paths).to.deep.equal([
-      { path: '/', methods: [ 'get', 'post' ] },
+      { path: '/', methods: [ 'get' ] },
+      { path: '/dnb/company-create', methods: [ 'post' ] },
       { path: '/dnb/company-search', methods: [ 'post' ] },
       { path: '/dnb/company-investigation', methods: [ 'post' ] },
     ])


### PR DESCRIPTION
## Description of change
When the user searches for a company and then selects that company, there will be a confirmation screen. Upon pressing `Add company` the company should be created in Data Hub. This change hooks up the `Add company` button so that it `POST`s to the Express endpoint.

## Test instructions
Whilst pointing at Sandbox:
- browse to `~/companies/create`
- search for a company
- select a company that does not exist on Data Hub
- click `Add company`, you will be redirect to the company page with a `Company added to Data Hub` flash message

## Screenshot
<img width="913" alt="Screenshot 2019-09-17 at 15 18 08" src="https://user-images.githubusercontent.com/1150417/65049847-610e6f80-d95e-11e9-8f12-ff479df7e4e3.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
