### PR TITLE
Expand urls module to work for sub apps of sub apps

### DIFF
--- a/src/apps/interactions/router.sub-app.js
+++ b/src/apps/interactions/router.sub-app.js
@@ -8,6 +8,7 @@ const { renderInteractionsForEntity } = require('./controllers/list')
 const { postDetails, getInteractionDetails } = require('./middleware/details')
 const { getInteractionsRequestBody, getInteractionCollectionForEntity, getInteractionSortForm } = require('./middleware/collection')
 const { detectUserAgent } = require('../../middleware/detect-useragent')
+const urls = require('../../lib/urls')
 
 router.param('interactionId', getInteractionDetails)
 
@@ -19,7 +20,7 @@ router.get('/interactions',
 )
 
 router
-  .route([ '/interactions/create', '/interactions/:interactionId/create' ])
+  .route(urls.interactions.subapp.create.route)
   .post(
     postCreate,
     renderCreate,

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -34,13 +34,17 @@ describe('urls', () => {
       companyId = faker.random.uuid()
     })
     it('should return the correct values', () => {
+      expect(urls.companies.index.mountPoint).to.equal('/companies')
+      expect(urls.companies.index.route).to.equal('/')
+      expect(urls.companies.index()).to.equal('/companies')
+
+      expect(urls.companies.detail.route).to.equal('/:companyId')
+      expect(urls.companies.detail(companyId)).to.equal(`/companies/${companyId}`)
+
       expect(urls.companies.activity.data(companyId)).to.equal(`/companies/${companyId}/activity/data`)
       expect(urls.companies.activity.index(companyId)).to.equal(`/companies/${companyId}/activity`)
 
       expect(urls.companies.advisers(companyId)).to.equal(`/companies/${companyId}/advisers`)
-
-      expect(urls.companies.detail.route).to.equal('/:companyId')
-      expect(urls.companies.detail(companyId)).to.equal(`/companies/${companyId}`)
 
       expect(urls.companies.dnbSubsidiaries.index.route).to.equal('/:companyId/dnb-subsidiaries')
       expect(urls.companies.dnbSubsidiaries.index(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries`)
@@ -51,17 +55,16 @@ describe('urls', () => {
       expect(urls.companies.exports.route).to.equal('/:companyId/exports')
       expect(urls.companies.exports(companyId)).to.equal(`/companies/${companyId}/exports`)
 
+      expect(urls.companies.subsidiaries(companyId)).to.equal(`/companies/${companyId}/subsidiaries`)
+
       const globalHqId = faker.random.uuid()
       expect(urls.companies.hierarchies.ghq.add.route).to.equal('/:companyId/hierarchies/ghq/:globalHqId/add')
       expect(urls.companies.hierarchies.ghq.add(companyId, globalHqId)).to.equal(`/companies/${companyId}/hierarchies/ghq/${globalHqId}/add`)
 
-      expect(urls.companies.index.mountPoint).to.equal('/companies')
-      expect(urls.companies.index.route).to.equal('/')
-      expect(urls.companies.index()).to.equal('/companies')
-
+      const interactionId = faker.random.uuid()
+      expect(urls.companies.interactions.create.route).to.equal(`/interactions/:interactionId?/create`)
       expect(urls.companies.interactions.create(companyId)).to.equal(`/companies/${companyId}/interactions/create`)
-
-      expect(urls.companies.subsidiaries(companyId)).to.equal(`/companies/${companyId}/subsidiaries`)
+      expect(urls.companies.interactions.create(companyId, interactionId)).to.equal(`/companies/${companyId}/interactions/${interactionId}/create`)
     })
   })
 
@@ -70,11 +73,14 @@ describe('urls', () => {
       expect(urls.contacts.index.mountPoint).to.equal('/contacts')
       expect(urls.contacts.index.route).to.equal('/')
       expect(urls.contacts.index()).to.equal('/contacts')
+
+      const contactId = faker.random.uuid()
+      expect(urls.contacts.interactions.create(contactId)).to.equal(`/contacts/${contactId}/interactions/create`)
     })
   })
 
   describe('search', () => {
-    it('should return the correct values ', () => {
+    it('should return the correct values', () => {
       expect(urls.search.index.mountPoint).to.equal('/search')
       expect(urls.search.index.route).to.equal('/')
       expect(urls.search.index()).to.equal('/search')
@@ -82,6 +88,15 @@ describe('urls', () => {
       const type = faker.lorem.word()
       expect(urls.search.type.route).to.equal('/:searchPath?')
       expect(urls.search.type(type)).to.equal(`/search/${type}`)
+    })
+  })
+
+  describe('interactions', () => {
+    describe('subapp', () => {
+      it('should return the correct values', () => {
+        expect(urls.interactions.subapp.create.mountPoint).to.equal(null)
+        expect(urls.interactions.subapp.create.route).to.equal('/interactions/:interactionId?/create')
+      })
     })
   })
 })


### PR DESCRIPTION
## Description of change

After picking up some work for interactions I noticed that there is a `router.sub-app` which means that the app becomes an app for another sub app, so this creates an issue for mountPoints and routes.

After pairing on this with @ian-leggett we have this proposal to ensure the `urls` module works for these scenarios whilst reducing duplication.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
