### PR TITLE
Redirect to large capital profile of company rather than index page

### DIFF
--- a/src/apps/investments/transformers/__test__/profiles.test.js
+++ b/src/apps/investments/transformers/__test__/profiles.test.js
@@ -1,4 +1,5 @@
 const { transformLargeCapitalProfiles } = require('../profiles')
+const { companies } = require('../../../../lib/urls')
 
 describe('#transformLargeCapitalProfiles', () => {
   let actual
@@ -16,7 +17,7 @@ describe('#transformLargeCapitalProfiles', () => {
   it('should return the transformed values', () => {
     const expected = {
       'headingText': 'ABC Inc',
-      'headingUrl': '/companies/1',
+      'headingUrl': companies.investments.largeCapitalProfile(1),
       'itemId': '1',
       'metadata': [
         {

--- a/src/apps/investments/transformers/profiles.js
+++ b/src/apps/investments/transformers/profiles.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 const moment = require('moment')
+const { companies } = require('../../../lib/urls')
 
 function transformLargeCapitalProfiles ({
   investor_company,
@@ -7,7 +8,7 @@ function transformLargeCapitalProfiles ({
 }) {
   return {
     headingText: investor_company.name,
-    headingUrl: `/companies/${investor_company.id}`,
+    headingUrl: companies.investments.largeCapitalProfile(investor_company.id),
     itemId: investor_company.id,
     metadata: [
       {

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -60,6 +60,8 @@ describe('urls', () => {
 
       expect(urls.companies.subsidiaries(companyId)).to.equal(`/companies/${companyId}/subsidiaries`)
 
+      expect(urls.companies.investments.largeCapitalProfile(companyId)).to.equal(`/companies/${companyId}/investments/large-capital-profile`)
+
       const globalHqId = faker.random.uuid()
       expect(urls.companies.hierarchies.ghq.add.route).to.equal('/:companyId/hierarchies/ghq/:globalHqId/add')
       expect(urls.companies.hierarchies.ghq.add(companyId, globalHqId)).to.equal(`/companies/${companyId}/hierarchies/ghq/${globalHqId}/add`)

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -95,6 +95,9 @@ module.exports = {
     subsidiaries: url('/companies', '/:companyId/subsidiaries'),
     interactions: createInteractionsSubApp('/companies', '/:companyId'),
     orders: url('/companies', '/:companyId/orders'),
+    investments: {
+      largeCapitalProfile: url('/companies', '/:companyId/investments/large-capital-profile'),
+    },
   },
   contacts: {
     index: url('/contacts'),


### PR DESCRIPTION
## Description of change

Currently when clicking on a large capital profile in the collection list view (viewable at `/investments/profiles`) you will be taken to the index page of that company. This change means you are taken directly to the large capital profile of that company. 

## Test instructions

You will now go to `/companies/:companyId/investments/large-capital-profile`


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
