### PR TITLE
Update text from "Select organisation" to "Select organisation type"

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -65,9 +65,8 @@ function AddCompanyForm ({ host, csrfToken, countries, organisationTypes, region
       window.location.href = `//${host}/companies/${data.id}`
     } catch (error) {
       // todo handle error
+      setIsSubmitting(false)
     }
-
-    setIsSubmitting(false)
   }
 
   return (

--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -18,7 +18,7 @@ function CompanyNotFoundStep ({ organisationTypes, regions, sectors }) {
       <FieldRadios
         name="business_type"
         label="Organisation type"
-        required="Select organisation"
+        required="Select organisation type"
         options={organisationTypes}
       />
 

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -192,7 +192,29 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.newCompanyRecordForm.sector).should('be.visible')
     })
 
-    context('when I complete the form', () => {
+    context('when I complete the form without filling the required fields', () => {
+      before(() => {
+        cy.get(selectors.companyAdd.submitButton).click()
+      })
+
+      it('should display error "Select organisation type"', () => {
+        cy.get(selectors.companyAdd.form).contains('Select organisation type')
+      })
+
+      it('should display error "Enter name"', () => {
+        cy.get(selectors.companyAdd.form).contains('Enter name')
+      })
+
+      it('should display error "Select DIT region"', () => {
+        cy.get(selectors.companyAdd.form).contains('Select DIT region')
+      })
+
+      it('should display error "Select DIT sector"', () => {
+        cy.get(selectors.companyAdd.form).contains('Select DIT sector')
+      })
+    })
+
+    context('when I complete the form after filling the required fields', () => {
       before(() => {
         cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.limitedCompany).click()
         cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).type('INVESTIGATION LIMITED')


### PR DESCRIPTION
## Description of change

Simple wording update.

https://trello.com/c/6yx3jrV4/327-organisation-type-missing-in-error-messaging

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/4199239/65168739-0dbf1e80-da3d-11e9-87b5-91fb75ac57e6.png)

### After 

![image](https://user-images.githubusercontent.com/4199239/65168605-d5b7db80-da3c-11e9-9c41-8b17d2d117d4.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
