### PR TITLE
add CollectionList component to to Investment Profiles list view

### DIFF
--- a/src/apps/investments/__test__/repos.test.js
+++ b/src/apps/investments/__test__/repos.test.js
@@ -1,4 +1,4 @@
-const config = require('~/src/config')
+const config = require('../../../config')
 
 const {
   getInvestment,
@@ -7,11 +7,12 @@ const {
   createInvestmentProject,
   archiveInvestmentProject,
   unarchiveInvestmentProject,
-} = require('~/src/apps/investments/repos')
+  fetchLargeCapitalProfiles,
+} = require('../../../apps/investments/repos')
 
-const companyData = require('~/test/unit/data/company.json')
-const investmentData = require('~/test/unit/data/investment/investment-data.json')
-const investmentProjectAuditData = require('~/test/unit/data/investment/audit-log.json')
+const companyData = require('../../../../test/unit/data/company.json')
+const investmentData = require('../../../../test/unit/data/investment/investment-data.json')
+const investmentProjectAuditData = require('../../../../test/unit/data/investment/audit-log.json')
 
 describe('Investment repository', () => {
   describe('#getCompanyInvestmentProjects', () => {
@@ -92,5 +93,13 @@ describe('Investment repository', () => {
     it('should call unarchive url', async () => {
       expect(this.investmentProjectAuditData).to.deep.equal(investmentProjectAuditData)
     })
+  })
+
+  it('#fetchLargeCapitalProfiles', async () => {
+    nock(config.apiRoot)
+      .get(`/v4/large-investor-profile?limit=10&offset=0&sortby=modified_on`)
+      .reply(200, 'data')
+
+    expect(await fetchLargeCapitalProfiles('token', 10)).to.equal('data')
   })
 })

--- a/src/apps/investments/client/LargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/LargeCapitalProfileCollection.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
+import { useSearchParam } from 'react-use'
+import { CollectionList } from 'data-hub-components'
+import LoadingBox from '@govuk-react/loading-box'
+import ErrorSummary from '@govuk-react/error-summary'
+import { investments } from '../../../lib/urls'
+
+const LargeCapitalProfileCollection = () => {
+  const [profiles, setProfiles] = useState([])
+  const [totalItems, setTotalItems] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState(null)
+
+  const activePage = parseInt(useSearchParam('page') || 1, 10)
+  const setActivePage = (page) =>
+    window.history.pushState({}, '', `${window.location.pathname}?page=${page}`)
+
+  const onPageClick = (page, event) => {
+    setActivePage(page)
+    event.target.blur()
+    event.preventDefault()
+  }
+
+  const getPageUrl = (page) => `?page${page}`
+
+  useEffect(() => {
+    async function fetchData () {
+      try {
+        const { data } = await axios.get(investments.profiles.data(), {
+          params: {
+            page: activePage,
+          },
+        })
+        setProfiles(data.results)
+        setTotalItems(data.count)
+        setIsLoading(false)
+      } catch {
+        setErrorMessage('Please try again later')
+      }
+    }
+    setIsLoading(true)
+    window.scrollTo(0, 0)
+    fetchData()
+  }, [activePage])
+
+  return (
+    errorMessage ? (
+      <ErrorSummary
+        heading='There was an error getting the investor profiles'
+        description={errorMessage}
+        errors={[]}
+      />
+    )
+      : (
+        <LoadingBox loading={isLoading} >
+          <CollectionList
+            itemName='profile'
+            items={profiles}
+            totalItems={totalItems}
+            onPageClick={onPageClick}
+            getPageUrl={getPageUrl}
+            activePage={activePage}
+          />
+        </LoadingBox>
+      )
+  )
+}
+
+export default LargeCapitalProfileCollection

--- a/src/apps/investments/controllers/__test__/profiles.test.js
+++ b/src/apps/investments/controllers/__test__/profiles.test.js
@@ -1,96 +1,114 @@
-const config = require('~/src/config')
-const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const config = require('../../../../config')
+const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
+const { renderProfilesView, fetchLargeCapitalProfilesHandler } = require('../profiles')
 
-describe('Investment profile controller', () => {
-  const metadataMock = {
-    sectorOptions: [
-      { id: 's1', name: 's1', disabled_on: null },
-    ],
-    adviserOptions: {
-      results: [
-        { id: 'ad1', name: 'ad1', is_active: true, dit_team: { name: 'ad1' } },
-      ],
-    },
-  }
-
-  beforeEach(async () => {
-    this.middlewareParameters = await buildMiddlewareParameters({ 'test': 'test' })
-
-    nock(config.apiRoot)
-      .get('/v4/metadata/sector?level__lte=0')
-      .reply(200, metadataMock.sectorOptions)
-      .get('/adviser/?limit=100000&offset=0')
-      .reply(200, metadataMock.adviserOptions)
-  })
+describe('test profile controllers', () => {
+  let middlewareParameters
 
   describe('#renderProfilesView', () => {
-    context('when the list renders successfully', () => {
-      beforeEach(async () => {
-        const controller = require('~/src/apps/investments/controllers/profiles')
+    describe('when the page renders successfully', () => {
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters()
 
-        await controller.renderProfilesView(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy)
+        await renderProfilesView(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should call breadcrumb with "Profiles"', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.be.calledWith('Profiles')
       })
 
       it('should render', () => {
-        expect(this.middlewareParameters.resMock.render).to.be.calledOnce
+        expect(middlewareParameters.resMock.render).to.be.calledOnce
       })
 
-      it('should render the collection template', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[0]).to
-          .equal('investments/views/profiles')
+      it('should render with a heading', () => {
+        expect(middlewareParameters.resMock.render).to.be.calledWith('investments/views/profiles', { heading: 'Investments' })
       })
 
-      it.skip('should render the view with a count label', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].countLabel).to
-          .equal('project')
-      })
-
-      it.skip('should render the view with a sort form', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].sortForm).to.exist
-      })
-
-      it.skip('should render the view with selected filters', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].selectedFilters).to.exist
-      })
-
-      it.skip('should render the view with an export action', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].exportAction).to
-          .deep.equal({ enabled: false })
-      })
-
-      it.skip('should render the view with filter fields', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].filtersFields).to.exist
+      it('should not call next', () => {
+        expect(middlewareParameters.nextSpy).to.not.be.called
       })
     })
 
