### PR TITLE
Show last interaction date

### DIFF
--- a/src/apps/companies/transformers/__test__/company-to-list-item.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-list-item.test.js
@@ -1,62 +1,64 @@
-const { assign, find } = require('lodash')
+const { find } = require('lodash')
 
-const companyData = require('~/test/unit/data/company')
-const transformCompanyToListItem = require('~/src/apps/companies/transformers/company-to-list-item')
+const companyData = require('../../../../../test/unit/data/company')
+const urls = require('../../../../lib/urls')
+const transformCompanyToListItem = require('../company-to-list-item')
 
 describe('transformCompanyToListItem', () => {
+  let listItem
   context('when there is no companies house data or datahub data', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem()
+    before(() => {
+      listItem = transformCompanyToListItem()
     })
 
     it('should return undefined', () => {
-      expect(this.listItem).to.be.undefined
+      expect(listItem).to.be.undefined
     })
   })
 
   context('when the object passed to the transformer is not a company', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem({ a: 'b' })
+    before(() => {
+      listItem = transformCompanyToListItem({ a: 'b' })
     })
 
     it('should return undefined', () => {
-      expect(this.listItem).to.be.undefined
+      expect(listItem).to.be.undefined
     })
   })
 
   context('when passed a company with no ID', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem({ a: 'b' })
+    before(() => {
+      listItem = transformCompanyToListItem({ a: 'b' })
     })
 
     it('should return undefined', () => {
-      expect(this.listItem).to.be.undefined
+      expect(listItem).to.be.undefined
     })
   })
 
   context('when called with a fully populated company', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem(companyData)
+    before(() => {
+      listItem = transformCompanyToListItem(companyData)
     })
 
     it('should return the id of the company', () => {
-      expect(this.listItem).to.have.property('id', 'dcdabbc9-1781-e411-8955-e4115bead28a')
+      expect(listItem).to.have.property('id', companyData.id)
     })
 
     it('should return a type of company', () => {
-      expect(this.listItem).to.have.property('type', 'company')
+      expect(listItem).to.have.property('type', 'company')
     })
 
     it('should return the company name', () => {
-      expect(this.listItem).to.have.property('name', 'Wonka Industries')
+      expect(listItem).to.have.property('name', 'Wonka Industries')
     })
 
     it('should return a url to view the company', () => {
-      expect(this.listItem).to.have.property('url', '/companies/dcdabbc9-1781-e411-8955-e4115bead28a')
+      expect(listItem).to.have.property('url', urls.companies.detail(companyData.id))
     })
 
     it('should return a modifed on property', () => {
-      expect(this.listItem).to.have.deep.property('subTitle', {
+      expect(listItem).to.have.deep.property('subTitle', {
         value: '2017-05-13T15:58:46.421721',
         type: 'datetime',
         label: 'Updated on',
@@ -65,19 +67,19 @@ describe('transformCompanyToListItem', () => {
   })
 
   context('when the company is based in the uk', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem(companyData)
+    before(() => {
+      listItem = transformCompanyToListItem(companyData)
     })
 
     it('should return the business sector for the company', () => {
-      expect(this.listItem.meta).to.containSubset([{
+      expect(listItem.meta).to.containSubset([{
         label: 'Sector',
         value: 'ICT',
       }])
     })
 
     it('should return the country', () => {
-      expect(this.listItem.meta).to.containSubset([{
+      expect(listItem.meta).to.containSubset([{
         label: 'Country',
         type: 'badge',
         value: 'United Kingdom',
@@ -85,7 +87,7 @@ describe('transformCompanyToListItem', () => {
     })
 
     it('should return the UK region', () => {
-      expect(this.listItem.meta).to.containSubset([{
+      expect(listItem.meta).to.containSubset([{
         label: 'UK region',
         type: 'badge',
         value: 'Yorkshire and The Humber',
@@ -94,21 +96,22 @@ describe('transformCompanyToListItem', () => {
   })
 
   context('when called with a non-UK company', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem(assign({}, companyData, {
+    before(() => {
+      listItem = transformCompanyToListItem({
+        ...companyData,
         uk_based: false,
-      }))
+      })
     })
 
     it('should return the business sector for the company', () => {
-      expect(this.listItem.meta).to.containSubset([{
+      expect(listItem.meta).to.containSubset([{
         label: 'Sector',
         value: 'ICT',
       }])
     })
 
     it('should return the country', () => {
-      expect(this.listItem.meta).to.containSubset([{
+      expect(listItem.meta).to.containSubset([{
         label: 'Country',
         type: 'badge',
         value: 'United Kingdom',
@@ -116,7 +119,7 @@ describe('transformCompanyToListItem', () => {
     })
 
     it('should not return the region', () => {
-      expect(this.listItem.meta).to.not.containSubset([{
+      expect(listItem.meta).to.not.containSubset([{
         label: 'UK region',
         type: 'badge',
         value: 'Yorkshire and The Humber',
@@ -125,8 +128,9 @@ describe('transformCompanyToListItem', () => {
   })
 
   context('when the company has an address', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem(assign({}, companyData, {
+    before(() => {
+      listItem = transformCompanyToListItem({
+        ...companyData,
         address: {
           line_1: 'line 1',
           line_2: null,
@@ -138,11 +142,11 @@ describe('transformCompanyToListItem', () => {
             name: 'United Kingdom',
           },
         },
-      }))
+      })
     })
 
     it('should include the address in the result', () => {
-      expect(this.listItem.meta).to.containSubset([{
+      expect(listItem.meta).to.containSubset([{
         label: 'Address',
         type: 'address',
         value: {
@@ -162,12 +166,12 @@ describe('transformCompanyToListItem', () => {
 
   context('headquarter information', () => {
     context('contains the headquarter information', () => {
-      beforeEach(() => {
-        this.listItem = transformCompanyToListItem(companyData)
+      before(() => {
+        listItem = transformCompanyToListItem(companyData)
       })
 
       it('should not include the headquarter info in the result', () => {
-        expect(this.listItem.meta).to.containSubset([{
+        expect(listItem.meta).to.containSubset([{
           label: 'Headquarter type',
           type: 'badge',
           value: 'European HQ',
@@ -176,15 +180,15 @@ describe('transformCompanyToListItem', () => {
     })
 
     context('should not contain the headquarter information', () => {
-      beforeEach(() => {
-        this.listItem = transformCompanyToListItem({
+      before(() => {
+        listItem = transformCompanyToListItem({
           ...companyData,
           headquarter_type: null,
         })
       })
 
       it('should not include the headquarter info in the result', () => {
-        expect(this.listItem.meta).to.not.containSubset([{
+        expect(listItem.meta).to.not.containSubset([{
           label: 'Headquarter type',
           type: 'badge',
           value: 'European HQ',
@@ -195,12 +199,12 @@ describe('transformCompanyToListItem', () => {
 
   context('global headquarters information', () => {
     context('contains the global headquarters information', () => {
-      beforeEach(() => {
-        this.listItem = transformCompanyToListItem(companyData)
+      before(() => {
+        listItem = transformCompanyToListItem(companyData)
       })
 
       it('should include the headquarter info in the result', () => {
-        expect(this.listItem.meta).to.containSubset([{
+        expect(listItem.meta).to.containSubset([{
           label: 'Global HQ',
           value: 'Mars Exports Ltd',
           url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
@@ -209,15 +213,15 @@ describe('transformCompanyToListItem', () => {
     })
 
     context('does not contain the headquarter information', () => {
-      beforeEach(() => {
-        this.listItem = transformCompanyToListItem({
+      before(() => {
+        listItem = transformCompanyToListItem({
           ...companyData,
           global_headquarters: null,
         })
       })
 
       it('should not include the headquarter info in the result', () => {
-        expect(this.listItem.meta).to.not.containSubset([{
+        expect(listItem.meta).to.not.containSubset([{
           label: 'Global HQ',
           value: 'Mars Exports Ltd',
           url: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
@@ -227,41 +231,71 @@ describe('transformCompanyToListItem', () => {
   })
 
   context('when the company does not have trading names', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem(companyData)
+    before(() => {
+      listItem = transformCompanyToListItem(companyData)
     })
 
     it('should not set a trading name meta item', () => {
-      const tradingNameMetaItem = find(this.listItem.meta, ({ label }) => label === 'Trading names')
+      const tradingNameMetaItem = find(listItem.meta, ({ label }) => label === 'Trading names')
       expect(tradingNameMetaItem).to.not.exist
     })
   })
 
   context('when the company does have trading names', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem({
+    before(() => {
+      listItem = transformCompanyToListItem({
         ...companyData,
         trading_names: [ 'trading name' ],
       })
     })
 
     it('should not set a trading name meta item', () => {
-      const tradingNameMetaItem = find(this.listItem.meta, ({ label }) => label === 'Trading names')
+      const tradingNameMetaItem = find(listItem.meta, ({ label }) => label === 'Trading names')
       expect(tradingNameMetaItem).to.exist
     })
   })
 
   context('when the company address is null', () => {
-    beforeEach(() => {
-      this.listItem = transformCompanyToListItem({
+    before(() => {
+      listItem = transformCompanyToListItem({
         ...companyData,
         address: null,
       })
     })
 
     it('should still transform the company and not return country', () => {
-      const country = find(this.listItem.meta, ({ label }) => label === 'Country')
+      const country = find(listItem.meta, ({ label }) => label === 'Country')
       expect(country).to.not.exist
+    })
+  })
+
+  describe('Latest interaction date', () => {
+    context('when the company has a last interaction date', () => {
+      it('should include the last interaction date in the result', () => {
+        const date = '2019-11-01'
+        const listItem = transformCompanyToListItem({
+          ...companyData,
+          latest_interaction_date: date,
+        })
+        expect(listItem.meta).to.containSubset([{
+          label: 'Last interaction date',
+          type: 'date',
+          value: date,
+        }])
+      })
+    })
+
+    context('when the company does not have a last interaction date', () => {
+      it('should not include the last interaction date in the result', () => {
+        const listItem = transformCompanyToListItem({
+          ...companyData,
+          latest_interaction_date: null,
+        })
+        expect(listItem.meta).to.not.containSubset([{
+          label: 'Last interaction date',
+          type: 'date',
+        }])
+      })
     })
   })
 })

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -2,6 +2,7 @@
 const { get } = require('lodash')
 
 const labels = require('../labels')
+const urls = require('../../../lib/urls')
 
 module.exports = function transformCompanyToListItem ({
   id,
@@ -63,7 +64,7 @@ module.exports = function transformCompanyToListItem ({
     meta.push({
       label: 'Global HQ',
       value: ghqName,
-      url: `/companies/${ghqId}`,
+      url: urls.companies.detail(ghqId),
     })
   }
 
@@ -73,12 +74,10 @@ module.exports = function transformCompanyToListItem ({
     value: address,
   })
 
-  const url = `/companies/${id}`
-
   return {
     id,
     name,
-    url,
+    url: urls.companies.detail(id),
     meta,
     subTitle: {
       type: 'datetime',

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -15,6 +15,7 @@ module.exports = function transformCompanyToListItem ({
   modified_on,
   headquarter_type,
   global_headquarters,
+  latest_interaction_date,
 } = {}) {
   if (!id) { return }
 
@@ -73,6 +74,14 @@ module.exports = function transformCompanyToListItem ({
     label: labels.address.companyAddress,
     value: address,
   })
+
+  if (latest_interaction_date) {
+    meta.push({
+      type: 'date',
+      label: 'Last interaction date',
+      value: latest_interaction_date,
+    })
+  }
 
   return {
     id,


### PR DESCRIPTION
## Description of change

Show the last interaction date in the companies collection (and subsidiaries list)

## Test instructions

When a last interaction date is available
 it should come out under the address in the companies collection (or subsidiaries list)
 
## Screenshots
### Before

<img width="658" alt="Screen Shot 2019-11-13 at 19 23 46" src="https://user-images.githubusercontent.com/1481883/68796729-43524380-064b-11ea-8592-5c3e8050e103.png">

### After 

<img width="668" alt="Screen Shot 2019-11-13 at 19 23 12" src="https://user-images.githubusercontent.com/1481883/68796757-52d18c80-064b-11ea-9e0e-e872abd6bead.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
