### PR TITLE
Release/v5.55.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub-frontend",
-  "version": "5.54.0",
+  "version": "5.55.0",
   "description": "Data Hub Frontend",
   "main": "src/server.js",
   "repository": {

--- a/src/apps/__test__/middleware.test.js
+++ b/src/apps/__test__/middleware.test.js
@@ -118,6 +118,27 @@ describe('Apps middleware', () => {
       })
     })
 
+    context('when the "appendBaseUrl" argument is set to false', () => {
+      it('should not append the baseUrl to the link', () => {
+        const url = '/some-url'
+        const mockNavItem = {
+          url,
+        }
+        const reqMock = {}
+        const resMock = {
+          locals: {
+            CURRENT_PATH: url,
+          },
+        }
+
+        this.middleware.setLocalNav([mockNavItem], false)(reqMock, resMock, this.nextSpy)
+
+        expect(resMock.locals.localNavItems[0].url).to.equal(url)
+        expect(resMock.locals.localNavItems[0].isActive).to.be.true
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
+    })
+
     context('user permitted nav items', () => {
       it('should include permitted items', () => {
         const reqMock = {

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/controllers.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/controllers.test.js
@@ -39,7 +39,7 @@ describe('D&B Company Subsidiaries', () => {
       it('should render the activity feed template', () => {
         expect(middlewareParams.resMock.render).to.be.calledOnceWithExactly(
           'companies/apps/dnb-subsidiaries/views/client-container', {
-            heading: 'Subsidiaries of Test company',
+            heading: 'Companies related to Test company',
             props: {
               dataEndpoint: urls.companies.dnbSubsidiaries.data('1'),
             },
@@ -54,7 +54,7 @@ describe('D&B Company Subsidiaries', () => {
           'Business details', urls.companies.businessDetails('1'))
 
         expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
-          'Subsidiaries')
+          'Related companies')
       })
 
       it('should not call "next" with an error', async () => {
@@ -145,14 +145,18 @@ describe('D&B Company Subsidiaries', () => {
         expect(middlewareParams.resMock.json).to.be
           .calledOnceWithExactly(
             {
-              count: 1,
+              count: 2,
               results: [{
+                badges: ['United States'],
+                headingText: 'Mars Exports Ltd',
+                headingUrl: '/companies/b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+                metadata: [{ label: 'Sector', value: 'Retail' }, { label: 'Address', value: '12 First Street, New York, 765413, United States' }],
+                subheading: 'Updated on 16 Nov 2017, 11:00am',
+              }, {
                 badges: ['United Kingdom', 'North West'],
                 headingText: 'Mars Components Ltd',
-                headingUrl: urls.companies.detail('731bdcc1-f685-4c8e-bd66-b356b2c16995'),
-                metadata: [
-                  { label: 'Sector', value: 'Retail' },
-                  { label: 'Address', value: '12 Alpha Street, Volcanus, NE28 5AQ, United Kingdom' }],
+                headingUrl: '/companies/731bdcc1-f685-4c8e-bd66-b356b2c16995',
+                metadata: [{ label: 'Sector', value: 'Retail' }, { label: 'Address', value: '12 Alpha Street, Volcanus, NE28 5AQ, United Kingdom' }],
                 subheading: 'Updated on 16 Oct 2017, 12:00pm',
               }],
             }

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/middleware.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/middleware.test.js
@@ -1,0 +1,126 @@
+const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
+const { setSubsidiariesLocalNav } = require('../middleware')
+const urls = require('../../../../../lib/urls')
+
+const buildSubsidiaryMiddlewareParameters = ({
+  reqMock = { baseUrl: '/companies/123/subsidiaries' },
+  features = { 'companies-ultimate-hq': true },
+  company = {
+    id: '123',
+    is_global_ultimate: true,
+    headquarter_type: {
+      name: 'ghq',
+    },
+  },
+  CURRENT_PATH = urls.companies.dnbSubsidiaries.index('123'),
+  permissions = ['company.view_company'],
+}) => buildMiddlewareParameters({
+  reqMock,
+  features,
+  company,
+  CURRENT_PATH,
+  user: {
+    permissions,
+  },
+})
+
+describe('Subsidiaries local navigation', () => {
+  let middlewareParameters
+
+  context('when a company is both Global HQ and Ultimate HQ and the flag is ON', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({})
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should render local nav with D&B hierarchy and manual subsidiaries tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([
+        {
+          'isActive': true,
+          'label': 'Dun & Bradstreet hierarchy',
+          'permissions': [
+            'company.view_company',
+          ],
+          'url': urls.companies.dnbSubsidiaries.index('123'),
+        },
+        {
+          'isActive': false,
+          'label': 'Manually linked subsidiaries',
+          'permissions': [
+            'company.view_company',
+          ],
+          'url': urls.companies.subsidiaries('123'),
+        },
+      ])
+    })
+  })
+
+  context('when the flag is OFF', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({
+        features: {},
+      })
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should not render tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([])
+    })
+  })
+
+  context('when the company is Global HQ but not Ultimate HQ', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({
+        company: {
+          is_global_ultimate: false,
+          headquarter_type: {
+            name: 'ghq',
+          },
+        },
+      })
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should not render tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([])
+    })
+  })
+
+  context('when the company is Ultimate HQ but not Global HQ', () => {
+    before(() => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({
+        company: {
+          is_global_ultimate: true,
+          headquarter_type: {
+            name: '',
+          },
+        },
+      })
+
+      setSubsidiariesLocalNav(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy,
+      )
+    })
+
+    it('should not render tabs', () => {
+      expect(middlewareParameters.resMock.locals.localNavItems).to.be.deep.equal([])
+    })
+  })
+})

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/repos.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/repos.test.js
@@ -3,27 +3,24 @@ const { getDnbSubsidiaries } = require('../repos')
 const { mockDnbSubsidiariesEndpoint } = require('./utils')
 const subsidiaries = require('../../../../../../test/unit/data/companies/subsidiary-company-search-response')
 
-const token = 'abcd'
+const TOKEN = 'abcd'
+const DUNS_NUMBER = 999999
 
 describe('D&B Subsidiaries repos', () => {
   describe('#getDnbSubsidiaries', () => {
     let actual
-    const DUNS_NUMBER = 999999
 
-    beforeEach(async () => {
+    before(async () => {
       mockDnbSubsidiariesEndpoint({
         globalUltimateSunsNumber: DUNS_NUMBER,
         responseBody: subsidiaries,
       })
 
-      actual = await getDnbSubsidiaries(token, DUNS_NUMBER, config.paginationDefaultSize, 1)
+      actual = await getDnbSubsidiaries(TOKEN, DUNS_NUMBER, config.paginationDefaultSize, 1)
     })
 
     it('should return the one subsidiary', () => {
-      expect(actual).to.deep.equal({
-        count: 1,
-        results: [subsidiaries.results[1]],
-      })
+      expect(actual).to.deep.equal(subsidiaries)
     })
   })
 })

--- a/src/apps/companies/apps/dnb-subsidiaries/__test__/transformers.test.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/__test__/transformers.test.js
@@ -1,29 +1,56 @@
 const { transformCompanyToSubsidiariesList } = require('../transformers')
 const urls = require('../../../../../lib/urls')
 
-const companyMock = require('../../../../../../test/unit/data/companies/company-v4')
-
 describe('Edit company form transformers', () => {
   describe('#transformCompanyToSubsidiariesList', () => {
     context('when called with a fully populated company', () => {
-      const actual = transformCompanyToSubsidiariesList(companyMock)
+      const actual = transformCompanyToSubsidiariesList({
+        id: '123',
+        name: 'Test company',
+        sector: {
+          name: 'Test sector',
+        },
+        uk_based: true,
+        uk_region: {
+          name: 'Test UK region',
+        },
+        trading_names: ['Test trading name'],
+        address: {
+          country: {
+            name: 'Test country',
+          },
+        },
+        modified_on: '2016-07-05T12:00:00Z',
+        headquarter_type: {
+          name: 'ghq',
+        },
+        is_global_ultimate: true,
+      })
 
       it('should return transformed values', () => {
         const expected = {
           'badges': [
-            'United Kingdom',
-            'North West',
+            'Test country',
+            'Test UK region',
+            'Global HQ',
+            'Ultimate HQ',
           ],
-          'headingText': 'Mercury Ltd',
-          'headingUrl': urls.companies.detail('a73efeba-8499-11e6-ae22-56b6b6499611'),
+          'headingText': 'Test company',
+          'headingUrl': '/companies/123',
           'metadata': [
             {
+              'label': 'Trading names',
+              'value': [
+                'Test trading name',
+              ],
+            },
+            {
               'label': 'Sector',
-              'value': 'Retail',
+              'value': 'Test sector',
             },
             {
               'label': 'Address',
-              'value': '82 Ramsgate Rd, Willington, NE28 5JB, United Kingdom',
+              'value': 'Test country',
             },
           ],
           'subheading': 'Updated on 5 Jul 2016, 1:00pm',

--- a/src/apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries.jsx
+++ b/src/apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries.jsx
@@ -39,16 +39,20 @@ const DnbSubsidiaries = ({ dataEndpoint }) => {
   }, [activePage])
 
   return (
-    <LoadingBox loading={isLoading}>
-      <CollectionList
-        itemName="subsidiary"
-        items={subsidiaries}
-        totalItems={totalItems}
-        onPageClick={onPageClick}
-        getPageUrl={getPageUrl}
-        activePage={activePage}
-      />
-    </LoadingBox>
+    <>
+      <p>This hierarchy information from Dun & Bradstreet cannot be edited.</p>
+
+      <LoadingBox loading={isLoading}>
+        <CollectionList
+          itemName="related company"
+          items={subsidiaries}
+          totalItems={totalItems}
+          onPageClick={onPageClick}
+          getPageUrl={getPageUrl}
+          activePage={activePage}
+        />
+      </LoadingBox>
+    </>
   )
 }
 

--- a/src/apps/companies/apps/dnb-subsidiaries/controllers.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/controllers.js
@@ -16,9 +16,9 @@ async function renderDnbSubsidiaries (req, res, next) {
     res
       .breadcrumb(company.name, urls.companies.detail(company.id))
       .breadcrumb('Business details', urls.companies.businessDetails(company.id))
-      .breadcrumb('Subsidiaries')
+      .breadcrumb('Related companies')
       .render('companies/apps/dnb-subsidiaries/views/client-container', {
-        heading: `Subsidiaries of ${company.name}`,
+        heading: `Companies related to ${company.name}`,
         props: {
           dataEndpoint: urls.companies.dnbSubsidiaries.data(company.id),
         },

--- a/src/apps/companies/apps/dnb-subsidiaries/middleware.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/middleware.js
@@ -1,0 +1,36 @@
+/* eslint-disable camelcase */
+
+const { setLocalNav } = require('../../../middleware')
+const urls = require('../../../../lib/urls')
+
+function setSubsidiariesLocalNav (req, res, next) {
+  const { company, features } = res.locals
+
+  const isGlobalHQ = company.headquarter_type && company.headquarter_type.name === 'ghq'
+
+  if (features['companies-ultimate-hq'] && company.is_global_ultimate && isGlobalHQ) {
+    const navItems = [
+      {
+        url: urls.companies.dnbSubsidiaries.index(company.id),
+        label: 'Dun & Bradstreet hierarchy',
+        permissions: [
+          'company.view_company',
+        ],
+      },
+      {
+        url: urls.companies.subsidiaries(company.id),
+        label: 'Manually linked subsidiaries',
+        permissions: [
+          'company.view_company',
+        ],
+      },
+    ]
+    setLocalNav(navItems, false)(req, res, next)
+  } else {
+    setLocalNav()(req, res, next)
+  }
+}
+
+module.exports = {
+  setSubsidiariesLocalNav,
+}

--- a/src/apps/companies/apps/dnb-subsidiaries/repos.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/repos.js
@@ -1,18 +1,11 @@
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 const config = require('../../../../config')
 
-function excludeGlobalUltimate (globalUltimateDunsNumber, response) {
-  return {
-    count: response.count - 1,
-    results: response.results.filter(c => c.duns_number !== globalUltimateDunsNumber + ''),
-  }
-}
-
-async function getDnbSubsidiaries (token, dunsNumber, limit, page) {
+function getDnbSubsidiaries (token, dunsNumber, limit, page) {
   const parsedPage = parseInt(page, 10) || 1
   const offset = limit * (parsedPage - 1)
 
-  const response = await authorisedRequest(token, {
+  return authorisedRequest(token, {
     url: `${config.apiRoot}/v4/company`,
     qs: {
       limit,
@@ -21,8 +14,6 @@ async function getDnbSubsidiaries (token, dunsNumber, limit, page) {
       global_ultimate_duns_number: dunsNumber,
     },
   })
-
-  return excludeGlobalUltimate(dunsNumber, response)
 }
 
 module.exports = {

--- a/src/apps/companies/apps/dnb-subsidiaries/transformers.js
+++ b/src/apps/companies/apps/dnb-subsidiaries/transformers.js
@@ -15,6 +15,7 @@ function transformCompanyToSubsidiariesList ({
   address,
   modified_on,
   headquarter_type,
+  is_global_ultimate,
 } = {}) {
   if (!id) { return }
 
@@ -45,6 +46,10 @@ function transformCompanyToSubsidiariesList ({
 
   if (headquarter_type) {
     badges.push(labels.hqLabels[get(headquarter_type, 'name')])
+  }
+
+  if (is_global_ultimate) {
+    badges.push(labels.companyDetailsLabels.ultimate_hq)
   }
 
   if (address) {

--- a/src/apps/companies/apps/dnb-subsidiaries/views/client-container.njk
+++ b/src/apps/companies/apps/dnb-subsidiaries/views/client-container.njk
@@ -1,5 +1,15 @@
 {% extends "_layouts/template.njk" %}
 
+{% block local_nav %}
+  {% if localNavItems.length > 0 %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ TabbedLocalNav({ items: localNavItems }) }}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block body_main_content %}
   {% component 'react-slot', {
     id: 'dnb-subsidiaries',

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -7,6 +7,7 @@ const companyDetailsLabels = {
   uk_region: 'UK region',
   headquarter_type: 'Headquarter type',
   global_headquarters: 'Global HQ',
+  ultimate_hq: 'Ultimate HQ',
   sector: 'Sector',
   website: 'Website',
   description: 'Business description',

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -45,6 +45,7 @@ const { getCompany, setIsCompanyAlreadyAdded, setDoAnyListsExist, addCompanyOrRe
 const { setInteractionsDetails } = require('./middleware/interactions')
 const { setGlobalHQ, removeGlobalHQ, addSubsidiary } = require('./middleware/hierarchies')
 const setCompaniesLocalNav = require('./middleware/local-navigation')
+const { setSubsidiariesLocalNav } = require('./apps/dnb-subsidiaries/middleware')
 const lastInteractionDate = require('./middleware/last-interaction-date')
 
 const { transformCompanyToListItem } = require('./transformers')
@@ -107,6 +108,7 @@ router.get('/:companyId/hierarchies/ghq/remove', removeGlobalHQ)
 router.get('/:companyId/hierarchies/subsidiaries/search', getSubsidiaryCompaniesCollection, renderLinkSubsidiary)
 router.get('/:companyId/hierarchies/subsidiaries/:subsidiaryCompanyId/add', addSubsidiary)
 
+router.use(urls.companies.dnbSubsidiaries.index.route, setSubsidiariesLocalNav)
 router.get(urls.companies.dnbSubsidiaries.index.route, dnbSubsidiariesControllers.renderDnbSubsidiaries)
 router.get(urls.companies.dnbSubsidiaries.data.route, dnbSubsidiariesControllers.fetchSubsidiariesHandler)
 
@@ -118,8 +120,11 @@ router.get('/:companyId/contacts',
 )
 
 router.get(urls.companies.exports.route, renderExports)
+
+router.use('/:companyId/subsidiaries', setSubsidiariesLocalNav)
 router.get('/:companyId/subsidiaries', renderSubsidiaries)
 router.get('/:companyId/subsidiaries/link', renderLinkSubsidiary)
+
 router.get('/:companyId/orders', renderOrders)
 router.get('/:companyId/audit', renderAuditLog)
 router.get('/:companyId/documents', renderDocuments)

--- a/src/apps/companies/views/subsidiaries.njk
+++ b/src/apps/companies/views/subsidiaries.njk
@@ -1,10 +1,28 @@
 {% extends "_layouts/template.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ heading: heading }) %}{% endcall %}
+  {{ LocalHeader({
+    heading: heading,
+    modifier: 'light-banner',
+    fullWidthContent: true
+  }) }}
+{% endblock %}
+
+{% block local_nav %}
+  {% if localNavItems.length > 0 %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {{ TabbedLocalNav({ items: localNavItems }) }}
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block body_main_content %}
+
+  <p>
+    This hierarchy information is manually recorded (linked) by Data Hub users. This means it can be different from the Dun & Bradstreet hierarchy, which in the future will replace this manually recorded information.
+  </p>
 
   {% if company.archived %}
     {{ govukDetails({

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -31,7 +31,7 @@
       <div class="c-local-header__description">
         {% if isUltimate %}
           {% set link =  props.subsidiaryCount + ' other company ' + 'record' | pluralise(props.subsidiaryCount) %}
-          <p>Data Hub contains <a class="subsidiaries" href={{ urls.companies.subsidiaries(company.id) }}>{{ link }}</a> related to this company</p>
+          <p>Data Hub contains <a class="subsidiaries" href={{ urls.companies.dnbSubsidiaries.index(company.id) }}>{{ link }}</a> related to this company</p>
         {% endif %}
         {% if isOneListTier %}
           <p>This is an account managed company (One List {{ company.one_list_group_tier.name }})</p>

--- a/src/apps/investments/__test__/repos.test.js
+++ b/src/apps/investments/__test__/repos.test.js
@@ -1,4 +1,4 @@
-const config = require('~/src/config')
+const config = require('../../../config')
 
 const {
   getInvestment,
@@ -7,11 +7,12 @@ const {
   createInvestmentProject,
   archiveInvestmentProject,
   unarchiveInvestmentProject,
-} = require('~/src/apps/investments/repos')
+  fetchLargeCapitalProfiles,
+} = require('../../../apps/investments/repos')
 
-const companyData = require('~/test/unit/data/company.json')
-const investmentData = require('~/test/unit/data/investment/investment-data.json')
-const investmentProjectAuditData = require('~/test/unit/data/investment/audit-log.json')
+const companyData = require('../../../../test/unit/data/company.json')
+const investmentData = require('../../../../test/unit/data/investment/investment-data.json')
+const investmentProjectAuditData = require('../../../../test/unit/data/investment/audit-log.json')
 
 describe('Investment repository', () => {
   describe('#getCompanyInvestmentProjects', () => {
@@ -92,5 +93,13 @@ describe('Investment repository', () => {
     it('should call unarchive url', async () => {
       expect(this.investmentProjectAuditData).to.deep.equal(investmentProjectAuditData)
     })
+  })
+
+  it('#fetchLargeCapitalProfiles', async () => {
+    nock(config.apiRoot)
+      .get(`/v4/large-investor-profile?limit=10&offset=0&sortby=modified_on`)
+      .reply(200, 'data')
+
+    expect(await fetchLargeCapitalProfiles('token', 10)).to.equal('data')
   })
 })

--- a/src/apps/investments/client/LargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/LargeCapitalProfileCollection.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
+import { useSearchParam } from 'react-use'
+import { CollectionList } from 'data-hub-components'
+import LoadingBox from '@govuk-react/loading-box'
+import ErrorSummary from '@govuk-react/error-summary'
+import { investments } from '../../../lib/urls'
+
+const LargeCapitalProfileCollection = () => {
+  const [profiles, setProfiles] = useState([])
+  const [totalItems, setTotalItems] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState(null)
+
+  const activePage = parseInt(useSearchParam('page') || 1, 10)
+  const setActivePage = (page) =>
+    window.history.pushState({}, '', `${window.location.pathname}?page=${page}`)
+
+  const onPageClick = (page, event) => {
+    setActivePage(page)
+    event.target.blur()
+    event.preventDefault()
+  }
+
+  const getPageUrl = (page) => `?page${page}`
+
+  useEffect(() => {
+    async function fetchData () {
+      try {
+        const { data } = await axios.get(investments.profiles.data(), {
+          params: {
+            page: activePage,
+          },
+        })
+        setProfiles(data.results)
+        setTotalItems(data.count)
+        setIsLoading(false)
+      } catch {
+        setErrorMessage('Please try again later')
+      }
+    }
+    setIsLoading(true)
+    window.scrollTo(0, 0)
+    fetchData()
+  }, [activePage])
+
+  return (
+    errorMessage ? (
+      <ErrorSummary
+        heading='There was an error getting the investor profiles'
+        description={errorMessage}
+        errors={[]}
+      />
+    )
+      : (
+        <LoadingBox loading={isLoading} >
+          <CollectionList
+            itemName='profile'
+            items={profiles}
+            totalItems={totalItems}
+            onPageClick={onPageClick}
+            getPageUrl={getPageUrl}
+            activePage={activePage}
+          />
+        </LoadingBox>
+      )
+  )
+}
+
+export default LargeCapitalProfileCollection

--- a/src/apps/investments/controllers/__test__/profiles.test.js
+++ b/src/apps/investments/controllers/__test__/profiles.test.js
@@ -1,96 +1,114 @@
-const config = require('~/src/config')
-const buildMiddlewareParameters = require('~/test/unit/helpers/middleware-parameters-builder.js')
+const config = require('../../../../config')
+const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
+const { renderProfilesView, fetchLargeCapitalProfilesHandler } = require('../profiles')
 
-describe('Investment profile controller', () => {
-  const metadataMock = {
-    sectorOptions: [
-      { id: 's1', name: 's1', disabled_on: null },
-    ],
-    adviserOptions: {
-      results: [
-        { id: 'ad1', name: 'ad1', is_active: true, dit_team: { name: 'ad1' } },
-      ],
-    },
-  }
-
-  beforeEach(async () => {
-    this.middlewareParameters = await buildMiddlewareParameters({ 'test': 'test' })
-
-    nock(config.apiRoot)
-      .get('/v4/metadata/sector?level__lte=0')
-      .reply(200, metadataMock.sectorOptions)
-      .get('/adviser/?limit=100000&offset=0')
-      .reply(200, metadataMock.adviserOptions)
-  })
+describe('test profile controllers', () => {
+  let middlewareParameters
 
   describe('#renderProfilesView', () => {
-    context('when the list renders successfully', () => {
-      beforeEach(async () => {
-        const controller = require('~/src/apps/investments/controllers/profiles')
+    describe('when the page renders successfully', () => {
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters()
 
-        await controller.renderProfilesView(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy)
+        await renderProfilesView(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should call breadcrumb with "Profiles"', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.be.calledWith('Profiles')
       })
 
       it('should render', () => {
-        expect(this.middlewareParameters.resMock.render).to.be.calledOnce
+        expect(middlewareParameters.resMock.render).to.be.calledOnce
       })
 
-      it('should render the collection template', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[0]).to
-          .equal('investments/views/profiles')
+      it('should render with a heading', () => {
+        expect(middlewareParameters.resMock.render).to.be.calledWith('investments/views/profiles', { heading: 'Investments' })
       })
 
-      it.skip('should render the view with a count label', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].countLabel).to
-          .equal('project')
-      })
-
-      it.skip('should render the view with a sort form', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].sortForm).to.exist
-      })
-
-      it.skip('should render the view with selected filters', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].selectedFilters).to.exist
-      })
-
-      it.skip('should render the view with an export action', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].exportAction).to
-          .deep.equal({ enabled: false })
-      })
-
-      it.skip('should render the view with filter fields', () => {
-        expect(this.middlewareParameters.resMock.render.firstCall.args[1].filtersFields).to.exist
+      it('should not call next', () => {
+        expect(middlewareParameters.nextSpy).to.not.be.called
       })
     })
 
-    context('when there is an error', () => {
-      beforeEach(async () => {
-        this.error = new Error('error')
-        const erroneousSpy = sinon.stub().throws(this.error)
+    describe('when there is an error', () => {
+      before(async () => {
+        middlewareParameters.resMock.render.throws()
 
-        const controller = proxyquire('~/src/apps/investments/controllers/profiles', {
-          '../../builders': {
-            buildSelectedFiltersSummary: erroneousSpy,
-            buildFieldsWithSelectedEntities: sinon.stub(),
+        await renderProfilesView(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should not call render', () => {
+        expect(middlewareParameters.resMock.render).to.be.thrown
+      })
+
+      it('should call next in the catch', () => {
+        expect(middlewareParameters.nextSpy).to.be.calledOnce
+      })
+    })
+  })
+
+  describe('#fetchLargeCapitalProfilesHandler', () => {
+    describe('when the response is successful', () => {
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {
+            page: 1,
           },
         })
 
-        await controller.renderProfilesView(
-          this.middlewareParameters.reqMock,
-          this.middlewareParameters.resMock,
-          this.middlewareParameters.nextSpy)
+        nock(config.apiRoot)
+          .get(`/v4/large-investor-profile?limit=10&offset=0&sortby=modified_on`)
+          .reply(200, { count: 0, results: [] })
+
+        await fetchLargeCapitalProfilesHandler(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
       })
 
-      it.skip('should not render the view', () => {
-        expect(this.middlewareParameters.resMock.render).to.not.be.called
+      it('should provide a json response', () => {
+        expect(middlewareParameters.resMock.json).to.be.calledOnceWithExactly({ count: 0, results: [] })
       })
 
-      it.skip('should call next with an error', () => {
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledWith(this.error)
-        expect(this.middlewareParameters.nextSpy).to.have.been.calledOnce
+      it('should not call next', () => {
+        expect(middlewareParameters.nextSpy).to.not.be.called
+      })
+    })
+
+    describe('when the response is unsuccessful', () => {
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {
+            page: 1,
+          },
+        })
+
+        nock(config.apiRoot)
+          .get(`/v4/large-investor-profile?limit=10&offset=0&sortby=modified_on`)
+          .reply(500)
+
+        await fetchLargeCapitalProfilesHandler(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should not provide a json response', () => {
+        expect(middlewareParameters.resMock.json).to.not.be.called
+      })
+
+      it('should call next in the catch', () => {
+        expect(middlewareParameters.nextSpy).to.be.called
       })
     })
   })

--- a/src/apps/investments/controllers/profiles.js
+++ b/src/apps/investments/controllers/profiles.js
@@ -1,9 +1,34 @@
+const { fetchLargeCapitalProfiles } = require('../repos')
+const { transformLargeCapitalProfiles } = require('../transformers/profiles')
+
 const renderProfilesView = async (req, res, next) => {
   try {
-    res.render('investments/views/profiles')
+    res
+      .breadcrumb('Profiles')
+      .render('investments/views/profiles', { heading: 'Investments' })
   } catch (error) {
     next(error)
   }
 }
 
-module.exports = { renderProfilesView }
+const fetchLargeCapitalProfilesHandler = async (req, res, next) => {
+  try {
+    const { token } = req.session
+    const { page } = req.query
+
+    const { count, results } = await fetchLargeCapitalProfiles(
+      token,
+      10,
+      parseInt(page, 10)
+    )
+
+    res.json({
+      count: count || 0,
+      results: results ? results.map(transformLargeCapitalProfiles) : [],
+    })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = { renderProfilesView, fetchLargeCapitalProfilesHandler }

--- a/src/apps/investments/repos.js
+++ b/src/apps/investments/repos.js
@@ -75,6 +75,18 @@ async function updateInvestmentTeamMembers (token, investmentId, investmentTeamM
   })
 }
 
+async function fetchLargeCapitalProfiles (token, limit, page = 1) {
+  const offset = limit * (page - 1)
+  return authorisedRequest(token,
+    { url: `${config.apiRoot}/v4/large-investor-profile`,
+      qs: {
+        limit,
+        offset,
+        sortby: 'modified_on',
+      },
+    })
+}
+
 module.exports = {
   getCompanyInvestmentProjects,
   getInvestment,
@@ -85,4 +97,5 @@ module.exports = {
   archiveInvestmentProject,
   unarchiveInvestmentProject,
   updateInvestmentTeamMembers,
+  fetchLargeCapitalProfiles,
 }

--- a/src/apps/investments/router-profiles.js
+++ b/src/apps/investments/router-profiles.js
@@ -1,8 +1,9 @@
 const router = require('express').Router()
 
-const { renderProfilesView } = require('./controllers/profiles')
+const { renderProfilesView, fetchLargeCapitalProfilesHandler } = require('./controllers/profiles')
 const setInvestmentTabItems = require('./middleware/investments-tab-items')
 
 router.get('/', setInvestmentTabItems, renderProfilesView)
+router.get('/data', fetchLargeCapitalProfilesHandler)
 
 module.exports = router

--- a/src/apps/investments/transformers/__test__/profiles.test.js
+++ b/src/apps/investments/transformers/__test__/profiles.test.js
@@ -1,0 +1,31 @@
+const { transformLargeCapitalProfiles } = require('../profiles')
+
+describe('#transformLargeCapitalProfiles', () => {
+  let actual
+
+  before(() => {
+    actual = transformLargeCapitalProfiles({
+      'investor_company': {
+        'name': 'ABC Inc',
+        'id': '1',
+      },
+      'created_on': '2019-10-29T15:50:58.399262Z',
+    })
+  })
+
+  it('should return the transformed values', () => {
+    const expected = {
+      'headingText': 'ABC Inc',
+      'headingUrl': '/companies/1',
+      'itemId': '1',
+      'metadata': [
+        {
+          'label': 'Updated on',
+          'value': '29 October 2019',
+        },
+      ],
+    }
+
+    expect(actual).to.deep.equal(expected)
+  })
+})

--- a/src/apps/investments/transformers/profiles.js
+++ b/src/apps/investments/transformers/profiles.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+const moment = require('moment')
+
+function transformLargeCapitalProfiles ({
+  investor_company,
+  created_on,
+}) {
+  return {
+    headingText: investor_company.name,
+    headingUrl: `/companies/${investor_company.id}`,
+    itemId: investor_company.id,
+    metadata: [
+      {
+        label: 'Updated on',
+        value: moment(created_on).format('D MMMM YYYY'),
+      },
+    ],
+  }
+}
+
+module.exports = { transformLargeCapitalProfiles }

--- a/src/apps/investments/views/profiles.njk
+++ b/src/apps/investments/views/profiles.njk
@@ -1,4 +1,3 @@
-{# {% extends "_layouts/template.njk" %} #}
 {% extends "_layouts/collection.njk" %}
 
 {% block content %}
@@ -9,35 +8,14 @@
       </div>
     </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <h4 class="govuk-heading-s govuk-!-padding-left-2 govuk-!-margin-bottom-2">Large capital</h4>
-        {# New filters section will be added here  #}
+      <div class="govuk-grid-column-full">
+          {% component 'react-slot', {
+            id: 'large-capital-profile-collection',
+            props: props
+          }
+          %}
       </div>
 
-      {% block xhr_content %}
-        <article class="govuk-grid-column-two-thirds" data-xhr="c781e8b1-9747-4b2e-8655-68b14ea49126">
-          {{
-            CollectionContent(results | assign({
-              countLabel: countLabel,
-              sortForm: assign({}, sortForm, { action: CURRENT_PATH }),
-              selectedFilters: selectedFilters,
-              highlightTerm: highlightTerm,
-              actionButtons: actionButtons,
-              exportAction: exportAction,
-              query: QUERY
-            }))
-          }}
-
-          {% if not results %}
-            <section id="no-profiles">
-              <p class="govuk-body-s govuk-!-font-weight-regular govuk-!-margin-top-4">There are no profiles to view</p>
-              <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-            </section>
-          {% endif %}
-
-        </article>
-      {% endblock %}
     </div>
   </div>
 {% endblock %}

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -1,6 +1,7 @@
 const { get, isEmpty, assign, intersection, isUndefined } = require('lodash')
 const queryString = require('qs')
 const { parse } = require('url')
+const path = require('path')
 
 const { filterNonPermittedItem } = require('../modules/permissions/filters')
 
@@ -46,15 +47,16 @@ function handleRoutePermissions (routes) {
   }
 }
 
-function setLocalNav (items = []) {
+function setLocalNav (items = [], appendBaseUrl = true) {
   return function buildLocalNav (req, res, next) {
     const userPermissions = get(res, 'locals.user.permissions')
+    const { CURRENT_PATH } = res.locals
 
     res.locals.localNavItems = items
       .filter(filterNonPermittedItem(userPermissions))
       .map((item) => {
-        const url = item.isExternal ? item.url : `${req.baseUrl}/${item.path}`
-        const isActive = res.locals.CURRENT_PATH === url || res.locals.CURRENT_PATH.startsWith(`${url}/`)
+        const url = item.isExternal || !appendBaseUrl ? item.url : path.join(req.baseUrl || '', item.path)
+        const isActive = CURRENT_PATH === url || CURRENT_PATH.startsWith(`${url}/`)
         return assign({}, item, {
           url,
           isActive,

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -10,6 +10,7 @@ import CreateListFormSection from './apps/company-lists/client/CreateListFormSec
 import AddRemoveFromListSection from './apps/company-lists/client/AddRemoveFromListSection'
 import DnbSubsidiaries from './apps/companies/apps/dnb-subsidiaries/client/DnbSubsidiaries'
 import LeadAdvisers from './apps/companies/apps/advisers/client/LeadAdvisers'
+import LargeCapitalProfileCollection from './apps/investments/client/LargeCapitalProfileCollection'
 
 const appWrapper = document.getElementById('react-app')
 
@@ -55,6 +56,9 @@ function App () {
       </Mount>
       <Mount selector="#dnb-subsidiaries">
         {props => <DnbSubsidiaries {...props} />}
+      </Mount>
+      <Mount selector="#large-capital-profile-collection">
+        {props => <LargeCapitalProfileCollection {...props} />}
       </Mount>
     </>
   )

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -68,6 +68,8 @@ describe('urls', () => {
       expect(urls.companies.interactions.create.route).to.equal(`/interactions/:interactionId?/create`)
       expect(urls.companies.interactions.create(companyId)).to.equal(`/companies/${companyId}/interactions/create`)
       expect(urls.companies.interactions.create(companyId, interactionId)).to.equal(`/companies/${companyId}/interactions/${interactionId}/create`)
+
+      expect(urls.companies.orders(companyId)).to.equal(`/companies/${companyId}/orders`)
     })
   })
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -94,6 +94,7 @@ module.exports = {
     index: url('/companies'),
     subsidiaries: url('/companies', '/:companyId/subsidiaries'),
     interactions: createInteractionsSubApp('/companies', '/:companyId'),
+    orders: url('/companies', '/:companyId/orders'),
   },
   contacts: {
     index: url('/contacts'),

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -106,4 +106,11 @@ module.exports = {
   interactions: {
     subapp: createInteractionsSubApp(),
   },
+  investments: {
+    index: url('/investments'),
+    profiles: {
+      index: url('/investments', '/profiles'),
+      data: url('/investments', '/profiles/data'),
+    },
+  },
 }

--- a/test/functional/cypress/fixtures/company/dnb-global-ultimate-and-global-hq.json
+++ b/test/functional/cypress/fixtures/company/dnb-global-ultimate-and-global-hq.json
@@ -1,0 +1,4 @@
+{
+  "id": "0418f79f-154b-4f55-85a6-8ddad559663e",
+  "name": "DnB Global Ultimate & Global HQ"
+}

--- a/test/functional/cypress/fixtures/default.json
+++ b/test/functional/cypress/fixtures/default.json
@@ -1,4 +1,4 @@
  {
-  "id": "375094ac-f79a-43e5-9c88-059a7caa17f0",
+  "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018",
   "name": "Default mocked response"
 }

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -7,6 +7,7 @@ module.exports = {
     dnbCorp: require('./company/dnb-corp.json'),
     dnbLtd: require('./company/dnb-ltd.json'),
     dnbGlobalUltimate: require('./company/dnb-global-ultimate.json'),
+    dnBGlobalUltimateAndGlobalHq: require('./company/dnb-global-ultimate-and-global-hq.json'),
     investigationLimited: require('./company/investigation-limited'),
     lambdaPlc: require('./company/lambda-plc'),
     marsExportsLtd: require('./company/mars-exports-ltd'),

--- a/test/functional/cypress/specs/companies/dnb-subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-subsidiaries-spec.js
@@ -1,16 +1,22 @@
 const { assertLocalHeader, assertBreadcrumbs } = require('../../support/assertions')
+const { assertLocalNav } = require('../../../../end-to-end/cypress/support/assertions')
 
-const { company: { dnbGlobalUltimate } } = require('../../fixtures')
+const selectors = require('../../../../selectors')
+const { company: { dnbGlobalUltimate, dnBGlobalUltimateAndGlobalHq } } = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
 
 describe('D&B Company subsidiaries', () => {
-  context('when viewing subsidiaries for a Dun & Bradstreet company', () => {
+  context('when viewing subsidiaries for a D&B Global Ultimate', () => {
     before(() => {
       cy.visit(urls.companies.dnbSubsidiaries.index(dnbGlobalUltimate.id))
     })
 
     it('should render the header', () => {
-      assertLocalHeader('Subsidiaries of DnB Global Ultimate')
+      assertLocalHeader('Companies related to DnB Global Ultimate')
+    })
+
+    it('should render the helper text', () => {
+      cy.get('p').should('contain', 'This hierarchy information from Dun & Bradstreet cannot be edited.')
     })
 
     it('should render breadcrumbs', () => {
@@ -19,19 +25,49 @@ describe('D&B Company subsidiaries', () => {
         'Companies': urls.companies.index(),
         [dnbGlobalUltimate.name]: urls.companies.detail(dnbGlobalUltimate.id),
         'Business details': urls.companies.businessDetails(dnbGlobalUltimate.id),
-        'Subsidiaries': null,
+        'Related companies': null,
       })
     })
 
-    it('should render subsidiaries', () => {
+    it('should render related companies', () => {
       cy.get('#dnb-subsidiaries')
-        .should('contain', '1 subsidiary')
+        .should('contain', '2 related companies')
+        .and('contain', 'DnB Global Ultimate')
+        .and('contain', 'DnB Global Ultimate subsidiary')
+    })
+  })
+
+  context('when viewing subsidiaries for a D&B Global Ultimate which is also Global HQ', () => {
+    before(() => {
+      cy.visit(urls.companies.dnbSubsidiaries.index(dnBGlobalUltimateAndGlobalHq.id))
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Companies related to DnB Global Ultimate')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [dnBGlobalUltimateAndGlobalHq.name]: urls.companies.detail(dnBGlobalUltimateAndGlobalHq.id),
+        'Business details': urls.companies.businessDetails(dnBGlobalUltimateAndGlobalHq.id),
+        'Related companies': null,
+      })
+    })
+
+    it('should render related companies', () => {
+      cy.get('#dnb-subsidiaries')
+        .should('contain', '2 related companies')
+        .and('contain', 'DnB Global Ultimate')
         .and('contain', 'DnB Global Ultimate subsidiary')
     })
 
-    it('should not include Global Ultimate', () => {
-      cy.get('#dnb-subsidiaries')
-        .should('not.contain', '1700 Amphitheatre Way')
+    it('should display the local nav', () => {
+      assertLocalNav(selectors.tabbedLocalNav().tabs, [
+        'Dun & Bradstreet hierarchy',
+        'Manually linked subsidiaries',
+      ])
     })
   })
 })

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -1,9 +1,10 @@
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
+const urls = require('../../../../../src/lib/urls')
 
 describe('Company OMIS Collections', () => {
   before(() => {
-    cy.visit(`/companies/${fixtures.default.id}/orders`)
+    cy.visit(urls.companies.orders(fixtures.company.oneListCorp.id))
   })
 
   it('should display a list of orders with the total result', () => {

--- a/test/functional/cypress/specs/companies/subsidiaries-spec.js
+++ b/test/functional/cypress/specs/companies/subsidiaries-spec.js
@@ -1,20 +1,21 @@
-import { assertBreadcrumbs } from '../../support/assertions'
-
+const { assertBreadcrumbs } = require('../../support/assertions')
+const urls = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
+const { assertLocalNav } = require('../../../../end-to-end/cypress/support/assertions')
 
 describe('Companies subsidiaries', () => {
   context('when viewing subsidiaries for a Dun & Bradstreet company', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.oneListCorp.id}/subsidiaries`)
+      cy.visit(urls.companies.subsidiaries(fixtures.company.oneListCorp.id))
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
-        'Home': '/',
-        'Companies': '/companies',
-        [fixtures.company.oneListCorp.name]: `/companies/${fixtures.company.oneListCorp.id}`,
-        'Business details': `/companies/${fixtures.company.oneListCorp.id}/business-details`,
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.oneListCorp.name]: urls.companies.detail(fixtures.company.oneListCorp.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.oneListCorp.id),
         'Subsidiaries': null,
       })
     })
@@ -26,15 +27,15 @@ describe('Companies subsidiaries', () => {
 
   context('when viewing subsidiaries for a Data Hub company', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.venusLtd.id}/subsidiaries`)
+      cy.visit(urls.companies.subsidiaries(fixtures.company.venusLtd.id))
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
-        'Home': '/',
-        'Companies': '/companies',
-        [fixtures.company.venusLtd.name]: `/companies/${fixtures.company.venusLtd.id}`,
-        'Business details': `/companies/${fixtures.company.venusLtd.id}/business-details`,
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.venusLtd.name]: urls.companies.detail(fixtures.company.venusLtd.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.venusLtd.id),
         'Subsidiaries': null,
       })
     })
@@ -46,21 +47,51 @@ describe('Companies subsidiaries', () => {
 
   context('when viewing subsidiaries for an archived company', () => {
     before(() => {
-      cy.visit(`/companies/${fixtures.company.archivedLtd.id}/subsidiaries`)
+      cy.visit(urls.companies.subsidiaries(fixtures.company.archivedLtd.id))
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
-        'Home': '/',
-        'Companies': '/companies',
-        [fixtures.company.archivedLtd.name]: `/companies/${fixtures.company.archivedLtd.id}`,
-        'Business details': `/companies/${fixtures.company.archivedLtd.id}/business-details`,
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.archivedLtd.name]: urls.companies.detail(fixtures.company.archivedLtd.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.archivedLtd.id),
         'Subsidiaries': null,
       })
     })
 
     it('should display the "Why can I not link a subsidiary?" archived details summary', () => {
       cy.get(selectors.companySubsidiaries().whyArchived).should('be.visible')
+    })
+  })
+
+  context('when viewing a company which is a D&B Global Ultimate and Global HQ at the same time', () => {
+    before(() => {
+      cy.visit(urls.companies.subsidiaries(fixtures.company.dnBGlobalUltimateAndGlobalHq.id))
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        [fixtures.company.dnBGlobalUltimateAndGlobalHq.name]: urls.companies.detail(fixtures.company.dnBGlobalUltimateAndGlobalHq.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.dnBGlobalUltimateAndGlobalHq.id),
+        'Subsidiaries': null,
+      })
+    })
+
+    it('should display tabs for two types of hierarchies', () => {
+      assertLocalNav(selectors.tabbedLocalNav().tabs, [
+        'Dun & Bradstreet hierarchy',
+        'Manually linked subsidiaries',
+      ])
+    })
+
+    it('should render the helper text', () => {
+      cy.get('p').should('contain',
+        'This hierarchy information is manually recorded (linked) by Data Hub users. ' +
+        'This means it can be different from the Dun & Bradstreet hierarchy, ' +
+        'which in the future will replace this manually recorded information.')
     })
   })
 })

--- a/test/functional/cypress/specs/investment-project/investment-profiles-spec.js
+++ b/test/functional/cypress/specs/investment-project/investment-profiles-spec.js
@@ -1,17 +1,82 @@
-const selectors = require('../../../../selectors')
+const { assertTabbedLocalNav, assertLocalHeader, assertBreadcrumbs } = require('../../support/assertions')
+const { investments } = require('../../../../../src/lib/urls')
 
-describe('Investment / Invenstor profiles', () => {
-  before(() => {
-    cy.visit('/investments/profiles')
-  })
-
-  context('When no profiles are available', () => {
-    it('should not display any profiles', () => {
-      cy.get(selectors.entityCollection.entities).should('have.length', 0)
+describe('Investor profiles', () => {
+  context('When there are 12 profiles and viewing the first page', () => {
+    before(() => {
+      cy.visit(investments.profiles.index())
     })
 
-    it('should display a proper message', () => {
-      cy.get('#no-profiles').should('be.visible')
+    it('should render the header', () => {
+      assertLocalHeader('Investments')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': '/',
+        'Investments': '/investments',
+        'Profiles': null,
+      })
+    })
+
+    it('should render the local navigation', () => {
+      assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('Investor profiles')
+    })
+
+    it('should display 10 profiles', () => {
+      cy.get('h3').should('have.length', 10)
+    })
+
+    it('should display 3 pagination links', () => {
+      cy.get('ul:last li a').should('have.length', 3)
+    })
+
+    it('should display the next button', () => {
+      cy.get('ul:last li a:last').should('have.text', 'Next')
+    })
+
+    it('should not display the previous button', () => {
+      cy.get('ul:last li a:first').should('not.have.text', 'Previous')
+    })
+  })
+
+  context('When there are 12 profiles and viewing the second page', () => {
+    before(() => {
+      cy.visit(`${investments.profiles.index()}?page=2`)
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Investments')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': '/',
+        'Investments': '/investments',
+        'Profiles': null,
+      })
+    })
+
+    it('should render the local navigation', () => {
+      assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('Investor profiles')
+    })
+
+    it('should display 2 profiles', () => {
+      cy.get('h3').should('have.length', 2)
+    })
+
+    it('should display 3 pagination links', () => {
+      cy.get('ul:last li a').should('have.length', 3)
+    })
+
+    it('should not display the next button', () => {
+      cy.get('ul:last li a:last').should('not.have.text', 'Next')
+    })
+
+    it('should display the previous button', () => {
+      cy.get('ul:last li a:first').should('have.text', 'Previous')
     })
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -71,6 +71,10 @@ const assertLocalHeader = (header) => {
   cy.get(selectors.localHeader).contains(header)
 }
 
+const assertTabbedLocalNav = (nav) => {
+  cy.get(selectors.tabbedLocalNav).contains(nav)
+}
+
 module.exports = {
   assertKeyValueTable,
   assertValueTable,
@@ -78,4 +82,5 @@ module.exports = {
   assertFieldInput,
   assertFieldUneditable,
   assertLocalHeader,
+  assertTabbedLocalNav,
 }


### PR DESCRIPTION
## Features

- add new list view of investment profiles in the investment section of Data Hub (currently only visible by going to `/investments/profiles`)
- display a tabbed view of subsidiaries. You can now switch between viewing DNB subsidiaries and manually linked subsidiaries. 