### PR TITLE
Ensure accepting untrusted certificates only happens once

### DIFF
--- a/src/lib/__test__/authorised-request.test.js
+++ b/src/lib/__test__/authorised-request.test.js
@@ -1,0 +1,47 @@
+const proxyquire = require('proxyquire').noPreserveCache()
+
+let PROXY
+let NODE_TLS_REJECT_UNAUTHORIZED
+
+describe('In dev', () => {
+  before(() => {
+    ({ PROXY, NODE_TLS_REJECT_UNAUTHORIZED } = process.env)
+  })
+
+  afterEach(() => {
+    if (PROXY) {
+      process.env.PROXY = PROXY
+    } else {
+      delete process.env.PROXY
+    }
+
+    if (NODE_TLS_REJECT_UNAUTHORIZED) {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = NODE_TLS_REJECT_UNAUTHORIZED
+    } else {
+      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED
+    }
+  })
+
+  describe('With a proxy', () => {
+    it('should set an env variable to allow untrusted certificates', () => {
+      process.env.PROXY = '1'
+      proxyquire('../authorised-request', {
+        '../../config': {
+          isDev: true,
+        },
+      })
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).to.equal('0')
+    })
+  })
+
+  describe('Without a proxy', () => {
+    it('Should not allow untrusted certificates', () => {
+      proxyquire('../authorised-request', {
+        '../../config': {
+          isDev: true,
+        },
+      })
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).to.be.undefined
+    })
+  })
+})

--- a/src/lib/authorised-request.js
+++ b/src/lib/authorised-request.js
@@ -52,18 +52,10 @@ function parseOptions (opts, token) {
   }
 }
 
-const acceptUntrustedCertificatesForDevEnvironments = () => {
-  if (process.env.PROXY && config.isDev) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-  }
-}
-
 // Accepts options as keys on an object or encoded as a url
 // Responses are parsed to remove any embedded XSS attempts with
 // script tags
 function authorisedRequest (token, opts) {
-  acceptUntrustedCertificatesForDevEnvironments()
-
   const requestOptions = parseOptions(opts, token)
 
   logger.debug('Send authorised request: ', requestOptions)
@@ -77,13 +69,16 @@ function authorisedRequest (token, opts) {
 // See request-promise #90 does not work with streams
 // https://github.com/request/request-promise/issues/90
 function authorisedRawRequest (token, opts) {
-  acceptUntrustedCertificatesForDevEnvironments()
-
   const requestOptions = parseOptions(opts, token)
 
   logger.debug('Send authorised raw request: ', requestOptions)
 
   return Promise.resolve(request(requestOptions))
+}
+
+// accept untrusted certificates for dev environments
+if (config.isDev && process.env.PROXY) {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 }
 
 module.exports = {


### PR DESCRIPTION
## Description of change

An unnecessary check was happening for each request when it only needs to happen once when the server starts
