### PR TITLE
Feature/show export potential

### DIFF
--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -8,6 +8,7 @@ module.exports = {
   projectPhase: config.projectPhase,
   description: 'Data Hub is a customer relationship, project management and analytical tool for Department for International Trade.',
   feedbackLink: '/support',
+  findExportersUrl: config.findExportersUrl,
 
   assign,
 

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -5,7 +5,7 @@ const metadataRepo = require('../../../lib/metadata')
 const { saveCompany } = require('../repos')
 const { transformObjectToOption } = require('../../transformers')
 const { transformCompanyToExportDetailsView } = require('../transformers')
-const { exportDetailsLabels } = require('../labels')
+const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
 
 function renderExports (req, res) {
   const { company } = res.locals
@@ -16,6 +16,7 @@ function renderExports (req, res) {
     .breadcrumb('Exports')
     .render('companies/views/exports-view', {
       exportDetails,
+      exportPotentials: Object.values(exportPotentialLabels),
     })
 }
 

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -94,6 +94,29 @@ const businessHierarchyLabels = {
   global_headquarters: 'Global HQ',
 }
 
+const exportPotentialLabels = {
+  very_high: {
+    text: 'Very High',
+    description: 'Most companies like this one are exporters',
+  },
+  high: {
+    text: 'High',
+    description: 'This business shares some features with successful exporters',
+  },
+  medium: {
+    text: 'Medium',
+    description: 'Some businesses that look like this one export, others don\'t',
+  },
+  low: {
+    text: 'Low',
+    description: 'This business shares many features with companies that do not export',
+  },
+  very_low: {
+    text: 'Very Low',
+    description: 'Most of the businesses like this aren\'t exporters',
+  },
+}
+
 module.exports = {
   companyDetailsLabels,
   chDetailsLabels,
@@ -105,4 +128,5 @@ module.exports = {
   coreTeamLabels,
   aboutLabels,
   businessHierarchyLabels,
+  exportPotentialLabels,
 }

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -64,6 +64,7 @@ const exportDetailsLabels = {
   exportExperienceCategory: 'Export win category',
   exportToCountries: 'Currently exporting to',
   futureInterestCountries: 'Future countries of interest',
+  exportPotential: 'Export potential',
 }
 
 const coreTeamLabels = {

--- a/src/apps/companies/transformers/company-to-export-details-view.js
+++ b/src/apps/companies/transformers/company-to-export-details-view.js
@@ -2,10 +2,16 @@
 const { flatMap } = require('lodash')
 
 const { getDataLabels } = require('../../../lib/controller-utils')
-const { exportDetailsLabels } = require('../labels')
+const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
 
 function getCountries (data) {
   return flatMap(data, ({ name }) => (name || null)).join(', ') || 'None'
+}
+
+function getExportPotentialLabel (key) {
+  const item = exportPotentialLabels[ key ]
+
+  return (item && item.text) || 'No score given'
 }
 
 module.exports = function transformCompanyToExportDetailsView ({
@@ -18,7 +24,7 @@ module.exports = function transformCompanyToExportDetailsView ({
     exportExperienceCategory: export_experience_category || 'None',
     exportToCountries: getCountries(export_to_countries),
     futureInterestCountries: getCountries(future_interest_countries),
-    exportPotential: (export_potential_score || 'No score given'),
+    exportPotential: getExportPotentialLabel(export_potential_score),
   }
 
   return getDataLabels(viewRecord, exportDetailsLabels)

--- a/src/apps/companies/transformers/company-to-export-details-view.js
+++ b/src/apps/companies/transformers/company-to-export-details-view.js
@@ -1,22 +1,24 @@
 /* eslint-disable camelcase */
-const { flatten } = require('lodash')
+const { flatMap } = require('lodash')
 
 const { getDataLabels } = require('../../../lib/controller-utils')
 const { exportDetailsLabels } = require('../labels')
+
+function getCountries (data) {
+  return flatMap(data, ({ name }) => (name || null)).join(', ') || 'None'
+}
 
 module.exports = function transformCompanyToExportDetailsView ({
   export_experience_category,
   export_to_countries,
   future_interest_countries,
+  export_potential_score,
 }) {
   const viewRecord = {
     exportExperienceCategory: export_experience_category || 'None',
-    exportToCountries: flatten([export_to_countries])
-      .map(country => (country.name || null))
-      .join(', ') || 'None',
-    futureInterestCountries: flatten([future_interest_countries])
-      .map(country => (country.name || null))
-      .join(', ') || 'None',
+    exportToCountries: getCountries(export_to_countries),
+    futureInterestCountries: getCountries(future_interest_countries),
+    exportPotential: (export_potential_score || 'No score given'),
   }
 
   return getDataLabels(viewRecord, exportDetailsLabels)

--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -1,9 +1,32 @@
 {% extends "./template.njk" %}
 
+{% from "details/macro.njk" import govukDetails %}
+
 {% block body_main_content %}
 
   {% call DetailsContainer({ heading: 'Exports' }) %}
     {% component 'key-value-table', items=exportDetails %}
+
+    {% set exportPotentialText %}
+      <p>
+        The export potential score is a prediction of a company's likelihood of exporting, and was originally created for the <a href="{{ findExportersUrl }}" target="_blank">Find Exporters tool</a> (opens in a new window). DIT's data science team compared all HMRC export information with the features of all UK companies to find patterns; they then repeatedly tested their model against a subset of known-good data to improve it. The scores are as follows:
+      </p>
+
+      <ol class="govuk-list">
+      {% for item in exportPotentials %}
+        <li><strong>{{ item.text }}</strong> - {{ item.description }}</li>
+      {% endfor %}
+      </ol>
+
+      <p>
+        We are continuing to improve the algorithm so please do share your feedback or let us know of any anomalies through the <a href="{{ feedbackLink }}">support channel</a>.
+      </p>
+    {% endset %}
+
+    {{ govukDetails({
+      summaryText: 'What is export potential?',
+      text: exportPotentialText | safe
+    }) }}
 
     {% if not company.archived %}
       <p class="actions">
@@ -11,6 +34,7 @@
       </p>
     {% endif %}
   {% endcall %}
+
 
   {% call DetailsContainer({ heading: 'Export wins' }) %}
     <p><a href="http://www.exportwins.service.trade.gov.uk/">Record your win</a> on our export wins site.<p>

--- a/test/acceptance/features/companies/exports.feature
+++ b/test/acceptance/features/companies/exports.feature
@@ -9,6 +9,7 @@ Feature: Company export save
       | Export win category          | None                              |
       | Currently exporting to       | company.currentlyExportingTo      |
       | Future countries of interest | company.futureCountriesOfInterest |
+      | Export potential             | No score given                    |
     When I click the "Edit export markets" link
     And I update the company Exports details
     And I submit the form
@@ -17,6 +18,7 @@ Feature: Company export save
       | Export win category          | company.exportWinCategory         |
       | Currently exporting to       | company.currentlyExportingTo      |
       | Future countries of interest | company.futureCountriesOfInterest |
+      | Export potential             | No score given                    |
 
   @companies-export--archived-company
   Scenario: Archived company without Edit export markets button

--- a/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
@@ -50,7 +50,7 @@ describe('transformCompanyToExportDetailsView', () => {
           id: '4321',
           name: 'Germany',
         }],
-        export_potential_score: 'Some score',
+        export_potential_score: 'low',
       })
 
       this.viewRecord = transformCompanyToExportDetailsView(company)
@@ -69,7 +69,7 @@ describe('transformCompanyToExportDetailsView', () => {
     })
 
     it('should show the export potential', () => {
-      expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'Some score')
+      expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'Low')
     })
   })
 

--- a/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
+++ b/test/unit/apps/companies/transformers/company-to-export-details-view.test.js
@@ -3,6 +3,8 @@ const { assign } = require('lodash')
 const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
 const { transformCompanyToExportDetailsView } = require('~/src/apps/companies/transformers')
 
+const EXPORT_POTENTIAL_LABEL = 'Export potential'
+
 describe('transformCompanyToExportDetailsView', () => {
   context('when no export market information has been entered', () => {
     beforeEach(() => {
@@ -26,6 +28,10 @@ describe('transformCompanyToExportDetailsView', () => {
     it('should show the export win category', () => {
       expect(this.viewRecord).to.have.property('Export win category', 'None')
     })
+
+    it('should show the export potential', () => {
+      expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'No score given')
+    })
   })
 
   context('when single values have been selected for drop down fields', () => {
@@ -44,6 +50,7 @@ describe('transformCompanyToExportDetailsView', () => {
           id: '4321',
           name: 'Germany',
         }],
+        export_potential_score: 'Some score',
       })
 
       this.viewRecord = transformCompanyToExportDetailsView(company)
@@ -59,6 +66,10 @@ describe('transformCompanyToExportDetailsView', () => {
 
     it('should show the export win category', () => {
       expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
+    })
+
+    it('should show the export potential', () => {
+      expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'Some score')
     })
   })
 


### PR DESCRIPTION
## Description of change

Show the new export potential value for a company on the export tab
 
## Screenshots

### Before
![export_before](https://user-images.githubusercontent.com/1481883/65967153-0e9e7a00-e459-11e9-8457-8573279dccae.png)

### After
![export_after](https://user-images.githubusercontent.com/1481883/65967171-1cec9600-e459-11e9-8c31-0102539f2c5a.png)
 
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
