### PR TITLE
Users can add themselves as a Lead Adviser on a company page

### DIFF
--- a/src/apps/companies/apps/edit-company/__test__/transformers.test.js
+++ b/src/apps/companies/apps/edit-company/__test__/transformers.test.js
@@ -86,6 +86,7 @@ describe('Edit company form transformers', () => {
         const actual = transformCompanyToForm(companiesHouseCompany)
         const expected = {
           'id': 15387806,
+          'one_list_group_tier': null,
           'company_number': '99919',
           'registered_address': {
             'line_1': '64 Ermin Street',

--- a/src/apps/companies/client/LeadAdvisers.jsx
+++ b/src/apps/companies/client/LeadAdvisers.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Button from '@govuk-react/button'
+import Link from '@govuk-react/link'
+import { H2 } from '@govuk-react/heading'
+import { LEVEL_SIZE } from '@govuk-react/constants'
+
+function LeadAdvisers ({ company, pageUrl, hasPermission, isItaTierDAccount }) {
+  const renderIsNotItaTierDAccount =
+    <div>
+      <H2 size={LEVEL_SIZE[3]}>Lead ITA for {company}</H2>
+      <p>This company has no Lead ITA</p>
+      <p>An ITA (International Trade Adviser) can add themselves as the Lead ITA, which will be visible to all Data Hub
+        users on the company page and any of its subsidiaries.</p>
+      {hasPermission && <Button
+        as={Link}
+        href={pageUrl}
+      >
+        Add myself as Lead ITA
+      </Button>}
+    </div>
+
+  const renderIsItaTierDAccount =
+    <div>
+      <H2 size={LEVEL_SIZE[3]}>Table to go here</H2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.</p>
+    </div>
+
+  return isItaTierDAccount
+    ? renderIsItaTierDAccount
+    : renderIsNotItaTierDAccount
+}
+
+LeadAdvisers.propTypes = {
+  company: PropTypes.object.isRequired,
+  pageUrl: PropTypes.string.isRequired,
+  hasPermission: PropTypes.bool.isRequired,
+}
+
+export default LeadAdvisers

--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -43,7 +43,7 @@ const LOCAL_NAV = [
   },
   {
     path: 'advisers',
-    label: 'Core team',
+    label: 'Lead Advisers',
   },
   {
     path: 'investments',

--- a/src/apps/companies/controllers/__test__/advisers.test.js
+++ b/src/apps/companies/controllers/__test__/advisers.test.js
@@ -6,50 +6,131 @@ const coreTeamMock = require('~/test/unit/data/companies/one-list-group-core-tea
 
 const { renderAdvisers } = require('~/src/apps/companies/controllers/advisers')
 
+let middlewareParameters
+
 describe('Company contact list controller', () => {
   describe('#renderAdvisers', () => {
-    beforeEach(async () => {
-      this.middlewareParameters = buildMiddlewareParameters({
-        company: companyMock,
+    context('When the company is a One List Tier D International Adviser Trade Accounts and the user has permission to add themselves as the lead ITA', () => {
+      beforeEach(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          company: {
+            ...companyMock,
+            one_list_group_tier: {
+              id: '1929c808-99b4-4abf-a891-45f2e187b410',
+            },
+          },
+          user: {
+            permissions: ['company.change_regional_account_manager'],
+          },
+          features: {
+            lead_advisers: true,
+          },
+        })
+
+        await renderAdvisers(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+      it('should add two breadcrumbs', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
+      })
+      it('should add the company breadcrumb', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.be.calledWith(companyMock.name, `/companies/${companyMock.id}`)
+      })
+      it('should add the Lead Advisers breadcrumb', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.be.calledWith('Lead Advisers')
+      })
+      it('should render the correct template', () => {
+        expect(middlewareParameters.resMock.render).to.be.calledWith('companies/views/lead-advisers')
+      })
+      it('should set the company name', () => {
+        expect(middlewareParameters.resMock.render.args[0][1].props.company).to.equal('Mercury Trading Ltd')
+      })
+      it('should set the button link for the next page', () => {
+        expect(middlewareParameters.resMock.render.args[0][1].props.pageUrl).to.equal('/companies/15387806/advisers/confirm')
+      })
+      it('should set the permission flag', () => {
+        expect(middlewareParameters.resMock.render.args[0][1].props.hasPermission).to.equal(true)
+      })
+      it('should set the isItaTierDAccount flag', () => {
+        expect(middlewareParameters.resMock.render.args[0][1].props.isItaTierDAccount).to.equal(true)
+      })
+    })
+    context('When the company is a One List Tier D International Adviser Trade Accounts and the user has not got permission to add themselves as the lead ITA', () => {
+      beforeEach(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          company: {
+            ...companyMock,
+            one_list_group_tier: {
+              id: '1929c808-99b4-4abf-a891-45f2e187b410',
+            },
+          },
+          user: {
+            permissions: [],
+          },
+          features: {
+            lead_advisers: true,
+          },
+        })
+
+        await renderAdvisers(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
+      })
+      it('should set the permission to true', () => {
+        expect(middlewareParameters.resMock.render.args[0][1].props.hasPermission).to.equal(false)
+      })
+    })
+    context('When the company is not a One List Tier D International Adviser Trade Accounts', () => {
+      beforeEach(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          company: {
+            ...companyMock,
+          },
+        })
+
+        nock(config.apiRoot)
+          .get(`/v4/company/${companyMock.id}/one-list-group-core-team`)
+          .reply(200, coreTeamMock)
+
+        await renderAdvisers(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy,
+        )
       })
 
-      nock(config.apiRoot)
-        .get(`/v4/company/${companyMock.id}/one-list-group-core-team`)
-        .reply(200, coreTeamMock)
+      it('should add two breadcrumbs', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
+      })
 
-      await renderAdvisers(
-        this.middlewareParameters.reqMock,
-        this.middlewareParameters.resMock,
-        this.middlewareParameters.nextSpy,
-      )
-    })
+      it('should add the company breadcrumb', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.be.calledWith(companyMock.name, `/companies/${companyMock.id}`)
+      })
 
-    it('should add two breadcrumbs', () => {
-      expect(this.middlewareParameters.resMock.breadcrumb).to.have.been.calledTwice
-    })
+      it('should add the Advisers breadcrumb', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.be.calledWith('Advisers')
+      })
 
-    it('should add the company breadcrumb', () => {
-      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith(companyMock.name, `/companies/${companyMock.id}`)
-    })
+      it('should render the correct template', () => {
+        expect(middlewareParameters.resMock.render).to.be.calledWith('companies/views/advisers')
+      })
 
-    it('should add the Advisers breadcrumb', () => {
-      expect(this.middlewareParameters.resMock.breadcrumb).to.be.calledWith('Advisers')
-    })
+      it('should set the company name', () => {
+        expect(middlewareParameters.resMock.render.args[0][1].companyName).to.equal('Mercury Trading Ltd')
+      })
 
-    it('should render the correct template', () => {
-      expect(this.middlewareParameters.resMock.render).to.be.calledWith('companies/views/advisers')
-    })
+      it('should set the core team', () => {
+        expect(middlewareParameters.resMock.render.args[0][1].coreTeam).to.not.be.null
+      })
 
-    it('should set the company name', () => {
-      expect(this.middlewareParameters.resMock.render.args[0][1].companyName).to.equal('Mercury Trading Ltd')
-    })
-
-    it('should set the core team', () => {
-      expect(this.middlewareParameters.resMock.render.args[0][1].coreTeam).to.not.be.null
-    })
-
-    it('should not call next', () => {
-      expect(this.middlewareParameters.nextSpy).to.not.be.called
+      it('should not call next', () => {
+        expect(middlewareParameters.nextSpy).to.not.be.called
+      })
     })
   })
 })

