### PR TITLE
Change markets to countries

### DIFF
--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/template.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ heading: 'Edit export markets' }) %}{% endcall %}
+  {% call LocalHeader({ heading: 'Edit export countries' }) %}{% endcall %}
 {% endblock %}
 
 {% block body_main_content %}
@@ -28,14 +28,14 @@
     <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
       <label class="c-form-group__label">
         <span class="c-form-group__label-text">
-          Select a market this company currently exports to (optional)
+          Select a country this company currently exports to (optional)
         </span>
       </label>
 
       {% for country in exportCountries %}
         {{ MultipleChoiceField({
           name: 'export_to_countries',
-          label: 'Select a market this company currently exports to',
+          label: 'Select a country this company currently exports to',
           value: country,
           options: countryOptions,
           initialOption: '-- Select country --',
@@ -52,14 +52,14 @@
     <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
       <label class="c-form-group__label">
         <span class="c-form-group__label-text">
-          Future markets of interest (optional)
+          Future countries of interest (optional)
         </span>
       </label>
 
       {% for country in futureCountries %}
         {{ MultipleChoiceField({
           name: 'future_interest_countries',
-          label: 'Future markets of interest',
+          label: 'Future countries of interest',
           value: country,
           options: countryOptions,
           initialOption: '-- Select country --',

--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -30,7 +30,7 @@
 
     {% if not company.archived %}
       <p class="actions">
-        <a href="/companies/{{company.id}}/exports/edit" class="govuk-button govuk-button--secondary">Edit export markets</a>
+        <a href="/companies/{{company.id}}/exports/edit" class="govuk-button govuk-button--secondary">Edit export countries</a>
       </p>
     {% endif %}
   {% endcall %}

--- a/test/acceptance/features/companies/exports.feature
+++ b/test/acceptance/features/companies/exports.feature
@@ -10,7 +10,7 @@ Feature: Company export save
       | Currently exporting to       | company.currentlyExportingTo      |
       | Future countries of interest | company.futureCountriesOfInterest |
       | Export potential             | No score given                    |
-    When I click the "Edit export markets" link
+    When I click the "Edit export countries" link
     And I update the company Exports details
     And I submit the form
     Then the Exports key value details are displayed
@@ -21,6 +21,6 @@ Feature: Company export save
       | Export potential             | No score given                    |
 
   @companies-export--archived-company
-  Scenario: Archived company without Edit export markets button
+  Scenario: Archived company without Edit export countries button
     When I navigate to the `companies.exports` page using `company` `Archived Ltd` fixture
-    And I should not see the "Edit export markets" button
+    And I should not see the "Edit export countries" button


### PR DESCRIPTION
## Description of change

On the export tab for a company change "markets" to "countries" to ensure constant language is used

## Test instructions

Go to the export tab and also click on the edit export countries button
 
## Screenshots
### Before

![edit_before](https://user-images.githubusercontent.com/1481883/67756675-4ede2180-fa32-11e9-9e80-60eb0e54550a.png)

![export_before](https://user-images.githubusercontent.com/1481883/67756687-54d40280-fa32-11e9-91cb-400fa8e83859.png)


### After 

![edit_after](https://user-images.githubusercontent.com/1481883/67756692-5b627a00-fa32-11e9-986c-5db7d82bc5ec.png)

![export_after](https://user-images.githubusercontent.com/1481883/67756699-60272e00-fa32-11e9-9bee-edaae912d3b4.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
