### PR TITLE
Add Ultimate HQ subsidiaries filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^2.14.0",
+    "data-hub-components": "^2.18.0",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/activity-feed/__test__/repos.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/repos.test.js
@@ -1,136 +1,63 @@
 const config = require('~/src/config')
 const activityFeedRawFixture = require('~/test/unit/data/activity-feed/activity-feed-from-es')
-
-const { ACTIVITY_TYPE_FILTER_KEYS, ACTIVITY_TYPE_FILTER_OBJECT } = require('../../../constants')
-
-const token = 'abcd'
+const { ES_KEYS_GROUPED } = require('../constants')
 
 describe('Activity feed repos', () => {
-  beforeEach(() => {
-    this.authorisedRequestStub = sinon.stub().resolves(activityFeedRawFixture)
-    this.repos = proxyquire('../../src/apps/companies/apps/activity-feed/repos', {
-      '../../../../lib/authorised-request': { authorisedRequest: this.authorisedRequestStub },
-    })
-  })
-
   describe('#fetchActivityFeed', () => {
-    context('when called with companyId', () => {
-      beforeEach(async () => {
-        this.results = await this.repos.fetchActivityFeed(
-          { token,
-            from: 1,
-            size: 21,
-            filter: {
-              terms: {
-                [ACTIVITY_TYPE_FILTER_OBJECT.TYPE]: ACTIVITY_TYPE_FILTER_KEYS.dataHubActivity.value,
-              },
-            },
-            companyId: '123',
-          })
-      })
-
-      it('should make a request with company ID in the request body', () => {
-        const expectedBody = {
-          from: 1,
-          query: {
-            bool: {
-              filter: [
-                { term: { [ACTIVITY_TYPE_FILTER_OBJECT.ATTRIBUTED_TO_ID]: 'dit:DataHubCompany:123' } },
-                { terms: { [ACTIVITY_TYPE_FILTER_OBJECT.TYPE]: ACTIVITY_TYPE_FILTER_KEYS.dataHubActivity.value } },
-              ],
-            },
-          },
-          size: 21,
-          sort: { 'object.startTime': 'desc' },
-        }
-        expect(this.authorisedRequestStub).to.be.calledOnceWith(token, {
-          body: expectedBody,
-          url: `${config.apiRoot}/v4/activity-feed`,
-        })
-      })
-
-      it('should return results', async () => {
-        expect(this.results).to.be.equal(activityFeedRawFixture)
-      })
+    const authorisedRequestStub = sinon.stub().resolves(activityFeedRawFixture)
+    const repos = proxyquire('../../src/apps/companies/apps/activity-feed/repos', {
+      '../../../../lib/authorised-request': { authorisedRequest: authorisedRequestStub },
     })
 
-    context('when called without companyId', () => {
-      beforeEach(async () => {
-        this.results = await this.repos.fetchActivityFeed(
-          { token,
-            from: 0,
-            size: 20,
-            filter: {
-              terms: {
-                [ACTIVITY_TYPE_FILTER_OBJECT.TYPE]: ACTIVITY_TYPE_FILTER_KEYS.dataHubActivity.value,
+    context('when called with filters', () => {
+      const { dataHubActivity } = ES_KEYS_GROUPED
+      let filter, results
+      const token = 'abcd'
+
+      before(async () => {
+        filter = [
+          {
+            terms: {
+              'object.type': dataHubActivity,
+            },
+          },
+          {
+            terms: {
+              'object.attributedTo.id': ['dit:DataHubCompany:123'],
+            },
+          },
+        ]
+
+        results = await repos.fetchActivityFeed({
+          token,
+          from: 0,
+          size: 20,
+          filter,
+        })
+      })
+
+      it('should make a request including the filters', () => {
+        expect(authorisedRequestStub).to.be.calledOnceWith(
+          token,
+          {
+            body: {
+              from: 0,
+              size: 20,
+              query: {
+                bool: {
+                  filter,
+                },
+              },
+              sort: {
+                'object.startTime': 'desc',
               },
             },
+            url: `${config.apiRoot}/v4/activity-feed`,
           })
       })
 
-      it('should make a request without company ID in the request body', () => {
-        const expectedBody = {
-          from: 0,
-          size: 20,
-          sort: { 'object.startTime': 'desc' },
-          query: {
-            bool: {
-              filter: [
-                { term: { [ACTIVITY_TYPE_FILTER_OBJECT.ATTRIBUTED_TO_ID]: 'dit:DataHubCompany:undefined' } },
-                { terms: { [ACTIVITY_TYPE_FILTER_OBJECT.TYPE]: ACTIVITY_TYPE_FILTER_KEYS.dataHubActivity.value } },
-              ],
-            },
-          },
-        }
-        expect(this.authorisedRequestStub).to.be.calledOnceWith(token, {
-          body: expectedBody,
-          url: `${config.apiRoot}/v4/activity-feed`,
-        })
-      })
-
       it('should return results', async () => {
-        expect(this.results).to.be.equal(activityFeedRawFixture)
-      })
-    })
-
-    context('when multiple filter items are applied', () => {
-      beforeEach(async () => {
-        this.results = await this.repos.fetchActivityFeed(
-          { token,
-            from: 0,
-            size: 20,
-            filter: [
-              { terms: {
-                [ACTIVITY_TYPE_FILTER_OBJECT.TYPE]: ACTIVITY_TYPE_FILTER_KEYS.dataHubActivity.value,
-              } },
-              { term: { [ACTIVITY_TYPE_FILTER_OBJECT.ATTRIBUTED_TO_ID]: 'dit:randomPrefix:stuff' } },
-            ],
-          })
-      })
-
-      it('should make a request with multiple filters in the request body', () => {
-        const expectedBody = {
-          from: 0,
-          size: 20,
-          sort: { 'object.startTime': 'desc' },
-          query: {
-            bool: {
-              filter: [
-                { term: { [ACTIVITY_TYPE_FILTER_OBJECT.ATTRIBUTED_TO_ID]: 'dit:DataHubCompany:undefined' } },
-                { terms: { [ACTIVITY_TYPE_FILTER_OBJECT.TYPE]: ACTIVITY_TYPE_FILTER_KEYS.dataHubActivity.value } },
-                { term: { 'object.attributedTo.id': 'dit:randomPrefix:stuff' } },
-              ],
-            },
-          },
-        }
-        expect(this.authorisedRequestStub).to.be.calledOnceWith(token, {
-          body: expectedBody,
-          url: `${config.apiRoot}/v4/activity-feed`,
-        })
-      })
-
-      it('should return results', async () => {
-        expect(this.results).to.be.equal(activityFeedRawFixture)
+        expect(results).to.be.equal(activityFeedRawFixture)
       })
     })
   })

--- a/src/apps/companies/apps/activity-feed/__test__/translators.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/translators.test.js
@@ -1,0 +1,64 @@
+const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
+const { convertQueryTypes } = require('../translators')
+
+describe('Converting query String types', () => {
+  let middlewareParameters
+
+  context('should cast the types when the values are defined', () => {
+    before(() => {
+      middlewareParameters = buildMiddlewareParameters({
+        requestQuery: {
+          from: '0',
+          size: '20',
+          activityTypeFilter: 'allActivity',
+          showDnbHierarchy: 'false',
+        },
+      })
+
+      convertQueryTypes(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should cast the types', () => {
+      expect(middlewareParameters.reqMock.query).to.deep.equal({
+        from: 0,
+        size: 20,
+        activityTypeFilter: 'allActivity',
+        showDnbHierarchy: false,
+      })
+    })
+
+    it('call next', () => {
+      expect(middlewareParameters.nextSpy).to.have.been.calledOnce
+    })
+  })
+
+  context('should not cast the types when the values are undefined', () => {
+    before(() => {
+      middlewareParameters = buildMiddlewareParameters({
+        requestQuery: {
+          activityTypeFilter: 'allActivity',
+        },
+      })
+
+      convertQueryTypes(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should not cast the types', () => {
+      expect(middlewareParameters.reqMock.query).to.deep.equal({
+        activityTypeFilter: 'allActivity',
+      })
+    })
+
+    it('call next', () => {
+      expect(middlewareParameters.nextSpy).to.have.been.calledOnce
+    })
+  })
+})

--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -1,0 +1,73 @@
+const ES_KEYS = {
+  companiesHouseAccount: 'dit:Accounts',
+  companiesHouseCompany: 'dit:Company',
+  hmrcExporter: 'dit:Export',
+  interaction: 'dit:Interaction',
+  serviceDelivery: 'dit:ServiceDelivery',
+  investmentProject: 'dit:InvestmentProject',
+  omis: 'dit:OMISOrder',
+  type: 'object.type',
+  attributedTo: 'object.attributedTo.id',
+}
+
+const ES_KEYS_GROUPED = {
+  allActivity: [
+    ES_KEYS.companiesHouseAccount,
+    ES_KEYS.companiesHouseCompany,
+    ES_KEYS.hmrcExporter,
+    ES_KEYS.interaction, // Interaction
+    ES_KEYS.serviceDelivery, // Interaction
+    ES_KEYS.investmentProject,
+    ES_KEYS.omis,
+  ],
+
+  externalActivity: [
+    ES_KEYS.companiesHouseAccount,
+    ES_KEYS.companiesHouseCompany,
+    ES_KEYS.hmrcExporter,
+  ],
+
+  dataHubActivity: [
+    ES_KEYS.interaction, // Interaction
+    ES_KEYS.serviceDelivery, // Interaction
+    ES_KEYS.investmentProject,
+    ES_KEYS.omis,
+  ],
+}
+
+const FILTER_KEYS = {
+  allActivity: 'allActivity',
+  myActivity: 'myActivity',
+  externalActivity: 'externalActivity',
+  dataHubActivity: 'dataHubActivity',
+  ultimateHQSubsidiaries: 'ultimateHQSubsidiaries',
+}
+
+const FILTER_ITEMS = {
+  allActivity: {
+    label: 'All Data Hub & external activity',
+    value: FILTER_KEYS.allActivity,
+  },
+
+  externalActivity: {
+    label: 'All external activity',
+    value: FILTER_KEYS.externalActivity,
+  },
+
+  myActivity: {
+    label: 'My activity',
+    value: FILTER_KEYS.myActivity,
+  },
+
+  dataHubActivity: {
+    label: 'All Data Hub activity',
+    value: FILTER_KEYS.dataHubActivity,
+  },
+}
+
+module.exports = {
+  ES_KEYS,
+  FILTER_KEYS,
+  FILTER_ITEMS,
+  ES_KEYS_GROUPED,
+}

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -1,24 +1,22 @@
 const config = require('../../../../config')
 const { authorisedRequest } = require('../../../../lib/authorised-request')
-const { buildActivityFeedFilters } = require('./builders')
 
 function fetchActivityFeed ({
   token,
-  size = config.activityFeed.paginationSize,
-  from = 0,
-  companyId,
-  filter = '',
+  from,
+  size,
+  filter,
 }) {
   const requestBody = {
     size,
     from,
-    sort: {
-      'object.startTime': 'desc',
-    },
     query: {
       bool: {
-        filter: buildActivityFeedFilters(companyId, filter),
+        filter,
       },
+    },
+    sort: {
+      'object.startTime': 'desc',
     },
   }
 

--- a/src/apps/companies/apps/activity-feed/router.js
+++ b/src/apps/companies/apps/activity-feed/router.js
@@ -1,11 +1,13 @@
 const router = require('express').Router()
 
+const { convertQueryTypes } = require('./translators')
+
 const {
   renderActivityFeed,
   fetchActivityFeedHandler,
 } = require('./controllers')
 
 router.get('/', renderActivityFeed)
-router.get('/data', fetchActivityFeedHandler)
+router.get('/data', convertQueryTypes, fetchActivityFeedHandler)
 
 module.exports = router

--- a/src/apps/companies/apps/activity-feed/translators.js
+++ b/src/apps/companies/apps/activity-feed/translators.js
@@ -1,0 +1,25 @@
+const convertQueryTypes = (req, res, next) => {
+  // Convert String to Number
+  const { from } = req.query
+  const { size } = req.query
+
+  if (from) {
+    req.query.from = parseInt(from, 10)
+  }
+
+  if (size) {
+    req.query.size = parseInt(size, 10)
+  }
+
+  // Convert String to Boolean
+  const { showDnbHierarchy } = req.query
+  if (showDnbHierarchy) {
+    req.query.showDnbHierarchy = showDnbHierarchy === 'true'
+  }
+
+  next()
+}
+
+module.exports = {
+  convertQueryTypes,
+}

--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -67,71 +67,6 @@ const LOCAL_NAV = [
   },
 ]
 
-const ACTIVITY_TYPE = {
-  CompaniesHouseAccount: ['dit:Accounts'],
-  CompaniesHouseCompany: ['dit:Company'],
-  HmrcExporter: ['dit:Export'],
-  Interaction: ['dit:Interaction', 'dit:ServiceDelivery'],
-  InvestmentProject: ['dit:InvestmentProject'],
-  Omis: ['dit:OMISOrder'],
-}
-
-const ACTIVITY_TYPE_FILTERS = {
-  allActivity: {
-    label: 'All Data Hub & external activity',
-    value: 'all',
-  },
-
-  myActivity: {
-    label: 'My activity',
-    value: 'my-activity',
-  },
-
-  externalActivity: {
-    label: 'All external activity',
-    value: 'external-activity',
-  },
-
-  dataHubActivity: {
-    label: 'All Data Hub activity',
-    value: 'datahub-activity',
-  },
-}
-
-const ACTIVITY_TYPE_FILTER_OBJECT = {
-  TYPE: 'object.type',
-  ATTRIBUTED_TO_ID: 'object.attributedTo.id',
-}
-
-const ACTIVITY_TYPE_FILTER_KEYS = {
-  allActivity: [].concat(
-    ...[
-      ACTIVITY_TYPE.CompaniesHouseAccount,
-      ACTIVITY_TYPE.CompaniesHouseCompany,
-      ACTIVITY_TYPE.HmrcExporter,
-      ACTIVITY_TYPE.Interaction,
-      ACTIVITY_TYPE.InvestmentProject,
-      ACTIVITY_TYPE.Omis,
-    ]
-  ),
-
-  externalActivity: [].concat(
-    ...[
-      ACTIVITY_TYPE.CompaniesHouseAccount,
-      ACTIVITY_TYPE.CompaniesHouseCompany,
-      ACTIVITY_TYPE.HmrcExporter,
-    ]
-  ),
-
-  dataHubActivity: [].concat(
-    ...[
-      ACTIVITY_TYPE.Interaction,
-      ACTIVITY_TYPE.InvestmentProject,
-      ACTIVITY_TYPE.Omis,
-    ]
-  ),
-}
-
 const APP_PERMISSIONS = concat(LOCAL_NAV, GLOBAL_NAV_ITEM)
 const QUERY_FIELDS = Object.values(QUERY_FIELDS_MAP)
 const NONE_TEXT = 'None'
@@ -139,10 +74,6 @@ const NOT_SET_TEXT = 'Not set'
 const NOT_AVAILABLE_TEXT = 'Not available'
 
 module.exports = {
-  ACTIVITY_TYPE,
-  ACTIVITY_TYPE_FILTERS,
-  ACTIVITY_TYPE_FILTER_KEYS,
-  ACTIVITY_TYPE_FILTER_OBJECT,
   GLOBAL_NAV_ITEM,
   LOCAL_NAV,
   DEFAULT_COLLECTION_QUERY,

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -86,7 +86,7 @@ function getCompanySubsidiaries (token, companyId, page = 1) {
   })
 }
 
-function getUltimateHQSubsidiaries (token, globalUltimateDunnsNumber) {
+function getGlobalUltimateHierarchy (token, globalUltimateDunnsNumber) {
   return authorisedRequest(token, {
     url: `${config.apiRoot}/v4/company`,
     qs: {
@@ -131,7 +131,7 @@ module.exports = {
   updateCompany,
   getCompanyAuditLog,
   getCompanySubsidiaries,
-  getUltimateHQSubsidiaries,
+  getGlobalUltimateHierarchy,
   getOneListGroupCoreTeam,
   saveDnbCompany,
   saveDnbCompanyInvestigation,

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -23,19 +23,19 @@
         </div>
       </div>
     {% endif %}
-    {% if company.hasManagedAccountDetails %}
+    {% if company.isUltimate or company.hasManagedAccountDetails %}
       <div class="c-local-header__description">
         {% if company.isUltimate %}
-          {% set link =  props.subsidiaryCount + ' other company ' + 'record' | pluralise(props.subsidiaryCount) %}
+          {% set link =  props.dnbSubsidiaryCount + ' other company ' + 'record' | pluralise(props.dnbSubsidiaryCount) %}
           <p>Data Hub contains <a class="subsidiaries" href={{ urls.companies.dnbSubsidiaries.index(company.id) }}>{{ link }}</a> related to this company</p>
         {% endif %}
-
-
+        {% if company.hasManagedAccountDetails %}
           <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>
           <p>
             {{ "Lead ITA" if company.isItaTierDAccount else "Global Account Manager" }}: {{ company.one_list_group_global_account_manager.name }}
             <a href={{ urls.companies.advisers.index(company.id) }}>{{ "View Lead adviser" if company.isItaTierDAccount else "View core team" }}</a>
           </p>
+        {% endif %}
       </div>
     {% endif %}
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,3 @@
-const { ACTIVITY_TYPE } = require('../apps/companies/constants')
 const path = require('path')
 
 const isDev = process.env.NODE_ENV !== 'production'
@@ -118,14 +117,6 @@ const config = {
   },
   activityFeed: {
     paginationSize: 20,
-    supportedActivityTypes: [].concat(
-      ...[
-        ACTIVITY_TYPE.Interaction,
-        ACTIVITY_TYPE.InvestmentProject,
-        ACTIVITY_TYPE.Omis,
-      ]
-    ),
-
   },
   helpCentre: {
     url: process.env.HELP_CENTRE_URL,

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -66,6 +66,34 @@ describe('Company Collections Filter', () => {
       .should('have.length', 1)
   })
 
+  it('should filter by region', () => {
+    cy.get(selectors.filter.firstUkRegion).click()
+
+    cy.wait('@filterResults').then(xhr => {
+      expect(xhr.url).to.contain(
+        'uk_region=934cd12a-6095-e211-a939-e4115bead28a'
+      )
+    })
+
+    cy
+      .get(selectors.entityCollection.entities)
+      .children()
+      .should('have.length', 1)
+  })
+
+  it('should filter by last interaction date', () => {
+    cy.get(selectors.filter.firstInteractionDate).click()
+
+    cy.wait('@filterResults').then(xhr => {
+      expect(xhr.url).to.contain('interaction_between=1')
+    })
+
+    cy
+      .get(selectors.entityCollection.entities)
+      .children()
+      .should('have.length', 1)
+  })
+
   it('should filter by sector', () => {
     const sector = selectors.filter.sector
     const { typeahead } = selectors.filter
@@ -107,21 +135,6 @@ describe('Company Collections Filter', () => {
     })
   })
 
-  it('should filter by region', () => {
-    cy.get(selectors.filter.firstUkRegion).click()
-
-    cy.wait('@filterResults').then(xhr => {
-      expect(xhr.url).to.contain(
-        'uk_region=934cd12a-6095-e211-a939-e4115bead28a'
-      )
-    })
-
-    cy
-      .get(selectors.entityCollection.entities)
-      .children()
-      .should('have.length', 1)
-  })
-
   it('should filter by currently exporting to', () => {
     const exportingTo = selectors.filter.exportingTo
     const { typeahead } = selectors.filter
@@ -160,19 +173,6 @@ describe('Company Collections Filter', () => {
     cy.wait('@filterResults').then(xhr => {
       expect(xhr.url).to.contain('future_interest_countries=a25f66a0-5d95-e211-a939-e4115bead28a')
     })
-  })
-
-  it('should filter by last interaction date', () => {
-    cy.get(selectors.filter.firstInteractionDate).click()
-
-    cy.wait('@filterResults').then(xhr => {
-      expect(xhr.url).to.contain('interaction_between=1')
-    })
-
-    cy
-      .get(selectors.entityCollection.entities)
-      .children()
-      .should('have.length', 1)
   })
 
   it('should remove all filters', () => {

--- a/test/functional/cypress/specs/omis/filter-spec.js
+++ b/test/functional/cypress/specs/omis/filter-spec.js
@@ -10,6 +10,16 @@ describe('OMIS Collections Filter', () => {
     cy.route('/omis?*').as('filterResults')
   })
 
+  it('should filter by region', () => {
+    cy.get(selectors.filter.omis.firstUkRegion).click()
+
+    cy.wait('@filterResults').then(xhr => {
+      expect(xhr.url).to.contain(
+        'uk_region=1718e330-6095-e211-a939-e4115bead28a'
+      )
+    })
+  })
+
   it('should filter by country', () => {
     const country = selectors.filter.omis.country
     const { typeahead } = selectors.filter
@@ -28,15 +38,6 @@ describe('OMIS Collections Filter', () => {
     cy.wait('@filterResults').then(xhr => {
       expect(xhr.url).to.contain(
         'primary_market=80756b9a-5d95-e211-a939-e4115bead28a'
-      )
-    })
-  })
-  it('should filter by region', () => {
-    cy.get(selectors.filter.omis.firstUkRegion).click()
-
-    cy.wait('@filterResults').then(xhr => {
-      expect(xhr.url).to.contain(
-        'uk_region=1718e330-6095-e211-a939-e4115bead28a'
       )
     })
   })

--- a/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+++ b/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
@@ -34,5 +34,13 @@
   {
     "code": "activity-feed-filters",
     "is_active": true
+  },
+  {
+    "code": "companies-ultimate-hq",
+    "is_active": true
+  },
+  {
+    "code": "activity-feed-type-filter-enabled",
+    "is_active": true
   }
 ]

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -2,9 +2,8 @@ var activities = require('../../../fixtures/v4/activity-feed/activities.json')
 var noActivities = require('../../../fixtures/v4/activity-feed/no-activities.json')
 
 exports.activityFeed = function (req, res) {
-  var term = req.body.query.bool.filter[0].term
-
-  if (term && term['object.attributedTo.id'] === 'dit:DataHubCompany:0f5216e0-849f-11e6-ae22-56b6b6499611') {
+  var terms = req.body.query.bool.filter[1].terms
+  if (terms && terms['object.attributedTo.id'][0] === 'dit:DataHubCompany:0f5216e0-849f-11e6-ae22-56b6b6499611') {
     return res.json(noActivities)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4208,10 +4208,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-2.14.0.tgz#7d9210fad51ee66c89445663e46907f05782ee5a"
-  integrity sha512-O3ENNk6ofaIaVLRzMpkyGZjHPhN0veIh78E55ws4kae0SYk+darI0q61XD0BKZDUFJst4mB4r96kTlCVMpN5mA==
+data-hub-components@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-2.18.0.tgz#c391cdbea385fa80dd180c403a5491617ff3dc3c"
+  integrity sha512-2WygVKOqBqDFfu/wLBvaypOo3mWTwuG/JNWe9OJhM0ITDtNG6GJsFkBxPHmRWLz4Mr76JNh0cV12plsgSOi7gw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change
When viewing a D&B Ultimate HQ company a user is now able to filter all subsidiary activities across the entire D&B Ultimate HQ hierarchy when clicking the filter box `Activities across all x companies`. For example, If you have three companies in a D&B hierarchy:

1. Ultimate HQ (has 3 activities)
2. Subsidiary A (has 2 activities)
3. Subsidiary B  (has 2 activities)

When applying the filter the Activity Feed list will display all 7 activities across this hierarchy. The filter works in conjunction with the following Activity types.

**Activity types**
1. `All Data Hub & external activity`
2. `All external activity`
3. `My activity`
4. `All Data Hub activity`

This functionality is hidden behind a feature flag `companies-ultimate-hq` and has a dependency on changes to the `data-hub-component` library. There will be another PR shortly for these changes. Within that piece of work will be the inclusion of a loading indicator which is omitted from the following `gif`.

![ultimate-hq-subsidiaries-filter](https://user-images.githubusercontent.com/964268/69140932-75d0c600-0abb-11ea-99ec-c442bbf6ef87.gif)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
