### PR TITLE
Improve wdio image diff cli and add package script to update baselines

### DIFF
--- a/docs/How to execute tests.md
+++ b/docs/How to execute tests.md
@@ -75,4 +75,4 @@ Updating the baseline consists in 2 steps:
 
 - 1:. Run the visual tests on your machine, if the baseline is no longer the correct representation of the page in test then execute step #2:
 
-- 2:. Run `wdio-image-diff -u` this will copy the comparison images over to the baseline folder, updating any baseline image that is no longer valid.
+- 2:. Run `$ yarn test:visual:update` to update the failed tests with updated images of how the page in test should look like.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:e2e:dit": "CYPRESS_integrationFolder=test/end-to-end/cypress/specs/DIT cypress run",
     "test:e2e:watch": "CYPRESS_integrationFolder=test/end-to-end/cypress/specs cypress open",
     "test:visual": "./node_modules/.bin/wdio test/visual/wdio.conf.js",
+    "test:visual:update": "wdio-image-diff -u",
     "coverage": "nyc --reporter=html --reporter=text --reporter=lcov npm run test:unit",
     "circle:unit": "nyc --reporter=lcov npm run test:unit -- --reporter mocha-circleci-reporter && codeclimate-test-reporter < coverage/lcov.info",
     "circle:unit-client": "mocha-webpack --webpack-config webpack.config.js ./test/unit-client/assets/javascripts/**/*.test.js --opts ./test/unit-client/mocha.opts --reporter mocha-circleci-reporter ./test/unit-client/assets/javascripts/**/*.test.js",
@@ -146,7 +147,7 @@
   },
   "devDependencies": {
     "@uktrade/client-matrix-js": "^1.0.38",
-    "@uktrade/wdio-image-diff-js": "1.0.173",
+    "@uktrade/wdio-image-diff-js": "1.0.180",
     "@vue/test-utils": "^1.0.0-beta.25",
     "@wdio/browserstack-service": "^5.9.3",
     "@wdio/cli": "5.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,10 +1523,10 @@
   resolved "https://registry.yarnpkg.com/@uktrade/datahub-header/-/datahub-header-1.2.0.tgz#45c380eb18c40994d5a0fc36a25cce1a942dbb0c"
   integrity sha512-OhzrnEuppfRbi3z+QZhbVKLQgwE3CCsG5dNQCz1WnQcqUDRJHvuqJJdGzDlEmnlJvUSwQn3ruyhs4BvKYDgKJw==
 
-"@uktrade/wdio-image-diff-js@1.0.173":
-  version "1.0.173"
-  resolved "https://registry.yarnpkg.com/@uktrade/wdio-image-diff-js/-/wdio-image-diff-js-1.0.173.tgz#c7f410c4645eebf2586b6e3900fda53c7c9ac6bd"
-  integrity sha512-D8db4d4e4imUl9gKkj5AB4HAcIs0ifbPcNHvAIur+XyuZGo02XjmwM9gnbftlKRkxbBgIUJVMXqie9SBK6RA9A==
+"@uktrade/wdio-image-diff-js@1.0.180":
+  version "1.0.180"
+  resolved "https://registry.yarnpkg.com/@uktrade/wdio-image-diff-js/-/wdio-image-diff-js-1.0.180.tgz#cc23cbe5a0bb9b52de49c40b687ee38f864f8cfa"
+  integrity sha512-C30EWSrNhED7qQSfpYOJmEhOYMoJy+b7vDbehVnckoLW/ia5VNGdPlQzuIaFvZa7i5denIS1W+2TecEvjO6UIg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     arg "^4.1.1"


### PR DESCRIPTION
## Description of change

bumped up the wdio image diff version to allow using the improved cli to update the baselines

## Test instructions

`yarn test:visual:update`

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
