### PR TITLE
Release v5.49.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub-frontend",
-  "version": "5.49.0",
+  "version": "5.49.1",
   "description": "Data Hub Frontend",
   "main": "src/server.js",
   "repository": {

--- a/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
@@ -50,7 +50,7 @@ describe('transformCompanyToExportDetailsView', () => {
           id: '4321',
           name: 'Germany',
         }],
-        export_potential_score: 'low',
+        export_potential: 'low',
       })
 
       this.viewRecord = transformCompanyToExportDetailsView(company)

--- a/src/apps/companies/transformers/company-to-export-details-view.js
+++ b/src/apps/companies/transformers/company-to-export-details-view.js
@@ -18,13 +18,13 @@ module.exports = function transformCompanyToExportDetailsView ({
   export_experience_category,
   export_to_countries,
   future_interest_countries,
-  export_potential_score,
+  export_potential,
 }) {
   const viewRecord = {
     exportExperienceCategory: export_experience_category || 'None',
     exportToCountries: getCountries(export_to_countries),
     futureInterestCountries: getCountries(future_interest_countries),
-    exportPotential: getExportPotentialLabel(export_potential_score),
+    exportPotential: getExportPotentialLabel(export_potential),
   }
 
   return getDataLabels(viewRecord, exportDetailsLabels)


### PR DESCRIPTION
`export_potential_score` got changed to `export_potential` in the API, this is to reflect that change in the FE so the exports tab displays the "Export potential" for a company