### PR TITLE
Fix POST D&B company

### DIFF
--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -51,7 +51,7 @@ async function postSearchDnbCompanies (req, res, next) {
 
 async function postAddDnbCompany (req, res, next) {
   try {
-    await saveDnbCompany(req.session.token, req.body.duns_number)
+    await saveDnbCompany(req.session.token, req.body.dnbCompany.duns_number)
       .then((result) => {
         req.flash('success', 'Company added to Data Hub')
         res.json(result)

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -51,11 +51,9 @@ async function postSearchDnbCompanies (req, res, next) {
 
 async function postAddDnbCompany (req, res, next) {
   try {
-    await saveDnbCompany(req.session.token, req.body.dnbCompany.duns_number)
-      .then((result) => {
-        req.flash('success', 'Company added to Data Hub')
-        res.json(result)
-      })
+    const result = await saveDnbCompany(req.session.token, req.body.dnbCompany.duns_number)
+    req.flash('success', 'Company added to Data Hub')
+    res.json(result)
   } catch (error) {
     next(error)
   }
@@ -64,11 +62,9 @@ async function postAddDnbCompany (req, res, next) {
 async function postAddDnbCompanyInvestigation (req, res, next) {
   try {
     const transformed = transformToDnbCompanyInvestigationApi(req.body)
-    await saveDnbCompanyInvestigation(req.session.token, transformed)
-      .then((result) => {
-        req.flash('success', 'Company added to Data Hub')
-        res.json(result)
-      })
+    const result = await saveDnbCompanyInvestigation(req.session.token, transformed)
+    req.flash('success', 'Company added to Data Hub')
+    res.json(result)
   } catch (error) {
     next(error)
   }

--- a/test/unit/apps/companies/apps/add-company/controllers.test.js
+++ b/test/unit/apps/companies/apps/add-company/controllers.test.js
@@ -222,7 +222,9 @@ describe('Add company form controllers', () => {
 
         this.middlewareParameters = buildMiddlewareParameters({
           requestBody: {
-            duns_number: '123',
+            dnbCompany: {
+              duns_number: '123',
+            },
           },
         })
 
@@ -256,7 +258,9 @@ describe('Add company form controllers', () => {
 
         this.middlewareParameters = buildMiddlewareParameters({
           requestBody: {
-            duns_number: '123',
+            dnbCompany: {
+              duns_number: '123',
+            },
           },
         })
 


### PR DESCRIPTION
## Description of change
Fixes a bug when posting the request to Leeloo which was not setting the `duns_number` correctly.

## Test instructions
Go through the process of adding a D&B company.
 
## Screenshots
There should be no visual difference although the `Add company` will now redirect to the company page on completion.

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
