### PR TITLE
Improve resilience against error responses from help centre

### DIFF
--- a/src/apps/dashboard/controllers.js
+++ b/src/apps/dashboard/controllers.js
@@ -29,7 +29,9 @@ async function renderDashboard (req, res, next) {
       })
       articleFeed = formatHelpCentreAnnouncements(helpCentreArticleFeed) || []
     } catch (e) {
-      next(e)
+      // If we encounter an error when fetching the latest help centre articles,
+      // just show an empty feed
+      articleFeed = []
     }
     const canViewCompanyList = userPermissions.includes(
       'company_list.view_companylistitem'

--- a/test/unit/apps/dashboard/controllers.test.js
+++ b/test/unit/apps/dashboard/controllers.test.js
@@ -1,3 +1,5 @@
+var rpErrors = require('request-promise/errors')
+
 describe('dashboard controller', () => {
   beforeEach(() => {
     this.reqMock = Object.assign({}, globalReq, {
@@ -196,7 +198,46 @@ describe('dashboard controller', () => {
         companyList: null,
         contacts: [{ id: '1234' }],
         interactions: [{ id: '4321' }],
-        articleFeed: undefined,
+        articleFeed: [],
+        interactionsPermitted: false,
+        canViewCompanyList: false,
+        helpCentre: {
+          announcementsURL: 'www',
+          token: '1',
+          url: 'www',
+        },
+      }
+      expect(this.resMock.render.firstCall.args[1]).to.deep.equal(expected)
+    })
+  })
+
+  context('when the Help centre API request throws an error', () => {
+    beforeEach(async () => {
+      this.resMock = {
+        locals: {
+          user: {
+            permissions: [],
+          },
+        },
+        render: sinon.spy(),
+        title: sinon.stub().returnsThis(),
+      }
+      this.fetchHomepageDataStub.resolves(this.dashData)
+      this.fetchCompanyListStub.resolves(this.companyData)
+      this.rpStub.throws(rpErrors.StatusCodeError(500))
+      await this.controllers.renderDashboard(
+        this.reqMock,
+        this.resMock,
+        this.nextSpy
+      )
+    })
+
+    it('should return an empty array', () => {
+      const expected = {
+        companyList: null,
+        contacts: [{ id: '1234' }],
+        interactions: [{ id: '4321' }],
+        articleFeed: [],
         interactionsPermitted: false,
         canViewCompanyList: false,
         helpCentre: {


### PR DESCRIPTION
## Description of change

This change ensures that the homepage can gracefully handle errors produced by the help centre feed.

Any response - other than a 200 - will cause request-promise to throw an error.  This error is now handled gracefully by setting the article feed as empty, previously the whole node app would die.

**NOTE:** I wouldn't expect the previous error handling code `next(e)` to cause the entire node app to crash.  I think there's a problem more deeply rooted in the exception handling for the app which is causing unexpected errors to kill node - but I don't have enough familiarity to investigate further.

## Test instructions

If you set your local copy to point to a failing help centre URL - e.g. a 404: `HELP_CENTRE_API_FEED=https://data-hub-sandbox.getsandbox.com:443/help-centre/foobar`, you should be able to see "No updates available" under "Data Hub Updates" on the homepage.
 
## Screenshots
### Before
![dead](https://user-images.githubusercontent.com/3239148/66411177-3490c500-e9eb-11e9-9c4e-1454aad6f956.png)


### After 

![graceful_failure](https://user-images.githubusercontent.com/3239148/66411190-39557900-e9eb-11e9-97b5-81a121fadd1d.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
