### PR TITLE
Remove hard coded apiRoot and use from config

### DIFF
--- a/src/lib/__test__/hawk-request.test.js
+++ b/src/lib/__test__/hawk-request.test.js
@@ -1,5 +1,7 @@
-const config = require('~/config')
+const config = require('../../../config')
 const rewire = require('rewire')
+
+const modulePath = '../hawk-request'
 
 const testDataHubCredentials = {
   id: 'test-key-id',
@@ -7,14 +9,14 @@ const testDataHubCredentials = {
   algorithm: 'sha256',
 }
 const testClientHeaderArtifacts = { fake: 'artifacts' }
-const testRequestOptions = { uri: 'http://localhost:8000/v4/metadata/countries',
+const testRequestOptions = { uri: `${config.apiRoot}/v4/metadata/countries`,
   method: 'GET',
   headers: { accept: 'application/json', Authorization: 'Fake header' },
 }
 
 describe('#hawkRequest: check getHawkHeader', () => {
   beforeEach(() => {
-    this.hawkRequest = rewire('~/src/lib/hawk-request')
+    this.hawkRequest = rewire(modulePath)
     this.configStub = sinon.stub()
     this.expectedHawkHeader = {
       header: 'Hawk id="test-key-id", ts="1501545600", nonce="Sj_D4e", hash="B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=", mac="eUfXrU30nDxsrP0+c6s54EaP8Dyuhp7JfBEFO4Ufllw="',
@@ -63,7 +65,7 @@ describe('#hawkRequest: check sendHawkRequest', () => {
     this.configStub = sinon.stub()
     this.configStub.hawkCredentials = sinon.stub()
     this.configStub.hawkCredentials.dataHubBackend = testDataHubCredentials
-    this.hawkRequest = rewire('~/src/lib/hawk-request')
+    this.hawkRequest = rewire(modulePath)
     this.hawkRequest.__set__('config', this.configStub)
     this.createPromiseRequestSpy = sinon.spy()
     this.hawkRequest.__set__('createPromiseRequest', this.createPromiseRequestSpy)
@@ -93,7 +95,7 @@ describe('#hawkRequest: check sendHawkRequest', () => {
 describe('#hawkRequest: check createPromiseRequest', () => {
   beforeEach(() => {
     this.configStub = sinon.stub()
-    this.hawkRequest = rewire('~/src/lib/hawk-request')
+    this.hawkRequest = rewire(modulePath)
     this.hawkRequest.__set__('config', this.configStub)
     this.hawkRequest.__set__('hawk.client.authenticate', sinon.stub().returns(true))
   })

--- a/src/lib/__test__/metadata.test.js
+++ b/src/lib/__test__/metadata.test.js
@@ -1,57 +1,60 @@
 const rewire = require('rewire')
+const config = require('../../../config')
 
-describe('#metadata: check getMetadata', () => {
+const modulePath = '../metadata'
+
+describe('metadata', () => {
+  let metadata
+  let hawkRequest
   beforeEach(() => {
-    this.metadata = rewire('~/src/lib/metadata')
-    this.metadata.__set__('redisClient', null)
+    metadata = rewire(modulePath)
+  })
+  afterEach(() => {
+    expect(hawkRequest).to.have.been.calledOnceWith(`${config.apiRoot}/v4/metadata/fake`)
+  })
+  describe('#getMetadata', () => {
+    beforeEach(() => {
+      metadata.__set__('redisClient', null)
+    })
+    it('gets metadata from URL', async () => {
+      let getMetadata = metadata.__get__('getMetadata')
+
+      hawkRequest = sinon.stub().resolves({ fake: 'metadata' })
+      metadata.__set__('hawkRequest', hawkRequest)
+      await getMetadata('fake', 'fakeOptions')
+      const { fakeOptions } = metadata.__get__('exports')
+      expect(fakeOptions).to.deep.equal({ fake: 'metadata' })
+    })
+
+    it('fails to get metadata if request cannot be made', async () => {
+      let getMetadata = metadata.__get__('getMetadata')
+
+      hawkRequest = sinon.stub().rejects()
+      metadata.__set__('hawkRequest', hawkRequest)
+      await expect(getMetadata('fake', 'fakeOptions')).to.be.rejectedWith(Error)
+      const { fakeOptions } = metadata.__get__('exports')
+      expect(fakeOptions).to.deep.equal(undefined)
+    })
   })
 
-  it('gets metadata from URL', async () => {
-    let getMetadata = this.metadata.__get__('getMetadata')
+  describe('#getMetadataItem', () => {
+    it('gets correct metadata item', async () => {
+      const getMetadataItem = metadata.__get__('exports').getMetadataItem
 
-    let hawkRequest = sinon.stub().resolves({ fake: 'metadata' })
-    this.metadata.__set__('hawkRequest', hawkRequest)
-    await getMetadata('fake', 'fakeOptions')
-    const { fakeOptions } = this.metadata.__get__('exports')
-    expect(hawkRequest).to.have.been.calledOnceWith('http://localhost:8000/v4/metadata/fake')
-    expect(fakeOptions).to.deep.equal({ fake: 'metadata' })
-  })
+      hawkRequest = sinon.stub().resolves(
+        [{ id: 1, name: 'Fake 1' }, { id: 2, name: 'Fake 2' }]
+      )
+      metadata.__set__('hawkRequest', hawkRequest)
+      const option = await getMetadataItem('fake', 2)
+      expect(option).to.be.deep.equal({ id: 2, name: 'Fake 2' })
+    })
 
-  it('fails to get metadata if request cannot be made', async () => {
-    let getMetadata = this.metadata.__get__('getMetadata')
+    it('fails to get correct metadata item when request cannot be made', async () => {
+      const getMetadataItem = metadata.__get__('exports').getMetadataItem
 
-    let hawkRequest = sinon.stub().rejects()
-    this.metadata.__set__('hawkRequest', hawkRequest)
-    await expect(getMetadata('fake', 'fakeOptions')).to.be.rejectedWith(Error)
-    const { fakeOptions } = this.metadata.__get__('exports')
-    expect(hawkRequest).to.have.been.calledOnceWith('http://localhost:8000/v4/metadata/fake')
-    expect(fakeOptions).to.deep.equal(undefined)
-  })
-})
-
-describe('#metadata: check getMetadataItem', () => {
-  beforeEach(() => {
-    this.metadata = rewire('~/src/lib/metadata')
-  })
-
-  it('gets correct metadata item', async () => {
-    let getMetadataItem = this.metadata.__get__('exports').getMetadataItem
-
-    let hawkRequest = sinon.stub().resolves(
-      [{ id: 1, name: 'Fake 1' }, { id: 2, name: 'Fake 2' }]
-    )
-    this.metadata.__set__('hawkRequest', hawkRequest)
-    const option = await getMetadataItem('fake', 2)
-    expect(hawkRequest).to.have.been.calledOnceWith('http://localhost:8000/v4/metadata/fake')
-    expect(option).to.be.deep.equal({ id: 2, name: 'Fake 2' })
-  })
-
-  it('fails to get correct metadata item when request cannot be made', async () => {
-    let getMetadataItem = this.metadata.__get__('exports').getMetadataItem
-
-    let hawkRequest = sinon.stub().rejects()
-    this.metadata.__set__('hawkRequest', hawkRequest)
-    await expect(getMetadataItem('fake', 2)).to.be.rejectedWith(Error)
-    expect(hawkRequest).to.have.been.calledOnceWith('http://localhost:8000/v4/metadata/fake')
+      hawkRequest = sinon.stub().rejects()
+      metadata.__set__('hawkRequest', hawkRequest)
+      await expect(getMetadataItem('fake', 2)).to.be.rejectedWith(Error)
+    })
   })
 })


### PR DESCRIPTION
## Description of change

Remove hard coded apiRoot so the tests don't break when you are not running the BE on port 8000
Also refactor tests to be simpler

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
