### PR TITLE
Fix for when a user edits a Client Relationship Manager

### DIFF
--- a/src/apps/adviser/filters.js
+++ b/src/apps/adviser/filters.js
@@ -1,12 +1,17 @@
-const { get, includes } = require('lodash')
+const {
+  get,
+  includes,
+  castArray,
+  compact,
+} = require('lodash')
 
-function filterActiveAdvisers ({ advisers = [], includeAdviser = [] }) {
-  includeAdviser = [...includeAdviser]
+function filterActiveAdvisers ({ advisers = [], includeAdviser }) {
+  let adviserIds = compact(castArray(includeAdviser))
   return advisers.filter(adviser => {
     // This returns all active users plus the include advisor (whether they are active or not)
     return (
       get(adviser, 'is_active', true) ||
-      includes(includeAdviser, adviser.id)
+      includes(adviserIds, adviser.id)
     )
   })
 }


### PR DESCRIPTION
## Fixes a known issue within Investment Projects

Previously this bug manifested itself when attempting to change a Client Relationship Manager (CRM) within Investment Project / teams. To reproduce the issue you have to remove any existing CRM within the admin tool.

https://datahub-api-staging.london.cloudapps.digital/admin/investment/investmentproject/b30dee70-b2d6-48cf-9ce4-b9264854470c/change/

Attempt to change the CRM here:

https://www.datahub.staging.uktrade.io/investments/projects/b30dee70-b2d6-48cf-9ce4-b9264854470c/team

<img width="1373" alt="error" src="https://user-images.githubusercontent.com/964268/69879637-dc29c580-12bf-11ea-9f3f-48fc8bd1c80a.png">

## Worth noting
In JavaScript, function parameters default to `undefined`. However, it's often useful to set a different default value. For example an array:

`const method = (a=[]) => { return a }`

It's important to point out that `null` like other falsey values are honoured:

| Function call  | Returns  |
| ------------- |:--------:|
| method(undefined) | [] |
| method('Hello') |   "Hello"  |
| method(['hi', 'again'])  |  ["hi", "again"]  |
| method('') |   ''  |
| method(null) |   null  |

You cannot rely that the argument `a` will always default to an empty array. 

That was the root cause of this bug where a developer depended on `includeAdviser ` never being `null`.

## Checklist
[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
