### PR TITLE
HOTFIX: Pass country ID to the API when creating companies

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -2,7 +2,7 @@
  * Functional tests: ./test/functional/cypress/specs/companies/add-company-spec.js
  */
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import axios from 'axios'
 import { get } from 'lodash'
@@ -69,10 +69,15 @@ function AddCompanyForm ({ host, csrfToken, countries, organisationTypes, region
 
   return (
     <Form onSubmit={onSubmit}>
-      {({ values }) => {
+      {({ values, setFieldValue }) => {
         const country = getCountry(values)
+        const countryID = get(country, 'key')
         const countryName = get(country, 'label')
         const countryIsoCode = get(country, 'value')
+
+        useEffect(() => {
+          setFieldValue('country', countryID)
+        }, [countryID])
 
         return (
           <LoadingBox loading={isSubmitting}>
@@ -119,7 +124,7 @@ AddCompanyForm.propTypes = {
   host: PropTypes.string.isRequired,
   csrfToken: PropTypes.string.isRequired,
   countries: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    key: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
   })).isRequired,

--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -51,6 +51,8 @@ function AddCompanyForm ({ host, csrfToken, countries, organisationTypes, region
     if (companyOverseasCountry) {
       return overseasCountries.find(c => c.value === companyOverseasCountry)
     }
+
+    return {}
   }
 
   async function onSubmit (values) {


### PR DESCRIPTION
## Description of change

Fix adding of companies on the unhappy path.

## Test instructions

1. Go to /companies/create
2. Select overseas company
3. Click "Continue"
4. Search for company
5. Click "I can still not find the company"
6. Fill the form and click "Add company"
7. Nothing happens, and no company is created

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
