### PR TITLE
feat: Add editable regions to Business details

### DIFF
--- a/src/apps/companies/client/BusinessDetailsRegionEdit.jsx
+++ b/src/apps/companies/client/BusinessDetailsRegionEdit.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable camelcase */
+import React from 'react'
+import axios from 'axios'
+import PropTypes from 'prop-types'
+import Button from '@govuk-react/button'
+import Link from '@govuk-react/link'
+import {
+  Form,
+  FieldSelect,
+  FormActions,
+  StatusMessage
+} from 'data-hub-components'
+
+const onSubmit = (url, csrfToken) => {
+  return async ({ uk_region }) => {
+    await axios.post(`${url}/region?_csrf=${csrfToken}`, { uk_region })
+    return url
+  }
+}
+
+function BusinesDetailsRegionEdit ({ companyId, csrfToken, ukRegions }) {
+  const url = `/companies/${companyId}/business-details`
+
+  return (
+    <Form onSubmit={onSubmit(url, csrfToken)}>
+      {form => (
+        <div>
+          {form.submissionError && (
+            <StatusMessage>There was a problem when submitting the form, try again later.</StatusMessage>
+          )}
+
+          <FieldSelect
+            name="uk_region"
+            label="DIT region"
+            emptyOption="-- Select DIT region --"
+            options={ukRegions}
+            required="Select DIT region"
+          />
+          <FormActions>
+            <Button>Save and return</Button>
+            <Link href={url}>Return without saving</Link>
+          </FormActions>
+        </div>
+      )}
+    </Form>
+  )
+}
+
+BusinesDetailsRegionEdit.propTypes = {
+  companyId: PropTypes.string.isRequired,
+  csrfToken: PropTypes.string.isRequired,
+  ukRegions: PropTypes.array.isRequired,
+}
+
+export default BusinesDetailsRegionEdit

