### PR TITLE
Handle subsidiaries page when company has multiple hierarchies

### DIFF
--- a/src/apps/__test__/middleware.test.js
+++ b/src/apps/__test__/middleware.test.js
@@ -118,6 +118,27 @@ describe('Apps middleware', () => {
       })
     })
 
+    context('when the "appendBaseUrl" argument is set to false', () => {
+      it('should not append the baseUrl to the link', () => {
+        const url = '/some-url'
+        const mockNavItem = {
+          url,
+        }
+        const reqMock = {}
+        const resMock = {
+          locals: {
+            CURRENT_PATH: url,
+          },
+        }
+
+        this.middleware.setLocalNav([mockNavItem], false)(reqMock, resMock, this.nextSpy)
+
+        expect(resMock.locals.localNavItems[0].url).to.equal(url)
+        expect(resMock.locals.localNavItems[0].isActive).to.be.true
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
+    })
+
     context('user permitted nav items', () => {
       it('should include permitted items', () => {
         const reqMock = {

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/controllers.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/controllers.test.js
@@ -39,7 +39,7 @@ describe('D&B Company Subsidiaries', () => {
       it('should render the activity feed template', () => {
         expect(middlewareParams.resMock.render).to.be.calledOnceWithExactly(
           'companies/apps/dnb-subsidiaries/views/client-container', {
-            heading: 'Subsidiaries of Test company',
+            heading: 'Companies related to Test company',
             props: {
               dataEndpoint: urls.companies.dnbSubsidiaries.data('1'),
             },
@@ -54,7 +54,7 @@ describe('D&B Company Subsidiaries', () => {
           'Business details', urls.companies.businessDetails('1'))
 
         expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
-          'Subsidiaries')
+          'Related companies')
       })
 
       it('should not call "next" with an error', async () => {
@@ -145,14 +145,18 @@ describe('D&B Company Subsidiaries', () => {
         expect(middlewareParams.resMock.json).to.be
           .calledOnceWithExactly(
             {
-              count: 1,
+              count: 2,
               results: [{
+                badges: ['United States'],
+                headingText: 'Mars Exports Ltd',
+                headingUrl: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+                metadata: [{ label: 'Sector', value: 'Retail' }, { label: 'Address', value: '12 First Street, New York, 765413, United States' }],
+                subheading: 'Updated on 16 Nov 2017, 11:00am',
+              }, {
                 badges: ['United Kingdom', 'North West'],
                 headingText: 'Mars Components Ltd',
-                headingUrl: urls.companies.detail('731bdcc1-f685-4c8e-bd66-b356b2c16995'),
-                metadata: [
-                  { label: 'Sector', value: 'Retail' },
-                  { label: 'Address', value: '12 Alpha Street, Volcanus, NE28 5AQ, United Kingdom' }],
+                headingUrl: '/companies/731bdcc1-f685-4c8e-bd66-b356b2c16995',
+                metadata: [{ label: 'Sector', value: 'Retail' }, { label: 'Address', value: '12 Alpha Street, Volcanus, NE28 5AQ, United Kingdom' }],
                 subheading: 'Updated on 16 Oct 2017, 12:00pm',
               }],
             }

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/middleware.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/middleware.test.js
@@ -1,0 +1,126 @@
+const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
+const { setSubsidiariesLocalNav } = require('../middleware')
+const urls = require('../../../../../lib/urls')
+
+const buildSubsidiaryMiddlewareParameters = ({
+  reqMock = { baseUrl: '/companies/123/subsidiaries' },
+  features = { 'companies-ultimate-hq': true },
+  company = {
+    id: '123',
+    is_global_ultimate: true,
+    headquarter_type: {
+      name: 'ghq',
+    },
+  },
+  CURRENT_PATH = urls.companies.dnbSubsidiaries.index('123'),
+  permissions = ['company.view_company'],
+}) => buildMiddlewareParameters({
+  reqMock,
+  features,
+  company,
+  CURRENT_PATH,
+  user: {
+    permissions,
+  },
+})
+
+describe('Subsidiaries local navigation', () => {
+  let middlewareParameters
+
+  context('when a company is both Global HQ and Ultimate HQ and the flag is ON', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({})
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should render local nav with D&B hierarchy and manual subsidiaries tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([
+        {
+          'isActive': true,
+          'label': 'Dun & Bradstreet hierarchy',
+          'permissions': [
+            'company.view_company',
+          ],
+          'url': urls.companies.dnbSubsidiaries.index('123'),
+        },
+        {
+          'isActive': false,
+          'label': 'Manually linked subsidiaries',
+          'permissions': [
+            'company.view_company',
+          ],
+          'url': urls.companies.subsidiaries('123'),
+        },
+      ])
+    })
+  })
+
+  context('when the flag is OFF', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({
+        features: {},
+      })
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should not render tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([])
+    })
+  })
+
+  context('when the company is Global HQ but not Ultimate HQ', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({
+        company: {
+          is_global_ultimate: false,
+          headquarter_type: {
+            name: 'ghq',
+          },
+        },
+      })
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should not render tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([])
+    })
+  })
+
+  context('when the company is Ultimate HQ but not Global HQ', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({
+        company: {
+          is_global_ultimate: true,
+          headquarter_type: {
+            name: '',
+          },
+        },
+      })
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should not render tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([])
+    })
+  })
+})

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/repos.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/repos.test.js
@@ -3,27 +3,24 @@ const { getDnbSubsidiaries } = require('../repos')
 const { mockDnbSubsidiariesEndpoint } = require('./utils')
 const subsidiaries = require('../../../../../../test/unit/data/companies/subsidiary-company-search-response')
 
-const token = 'abcd'
+const TOKEN = 'abcd'
+const DUNS_NUMBER = 999999
 
 describe('D&B Subsidiaries repos', () => {
   describe('#getDnbSubsidiaries', () => {
     let actual
-    const DUNS_NUMBER = 999999
 
-    beforeEach(async () => {
+    before(async () => {
       mockDnbSubsidiariesEndpoint({
         globalUltimateSunsNumber: DUNS_NUMBER,
         responseBody: subsidiaries,
       })
 
-      actual = await getDnbSubsidiaries(token, DUNS_NUMBER, config.paginationDefaultSize, 1)
+      actual = await getDnbSubsidiaries(TOKEN, DUNS_NUMBER, config.paginationDefaultSize, 1)
     })
 
     it('should return the one subsidiary', () => {
-      expect(actual).to.deep.equal({
-        count: 1,
-        results: [subsidiaries.results[1]],
-      })
+      expect(actual).to.deep.equal(subsidiaries)
     })
   })
 })

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/transformers.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/transformers.test.js
@@ -1,29 +1,56 @@
 const { transformCompanyToSubsidiariesList } = require('../transformers')
 const urls = require('../../../../../lib/urls')
 
-const companyMock = require('../../../../../../test/unit/data/companies/company-v4')
-
 describe('Edit company form transformers', () => {
   describe('#transformCompanyToSubsidiariesList', () => {
     context('when called with a fully populated company', () => {
-      const actual = transformCompanyToSubsidiariesList(companyMock)
+      const actual = transformCompanyToSubsidiariesList({
+        id: '123',
+        name: 'Test company',
+        sector: {
+          name: 'Test sector',
+        },
+        uk_based: true,
+        uk_region: {
+          name: 'Test UK region',
+        },
+        trading_names: ['Test trading name'],
+        address: {
+          country: {
+            name: 'Test country',
+          },
+        },
+        modified_on: '2016-07-05T12:00:00Z',
+        headquarter_type: {
+          name: 'ghq',
+        },
+        is_global_ultimate: true,
+      })
 
       it('should return transformed values', () => {
         const expected = {
           'badges': [
-            'United Kingdom',
-            'North West',
+            'Test country',
+            'Test UK region',
+            'Global HQ',
+            'Ultimate HQ',
           ],
-          'headingText': 'Mercury Ltd',
-          'headingUrl': urls.companies.detail('a73efeba-8499-11e6-ae22-56b6b6499611'),
+          'headingText': 'Test company',
+          'headingUrl': '/companies/123',
           'metadata': [
             {
+              'label': 'Trading names',
+              'value': [
+                'Test trading name',
+              ],
+            },
+            {
               'label': 'Sector',
-              'value': 'Retail',
+              'value': 'Test sector',
             },
             {
               'label': 'Address',
-              'value': '82 Ramsgate Rd, Willington, NE28 5JB, United Kingdom',
+              'value': 'Test country',
             },
           ],
           'subheading': 'Updated on 5 Jul 2016, 1:00pm',

--- a/src/apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries.jsx
+++ b/src/apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries.jsx
@@ -39,16 +39,20 @@ const DnbSubsidiaries = ({ dataEndpoint }) => {
   }, [activePage])
 
   return (
-    <LoadingBox loading={isLoading}>
-      <CollectionList
-        itemName="subsidiary"
-        items={subsidiaries}
-        totalItems={totalItems}
-        onPageClick={onPageClick}
-        getPageUrl={getPageUrl}
-        activePage={activePage}
-      />
-    </LoadingBox>
+    <>
+      <p>This hierarchy information from Dun & Bradstreet cannot be edited.</p>
+
+      <LoadingBox loading={isLoading}>
+        <CollectionList
+          itemName="related company"
+          items={subsidiaries}
+          totalItems={totalItems}
+          onPageClick={onPageClick}
+          getPageUrl={getPageUrl}
+          activePage={activePage}
+        />
+      </LoadingBox>
+    </>
   )
 }
 

--- a/src/apps/companies/apps/dnb-subsidiaries/controllers.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/controllers.js
@@ -16,9 +16,9 @@ async function renderDnbSubsidiaries (req, res, next) {
     res
       .breadcrumb(company.name, urls.companies.detail(company.id))
       .breadcrumb('Business details', urls.companies.businessDetails(company.id))
-      .breadcrumb('Subsidiaries')
+      .breadcrumb('Related companies')
       .render('companies/apps/dnb-subsidiaries/views/client-container', {
-        heading: `Subsidiaries of ${company.name}`,
+        heading: `Companies related to ${company.name}`,
         props: {
           dataEndpoint: urls.companies.dnbSubsidiaries.data(company.id),
         },

--- a/src/apps/companies/apps/dnb-subsidiaries/middleware.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/middleware.js
@@ -1,0 +1,36 @@
+/* eslint-disable camelcase */
+
+const { setLocalNav } = require('../../../middleware')
+const urls = require('../../../../lib/urls')
+
+function setSubsidiariesLocalNav (req, res, next) {
+  const { company, features } = res.locals
+
+  const isGlobalHQ = company.headquarter_type && company.headquarter_type.name === 'ghq'
+
+  if (features['companies-ultimate-hq'] && company.is_global_ultimate && isGlobalHQ) {
+    const navItems = [
+      {
+        url: urls.companies.dnbSubsidiaries.index(company.id),
+        label: 'Dun & Bradstreet hierarchy',
+        permissions: [
+          'company.view_company',
+        ],
+      },
+      {
+        url: urls.companies.subsidiaries(company.id),
+        label: 'Manually linked subsidiaries',
+        permissions: [
+          'company.view_company',
+        ],
+      },
+    ]
+    setLocalNav(navItems, false)(req, res, next)
+  } else {
+    setLocalNav()(req, res, next)
+  }
+}
+
+module.exports = {
+  setSubsidiariesLocalNav,
+}

--- a/src/apps/companies/apps/dnb-subsidiaries/repos.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/repos.js
@@ -1,18 +1,11 @@
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 const config = require('../../../../config')
 
-function excludeGlobalUltimate (globalUltimateDunsNumber, response) {
-  return {
-    count: response.count - 1,
-    results: response.results.filter(c => c.duns_number !== globalUltimateDunsNumber + ''),
-  }
-}
-
-async function getDnbSubsidiaries (token, dunsNumber, limit, page) {
+function getDnbSubsidiaries (token, dunsNumber, limit, page) {
   const parsedPage = parseInt(page, 10) || 1
   const offset = limit * (parsedPage - 1)
 
-  const response = await authorisedRequest(token, {
+  return authorisedRequest(token, {
     url: `${config.apiRoot}/v4/company`,
     qs: {
       limit,
@@ -21,8 +14,6 @@ async function getDnbSubsidiaries (token, dunsNumber, limit, page) {
       global_ultimate_duns_number: dunsNumber,
     },
   })
-
-  return excludeGlobalUltimate(dunsNumber, response)
 }
 
 module.exports = {

--- a/src/apps/companies/apps/dnb-subsidiaries/transformers.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/transformers.js
@@ -15,6 +15,7 @@ function transformCompanyToSubsidiariesList ({
   address,
   modified_on,
   headquarter_type,
+  is_global_ultimate,
 } = {}) {
   if (!id) { return }
 
@@ -45,6 +46,10 @@ function transformCompanyToSubsidiariesList ({
 
   if (headquarter_type) {
     badges.push(labels.hqLabels[get(headquarter_type, 'name')])
+  }
+
+  if (is_global_ultimate) {
+    badges.push(labels.companyDetailsLabels.ultimate_hq)
   }
 
   if (address) {

--- a/src/apps/companies/apps/dnb-subsidiaries/views/client-container.njk
+++ b/src/apps/companies/apps/dnb-subsidiaries/views/client-container.njk
@@ -1,5 +1,15 @@
 {% extends "_layouts/template.njk" %}
 
+{% block local_nav %}
+  {% if localNavItems.length > 0 %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ TabbedLocalNav({ items: localNavItems }) }}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block body_main_content %}
   {% component 'react-slot', {
     id: 'dnb-subsidiaries',

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -7,6 +7,7 @@ const companyDetailsLabels = {
   uk_region: 'UK region',
   headquarter_type: 'Headquarter type',
   global_headquarters: 'Global HQ',
+  ultimate_hq: 'Ultimate HQ',
   sector: 'Sector',
   website: 'Website',
   description: 'Business description',

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -45,6 +45,7 @@ const { getCompany, setIsCompanyAlreadyAdded, setDoAnyListsExist, addCompanyOrRe
 const { setInteractionsDetails } = require('./middleware/interactions')
 const { setGlobalHQ, removeGlobalHQ, addSubsidiary } = require('./middleware/hierarchies')
 const setCompaniesLocalNav = require('./middleware/local-navigation')
+const { setSubsidiariesLocalNav } = require('./apps/dnb-subsidiaries/middleware')
 const lastInteractionDate = require('./middleware/last-interaction-date')
 
 const { transformCompanyToListItem } = require('./transformers')
@@ -107,6 +108,7 @@ router.get('/:companyId/hierarchies/ghq/remove', removeGlobalHQ)
 router.get('/:companyId/hierarchies/subsidiaries/search', getSubsidiaryCompaniesCollection, renderLinkSubsidiary)
 router.get('/:companyId/hierarchies/subsidiaries/:subsidiaryCompanyId/add', addSubsidiary)
 
+router.use(urls.companies.dnbSubsidiaries.index.route, setSubsidiariesLocalNav)
 router.get(urls.companies.dnbSubsidiaries.index.route, dnbSubsidiariesControllers.renderDnbSubsidiaries)
 router.get(urls.companies.dnbSubsidiaries.data.route, dnbSubsidiariesControllers.fetchSubsidiariesHandler)
 
@@ -118,8 +120,11 @@ router.get('/:companyId/contacts',
 )
 
 router.get(urls.companies.exports.route, renderExports)
+
+router.use('/:companyId/subsidiaries', setSubsidiariesLocalNav)
 router.get('/:companyId/subsidiaries', renderSubsidiaries)
 router.get('/:companyId/subsidiaries/link', renderLinkSubsidiary)
+
 router.get('/:companyId/orders', renderOrders)
 router.get('/:companyId/audit', renderAuditLog)
 router.get('/:companyId/documents', renderDocuments)

--- a/src/apps/companies/views/subsidiaries.njk
+++ b/src/apps/companies/views/subsidiaries.njk
@@ -1,10 +1,28 @@
 {% extends "_layouts/template.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ heading: heading }) %}{% endcall %}
+  {{ LocalHeader({
+    heading: heading,
+    modifier: 'light-banner',
+    fullWidthContent: true
+  }) }}
+{% endblock %}
+
+{% block local_nav %}
+  {% if localNavItems.length > 0 %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ TabbedLocalNav({ items: localNavItems }) }}
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block body_main_content %}
+
+  <p>
+    This hierarchy information is manually recorded (linked) by Data Hub users. This means it can be different from the Dun & Bradstreet hierarchy, which in the future will replace this manually recorded information.
+  </p>
 
   {% if company.archived %}
     {{ govukDetails({

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -31,7 +31,7 @@
       <div class="c-local-header__description">
         {% if isUltimate %}
           {% set link =  props.subsidiaryCount + ' other company ' + 'record' | pluralise(props.subsidiaryCount) %}
-          <p>Data Hub contains <a class="subsidiaries" href={{ urls.companies.subsidiaries(company.id) }}>{{ link }}</a> related to this company</p>
+          <p>Data Hub contains <a class="subsidiaries" href={{ urls.companies.dnbSubsidiaries.index(company.id) }}>{{ link }}</a> related to this company</p>
         {% endif %}
         {% if isOneListTier %}
           <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -1,6 +1,7 @@
 const { get, isEmpty, assign, intersection, isUndefined } = require('lodash')
 const queryString = require('qs')
 const { parse } = require('url')
+const path = require('path')
 
 const { filterNonPermittedItem } = require('../modules/permissions/filters')
 
@@ -46,15 +47,16 @@ function handleRoutePermissions (routes) {
   }
 }
 
-function setLocalNav (items = []) {
+function setLocalNav (items = [], appendBaseUrl = true) {
   return function buildLocalNav (req, res, next) {
     const userPermissions = get(res, 'locals.user.permissions')
+    const { CURRENT_PATH } = res.locals
 
     res.locals.localNavItems = items
       .filter(filterNonPermittedItem(userPermissions))
       .map((item) => {
-        const url = item.isExternal ? item.url : `${req.baseUrl}/${item.path}`
-        const isActive = res.locals.CURRENT_PATH === url || res.locals.CURRENT_PATH.startsWith(`${url}/`)
+        const url = item.isExternal || !appendBaseUrl ? item.url : path.join(req.baseUrl || '', item.path)
+        const isActive = CURRENT_PATH === url || CURRENT_PATH.startsWith(`${url}/`)
         return assign({}, item, {
           url,
           isActive,

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -68,6 +68,8 @@ describe('urls', () => {
       expect(urls.companies.interactions.create.route).to.equal(`/interactions/:interactionId?/create`)
       expect(urls.companies.interactions.create(companyId)).to.equal(`/companies/${companyId}/interactions/create`)
       expect(urls.companies.interactions.create(companyId, interactionId)).to.equal(`/companies/${companyId}/interactions/${interactionId}/create`)
+
+      expect(urls.companies.orders(companyId)).to.equal(`/companies/${companyId}/orders`)
     })
   })
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -94,6 +94,7 @@ module.exports = {
     index: url('/companies'),
     subsidiaries: url('/companies', '/:companyId/subsidiaries'),
     interactions: createInteractionsSubApp('/companies', '/:companyId'),
+    orders: url('/companies', '/:companyId/orders'),
   },
   contacts: {
     index: url('/contacts'),

--- a/test/functional/cypress/fixtures/company/dnb-global-ultimate-and-global-hq.json
+++ b/test/functional/cypress/fixtures/company/dnb-global-ultimate-and-global-hq.json
@@ -1,0 +1,4 @@
+{
+  "id": "0418f79f-154b-4f55-85a6-8ddad559663e",
+  "name": "DnB Global Ultimate & Global HQ"
+}

--- a/test/functional/cypress/fixtures/default.json
+++ b/test/functional/cypress/fixtures/default.json
@@ -1,4 +1,4 @@
  {
-  "id": "375094ac-f79a-43e5-9c88-059a7caa17f0",
+  "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018",
   "name": "Default mocked response"
 }

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -7,6 +7,7 @@ module.exports = {
     dnbCorp: require('./company/dnb-corp.json'),
     dnbLtd: require('./company/dnb-ltd.json'),
     dnbGlobalUltimate: require('./company/dnb-global-ultimate.json'),
+    dnBGlobalUltimateAndGlobalHq: require('./company/dnb-global-ultimate-and-global-hq.json'),
     investigationLimited: require('./company/investigation-limited'),
     lambdaPlc: require('./company/lambda-plc'),
     marsExportsLtd: require('./company/mars-exports-ltd'),

--- a/test/functional/cypress/specs/companies/dnb-subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-subsidiaries-spec.js
@@ -1,16 +1,22 @@
 const { assertLocalHeader, assertBreadcrumbs } = require('../../support/assertions')
+const { assertLocalNav } = require('../../../../end-to-end/cypress/support/assertions')
 
-const { company: { dnbGlobalUltimate } } = require('../../fixtures')
+const selectors = require('../../../../selectors')
+const { company: { dnbGlobalUltimate, dnBGlobalUltimateAndGlobalHq } } = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
 
 describe('D&B Company subsidiaries', () => {
-  context('when viewing subsidiaries for a Dun & Bradstreet company', () => {
+  context('when viewing subsidiaries for a D&B Global Ultimate', () => {
     before(() => {
       cy.visit(urls.companies.dnbSubsidiaries.index(dnbGlobalUltimate.id))
     })
 
     it('should render the header', () => {
-      assertLocalHeader('Subsidiaries of DnB Global Ultimate')
+      assertLocalHeader('Companies related to DnB Global Ultimate')
+    })
+
+    it('should render the helper text', () => {
+      cy.get('p').should('contain', 'This hierarchy information from Dun & Bradstreet cannot be edited.')
     })
 
     it('should render breadcrumbs', () => {
@@ -19,19 +25,49 @@ describe('D&B Company subsidiaries', () => {
         'Companies': urls.companies.index(),
         [dnbGlobalUltimate.name]: urls.companies.detail(dnbGlobalUltimate.id),
         'Business details': urls.companies.businessDetails(dnbGlobalUltimate.id),
-        'Subsidiaries': null,
+        'Related companies': null,
       })
     })
 
-    it('should render subsidiaries', () => {
+    it('should render related companies', () => {
       cy.get('#dnb-subsidiaries')
-        .should('contain', '1 subsidiary')
+        .should('contain', '2 related companies')
+        .and('contain', 'DnB Global Ultimate')
+        .and('contain', 'DnB Global Ultimate subsidiary')
+    })
+  })
+
+  context('when viewing subsidiaries for a D&B Global Ultimate which is also Global HQ', () => {
+    before(() => {
+      cy.visit(urls.companies.dnbSubsidiaries.index(dnBGlobalUltimateAndGlobalHq.id))
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Companies related to DnB Global Ultimate')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [dnBGlobalUltimateAndGlobalHq.name]: urls.companies.detail(dnBGlobalUltimateAndGlobalHq.id),
+        'Business details': urls.companies.businessDetails(dnBGlobalUltimateAndGlobalHq.id),
+        'Related companies': null,
+      })
+    })
+
+    it('should render related companies', () => {
+      cy.get('#dnb-subsidiaries')
+        .should('contain', '2 related companies')
+        .and('contain', 'DnB Global Ultimate')
         .and('contain', 'DnB Global Ultimate subsidiary')
     })
 
-    it('should not include Global Ultimate', () => {
-      cy.get('#dnb-subsidiaries')
-        .should('not.contain', '1700 Amphitheatre Way')
+    it('should display the local nav', () => {
+      assertLocalNav(selectors.tabbedLocalNav().tabs, [
+        'Dun & Bradstreet hierarchy',
+        'Manually linked subsidiaries',
+      ])
     })
   })
 })

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -1,9 +1,10 @@
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
+const urls = require('../../../../../src/lib/urls')
 
 describe('Company OMIS Collections', () => {
   before(() => {
-    cy.visit(`/companies/${fixtures.default.id}/orders`)
+    cy.visit(urls.companies.orders(fixtures.company.oneListCorp.id))
   })
 
   it('should display a list of orders with the total result', () => {

--- a/test/functional/cypress/specs/companies/subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-spec.js
@@ -1,20 +1,21 @@
-import { assertBreadcrumbs } from '../../support/assertions'
-
+const { assertBreadcrumbs } = require('../../support/assertions')
+const urls = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
+const { assertLocalNav } = require('../../../../end-to-end/cypress/support/assertions')
 
 describe('Companies subsidiaries', () => {
   context('when viewing subsidiaries for a Dun & Bradstreet company', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.oneListCorp.id}/subsidiaries`)
+      cy.visit(urls.companies.subsidiaries(fixtures.company.oneListCorp.id))
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
-        'Home': '/',
-        'Companies': '/companies',
-        [fixtures.company.oneListCorp.name]: `/companies/${fixtures.company.oneListCorp.id}`,
-        'Business details': `/companies/${fixtures.company.oneListCorp.id}/business-details`,
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.oneListCorp.name]: urls.companies.detail(fixtures.company.oneListCorp.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.oneListCorp.id),
         'Subsidiaries': null,
       })
     })
@@ -26,15 +27,15 @@ describe('Companies subsidiaries', () => {
 
   context('when viewing subsidiaries for a Data Hub company', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.venusLtd.id}/subsidiaries`)
+      cy.visit(urls.companies.subsidiaries(fixtures.company.venusLtd.id))
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
-        'Home': '/',
-        'Companies': '/companies',
-        [fixtures.company.venusLtd.name]: `/companies/${fixtures.company.venusLtd.id}`,
-        'Business details': `/companies/${fixtures.company.venusLtd.id}/business-details`,
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.venusLtd.name]: urls.companies.detail(fixtures.company.venusLtd.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.venusLtd.id),
         'Subsidiaries': null,
       })
     })
@@ -46,21 +47,51 @@ describe('Companies subsidiaries', () => {
 
   context('when viewing subsidiaries for an archived company', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.archivedLtd.id}/subsidiaries`)
+      cy.visit(urls.companies.subsidiaries(fixtures.company.archivedLtd.id))
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
-        'Home': '/',
-        'Companies': '/companies',
-        [fixtures.company.archivedLtd.name]: `/companies/${fixtures.company.archivedLtd.id}`,
-        'Business details': `/companies/${fixtures.company.archivedLtd.id}/business-details`,
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.archivedLtd.name]: urls.companies.detail(fixtures.company.archivedLtd.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.archivedLtd.id),
         'Subsidiaries': null,
       })
     })
 
     it('should display the "Why can I not link a subsidiary?" archived details summary', () => {
       cy.get(selectors.companySubsidiaries().whyArchived).should('be.visible')
+    })
+  })
+
+  context('when viewing a company which is a D&B Global Ultimate and Global HQ at the same time', () => {
+    before(() => {
+      cy.visit(urls.companies.subsidiaries(fixtures.company.dnBGlobalUltimateAndGlobalHq.id))
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.dnBGlobalUltimateAndGlobalHq.name]: urls.companies.detail(fixtures.company.dnBGlobalUltimateAndGlobalHq.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.dnBGlobalUltimateAndGlobalHq.id),
+        'Subsidiaries': null,
+      })
+    })
+
+    it('should display tabs for two types of hierarchies', () => {
+      assertLocalNav(selectors.tabbedLocalNav().tabs, [
+        'Dun & Bradstreet hierarchy',
+        'Manually linked subsidiaries',
+      ])
+    })
+
+    it('should render the helper text', () => {
+      cy.get('p').should('contain',
+        'This hierarchy information is manually recorded (linked) by Data Hub users. ' +
+        'This means it can be different from the Dun & Bradstreet hierarchy, ' +
+        'which in the future will replace this manually recorded information.')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Display D&B and DH hierarchies alongside.

## Test instructions

1. Go to the subsidiaries page of a company which is both D&B Global Ultimate and Global HQ (manually linked).
2. Check if the tabs are visible
 
## Screenshots
### Before

![image](https://user-images.githubusercontent.com/4199239/68934647-f7101c00-078e-11ea-8067-c59255b4aa5e.png)


### After 

![image](https://user-images.githubusercontent.com/4199239/68934622-e6f83c80-078e-11ea-9508-8df9705c9690.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
