### PR TITLE
Add delete company list page

### DIFF
--- a/src/apps/company-lists/client/DeleteCompanyList.jsx
+++ b/src/apps/company-lists/client/DeleteCompanyList.jsx
@@ -1,0 +1,42 @@
+import axios from 'axios'
+import { get } from 'lodash'
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { DeleteCompanyListSection } from 'data-hub-components'
+
+const notFoundMessage = 'The list was not found. It may have already been deleted.'
+
+function DeleteCompanyList ({ companyList, csrfToken, returnUrl }) {
+  const [errorMessage, setErrorMessage] = useState(null)
+  const onDelete = async () => {
+    try {
+      await axios.post(`/company-lists/${companyList.id}/delete`,
+        null,
+        { params: { _csrf: csrfToken } })
+      window.location.assign('/company-lists')
+    } catch (error) {
+      if (get(error, 'response.status') === 404) {
+        setErrorMessage(notFoundMessage)
+      } else {
+        setErrorMessage(error.message || error.toString())
+      }
+    }
+  }
+
+  return (
+    <DeleteCompanyListSection
+      companyList={companyList}
+      returnUrl={returnUrl}
+      onDelete={onDelete}
+      errorMessage={errorMessage}
+    />
+  )
+}
+
+DeleteCompanyList.propTypes = {
+  companyList: PropTypes.object.isRequired,
+  csrfToken: PropTypes.string.isRequired,
+  returnUrl: PropTypes.string.isRequired,
+}
+
+export default DeleteCompanyList

