### PR TITLE
Add redis-check middleware with an error template

### DIFF
--- a/src/middleware/redis-check.js
+++ b/src/middleware/redis-check.js
@@ -1,0 +1,20 @@
+const redisClient = require('../lib/redis-client')
+
+const client = redisClient.get()
+let connected = false
+
+client.on('error', () => {
+  connected = false
+})
+
+client.on('ready', () => {
+  connected = true
+})
+
+module.exports = (req, res, next) => {
+  if (connected) {
+    next()
+  } else {
+    res.render('redis-lost')
+  }
+}

--- a/src/middleware/user-locals.js
+++ b/src/middleware/user-locals.js
@@ -1,0 +1,41 @@
+const { get } = require('lodash')
+const config = require('../config')
+const { filterNonPermittedItem } = require('../modules/permissions/filters')
+
+const GLOBAL_NAV_ITEMS = require('../apps/global-nav-items')
+
+function getActiveHeaderKey (requestPath, permittedNavItems) {
+  if (requestPath.startsWith('/support')) {
+    return 'datahub-support'
+  } else if (requestPath === '/profile') {
+    return 'datahub-profile'
+  } else {
+    for (const { path, headerKey } of permittedNavItems) {
+      if (requestPath.startsWith(path)) {
+        return headerKey
+      }
+    }
+  }
+}
+
+module.exports = (req, res, next) => {
+  const userPermissions = get(res, 'locals.user.permissions')
+  const userProfile = config.oauth.bypassSSO ? null : get(req.session, 'userProfile')
+  const permittedApplications = get(userProfile, 'permitted_applications', [])
+  const permittedNavItems = GLOBAL_NAV_ITEMS.filter(filterNonPermittedItem(userPermissions))
+
+  Object.assign(res.locals, {
+    PERMITTED_APPLICATIONS: (config.oauth.bypassSSO ? [{ key: 'datahub-crm' }] : permittedApplications),
+    ALLOWED_APPS: permittedNavItems.reduce((apps, { headerKey }) => {
+      headerKey && apps.push(headerKey)
+      return apps
+    }, []),
+    ACTIVE_KEY: getActiveHeaderKey(req.path, permittedNavItems),
+
+    getMessages () {
+      return req.flash()
+    },
+  })
+
+  next()
+}

--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,7 @@ const currentJourney = require('./modules/form/current-journey')
 const nunjucks = require('./config/nunjucks')
 const headers = require('./middleware/headers')
 const locals = require('./middleware/locals')
+const userLocals = require('./middleware/user-locals')
 const metadata = require('./lib/metadata')
 const user = require('./middleware/user')
 const auth = require('./middleware/auth')
@@ -30,6 +31,7 @@ const ssoBypass = require('./middleware/sso-bypass')
 const logger = require('./config/logger')
 const basicAuth = require('./middleware/basic-auth')
 const features = require('./middleware/features')
+const redisCheck = require('./middleware/redis-check')
 const reporter = require('./lib/reporter')
 
 const routers = require('./apps/routers')
@@ -53,11 +55,6 @@ if (!config.isDev) {
 }
 
 app.use(cookieParser())
-app.use(sessionStore)
-
-app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
-app.use(bodyParser.json())
-
 app.use(compression())
 
 app.set('view engine', 'njk')
@@ -89,6 +86,13 @@ app.use('/assets', express.static(path.join(config.root, 'node_modules/govuk-fro
 app.use(title())
 app.use(breadcrumbs.init())
 app.use(breadcrumbs.setHome())
+app.use(locals)
+app.use(redisCheck)
+
+app.use(sessionStore)
+
+app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
+app.use(bodyParser.json())
 
 app.use(currentJourney())
 
@@ -99,7 +103,7 @@ app.use(basicAuth)
 app.use(auth)
 app.use(user)
 app.use(features)
-app.use(locals)
+app.use(userLocals)
 app.use(headers)
 app.use(store())
 app.use(csrf())

--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -14,7 +14,7 @@
  #}
 {% macro LocalHeader(props) %}
   {% set breadcrumbs = props.breadcrumbs | default(getBreadcrumbs()) %}
-  {% set messages = props.messages | default(getMessages()) %}
+  {% set messages = props.messages | default(getMessages() if getMessages) %}
   {% set modifier = props.modifier | concat('') | reverse | join(' c-local-header--') if props.modifier %}
 
   {% if props %}

--- a/src/templates/redis-lost.njk
+++ b/src/templates/redis-lost.njk
@@ -1,0 +1,13 @@
+{% extends "_layouts/template.njk" %}
+
+{% block local_header %}
+  {{ LocalHeader({ heading: 'System down', modifier: 'light-banner' }) }}
+{% endblock %}
+
+{% block body_main_content %}
+
+  <p>
+    Part of the system is down, please try again shortly. The team has been notified.
+  </p>
+
+{% endblock %}


### PR DESCRIPTION
## Description of change

Add new middleware to render an error when the connection to Redis is lost.
To enable re-use of the current template the locals.js needed to be split up,
so there are 'pre session' and 'post-session' locals

## Test instructions

Start the app and then kill Redis, now refresh the page on the app. You should see a message saying part of the system is down.
 
## Screenshots

### Before
Useless `getAssetPath` error

### After

<img width="388" alt="Screen Shot 2019-11-11 at 15 41 48" src="https://user-images.githubusercontent.com/1481883/68600250-16126380-049a-11ea-89de-4238ecb4cfd2.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
