### PR TITLE
Ensure e2e are more robust and remove compatibility test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,38 +524,6 @@ jobs:
       - store_artifacts:
           path: cypress/screenshots
 
-  # Run acceptance tests on different browsers
-  compatibility_at:
-    <<: *at_container_config
-    docker:
-      - <<: *docker_data_hub_base
-        environment:
-          <<: *data_hub_base_envs
-          OAUTH2_DEV_TOKEN: *oauth2_da_staff_token
-      - *docker_redis
-      - *docker_elasticsearch
-      - *docker_postgres
-      - *docker_mi_postgres
-      - *docker_mock_sso
-      - *docker_data_hub_backend_api
-      - *docker_data_hub_backend_celery
-    steps:
-      - checkout
-      - *wait_for_backend
-      - *wait_for_mock_sso
-      - *restore_yarn_cache
-      - run: yarn install --pure-lockfile
-      - run: yarn build:prod
-      - *start_frontend
-      - *wait_for_frontend
-      - *create_cucumber_dirs
-      - run:
-          name: Run compatibility acceptance tests
-          command: REMOTE_RUN=true yarn test:acceptance:remote --env ie11,firefox --tag smoke
-      - *create_at_reports
-      - *store_test_results
-      - *store_test_artifacts
-
   # Run acceptance tests for DIT staff using the master version of the backend
   master-dit_staff_at:
     <<: *dit_staff_at
@@ -630,17 +598,6 @@ workflows:
       - dit_staff_e2e: *common_at_workflow_config
       - da_staff_e2e: *common_at_workflow_config
       - lep_staff_e2e: *common_at_workflow_config
-      - compatibility_at:
-          requires:
-            - dit_staff_at
-            - dit_staff_e2e
-            - da_staff_e2e
-            - lep_staff_e2e
-            - visual_tests
-          filters:
-            branches:
-              only:
-                - develop
       - master-dit_staff_at: *master_common_at_workflow_config
       - master-da_staff_e2e: *master_common_at_workflow_config
       - master-lep_staff_e2e: *master_common_at_workflow_config

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -1,6 +1,8 @@
 const selectors = require('../../../../selectors')
 const userActions = require('../../support/user-actions')
 
