### PR TITLE
Add a button to remove the Lead ITA

### DIFF
--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -14,6 +14,7 @@ const RenderHasAccountManager = (
     name,
     email,
     replaceUrl,
+    removeUrl,
     hasPermissionToAddIta,
     companyName,
     companyId,
@@ -33,12 +34,17 @@ const RenderHasAccountManager = (
       </Table.Row>
     </Table>
     <p>You can <a href={companies.audit(companyId)}>see changes in the Audit trail</a></p>
-    {hasPermissionToAddIta && <Button
+    {hasPermissionToAddIta && <FormActions><Button
       as={Link}
       href={replaceUrl}
     >
       Replace Lead ITA
-    </Button>}
+    </Button><Button
+      as={Link}
+      href={removeUrl}
+    >
+      Remove Lead ITA
+    </Button></FormActions>}
   </div>
 
 const RenderHasNoAccountManager = (
@@ -70,6 +76,7 @@ const LeadAdvisers = (
     companyId,
     confirmUrl,
     replaceUrl,
+    removeUrl,
     hasPermissionToAddIta,
   }) => {
   return hasAccountManager
@@ -81,6 +88,7 @@ const LeadAdvisers = (
       companyName={companyName}
       hasPermissionToAddIta={hasPermissionToAddIta}
       replaceUrl={replaceUrl}
+      removeUrl={removeUrl}
     />
     : <RenderHasNoAccountManager
       companyName={companyName}
@@ -98,6 +106,7 @@ LeadAdvisers.propTypes = {
   companyId: PropTypes.string.isRequired,
   confirmUrl: PropTypes.string.isRequired,
   replaceUrl: PropTypes.string.isRequired,
+  removeUrl: PropTypes.string.isRequired,
   hasPermissionToAddIta: PropTypes.bool.isRequired,
 }
 

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -5,7 +5,7 @@ import Link from '@govuk-react/link'
 import { H2 } from '@govuk-react/heading'
 import Table from '@govuk-react/table'
 import { LEVEL_SIZE } from '@govuk-react/constants'
-
+import { FormActions } from 'data-hub-components'
 import { companies } from '../../../../../lib/urls'
 
 const RenderHasAccountManager = (

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -34,17 +34,15 @@ const RenderHasAccountManager = (
       </Table.Row>
     </Table>
     <p>You can <a href={companies.audit(companyId)}>see changes in the Audit trail</a></p>
-    {hasPermissionToAddIta && <FormActions><Button
-      as={Link}
-      href={replaceUrl}
-    >
-      Replace Lead ITA
-    </Button><Button
-      as={Link}
-      href={removeUrl}
-    >
-      Remove Lead ITA
-    </Button></FormActions>}
+    {hasPermissionToAddIta &&
+    <FormActions>
+      <Button as={Link} href={replaceUrl}>
+        Replace Lead ITA
+      </Button>
+      <Button as={Link} href={removeUrl}>
+        Remove Lead ITA
+      </Button>
+    </FormActions>}
   </div>
 
 const RenderHasNoAccountManager = (

--- a/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
+++ b/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
@@ -71,6 +71,9 @@ describe('Company adviser list controller', () => {
         it('should set a link to replace the account manager', () => {
           expect(middlewareParameters.resMock.render.args[0][1].props.replaceUrl).to.equal(`${companies.advisers.replace('15387806')}`)
         })
+        it('should set a link to remove the account manager', () => {
+          expect(middlewareParameters.resMock.render.args[0][1].props.removeUrl).to.equal(`${companies.advisers.remove('15387806')}`)
+        })
         it('should set the permission flag', () => {
           expect(middlewareParameters.resMock.render.args[0][1].props.hasPermissionToAddIta).to.equal(true)
         })

--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -24,6 +24,7 @@ function renderLeadAdvisers (req, res) {
         companyId: company.id,
         confirmUrl: `${companies.advisers.confirm(company.id)}`,
         replaceUrl: `${companies.advisers.replace(company.id)}`,
+        removeUrl: `${companies.advisers.remove(company.id)}`,
         hasPermissionToAddIta: permissions.includes('company.change_regional_account_manager'),
       },
     })

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -48,6 +48,7 @@ describe('urls', () => {
 
       expect(urls.companies.advisers.confirm(companyId)).to.equal(`/companies/${companyId}/advisers/add`)
       expect(urls.companies.advisers.replace(companyId)).to.equal(`/companies/${companyId}/advisers/replace`)
+      expect(urls.companies.advisers.remove(companyId)).to.equal(`/companies/${companyId}/advisers/remove`)
 
       expect(urls.companies.dnbSubsidiaries.index.route).to.equal('/:companyId/dnb-subsidiaries')
       expect(urls.companies.dnbSubsidiaries.index(companyId)).to.equal(`/companies/${companyId}/dnb-subsidiaries`)

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -90,6 +90,7 @@ module.exports = {
       index: url('/companies', '/:companyId/advisers'),
       confirm: url('/companies', '/:companyId/advisers/add'),
       replace: url('/companies', '/:companyId/advisers/replace'),
+      remove: url('/companies', '/:companyId/advisers/remove'),
     },
     index: url('/companies'),
     subsidiaries: url('/companies', '/:companyId/subsidiaries'),

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -90,5 +90,8 @@ describe('Lead advisers', () => {
     it('should display a button to replace the Lead ITA', () => {
       cy.contains('Replace Lead ITA').invoke('attr', 'href').should('eq', companies.advisers.replace(fixtures.company.oneListTierDita.id))
     })
+    it('should display a button to remove the Lead ITA', () => {
+      cy.contains('Remove Lead ITA').invoke('attr', 'href').should('eq', companies.advisers.remove(fixtures.company.oneListTierDita.id))
+    })
   })
 })

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -88,10 +88,16 @@ describe('Lead advisers', () => {
       cy.get(selectors.companyLeadAdviser.table.email).should('have.text', 'travis@travis.com')
     })
     it('should display a button to replace the Lead ITA', () => {
-      cy.contains('Replace Lead ITA').invoke('attr', 'href').should('eq', companies.advisers.replace(fixtures.company.oneListTierDita.id))
+      cy
+        .contains('Replace Lead ITA')
+        .invoke('attr', 'href')
+        .should('eq', companies.advisers.replace(fixtures.company.oneListTierDita.id))
     })
     it('should display a button to remove the Lead ITA', () => {
-      cy.contains('Remove Lead ITA').invoke('attr', 'href').should('eq', companies.advisers.remove(fixtures.company.oneListTierDita.id))
+      cy
+        .contains('Remove Lead ITA')
+        .invoke('attr', 'href')
+        .should('eq', companies.advisers.remove(fixtures.company.oneListTierDita.id))
     })
   })
 })


### PR DESCRIPTION
## Description of change

As well as replacing the Lead ITA we need a button that removes the Lead ITA.

## Test instructions
You will need the feature flag `lead_adviser`
View a company that has an allocated Lead ITA and you should see a "Remove Lead ITA" button to the right of the replace button. The page it links to has not been created yet.
 
## Screenshots
![Screenshot 2019-11-21 at 09 59 10](https://user-images.githubusercontent.com/10154302/69327828-13f09780-0c46-11ea-81d4-5abf51ad948b.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
