### PR TITLE
Create a page listing subsidiaries for D&B company

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "react": "^16.8.6",
     "react-app-polyfill": "^1.0.1",
     "react-dom": "^16.8.6",
+    "react-use": "^13.2.1",
     "redis": "^2.8.0",
     "request": "^2.87.0",
     "request-promise": "^4.2.2",

--- a/src/apps/companies/__test__/router.test.js
+++ b/src/apps/companies/__test__/router.test.js
@@ -20,6 +20,8 @@ describe('Company router', () => {
       '/:companyId/hierarchies/ghq/remove',
       '/:companyId/hierarchies/subsidiaries/search',
       '/:companyId/hierarchies/subsidiaries/:subsidiaryCompanyId/add',
+      '/:companyId/dnb-subsidiaries',
+      '/:companyId/dnb-subsidiaries/data',
       '/:companyId/contacts',
       '/:companyId/exports',
       '/:companyId/subsidiaries',

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/controllers.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/controllers.test.js
@@ -1,0 +1,200 @@
+const urls = require('../../../../../lib/urls')
+const {
+  renderDnbSubsidiaries,
+  fetchSubsidiariesHandler,
+} = require('../controllers')
+
+const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
+const subsidiaries = require('../../../../../../test/unit/data/companies/subsidiary-company-search-response')
+const { mockDnbSubsidiariesEndpoint } = require('./utils')
+
+const companyMock = {
+  id: '1',
+  name: 'Test company',
+  duns_number: '999999',
+  is_global_ultimate: true,
+}
+
+describe('D&B Company Subsidiaries', () => {
+  describe('#renderDnbSubsidiaries', () => {
+    context('when the collection renders successfully', async () => {
+      let middlewareParams
+
+      before(async () => {
+        middlewareParams = buildMiddlewareParameters({
+          company: companyMock,
+        })
+
+        await renderDnbSubsidiaries(
+          middlewareParams.reqMock,
+          middlewareParams.resMock,
+          middlewareParams.nextSpy,
+        )
+      })
+
+      it('should render', () => {
+        expect(middlewareParams.resMock.render).to.be.calledOnce
+      })
+
+      it('should render the activity feed template', () => {
+        expect(middlewareParams.resMock.render).to.be.calledOnceWithExactly(
+          'companies/apps/dnb-subsidiaries/views/client-container', {
+            heading: 'Subsidiaries of Test company',
+            props: {
+              dataEndpoint: urls.companies.dnbSubsidiaries.data('1'),
+            },
+          })
+      })
+
+      it('should add a breadcrumb', () => {
+        expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
+          'Test company', urls.companies.detail('1'))
+
+        expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
+          'Business details', urls.companies.businessDetails('1'))
+
+        expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
+          'Subsidiaries')
+      })
+
+      it('should not call "next" with an error', async () => {
+        expect(middlewareParams.nextSpy).to.not.have.been.called
+      })
+    })
+
+    context('when the rendering fails', async () => {
+      let middlewareParams
+      const error = new Error('Could not render')
+
+      before(async () => {
+        middlewareParams = buildMiddlewareParameters({
+          company: companyMock,
+        })
+
+        const errorRes = {
+          ...middlewareParams.resMock,
+          render: () => {
+            throw error
+          },
+        }
+
+        await renderDnbSubsidiaries(
+          middlewareParams.reqMock,
+          errorRes,
+          middlewareParams.nextSpy,
+        )
+      })
+
+      it('should call next with an error', async () => {
+        expect(middlewareParams.nextSpy).to.have.been.calledWith(error)
+      })
+    })
+
+    context('when a company is not a D&B Global Ultimate', async () => {
+      let middlewareParams
+
+      before(async () => {
+        middlewareParams = buildMiddlewareParameters({
+          company: {
+            is_global_ultimate: false,
+          },
+        })
+
+        await renderDnbSubsidiaries(
+          middlewareParams.reqMock,
+          middlewareParams.resMock,
+          middlewareParams.nextSpy,
+        )
+      })
+
+      it('should call next() with an error', async () => {
+        expect(middlewareParams.nextSpy).to.have.been.calledOnceWithExactly(sinon.match({
+          message: 'This company is not a D&B Global Ultimate',
+          statusCode: 403,
+        }))
+      })
+    })
+  })
+
+  describe('#fetchSubsidiariesHandler', () => {
+    context('when fetching D&B subsidiaries', async () => {
+      let middlewareParams
+
+      before(async () => {
+        middlewareParams = buildMiddlewareParameters({
+          company: companyMock,
+          requestQuery: {
+            page: 2,
+          },
+        })
+
+        mockDnbSubsidiariesEndpoint({
+          globalUltimateSunsNumber: companyMock.duns_number,
+          responseBody: subsidiaries,
+          offset: 10,
+        })
+
+        await fetchSubsidiariesHandler(
+          middlewareParams.reqMock,
+          middlewareParams.resMock,
+          middlewareParams.nextSpy,
+        )
+      })
+
+      it('should respond with a list of D&B subsidiaries', () => {
+        expect(middlewareParams.resMock.json).to.be
+          .calledOnceWithExactly(
+            {
+              count: 1,
+              results: [{
+                badges: ['United Kingdom', 'North West'],
+                headingText: 'Mars Components Ltd',
+                headingUrl: urls.companies.detail('731bdcc1-f685-4c8e-bd66-b356b2c16995'),
+                metadata: [
+                  { label: 'Sector', value: 'Retail' },
+                  { label: 'Address', value: '12 Alpha Street, Volcanus, NE28 5AQ, United Kingdom' }],
+                subheading: 'Updated on 16 Oct 2017, 12:00pm',
+              }],
+            }
+          )
+      })
+
+      it('should not call next() with an error', async () => {
+        expect(middlewareParams.nextSpy).to.not.have.been.called
+      })
+    })
+
+    context('when there is an error', async () => {
+      let middlewareParams
+
+      before(async () => {
+        mockDnbSubsidiariesEndpoint({
+          globalUltimateSunsNumber: companyMock.duns_number,
+          responseCode: 500,
+          responseBody: 'Error message',
+        })
+
+        middlewareParams = buildMiddlewareParameters({
+          company: companyMock,
+          requestBody: companyMock,
+        })
+
+        await fetchSubsidiariesHandler(
+          middlewareParams.reqMock,
+          middlewareParams.resMock,
+          middlewareParams.nextSpy,
+        )
+      })
+
+      it('should not respond', () => {
+        expect(middlewareParams.resMock.json).to.not.have.been.called
+      })
+
+      it('should call next() with an error', async () => {
+        expect(middlewareParams.nextSpy).to.have.been.calledOnceWithExactly(sinon.match({
+          message: '500 - "Error message"',
+        }))
+      })
+    })
+  })
+})

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/repos.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/repos.test.js
@@ -1,0 +1,29 @@
+const config = require('../../../../../config')
+const { getDnbSubsidiaries } = require('../repos')
+const { mockDnbSubsidiariesEndpoint } = require('./utils')
+const subsidiaries = require('../../../../../../test/unit/data/companies/subsidiary-company-search-response')
+
+const token = 'abcd'
+
+describe('D&B Subsidiaries repos', () => {
+  describe('#getDnbSubsidiaries', () => {
+    let actual
+    const DUNS_NUMBER = 999999
+
+    beforeEach(async () => {
+      mockDnbSubsidiariesEndpoint({
+        globalUltimateSunsNumber: DUNS_NUMBER,
+        responseBody: subsidiaries,
+      })
+
+      actual = await getDnbSubsidiaries(token, DUNS_NUMBER, config.paginationDefaultSize, 1)
+    })
+
+    it('should return the one subsidiary', () => {
+      expect(actual).to.deep.equal({
+        count: 1,
+        results: [subsidiaries.results[1]],
+      })
+    })
+  })
+})

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/transformers.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/transformers.test.js
@@ -1,0 +1,60 @@
+const { transformCompanyToSubsidiariesList } = require('../transformers')
+const urls = require('../../../../../lib/urls')
+
+const companyMock = require('../../../../../../test/unit/data/companies/company-v4')
+
+describe('Edit company form transformers', () => {
+  describe('#transformCompanyToSubsidiariesList', () => {
+    context('when called with a fully populated company', () => {
+      const actual = transformCompanyToSubsidiariesList(companyMock)
+
+      it('should return transformed values', () => {
+        const expected = {
+          'badges': [
+            'United Kingdom',
+            'North West',
+          ],
+          'headingText': 'Mercury Ltd',
+          'headingUrl': urls.companies.detail('a73efeba-8499-11e6-ae22-56b6b6499611'),
+          'metadata': [
+            {
+              'label': 'Sector',
+              'value': 'Retail',
+            },
+            {
+              'label': 'Address',
+              'value': '82 Ramsgate Rd, Willington, NE28 5JB, United Kingdom',
+            },
+          ],
+          'subheading': 'Updated on 5 Jul 2016, 1:00pm',
+        }
+
+        expect(actual).to.deep.equal(expected)
+      })
+    })
+
+    context('when called without ID', () => {
+      const actual = transformCompanyToSubsidiariesList({})
+
+      it('should return undefined', () => {
+        expect(actual).to.be.undefined
+      })
+    })
+
+    context('when called only with ID', () => {
+      const actual = transformCompanyToSubsidiariesList({
+        id: '123',
+      })
+
+      it('should return minimal object', () => {
+        expect(actual).to.deep.equal({
+          headingText: undefined,
+          headingUrl: urls.companies.detail('123'),
+          subheading: 'Updated on undefined',
+          metadata: [],
+          badges: [],
+        })
+      })
+    })
+  })
+})

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/utils.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/utils.js
@@ -1,0 +1,17 @@
+const nock = require('nock')
+const config = require('../../../../../config')
+
+function mockDnbSubsidiariesEndpoint ({
+  globalUltimateSunsNumber,
+  responseBody,
+  responseCode = 200,
+  offset = 0,
+}) {
+  nock(config.apiRoot)
+    .get(`/v4/company?limit=10&offset=${offset}&sortby=name&global_ultimate_duns_number=${globalUltimateSunsNumber}`)
+    .reply(responseCode, responseBody)
+}
+
+module.exports = {
+  mockDnbSubsidiariesEndpoint,
+}

