### PR TITLE
Refactor routers to surface errors

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -3,19 +3,19 @@ const fs = require('fs')
 
 const { setHomeBreadcrumb } = require('./middleware')
 
-const subApps = fs.readdirSync(__dirname)
+const subApps = fs.readdirSync(__dirname, { withFileTypes: true })
 
-const appsRouters = subApps.map(subAppDir => {
-  try {
-    const subApp = require(`./${subAppDir}/index.js`)
+const appsRouters = []
+
+subApps.forEach(subAppDir => {
+  if (subAppDir.isDirectory() && !subAppDir.name.startsWith('__')) {
+    const subApp = require(`./${subAppDir.name}`)
     if (subApp.mountpath) {
-      return router.use(subApp.mountpath, setHomeBreadcrumb(subApp.displayName), subApp.router)
+      appsRouters.push(router.use(subApp.mountpath, setHomeBreadcrumb(subApp.displayName), subApp.router))
     } else if (subApp.router) {
-      return router.use(subApp.router)
+      appsRouters.push(router.use(subApp.router))
     }
-  } catch (e) {}
-
-  return (req, res, next) => next()
+  }
 })
 
 module.exports = appsRouters


### PR DESCRIPTION
## Description of change

Currently when a required module has an error the error is eaten by the try catch
this is not useful when a larger refactor has taken place upstream and errors are not surfaced
after a rebase
This is also a problem as we don't know there is an error until the route is hit

This also removes noop router functions

## Test instructions

Ensure the app is able to start
 
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
