### PR TITLE
Validate website when adding new company

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -6,14 +6,16 @@ import PropTypes from 'prop-types'
 import { FieldInput, FieldRadios, FieldSelect, Step } from 'data-hub-components'
 import FieldAddress from 'data-hub-components/dist/forms/elements/FieldAddress'
 
-import { ISO_CODE } from './constants'
+import { ISO_CODE, WEBSITE_REGEX } from './constants'
 import InformationList from './InformationList'
 
-function CompanyNotFoundStep ({ host, organisationTypes, regions, sectors, country }) {
-  function requireWebsiteOrPhone (value, name, { values: { website, telephone_number } }) {
-    return !website && !telephone_number ? 'Enter at least a website or a phone number' : null
-  }
+const requiredWebsiteOrPhoneValidator = (value, name, { values: { website, telephone_number } }) => {
+  return !website && !telephone_number ? 'Enter at least a website or a phone number' : null
+}
 
+const websiteValidator = (value) => !WEBSITE_REGEX.test(value) ? 'Enter a valid website URL' : null
+
+function CompanyNotFoundStep ({ host, organisationTypes, regions, sectors, country }) {
   return (
     <Step name="unhappy" forwardButton="Add company">
       <Details summary="Why am I seeing this?">
@@ -40,14 +42,17 @@ function CompanyNotFoundStep ({ host, organisationTypes, regions, sectors, count
         label="Company's website"
         name="website"
         type="url"
-        validate={requireWebsiteOrPhone}
+        validate={[
+          requiredWebsiteOrPhoneValidator,
+          websiteValidator,
+        ]}
       />
 
       <FieldInput
         label="Company's telephone number"
         name="telephone_number"
         type="tel"
-        validate={requireWebsiteOrPhone}
+        validate={requiredWebsiteOrPhoneValidator}
       />
 
       <FieldAddress

--- a/src/apps/companies/apps/add-company/client/constants.js
+++ b/src/apps/companies/apps/add-company/client/constants.js
@@ -1,3 +1,7 @@
-export var ISO_CODE = {
+export const ISO_CODE = {
   UK: 'GB',
 }
+
+// Based on https://gist.github.com/dperini/729294
+// Our version doesn't require protocol and don't accept ftp addresses.
+export const WEBSITE_REGEX = /^(?:(?:(?:https?):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -216,6 +216,17 @@ describe('Add company form', () => {
       })
     })
 
+    context('when an invalid website URL is filled', () => {
+      before(() => {
+        cy.get(selectors.companyAdd.newCompanyRecordForm.website).type('hello')
+        cy.get(selectors.companyAdd.submitButton).click()
+      })
+
+      it('should display invalid website URL error', () => {
+        cy.get(selectors.companyAdd.form).contains('Enter a valid website URL')
+      })
+    })
+
     context('when the form is submitted after filling the required fields', () => {
       before(() => {
         cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.limitedCompany).click()


### PR DESCRIPTION
## Description of change

Add website validation so users can't type incorrect URLs when adding companies.

## Screenshots
![image](https://user-images.githubusercontent.com/4199239/66225556-9a6e0b80-e6d0-11e9-9f38-68afd7617aab.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
