### PR TITLE
Add Lead adviser information in company header

### DIFF
--- a/src/apps/companies/middleware/__test__/params.test.js
+++ b/src/apps/companies/middleware/__test__/params.test.js
@@ -1,5 +1,6 @@
 const proxyquire = require('proxyquire')
 const company = require('../../../../../test/unit/data/companies/company-v4.json')
+const oneListTypeDItaCompany = require('../../../../../test/unit/data/companies/one-list-group-tier-d-ita.json')
 
 describe('Companies form middleware', () => {
   let nextSpy
@@ -14,7 +15,7 @@ describe('Companies form middleware', () => {
   let resMock
   let middleware
 
-  beforeEach(() => {
+  before(() => {
     nextSpy = sinon.spy()
     getDitCompanyStub = sinon.stub()
     getDitCompanyFromListStub = sinon.stub()
@@ -42,19 +43,45 @@ describe('Companies form middleware', () => {
   })
 
   describe('getCompany', () => {
-    beforeEach(async () => {
-      getDitCompanyStub.resolves(company)
-      await middleware.getCompany(reqMock, resMock, nextSpy, 2)
-    })
+    context('when the company is not a One list Tier D ITA', () => {
+      before(async () => {
+        getDitCompanyStub.resolves(company)
+        await middleware.getCompany(reqMock, resMock, nextSpy, 2)
+      })
 
-    it('should return the company', () => {
-      expect(resMock.locals).to.have.deep.property('company', company)
+      it('should return the company', () => {
+        expect(resMock.locals).to.have.deep.property('company', {
+          ...company,
+          isItaTierDAccount: false,
+          hasAllocatedLeadIta: true,
+          hasManagedAccountDetails: true,
+          isGlobalHQ: null,
+          isUltimate: false,
+        })
+      })
+    })
+    context('when the company is a One list Tier D ITA', () => {
+      before(async () => {
+        getDitCompanyStub.resolves(oneListTypeDItaCompany)
+        await middleware.getCompany(reqMock, resMock, nextSpy, 2)
+      })
+
+      it('should return the company', () => {
+        expect(resMock.locals).to.have.deep.property('company', {
+          ...oneListTypeDItaCompany,
+          isItaTierDAccount: true,
+          hasAllocatedLeadIta: true,
+          hasManagedAccountDetails: true,
+          isGlobalHQ: null,
+          isUltimate: false,
+        })
+      })
     })
   })
 
   describe('setIsCompanyAlreadyAdded', () => {
     context('when the company is already added to the user company list', async () => {
-      beforeEach(async () => {
+      before(async () => {
         getDitCompanyFromListStub.resolves()
         await middleware.setIsCompanyAlreadyAdded(reqMock, resMock, nextSpy, 2)
       })
@@ -65,7 +92,7 @@ describe('Companies form middleware', () => {
     })
 
     context('when the company is not added to the user company list', async () => {
-      beforeEach(async () => {
+      before(async () => {
         getDitCompanyFromListStub.rejects()
         await middleware.setIsCompanyAlreadyAdded(reqMock, resMock, nextSpy, 2)
       })
@@ -78,7 +105,7 @@ describe('Companies form middleware', () => {
 
   describe('addCompanyOrRemoveFromList', () => {
     context('when adding a company to the user company list', async () => {
-      beforeEach(async () => {
+      before(async () => {
         resMock = {
           ...resMock,
           locals: {
@@ -106,7 +133,7 @@ describe('Companies form middleware', () => {
       })
     })
     context('when removing a company from the user company list', async () => {
-      beforeEach(async () => {
+      before(async () => {
         resMock = {
           ...resMock,
           locals: {

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -5,9 +5,18 @@ const {
   removeDitCompanyFromList,
 } = require('../repos')
 
+const { isItaTierDAccount } = require('../../../lib/is-tier-type-company')
+
 async function getCompany (req, res, next, id) {
   try {
-    res.locals.company = await getDitCompany(req.session.token, id)
+    const company = await getDitCompany(req.session.token, id)
+    company.isItaTierDAccount = isItaTierDAccount(company)
+    company.hasAllocatedLeadIta = company.one_list_group_global_account_manager != null
+    company.hasManagedAccountDetails = company.one_list_group_tier && company.hasAllocatedLeadIta
+    company.isUltimate = !!company.is_global_ultimate && res.locals.features['companies-ultimate-hq']
+    company.isGlobalHQ = company.headquarter_type && company.headquarter_type.name === 'ghq'
+
+    res.locals.company = company
     next()
   } catch (error) {
     next(error)

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -15,31 +15,27 @@
     fullWidthContent: true
   }) %}
     <p class="c-local-header__heading-after">{{ company.address | formatAddress }}</p>
-    {% set isUltimate = company.is_global_ultimate and features["companies-ultimate-hq"] %}
-    {% set isGlobalHQ = company.headquarter_type and company.headquarter_type.name == 'ghq' %}
-    {% set isOneListTier = company.one_list_group_tier %}
 
-    {% if isUltimate or isGlobalHQ %}
+    {% if company.isUltimate or company.isGlobalHQ %}
       <div class="c-meta-list">
         <div class="c-meta-list__item">
-          <span class="c-badge">{{ "Ultimate" if isUltimate else "Global" }} HQ</span>
+          <span class="c-badge">{{ "Ultimate" if company.isUltimate else "Global" }} HQ</span>
         </div>
       </div>
     {% endif %}
-
-    {% if isUltimate or isOneListTier %}
+    {% if company.hasManagedAccountDetails %}
       <div class="c-local-header__description">
-        {% if isUltimate %}
+        {% if company.isUltimate %}
           {% set link =  props.subsidiaryCount + ' other company ' + 'record' | pluralise(props.subsidiaryCount) %}
           <p>Data Hub contains <a class="subsidiaries" href={{ urls.companies.dnbSubsidiaries.index(company.id) }}>{{ link }}</a> related to this company</p>
         {% endif %}
-        {% if isOneListTier %}
+
+
           <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>
           <p>
-            Global Account Manager: {{ company.one_list_group_global_account_manager.name }}
-            <a href={{ urls.companies.advisers.index(company.id) }}>View core team</a>
+            {{ "Lead ITA" if company.isItaTierDAccount else "Global Account Manager" }}: {{ company.one_list_group_global_account_manager.name }}
+            <a href={{ urls.companies.advisers.index(company.id) }}>{{ "View Lead adviser" if company.isItaTierDAccount else "View core team" }}</a>
           </p>
-        {% endif %}
       </div>
     {% endif %}
 

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -57,6 +57,12 @@ describe('Lead advisers', () => {
         'Lead adviser': null,
       })
     })
+    it('should show the allocated Lead adviser in the company header', () => {
+      cy.get(selectors.localHeader().description.paragraph(2)).should('contain', 'Lead ITA: Travis Greene')
+    })
+    it('should have a link to the Lead adviser tab', () => {
+      cy.contains('View Lead adviser').invoke('attr', 'href').should('eq', companies.advisers.index(fixtures.company.oneListTierDita.id))
+    })
     it('should display the "Lead Adviser" tab in the navigation', () => {
       cy.get(selectors.tabbedLocalNav().item(3)).should('contain', 'Lead adviser')
     })

--- a/test/unit/data/companies/one-list-group-tier-d-ita.json
+++ b/test/unit/data/companies/one-list-group-tier-d-ita.json
@@ -1,7 +1,7 @@
 {
   "id": "a73efeba-8499-11e6-ae22-56b6b6499611",
   "reference_code": "",
-  "name": "Mercury Ltd",
+  "name": "Ian's Camper Vans Ltd",
   "trading_names": [],
   "uk_based": true,
   "company_number": "99919",
@@ -23,6 +23,10 @@
   "business_type": {
     "name": "Private limited company",
     "id": "6f75408b-03e7-e611-bca1-e4115bead28a"
+  },
+  "one_list_group_tier": {
+    "name": "Tier D - International Trade Adviser Accounts",
+    "id": "1929c808-99b4-4abf-a891-45f2e187b410"
   },
   "contacts": [],
   "employee_range": {
@@ -48,6 +52,25 @@
     }
   ],
   "headquarter_type": null,
+  "one_list_group_global_account_manager": {
+    "name": "Ian Leggett",
+    "first_name": "Ian",
+    "last_name": "Leggett",
+    "contact_email": "caravans@ian.com",
+    "dit_team": {
+      "name": "DSO Senior Management Team",
+      "uk_region": {
+        "name": "London",
+        "id": "874cd12a-6095-e211-a939-e4115bead28a"
+      },
+      "country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "id": "e9ad674d-16ad-e211-a646-e4115bead28a"
+    },
+    "id": "b2776473-e65f-4de3-a9c2-022de1902610"
+  },
   "global_headquarters": null,
   "sector": {
     "name": "Retail",
@@ -88,27 +111,5 @@
       "name": "United Kingdom",
       "id": "80756b9a-5d95-e211-a939-e4115bead28a"
     }
-  },
-  "one_list_group_global_account_manager": {
-    "name": "Travis Greene",
-    "first_name": "Travis",
-    "last_name": "Greene",
-    "dit_team": {
-      "name": "IST - Sector Advisory Services",
-      "uk_region": {
-        "name": "London",
-        "id": "874cd12a-6095-e211-a939-e4115bead28a"
-      },
-      "country": {
-        "name": "United Kingdom",
-        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
-      },
-      "id": "fc3a6667-cfe9-e511-8ffa-e4115bead28a"
-    },
-    "id": "8eefe6b4-2816-4e47-94b5-a13409dcef70"
-  },
-  "one_list_group_tier": {
-    "name": "Tier A - Strategic Account",
-    "id": "b91bf800-8d53-e311-aef3-441ea13961e2"
   }
 }


### PR DESCRIPTION
## Description of change
If a company has an allocated Lead adviser this information should be present in the company header.

## Test instructions
View a company that has an allocated account manager
![Screenshot 2019-11-19 at 15 41 52](https://user-images.githubusercontent.com/10154302/69161792-97de3e80-0ae3-11ea-94ee-19825d896405.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
