### PR TITLE
Add check for companies-create feature flag

### DIFF
--- a/src/apps/companies/controllers/add.js
+++ b/src/apps/companies/controllers/add.js
@@ -6,15 +6,19 @@ const { companyDetailsLabels, companyTypeOptions } = require('../labels')
 
 async function renderAddStepOne (req, res, next) {
   try {
+    if (res.locals.features['companies-create']) {
+      return res.redirect(301, 'create')
+    }
+
     const ukOtherCompanyOptions = await buildUkOtherCompanyOptions(req.session.token)
     const foreignOtherCompanyOptions = await buildForeignOtherCompanyOptions(req.session.token)
 
     res.render('companies/views/add-step-1.njk', {
       ukOtherCompanyOptions,
       foreignOtherCompanyOptions,
-      company: req.body,
       companyTypeOptions,
       companyDetailsLabels,
+      company: req.body,
     })
   } catch (error) {
     next(error)


### PR DESCRIPTION
## Description of change
Checks a `companies-create` flag to make a decision on showing the legacy add company journey or the new add company journey.

## Test instructions
1. Click the `Add company` button. You should be sent to `add-step-1` of the legacy add company
2. Add the `companies-create` feature flag in Django Admin
3. Click the `Add company` button. You should be sent to `create` of the new add company


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
