### PR TITLE
Fix - Now posts proper value to the API rather than an object

### DIFF
--- a/src/apps/company-lists/client/CreateListFormSection.jsx
+++ b/src/apps/company-lists/client/CreateListFormSection.jsx
@@ -15,7 +15,7 @@ const CreateListFormSection = (
     maxLength,
   }) => {
 
-  async function onCreateList (listName) {
+  async function onCreateList ({listName}) {
     await axios({
       method: 'POST',
       url: `/companies/${id}/lists/create?_csrf=${csrfToken}`,


### PR DESCRIPTION
## Description of change
In the onSubmit handler we need to deconstruct the prop value 'listName' so we post the right value to the API rather than an object.

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
