### PR TITLE
Replace a Lead ITA

### DIFF
--- a/src/apps/companies/apps/advisers/client/AddAdviser.jsx
+++ b/src/apps/companies/apps/advisers/client/AddAdviser.jsx
@@ -1,11 +1,25 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, H3, Details, UnorderedList, Link, ListItem } from 'govuk-react'
+import { Button, H3, Details, UnorderedList, Link, ListItem, InsetText } from 'govuk-react'
 import { FormActions } from 'data-hub-components'
 
-const AddAdviser = ({ csrfToken }) =>
+import urls from '../../../../../lib/urls'
+
+const AddAdviser = ({ cancelUrl, csrfToken, currentLeadITA }) =>
   <>
     <H3>Do you want to add yourself as the first point of contact?</H3>
+    {currentLeadITA &&
+      <>
+        <p>
+          You would replace Lead ITA:
+        </p>
+        <InsetText>
+          Name: {currentLeadITA.name}
+          <br />
+          Team: {currentLeadITA.team}
+        </InsetText>
+      </>
+    }
     <Details summary="How do I add someone else as the Lead ITA?">
       You can only add yourself as the Lead ITA.
       If you think another International Trade Adviser is the first point of contact
@@ -28,13 +42,18 @@ const AddAdviser = ({ csrfToken }) =>
       <input type="hidden" name="_csrf" value={csrfToken}/>
       <FormActions>
         <Button>Add myself as Lead ITA</Button>
-        <Link href="../advisers">Cancel</Link>
+        <Link href={cancelUrl}>Cancel</Link>
       </FormActions>
     </form>
   </>
 
 AddAdviser.propTypes = {
+  cancelUrl: PropTypes.string.isRequired,
   csrfToken: PropTypes.string.isRequired,
+  currentLeadITA: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    team: PropTypes.string.isRequired,
+  }),
 }
 
 export default AddAdviser

--- a/src/apps/companies/apps/advisers/client/AddAdviser.jsx
+++ b/src/apps/companies/apps/advisers/client/AddAdviser.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import { Button, H3, Details, UnorderedList, Link, ListItem, InsetText } from 'govuk-react'
 import { FormActions } from 'data-hub-components'
 