-    context('when there is an error', () => {
-      beforeEach(async () => {
-        this.error = new Error('error')
-        const erroneousSpy = sinon.stub().throws(this.error)
+    describe('when there is an error', () => {
+      before(async () => {
+        middlewareParameters.resMock.render.throws()
 
-        const controller = proxyquire('~/src/apps/investments/controllers/profiles', {
-          '../../builders': {
-            buildSelectedFiltersSummary: erroneousSpy,
-            buildFieldsWithSelectedEntities: sinon.stub(),
+        await renderProfilesView(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should not call render', () => {
+        expect(middlewareParameters.resMock.render).to.be.thrown
+      })
+
+      it('should call next in the catch', () => {
+        expect(middlewareParameters.nextSpy).to.be.calledOnce
+      })
+    })
+  })
+
+  describe('#fetchLargeCapitalProfilesHandler', () => {
+    describe('when the response is successful', () => {
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {
+            page: 1,
           },
         })
 
-        await controller.renderProfilesView(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy)
+        nock(config.apiRoot)
+          .get(`/v4/large-investor-profile?limit=10&offset=0&sortby=modified_on`)
+          .reply(200, { count: 0, results: [] })
+
+        await fetchLargeCapitalProfilesHandler(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
       })
 
-      it.skip('should not render the view', () => {
-        expect(this.middlewareParameters.resMock.render).to.not.be.called
+      it('should provide a json response', () => {
+        expect(middlewareParameters.resMock.json).to.be.calledOnceWithExactly({ count: 0, results: [] })
       })
 
-      it.skip('should call next with an error', () => {
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledWith(this.error)
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
+      it('should not call next', () => {
+        expect(middlewareParameters.nextSpy).to.not.be.called
+      })
+    })
+
+    describe('when the response is unsuccessful', () => {
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {
+            page: 1,
+          },
+        })
+
+        nock(config.apiRoot)
+          .get(`/v4/large-investor-profile?limit=10&offset=0&sortby=modified_on`)
+          .reply(500)
+
+        await fetchLargeCapitalProfilesHandler(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should not provide a json response', () => {
+        expect(middlewareParameters.resMock.json).to.not.be.called
+      })
+
+      it('should call next in the catch', () => {
+        expect(middlewareParameters.nextSpy).to.be.called
       })
     })
   })

--- a/src/apps/investments/controllers/profiles.js
+++ b/src/apps/investments/controllers/profiles.js
@@ -1,9 +1,34 @@
+const { fetchLargeCapitalProfiles } = require('../repos')
+const { transformLargeCapitalProfiles } = require('../transformers/profiles')
+
 const renderProfilesView = async (req, res, next) => {
   try {
-    res.render('investments/views/profiles')
+    res
+      .breadcrumb('Profiles')
+      .render('investments/views/profiles', { heading: 'Investments' })
   } catch (error) {
     next(error)
   }
 }
 
-module.exports = { renderProfilesView }
+const fetchLargeCapitalProfilesHandler = async (req, res, next) => {
+  try {
+    const { token } = req.session
+    const { page } = req.query
+
+    const { count, results } = await fetchLargeCapitalProfiles(
+      token,
+      10,
+      parseInt(page, 10)
+    )
+
+    res.json({
+      count: count || 0,
+      results: results ? results.map(transformLargeCapitalProfiles) : [],
+    })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = { renderProfilesView, fetchLargeCapitalProfilesHandler }

--- a/src/apps/investments/repos.js
+++ b/src/apps/investments/repos.js
@@ -75,6 +75,18 @@ async function updateInvestmentTeamMembers (token, investmentId, investmentTeamM
   })
 }
 
+async function fetchLargeCapitalProfiles (token, limit, page = 1) {
+  const offset = limit * (page - 1)
+  return authorisedRequest(token,
+    { url: `${config.apiRoot}/v4/large-investor-profile`,
+      qs: {
+        limit,
+        offset,
+        sortby: 'modified_on',
+      },
+    })
+}
+
 module.exports = {
   getCompanyInvestmentProjects,
   getInvestment,
@@ -85,4 +97,5 @@ module.exports = {
   archiveInvestmentProject,
   unarchiveInvestmentProject,
   updateInvestmentTeamMembers,
+  fetchLargeCapitalProfiles,
 }

--- a/src/apps/investments/router-profiles.js
+++ b/src/apps/investments/router-profiles.js
@@ -1,8 +1,9 @@
 const router = require('express').Router()
 
-const { renderProfilesView } = require('./controllers/profiles')
+const { renderProfilesView, fetchLargeCapitalProfilesHandler } = require('./controllers/profiles')
 const setInvestmentTabItems = require('./middleware/investments-tab-items')
 
 router.get('/', setInvestmentTabItems, renderProfilesView)
+router.get('/data', fetchLargeCapitalProfilesHandler)
 
 module.exports = router

--- a/src/apps/investments/transformers/__test__/profiles.test.js
+++ b/src/apps/investments/transformers/__test__/profiles.test.js
@@ -1,0 +1,31 @@
+const { transformLargeCapitalProfiles } = require('../profiles')
+
+describe('#transformLargeCapitalProfiles', () => {
+  let actual
+
+  before(() => {
+    actual = transformLargeCapitalProfiles({
+      'investor_company': {
+        'name': 'ABC Inc',
+        'id': '1',
+      },
+      'created_on': '2019-10-29T15:50:58.399262Z',
+    })
+  })
+
+  it('should return the transformed values', () => {
+    const expected = {
+      'headingText': 'ABC Inc',
+      'headingUrl': '/companies/1',
+      'itemId': '1',
+      'metadata': [
+        {
+          'label': 'Updated on',
+          'value': '29 October 2019',
+        },
+      ],
+    }
+
+    expect(actual).to.deep.equal(expected)
+  })
+})

--- a/src/apps/investments/transformers/profiles.js
+++ b/src/apps/investments/transformers/profiles.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+const moment = require('moment')
+
+function transformLargeCapitalProfiles ({
+  investor_company,
+  created_on,
+}) {
+  return {
+    headingText: investor_company.name,
+    headingUrl: `/companies/${investor_company.id}`,
+    itemId: investor_company.id,
+    metadata: [
+      {
+        label: 'Updated on',
+        value: moment(created_on).format('D MMMM YYYY'),
+      },
+    ],
+  }
+}
+
+module.exports = { transformLargeCapitalProfiles }

--- a/src/apps/investments/views/profiles.njk
+++ b/src/apps/investments/views/profiles.njk
@@ -1,4 +1,3 @@
-{# {% extends "_layouts/template.njk" %} #}
 {% extends "_layouts/collection.njk" %}
 
 {% block content %}
@@ -9,35 +8,14 @@
       </div>
     </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <h4 class="govuk-heading-s govuk-!-padding-left-2 govuk-!-margin-bottom-2">Large capital</h4>
-        {# New filters section will be added here  #}
+      <div class="govuk-grid-column-full">
+          {% component 'react-slot', {
+            id: 'large-capital-profile-collection',
+            props: props
+          }
+          %}
       </div>
 
-      {% block xhr_content %}
-        <article class="govuk-grid-column-two-thirds" data-xhr="c781e8b1-9747-4b2e-8655-68b14ea49126">
-          {{
-            CollectionContent(results | assign({
-              countLabel: countLabel,
-              sortForm: assign({}, sortForm, { action: CURRENT_PATH }),
-              selectedFilters: selectedFilters,
-              highlightTerm: highlightTerm,
-              actionButtons: actionButtons,
-              exportAction: exportAction,
-              query: QUERY
-            }))
-          }}
-
-          {% if not results %}
-            <section id="no-profiles">
-              <p class="govuk-body-s govuk-!-font-weight-regular govuk-!-margin-top-4">There are no profiles to view</p>
-              <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-            </section>
-          {% endif %}
-
-        </article>
-      {% endblock %}
     </div>
   </div>
 {% endblock %}

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -10,6 +10,7 @@ import CreateListFormSection from './apps/company-lists/client/CreateListFormSec
 import AddRemoveFromListSection from './apps/company-lists/client/AddRemoveFromListSection'
 import DnbSubsidiaries from './apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries'
 import LeadAdvisers from './apps/companies/apps/advisers/client/LeadAdvisers'
+import LargeCapitalProfileCollection from './apps/investments/client/LargeCapitalProfileCollection'
 
 const appWrapper = document.getElementById('react-app')
 
@@ -55,6 +56,9 @@ function App () {
       </Mount>
       <Mount selector="#dnb-subsidiaries">
         {props => <DnbSubsidiaries {...props} />}
+      </Mount>
+      <Mount selector="#large-capital-profile-collection">
+        {props => <LargeCapitalProfileCollection {...props} />}
       </Mount>
     </>
   )

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -106,4 +106,11 @@ module.exports = {
   interactions: {
     subapp: createInteractionsSubApp(),
   },
+  investments: {
+    index: url('/investments'),
+    profiles: {
+      index: url('/investments', '/profiles'),
+      data: url('/investments', '/profiles/data'),
+    },
+  },
 }

--- a/test/functional/cypress/specs/investment-project/investment-profiles-spec.js
+++ b/test/functional/cypress/specs/investment-project/investment-profiles-spec.js
@@ -1,17 +1,82 @@
-const selectors = require('../../../../selectors')
+const { assertTabbedLocalNav, assertLocalHeader, assertBreadcrumbs } = require('../../support/assertions')
+const { investments } = require('../../../../../src/lib/urls')
 
-describe('Investment / Invenstor profiles', () => {
-  before(() => {
-    cy.visit('/investments/profiles')
-  })
-
-  context('When no profiles are available', () => {
-    it('should not display any profiles', () => {
-      cy.get(selectors.entityCollection.entities).should('have.length', 0)
+describe('Investor profiles', () => {
+  context('When there are 12 profiles and viewing the first page', () => {
+    before(() => {
+      cy.visit(investments.profiles.index())
     })
 
-    it('should display a proper message', () => {
-      cy.get('#no-profiles').should('be.visible')
+    it('should render the header', () => {
+      assertLocalHeader('Investments')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': '/',
+        'Investments': '/investments',
+        'Profiles': null,
+      })
+    })
+
+    it('should render the local navigation', () => {
+      assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('Investor profiles')
+    })
+
+    it('should display 10 profiles', () => {
+      cy.get('h3').should('have.length', 10)
+    })
+
+    it('should display 3 pagination links', () => {
+      cy.get('ul:last li a').should('have.length', 3)
+    })
+
+    it('should display the next button', () => {
+      cy.get('ul:last li a:last').should('have.text', 'Next')
+    })
+
+    it('should not display the previous button', () => {
+      cy.get('ul:last li a:first').should('not.have.text', 'Previous')
+    })
+  })
+
+  context('When there are 12 profiles and viewing the second page', () => {
+    before(() => {
+      cy.visit(`${investments.profiles.index()}?page=2`)
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Investments')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': '/',
+        'Investments': '/investments',
+        'Profiles': null,
+      })
+    })
+
+    it('should render the local navigation', () => {
+      assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('Investor profiles')
+    })
+
+    it('should display 2 profiles', () => {
+      cy.get('h3').should('have.length', 2)
+    })
+
+    it('should display 3 pagination links', () => {
+      cy.get('ul:last li a').should('have.length', 3)
+    })
+
+    it('should not display the next button', () => {
+      cy.get('ul:last li a:last').should('not.have.text', 'Next')
+    })
+
+    it('should display the previous button', () => {
+      cy.get('ul:last li a:first').should('have.text', 'Previous')
     })
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -71,6 +71,10 @@ const assertLocalHeader = (header) => {
   cy.get(selectors.localHeader).contains(header)
 }
 
+const assertTabbedLocalNav = (nav) => {
+  cy.get(selectors.tabbedLocalNav).contains(nav)
+}
+
 module.exports = {
   assertKeyValueTable,
   assertValueTable,
@@ -78,4 +82,5 @@ module.exports = {
   assertFieldInput,
   assertFieldUneditable,
   assertLocalHeader,
+  assertTabbedLocalNav,
 }


### PR DESCRIPTION
## Description of change

Show the profiles tab within Investments and display a list of profiles using the `CollectionList` component.

You need to go to `/investments/profiles` to view the new collection. Showing the local nav tab on the projects screen will be in a following PR. 
 
## Screenshots
### Before
![FireShot Capture 011 - Investments - DIT Data Hub - localhost](https://user-images.githubusercontent.com/42253716/68388008-92820b00-0157-11ea-885c-437c840bb9be.png)

### After
![profiles collectionList](https://user-images.githubusercontent.com/42253716/68387947-72524c00-0157-11ea-8291-516066a9bf95.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
