### PR TITLE
Abstract "What happens next" into InformationList

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { H3 } from '@govuk-react/heading'
+import { Details } from 'govuk-react'
+import PropTypes from 'prop-types'
 import { FieldInput, FieldRadios, FieldSelect, Step } from 'data-hub-components'
 
-import { Details, ListItem, UnorderedList } from 'govuk-react'
-import PropTypes from 'prop-types'
+import InformationList from './InformationList'
 
 function CompanyNotFoundStep ({ organisationTypes, regions, sectors }) {
   return (
@@ -58,21 +58,20 @@ function CompanyNotFoundStep ({ organisationTypes, regions, sectors }) {
         required="Select DIT sector"
       />
 
-      <H3>What happens next</H3>
-      <p>
-        You are requesting that a new company be added to Data Hub. Once you select the ‘Add company’ button below:
-        <UnorderedList>
-          <ListItem>
-            you can continue to record interactions with the company
-          </ListItem>
-          <ListItem>
-            Data Hub’s external data provider will confirm with the company that the information on this page is correct
-          </ListItem>
-          <ListItem>
-            within 3 weeks the Data Hub support team will send you an email to tell you whether the information on this page has been confirmed
-          </ListItem>
-        </UnorderedList>
-      </p>
+      <InformationList
+        heading="What happens next"
+        description="You are requesting that a new company be added to Data Hub. Once you select the ‘Add company’ button below:"
+      >
+        <InformationList.Item>
+          you can continue to record interactions with the company
+        </InformationList.Item>
+        <InformationList.Item>
+          Data Hub’s external data provider will confirm with the company that the information on this page is correct
+        </InformationList.Item>
+        <InformationList.Item>
+          within 3 weeks the Data Hub support team will send you an email to tell you whether the information on this page has been confirmed
+        </InformationList.Item>
+      </InformationList>
 
     </Step>
   )

--- a/src/apps/companies/apps/add-company/client/InformationList.jsx
+++ b/src/apps/companies/apps/add-company/client/InformationList.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { H3, UnorderedList, ListItem } from 'govuk-react'
+import { SPACING } from '@govuk-react/constants'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+const StyledUnorderedList = styled(UnorderedList)`
+  list-style-type: disc;
+  padding-left: ${SPACING.SCALE_5};
+`
+
+const Item = ({ children }) => {
+  return (
+    <ListItem>{children}</ListItem>
+  )
+}
+
+Item.propTypes = {
+  children: PropTypes.node,
+}
+
+const InformationList = ({ heading, description, children }) => {
+  return (
+    <>
+      <H3>{heading}</H3>
+      <p>{description}</p>
+      <StyledUnorderedList>
+        {children}
+      </StyledUnorderedList>
+    </>
+  )
+}
+
+InformationList.propTypes = {
+  heading: PropTypes.string,
+  description: PropTypes.string,
+  children: PropTypes.node,
+}
+
+InformationList.Item = Item
+
+export default InformationList


### PR DESCRIPTION
## Description of change
The `What happens next` information needs to be styled correctly. As part of the process, this collection of components can be abstracted to an `InformationList` component.

## Test instructions
- Browse to `~/companies/create`
- Follow the unhappy path
- Browse to the bottom of the manual entry where you will see the updated component
 
## Screenshots
### Before
<img width="960" alt="Screenshot 2019-09-17 at 15 23 49" src="https://user-images.githubusercontent.com/1150417/65050422-45f02f80-d95f-11e9-8065-387dc0fdf61d.png">

### After 
<img width="942" alt="Screenshot 2019-09-17 at 15 23 27" src="https://user-images.githubusercontent.com/1150417/65050441-4c7ea700-d95f-11e9-8eba-e9886b1b0b01.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