--- a/src/apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries.jsx
+++ b/src/apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { useSearchParam } from 'react-use'
+import { CollectionList } from 'data-hub-components'
+import axios from 'axios'
+import { LoadingBox } from 'govuk-react'
+
+const DnbSubsidiaries = ({ dataEndpoint }) => {
+  const [subsidiaries, setSubsidiaries] = useState([])
+  const [totalItems, setTotalItems] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const activePage = parseInt(useSearchParam('page'), 10) || 1
+  const setActivePage = (page) =>
+    window.history.pushState({}, '', `${window.location.pathname}?page=${page}`)
+
+  const onPageClick = (page, event) => {
+    setActivePage(page)
+    event.target.blur()
+    event.preventDefault()
+  }
+
+  const getPageUrl = (page) => `?page=${page}`
+
+  useEffect(() => {
+    async function fetchData () {
+      const { data } = await axios.get(dataEndpoint, {
+        params: {
+          page: activePage,
+        },
+      })
+      setSubsidiaries(data.results)
+      setTotalItems(data.count)
+      setIsLoading(false)
+    }
+    setIsLoading(true)
+    window.scrollTo(0, 0)
+    fetchData()
+  }, [activePage])
+
+  return (
+    <LoadingBox loading={isLoading}>
+      <CollectionList
+        itemName="subsidiary"
+        items={subsidiaries}
+        totalItems={totalItems}
+        onPageClick={onPageClick}
+        getPageUrl={getPageUrl}
+        activePage={activePage}
+      />
+    </LoadingBox>
+  )
+}
+
+DnbSubsidiaries.propTypes = {
+  dataEndpoint: PropTypes.string.isRequired,
+}
+
+export default DnbSubsidiaries

