### PR TITLE
Fix error on companies page when the company address is empty

### DIFF
--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -33,11 +33,13 @@ module.exports = function transformCompanyToListItem ({
     })
   }
 
-  meta.push({
-    label: 'Country',
-    type: 'badge',
-    value: address.country.name,
-  })
+  if (address && address.country) {
+    meta.push({
+      label: 'Country',
+      type: 'badge',
+      value: get(address, 'country.name'),
+    })
+  }
 
   if (uk_based) {
     meta.push({

--- a/test/unit/apps/companies/transformers/company-to-list-item.test.js
+++ b/test/unit/apps/companies/transformers/company-to-list-item.test.js
@@ -250,4 +250,18 @@ describe('transformCompanyToListItem', () => {
       expect(tradingNameMetaItem).to.exist
     })
   })
+
+  context('when the company address is null', () => {
+    beforeEach(() => {
+      this.listItem = transformCompanyToListItem({
+        ...companyData,
+        address: null,
+      })
+    })
+
+    it('should still transform the company and not return country', () => {
+      const country = find(this.listItem.meta, ({ label }) => label === 'Country')
+      expect(country).to.not.exist
+    })
+  })
 })


### PR DESCRIPTION
## Description of change

Fix an error on the `/companies` page when the company address is `null`.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
