### PR TITLE
Update tests to use anonymised advisers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ aliases:
       - MOCK_SSO_TOKEN: 123
 
   - &docker_data_api_sandbox
-    image: ukti/data-hub-sandbox
+    image: ukti/data-hub-sandbox:3.0.2
 
   # Data hub backend
   - &docker_data_hub_backend_base

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -208,7 +208,7 @@ describe('Company Investments and Large capital profile', () => {
 
   context('when viewing the "Investor details" edit section', () => {
     const { investorDetails } = selectors
-    const adviser = 'Aaron Chan, British Embassy Manila Philippines'
+    const adviser = 'Seth Hernandez, Callie Taylor'
 
     it('should display all the field values apart from "Investor Description"', () => {
       cy.visit(`${largeCapitalProfile}?editing=investor-details`)
@@ -230,11 +230,11 @@ describe('Company Investments and Large capital profile', () => {
     it('should be able to select an Adviser', () => {
       cy.visit(`${largeCapitalProfile}?editing=investor-details`)
         .get(investorDetails.requiredChecks.adviser.placeHolder).click()
-        .get(investorDetails.requiredChecks.adviser.textInput).type('abby').wait(500)
+        .get(investorDetails.requiredChecks.adviser.textInput).type('Seth').wait(500)
         .get(investorDetails.requiredChecks.adviser.textInput).type('{downarrow}')
         .get(investorDetails.requiredChecks.adviser.textInput).type('{enter}')
         .get(investorDetails.requiredChecks.adviser.selectedOption)
-        .should('contain', 'Abby Chan, British High Commission Singapore')
+        .should('contain', 'Seth Hernandez, Callie Taylor')
     })
   })
 

--- a/test/functional/cypress/specs/companies/matching/select-spec.js
+++ b/test/functional/cypress/specs/companies/matching/select-spec.js
@@ -1,5 +1,5 @@
-const fixtures = require('~/test/functional/cypress/fixtures')
-const selectors = require('~/test/functional/cypress/selectors')
+const fixtures = require('../../../fixtures')
+const selectors = require('../../../selectors')
 
 describe('Companies matching select', () => {
   context('when viewing the matching select form', () => {

--- a/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
+++ b/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
@@ -65,7 +65,7 @@ describe('Service delivery form', () => {
     it('should contain an pre-populated input with an adviser', () => {
       cy.get(selectors.interactionForm.ditAdviserTypeahead.placeHolder)
         .should('have.attr', 'placeholder')
-        .and('include', 'Ade Walton, RTC North : North East R & D Collaboration Project')
+        .and('include', 'Jimmy West, Bertie Drake')
     })
 
     it('should be able to select an adviser', () => {
@@ -76,7 +76,7 @@ describe('Service delivery form', () => {
       cy.get(selectors.interactionForm.ditAdviserTypeahead.placeHolder).first().type('{enter}')
 
       cy.get(selectors.interactionForm.ditAdviserTypeahead.selectedOption).first()
-        .should('contain', 'Barbara Benedicto, British Consulate General Sao Paulo Brazil')
+        .should('contain', 'Leroy Powers, Walter Wolfe')
     })
 
     it('should be able to create and remove a new adviser typeahead input field', () => {


### PR DESCRIPTION
## Description of change

Updating tests so that they use the anonymised advisers data

## Test instructions

`yarn test:functional`

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