--- a/src/apps/companies/apps/dnb-subsidiaries/controllers.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/controllers.js
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+
+const config = require('../../../../config')
+const { transformCompanyToSubsidiariesList } = require('./transformers')
+const { getDnbSubsidiaries } = require('./repos')
+const urls = require('../../../../lib/urls')
+
+async function renderDnbSubsidiaries (req, res, next) {
+  try {
+    const { company } = res.locals
+
+    if (!company.is_global_ultimate) {
+      return next({ statusCode: 403, message: 'This company is not a D&B Global Ultimate' })
+    }
+
+    res
+      .breadcrumb(company.name, urls.companies.detail(company.id))
+      .breadcrumb('Business details', urls.companies.businessDetails(company.id))
+      .breadcrumb('Subsidiaries')
+      .render('companies/apps/dnb-subsidiaries/views/client-container', {
+        heading: `Subsidiaries of ${company.name}`,
+        props: {
+          dataEndpoint: urls.companies.dnbSubsidiaries.data(company.id),
+        },
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function fetchSubsidiariesHandler (req, res, next) {
+  try {
+    const { company } = res.locals
+    const { token } = req.session
+    const { page } = req.query
+
+    const { count, results } = await getDnbSubsidiaries(
+      token, company.duns_number, config.paginationDefaultSize, page
+    )
+
+    res.json({
+      count: count || 0,
+      results: results ? results.map(transformCompanyToSubsidiariesList) : [],
+    })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderDnbSubsidiaries,
+  fetchSubsidiariesHandler,
+}

--- a/src/apps/companies/apps/dnb-subsidiaries/repos.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/repos.js
@@ -1,0 +1,30 @@
+const { authorisedRequest } = require('../../../../lib/authorised-request')
+const config = require('../../../../config')
+
+function excludeGlobalUltimate (globalUltimateDunsNumber, response) {
+  return {
+    count: response.count - 1,
+    results: response.results.filter(c => c.duns_number !== globalUltimateDunsNumber + ''),
+  }
+}
+
+async function getDnbSubsidiaries (token, dunsNumber, limit, page) {
+  const parsedPage = parseInt(page, 10) || 1
+  const offset = limit * (parsedPage - 1)
+
+  const response = await authorisedRequest(token, {
+    url: `${config.apiRoot}/v4/company`,
+    qs: {
+      limit,
+      offset,
+      sortby: 'name',
+      global_ultimate_duns_number: dunsNumber,
+    },
+  })
+
+  return excludeGlobalUltimate(dunsNumber, response)
+}
+
+module.exports = {
+  getDnbSubsidiaries,
+}

--- a/src/apps/companies/apps/dnb-subsidiaries/transformers.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/transformers.js
@@ -1,0 +1,68 @@
+/* eslint-disable camelcase */
+const { get } = require('lodash')
+
+const { formatAddress, formatDateTime } = require('../../../../config/nunjucks/filters')
+const urls = require('../../../../lib/urls')
+const labels = require('../../labels')
+
+function transformCompanyToSubsidiariesList ({
+  id,
+  name,
+  sector,
+  uk_based,
+  uk_region,
+  trading_names,
+  address,
+  modified_on,
+  headquarter_type,
+} = {}) {
+  if (!id) { return }
+
+  const metadata = []
+  const badges = []
+
+  if (trading_names && trading_names.length) {
+    metadata.push({
+      label: labels.hqLabels.trading_names,
+      value: trading_names,
+    })
+  }
+
+  if (sector) {
+    metadata.push({
+      label: 'Sector',
+      value: get(sector, 'name'),
+    })
+  }
+
+  if (address && address.country) {
+    badges.push(get(address, 'country.name'))
+  }
+
+  if (uk_based) {
+    badges.push(get(uk_region, 'name'))
+  }
+
+  if (headquarter_type) {
+    badges.push(labels.hqLabels[get(headquarter_type, 'name')])
+  }
+
+  if (address) {
+    metadata.push({
+      label: labels.address.companyAddress,
+      value: formatAddress(address),
+    })
+  }
+
+  return {
+    headingText: name,
+    headingUrl: urls.companies.detail(id),
+    subheading: `Updated on ${formatDateTime(modified_on)}`,
+    metadata,
+    badges,
+  }
+}
+
+module.exports = {
+  transformCompanyToSubsidiariesList,
+}

--- a/src/apps/companies/apps/dnb-subsidiaries/views/client-container.njk
+++ b/src/apps/companies/apps/dnb-subsidiaries/views/client-container.njk
@@ -1,0 +1,9 @@
+{% extends "_layouts/template.njk" %}
+
+{% block body_main_content %}
+  {% component 'react-slot', {
+    id: 'dnb-subsidiaries',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -59,6 +59,8 @@ const interactionsRouter = require('../interactions/router.sub-app')
 const activityFeedRouter = require('./apps/activity-feed/router')
 const companyListsRouter = require('../company-lists/router')
 
+const dnbSubsidiariesControllers = require('./apps/dnb-subsidiaries/controllers')
+
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
 router.param('companyId', getCompany)
@@ -120,6 +122,9 @@ router.get('/:companyId/hierarchies/ghq/remove', removeGlobalHQ)
 
 router.get('/:companyId/hierarchies/subsidiaries/search', getSubsidiaryCompaniesCollection, renderLinkSubsidiary)
 router.get('/:companyId/hierarchies/subsidiaries/:subsidiaryCompanyId/add', addSubsidiary)
+
+router.get(urls.companies.dnbSubsidiaries.index.route, dnbSubsidiariesControllers.renderDnbSubsidiaries)
+router.get(urls.companies.dnbSubsidiaries.data.route, dnbSubsidiariesControllers.fetchSubsidiariesHandler)
 
 router.get('/:companyId/contacts',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -11,6 +11,7 @@ import AddRemoveFromListSection from './apps/company-lists/client/AddRemoveFromL
 import BusinessDetailsRegionEdit from './apps/companies/client/BusinessDetailsRegionEdit'
 import BusinessDetailsSectorEdit from './apps/companies/client/BusinessDetailsSectorEdit'
 import LeadAdvisers from './apps/companies/client/LeadAdvisers'
+import DnbSubsidiaries from './apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries'
 
 const appWrapper = document.getElementById('react-app')
 
@@ -59,6 +60,9 @@ function App () {
       </Mount>
       <Mount selector="#lead-advisers">
         {props => <LeadAdvisers {...props} />}
+      </Mount>
+      <Mount selector="#dnb-subsidiaries">
+        {props => <DnbSubsidiaries {...props} />}
       </Mount>
     </>
   )

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -84,6 +84,7 @@ const config = {
   mediumDateFormat: 'D MMM YYYY',
   mediumDateTimeFormat: 'D MMM YYYY, h:mma',
   paginationMaxResults: 10000,
+  paginationDefaultSize: 10,
   performanceDashboardsUrl: process.env.PERFORMANCE_DASHBOARDS_URL,
   findExportersUrl: process.env.FIND_EXPORTERS_URL,
   archivedDocumentsBaseUrl: process.env.ARCHIVED_DOCUMENTS_BASE_URL,

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -47,6 +47,12 @@ describe('urls', () => {
       const globalHqId = faker.random.uuid()
       expect(urls.companies.hierarchies.ghq.add.route).to.equal('/:companyId/hierarchies/ghq/:globalHqId/add')
       expect(urls.companies.hierarchies.ghq.add(companyId, globalHqId)).to.equal(`/companies/${companyId}/hierarchies/ghq/${globalHqId}/add`)
+
+      expect(urls.companies.dnbSubsidiaries.index.route).to.equal('/:companyId/dnb-subsidiaries')
+      expect(urls.companies.dnbSubsidiaries.index(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries`)
+
+      expect(urls.companies.dnbSubsidiaries.data.route).to.equal('/:companyId/dnb-subsidiaries/data')
+      expect(urls.companies.dnbSubsidiaries.data(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries/data`)
     })
   })
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -44,11 +44,16 @@ module.exports = {
   companies: {
     index: url('/companies'),
     detail: url('/companies', '/:companyId'),
+    businessDetails: url('/companies', '/:companyId/business-details'),
     exports: url('/companies', '/:companyId/exports'),
     hierarchies: {
       ghq: {
         add: url('/companies', '/:companyId/hierarchies/ghq/:globalHqId/add'),
       },
+    },
+    dnbSubsidiaries: {
+      index: url('/companies', '/:companyId/dnb-subsidiaries'),
+      data: url('/companies', '/:companyId/dnb-subsidiaries/data'),
     },
   },
   contacts: {

--- a/test/functional/cypress/fixtures/company/dnb-global-ultimate.json
+++ b/test/functional/cypress/fixtures/company/dnb-global-ultimate.json
@@ -1,4 +1,4 @@
 {
-  "id": "e72e4g28-5250-3a51-j26a-g87617520879",
+  "id": "d27bde24-6330-464b-a48c-0394831586fd",
   "name": "DnB Global Ultimate"
 }

--- a/test/functional/cypress/specs/companies/company-global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/company-global-ultimate-spec.js
@@ -7,8 +7,8 @@ describe('Company Global Ultimate HQ', () => {
       cy.visit(`/companies/${fixtures.company.dnbGlobalUltimate.id}/activity`)
     })
 
-    it('should not display a "Ultimate HQ" badge when the feature flag "companies-ultimate-hq" is false', () => {
-      cy.get(selectors.localHeader().badge(1)).should('not.be.visible')
+    it('should display a "Ultimate HQ" badge', () => {
+      cy.get(selectors.localHeader().badge(1)).should('be.visible')
     })
   })
 })

--- a/test/functional/cypress/specs/companies/dnb-subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-subsidiaries-spec.js
@@ -1,0 +1,37 @@
+const { assertLocalHeader, assertBreadcrumbs } = require('../../support/assertions')
+
+const { company: { dnbGlobalUltimate } } = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+
+describe('D&B Company subsidiaries', () => {
+  context('when viewing subsidiaries for a Dun & Bradstreet company', () => {
+    before(() => {
+      cy.visit(urls.companies.dnbSubsidiaries.index(dnbGlobalUltimate.id))
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Subsidiaries of DnB Global Ultimate')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [dnbGlobalUltimate.name]: urls.companies.detail(dnbGlobalUltimate.id),
+        'Business details': urls.companies.businessDetails(dnbGlobalUltimate.id),
+        'Subsidiaries': null,
+      })
+    })
+
+    it('should render subsidiaries', () => {
+      cy.get('#dnb-subsidiaries')
+        .should('contain', '1 subsidiary')
+        .and('contain', 'DnB Global Ultimate subsidiary')
+    })
+
+    it('should not include Global Ultimate', () => {
+      cy.get('#dnb-subsidiaries')
+        .should('not.contain', '1700 Amphitheatre Way')
+    })
+  })
+})

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -67,10 +67,15 @@ const assertFieldUneditable = ({ name, label = null, value = null }) => {
   }
 }
 
+const assertLocalHeader = (header) => {
+  cy.get(selectors.localHeader).contains(header)
+}
+
 module.exports = {
   assertKeyValueTable,
   assertValueTable,
   assertBreadcrumbs,
   assertFieldInput,
   assertFieldUneditable,
+  assertLocalHeader,
 }

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -18,6 +18,8 @@ global.rootPath = `${process.cwd()}`
 global.globalReq = reqres.req()
 global.globalRes = reqres.res()
 
+process.env.TZ = 'Europe/London'
+
 chai.config.truncateThreshold = 0
 
 process.setMaxListeners(0)

--- a/test/unit/data/companies/subsidiary-company-search-response.json
+++ b/test/unit/data/companies/subsidiary-company-search-response.json
@@ -8,6 +8,7 @@
         "id": "98d14e94-5d95-e211-a939-e4115bead28a",
         "name": "Company"
       },
+      "duns_number": "999999",
       "one_list_group_tier": null,
       "contacts": [
         {
@@ -87,6 +88,7 @@
     {
       "id": "731bdcc1-f685-4c8e-bd66-b356b2c16995",
       "archived_by": null,
+      "duns_number": "123",
       "business_type": {
         "id": "9ad14e94-5d95-e211-a939-e4115bead28a",
         "name": "Partnership"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ const common = {
 
         // Packages "hex-rgb" and "set-harmonic-interval" are not transpiled to ES5 by default so we need to transpile them again.
         // See: https://stackoverflow.com/questions/51289261/babel-does-not-transpile-imported-modules-from-node-modules
-        exclude: /node_modules\/(?!(hex-rgb|set-harmonic-interval)\/).*/,
+        exclude: /node_modules\/(?!(.*(hex-rgb|set-harmonic-interval))\/).*/,
 
         loader: 'babel-loader',
         options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3757,7 +3757,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3.1.0:
+copy-to-clipboard@^3.1.0, copy-to-clipboard@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz#d2724a3ccbfed89706fac8a894872c979ac74467"
   integrity sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==
@@ -9672,7 +9672,7 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nano-css@^5.1.0:
+nano-css@^5.1.0, nano-css@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/nano-css/-/nano-css-5.2.1.tgz#73b8470fa40b028a134d3393ae36bbb34b9fa332"
   integrity sha512-T54okxMAha0+de+W8o3qFtuWhTxYvqQh2ku1cYEqTTP9mR62nWV2lLK9qRuAGWmoaYWhU7K4evT9Lc1iF65wuw==
@@ -11468,6 +11468,21 @@ react-use@^12.2.0:
     screenfull "^5.0.0"
     set-harmonic-interval "^1.0.1"
     throttle-debounce "^2.0.1"
+    ts-easing "^0.2.0"
+    tslib "^1.10.0"
+
+react-use@^13.2.1:
+  version "13.2.1"
+  resolved "https://registry.yarnpkg.com/react-use/-/react-use-13.2.1.tgz#95ea7f697423f66f06254a3a82820a8f1b74a9e5"
+  integrity sha512-GgC9SH8Fx01B27whvbLYclsk5i9nETgxRHzpPH6PkKITohg0pPAfRfxiglSjdJO6jXDzDRJvayxpdvANodw2Lg==
+  dependencies:
+    copy-to-clipboard "^3.2.0"
+    nano-css "^5.2.1"
+    react-fast-compare "^2.0.4"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.0.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^2.1.0"
     ts-easing "^0.2.0"
     tslib "^1.10.0"
 
@@ -13500,7 +13515,7 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-throttle-debounce@^2.0.1:
+throttle-debounce@^2.0.1, throttle-debounce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
   integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==


### PR DESCRIPTION
## Description of change

Introducing new page which will list subsidiaries for companies matched with D&B record.

For now there won't be many companies which has D&B subsidiaries as this data need time to populate.

## Test instructions

1. Open `/companies/ID/dnb-subsidiaries`
2. You should see a list of D&B companies which are subsidiaries of the Global Ultimate
 
## Screenshots

![image](https://user-images.githubusercontent.com/4199239/68229909-fee1fa80-ffef-11e9-8bea-774b492adfa3.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
