### PR TITLE
Remove browser-sync-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "@wdio/sync": "5.10.0",
     "babel-eslint": "^10.0.2",
     "browser-sync": "^2.24.4",
-    "browser-sync-webpack-plugin": "^2.0.0",
     "browserstack-local": "^1.4.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/webpack.config.develop.js
+++ b/webpack.config.develop.js
@@ -1,7 +1,4 @@
-const BrowserSyncPlugin = require('browser-sync-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
-
-const config = require('./src/config')
 
 module.exports = {
   output: {
@@ -11,18 +8,5 @@ module.exports = {
   },
   plugins: [
     new ExtractTextPlugin('css/[name].css'),
-    new BrowserSyncPlugin({
-      port: 3001,
-      proxy: `http://localhost:${config.port}`,
-      open: false,
-      files: [
-        '.build/css/*.css',
-        '.build/js/*.js',
-        '.build/images/*',
-        'src/**/*.njk',
-      ],
-    }, {
-      reload: false,
-    }),
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2706,13 +2706,6 @@ browser-sync-ui@^2.26.4:
     socket.io-client "^2.0.4"
     stream-throttle "^0.1.3"
 
-browser-sync-webpack-plugin@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/browser-sync-webpack-plugin/-/browser-sync-webpack-plugin-2.2.2.tgz#46092da62ff36354a50bf0e2903e78a6974fea54"
-  integrity sha512-x92kl8LdBi4dp6YVXYqrSoDkOCOLCeBOrYSY0h9Sk1VcCDSoZC1Vc62eae6TfC2ljN4/L+aYlkzE46kirHzbgA==
-  dependencies:
-    lodash "^4"
-
 browser-sync@^2.24.4:
   version "2.26.7"
   resolved "https://registry.yarnpkg.com/browser-sync/-/browser-sync-2.26.7.tgz#120287716eb405651a76cc74fe851c31350557f9"
@@ -8943,7 +8936,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@4.17.15, lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
## Description of change

It seems that `browser-sync-webpack-plugin` consumes lots of resources on each save of a watched file
It should be optional for a developer to use this plugin and it seems none of us are, so best to remove it

## Test instructions

Does the app still build and does editing any CSS/JS on the client still get built by webpack
 
Upon editing any of the above files you should notice a lack of fan spin up on a Mac.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
