### PR TITLE
Fix - Guard against no team, email or name

### DIFF
--- a/src/apps/companies/transformers/company-to-account-manager.js
+++ b/src/apps/companies/transformers/company-to-account-manager.js
@@ -4,7 +4,7 @@ const { get } = require('lodash')
 const transformAccountManager = ({ one_list_group_global_account_manager }) => ({
   name: get(one_list_group_global_account_manager, 'name'),
   email: get(one_list_group_global_account_manager, 'contact_email'),
-  team: get(one_list_group_global_account_manager, '["dit_team"].name'),
+  team: get(one_list_group_global_account_manager, 'dit_team.name'),
 })
 
 module.exports = transformAccountManager

--- a/src/apps/companies/transformers/company-to-account-manager.js
+++ b/src/apps/companies/transformers/company-to-account-manager.js
@@ -1,8 +1,10 @@
+const { get } = require('lodash')
+
 // eslint-disable-next-line camelcase
 const transformAccountManager = ({ one_list_group_global_account_manager }) => ({
-  name: one_list_group_global_account_manager.name,
-  email: one_list_group_global_account_manager.contact_email,
-  team: one_list_group_global_account_manager.dit_team.name,
+  name: get(one_list_group_global_account_manager, 'name'),
+  email: get(one_list_group_global_account_manager, 'contact_email'),
+  team: get(one_list_group_global_account_manager, '["dit_team"].name'),
 })
 
 module.exports = transformAccountManager


### PR DESCRIPTION
## Description of change
If a Lead ITA has no team allocated to them then the route to the advisers tab blows up as it tries to find a prop value that is null.

## Solution
Guard with lodash `get`

_Document what the PR does and why the change is needed_

## Test instructions
Use dev data and click on Alphabet Inc, click the "Lead advisers" tab or "View Lead adviser" in the company header and the page details should show as expected.
 
## Screenshots
<img width="1451" alt="pointing-at-dev" src="https://user-images.githubusercontent.com/10154302/69863646-411bf600-1295-11ea-8ed9-c012d2041dfc.png">



## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
