### PR TITLE
Display country on the summary of the "Add company form"

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -100,7 +100,7 @@ function AddCompanyForm ({ host, csrfToken, countries, organisationTypes, region
               />
             </Step>
 
-            {!values.cannotFind && <CompanyFoundStep />}
+            {!values.cannotFind && <CompanyFoundStep countryName={countryName} />}
 
             {values.cannotFind && (
               <CompanyNotFoundStep

--- a/src/apps/companies/apps/add-company/client/CompanyFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyFoundStep.jsx
@@ -6,6 +6,7 @@ import { H3 } from '@govuk-react/heading'
 import { Step, useFormContext } from 'data-hub-components'
 
 import DefinitionList from './DefinitionList'
+import PropTypes from 'prop-types'
 
 function getCompanyAddress (dnbCompany) {
   if (dnbCompany) {
@@ -29,7 +30,7 @@ function getCompaniesHouseNumber (dnbCompany) {
   }
 }
 
-function CompanyFoundStep () {
+function CompanyFoundStep ({ countryName }) {
   const { values } = useFormContext()
 
   const dnbCompany = get(values, 'dnbCompany')
@@ -47,12 +48,20 @@ function CompanyFoundStep () {
           description={companiesHouseNumber}
         />
         <DefinitionList.Row
+          label="Country"
+          description={countryName}
+        />
+        <DefinitionList.Row
           label="Address"
           description={companyAddress}
         />
       </DefinitionList>
     </Step>
   )
+}
+
+CompanyFoundStep.propTypes = {
+  countryName: PropTypes.string.isRequired,
 }
 
 export default CompanyFoundStep

--- a/test/functional/cypress/selectors/company/add-company.js
+++ b/test/functional/cypress/selectors/company/add-company.js
@@ -5,6 +5,7 @@ module.exports = {
   backButton: 'form button:contains("Back")',
   subheader: 'form p',
   stepHeader: 'form h3',
+  summary: 'form dl',
   entitySearch: {
     companyNameField: 'input[name="dnbCompanyName"]',
     postalCodeField: 'input[name="dnbPostalCode"]',

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -123,6 +123,21 @@ describe('Add company form', () => {
             cy.get(selectors.companyAdd.stepHeader).should('have.text', 'Confirm you want to add this company to Data Hub')
           })
 
+          it('should display Companies House number', () => {
+            cy.get(selectors.companyAdd.summary).should('contain', 'Companies House number')
+            cy.get(selectors.companyAdd.summary).should('contain', '00016033')
+          })
+
+          it('should display address', () => {
+            cy.get(selectors.companyAdd.summary).should('contain', 'Address')
+            cy.get(selectors.companyAdd.summary).should('contain', '123 ABC Road, Brighton, BN2 9QB')
+          })
+
+          it('should display country', () => {
+            cy.get(selectors.companyAdd.summary).should('contain', 'Country')
+            cy.get(selectors.companyAdd.summary).should('contain', 'Poland')
+          })
+
           it('should display "Back" button', () => {
             cy.get(selectors.companyAdd.backButton).should('be.visible')
           })


### PR DESCRIPTION
## Description of change

https://trello.com/c/bYEArNpv/332-add-country-to-confirm-page

Add country on the last step of the new "Add company form" so the user has more confidence when submitting the form.
 
## Screenshots
### Before

![image](https://user-images.githubusercontent.com/4199239/65167914-5970c880-da3b-11e9-83fa-cace3c3a9968.png)


### After 

![image](https://user-images.githubusercontent.com/4199239/65167869-4bbb4300-da3b-11e9-8e35-1145f07c95b0.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