--- a/src/apps/company-lists/constants.js
+++ b/src/apps/company-lists/constants.js
@@ -1,4 +1,11 @@
-const APP_PERMISSIONS = []
+const APP_PERMISSIONS = [
+  {
+    'path': 'delete',
+    'permissions': [
+      'company_list.delete_companylist',
+    ],
+  },
+]
 
 module.exports = {
   APP_PERMISSIONS,

--- a/src/apps/company-lists/controllers/delete.js
+++ b/src/apps/company-lists/controllers/delete.js
@@ -1,0 +1,44 @@
+const { deleteCompanyList, getCompanyList } = require('../repos')
+
+async function fetchCompanyList (req, res, next) {
+  try {
+    res.locals.companyList = await getCompanyList(req.session.token, req.params.listId)
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function renderDeleteCompanyListPage (req, res, next) {
+  const props = {
+    companyList: res.locals.companyList,
+    csrfToken: res.locals.csrfToken,
+    returnUrl: '/company-lists',
+  }
+
+  try {
+    res
+      .breadcrumb('Delete list')
+      .render('company-lists/views/delete-list', {
+        props,
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function handleDeleteCompanyList (req, res, next) {
+  try {
+    await deleteCompanyList(req.session.token, req.params.listId)
+    req.flash('success', 'List deleted')
+    res.send()
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  fetchCompanyList,
+  handleDeleteCompanyList,
+  renderDeleteCompanyListPage,
+}

--- a/src/apps/company-lists/index.js
+++ b/src/apps/company-lists/index.js
@@ -1,7 +1,7 @@
 const router = require('./router')
 
 module.exports = {
-  displayName: 'My company lists',
+  displayName: 'Edit my company lists',
   mountpath: '/company-lists',
   router,
 }

--- a/src/apps/company-lists/router.js
+++ b/src/apps/company-lists/router.js
@@ -1,8 +1,12 @@
 const router = require('express').Router()
 
 const { APP_PERMISSIONS } = require('./constants')
+const { fetchCompanyList, handleDeleteCompanyList, renderDeleteCompanyListPage } = require('./controllers/delete')
 const { handleRoutePermissions } = require('../middleware')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
+
+router.get('/:listId/delete', fetchCompanyList, renderDeleteCompanyListPage)
+router.post('/:listId/delete', handleDeleteCompanyList)
 
 module.exports = router

--- a/src/apps/company-lists/views/delete-list.njk
+++ b/src/apps/company-lists/views/delete-list.njk
@@ -1,0 +1,13 @@
+{% extends "_layouts/template.njk" %}
+
+{% block local_header %}
+  {% call LocalHeader({ heading: 'Delete list' }) %}{% endcall %}
+{% endblock %}
+
+{% block body_main_content %}
+  {% component 'react-slot', {
+    id: 'delete-company-list',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 
 import { ActivityFeedApp } from 'data-hub-components'
 import AddCompanyForm from './apps/companies/apps/add-company/client/AddCompanyForm'
+import DeleteCompanyList from './apps/company-lists/client/DeleteCompanyList'
 import MyCompanies from './apps/dashboard/client/MyCompanies.jsx'
 
 function Mount ({ selector, children }) {
@@ -27,6 +28,9 @@ function App () {
       </Mount>
       <Mount selector="#react-mount-my-companies">
         {props => <MyCompanies {...props} />}
+      </Mount>
+      <Mount selector="#delete-company-list">
+        {props => <DeleteCompanyList {...props} />}
       </Mount>
     </>
   )

--- a/test/functional/cypress/selectors/company-lists/delete.js
+++ b/test/functional/cypress/selectors/company-lists/delete.js
@@ -1,0 +1,8 @@
+module.exports = {
+  errorHeader: 'div h2',
+  insetListItem: {
+    byIndex: (index) => `#delete-company-list li:nth-child(${index})`,
+  },
+  deleteButton: '#delete-company-list button',
+  returnAnchor: '#delete-company-list a',
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -9,6 +9,10 @@ exports.companySubsidiariesLink = require('./company/subsidiaries-link')
 exports.companySubsidiaries = require('./company/subsidiaries')
 exports.companyAddToListButton = require('./company/add-to-list')
 
+exports.companyList = {
+  delete: require('./company-lists/delete'),
+}
+
 exports.contactCreate = require('./contact/create')
 
 exports.omisCreate = require('./omis/create')

--- a/test/functional/cypress/specs/company-lists/delete-spec.js
+++ b/test/functional/cypress/specs/company-lists/delete-spec.js
@@ -1,0 +1,82 @@
+const selectors = require('../../selectors')
+
+describe('Delete company list page', () => {
+  beforeEach(function () {
+    Cypress.Cookies.preserveOnce('datahub.sid')
+  })
+
+  context('when viewing "Delete company list"', () => {
+    before(() => {
+      cy.visit('/company-lists/2a8fb06f-2099-44d6-b404-e0fae0b9ea59/delete')
+    })
+
+    it('displays breadcrumbs', () => {
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.text', 'Home')
+      cy.get(selectors.breadcrumbs.item.byNumber(1)).should('have.attr', 'href', '/')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.text', 'Edit my company lists')
+      cy.get(selectors.breadcrumbs.item.byNumber(2)).should('have.attr', 'href', '/company-lists')
+      cy.get(selectors.breadcrumbs.item.last()).should('have.text', 'Delete list')
+    })
+
+    it('displays the "Delete list" heading', () => {
+      cy.get(selectors.localHeader().heading).should('have.text', 'Delete list')
+    })
+
+    it('displays the list name', () => {
+      cy.get(selectors.companyList.delete.insetListItem.byIndex(1))
+        .should('have.text', 'A list with multiple items')
+    })
+
+    it('displays the number of companies on the list', () => {
+      cy.get(selectors.companyList.delete.insetListItem.byIndex(2))
+        .should('have.text', '13 companies')
+    })
+
+    it('displays the "Delete list" button', () => {
+      cy.get(selectors.companyList.delete.deleteButton).should('have.text', 'Delete list')
+    })
+
+    it('displays the "Return without deleting" link', () => {
+      cy.get(selectors.companyList.delete.returnAnchor).should('have.text', 'Return without deleting')
+    })
+  })
+
+  context('after clicking the "Delete list" button', () => {
+    before(() => {
+      cy.visit('/company-lists/2a8fb06f-2099-44d6-b404-e0fae0b9ea59/delete')
+      cy.get(selectors.companyList.delete.deleteButton).click()
+    })
+
+    it('redirects to the edit company lists page', () => {
+      cy.location().should((loc) => {
+        expect(loc.origin).to.eq(Cypress.config().baseUrl)
+        expect(loc.pathname).to.eq('/company-lists')
+      })
+    })
+
+    it('displays the "List deleted" flash message', () => {
+      cy.get(selectors.localHeader().flash).should('contain.text', 'List deleted')
+    })
+  })
+
+  context('when there is an error deleting the list', () => {
+    before(() => {
+      cy.visit('/company-lists/0b89bb58-2769-4783-bb2f-7a22bb566473/delete')
+      cy.get(selectors.companyList.delete.deleteButton).click()
+    })
+
+    it('displays the "List deleted" flash message', () => {
+      cy.get(selectors.companyList.delete.errorHeader).should('have.text', 'There was an error deleting this list')
+    })
+  })
+
+  context("when the list doesn't exist", () => {
+    before(() => {
+      cy.visit('/company-lists/non-existent-list/delete', { failOnStatusCode: false })
+    })
+
+    it('displays the "List deleted" flash message', () => {
+      cy.get(selectors.localHeader().heading).should('contain.text', 'Page not found')
+    })
+  })
+})

--- a/test/unit/apps/company-lists/controllers/delete.test.js
+++ b/test/unit/apps/company-lists/controllers/delete.test.js
@@ -1,0 +1,160 @@
+const requestErrors = require('request-promise/errors')
+
+const config = require('~/config')
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const {
+  fetchCompanyList,
+  handleDeleteCompanyList,
+  renderDeleteCompanyListPage,
+} = require('~/src/apps/company-lists/controllers/delete')
+
+const companyList = require('~/test/unit/data/company-lists/list-with-multiple-items.json')
+
+const companyListId = '2a8fb06f-2099-44d6-b404-e0fae0b9ea59'
+
+describe('Delete company list controller', () => {
+  let middlewareParameters
+
+  beforeEach(() => {
+    middlewareParameters = buildMiddlewareParameters({
+      requestParams: {
+        listId: companyListId,
+      },
+    })
+  })
+
+  describe('#fetchCompanyList', () => {
+    context('when the list is successfully retrieved', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .get(`/v4/company-list/${companyListId}`)
+          .reply(200, companyList)
+
+        await fetchCompanyList(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+
+      it('adds the company list to res.locals', () => {
+        expect(middlewareParameters.resMock.locals.companyList).to.be.deep.equal(companyList)
+      })
+    })
+
+    context('when there is an error retrieving the list', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .get(`/v4/company-list/${companyListId}`)
+          .reply(404)
+
+        await fetchCompanyList(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+
+      it('forwards the error to the next middleware', () => {
+        expect(middlewareParameters.resMock.locals.companyList).to.be.undefined
+        expect(middlewareParameters.nextSpy).to.be.called
+        expect(middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(requestErrors.StatusCodeError)
+      })
+    })
+  })
+
+  describe('#renderDeleteCompanyListPage', () => {
+    beforeEach(async () => {
+      middlewareParameters.resMock.locals.companyList = companyList
+    })
+
+    context('when it renders successfully', () => {
+      beforeEach(async () => {
+        await renderDeleteCompanyListPage(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+
+      it('renders the delete list page', () => {
+        expect(middlewareParameters.resMock.render).to.be.calledWith('company-lists/views/delete-list')
+        expect(middlewareParameters.resMock.render).to.have.been.calledOnce
+      })
+
+      it('passes props to react-slot', () => {
+        const actualProps = middlewareParameters.resMock.render.getCall(0).args[1].props
+        expect(actualProps).to.be.deep.equal({
+          companyList: companyList,
+          csrfToken: 'csrf',
+          returnUrl: '/company-lists',
+        })
+      })
+
+      it('adds a breadcrumb', () => {
+        expect(middlewareParameters.resMock.breadcrumb.firstCall).to.be.calledWith('Delete list')
+      })
+    })
+
+    context('when there is an error rendering', () => {
+      beforeEach(async () => {
+        middlewareParameters.resMock.render.throws()
+
+        await renderDeleteCompanyListPage(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+
+      it('forwards the error to the next middleware', () => {
+        expect(middlewareParameters.nextSpy).to.be.called
+        expect(middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(Error)
+      })
+    })
+  })
+
+  describe('#handleDeleteCompanyList', () => {
+    context('when the deletion succeeds', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .delete(`/v4/company-list/${companyListId}`)
+          .reply(201)
+
+        await handleDeleteCompanyList(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+
+      it('sets a flash message', () => {
+        expect(middlewareParameters.reqMock.flash).to.be.calledWith('success', 'List deleted')
+      })
+
+      it('sends a response', () => {
+        expect(middlewareParameters.resMock.send).to.be.calledWith()
+      })
+    })
+
+    context('when the deletion fails', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .delete(`/v4/company-list/${companyListId}`)
+          .reply(404)
+
+        await handleDeleteCompanyList(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+
+      it('forwards the error to the next middleware', () => {
+        expect(middlewareParameters.resMock.send).to.not.be.called
+        expect(middlewareParameters.nextSpy).to.be.called
+        expect(middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(requestErrors.StatusCodeError)
+      })
+    })
+  })
+})

--- a/test/unit/helpers/middleware-parameters-builder.js
+++ b/test/unit/helpers/middleware-parameters-builder.js
@@ -39,9 +39,10 @@ module.exports = ({
       ...resMock,
       breadcrumb,
       title,
-      render: sinon.spy(),
+      render: sinon.stub(),
       redirect: sinon.spy(),
       json: sinon.spy(),
+      send: sinon.spy(),
       header: sinon.spy(),
       locals: {
         CURRENT_PATH,


### PR DESCRIPTION
## Description of change

This adds the page for deleting a company list using the `DeleteCompanyListSection` component from data-hub-components.

This page is currently deliberately not linked to. Also, the page it will be linked from has not been built yet.

## Test instructions

1. Create a company list. 
    
    This can be done by e.g. making a POST request to the API at http://localhost:8000/v4/company-list with a body of `{"name": "test"}`
1. Navigate to `http://localhost:3000/company-lists/<listId>/delete` (replacing `listId` with the ID of the list just created)
1. Try to delete the list
1. The page should redirect to `/company-lists` and a success message displayed

**Note** As `/company-lists` hasn't been build yet, it is currently a 404. The breadcrumbs also misbehave on this page which is unrelated to this PR (and should be fixed once the page is built).
 
## Screenshots

## Initial state

![image](https://user-images.githubusercontent.com/12693549/65133878-52c26100-d9fb-11e9-881e-171169d9714a.png)

## With error

![image](https://user-images.githubusercontent.com/12693549/65232589-50c6d380-dac9-11e9-9801-c96480ef0da1.png)

## Success message

![image](https://user-images.githubusercontent.com/12693549/65232648-663bfd80-dac9-11e9-9e6d-8640eb2bbb83.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