+const { assertKeyValueTable } = require('../../support/assertions')
+
 describe('Advisors', () => {
   const globalManagerTable = 2
   const adviserTable = 3
@@ -36,11 +38,25 @@ describe('Contacts', () => {
     email: 'company.contact@dit.com',
   }
 
-  it('should list a newly created contact in collection page', () => {
+  it('should create a contact for a given company', () => {
     cy.visit('/contacts/create?company=0fb3379c-341c-4da4-b825-bf8d47b26baa')
     userActions.contacts.create(data)
 
-    cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/contacts')
+    cy.get(selectors.message.successful).should('contain', 'Added new contact')
+
+    assertKeyValueTable('bodyMainContent', {
+      'Job title': 'Coffee machine operator',
+      'Phone number': '(44) 0778877778800',
+      'Address': '12 St George\'s Road, Paris, 75001, France',
+      'Email': 'company.contact@dit.com',
+      'Email marketing': 'Can be marketed to',
+    })
+  })
+
+  it('should display the newly created contact in company contact collection page', () => {
+    cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/activity')
+
+    cy.contains('Company contacts').click()
     cy.get(selectors.collection.items)
       .should('contain', 'Company Contact')
       .and('contain', 'Coffee machine operator')

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -1,20 +1,6 @@
 const selectors = require('../../../../selectors')
-const { keys, forEach } = require('lodash')
 
-// will refactor this later, so it's not duplicate from functional support assertion
-const assertKeyValueTable = (dataAutoId, expected) => {
-  forEach(keys(expected), (key, i) => {
-    const rowNumber = i + 1
-    cy.get(selectors.keyValueTable(dataAutoId).keyCell(rowNumber)).should('have.text', key)
-
-    if (expected[key].href) {
-      cy.get(selectors.keyValueTable(dataAutoId).valueCellLink(rowNumber)).should('have.attr', 'href', expected[key].href)
-      cy.get(selectors.keyValueTable(dataAutoId).valueCellLink(rowNumber)).should('have.text', expected[key].name)
-    } else {
-      cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expected[key])
-    }
-  })
-}
+const { assertKeyValueTable } = require('../../support/assertions')
 
 const createEvent = () => {
   cy.get(selectors.eventCreate.eventName).type('Eventful event')

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -16,6 +16,37 @@ const assertKeyValueTable = (dataAutoId, expected) => {
   })
 }
 
+const createEvent = () => {
+  cy.get(selectors.eventCreate.eventName).type('Eventful event')
+  cy.get(selectors.eventCreate.eventType).select('Account management')
+  cy.get(selectors.eventCreate.startDateDay).type(today.format('DD'))
+  cy.get(selectors.eventCreate.startDateMonth).type(today.format('MM'))
+  cy.get(selectors.eventCreate.startDateYear).type(today.format('YYYY'))
+  cy.get(selectors.eventCreate.endDateDay).type(today.format('DD'))
+  cy.get(selectors.eventCreate.endDateMonth).type(today.format('MM'))
+  cy.get(selectors.eventCreate.endDateYear).type(today.format('YYYY'))
+  cy.get(selectors.eventCreate.addressLine1).type('Address1')
+  cy.get(selectors.eventCreate.addressLine2).type('Address2')
+  cy.get(selectors.eventCreate.addressTown).type('Campinas')
+  cy.get(selectors.eventCreate.addressCountry).select('Brazil')
+  cy.get(selectors.eventCreate.service).select('Account Management : Northern Powerhouse')
+  cy.get(selectors.eventCreate.organiser).click()
+  cy.get(selectors.eventCreate.organiserInput)
+    .type('Barry')
+  cy.get(selectors.eventCreate.organiserOption)
+    .should('be.visible')
+  cy.get(selectors.eventCreate.organiserInput)
+    .type('{enter}')
+  cy.get(selectors.eventCreate.sharedYes).click()
+  cy.get(selectors.eventCreate.relatedProgrammes).eq(0).select('CEN Energy')
+  cy.get(selectors.eventCreate.addAnotherProgramme).click()
+  cy.get(selectors.eventCreate.relatedProgrammes).eq(1).select('CEN Services')
+
+  cy.get(selectors.eventCreate.saveEvent).click()
+
+  cy.get(selectors.message.successful).should('contain', 'Event created')
+}
+
 const today = Cypress.moment()
 
 describe('Event', () => {
@@ -39,41 +70,13 @@ describe('Event', () => {
     })
 
     it('should create an event successfully', () => {
-      cy.get(selectors.eventCreate.eventName).type('Eventful event')
-      cy.get(selectors.eventCreate.eventType).select('Account management')
-      cy.get(selectors.eventCreate.startDateDay).type(today.format('DD'))
-      cy.get(selectors.eventCreate.startDateMonth).type(today.format('MM'))
-      cy.get(selectors.eventCreate.startDateYear).type(today.format('YYYY'))
-      cy.get(selectors.eventCreate.endDateDay).type(today.format('DD'))
-      cy.get(selectors.eventCreate.endDateMonth).type(today.format('MM'))
-      cy.get(selectors.eventCreate.endDateYear).type(today.format('YYYY'))
-      cy.get(selectors.eventCreate.addressLine1).type('Address1')
-      cy.get(selectors.eventCreate.addressLine2).type('Address2')
-      cy.get(selectors.eventCreate.addressTown).type('Campinas')
-      cy.get(selectors.eventCreate.addressCountry).select('Brazil')
-      cy.get(selectors.eventCreate.service).select('Account Management : Northern Powerhouse')
-      cy.get(selectors.eventCreate.organiser).click()
-      cy.get(selectors.eventCreate.organiserInput)
-        .type('Barry')
-      cy.get(selectors.eventCreate.organiserOption)
-        .should('be.visible')
-      cy.get(selectors.eventCreate.organiserInput)
-        .type('{enter}')
-      cy.get(selectors.eventCreate.sharedYes).click()
-      cy.get(selectors.eventCreate.relatedProgrammes).eq(0).select('CEN Energy')
-      cy.get(selectors.eventCreate.addAnotherProgramme).click()
-      cy.get(selectors.eventCreate.relatedProgrammes).eq(1).select('CEN Services')
-
-      cy.get(selectors.eventCreate.saveEvent).click()
-
-      cy.get(selectors.message.successful).should('contain', 'Event created')
+      createEvent()
     })
-  })
 
-  describe('attendee', () => {
-    it('should create an attendee on the newly created event', () => {
+    it('should create an attendee on a event', () => {
+      createEvent()
+
       cy.visit('/events')
-
       cy.contains('Eventful event').click()
       cy.contains('Attendees').click()
       cy.get(selectors.entityCollection.addAttendee).click()

--- a/test/end-to-end/cypress/support/assertions.js
+++ b/test/end-to-end/cypress/support/assertions.js
@@ -1,3 +1,7 @@
+const selectors = require('../../../selectors')
+
+const { keys, forEach } = require('lodash')
+
 const assertError = (message) => {
   cy.get('body').should('contain', message)
 }
@@ -7,6 +11,20 @@ const assertCollection = (headerCountSelector, collectionItemsSelector) => {
     cy.get(collectionItemsSelector).should((collectionItems) => {
       expect(headerCount).to.eq(collectionItems.length.toString())
     })
+  })
+}
+
+const assertKeyValueTable = (dataAutoId, expected) => {
+  forEach(keys(expected), (key, i) => {
+    const rowNumber = i + 1
+    cy.get(selectors.keyValueTable(dataAutoId).keyCell(rowNumber)).should('have.text', key)
+
+    if (expected[key].href) {
+      cy.get(selectors.keyValueTable(dataAutoId).valueCellLink(rowNumber)).should('have.attr', 'href', expected[key].href)
+      cy.get(selectors.keyValueTable(dataAutoId).valueCellLink(rowNumber)).should('have.text', expected[key].name)
+    } else {
+      cy.get(selectors.keyValueTable(dataAutoId).valueCell(rowNumber)).should('have.text', expected[key])
+    }
   })
 }
 
@@ -23,4 +41,5 @@ module.exports = {
   assertError,
   assertCollection,
   assertLocalNav,
+  assertKeyValueTable,
 }


### PR DESCRIPTION
## Description of change

This PR ensures event spec is repeatable locally and robust when running in CI along with removing compatibility suite as we now rely on visual tests for the same.

## Test instructions

yarn test:e2e:dit
 
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
