### PR TITLE
Fix Tier D ITA companies so the business details are  editable

### DIFF
--- a/src/apps/companies/apps/edit-company/__test__/controllers.test.js
+++ b/src/apps/companies/apps/edit-company/__test__/controllers.test.js
@@ -6,6 +6,7 @@ const {
 const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
 
 const companyMock = require('../../../../../../test/unit/data/companies/company-v4.json')
+const companyTierDItaMock = require('../../../../../../test/unit/data/companies/one-list-group-tier-d-ita.json')
 
 const metadataMock = {
   turnoverRangeOptions: [
@@ -84,6 +85,38 @@ describe('Edit company form controllers', () => {
       nock(config.apiRoot)
         .get('/v4/metadata/headquarter-type')
         .reply(200, metadataMock.headquarterTypeOptions)
+    })
+
+    context('when editing a One List company', () => {
+      beforeEach(async () => {
+        middlewareParams = buildMiddlewareParameters({
+          company: companyMock,
+        })
+        await renderEditCompanyForm(
+          middlewareParams.reqMock,
+          middlewareParams.resMock,
+          middlewareParams.nextSpy,
+        )
+      })
+      it('should set the isOneList flag to true', () => {
+        expect(middlewareParams.resMock.render.firstCall.args[1].props.isOnOneList).to.be.true
+      })
+    })
+
+    context('when editing a One List Tier D ITA', () => {
+      beforeEach(async () => {
+        middlewareParams = buildMiddlewareParameters({
+          company: companyTierDItaMock,
+        })
+        await renderEditCompanyForm(
+          middlewareParams.reqMock,
+          middlewareParams.resMock,
+          middlewareParams.nextSpy,
+        )
+      })
+      it('should set the isOneList flag to false', () => {
+        expect(middlewareParams.resMock.render.firstCall.args[1].props.isOnOneList).to.be.false
+      })
     })
 
     context('when editing a foreign company', () => {

--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -36,6 +36,7 @@ function EditCompanyForm ({
   sectors,
   headquarterTypes,
   oneListEmail,
+  isOnOneList,
   showCompanyNumberForUkBranch,
 }) {
   const returnUrl = `/companies/${companyDetails.id}/business-details`
@@ -44,7 +45,6 @@ function EditCompanyForm ({
   const headquarterType = get(headquarterTypes.find(s => s.value === companyDetails.headquarter_type), 'label')
 
   const isBasedInUK = !!companyDetails.uk_based
-  const isOnOneList = !!companyDetails.one_list_group_tier
   const isDnbCompany = !!companyDetails.duns_number
 
   async function onSubmit (values) {
@@ -214,6 +214,7 @@ function EditCompanyForm ({
 }
 
 EditCompanyForm.propTypes = {
+  isOnOneList: PropTypes.bool.isRequired,
   csrfToken: PropTypes.string.isRequired,
   companyDetails: PropTypes.object.isRequired,
   turnoverRanges: PropTypes.arrayOf(PropTypes.shape({

--- a/src/apps/companies/apps/edit-company/controllers.js
+++ b/src/apps/companies/apps/edit-company/controllers.js
@@ -7,6 +7,7 @@ const { transformCompanyToForm, transformFormToCompany } = require('./transforme
 const { updateCompany } = require('../../repos')
 const { getHeadquarterOptions } = require('./repos')
 const { getOptions } = require('../../../../lib/options')
+const { isItaTierDAccount } = require('../../../../lib/is-tier-type-company')
 
 // Foreign companies can have a UK branch.
 const UK_BRANCH_OF_FOREIGN_COMPANY_ID = 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98'
@@ -18,6 +19,7 @@ async function renderEditCompanyForm (req, res, next) {
 
     const companyDetails = transformCompanyToForm(company)
     const businessType = get(company, 'business_type.id')
+    const isOnOneList = !!(company.one_list_group_tier && !isItaTierDAccount(company))
 
     const [turnoverRanges, employeeRanges, regions, sectors, headquarterTypes] = await Promise.all([
       getOptions(token, 'turnover', { sorted: false }),
@@ -33,6 +35,7 @@ async function renderEditCompanyForm (req, res, next) {
       .breadcrumb('Edit business details')
       .render('companies/apps/edit-company/views/client-container', {
         props: {
+          isOnOneList,
           companyDetails,
           showCompanyNumberForUkBranch: businessType === UK_BRANCH_OF_FOREIGN_COMPANY_ID,
           oneListEmail: config.oneList.email,


### PR DESCRIPTION
## Description of change

You should be able to edit business details of Tier D ITA company and currently you cannot as its behaving like other One List companies which have their editable business detail fields locked down.

## Test instructions
Using the `lead_advisers` feature flag (which is set in dev) you need to try and edit business details on a One List Tier D ITA, you should still be able to edit the fields. Then try a One List Tier A - D and you should not be able to edit the business details.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
