### PR TITLE
Fix failing test due to dynamic dates

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -1,6 +1,6 @@
 const selectors = require('../../../../selectors')
 
-const todaysDate = Cypress.moment().format('DD MMM YYYY')
+const todaysDate = Cypress.moment().format('D MMM YYYY')
 
 describe('Company', () => {
   before(() => {


### PR DESCRIPTION
## Description of change

Unforeseen date format expectation caused newly migrated e2e tests to fail. This PR should address that. 

## Test instructions

yarn test:e2e
 
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