--- a/src/apps/companies/middleware/__test__/local-navigation.test.js
+++ b/src/apps/companies/middleware/__test__/local-navigation.test.js
@@ -1,12 +1,14 @@
 const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
 
-const setCompaniesLocalNav = require('~/src/apps/companies/middleware/local-navigation')
+const localNavigation = require('../local-navigation')
+
+let middlewareParameters
 
 describe('Companies local navigation', () => {
   const commonTests = (expectedItems) => {
     it('should have items', () => {
       expectedItems.forEach((label) => {
-        const item = this.middlewareParameters.resMock.locals.localNavItems.find(item => item.label === label)
+        const item = middlewareParameters.resMock.locals.localNavItems.find(item => item.label === label)
         expect(item, label).to.exist
       })
     })
@@ -14,7 +16,7 @@ describe('Companies local navigation', () => {
 
   context('default menu items', () => {
     beforeEach(() => {
-      this.middlewareParameters = buildMiddlewareParameters({
+      middlewareParameters = buildMiddlewareParameters({
         company: {
           id: '1234',
           headquarter_type: null,
@@ -31,10 +33,10 @@ describe('Companies local navigation', () => {
         },
       })
 
-      setCompaniesLocalNav(
-        this.middlewareParameters.reqMock,
-        this.middlewareParameters.resMock,
-        this.middlewareParameters.nextSpy,
+      localNavigation(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
       )
     })
 
@@ -49,7 +51,7 @@ describe('Companies local navigation', () => {
 
   context('when the company is on the One List', () => {
     beforeEach(() => {
-      this.middlewareParameters = buildMiddlewareParameters({
+      middlewareParameters = buildMiddlewareParameters({
         company: {
           id: '1234',
           headquarter_type: null,
@@ -70,10 +72,10 @@ describe('Companies local navigation', () => {
         },
       })
 
-      setCompaniesLocalNav(
-        this.middlewareParameters.reqMock,
-        this.middlewareParameters.resMock,
-        this.middlewareParameters.nextSpy,
+      localNavigation(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
       )
     })
 
@@ -81,6 +83,85 @@ describe('Companies local navigation', () => {
       'Activity',
       'Company contacts',
       'Core team',
+      'Investment',
+      'Export',
+      'Orders',
+    ])
+  })
+
+  context('when the company is on the One List and is a Tier D - International Trade Adviser Accounts', () => {
+    beforeEach(() => {
+      middlewareParameters = buildMiddlewareParameters({
+        company: {
+          id: '1234',
+          headquarter_type: null,
+          company_number: null,
+          duns_number: '123456',
+          one_list_group_tier: {
+            id: '1929c808-99b4-4abf-a891-45f2e187b410',
+          },
+        },
+        user: {
+          permissions: [
+            'interaction.view_all_interaction',
+            'company.view_contact',
+            'investment.view_all_investmentproject',
+            'order.view_order',
+          ],
+        },
+        features: {
+          lead_advisers: true,
+        },
+      })
+
+      localNavigation(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+    commonTests([
+      'Activity',
+      'Company contacts',
+      'Lead Advisers',
+      'Investment',
+      'Export',
+      'Orders',
+    ])
+  })
+  context('when the company is not on the One List', () => {
+    beforeEach(() => {
+      middlewareParameters = buildMiddlewareParameters({
+        company: {
+          id: '1234',
+          headquarter_type: null,
+          company_number: null,
+          duns_number: '123456',
+          one_list_group_tier: null,
+        },
+        user: {
+          permissions: [
+            'interaction.view_all_interaction',
+            'company.view_contact',
+            'investment.view_all_investmentproject',
+            'order.view_order',
+          ],
+        },
+        features: {
+          lead_advisers: true,
+        },
+      })
+
+      localNavigation(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+    commonTests([
+      'Activity',
+      'Company contacts',
+      'Lead Advisers',
       'Investment',
       'Export',
       'Orders',

--- a/src/apps/companies/middleware/local-navigation.js
+++ b/src/apps/companies/middleware/local-navigation.js
@@ -1,15 +1,26 @@
 /* eslint-disable camelcase */
 const { setLocalNav } = require('../../middleware')
+const { isItaTierDAccount } = require('../../../lib/is-tier-type-company')
 const { LOCAL_NAV } = require('../constants')
 
 function setCompaniesLocalNav (req, res, next) {
-  const { company } = res.locals
-
-  const navItems = LOCAL_NAV.filter(({ path }) => {
-    return (path !== 'advisers' || company.one_list_group_tier)
-  })
-
-  setLocalNav(navItems)(req, res, next)
+  const { company, features } = res.locals
+  if (features.lead_advisers) {
+    const isCoreTeamCompany = !isItaTierDAccount(company) && company.one_list_group_tier
+    const navItems = LOCAL_NAV.map((item) =>
+      item.path === 'advisers' && isCoreTeamCompany
+        ? { ...item, label: 'Core team' }
+        : item
+    )
+    setLocalNav(navItems)(req, res, next)
+  } else {
+    const navItems = LOCAL_NAV.map((item) =>
+      item.path === 'advisers'
+        ? { ...item, label: 'Core team' }
+        : item
+    ).filter((item) => item.path !== 'advisers' || company.one_list_group_tier)
+    setLocalNav(navItems)(req, res, next)
+  }
 }
 
 module.exports = setCompaniesLocalNav

--- a/src/apps/companies/views/lead-advisers.njk
+++ b/src/apps/companies/views/lead-advisers.njk
@@ -1,0 +1,9 @@
+{% extends "./template.njk" %}
+
+{% block body_main_content %}
+  {% component 'react-slot', {
+    id: 'lead-advisers',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -10,6 +10,7 @@ import CreateListFormSection from './apps/company-lists/client/CreateListFormSec
 import AddRemoveFromListSection from './apps/company-lists/client/AddRemoveFromListSection'
 import BusinessDetailsRegionEdit from './apps/companies/client/BusinessDetailsRegionEdit'
 import BusinessDetailsSectorEdit from './apps/companies/client/BusinessDetailsSectorEdit'
+import LeadAdvisers from './apps/companies/client/LeadAdvisers'
 
 const appWrapper = document.getElementById('react-app')
 
@@ -55,6 +56,9 @@ function App () {
       </Mount>
       <Mount selector="#business-details-sector-edit">
         {props => <BusinessDetailsSectorEdit {...props} />}
+      </Mount>
+      <Mount selector="#lead-advisers">
+        {props => <LeadAdvisers {...props} />}
       </Mount>
     </>
   )

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -128,6 +128,13 @@ const config = {
     apiFeed: process.env.HELP_CENTRE_API_FEED,
     token: process.env.HELP_CENTRE_FEED_API_TOKEN,
   },
+  companies: {
+    tierTypes: {
+      typeD: {
+        itaAccount: '1929c808-99b4-4abf-a891-45f2e187b410',
+      },
+    },
+  },
   greatProfileUrl: process.env.GREAT_PROFILE_URL,
 }
 

--- a/src/lib/__test__/is-tier-type-company.test.js
+++ b/src/lib/__test__/is-tier-type-company.test.js
@@ -1,0 +1,26 @@
+const { isItaTierDAccount } = require('../is-tier-type-company')
+
+describe('Check tier type', () => {
+  describe('#isItaTierDAccount', () => {
+    const companyA = {
+      one_list_group_tier: {
+        id: '1929c808-99b4-4abf-a891-45f2e187b410',
+      },
+    }
+    const companyB = {
+      one_list_group_tier: {
+        id: '1',
+      },
+    }
+    context('when a company is in Tier D International Adviser Trade Accounts', () => {
+      it('should return true', () => {
+        expect(isItaTierDAccount(companyA)).to.equal(true)
+      })
+    })
+    context('when a company is not in Tier D International Adviser Trade Accounts but is in the One List', () => {
+      it('should return false', () => {
+        expect(isItaTierDAccount(companyB)).to.equal(false)
+      })
+    })
+  })
+})

--- a/src/lib/is-tier-type-company.js
+++ b/src/lib/is-tier-type-company.js
@@ -1,0 +1,8 @@
+const config = require('../../src/config')
+
+const isItaTierDAccount = company =>
+  company.one_list_group_tier && company.one_list_group_tier.id === config.companies.tierTypes.typeD.itaAccount
+
+module.exports = {
+  isItaTierDAccount,
+}

--- a/test/functional/cypress/specs/companies/lead-advisers.spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers.spec.js
@@ -1,0 +1,28 @@
+const fixtures = require('../../fixtures')
+const selectors = require('../../../../selectors')
+
+describe('Lead advisers', () => {
+  context('when viewing a non One List tier company', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.lambdaPlc.id}`)
+      cy.get(selectors.tabbedLocalNav().item(3)).click()
+    })
+    it('should display the "Lead Advisers" tab in the navigation', () => {
+      cy.get(selectors.tabbedLocalNav().item(3)).should('contain', 'Lead Adviser')
+    })
+    it('should display a header with the company name', () => {
+      cy.get(selectors.companyLeadAdviser.header).should('have.text', 'Lead ITA for Lambda plc')
+    })
+    it('should display a button to add myself as lead adviser', () => {
+      cy.contains('Add myself as Lead ITA').invoke('attr', 'href').should('eq', `/companies/${fixtures.company.lambdaPlc.id}/advisers/confirm`)
+    })
+  })
+  context('when viewing a One List Tier company', () => {
+    before(() => {
+      cy.visit(`/companies/${fixtures.company.oneListCorp.id}`)
+    })
+    it('should display the "Core team" tab in the navigation', () => {
+      cy.get(selectors.tabbedLocalNav().item(3)).should('contain', 'Core team')
+    })
+  })
+})

--- a/test/selectors/company/lead-adviser.js
+++ b/test/selectors/company/lead-adviser.js
@@ -1,0 +1,4 @@
+module.exports = {
+  header: '#lead-advisers > div > h2',
+  button: '#lead-advisers > div > a',
+}

--- a/test/selectors/index.js
+++ b/test/selectors/index.js
@@ -13,6 +13,7 @@ exports.companySubsidiaries = require('./company/subsidiaries')
 exports.companyAddToListButton = require('./company/add-to-list')
 exports.companyCreateListButton = require('./company')
 exports.companyAddRemoveFromLists = require('./company-lists/add-remove')
+exports.companyLeadAdviser = require('../selectors/company/lead-adviser')
 
 exports.companyList = {
   delete: require('./company-lists/delete'),

--- a/test/unit/data/companies/companies-house.json
+++ b/test/unit/data/companies/companies-house.json
@@ -1,5 +1,6 @@
 {
   "id": 15387806,
+  "one_list_group_tier": null,
   "name": "Mercury Trading Ltd",
   "company_number": "99919",
   "company_category": "Private Limited Company",


### PR DESCRIPTION
## Description of change

This is the first stage of being able to add yourself as a Lead ITA/Lead Adviser - https://trello.com/c/gaTtFM4R/969-state-1-on-new-tab

Feature flag used - `lead_advisers`

All company pages apart from One List tiers A - D should show the "Lead Advisers" tab. The "Lead Advisers" tab should show content around adding yourself as a "Lead Adviser" and providing you have permission `company.change_regional_account_manager` you will see a button to add yourself as a lead adviser.

If a company is a **Tier D International Adviser Trade Accounts** you should see the "Lead Advisers" tab but for now just some place holder content. One List companies other than  **Tier D International Adviser Trade Accounts** should show the "Core Team" tab as before.

So:
- One List tier A - D shows "Core Team" tab
- All other companies show "Lead Advisers" tab (content and button)
- One List Tier D International Adviser Trade Accounts show "Lead Advisers" tab (with placeholder content)

## One List A - D
![Screenshot 2019-10-31 at 13 44 32](https://user-images.githubusercontent.com/10154302/67952112-acb26b00-fbe4-11e9-8d9d-7a07f62553ca.png)

## All other companies
![Screenshot 2019-10-31 at 13 44 17](https://user-images.githubusercontent.com/10154302/67952130-b50aa600-fbe4-11e9-9889-1dc9860484f1.png)

## One List Tier D International Adviser Trade Accounts
![Screenshot 2019-10-31 at 13 44 45](https://user-images.githubusercontent.com/10154302/67952155-c0f66800-fbe4-11e9-914a-b5fc32f72a4e.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
