### PR TITLE
Ignore test files from nodemon watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "develop": "run-p watch:js:*",
     "watch:test": "npm run test:unit -- -w",
     "watch:js:client": "webpack --watch --progress",
-    "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect",
+    "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect --ignore 'src/**/__test__/**/*'",
     "lint": "npm-run-all lint:all:*",
     "lint:all:js": "eslint ./test ./src ./assets ./circleci",
     "lint:all:styles": "sass-lint -v -q -c .sass-lint.yml assets/stylesheets/**/*.scss",


### PR DESCRIPTION
## Description of change

Ignore test files from nodemon to stop the app getting restarted unnecessarily 

- [x] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
