### PR TITLE
Fix display of the stack trace

### DIFF
--- a/src/templates/errors.njk
+++ b/src/templates/errors.njk
@@ -27,7 +27,7 @@
     <h3 class="heading-medium">{{ statusCode }}</h3>
     <dl class="stack-trace">
       <dt class="stack-trace__heading">{{ error.message }}</dt>
-      <dd class="stack-trace__details">{{ error.stack }}</dd>
+      <dd class="stack-trace__details"><pre>{{ error.stack }}</pre></dd>
     </dl>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description of change

Wrap the stack trace in `<pre>`
This stops HTML minifyer from stripping the whitespace making the stack trace readable

## Test instructions

Make up a URL to get a 404 and the stack trace should be readable
 
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
