### PR TITLE
Remove the "Lead Advisers" feature flag...

### DIFF
--- a/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
+++ b/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
@@ -24,9 +24,6 @@ describe('Company adviser list controller', () => {
             user: {
               permissions: ['company.change_regional_account_manager'],
             },
-            features: {
-              lead_advisers: true,
-            },
           })
 
           await renderAdvisers(
@@ -88,9 +85,6 @@ describe('Company adviser list controller', () => {
             user: {
               permissions: [],
             },
-            features: {
-              lead_advisers: true,
-            },
           })
 
           await renderAdvisers(
@@ -121,9 +115,6 @@ describe('Company adviser list controller', () => {
             },
             user: {
               permissions: [],
-            },
-            features: {
-              lead_advisers: true,
             },
           })
 

--- a/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
+++ b/src/apps/companies/apps/advisers/controllers/__test__/advisers.test.js
@@ -141,6 +141,17 @@ describe('Company adviser list controller', () => {
           middlewareParameters = buildMiddlewareParameters({
             company: {
               ...companyMock,
+              one_list_group_tier: {
+                name: 'Tier A - Strategic Account',
+                id: 'b91bf800-8d53-e311-aef3-441ea13961e2',
+              },
+              one_list_group_global_account_manager: {
+                name: 'Travis Greene',
+                contact_email: 'travis@travis.com',
+                dit_team: {
+                  name: 'DIT Team',
+                },
+              },
             },
           })
 

--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -71,8 +71,8 @@ async function renderCoreTeamAdvisers (req, res, next) {
 }
 
 async function renderAdvisers (req, res, next) {
-  const { company, features } = res.locals
-  features.lead_advisers && (isItaTierDAccount(company) || company.one_list_group_tier === null)
+  const { company } = res.locals
+  isItaTierDAccount(company) || company.one_list_group_tier === null
     ? renderLeadAdvisers(req, res)
     : await renderCoreTeamAdvisers(req, res, next)
 }

--- a/src/apps/companies/apps/advisers/router.js
+++ b/src/apps/companies/apps/advisers/router.js
@@ -1,12 +1,11 @@
 const router = require('express').Router()
 
-const { allFeaturesOr404, allPermissionsOr403 } = require('../../../../middleware/conditionals')
+const { allPermissionsOr403 } = require('../../../../middleware/conditionals')
 const { submit, renderAdvisers, form } = require('./controllers/advisers')
 
 router.get('/', renderAdvisers)
 
-router.route(['/assign', '/remove'])
-  .all(allFeaturesOr404('lead_advisers'))
+router.route(['/assign', 'remove'])
   .all(allPermissionsOr403('company.change_regional_account_manager'))
   .get(form)
   .post(submit)

--- a/src/apps/companies/apps/advisers/router.js
+++ b/src/apps/companies/apps/advisers/router.js
@@ -5,7 +5,7 @@ const { submit, renderAdvisers, form } = require('./controllers/advisers')
 
 router.get('/', renderAdvisers)
 
-router.route(['/assign', 'remove'])
+router.route(['/assign', '/remove'])
   .all(allPermissionsOr403('company.change_regional_account_manager'))
   .get(form)
   .post(submit)

--- a/src/apps/companies/middleware/__test__/local-navigation.test.js
+++ b/src/apps/companies/middleware/__test__/local-navigation.test.js
@@ -109,9 +109,6 @@ describe('Companies local navigation', () => {
             'order.view_order',
           ],
         },
-        features: {
-          lead_advisers: true,
-        },
       })
 
       localNavigation(
@@ -146,9 +143,6 @@ describe('Companies local navigation', () => {
             'investment.view_all_investmentproject',
             'order.view_order',
           ],
-        },
-        features: {
-          lead_advisers: true,
         },
       })
 

--- a/src/apps/companies/middleware/local-navigation.js
+++ b/src/apps/companies/middleware/local-navigation.js
@@ -4,23 +4,14 @@ const { isItaTierDAccount } = require('../../../lib/is-tier-type-company')
 const { LOCAL_NAV } = require('../constants')
 
 function setCompaniesLocalNav (req, res, next) {
-  const { company, features } = res.locals
-  if (features.lead_advisers) {
-    const isCoreTeamCompany = !isItaTierDAccount(company) && company.one_list_group_tier
-    const navItems = LOCAL_NAV.map((item) =>
-      item.path === 'advisers' && isCoreTeamCompany
-        ? { ...item, label: 'Core team' }
-        : item
-    )
-    setLocalNav(navItems)(req, res, next)
-  } else {
-    const navItems = LOCAL_NAV.map((item) =>
-      item.path === 'advisers'
-        ? { ...item, label: 'Core team' }
-        : item
-    ).filter((item) => item.path !== 'advisers' || company.one_list_group_tier)
-    setLocalNav(navItems)(req, res, next)
-  }
+  const { company } = res.locals
+  const isCoreTeamCompany = !isItaTierDAccount(company) && company.one_list_group_tier
+  const navItems = LOCAL_NAV.map((item) =>
+    item.path === 'advisers' && isCoreTeamCompany
+      ? { ...item, label: 'Core team' }
+      : item
+  )
+  setLocalNav(navItems)(req, res, next)
 }
 
 module.exports = setCompaniesLocalNav

--- a/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+++ b/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
@@ -28,10 +28,6 @@
     "is_active": true
   },
   {
-    "code": "lead_advisers",
-    "is_active": true
-  },
-  {
     "code": "activity-feed-filters",
     "is_active": true
   },


### PR DESCRIPTION
## Description of change

Remove the `lead_advisers` feature flag as the "Lead ITA" feature is now live.

## Test instructions

If you have the feature flag `lead_advisers` running locally, de-activate it and make sure that the flow for adding yourself as a Lead ITA still works.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
