### PR TITLE
Add urls to nunjucks globals for use in templates

### DIFF
--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -5,7 +5,7 @@
     {{ EntitySearchForm({
       inputName: 'term',
       modifier: 'global',
-      action: '/search/companies',
+      action: urls.search.type('companies'),
       inputLabel: 'Search for company, contact, event, investment project or OMIS order'
     }) }}
   {% endcall %}

--- a/src/apps/search/index.js
+++ b/src/apps/search/index.js
@@ -1,7 +1,8 @@
+const urls = require('../../lib/urls')
 const router = require('./router')
 
 module.exports = {
   displayName: 'Search',
-  mountpath: '/search',
+  mountpath: urls.search.index.mountPoint,
   router,
 }

--- a/src/apps/search/router.js
+++ b/src/apps/search/router.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
 const queryString = require('qs')
 
+const urls = require('../../lib/urls')
 const { ENTITIES } = require('./constants')
 const { handleRoutePermissions } = require('../middleware')
 const { renderSearchResults } = require('./controllers')
@@ -11,7 +12,7 @@ function redirectToCompaniesSearch (req, res) {
 
 router.use(handleRoutePermissions(ENTITIES))
 
-router.get('/', redirectToCompaniesSearch)
-router.get('/:searchPath?', renderSearchResults)
+router.get(urls.search.index.route, redirectToCompaniesSearch)
+router.get(urls.search.type.route, renderSearchResults)
 
 module.exports = router

--- a/src/config/nunjucks/globals.js
+++ b/src/config/nunjucks/globals.js
@@ -2,6 +2,7 @@ const nunjucks = require('nunjucks')
 const { assign, omit, isFunction, isArray, map } = require('lodash')
 const queryString = require('qs')
 const config = require('../')
+const urls = require('../../lib/urls')
 
 module.exports = {
   serviceTitle: 'Data Hub',
@@ -11,6 +12,7 @@ module.exports = {
   findExportersUrl: config.findExportersUrl,
 
   assign,
+  urls,
 
   callAsMacro (name) {
     const macro = this.ctx[name]

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -1,13 +1,13 @@
 const faker = require('faker')
 const proxyquire = require('proxyquire')
 
-const modulePath = '../../../src/lib/urls'
+const modulePath = '../urls'
 
 describe('urls', () => {
   let urls
   before(() => {
     urls = proxyquire(modulePath, {
-      '../../config': {
+      '../config': {
         greatProfileUrl: 'http://a.b.c.com/path/{id}',
       },
     })
@@ -55,6 +55,18 @@ describe('urls', () => {
       expect(urls.contacts.index.mountPoint).to.equal('/contacts')
       expect(urls.contacts.index.route).to.equal('/')
       expect(urls.contacts.index()).to.equal('/contacts')
+    })
+  })
+
+  describe('search', () => {
+    it('should return the correct values ', () => {
+      expect(urls.search.index.mountPoint).to.equal('/search')
+      expect(urls.search.index.route).to.equal('/')
+      expect(urls.search.index()).to.equal('/search')
+
+      const type = faker.lorem.word()
+      expect(urls.search.type.route).to.equal('/:searchPath?')
+      expect(urls.search.type(type)).to.equal(`/search/${type}`)
     })
   })
 })

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -54,4 +54,8 @@ module.exports = {
   contacts: {
     index: url('/contacts'),
   },
+  search: {
+    index: url('/search'),
+    type: url('/search', '/:searchPath?'),
+  },
 }

--- a/src/templates/_macros/form/entity-search-form.njk
+++ b/src/templates/_macros/form/entity-search-form.njk
@@ -58,7 +58,7 @@
               {% if isCurrentPage %}
                 {{ item.text }}
               {% else %}
-                <a class="c-entity-search__aggregations-link" href="/search/{{ item.path }}?term={{ props.searchTerm }}">{{ item.text }}</a>
+                <a class="c-entity-search__aggregations-link" href="{{ urls.search.type(item.path) }}?term={{ props.searchTerm }}">{{ item.text }}</a>
               {% endif %}
               <span class="c-entity-search__aggregations-count">({{ item.count | formatNumber }})</span>
             </li>


### PR DESCRIPTION
## Description of change

So the all templates and macros have access to the urls module
This means hard coded urls can be removed from templates as well as node code

Also move the test file to the correct location

Use the urls module for search to prove it works as expected and have a usage example

## Test instructions

Search should continue to work
 
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
