### PR TITLE
Update references to the API following its renaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ aliases:
   - &oauth2_dit_staff_token     ditStaffToken
   - &oauth2_da_staff_token      daStaffToken
   - &oauth2_lep_staff_token     lepStaffToken
-  - &api_develop_image          quay.io/uktrade/data-hub-leeloo:develop
-  - &api_master_image           quay.io/uktrade/data-hub-leeloo:master
+  - &api_develop_image          quay.io/uktrade/data-hub-api:develop
+  - &api_master_image           quay.io/uktrade/data-hub-api:master
 
   # Common steps
   - &restore_yarn_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ aliases:
   - &oauth2_dit_staff_token     ditStaffToken
   - &oauth2_da_staff_token      daStaffToken
   - &oauth2_lep_staff_token     lepStaffToken
-  - &leeloo_develop_image       quay.io/uktrade/data-hub-leeloo:develop
-  - &leeloo_master_image        quay.io/uktrade/data-hub-leeloo:master
+  - &api_develop_image          quay.io/uktrade/data-hub-leeloo:develop
+  - &api_master_image           quay.io/uktrade/data-hub-leeloo:master
 
   # Common steps
   - &restore_yarn_cache
@@ -162,7 +162,7 @@ aliases:
 
   # Data hub backend
   - &docker_data_hub_backend_base
-    image: *leeloo_develop_image
+    image: *api_develop_image
     environment:
       AWS_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: foo
@@ -531,9 +531,9 @@ jobs:
       - *docker_mi_postgres
       - *docker_mock_sso
       - <<: *docker_data_hub_backend_api
-        image: *leeloo_master_image
+        image: *api_master_image
       - <<: *docker_data_hub_backend_celery
-        image: *leeloo_master_image
+        image: *api_master_image
 
   # Run acceptance tests for LEP staff using the master version of the backend
   master-lep_staff_at:
@@ -549,9 +549,9 @@ jobs:
       - *docker_mi_postgres
       - *docker_mock_sso
       - <<: *docker_data_hub_backend_api
-        image: *leeloo_master_image
+        image: *api_master_image
       - <<: *docker_data_hub_backend_celery
-        image: *leeloo_master_image
+        image: *api_master_image
 
   # Run acceptance tests for DA staff using the master version of the backend
   master-da_staff_at:
@@ -567,9 +567,9 @@ jobs:
       - *docker_mi_postgres
       - *docker_mock_sso
       - <<: *docker_data_hub_backend_api
-        image: *leeloo_master_image
+        image: *api_master_image
       - <<: *docker_data_hub_backend_celery
-        image: *leeloo_master_image
+        image: *api_master_image
 
 # CircleCI workflows
 workflows:

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ To run tests against a specific user permissions type:
 The above permissions tokens are available on the dev api
 
 ##### Backend locally with user permission tokens
