### PR TITLE
Update Business details edit URL

### DIFF
--- a/src/apps/companies/views/business-details.njk
+++ b/src/apps/companies/views/business-details.njk
@@ -1,7 +1,6 @@
 {% extends "_layouts/template.njk" %}
 
 {% set editUrl = '/companies/' + company.id + '/edit' if not company.duns_number and not company.archived %}
-{% set regionUrl = '/companies/' + company.id + '/business-details/region' if not company.archived %}
 
 {% macro AddressCell(address, isRegistered) %}
   <td>
@@ -83,7 +82,14 @@
     </table>
   {% endcall %}
 
-  {% if regionDetails %}
+  {% if regionDetails %}   
+    {% if not company.archived %}
+        {% if company.duns_number %}
+            {% set regionUrl = '/companies/' + company.id + '/business-details/region' %}  
+        {% else %}
+            {% set regionUrl = '/companies/' + company.id + '/edit' %}
+        {% endif %}
+    {% endif %}        
     {% call DetailsContainer({ heading: 'DIT region', editUrl: regionUrl, dataAutoId: 'regionDetailsContainer' }) %}
       <table class="table--key-value">
         <tbody>


### PR DESCRIPTION
https://www.datahub.staging.uktrade.io/companies/82fb729d-a098-e211-a939-e4115bead28a/business-details

## Description of change
When looking at the "Business details" page a user should be able to edit the region. There are two approaches for editing regions:

1. The business is a D&B company:
Link into a view that contains a single select element containing the regions.
`/companies/companyId/business-details/region`

2. The business is **not** a D&B company: (existing implementation)
Link into the existing view that contains all the edit fields for editing a company.
`/companies/companyId/edit`

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