-import urls from '../../../../../lib/urls'
-
 const AddAdviser = ({ cancelUrl, csrfToken, currentLeadITA }) =>
   <>
     <H3>Do you want to add yourself as the first point of contact?</H3>

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -39,9 +39,10 @@ const RenderHasAccountManager = (
       <Button as={Link} href={addUrl}>
         Replace Lead ITA
       </Button>
-      <Button as={Link} href={removeUrl}>
+      {/* TODO: Uncomment when the remove page is implemented */}
+      {/* <Button as={Link} href={removeUrl}>
         Remove Lead ITA
-      </Button>
+      </Button> */}
     </FormActions>}
   </div>
 

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -13,7 +13,7 @@ const RenderHasAccountManager = (
     team,
     name,
     email,
-    replaceUrl,
+    addUrl,
     removeUrl,
     hasPermissionToAddIta,
     companyName,
@@ -36,7 +36,7 @@ const RenderHasAccountManager = (
     <p>You can <a href={companies.audit(companyId)}>see changes in the Audit trail</a></p>
     {hasPermissionToAddIta &&
     <FormActions>
-      <Button as={Link} href={replaceUrl}>
+      <Button as={Link} href={addUrl}>
         Replace Lead ITA
       </Button>
       <Button as={Link} href={removeUrl}>
@@ -48,7 +48,7 @@ const RenderHasAccountManager = (
 const RenderHasNoAccountManager = (
   {
     hasPermissionToAddIta,
-    confirmUrl,
+    addUrl,
     companyName,
   }) =>
   <div>
@@ -58,7 +58,7 @@ const RenderHasNoAccountManager = (
       users on the company page and any of its subsidiaries.</p>
     {hasPermissionToAddIta && <Button
       as={Link}
-      href={confirmUrl}
+      href={addUrl}
     >
       Add myself as Lead ITA
     </Button>}
@@ -72,8 +72,7 @@ const LeadAdvisers = (
     email,
     companyName,
     companyId,
-    confirmUrl,
-    replaceUrl,
+    addUrl,
     removeUrl,
     hasPermissionToAddIta,
   }) => {
@@ -85,13 +84,14 @@ const LeadAdvisers = (
       companyId={companyId}
       companyName={companyName}
       hasPermissionToAddIta={hasPermissionToAddIta}
-      replaceUrl={replaceUrl}
+      addUrl={addUrl}
       removeUrl={removeUrl}
     />
     : <RenderHasNoAccountManager
       companyName={companyName}
       hasPermissionToAddIta={hasPermissionToAddIta}
-      confirmUrl={confirmUrl}
+      addUrl={addUrl}
+      removeUrl={removeUrl}
     />
 }
 
@@ -102,8 +102,7 @@ LeadAdvisers.propTypes = {
   email: PropTypes.string,
   companyName: PropTypes.string.isRequired,
   companyId: PropTypes.string.isRequired,
-  confirmUrl: PropTypes.string.isRequired,
-  replaceUrl: PropTypes.string.isRequired,
+  addUrl: PropTypes.string.isRequired,
   removeUrl: PropTypes.string.isRequired,
   hasPermissionToAddIta: PropTypes.bool.isRequired,
 }
@@ -112,14 +111,15 @@ RenderHasAccountManager.propTypes = {
   name: PropTypes.string.isRequired,
   team: PropTypes.string.isRequired,
   email: PropTypes.string,
-  replaceUrl: PropTypes.string.isRequired,
+  addUrl: PropTypes.string.isRequired,
+  addUrl: PropTypes.string.isRequired,
   hasPermissionToAddIta: PropTypes.bool.isRequired,
   companyName: PropTypes.string.isRequired,
   companyId: PropTypes.string.isRequired,
 }
 
 RenderHasNoAccountManager.propTypes = {
-  confirmUrl: PropTypes.string.isRequired,
+  addUrl: PropTypes.string.isRequired,
   hasPermissionToAddIta: PropTypes.bool.isRequired,
   companyName: PropTypes.string.isRequired,
 }

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -113,7 +113,7 @@ RenderHasAccountManager.propTypes = {
   team: PropTypes.string.isRequired,
   email: PropTypes.string,
   addUrl: PropTypes.string.isRequired,
-  addUrl: PropTypes.string.isRequired,
+  removeUrl: PropTypes.string.isRequired,
   hasPermissionToAddIta: PropTypes.bool.isRequired,
   companyName: PropTypes.string.isRequired,
   companyId: PropTypes.string.isRequired,

--- a/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
+++ b/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
@@ -66,10 +66,10 @@ describe('Company adviser list controller', () => {
           expect(middlewareParameters.resMock.render.args[0][1].props.companyId).to.equal(15387806)
         })
         it('should set a link to add and replae the account manager', () => {
-          expect(middlewareParameters.resMock.render.args[0][1].props.addUrl).to.equal(`${companies.advisers.add('15387806')}`)
+          expect(middlewareParameters.resMock.render.args[0][1].props.addUrl).to.equal(companies.advisers.assign('15387806'))
         })
         it('should set a link to remove the account manager', () => {
-          expect(middlewareParameters.resMock.render.args[0][1].props.removeUrl).to.equal(`${companies.advisers.remove('15387806')}`)
+          expect(middlewareParameters.resMock.render.args[0][1].props.removeUrl).to.equal(companies.advisers.remove('15387806'))
         })
         it('should set the permission flag', () => {
           expect(middlewareParameters.resMock.render.args[0][1].props.hasPermissionToAddIta).to.equal(true)

--- a/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
+++ b/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
@@ -65,11 +65,8 @@ describe('Company adviser list controller', () => {
         it('should set the company id', () => {
           expect(middlewareParameters.resMock.render.args[0][1].props.companyId).to.equal(15387806)
         })
-        it('should set a link to confirm the account manager', () => {
-          expect(middlewareParameters.resMock.render.args[0][1].props.confirmUrl).to.equal(`${companies.advisers.confirm('15387806')}`)
-        })
-        it('should set a link to replace the account manager', () => {
-          expect(middlewareParameters.resMock.render.args[0][1].props.replaceUrl).to.equal(`${companies.advisers.replace('15387806')}`)
+        it('should set a link to add and replae the account manager', () => {
+          expect(middlewareParameters.resMock.render.args[0][1].props.addUrl).to.equal(`${companies.advisers.add('15387806')}`)
         })
         it('should set a link to remove the account manager', () => {
           expect(middlewareParameters.resMock.render.args[0][1].props.removeUrl).to.equal(`${companies.advisers.remove('15387806')}`)

--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -23,8 +23,8 @@ function renderLeadAdvisers (req, res) {
         email,
         companyName: company.name,
         companyId: company.id,
-        addUrl: `${companies.advisers.add(company.id)}`,
-        removeUrl: `${companies.advisers.remove(company.id)}`,
+        addUrl: companies.advisers.assign(company.id),
+        removeUrl: companies.advisers.remove(company.id),
         hasPermissionToAddIta: permissions.includes('company.change_regional_account_manager'),
       },
     })

--- a/src/apps/companies/apps/advisers/router.js
+++ b/src/apps/companies/apps/advisers/router.js
@@ -5,7 +5,7 @@ const { renderAdvisers, renderAddAdviserForm, addAdviser } = require('./controll
 
 router.get('/', renderAdvisers)
 
-router.route('/add')
+router.route('/assign')
   .all(allFeaturesOr404('lead_advisers'))
   .all(allPermissionsOr403('company.change_regional_account_manager'))
   .get(renderAddAdviserForm)

--- a/src/apps/companies/apps/advisers/views/add-adviser.njk
+++ b/src/apps/companies/apps/advisers/views/add-adviser.njk
@@ -2,6 +2,7 @@
 
 {% block content %}
     {% component 'react-slot', {
-        id: 'add-adviser'
+        id: 'add-adviser',
+        props: props
     } %}
 {% endblock %}

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -35,6 +35,7 @@ function App () {
   const globalProps = parseProps(appWrapper)
   return (
     <>
+      <h1>true: {true} false: {false} undefined: {undefined} null: {null}</h1>
       <Mount selector="#add-company-form">
         {props => <AddCompanyForm csrfToken={globalProps.csrfToken} {...props} />}
       </Mount>
@@ -67,7 +68,7 @@ function App () {
         {props => <LargeCapitalProfileCollection {...props} />}
       </Mount>
       <Mount selector="#add-adviser">
-        <AddAdviser csrfToken={globalProps.csrfToken}/>
+        {props => <AddAdviser {...props} csrfToken={globalProps.csrfToken} />}
       </Mount>
     </>
   )

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -35,7 +35,6 @@ function App () {
   const globalProps = parseProps(appWrapper)
   return (
     <>
-      <h1>true: {true} false: {false} undefined: {undefined} null: {null}</h1>
       <Mount selector="#add-company-form">
         {props => <AddCompanyForm csrfToken={globalProps.csrfToken} {...props} />}
       </Mount>

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -66,7 +66,7 @@ describe('urls', () => {
       expect(urls.companies.advisers.index(companyId)).to.equal(`/companies/${companyId}/advisers`)
       expect(urls.companies.advisers.index.route).to.equal('/:companyId/advisers')
 
-      expect(urls.companies.advisers.add(companyId)).to.equal(`/companies/${companyId}/advisers/add`)
+      expect(urls.companies.advisers.assign(companyId)).to.equal(`/companies/${companyId}/advisers/assign`)
       expect(urls.companies.advisers.remove(companyId)).to.equal(`/companies/${companyId}/advisers/remove`)
       expect(urls.companies.advisers.remove.route).to.equal('/:companyId/advisers/remove')
 

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -66,12 +66,7 @@ describe('urls', () => {
       expect(urls.companies.advisers.index(companyId)).to.equal(`/companies/${companyId}/advisers`)
       expect(urls.companies.advisers.index.route).to.equal('/:companyId/advisers')
 
-      expect(urls.companies.advisers.confirm(companyId)).to.equal(`/companies/${companyId}/advisers/add`)
-      expect(urls.companies.advisers.confirm.route).to.equal('/:companyId/advisers/add')
-
-      expect(urls.companies.advisers.remove(companyId)).to.equal(`/companies/${companyId}/advisers/remove`)
-      expect(urls.companies.advisers.replace(companyId)).to.equal(`/companies/${companyId}/advisers/replace`)
-
+      expect(urls.companies.advisers.add(companyId)).to.equal(`/companies/${companyId}/advisers/add`)
       expect(urls.companies.advisers.remove(companyId)).to.equal(`/companies/${companyId}/advisers/remove`)
       expect(urls.companies.advisers.remove.route).to.equal('/:companyId/advisers/remove')
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -77,7 +77,6 @@ module.exports = {
     advisers: {
       index: url('/companies', '/:companyId/advisers'),
       add: url('/companies', '/:companyId/advisers/add'),
-      replace: url('/companies', '/:companyId/advisers/replace'),
       remove: url('/companies', '/:companyId/advisers/remove'),
     },
     audit: url('/companies', '/:companyId/audit'),

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -76,7 +76,7 @@ module.exports = {
     },
     advisers: {
       index: url('/companies', '/:companyId/advisers'),
-      confirm: url('/companies', '/:companyId/advisers/add'),
+      add: url('/companies', '/:companyId/advisers/add'),
       replace: url('/companies', '/:companyId/advisers/replace'),
       remove: url('/companies', '/:companyId/advisers/remove'),
     },

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -76,7 +76,7 @@ module.exports = {
     },
     advisers: {
       index: url('/companies', '/:companyId/advisers'),
-      add: url('/companies', '/:companyId/advisers/add'),
+      assign: url('/companies', '/:companyId/advisers/assign'),
       remove: url('/companies', '/:companyId/advisers/remove'),
     },
     audit: url('/companies', '/:companyId/audit'),

--- a/test/functional/cypress/specs/companies/lead-advisers/add-adviser-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/add-adviser-spec.js
@@ -1,8 +1,9 @@
 const { assertBreadcrumbs } = require('../../../support/assertions')
+const urls = require('../../../../../../src/lib/urls')
 
 const testCase = ({ companyId, companyName, replace }) =>
   it(`Should render the ${replace ? 'replace' : 'add'} variant`, () => {
-    cy.visit(`/companies/${companyId}/advisers/add`)
+    cy.visit(urls.companies.advisers.assign(companyId))
 
     const headline = replace
       ? 'Replace the Lead ITA'

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -93,11 +93,12 @@ describe('Lead advisers', () => {
         .invoke('attr', 'href')
         .should('eq', companies.advisers.add(fixtures.company.oneListTierDita.id))
     })
-    it('should display a button to remove the Lead ITA', () => {
-      cy
-        .contains('Remove Lead ITA')
-        .invoke('attr', 'href')
-        .should('eq', companies.advisers.remove(fixtures.company.oneListTierDita.id))
-    })
+    // TODO: Uncomment when the remove page is implemented
+    // it('should display a button to remove the Lead ITA', () => {
+    //   cy
+    //     .contains('Remove Lead ITA')
+    //     .invoke('attr', 'href')
+    //     .should('eq', companies.advisers.remove(fixtures.company.oneListTierDita.id))
+    // })
   })
 })

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -25,7 +25,8 @@ describe('Lead advisers', () => {
       cy.get(selectors.companyLeadAdviser.header).should('have.text', 'Lead ITA for Mars Exports Ltd')
     })
     it('should display a button to add myself as lead adviser', () => {
-      cy.contains('Add myself as Lead ITA').invoke('attr', 'href').should('eq', `/companies/${fixtures.company.marsExportsLtd.id}/advisers/add`)
+      cy.contains('Add myself as Lead ITA').invoke('attr', 'href')
+        .should('eq', companies.advisers.assign(fixtures.company.marsExportsLtd.id))
     })
   })
   context('when viewing a One List Tier company', () => {
@@ -91,7 +92,7 @@ describe('Lead advisers', () => {
       cy
         .contains('Replace Lead ITA')
         .invoke('attr', 'href')
-        .should('eq', companies.advisers.add(fixtures.company.oneListTierDita.id))
+        .should('eq', companies.advisers.assign(fixtures.company.oneListTierDita.id))
     })
     // TODO: Uncomment when the remove page is implemented
     // it('should display a button to remove the Lead ITA', () => {

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -91,7 +91,7 @@ describe('Lead advisers', () => {
       cy
         .contains('Replace Lead ITA')
         .invoke('attr', 'href')
-        .should('eq', companies.advisers.replace(fixtures.company.oneListTierDita.id))
+        .should('eq', companies.advisers.add(fixtures.company.oneListTierDita.id))
     })
     it('should display a button to remove the Lead ITA', () => {
       cy

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -92,6 +92,20 @@ exports.company = function (req, res) {
     'a73efeba-8499-11e6-ae22-56b6b6499611': companyWithInvestment2,
     '0f5216e0-849f-11e6-ae22-56b6b6499622': companyWithContacts,
     'w2c34b41-1d5a-4b4b-7685-7c53ff2868dg': companyOneListTierDIta,
+    'not-managed': _.assign({}, company, {
+      name: 'Not Managed Company',
+      id: 'not-managed',
+    }),
+    'managed': _.assign({}, company, {
+      name: 'Managed Company',
+      id: 'managed',
+      one_list_group_global_account_manager: {
+        name: 'Andy Pipkin',
+        dit_team: {
+          name: 'Little Britain',
+        },
+      },
+    }),
   }
 
   res.json(companies[req.params.companyId] || company)


### PR DESCRIPTION
## Description of change

The `/companies/<id>/advisers/add` will act like a _replace_ Lead ITA confirmation, if the company already has a Lead ITA assigned.

## Test instructions

1. Go to a `/companies/<id>` page
2. Click on the _Lead adviser_ tab
3. Click the _Add myself as Lead ITA_ button
4. The `/companies/<id>/advisers/add` should say: _Confirm you are the Lead ITA_
5. Click the _Add myself as Lead ITA_ button
6. After being redirected back to the company page, click the _Add myself as Lead ITA_ button again
7. The `/companies/<id>/advisers/add` should
   * have a  _Replace the Lead ITA_ heading
   * show information about whom the user is about to replace as a Lead ITA 
 
## Screenshots

![Screen Shot 2019-11-25 at 1 57 33 PM](https://user-images.githubusercontent.com/2333157/69546386-92717000-0f8b-11ea-8819-1d7d50445505.png)

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