-If you are running the api locally please run the [https://github.com/uktrade/data-hub-leeloo/blob/develop/setup-uat.sh](https://github.com/uktrade/data-hub-leeloo/blob/develop/setup-uat.sh) to setup the relevant users and permission tokens
+If you are running the api locally please run the [https://github.com/uktrade/data-hub-api/blob/develop/setup-uat.sh](https://github.com/uktrade/data-hub-api/blob/develop/setup-uat.sh) to setup the relevant users and permission tokens
 
 ##### Adding tokens
 If you need to add a token have a look in confluence on how to do this `Data Hub team > Technical Documentation > Frontend > SSO for developers > Adding an Access token`.
@@ -556,7 +556,7 @@ Data hub uses [CircleCI](https://circleci.com/) for continuous integration.
 ### Running CI jobs
 - All branches run the `lint_code`, `unit_tests` and `user_acceptance_tests` CI jobs
 - You can skip the `user_acceptance_tests` CI job by using a branch starting with `/^skip-tests.*/`
-- The `user_acceptance_tests_master` job will run on branches that match the regex `release.*` or the `master` branch. This job runs a branch against the `master` branch of [data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo/tree/master)
+- The `user_acceptance_tests_master` job will run on branches that match the regex `release.*` or the `master` branch. This job runs a branch against the `master` branch of [data-hub-api](https://github.com/uktrade/data-hub-api/tree/master)
 
 ### Setting up users with different permissions
 On CircleCi we run Acceptance tests against users with different permissions. We do this via the environment variable `OAUTH2_DEV_TOKEN`. Essentially we have users with different permissions setup in a job via `OAUTH2_DEV_TOKEN` and then we run tests with the specified permissions tag.
@@ -571,11 +571,11 @@ The acceptance tests `user_acceptance_tests` job uses the docker image `ukti/doc
 Details can be found in the [GitHub](https://github.com/uktrade/docker-data-hub-base) and [docker](https://hub.docker.com/r/ukti/docker-data-hub-base/) repositories.
 
 ### Data hub backend docker image
-The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo).
-The `uktrade/data-hub-leeloo` docker image and tags that is used is automatically built via a Docker hub automated job. Details can be found [https://hub.docker.com/r/ukti/data-hub-leeloo](https://hub.docker.com/r/ukti/data-hub-leeloo).
+The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-api](https://github.com/uktrade/data-hub-api).
+The `quay.io/uktrade/data-hub-leeloo` docker image and tags that is used is automatically built via a Docker hub automated job. Details can be found [https://quay.io/repository/uktrade/data-hub-leeloo](https://quay.io/repository/uktrade/data-hub-leeloo).
 
-- `user_acceptance_tests` job uses `ukti/data-hub-leeloo:latest`
-- `user_acceptance_tests_master` job uses `ukti/data-hub-leeloo:master`
+- `user_acceptance_tests` job uses `quay.io/uktrade/data-hub-leeloo:develop`
+- `user_acceptance_tests_master` job uses `quay.io/uktrade/data-hub-leeloo:master`
 
 ### Mock SSO docker build
 The acceptance tests `user_acceptance_tests` job on circleCi uses [uktrade/mock-sso](https://github.com/uktrade/mock-sso)

--- a/README.md
+++ b/README.md
@@ -572,10 +572,10 @@ Details can be found in the [GitHub](https://github.com/uktrade/docker-data-hub-
 
 ### Data hub backend docker image
 The acceptance tests `user_acceptance_tests` job on circleCi uses its own version of [uktrade/data-hub-api](https://github.com/uktrade/data-hub-api).
-The `quay.io/uktrade/data-hub-leeloo` docker image and tags that is used is automatically built via a Docker hub automated job. Details can be found [https://quay.io/repository/uktrade/data-hub-leeloo](https://quay.io/repository/uktrade/data-hub-leeloo).
+The `quay.io/uktrade/data-hub-api` docker image and tags that is used is automatically built via a Docker hub automated job. Details can be found [https://quay.io/repository/uktrade/data-hub-api](https://quay.io/repository/uktrade/data-hub-api).
 
-- `user_acceptance_tests` job uses `quay.io/uktrade/data-hub-leeloo:develop`
-- `user_acceptance_tests_master` job uses `quay.io/uktrade/data-hub-leeloo:master`
+- `user_acceptance_tests` job uses `quay.io/uktrade/data-hub-api:develop`
+- `user_acceptance_tests_master` job uses `quay.io/uktrade/data-hub-api:master`
 
 ### Mock SSO docker build
 The acceptance tests `user_acceptance_tests` job on circleCi uses [uktrade/mock-sso](https://github.com/uktrade/mock-sso)

--- a/src/apps/dashboard/__test__/utils.js
+++ b/src/apps/dashboard/__test__/utils.js
@@ -5,7 +5,7 @@ const companyListItemRegexp = /\/v4\/company-list\/([^/]+)\/item/
 
 /**
  * @function mockCompanyListsServer
- * @description Mocks the API (leeloo) end points needed to display the user's
+ * @description Mocks the API end points needed to display the user's
  * list of company lists. The mocked endpoints are: `/v4/company-list` and
  * `/v4/company-list/<list-id>/item`.
  * @param {Object} options

--- a/src/apps/healthcheck/serviceDependencies.js
+++ b/src/apps/healthcheck/serviceDependencies.js
@@ -4,7 +4,7 @@ const { redisStore } = require('../../../config/redis-store')
 
 module.exports = [
   {
-    name: 'leeloo',
+    name: 'api',
     healthCheck: () => axios.get(`${config.apiRoot}/ping.xml`),
   },
   {


### PR DESCRIPTION
## Description of change

The API repository has been renamed to `data-hub-api`. This updates references to it to match. 

~(The quay.io Docker repository not been renamed yet, so that stays unchanged.)~ This has been done now.

## Test instructions

_What should I see?_

The CircleCI build should still pass.


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