--- a/src/apps/companies/controllers/business-details-region.js
+++ b/src/apps/companies/controllers/business-details-region.js
@@ -1,0 +1,45 @@
+/* eslint-disable camelcase */
+const { updateCompany } = require('../repos')
+const { getOptions } = require('../../../lib/options')
+
+async function renderRegion (req, res, next) {
+  const { company } = res.locals
+  const { token } = req.session
+
+  const props = {
+    companyId: company.id,
+    csrfToken: res.locals.csrfToken,
+  }
+
+  try {
+    props.ukRegions = await getOptions(token, 'uk-region')
+
+    res
+      .breadcrumb(company.name, `/companies/${company.id}`)
+      .breadcrumb('Business details')
+      .breadcrumb('Edit the DIT region')
+      .render('companies/views/business-details-edit', { props })
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function updateRegion (req, res, next) {
+  const { token } = req.session
+  const { companyId } = req.params
+  const { uk_region } = req.body
+
+  try {
+    await updateCompany(token, companyId, { uk_region })
+    req.flash('success', 'Company region updated')
+    return res.status(200).json({})
+  } catch (error) {
+    req.flash('error', 'Company region could not be updated')
+    return res.status(error.statusCode).json({ message: error.message })
+  }
+}
+
+module.exports = {
+  renderRegion,
+  updateRegion,
+}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -14,7 +14,16 @@ const {
 const { renderCompanyList } = require('./controllers/list')
 const { renderForm } = require('./controllers/edit')
 const { renderDetails } = require('./controllers/details')
-const { renderBusinessDetails } = require('./controllers/business-details')
+
+const {
+  renderBusinessDetails,
+} = require('./controllers/business-details')
+
+const {
+  renderRegion,
+  updateRegion,
+} = require('./controllers/business-details-region')
+
 const { renderOrders } = require('./controllers/orders')
 const { renderAuditLog } = require('./controllers/audit')
 const { archiveCompany, unarchiveCompany } = require('./controllers/archive')
@@ -109,7 +118,14 @@ router.get('/:companyId/unarchive', unarchiveCompany)
 router.use('/:companyId', handleRoutePermissions(LOCAL_NAV), setCompaniesLocalNav)
 router.get('/:companyId', redirectToFirstNavItem)
 router.get('/:companyId/details', renderDetails)
+
 router.get('/:companyId/business-details', renderBusinessDetails)
+
+router
+  .route('/:companyId/business-details/region')
+  .get(renderRegion)
+  .post(updateRegion)
+
 router.get('/:companyId/advisers', renderAdvisers)
 
 router.get('/:companyId/hierarchies/ghq/search', getGlobalHQCompaniesCollection, renderAddGlobalHQ)

--- a/src/apps/companies/views/business-details-edit.njk
+++ b/src/apps/companies/views/business-details-edit.njk
@@ -1,0 +1,13 @@
+{% extends "_layouts/template.njk" %}
+
+{% block local_header %}
+  {% call LocalHeader({ heading: 'Edit the DIT region' }) %}{% endcall %}
+{% endblock %}
+
+{% block body_main_content %}
+  {% component 'react-slot', {
+    id: 'business-details-region-edit',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -1,6 +1,7 @@
 {% extends "_layouts/template.njk" %}
 
 {% set editUrl = '/companies/' + company.id + '/edit' if not company.duns_number and not company.archived %}
+{% set regionUrl = '/companies/' + company.id + '/business-details/region' if not company.archived %}
 
 {% macro AddressCell(address, isRegistered) %}
   <td>
@@ -83,7 +84,7 @@
   {% endcall %}
 
   {% if regionDetails %}
-    {% call DetailsContainer({ heading: 'DIT region', editUrl: editUrl, dataAutoId: 'regionDetailsContainer' }) %}
+    {% call DetailsContainer({ heading: 'DIT region', editUrl: regionUrl, dataAutoId: 'regionDetailsContainer' }) %}
       <table class="table--key-value">
         <tbody>
           <tr>

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -6,6 +6,7 @@ import AddCompanyForm from './apps/companies/apps/add-company/client/AddCompanyF
 import DeleteCompanyList from './apps/company-lists/client/DeleteCompanyList'
 import MyCompanies from './apps/dashboard/client/MyCompanies.jsx'
 import CreateListFormSection from './apps/company-lists/client/CreateListFormSection'
+import BusinessDetailsRegionEdit from './apps/companies/client/BusinessDetailsRegionEdit'
 
 function Mount ({ selector, children }) {
   return [...document.querySelectorAll(selector)].map(domNode => {
@@ -35,6 +36,9 @@ function App () {
       </Mount>
       <Mount selector="#create-company-list-form">
         {props => <CreateListFormSection {...props} />}
+      </Mount>
+      <Mount selector="#business-details-region-edit">
+        {props => <BusinessDetailsRegionEdit {...props} />}
       </Mount>
     </>
   )

--- a/test/functional/cypress/selectors/company/business-details-region.js
+++ b/test/functional/cypress/selectors/company/business-details-region.js
@@ -1,0 +1,7 @@
+module.exports = {
+  editRegionLink: '[data-auto-id="regionDetailsContainer"] a',
+  editRegionListLabel: '[data-auto-id="bodyMainContent"] label[for="uk_region"]',
+  editRegionList: '[data-auto-id="bodyMainContent"] select option',
+  saveAndReturnBtn: '[data-auto-id="bodyMainContent"] button',
+  returnWithoutSavingLink: '[data-auto-id="bodyMainContent"] a',
+}

--- a/test/functional/cypress/selectors/index.js
+++ b/test/functional/cypress/selectors/index.js
@@ -1,5 +1,6 @@
 exports.companyAdd = require('./company/add-company')
 exports.companyActivity = require('./company/activity')
+exports.companyBusinessDetailsRegion = require('./company/business-details-region')
 exports.companyBusinessDetails = require('./company/business-details')
 exports.companyAddStep2 = require('./company/add-step-2')
 exports.companyEdit = require('./company/edit')

--- a/test/functional/cypress/specs/companies/business-details-region-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-region-spec.js
@@ -1,0 +1,68 @@
+const { localHeader, companyBusinessDetailsRegion: selectors } = require('../../selectors')
+const { venusLtd } = require('../../fixtures').company
+
+const businessDetailsUrl = `/companies/${venusLtd.id}/business-details`
+const editRegionUrl = `${businessDetailsUrl}/region`
+
+describe('Companies business details - region', () => {
+  context('when viewing the region of a Dun & Bradstreet company in the UK', () => {
+    before(() => {
+      cy.visit(businessDetailsUrl)
+    })
+
+    it('should show an "Edit" link with the correct URL', () => {
+      cy.get(selectors.editRegionLink)
+        .should('have.text', 'Edit')
+        .should('have.prop', 'href')
+        .and('contain', editRegionUrl)
+    })
+
+    it('should take you to the "Edit the DIT region" page when clicked', () => {
+      cy.get(selectors.editRegionLink).click()
+        .url().should('contain', editRegionUrl)
+    })
+  })
+
+  context('when viewing the edit regions page', () => {
+    before(() => {
+      cy.visit(editRegionUrl)
+    })
+
+    it('should display the "Edit the DIT region" heading', () => {
+      cy.get(localHeader().heading)
+        .should('be.visible')
+        .should('have.text', 'Edit the DIT region')
+    })
+
+    it('should show a "DIT region" label above the select', () => {
+      cy.get(selectors.editRegionListLabel)
+        .should('be.visible')
+        .should('have.text', 'DIT region')
+    })
+
+    it('should show a list of 16 regions', () => {
+      cy.get(selectors.editRegionList)
+        .should('be.visible')
+        .should('have.length', 16)
+    })
+
+    it('should show a "Save a return" button', () => {
+      cy.get(selectors.saveAndReturnBtn)
+        .should('be.visible')
+        .should('have.text', 'Save and return')
+    })
+
+    it('should take you back to the "Business details" page when saving', () => {
+      cy.get(selectors.saveAndReturnBtn).click()
+        .url().should('contain', businessDetailsUrl)
+    })
+
+    it('should show a "Return without saving" link with the correct URL', () => {
+      cy.get(selectors.returnWithoutSavingLink)
+        .should('be.visible')
+        .should('have.text', 'Return without saving')
+        .should('have.prop', 'href')
+        .and('contain', businessDetailsUrl)
+    })
+  })
+})

--- a/test/unit/apps/companies/controllers/business-details-region.test.js
+++ b/test/unit/apps/companies/controllers/business-details-region.test.js
@@ -1,0 +1,187 @@
+const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const companyMock = require('~/test/unit/data/companies/company-v4.json')
+const { renderRegion, updateRegion } = require('~/src/apps/companies/controllers/business-details-region')
+const config = require('~/config')
+
+const regionOptions = [{
+  id: '1',
+  name: 'East of England',
+}, {
+  id: '2',
+  name: 'London',
+}, {
+  id: '3',
+  name: 'North East' },
+]
+
+describe('#renderRegion', () => {
+  context('when the view renders successfully', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get('/v4/metadata/uk-region')
+        .reply(200, regionOptions)
+
+      this.middlewareParameters = buildMiddlewareParameters({
+        company: companyMock,
+      })
+
+      await renderRegion(
+        this.middlewareParameters.reqMock,
+        this.middlewareParameters.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should render the "Edit DIT region" view', () => {
+      const view = 'companies/views/business-details-edit'
+
+      expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(view, {
+        props: {
+          companyId: 'a73efeba-8499-11e6-ae22-56b6b6499611',
+          csrfToken: 'csrf',
+          ukRegions: [
+            { value: '1', label: 'East of England' },
+            { value: '2', label: 'London' },
+            { value: '3', label: 'North East' },
+          ],
+        },
+      })
+    })
+
+    it('should add three breadcrumbs', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledThrice
+    })
+
+    it('should add the company breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(companyMock.name, `/companies/${companyMock.id}`)
+    })
+
+    it('should add the "Mercury" breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith('Mercury Ltd')
+    })
+
+    it('should add the "Business details" breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith('Business details')
+    })
+
+    it('should add the "Edit the DIT region" breadcrumb', () => {
+      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith('Edit the DIT region')
+    })
+
+    it('should not call next() with an error', () => {
+      expect(this.middlewareParameters.nextSpy).to.not.have.been.called
+    })
+  })
+
+  context('when there is an error', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .get('/v4/metadata/uk-region')
+        .reply(400, { message: 'Error message' })
+
+      this.middlewareParameters = buildMiddlewareParameters({
+        company: companyMock,
+      })
+
+      await renderRegion(
+        this.middlewareParameters.reqMock,
+        this.middlewareParameters.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should call next() with an error', async () => {
+      expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
+    })
+  })
+})
+
+describe('#updateRegion', () => {
+  context('when the company update is successful', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .patch(`/v4/company/${companyMock.id}`)
+        .reply(200, {})
+
+      this.middlewareParameters = buildMiddlewareParameters({
+        company: companyMock,
+        requestBody: {
+          uk_region: '1',
+        },
+        requestParams: {
+          companyId: companyMock.id,
+        },
+      })
+
+      this.resMock = {
+        status: sinon.stub().returns({
+          json: sinon.spy(),
+        }),
+      }
+
+      await updateRegion(
+        this.middlewareParameters.reqMock,
+        this.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should call status', async () => {
+      expect(this.resMock.status).to.have.been.calledOnce
+      expect(this.resMock.status).to.have.been.calledWith(200)
+    })
+
+    it('should flash a message', async () => {
+      expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+      expect(this.middlewareParameters.reqMock.flash).to.have.been.calledWith('success', 'Company region updated')
+    })
+
+    it('should not call next() with an error', () => {
+      expect(this.middlewareParameters.nextSpy).to.not.have.been.called
+    })
+  })
+
+  context('when the company update is unsuccessful', () => {
+    beforeEach(async () => {
+      nock(config.apiRoot)
+        .patch(`/v4/company/${companyMock.id}`)
+        .reply(400, { error: 'Error message' })
+
+      this.middlewareParameters = buildMiddlewareParameters({
+        company: companyMock,
+        requestBody: {
+          uk_region: 'London',
+        },
+        requestParams: {
+          companyId: companyMock.id,
+        },
+      })
+
+      this.resMock = {
+        status: sinon.stub().returns({
+          json: sinon.spy(),
+        }),
+      }
+
+      await updateRegion(
+        this.middlewareParameters.reqMock,
+        this.resMock,
+        this.middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should flash a message', async () => {
+      expect(this.middlewareParameters.reqMock.flash).to.have.been.calledOnce
+      expect(this.middlewareParameters.reqMock.flash).to.have.been.calledWith('error', 'Company region could not be updated')
+    })
+
+    it('should call status', async () => {
+      expect(this.resMock.status).to.have.been.calledOnce
+      expect(this.resMock.status).to.have.been.calledWith(400)
+    })
+
+    it('should not call next() with an error', () => {
+      expect(this.middlewareParameters.nextSpy).to.not.have.been.called
+    })
+  })
+})

--- a/test/unit/apps/companies/router.test.js
+++ b/test/unit/apps/companies/router.test.js
@@ -15,6 +15,7 @@ describe('Company router', () => {
       '/:companyId',
       '/:companyId/details',
       '/:companyId/business-details',
+      '/:companyId/business-details/region',
       '/:companyId/advisers',
       '/:companyId/hierarchies/ghq/search',
       '/:companyId/hierarchies/ghq/:globalHqId/add',


### PR DESCRIPTION
## Add editable regions to Business details

**Dependency note: requires `data-hub-components v2.5.0`**
**Testing note: more to follow**

Enable users to edit the UK region from the Business details page.

## Business details - edit
![edit-the-region](https://user-images.githubusercontent.com/964268/66331456-7efe3d00-e92a-11e9-99df-1b82eef4b08f.png)

## Edit DIT region
![edit-dit-region](https://user-images.githubusercontent.com/964268/66331496-9dfccf00-e92a-11e9-86d3-7d0eef28ce66.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
