### PR TITLE
Delete list - Change the re-direct after deleting

### DIFF
--- a/src/apps/company-lists/client/DeleteCompanyList.jsx
+++ b/src/apps/company-lists/client/DeleteCompanyList.jsx
@@ -15,7 +15,7 @@ function DeleteCompanyList ({ companyList, csrfToken, returnUrl }) {
         null,
         { params: { _csrf: csrfToken } },
       )
-      window.location.assign('/company-lists')
+      window.location.assign('/')
     } catch (error) {
       if (get(error, 'response.status') === 404) {
         setErrorMessage(notFoundMessage)

--- a/src/apps/company-lists/controllers/__test__/delete.test.js
+++ b/src/apps/company-lists/controllers/__test__/delete.test.js
@@ -86,7 +86,7 @@ describe('Delete company list controller', () => {
         const actualProps = middlewareParameters.resMock.render.getCall(0).args[1].props
         expect(actualProps).to.be.deep.equal({
           companyList: companyList,
-          returnUrl: '/company-lists',
+          returnUrl: '/',
         })
       })
 

--- a/src/apps/company-lists/controllers/delete.js
+++ b/src/apps/company-lists/controllers/delete.js
@@ -12,7 +12,7 @@ async function fetchCompanyList (req, res, next) {
 async function renderDeleteCompanyListPage (req, res, next) {
   const props = {
     companyList: res.locals.companyList,
-    returnUrl: '/company-lists',
+    returnUrl: '/',
   }
 
   try {

--- a/test/functional/cypress/specs/company-lists/delete-spec.js
+++ b/test/functional/cypress/specs/company-lists/delete-spec.js
@@ -51,7 +51,7 @@ describe('Delete company list page', () => {
     it('redirects to the edit company lists page', () => {
       cy.location().should((loc) => {
         expect(loc.origin).to.eq(Cypress.config().baseUrl)
-        expect(loc.pathname).to.eq('/company-lists')
+        expect(loc.pathname).to.eq('/')
       })
     })
 


### PR DESCRIPTION
## Description of change
As we did not create the edit list page we need to re-direct the user back to the home page when deleting the list.

No visual changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
