### PR TITLE
Bug/activity feed filter 'My activity'

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-loader": "^8.0.0",
     "basic-auth": "^2.0.0",
     "body-parser": "^1.18.3",
+    "bodybuilder": "^2.2.20",
     "case": "^1.5.5",
     "chrono-node": "^1.3.5",
     "churchill": "^1.2.0",

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -105,11 +105,21 @@ describe('Activity feed controllers', () => {
       })
 
       it('should call fetchActivityFeed with a user id', async () => {
-        const { dataHubActivity } = ES_KEYS_GROUPED
-        commonTests(dataHubActivity, [
-          'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
-          'dit:DataHubAdviser:123',
-        ])
+        expect(fetchActivityFeedStub).to.be.calledWith({
+          token: '1234',
+          from: 0,
+          size: 20,
+          filter: [
+            {
+              terms: {
+                'object.attributedTo.id': [
+                  'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
+                  'dit:DataHubAdviser:123',
+                ],
+              },
+            },
+          ],
+        })
       })
     })
 

--- a/src/apps/companies/apps/activity-feed/__test__/repos.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/repos.test.js
@@ -11,28 +11,45 @@ describe('Activity feed repos', () => {
 
     context('when called with filters', () => {
       const { dataHubActivity } = ES_KEYS_GROUPED
-      let filter, results
+      let body, results
       const token = 'abcd'
 
       before(async () => {
-        filter = [
-          {
-            terms: {
-              'object.type': dataHubActivity,
+        body = {
+          from: 0,
+          size: 20,
+          sort: [
+            {
+              'object.startTime': {
+                order: 'desc',
+              },
+            },
+          ],
+          query: {
+            bool: {
+              filter: {
+                bool: {
+                  must: [
+                    {
+                      terms: {
+                        'object.type': dataHubActivity,
+                      },
+                    },
+                    {
+                      term: {
+                        'object.attributedTo.id': 'dit:DataHubCompany:123',
+                      },
+                    },
+                  ],
+                },
+              },
             },
           },
-          {
-            terms: {
-              'object.attributedTo.id': ['dit:DataHubCompany:123'],
-            },
-          },
-        ]
+        }
 
         results = await repos.fetchActivityFeed({
           token,
-          from: 0,
-          size: 20,
-          filter,
+          body,
         })
       })
 
@@ -40,18 +57,7 @@ describe('Activity feed repos', () => {
         expect(authorisedRequestStub).to.be.calledOnceWith(
           token,
           {
-            body: {
-              from: 0,
-              size: 20,
-              query: {
-                bool: {
-                  filter,
-                },
-              },
-              sort: {
-                'object.startTime': 'desc',
-              },
-            },
+            body,
             url: `${config.apiRoot}/v4/activity-feed`,
           })
       })

--- a/src/apps/companies/apps/activity-feed/builders.js
+++ b/src/apps/companies/apps/activity-feed/builders.js
@@ -13,7 +13,7 @@ const {
 const FILTER_KEY_MAP = {
   [FILTER_KEYS.allActivity]: allActivity,
   [FILTER_KEYS.externalActivity]: externalActivity,
-  [FILTER_KEYS.myActivity]: dataHubActivity,
+  [FILTER_KEYS.myActivity]: [],
   [FILTER_KEYS.dataHubActivity]: dataHubActivity,
 }
 
@@ -29,18 +29,25 @@ function createESFilters (activityTypeFilter, ultimateHQSubsidiaryIds = [], comp
     ultimateHQSubsidiaryIds.forEach((id) => attributedToIds.push(`dit:DataHubCompany:${id}`))
   }
 
-  return [
-    {
-      terms: {
-        [ES_KEYS.type]: types,
+  const esQuery = []
+
+  if (types.length) {
+    esQuery.push(
+      {
+        terms: {
+          [ES_KEYS.type]: types,
+        },
       },
+    )
+  }
+
+  esQuery.push({
+    terms: {
+      [ES_KEYS.attributedTo]: attributedToIds,
     },
-    {
-      terms: {
-        [ES_KEYS.attributedTo]: attributedToIds,
-      },
-    },
-  ]
+  })
+
+  return esQuery
 }
 
 module.exports = {

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -47,17 +47,15 @@ async function fetchActivityFeedHandler (req, res, next) {
       showDnbHierarchy = false,
     } = req.query
 
-    let ultimateHQSubsidiaryIds = []
+    let dnbHierarchyIds = []
     if (company.is_global_ultimate && showDnbHierarchy) {
       const { results } = await getGlobalUltimateHierarchy(token, company.global_ultimate_duns_number)
-      ultimateHQSubsidiaryIds = results.filter((company) => !company.is_global_ultimate).map((company) => company.id)
+      dnbHierarchyIds = results.filter((company) => !company.is_global_ultimate).map((company) => company.id)
     }
 
     const results = await fetchActivityFeed({
       token: req.session.token,
-      from,
-      size,
-      filter: createESFilters(activityTypeFilter, ultimateHQSubsidiaryIds, company, user),
+      body: createESFilters(activityTypeFilter, dnbHierarchyIds, company, user, from, size),
     })
 
     res.json(results)

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -1,28 +1,10 @@
 const config = require('../../../../config')
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 
-function fetchActivityFeed ({
-  token,
-  from,
-  size,
-  filter,
-}) {
-  const requestBody = {
-    size,
-    from,
-    query: {
-      bool: {
-        filter,
-      },
-    },
-    sort: {
-      'object.startTime': 'desc',
-    },
-  }
-
+function fetchActivityFeed ({ token, body }) {
   return authorisedRequest(token, {
     url: `${config.apiRoot}/v4/activity-feed`,
-    body: requestBody,
+    body,
   })
 }
 

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -2,8 +2,8 @@ var activities = require('../../../fixtures/v4/activity-feed/activities.json')
 var noActivities = require('../../../fixtures/v4/activity-feed/no-activities.json')
 
 exports.activityFeed = function (req, res) {
-  var terms = req.body.query.bool.filter[1].terms
-  if (terms && terms['object.attributedTo.id'][0] === 'dit:DataHubCompany:0f5216e0-849f-11e6-ae22-56b6b6499611') {
+  var term = req.body.query.bool.filter.bool.must[1].term
+  if (term && term['object.attributedTo.id'] === 'dit:DataHubCompany:0f5216e0-849f-11e6-ae22-56b6b6499611') {
     return res.json(noActivities)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,6 +2601,13 @@ body-parser@1.19.0, body-parser@^1.18.2, body-parser@^1.18.3:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
+bodybuilder@^2.2.20:
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/bodybuilder/-/bodybuilder-2.2.20.tgz#df593e73e3ba505931020b4e40d6dbb49c7b5122"
+  integrity sha512-yHxV/UrGBoA0pkEYsCmZ7TuONPJ/+LWIqBhNWT87bSwRH1lcSkzQHnMSuZm7wSJiltzlzALgF6301Xeaq5Hbfg==
+  dependencies:
+    lodash "^4.17.11"
+
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"


### PR DESCRIPTION
## Introduces an Elastic Search query builder
This fixes a `My activity` bug within the Activity Feed with the introduction of an Elastic Search query builder that creates queries for us.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
