### PR TITLE
Add link to great profile on export tab

### DIFF
--- a/src/apps/companies/controllers/__test__/exports.test.js
+++ b/src/apps/companies/controllers/__test__/exports.test.js
@@ -1,13 +1,15 @@
-const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const proxyquire = require('proxyquire')
+const urls = require('../../../../../src/lib/urls')
+const buildMiddlewareParameters = require('../../../helpers/middleware-parameters-builder')
 
-const companyMock = require('~/test/unit/data/companies/company-v4.json')
+const companyMock = require('../../../data/companies/company-v4.json')
 
 describe('Company export controller', () => {
   beforeEach(() => {
     this.saveCompany = sinon.stub()
     this.transformerSpy = sinon.spy()
 
-    this.controller = proxyquire('~/src/apps/companies/controllers/exports', {
+    this.controller = proxyquire('../../../../../src/apps/companies/controllers/exports', {
       '../repos': {
         saveCompany: this.saveCompany,
       },
@@ -204,7 +206,7 @@ describe('Company export controller', () => {
       })
 
       it('should redirect to exports routes', () => {
-        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(`/companies/${companyMock.id}/exports`)
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(urls.companies.exports(companyMock.id))
         expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
       })
 

--- a/src/apps/companies/controllers/__test__/exports.test.js
+++ b/src/apps/companies/controllers/__test__/exports.test.js
@@ -1,15 +1,15 @@
 const proxyquire = require('proxyquire')
-const urls = require('../../../../../src/lib/urls')
-const buildMiddlewareParameters = require('../../../helpers/middleware-parameters-builder')
+const urls = require('../../../../lib/urls')
+const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
 
-const companyMock = require('../../../data/companies/company-v4.json')
+const companyMock = require('../../../../../test/unit/data/companies/company-v4.json')
 
 describe('Company export controller', () => {
   beforeEach(() => {
     this.saveCompany = sinon.stub()
     this.transformerSpy = sinon.spy()
 
-    this.controller = proxyquire('../../../../../src/apps/companies/controllers/exports', {
+    this.controller = proxyquire('../exports', {
       '../repos': {
         saveCompany: this.saveCompany,
       },

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -2,6 +2,7 @@
 const { assign, filter, flatten } = require('lodash')
 
 const metadataRepo = require('../../../lib/metadata')
+const urls = require('../../../lib/urls')
 const { saveCompany } = require('../repos')
 const { transformObjectToOption } = require('../../transformers')
 const { transformCompanyToExportDetailsView } = require('../transformers')
@@ -12,7 +13,7 @@ function renderExports (req, res) {
   const exportDetails = transformCompanyToExportDetailsView(company)
 
   res
-    .breadcrumb(company.name, `/companies/${company.id}`)
+    .breadcrumb(company.name, urls.companies.detail(company.id))
     .breadcrumb('Exports')
     .render('companies/views/exports-view', {
       exportDetails,
@@ -40,8 +41,8 @@ function renderExportEdit (req, res) {
   const { company } = res.locals
 
   res
-    .breadcrumb(company.name, `/companies/${company.id}`)
-    .breadcrumb('Exports', `/companies/${company.id}/exports`)
+    .breadcrumb(company.name, urls.companies.detail(company.id))
+    .breadcrumb('Exports', urls.companies.exports(company.id))
     .breadcrumb('Edit')
     .render('companies/views/exports-edit', {
       exportDetailsLabels,
@@ -63,7 +64,7 @@ async function handleEditFormPost (req, res, next) {
   try {
     const save = await saveCompany(req.session.token, data)
 
-    res.redirect(`/companies/${save.id}/exports`)
+    res.redirect(urls.companies.exports(save.id))
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/index.js
+++ b/src/apps/companies/index.js
@@ -1,7 +1,8 @@
+const urls = require('../../lib/urls')
 const router = require('./router')
 
 module.exports = {
   displayName: 'Companies',
-  mountpath: '/companies',
+  mountpath: urls.companies.index.mountPoint,
   router,
 }

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -55,6 +55,7 @@ const exportDetailsLabels = {
   exportExperienceCategory: 'Export win category',
   exportToCountries: 'Currently exporting to',
   futureInterestCountries: 'Future countries of interest',
+  greatProfile: 'great.gov.uk company profile',
   exportPotential: 'Export potential',
 }
 

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -55,7 +55,7 @@ const exportDetailsLabels = {
   exportExperienceCategory: 'Export win category',
   exportToCountries: 'Currently exporting to',
   futureInterestCountries: 'Future countries of interest',
-  greatProfile: 'great.gov.uk company profile',
+  greatProfile: 'great.gov.uk business profile',
   exportPotential: 'Export potential',
 }
 

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -1,3 +1,4 @@
+const urls = require('../../lib/urls')
 const router = require('express').Router()
 const { ENTITIES } = require('../search/constants')
 const { LOCAL_NAV, DEFAULT_COLLECTION_QUERY, APP_PERMISSIONS, QUERY_FIELDS } = require('./constants')
@@ -64,7 +65,7 @@ router.param('companyId', getCompany)
 router.param('companyId', setIsCompanyAlreadyAdded)
 router.param('companyId', setDoAnyListsExist)
 
-router.get('/',
+router.get(urls.companies.index.route,
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
   getRequestBody(QUERY_FIELDS),
   getCollection('company', ENTITIES, transformCompanyToListItem),
@@ -114,7 +115,7 @@ router
 router.get('/:companyId/advisers', renderAdvisers)
 
 router.get('/:companyId/hierarchies/ghq/search', getGlobalHQCompaniesCollection, renderAddGlobalHQ)
-router.get('/:companyId/hierarchies/ghq/:globalHqId/add', setGlobalHQ)
+router.get(urls.companies.hierarchies.ghq.add.route, setGlobalHQ)
 router.get('/:companyId/hierarchies/ghq/remove', removeGlobalHQ)
 
 router.get('/:companyId/hierarchies/subsidiaries/search', getSubsidiaryCompaniesCollection, renderLinkSubsidiary)
@@ -127,7 +128,7 @@ router.get('/:companyId/contacts',
   renderContacts
 )
 
-router.get('/:companyId/exports', renderExports)
+router.get(urls.companies.exports.route, renderExports)
 router.get('/:companyId/subsidiaries', renderSubsidiaries)
 router.get('/:companyId/subsidiaries/link', renderLinkSubsidiary)
 router.get('/:companyId/orders', renderOrders)

--- a/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
@@ -1,5 +1,5 @@
-const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
-const { transformCompanyToExportDetailsView } = require('~/src/apps/companies/transformers')
+const minimalCompany = require('../../../data/companies/minimal-company.json')
+const { transformCompanyToExportDetailsView } = require('../../../../../src/apps/companies/transformers')
 
 const EXPORT_POTENTIAL_LABEL = 'Export potential'
 

--- a/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
@@ -8,13 +8,13 @@ const EXPORT_POTENTIAL_LABEL = 'Export potential'
 describe('transformCompanyToExportDetailsView', () => {
   let transformCompanyToExportDetailsView
   let urls
-  let greatProfileResponse
+  let greatUrlProfileResponse
 
   beforeEach(() => {
-    greatProfileResponse = faker.internet.url()
+    greatUrlProfileResponse = faker.internet.url()
     urls = {
       external: {
-        greatProfile: sinon.stub().returns(greatProfileResponse),
+        greatProfile: sinon.stub().returns(greatUrlProfileResponse),
       },
     }
     transformCompanyToExportDetailsView = proxyquire(transformerPath, {
@@ -155,7 +155,7 @@ describe('transformCompanyToExportDetailsView', () => {
         const viewRecord = createRecord({ great_profile_status: 'published' })
         const data = viewRecord[GREAT_LABEL]
 
-        expect(data).to.have.property('url', greatProfileResponse)
+        expect(data).to.have.property('url', greatUrlProfileResponse)
         expect(data).to.have.property('newWindow', true)
         expect(data).to.have.property('name', '"Find a supplier" profile')
         expect(data).to.have.property('hint', '(opens in a new window)')

--- a/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
@@ -1,5 +1,3 @@
-const { assign } = require('lodash')
-
 const minimalCompany = require('~/test/unit/data/companies/minimal-company.json')
 const { transformCompanyToExportDetailsView } = require('~/src/apps/companies/transformers')
 
@@ -8,11 +6,12 @@ const EXPORT_POTENTIAL_LABEL = 'Export potential'
 describe('transformCompanyToExportDetailsView', () => {
   context('when no export market information has been entered', () => {
     beforeEach(() => {
-      const company = assign({}, minimalCompany, {
+      const company = {
+        ...minimalCompany,
         export_experience_category: null,
         export_to_countries: [],
         future_interest_countries: [],
-      })
+      }
 
       this.viewRecord = transformCompanyToExportDetailsView(company)
     })
@@ -40,7 +39,8 @@ describe('transformCompanyToExportDetailsView', () => {
         id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
         name: 'Increasing export markets',
       }
-      const company = assign({}, minimalCompany, {
+      const company = {
+        ...minimalCompany,
         export_experience_category: this.exportExperienceCategory,
         export_to_countries: [{
           id: '1234',
@@ -50,8 +50,8 @@ describe('transformCompanyToExportDetailsView', () => {
           id: '4321',
           name: 'Germany',
         }],
-        export_potential: 'low',
-      })
+        export_potential_score: 'low',
+      }
 
       this.viewRecord = transformCompanyToExportDetailsView(company)
     })
@@ -79,7 +79,8 @@ describe('transformCompanyToExportDetailsView', () => {
         id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
         name: 'Increasing export markets',
       }
-      const company = assign({}, minimalCompany, {
+      const company = {
+        ...minimalCompany,
         export_experience_category: this.exportExperienceCategory,
         export_to_countries: [{
           id: '1234',
@@ -95,7 +96,7 @@ describe('transformCompanyToExportDetailsView', () => {
           id: '4123',
           name: 'Sweden',
         }],
-      })
+      }
 
       this.viewRecord = transformCompanyToExportDetailsView(company)
     })

--- a/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
@@ -1,8 +1,8 @@
 const proxyquire = require('proxyquire')
 const faker = require('faker')
-const minimalCompany = require('../../../data/companies/minimal-company.json')
+const minimalCompany = require('../../../../../test/unit/data/companies/minimal-company.json')
 
-const transformerPath = '../../../../../src/apps/companies/transformers/company-to-export-details-view'
+const transformerPath = '../company-to-export-details-view'
 const EXPORT_POTENTIAL_LABEL = 'Export potential'
 
 describe('transformCompanyToExportDetailsView', () => {

--- a/src/apps/companies/transformers/company-to-export-details-view.js
+++ b/src/apps/companies/transformers/company-to-export-details-view.js
@@ -2,6 +2,7 @@
 const { flatMap } = require('lodash')
 
 const { getDataLabels } = require('../../../lib/controller-utils')
+const urls = require('../../../lib/urls')
 const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
 
 function getCountries (data) {
@@ -14,17 +15,33 @@ function getExportPotentialLabel (key) {
   return (item && item.text) || 'No score given'
 }
 
+function getGreatProfileValue (profileStatus, companiesHouseNumber) {
+  if (profileStatus === 'published') {
+    return {
+      url: urls.external.greatProfile(companiesHouseNumber),
+      newWindow: true,
+      name: '"Find a supplier" profile',
+      hint: '(opens in a new window)',
+    }
+  } else {
+    return (profileStatus === 'unpublished' ? 'Profile not published' : 'No profile')
+  }
+}
+
 module.exports = function transformCompanyToExportDetailsView ({
   export_experience_category,
   export_to_countries,
   future_interest_countries,
-  export_potential,
+  export_potential_score,
+  great_profile_status,
+  company_number,
 }) {
   const viewRecord = {
     exportExperienceCategory: export_experience_category || 'None',
     exportToCountries: getCountries(export_to_countries),
     futureInterestCountries: getCountries(future_interest_countries),
-    exportPotential: getExportPotentialLabel(export_potential),
+    exportPotential: getExportPotentialLabel(export_potential_score),
+    greatProfile: getGreatProfileValue(great_profile_status, company_number),
   }
 
   return getDataLabels(viewRecord, exportDetailsLabels)

--- a/src/apps/contacts/index.js
+++ b/src/apps/contacts/index.js
@@ -1,7 +1,8 @@
+const urls = require('../../lib/urls')
 const router = require('./router')
 
 module.exports = {
   displayName: 'Contacts',
-  mountpath: '/contacts',
+  mountpath: urls.contacts.index.mountPoint,
   router,
 }

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -1,4 +1,5 @@
 const router = require('express').Router()
+const urls = require('../../lib/urls')
 
 const { ENTITIES } = require('../search/constants')
 const { LOCAL_NAV, DEFAULT_COLLECTION_QUERY, QUERY_FIELDS } = require('./constants')
@@ -20,7 +21,7 @@ const { transformContactToListItem } = require('./transformers')
 
 const interactionsRouter = require('../interactions/router.sub-app')
 
-router.get('/',
+router.get(urls.contacts.index.route,
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
   getRequestBody(QUERY_FIELDS),
   getCollection('contact', ENTITIES, transformContactToListItem),

--- a/src/apps/dashboard/index.js
+++ b/src/apps/dashboard/index.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
+const urls = require('../../lib/urls')
 const { renderDashboard } = require('./controllers')
 
 module.exports = {
-  router: router.get('/', renderDashboard),
+  router: router.get(urls.dashboard.route, renderDashboard),
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -128,6 +128,7 @@ const config = {
     apiFeed: process.env.HELP_CENTRE_API_FEED,
     token: process.env.HELP_CENTRE_FEED_API_TOKEN,
   },
+  greatProfileUrl: process.env.GREAT_PROFILE_URL,
 }
 
 module.exports = config

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -1,0 +1,11 @@
+const config = require('../../config')
+
+module.exports = {
+  external: {
+    greatProfile: (id) => config.greatProfileUrl.replace('{id}', id),
+  },
+  companies: {
+    detail: (id) => `/companies/${id}`,
+    exports: (id) => `/companies/${id}/exports`,
+  },
+}

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -1,11 +1,57 @@
 const config = require('../../config')
 
+function getTokens (path) {
+  const tokens = []
+  const parts = path.split('/')
+
+  parts.forEach((part) => {
+    if (part.startsWith(':')) {
+      tokens.push(part)
+    }
+  })
+
+  return tokens
+}
+
+function getPath (path, tokens, params) {
+  if (path === '/') {
+    return ''
+  }
+  tokens.forEach((token, index) => {
+    path = path.replace(token, params[index])
+  })
+  return path
+}
+
+function url (mountPoint, path = '/') {
+  const tokens = getTokens(path)
+
+  function getUrl (...params) {
+    return (mountPoint + getPath(path, tokens, params))
+  }
+
+  getUrl.mountPoint = mountPoint
+  getUrl.route = path
+
+  return getUrl
+}
+
 module.exports = {
   external: {
     greatProfile: (id) => config.greatProfileUrl.replace('{id}', id),
   },
+  dashboard: url('/'),
   companies: {
-    detail: (id) => `/companies/${id}`,
-    exports: (id) => `/companies/${id}/exports`,
+    index: url('/companies'),
+    detail: url('/companies', '/:companyId'),
+    exports: url('/companies', '/:companyId/exports'),
+    hierarchies: {
+      ghq: {
+        add: url('/companies', '/:companyId/hierarchies/ghq/:globalHqId/add'),
+      },
+    },
+  },
+  contacts: {
+    index: url('/contacts'),
   },
 }

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -1,4 +1,4 @@
-const config = require('../../config')
+const config = require('../config')
 
 function getTokens (path) {
   const tokens = []

--- a/test/acceptance/features/companies/exports.feature
+++ b/test/acceptance/features/companies/exports.feature
@@ -5,20 +5,22 @@ Feature: Company export save
   Scenario: Save company export details
     When I navigate to the `companies.exports` page using `company` `Lambda plc` fixture
     Then the Exports key value details are displayed
-      | key                          | value                             |
-      | Export win category          | None                              |
-      | Currently exporting to       | company.currentlyExportingTo      |
-      | Future countries of interest | company.futureCountriesOfInterest |
-      | Export potential             | No score given                    |
+      | key                           | value                             |
+      | Export win category           | None                              |
+      | Currently exporting to        | company.currentlyExportingTo      |
+      | Future countries of interest  | company.futureCountriesOfInterest |
+      | great.gov.uk business profile | No profile                        |
+      | Export potential              | No score given                    |
     When I click the "Edit export markets" link
     And I update the company Exports details
     And I submit the form
     Then the Exports key value details are displayed
-      | key                          | value                             |
-      | Export win category          | company.exportWinCategory         |
-      | Currently exporting to       | company.currentlyExportingTo      |
-      | Future countries of interest | company.futureCountriesOfInterest |
-      | Export potential             | No score given                    |
+      | key                           | value                             |
+      | Export win category           | company.exportWinCategory         |
+      | Currently exporting to        | company.currentlyExportingTo      |
+      | Future countries of interest  | company.futureCountriesOfInterest |
+      | great.gov.uk business profile | No profile                        |
+      | Export potential              | No score given                    |
 
   @companies-export--archived-company
   Scenario: Archived company without Edit export markets button

--- a/test/unit/lib/urls.test.js
+++ b/test/unit/lib/urls.test.js
@@ -1,0 +1,33 @@
+const faker = require('faker')
+const proxyquire = require('proxyquire')
+
+const modulePath = '../../../src/lib/urls'
+
+describe('urls', () => {
+  let urls
+  before(() => {
+    urls = proxyquire(modulePath, {
+      '../../config': {
+        greatProfileUrl: 'http://a.b.c.com/path/{id}',
+      },
+    })
+  })
+
+  describe('external', () => {
+    it('should have the correct urls', () => {
+      const companyNumber = faker.random.alphaNumeric(8)
+      expect(urls.external.greatProfile(companyNumber)).to.equal(`http://a.b.c.com/path/${companyNumber}`)
+    })
+  })
+
+  describe('companies', () => {
+    let companyId
+    beforeEach(() => {
+      companyId = faker.random.uuid()
+    })
+    it('should return the correct values', () => {
+      expect(urls.companies.detail(companyId)).to.equal(`/companies/${companyId}`)
+      expect(urls.companies.exports(companyId)).to.equal(`/companies/${companyId}/exports`)
+    })
+  })
+})

--- a/test/unit/lib/urls.test.js
+++ b/test/unit/lib/urls.test.js
@@ -20,14 +20,41 @@ describe('urls', () => {
     })
   })
 
+  describe('dashboard', () => {
+    it('should return the correct value', () => {
+      expect(urls.dashboard()).to.equal('/')
+      expect(urls.dashboard.mountPoint).to.equal('/')
+      expect(urls.dashboard.route).to.equal('/')
+    })
+  })
+
   describe('companies', () => {
     let companyId
     beforeEach(() => {
       companyId = faker.random.uuid()
     })
     it('should return the correct values', () => {
+      expect(urls.companies.index.mountPoint).to.equal('/companies')
+      expect(urls.companies.index.route).to.equal('/')
+      expect(urls.companies.index()).to.equal('/companies')
+
+      expect(urls.companies.detail.route).to.equal('/:companyId')
       expect(urls.companies.detail(companyId)).to.equal(`/companies/${companyId}`)
+
+      expect(urls.companies.exports.route).to.equal('/:companyId/exports')
       expect(urls.companies.exports(companyId)).to.equal(`/companies/${companyId}/exports`)
+
+      const globalHqId = faker.random.uuid()
+      expect(urls.companies.hierarchies.ghq.add.route).to.equal('/:companyId/hierarchies/ghq/:globalHqId/add')
+      expect(urls.companies.hierarchies.ghq.add(companyId, globalHqId)).to.equal(`/companies/${companyId}/hierarchies/ghq/${globalHqId}/add`)
+    })
+  })
+
+  describe('contacts', () => {
+    it('should return the correct values', () => {
+      expect(urls.contacts.index.mountPoint).to.equal('/contacts')
+      expect(urls.contacts.index.route).to.equal('/')
+      expect(urls.contacts.index()).to.equal('/contacts')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Using a new property on the company object to determine if the company has a profile on GREAT. If a profile exists then a link will be made to the profile, if there is a profile but it is not published then it will say "Profile not published" otherwise it will say "No profile"

**Requires new field in BE**

## Test instructions

View the export tab for a company
 
## Screenshots
### Before

<img width="845" alt="Screen Shot 2019-10-11 at 10 04 56" src="https://user-images.githubusercontent.com/1481883/66639599-0ab7e800-ec0f-11e9-9b49-2d446b6a3eb7.png">

### After 

<img width="956" alt="Screen Shot 2019-10-30 at 07 52 11" src="https://user-images.githubusercontent.com/1481883/67838888-4517f500-faea-11e9-8c9d-2f368ab13640.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
