### PR TITLE
Add Ultimate HQ subsidiary block

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -174,3 +174,7 @@
     margin-top: $default-spacing-unit;
   }
 }
+
+.c-local-header__description .subsidiaries {
+  margin-left: 0;
+}

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -1,32 +1,32 @@
-const { renderActivityFeed } = require('../controllers')
-const { ACTIVITY_TYPE_FILTERS } = require('../../../constants')
+const activityFeedEsFixtures = require('../../../../../../test/unit/data/activity-feed/activity-feed-from-es.json')
+const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
+const companyMock = require('../../../../../../test/unit/data/company.json')
 const { ACTIVITY_TYPE_FILTER_KEYS } = require('../../../constants')
+const { ACTIVITY_TYPE_FILTERS } = require('../../../constants')
+const { companies } = require('../../../../../lib/urls')
 const config = require('../../../../../config')
-
-const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder')
-const activityFeedEsFixtures = require('~/test/unit/data/activity-feed/activity-feed-from-es')
-const companyMock = require('~/test/unit/data/company.json')
 
 describe('Activity feed controllers', () => {
   describe('#fetchActivityFeedHandler', () => {
     beforeEach(() => {
-      this.fetchActivityFeedStub = sinon.stub().resolves(activityFeedEsFixtures)
-
-      this.controllers = proxyquire('../../src/apps/companies/apps/activity-feed/controllers', {
-        './repos': { fetchActivityFeed: this.fetchActivityFeedStub },
+      global.fetchActivityFeedStub = sinon.stub().resolves(activityFeedEsFixtures)
+      global.controllers = proxyquire('../../src/apps/companies/apps/activity-feed/controllers', {
+        './repos': {
+          fetchActivityFeed: global.fetchActivityFeedStub,
+        },
       })
     })
 
     context('when fetching feed for a company', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
         })
 
-        await this.controllers.fetchActivityFeedHandler(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.fetchActivityFeedHandler(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
@@ -42,39 +42,39 @@ describe('Activity feed controllers', () => {
           token: '1234',
         }
 
-        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
-        expect(this.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
+        expect(global.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(global.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
       })
     })
 
     context('when filtering for "all" activity feed for a company', () => {
       const { allActivity } = ACTIVITY_TYPE_FILTER_KEYS
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           requestQuery: {
             queryParams: 'all',
           },
         })
 
-        await this.controllers.fetchActivityFeedHandler(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.fetchActivityFeedHandler(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
       it('should call fetchActivityFeed with the right params', async () => {
         const expectedParams = { companyId: 'dcdabbc9-1781-e411-8955-e4115bead28a', filter: { 'terms': { 'object.type': allActivity } }, from: 0, token: '1234' }
 
-        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
-        expect(this.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
+        expect(global.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(global.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
       })
     })
 
     context('when filtering for "my" activity feed for a company', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           requestQuery: {
             queryParams: 'my-activity',
@@ -84,10 +84,10 @@ describe('Activity feed controllers', () => {
           },
         })
 
-        await this.controllers.fetchActivityFeedHandler(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.fetchActivityFeedHandler(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
@@ -99,25 +99,25 @@ describe('Activity feed controllers', () => {
           token: '1234',
         }
 
-        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
-        expect(this.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
+        expect(global.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(global.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
       })
     })
 
     context('when filtering for "data-hub activity" activity feed for a company', () => {
       const { dataHubActivity } = ACTIVITY_TYPE_FILTER_KEYS
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           requestQuery: {
             queryParams: 'datahub-activity',
           },
         })
 
-        await this.controllers.fetchActivityFeedHandler(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.fetchActivityFeedHandler(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
@@ -129,25 +129,25 @@ describe('Activity feed controllers', () => {
           token: '1234',
         }
 
-        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
-        expect(this.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
+        expect(global.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(global.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
       })
     })
 
     context('when filtering for "external activity" activity feed for a company', () => {
       const { externalActivity } = ACTIVITY_TYPE_FILTER_KEYS
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           requestQuery: {
             queryParams: 'external-activity',
           },
         })
 
-        await this.controllers.fetchActivityFeedHandler(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.fetchActivityFeedHandler(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
@@ -159,24 +159,24 @@ describe('Activity feed controllers', () => {
           token: '1234',
         }
 
-        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
-        expect(this.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
+        expect(global.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(global.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
       })
     })
 
     context('when filtering param is invalid', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           requestQuery: {
             queryParams: 'foobar',
           },
         })
 
-        await this.controllers.fetchActivityFeedHandler(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.fetchActivityFeedHandler(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
@@ -188,26 +188,26 @@ describe('Activity feed controllers', () => {
           token: '1234',
         }
 
-        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
-        expect(this.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
+        expect(global.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(global.middlewareParameters.resMock.json).to.be.calledOnceWithExactly(activityFeedEsFixtures)
       })
     })
 
     context('when the endpoint returns error', () => {
       beforeEach(async () => {
-        this.error = {
+        global.error = {
           statusCode: 404,
         }
-        this.fetchActivityFeedStub.rejects(this.error)
+        global.fetchActivityFeedStub.rejects(global.error)
 
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
         })
 
-        await this.controllers.fetchActivityFeedHandler(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.fetchActivityFeedHandler(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
@@ -223,74 +223,106 @@ describe('Activity feed controllers', () => {
           token: '1234',
         }
 
-        expect(this.fetchActivityFeedStub).to.be.calledWith(expectedParams)
-        expect(this.middlewareParameters.resMock.json).to.not.have.been.called
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledWith(this.error)
+        expect(global.fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(global.middlewareParameters.resMock.json).to.not.have.been.called
+        expect(global.middlewareParameters.nextSpy).to.have.been.calledWith(global.error)
       })
     })
   })
 
   describe('#renderActivityFeed', () => {
     context('when the feed renders successfully', () => {
-      const { allActivity, dataHubActivity, externalActivity, myActivity } = ACTIVITY_TYPE_FILTERS
-      const addActivityTypeFilter = {
-        allActivity,
-        myActivity: {
-          label: myActivity.label,
-          value: 'my-activity',
-        },
-        externalActivity,
-        dataHubActivity,
-      }
-
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
+        global.middlewareParameters = buildMiddlewareParameters({
+          company: {
+            ...companyMock,
+          },
           user: {
             id: 123,
           },
         })
 
-        await renderActivityFeed(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.renderActivityFeed(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
       it('should render', () => {
-        expect(this.middlewareParameters.resMock.render).to.be.calledOnce
+        expect(global.middlewareParameters.resMock.render).to.be.calledOnce
       })
 
       it('should render the activity feed template', () => {
-        expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(
+        const companyId = global.middlewareParameters.resMock.locals.company.id
+        expect(global.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(
           'companies/apps/activity-feed/views/client-container', {
             props: {
-              addActivityTypeFilter,
-              addContentLink: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/interactions/create',
+              addActivityTypeFilter: {
+                ...ACTIVITY_TYPE_FILTERS,
+              },
+              addContentLink: companies.interactions.create(companyId),
               addContentText: 'Add interaction',
-              apiEndpoint: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/activity/data',
+              apiEndpoint: companies.activity.data(companyId),
               isTypeFilterEnabled: undefined,
             },
           })
       })
 
       it('should add a breadcrumb', () => {
-        expect(this.middlewareParameters.resMock.breadcrumb.firstCall).to.be.calledWith(
+        expect(global.middlewareParameters.resMock.breadcrumb.firstCall).to.be.calledWith(
           'Wonka Industries',
           '/companies/dcdabbc9-1781-e411-8955-e4115bead28a'
         )
-        expect(this.middlewareParameters.resMock.breadcrumb.lastCall).to.be.calledWith('Activity Feed')
+        expect(global.middlewareParameters.resMock.breadcrumb.lastCall).to.be.calledWith('Activity Feed')
       })
 
       it('should not call "next" with an error', async () => {
-        expect(this.middlewareParameters.nextSpy).to.not.have.been.called
+        expect(global.middlewareParameters.nextSpy).to.not.have.been.called
+      })
+    })
+
+    context('when viewing the Ulitmate HQ block', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .get(`/v4/company?limit=200&global_ultimate_duns_number=123456789`)
+          .reply(200, { results: [{}, {}, {}] })
+
+        global.middlewareParameters = buildMiddlewareParameters({
+          company: {
+            ...companyMock,
+            is_global_ultimate: true,
+          },
+        })
+
+        await global.controllers.renderActivityFeed(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
+        )
+      })
+
+      it('should make an API call to get the Ultimate HQ subsidiary count', () => {
+        const companyId = global.middlewareParameters.resMock.locals.company.id
+        expect(global.middlewareParameters.resMock.render).to.be.calledOnceWithExactly(
+          'companies/apps/activity-feed/views/client-container', {
+            props: {
+              addActivityTypeFilter: {
+                ...ACTIVITY_TYPE_FILTERS,
+              },
+              addContentLink: companies.interactions.create(companyId),
+              addContentText: 'Add interaction',
+              apiEndpoint: companies.activity.data(companyId),
+              isTypeFilterEnabled: undefined,
+              subsidiaryCount: 2,
+            },
+          })
       })
     })
 
     context('when viewing the feed for archived company', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: {
             ...companyMock,
             archived: true,
@@ -300,15 +332,15 @@ describe('Activity feed controllers', () => {
           },
         })
 
-        await renderActivityFeed(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy,
+        await global.controllers.renderActivityFeed(
+          global.middlewareParameters.reqMock,
+          global.middlewareParameters.resMock,
+          global.middlewareParameters.nextSpy,
         )
       })
 
       it('should render the template without the "Add interaction" button', () => {
-        expect(this.middlewareParameters.resMock.render).to.be.calledOnceWithExactly('companies/apps/activity-feed/views/client-container', {
+        expect(global.middlewareParameters.resMock.render).to.be.calledOnceWithExactly('companies/apps/activity-feed/views/client-container', {
           props: {
             apiEndpoint: '/companies/dcdabbc9-1781-e411-8955-e4115bead28a/activity/data',
           },
@@ -318,29 +350,29 @@ describe('Activity feed controllers', () => {
 
     context('when the rendering fails', () => {
       beforeEach(async () => {
-        this.middlewareParameters = buildMiddlewareParameters({
+        global.middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           user: {
             id: 123,
           },
         })
 
-        this.error = new Error('Could not render')
+        global.error = new Error('Could not render')
 
         const errorRes = {
-          ...this.middlewareParameters.resMock,
-          render: () => { throw this.error },
+          ...global.middlewareParameters.resMock,
+          render: () => { throw global.error },
         }
 
-        await renderActivityFeed(
-          this.middlewareParameters.reqMock,
+        await global.controllers.renderActivityFeed(
+          global.middlewareParameters.reqMock,
           errorRes,
-          this.middlewareParameters.nextSpy,
+          global.middlewareParameters.nextSpy,
         )
       })
 
       it('should call next with an error', async () => {
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledWith(this.error)
+        expect(global.middlewareParameters.nextSpy).to.have.been.calledWith(global.error)
       })
     })
   })

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -1,10 +1,13 @@
 const { ACTIVITY_TYPE_FILTERS } = require('../../constants')
 const { fetchActivityFeed } = require('./repos')
 const { buildEsFilterQuery } = require('./builders')
+const { getUltimateHQSubsidiaries } = require('../../repos')
+const { companies } = require('../../../../lib/urls')
 
 async function renderActivityFeed (req, res, next) {
   const { allActivity, dataHubActivity, externalActivity, myActivity } = ACTIVITY_TYPE_FILTERS
   const { company, features } = res.locals
+  const { token } = req.session
 
   const addActivityTypeFilter = {
     allActivity,
@@ -16,20 +19,26 @@ async function renderActivityFeed (req, res, next) {
   try {
     const addContentProps = company.archived ? {} : {
       addContentText: 'Add interaction',
-      addContentLink: `/companies/${company.id}/interactions/create`,
+      addContentLink: companies.interactions.create(company.id),
       addActivityTypeFilter,
       isTypeFilterEnabled: features['activity-feed-type-filter-enabled'],
     }
 
+    const props = {
+      ...addContentProps,
+      apiEndpoint: companies.activity.data(company.id),
+    }
+
+    if (company.is_global_ultimate) {
+      const subsidiaries = await getUltimateHQSubsidiaries(token, company.global_ultimate_duns_number)
+      // Substract the Utlimate HQ from the count
+      props.subsidiaryCount = subsidiaries.results.length - 1
+    }
+
     res
-      .breadcrumb(company.name, `/companies/${company.id}`)
+      .breadcrumb(company.name, companies.detail(company.id))
       .breadcrumb('Activity Feed')
-      .render('companies/apps/activity-feed/views/client-container', {
-        props: {
-          ...addContentProps,
-          apiEndpoint: `/companies/${company.id}/activity/data`,
-        },
-      })
+      .render('companies/apps/activity-feed/views/client-container', { props })
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -86,6 +86,16 @@ function getCompanySubsidiaries (token, companyId, page = 1) {
   })
 }
 
+function getUltimateHQSubsidiaries (token, globalUltimateDunnsNumber) {
+  return authorisedRequest(token, {
+    url: `${config.apiRoot}/v4/company`,
+    qs: {
+      limit: 200,
+      global_ultimate_duns_number: globalUltimateDunnsNumber,
+    },
+  })
+}
+
 function getOneListGroupCoreTeam (token, companyId) {
   return authorisedRequest(token, {
     url: `${config.apiRoot}/v4/company/${companyId}/one-list-group-core-team`,
@@ -121,6 +131,7 @@ module.exports = {
   updateCompany,
   getCompanyAuditLog,
   getCompanySubsidiaries,
+  getUltimateHQSubsidiaries,
   getOneListGroupCoreTeam,
   saveDnbCompany,
   saveDnbCompanyInvestigation,

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -17,6 +17,7 @@
     <p class="c-local-header__heading-after">{{ company.address | formatAddress }}</p>
     {% set isUltimate = company.is_global_ultimate and features["companies-ultimate-hq"] %}
     {% set isGlobalHQ = company.headquarter_type and company.headquarter_type.name == 'ghq' %}
+    {% set isOneListTier = company.one_list_group_tier %}
     
     {% if isUltimate or isGlobalHQ %}
       <div class="c-meta-list">
@@ -26,13 +27,19 @@
       </div>
     {% endif %}
 
-    {% if company.one_list_group_tier %}
+    {% if isUltimate or isOneListTier %}
       <div class="c-local-header__description">
-        <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>
-        <p>
-          Global Account Manager: {{ company.one_list_group_global_account_manager.name }}
-          <a href="/companies/{{ company.id }}/advisers">View core team</a>
-        </p>
+        {% if isUltimate %}
+          {% set link =  props.subsidiaryCount + ' other company ' + 'record' | pluralise(props.subsidiaryCount) %}
+          <p>Data Hub contains <a class="subsidiaries" href={{ urls.companies.subsidiaries(company.id) }}>{{ link }}</a> related to this company</p>        
+        {% endif %}
+        {% if isOneListTier %}
+          <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>
+          <p>
+            Global Account Manager: {{ company.one_list_group_global_account_manager.name }}
+            <a href={{ urls.companies.advisers(company.id) }}>View core team</a>
+          </p>
+        {% endif %}
       </div>
     {% endif %}
 

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -34,12 +34,19 @@ describe('urls', () => {
       companyId = faker.random.uuid()
     })
     it('should return the correct values', () => {
-      expect(urls.companies.index.mountPoint).to.equal('/companies')
-      expect(urls.companies.index.route).to.equal('/')
-      expect(urls.companies.index()).to.equal('/companies')
+      expect(urls.companies.activity.data(companyId)).to.equal(`/companies/${companyId}/activity/data`)
+      expect(urls.companies.activity.index(companyId)).to.equal(`/companies/${companyId}/activity`)
+
+      expect(urls.companies.advisers(companyId)).to.equal(`/companies/${companyId}/advisers`)
 
       expect(urls.companies.detail.route).to.equal('/:companyId')
       expect(urls.companies.detail(companyId)).to.equal(`/companies/${companyId}`)
+
+      expect(urls.companies.dnbSubsidiaries.index.route).to.equal('/:companyId/dnb-subsidiaries')
+      expect(urls.companies.dnbSubsidiaries.index(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries`)
+
+      expect(urls.companies.dnbSubsidiaries.data.route).to.equal('/:companyId/dnb-subsidiaries/data')
+      expect(urls.companies.dnbSubsidiaries.data(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries/data`)
 
       expect(urls.companies.exports.route).to.equal('/:companyId/exports')
       expect(urls.companies.exports(companyId)).to.equal(`/companies/${companyId}/exports`)
@@ -48,11 +55,13 @@ describe('urls', () => {
       expect(urls.companies.hierarchies.ghq.add.route).to.equal('/:companyId/hierarchies/ghq/:globalHqId/add')
       expect(urls.companies.hierarchies.ghq.add(companyId, globalHqId)).to.equal(`/companies/${companyId}/hierarchies/ghq/${globalHqId}/add`)
 
-      expect(urls.companies.dnbSubsidiaries.index.route).to.equal('/:companyId/dnb-subsidiaries')
-      expect(urls.companies.dnbSubsidiaries.index(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries`)
+      expect(urls.companies.index.mountPoint).to.equal('/companies')
+      expect(urls.companies.index.route).to.equal('/')
+      expect(urls.companies.index()).to.equal('/companies')
 
-      expect(urls.companies.dnbSubsidiaries.data.route).to.equal('/:companyId/dnb-subsidiaries/data')
-      expect(urls.companies.dnbSubsidiaries.data(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries/data`)
+      expect(urls.companies.interactions.create(companyId)).to.equal(`/companies/${companyId}/interactions/create`)
+
+      expect(urls.companies.subsidiaries(companyId)).to.equal(`/companies/${companyId}/subsidiaries`)
     })
   })
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -42,19 +42,28 @@ module.exports = {
   },
   dashboard: url('/'),
   companies: {
-    index: url('/companies'),
-    detail: url('/companies', '/:companyId'),
+    activity: {
+      index: url('/companies', '/:companyId/activity'),
+      data: url('/companies', '/:companyId/activity/data'),
+    },
+    advisers: url('/companies', '/:companyId/advisers'),
     businessDetails: url('/companies', '/:companyId/business-details'),
+    detail: url('/companies', '/:companyId'),
+    dnbSubsidiaries: {
+      index: url('/companies', '/:companyId/dnb-subsidiaries'),
+      data: url('/companies', '/:companyId/dnb-subsidiaries/data'),
+    },
     exports: url('/companies', '/:companyId/exports'),
     hierarchies: {
       ghq: {
         add: url('/companies', '/:companyId/hierarchies/ghq/:globalHqId/add'),
       },
     },
-    dnbSubsidiaries: {
-      index: url('/companies', '/:companyId/dnb-subsidiaries'),
-      data: url('/companies', '/:companyId/dnb-subsidiaries/data'),
+    index: url('/companies'),
+    interactions: {
+      create: url('/companies', '/:companyId/interactions/create'),
     },
+    subsidiaries: url('/companies', '/:companyId/subsidiaries'),
   },
   contacts: {
     index: url('/contacts'),

--- a/test/functional/cypress/specs/companies/company-global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/company-global-ultimate-spec.js
@@ -1,14 +1,20 @@
 const selectors = require('../../../../selectors')
 const fixtures = require('../../fixtures')
+const { companies } = require('../../../../../src/lib/urls')
 
 describe('Company Global Ultimate HQ', () => {
   context('when a company has a DnB Ultimate HQ badge', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.dnbGlobalUltimate.id}/activity`)
+      cy.visit(`${companies.activity.index(fixtures.company.dnbGlobalUltimate.id)}`)
     })
 
-    it('should display a "Ultimate HQ" badge', () => {
+    it('should display an "Ultimate HQ" badge', () => {
       cy.get(selectors.localHeader().badge(1)).should('be.visible')
+    })
+
+    it('should display a single subsidiary', () => {
+      const expected = 'Data Hub contains 1 other company record related to this company'
+      cy.get(selectors.localHeader().description.paragraph(1)).should('have.text', expected)
     })
   })
 })

--- a/test/unit/data/company.json
+++ b/test/unit/data/company.json
@@ -179,6 +179,8 @@
   "archived_on": null,
   "archived_reason": "",
   "company_number": null,
+  "is_global_ultimate": false,
+  "global_ultimate_duns_number": "123456789",
   "lead": false,
   "description": null,
   "website": "http://www.wonka-industries.com",


### PR DESCRIPTION
## Sandbox changes
https://github.com/uktrade/data-hub-sandbox/commit/db7b24165f03df2e6e992303696d61f66f2e9e18

## Add Ultimate HQ subsidiary block 
"Data Hub contains `n` other company record related to this company"

This is hidden behind a feature flag `companies-ultimate-hq`

## Test instructions
1. add an Ultimate HQ company such as `Alphabet Inc` via the new D&B `Add a company` journey.
2. add a subsidiary company such as `Nest Labs, Inc` as above.
3. Navigate to the `Alphabet Inc` companies page.
 
## Screenshots
![add-subsidiaries-to-ultimate-hq](https://user-images.githubusercontent.com/964268/67935861-a01d1b00-fbc2-11e9-8698-a635d30f1ce0.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
