### PR TITLE
Hide uk region when overseas

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -19,14 +19,12 @@ import {
 
 import CompanyFoundStep from './CompanyFoundStep'
 import CompanyNotFoundStep from './CompanyNotFoundStep'
+import { ISO_CODE } from './constants'
 
 function AddCompanyForm ({ host, csrfToken, countries, organisationTypes, regions, sectors }) {
   const [isSubmitting, setIsSubmitting] = useState(false)
-
-  const UK_ISO_CODE = 'GB'
-
-  const optionCountryUK = countries.find(({ value }) => value === UK_ISO_CODE)
-  const overseasCountries = countries.filter(({ value }) => value && value !== UK_ISO_CODE)
+  const optionCountryUK = countries.find(({ value }) => value === ISO_CODE.UK)
+  const overseasCountries = countries.filter(({ value }) => value && value !== ISO_CODE.UK)
 
   const COMPANY_LOCATION_OPTIONS = {
     uk: optionCountryUK,
@@ -106,6 +104,7 @@ function AddCompanyForm ({ host, csrfToken, countries, organisationTypes, region
                 organisationTypes={organisationTypes}
                 regions={regions}
                 sectors={sectors}
+                countryIsoCode={countryIsoCode}
               />
             )}
           </LoadingBox>

--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -3,9 +3,10 @@ import { Details } from 'govuk-react'
 import PropTypes from 'prop-types'
 import { FieldInput, FieldRadios, FieldSelect, Step } from 'data-hub-components'
 
+import { ISO_CODE } from './constants'
 import InformationList from './InformationList'
 
-function CompanyNotFoundStep ({ organisationTypes, regions, sectors }) {
+function CompanyNotFoundStep ({ organisationTypes, regions, sectors, countryIsoCode }) {
   return (
     <Step name="unhappy" forwardButtonText="Add company">
 
@@ -42,13 +43,15 @@ function CompanyNotFoundStep ({ organisationTypes, regions, sectors }) {
         type="tel"
       />
 
-      <FieldSelect
-        name="uk_region"
-        label="DIT region"
-        emptyOption="-- Select DIT region --"
-        options={regions}
-        required="Select DIT region"
-      />
+      {countryIsoCode === ISO_CODE.UK && (
+        <FieldSelect
+          name="uk_region"
+          label="DIT region"
+          emptyOption="-- Select DIT region --"
+          options={regions}
+          required="Select DIT region"
+        />
+      )}
 
       <FieldSelect
         name="sector"

--- a/src/apps/companies/apps/add-company/client/constants.js
+++ b/src/apps/companies/apps/add-company/client/constants.js
@@ -1,0 +1,3 @@
+export var ISO_CODE = {
+  UK: 'GB',
+}

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -239,4 +239,34 @@ describe('Add company form', () => {
       })
     })
   })
+
+  context('when the user clicks "I still cannot find the company" for an overseas country', () => {
+    before(() => {
+      cy.visit('/companies/create')
+
+      cy.get(selectors.companyAdd.form).find('[type="radio"]').check('overseas')
+      cy.get(selectors.companyAdd.form).find('select').select('India')
+      cy.get(selectors.companyAdd.nextButton).click()
+
+      cy.get(selectors.companyAdd.entitySearch.companyNameField).type('some company')
+      cy.get(selectors.companyAdd.entitySearch.searchButton).click()
+
+      cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
+      cy.get(selectors.companyAdd.entitySearch.cannotFind.stillCannotFind).click()
+    })
+
+    it('should display the form', () => {
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.governmentDepartmentOrOtherPublicBody).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.limitedCompany).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.limitedPartnership).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.partnership).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.website).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.region).should('not.be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.sector).should('be.visible')
+    })
+  })
 })


### PR DESCRIPTION
## Description of change
When a user selects a country which is not UK then they should not be presented with `DIT region` when taking the unhappy path.

## Test instructions
- Browse to `~/companies/create`
- Select an overseas country
- Take the unhappy path
- There should not be a `DIT region` field
 
## Screenshots
### Before
![Screenshot 2019-09-19 at 22 41 38](https://user-images.githubusercontent.com/1150417/65283363-d761cc00-db2e-11e9-9eb5-1926c80786bf.png)

### After 
![Screenshot 2019-09-19 at 22 40 57](https://user-images.githubusercontent.com/1150417/65283368-dcbf1680-db2e-11e9-8479-2d4d760cfb00.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
