### PR TITLE
Add countries when adding an interaction - Part 2 (save)

### DIFF
--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -118,6 +118,12 @@ const KINDS = {
   SERVICE_DELIVERY: 'service-delivery',
 }
 
+const EXPORT_INTEREST_STATUS = {
+  FUTURE_INTEREST: 'future_interest',
+  EXPORTING_TO: 'currently_exporting',
+  NOT_INTERESTED: 'not_interested',
+}
+
 module.exports = {
   QUERY_FIELDS,
   QUERY_DATE_FIELDS,
@@ -132,4 +138,6 @@ module.exports = {
   INTERACTION_CONTEXTS,
   THEMES,
   KINDS,
+  EXPORT_INTEREST_STATUS,
+  EXPORT_INTEREST_STATUS_VALUES: Object.values(EXPORT_INTEREST_STATUS),
 }

--- a/src/apps/interactions/controllers/__test__/edit.interaction.test.js
+++ b/src/apps/interactions/controllers/__test__/edit.interaction.test.js
@@ -1,5 +1,6 @@
 const moment = require('moment')
 const { find, pick } = require('lodash')
+const { format } = require('date-fns')
 
 const config = require('../../../../config')
 const controller = require('../edit')
@@ -9,8 +10,13 @@ const serviceOptionData = require('../../../../../test/unit/data/interactions/se
 const currentUserTeam = '99887766553'
 
 describe('Interaction edit controller (Interactions)', () => {
+  let req
+  let res
+  let nextStub
+  let metadataMock
+
   beforeEach(() => {
-    this.req = {
+    req = {
       session: {
         token: 'abcd',
         user: {
@@ -24,7 +30,7 @@ describe('Interaction edit controller (Interactions)', () => {
       params: {},
     }
 
-    this.res = {
+    res = {
       breadcrumb: sinon.stub().returnsThis(),
       title: sinon.stub().returnsThis(),
       render: sinon.spy(),
@@ -32,13 +38,13 @@ describe('Interaction edit controller (Interactions)', () => {
       locals: { features: {} },
     }
 
-    this.nextStub = sinon.stub()
+    nextStub = sinon.stub()
 
     const yesterday = moment()
       .subtract(1, 'days')
       .toISOString()
 
-    this.metadataMock = {
+    metadataMock = {
       teamOptions: [
         { id: '1', name: 'te1', disabled_on: null },
         { id: '2', name: 'te2', disabled_on: yesterday },
@@ -118,20 +124,17 @@ describe('Interaction edit controller (Interactions)', () => {
 
   context('When adding an other interaction', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'other',
         kind: 'interaction',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
-        },
-        interaction: {
-          ...interactionData,
         },
         interactions: {
           returnLink: '/return',
@@ -143,48 +146,46 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=other_interaction')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
+
     it('should render the interaction page', async () => {
-      expect(this.res.render).to.be.calledWith('interactions/views/edit')
-      expect(this.res.render).to.have.been.calledOnce
+      expect(res.render).to.be.calledWith('interactions/views/edit')
+      expect(res.render).to.have.been.calledOnce
     })
   })
 
   context('When adding an investment interaction', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'investment',
         kind: 'interaction',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
         },
         interaction: {
           ...interactionData,
-        },
-        interactions: {
-          returnLink: '/return',
         },
         entityName: 'Fred Bloggs',
       }
@@ -193,45 +194,42 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=investment_interaction')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
     it('should render the interaction page', async () => {
-      expect(this.res.render).to.be.calledWith('interactions/views/edit')
-      expect(this.res.render).to.have.been.calledOnce
+      expect(res.render).to.be.calledWith('interactions/views/edit')
+      expect(res.render).to.have.been.calledOnce
     })
   })
 
   context('When adding an interaction from company contact', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'export',
         kind: 'interaction',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
-        },
-        interaction: {
-          ...interactionData,
         },
         interactions: {
           returnLink: '/return',
@@ -243,41 +241,41 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=export_interaction')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
 
     it('should render the interaction page', async () => {
-      expect(this.res.render).to.be.calledWith('interactions/views/edit')
-      expect(this.res.render).to.have.been.calledOnce
+      expect(res.render).to.be.calledWith('interactions/views/edit')
+      expect(res.render).to.have.been.calledOnce
     })
 
     it('should add a breadcrumb', () => {
-      expect(this.res.breadcrumb.firstCall).to.be.calledWith('Add interaction')
+      expect(res.breadcrumb.firstCall).to.be.calledWith('Add interaction')
     })
 
     it('should add a title', () => {
-      expect(this.res.title.firstCall).to.be.calledWith(
+      expect(res.title.firstCall).to.be.calledWith(
         'Add interaction for Fred Bloggs'
       )
     })
 
     it('should include an interaction form', async () => {
-      const actual = this.res.render.firstCall.args[1].interactionForm.children
+      const actual = res.render.firstCall.args[1].interactionForm.children
       expect(actual).to.be.an('array')
     })
 
@@ -448,7 +446,6 @@ describe('Interaction edit controller (Interactions)', () => {
       )
       expect(communicationChannelField.options).to.deep.equal([
         { value: '1', label: 'c1' },
-        { value: '2', label: 'c2' },
         { value: '3', label: 'c3' },
       ])
     })
@@ -475,7 +472,7 @@ describe('Interaction edit controller (Interactions)', () => {
         this.interactionForm.children,
         ({ name }) => name === 'dit_participants'
       )
-      expect(adviserField.value).to.deep.equal([1])
+      expect(adviserField.value).to.deep.equal(['user1'])
     })
 
     it('should set the interaction date to the current date', () => {
@@ -483,9 +480,11 @@ describe('Interaction edit controller (Interactions)', () => {
         this.interactionForm.children,
         ({ name }) => name === 'date'
       )
-      expect(dateField.value).to.have.property('year', '2058')
-      expect(dateField.value).to.have.property('month', '11')
-      expect(dateField.value).to.have.property('day', '25')
+      const today = new Date()
+
+      expect(dateField.value).to.have.property('year', format(today, 'YYYY'))
+      expect(dateField.value).to.have.property('month', format(today, 'MM'))
+      expect(dateField.value).to.have.property('day', format(today, 'DD'))
     })
 
     it('should not include policy feedback as a service option', () => {
@@ -515,14 +514,14 @@ describe('Interaction edit controller (Interactions)', () => {
 
   context('When adding an interaction from a company', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.params,
+      req.params = {
+        ...req.params,
         theme: 'export',
         kind: 'interaction',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -534,22 +533,22 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=export_interaction')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
 
     it('should set the company id as a hidden field', () => {
@@ -568,15 +567,15 @@ describe('Interaction edit controller (Interactions)', () => {
 
   context('when editing an interaction from a company', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'export',
         kind: 'interaction',
         interactionId: 'af4aac84-4d6a-47df-a733-5a54e3008c32',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -590,39 +589,39 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=export_interaction')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
 
     it('should render the interaction page', async () => {
-      expect(this.res.render).to.be.calledWith('interactions/views/edit')
-      expect(this.res.render).to.have.been.calledOnce
+      expect(res.render).to.be.calledWith('interactions/views/edit')
+      expect(res.render).to.have.been.calledOnce
     })
 
     it('should add a breadcrumb', () => {
-      expect(this.res.breadcrumb.firstCall).to.be.calledWith('Edit interaction')
+      expect(res.breadcrumb.firstCall).to.be.calledWith('Edit interaction')
     })
 
     it('should add a title', () => {
-      expect(this.res.title.firstCall).to.be.calledWith('Edit interaction')
+      expect(res.title.firstCall).to.be.calledWith('Edit interaction')
     })
 
     it('should include an interaction form', async () => {
-      const actual = this.res.render.firstCall.args[1].interactionForm.children
+      const actual = res.render.firstCall.args[1].interactionForm.children
       expect(actual).to.be.an('array')
     })
 
@@ -861,14 +860,14 @@ describe('Interaction edit controller (Interactions)', () => {
 
   context('When adding an interaction from an investment project', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'investment',
         kind: 'interaction',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -884,24 +883,24 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get(
           '/v4/metadata/service?contexts__has_any=investment_project_interaction'
         )
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
 
     it('should set the investment project id as a hidden field', () => {
@@ -926,15 +925,15 @@ describe('Interaction edit controller (Interactions)', () => {
 
   context('when editing an interaction from an investment project', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'investment',
         kind: 'interaction',
         interactionId: 'af4aac84-4d6a-47df-a733-5a54e3008c32',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -951,24 +950,24 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get(
           '/v4/metadata/service?contexts__has_any=investment_project_interaction'
         )
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
 
     it('should set the interaction id in a hidden field', () => {
@@ -979,15 +978,15 @@ describe('Interaction edit controller (Interactions)', () => {
 
   context('when displaying an interaction that failed to save', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'export',
         kind: 'interaction',
         interactionId: 'af4aac84-4d6a-47df-a733-5a54e3008c32',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -1011,22 +1010,22 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=export_interaction')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
-      this.interactionForm = this.res.render.getCall(0).args[1].interactionForm
+      await controller.renderEditPage(req, res, nextStub)
+      this.interactionForm = res.render.getCall(0).args[1].interactionForm
     })
 
     it('should merge the changes on top of the original record', () => {
@@ -1179,14 +1178,14 @@ describe('Interaction edit controller (Interactions)', () => {
 
   context('when a new interaction has no kind', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.parms,
+      req.params = {
+        ...req.params,
         theme: 'export',
         kind: '',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -1207,39 +1206,39 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=export_service_delivery')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
+      await controller.renderEditPage(req, res, nextStub)
     })
     it('should throw an error', () => {
-      expect(this.nextStub).to.have.been.called
-      expect(this.nextStub.firstCall.args[0]).to.be.instanceof(Error)
-      expect(this.nextStub.firstCall.args[0].message).to.equal('Invalid kind')
+      expect(nextStub).to.have.been.called
+      expect(nextStub.firstCall.args[0]).to.be.instanceof(Error)
+      expect(nextStub.firstCall.args[0].message).to.equal('Invalid kind')
     })
   })
 
   context('when a new interaction has a kind that does not match service-delivery or interaction', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.params,
+      req.params = {
+        ...req.params,
         theme: 'export',
         kind: 'not-really-an-interaction',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -1260,39 +1259,39 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=export_service_delivery')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
+      await controller.renderEditPage(req, res, nextStub)
     })
     it('should throw an error', () => {
-      expect(this.nextStub).to.have.been.called
-      expect(this.nextStub.firstCall.args[0]).to.be.instanceof(Error)
-      expect(this.nextStub.firstCall.args[0].message).to.equal('Invalid kind')
+      expect(nextStub).to.have.been.called
+      expect(nextStub.firstCall.args[0]).to.be.instanceof(Error)
+      expect(nextStub.firstCall.args[0].message).to.equal('Invalid kind')
     })
   })
 
   context('when a new interaction has a theme that does not match', () => {
     beforeEach(async () => {
-      this.req.params = {
-        ...this.req.params,
+      req.params = {
+        ...req.params,
         theme: 'foo',
         kind: 'not-really-an-interaction',
       }
 
-      this.res.locals = {
-        ...this.res.locals,
+      res.locals = {
+        ...res.locals,
         company: {
           id: '1',
           name: 'Fred ltd.',
@@ -1313,27 +1312,27 @@ describe('Interaction edit controller (Interactions)', () => {
         .get('/v3/contact?company_id=1&limit=500')
         .reply(200, { results: this.contactsData })
         .get('/v4/metadata/team')
-        .reply(200, this.metadataMock.teamOptions)
+        .reply(200, metadataMock.teamOptions)
         .get('/v4/metadata/service?contexts__has_any=export_service_delivery')
-        .reply(200, this.metadataMock.serviceOptions)
+        .reply(200, metadataMock.serviceOptions)
         .get('/adviser/?limit=100000&offset=0')
         .reply(200, { results: this.activeInactiveAdviserData })
         .get('/v4/metadata/communication-channel')
-        .reply(200, this.metadataMock.channelOptions)
+        .reply(200, metadataMock.channelOptions)
         .get('/v4/metadata/service-delivery-status')
-        .reply(200, this.metadataMock.serviceDeliveryStatus)
+        .reply(200, metadataMock.serviceDeliveryStatus)
         .get('/v4/metadata/policy-area')
-        .reply(200, this.metadataMock.policyAreaOptions)
+        .reply(200, metadataMock.policyAreaOptions)
         .get('/v4/metadata/policy-issue-type')
-        .reply(200, this.metadataMock.policyIssueType)
+        .reply(200, metadataMock.policyIssueType)
 
-      await controller.renderEditPage(this.req, this.res, this.nextStub)
+      await controller.renderEditPage(req, res, nextStub)
     })
 
     it('should throw an error', () => {
-      expect(this.nextStub).to.have.been.called
-      expect(this.nextStub.firstCall.args[0]).to.be.instanceof(Error)
-      expect(this.nextStub.firstCall.args[0].message).to.equal('Invalid theme')
+      expect(nextStub).to.have.been.called
+      expect(nextStub.firstCall.args[0]).to.be.instanceof(Error)
+      expect(nextStub.firstCall.args[0].message).to.equal('Invalid theme')
     })
   })
 })

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -11,7 +11,7 @@ const { joinPaths } = require('../../../lib/path')
 const isValidTheme = require('../macros/is-valid-theme')
 const canAddCountries = require('../macros/can-add-countries')
 
-const { KINDS, THEMES } = require('../constants')
+const { KINDS, THEMES, EXPORT_INTEREST_STATUS_VALUES } = require('../constants')
 
 const formConfigs = {
   [KINDS.INTERACTION]: interactionForm,
@@ -146,11 +146,7 @@ async function renderEditPage (req, res, next) {
       : `Add ${kindName + forEntityName}`
 
     if (canAddCountries(theme, res.locals.features)) {
-      [
-        'future_countries',
-        'export_countries',
-        'no_interest_countries',
-      ].forEach(addSelectedOptions(interactionForm.children))
+      EXPORT_INTEREST_STATUS_VALUES.forEach(addSelectedOptions(interactionForm.children))
     }
 
     res

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -146,6 +146,7 @@ async function renderEditPage (req, res, next) {
       ? `Edit ${kindName}`
       : `Add ${kindName + forEntityName}`
 
+    // istanbul ignore next: Covered by functional tests
     if (canAddCountries(theme, res.locals.interaction, res.locals.features)) {
       EXPORT_INTEREST_STATUS_VALUES.forEach(addSelectedOptions(interactionForm.children))
     }

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -46,6 +46,7 @@ async function buildForm (req, res, params) {
       : `Add ${lowerCase(kind)}`,
     company: get(res.locals, 'company.name'),
     theme,
+    interaction: res.locals.interaction,
     featureFlags: res.locals.features,
   }
 
@@ -145,7 +146,7 @@ async function renderEditPage (req, res, next) {
       ? `Edit ${kindName}`
       : `Add ${kindName + forEntityName}`
 
-    if (canAddCountries(theme, res.locals.features)) {
+    if (canAddCountries(theme, res.locals.interaction, res.locals.features)) {
       EXPORT_INTEREST_STATUS_VALUES.forEach(addSelectedOptions(interactionForm.children))
     }
 

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -1,8 +1,10 @@
+const { EXPORT_INTEREST_STATUS } = require('./constants')
+
 const countriesDiscussed = {
-  was_country_discussed: 'Were any countries discussed?',
-  future_countries: 'Future countries of interest',
-  export_countries: 'Countries currently exporting to',
-  no_interest_countries: 'Countries not interested in',
+  were_countries_discussed: 'Were any countries discussed?',
+  [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: 'Future countries of interest',
+  [EXPORT_INTEREST_STATUS.EXPORTING_TO]: 'Countries currently exporting to',
+  [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: 'Countries not interested in',
 }
 
 const interaction = {

--- a/src/apps/interactions/macros/__test__/can-add-countries.test.js
+++ b/src/apps/interactions/macros/__test__/can-add-countries.test.js
@@ -1,8 +1,14 @@
+const faker = require('faker')
+
 const canAddCountries = require('../can-add-countries')
 
 const { THEMES } = require('../../constants')
 
 const FLAG_NAME = 'interaction-add-countries'
+
+function generateInteraction () {
+  return { id: faker.random.uuid() }
+}
 
 describe('canAddCountries', () => {
   let flags = {}
@@ -13,16 +19,34 @@ describe('canAddCountries', () => {
     })
 
     context('When the theme is export or other', () => {
-      it('returns true', () => {
-        expect(canAddCountries(THEMES.EXPORT, flags)).to.equal(true)
-        expect(canAddCountries(THEMES.OTHER, flags)).to.equal(true)
+      context('When there is an interaction', () => {
+        it('returns false', () => {
+          expect(canAddCountries(THEMES.EXPORT, generateInteraction(), flags)).to.equal(false)
+          expect(canAddCountries(THEMES.OTHER, generateInteraction(), flags)).to.equal(false)
+        })
+      })
+
+      context('When there is NOT an interaction', () => {
+        it('returns true', () => {
+          expect(canAddCountries(THEMES.EXPORT, undefined, flags)).to.equal(true)
+          expect(canAddCountries(THEMES.OTHER, undefined, flags)).to.equal(true)
+        })
       })
     })
 
     context('When the theme is something else', () => {
-      it('returns false', () => {
-        expect(canAddCountries(THEMES.INVESTMENT, flags)).to.equal(false)
-        expect(canAddCountries('test', flags)).to.equal(false)
+      context('When there is an interaction', () => {
+        it('returns false', () => {
+          expect(canAddCountries(THEMES.INVESTMENT, generateInteraction(), flags)).to.equal(false)
+          expect(canAddCountries('test', generateInteraction(), flags)).to.equal(false)
+        })
+      })
+
+      context('When there is NOT an interaction', () => {
+        it('returns false', () => {
+          expect(canAddCountries(THEMES.INVESTMENT, undefined, flags)).to.equal(false)
+          expect(canAddCountries('test', undefined, flags)).to.equal(false)
+        })
       })
     })
   })
@@ -33,16 +57,32 @@ describe('canAddCountries', () => {
     })
 
     context('When the theme is export or other', () => {
-      it('returns false', () => {
-        expect(canAddCountries(THEMES.EXPORT, flags)).to.equal(false)
-        expect(canAddCountries(THEMES.OTHER, flags)).to.equal(false)
+      context('When there is an interaction', () => {
+        it('returns false', () => {
+          expect(canAddCountries(THEMES.EXPORT, generateInteraction(), flags)).to.equal(false)
+          expect(canAddCountries(THEMES.OTHER, generateInteraction(), flags)).to.equal(false)
+        })
+      })
+      context('When there is NOT an interaction', () => {
+        it('returns false', () => {
+          expect(canAddCountries(THEMES.EXPORT, undefined, flags)).to.equal(false)
+          expect(canAddCountries(THEMES.OTHER, undefined, flags)).to.equal(false)
+        })
       })
     })
 
     context('When the theme is something else', () => {
-      it('returns false', () => {
-        expect(canAddCountries(THEMES.INVESTMENT, flags)).to.equal(false)
-        expect(canAddCountries('test', flags)).to.equal(false)
+      context('When there is an interaction', () => {
+        it('returns false', () => {
+          expect(canAddCountries(THEMES.INVESTMENT, generateInteraction(), flags)).to.equal(false)
+          expect(canAddCountries('test', generateInteraction(), flags)).to.equal(false)
+        })
+      })
+      context('When there is NOT an interaction', () => {
+        it('returns false', () => {
+          expect(canAddCountries(THEMES.INVESTMENT, undefined, flags)).to.equal(false)
+          expect(canAddCountries('test', undefined, flags)).to.equal(false)
+        })
       })
     })
   })

--- a/src/apps/interactions/macros/__test__/get-export-countries.test.js
+++ b/src/apps/interactions/macros/__test__/get-export-countries.test.js
@@ -73,7 +73,7 @@ describe('getExportCountries', () => {
 
   context('When there are no countries', () => {
     it('should return an empty array', () => {
-      expect(getExportCountries({})).to.deep.equal([])
+      expect(getExportCountries({})).to.deep.equal(null)
     })
   })
 })

--- a/src/apps/interactions/macros/__test__/get-export-countries.test.js
+++ b/src/apps/interactions/macros/__test__/get-export-countries.test.js
@@ -1,0 +1,40 @@
+const faker = require('faker')
+
+const { EXPORT_INTEREST_STATUS } = require('../../constants')
+const getExportCountries = require('../get-export-countries')
+
+describe('getExportCountries', () => {
+  it('should transform the countries into an object', () => {
+    const countries = Array.from({ length: 6 }).map(faker.random.uuid)
+
+    const future = countries.slice(0, 2)
+    const exporting = countries.slice(2, 4)
+    const notInterested = countries.slice(4, 6)
+
+    expect(getExportCountries({
+      [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: future,
+      [EXPORT_INTEREST_STATUS.EXPORTING_TO]: exporting,
+      [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: notInterested,
+    })).to.deep.equal([
+      {
+        country: { id: countries[0] },
+        status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+      }, {
+        country: { id: countries[1] },
+        status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+      }, {
+        country: { id: countries[2] },
+        status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
+      }, {
+        country: { id: countries[3] },
+        status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
+      }, {
+        country: { id: countries[4] },
+        status: EXPORT_INTEREST_STATUS.NOT_INTERESTED,
+      }, {
+        country: { id: countries[5] },
+        status: EXPORT_INTEREST_STATUS.NOT_INTERESTED,
+      },
+    ])
+  })
+})

--- a/src/apps/interactions/macros/__test__/get-export-countries.test.js
+++ b/src/apps/interactions/macros/__test__/get-export-countries.test.js
@@ -3,38 +3,77 @@ const faker = require('faker')
 const { EXPORT_INTEREST_STATUS } = require('../../constants')
 const getExportCountries = require('../get-export-countries')
 
+function generateCountries (length) {
+  return Array.from({ length }).map(faker.random.uuid)
+}
+
 describe('getExportCountries', () => {
-  it('should transform the countries into an object', () => {
-    const countries = Array.from({ length: 6 }).map(faker.random.uuid)
+  context('When the countries are an array', () => {
+    it('should transform the countries into an object', () => {
+      const countries = generateCountries(6)
 
-    const future = countries.slice(0, 2)
-    const exporting = countries.slice(2, 4)
-    const notInterested = countries.slice(4, 6)
+      const future = countries.slice(0, 2)
+      const exporting = countries.slice(2, 4)
+      const notInterested = countries.slice(4, 6)
 
-    expect(getExportCountries({
-      [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: future,
-      [EXPORT_INTEREST_STATUS.EXPORTING_TO]: exporting,
-      [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: notInterested,
-    })).to.deep.equal([
-      {
-        country: { id: countries[0] },
-        status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
-      }, {
-        country: { id: countries[1] },
-        status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
-      }, {
-        country: { id: countries[2] },
-        status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
-      }, {
-        country: { id: countries[3] },
-        status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
-      }, {
-        country: { id: countries[4] },
-        status: EXPORT_INTEREST_STATUS.NOT_INTERESTED,
-      }, {
-        country: { id: countries[5] },
-        status: EXPORT_INTEREST_STATUS.NOT_INTERESTED,
-      },
-    ])
+      expect(getExportCountries({
+        [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: future,
+        [EXPORT_INTEREST_STATUS.EXPORTING_TO]: exporting,
+        [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: notInterested,
+      })).to.deep.equal([
+        {
+          country: { id: countries[0] },
+          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+        }, {
+          country: { id: countries[1] },
+          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+        }, {
+          country: { id: countries[2] },
+          status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
+        }, {
+          country: { id: countries[3] },
+          status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
+        }, {
+          country: { id: countries[4] },
+          status: EXPORT_INTEREST_STATUS.NOT_INTERESTED,
+        }, {
+          country: { id: countries[5] },
+          status: EXPORT_INTEREST_STATUS.NOT_INTERESTED,
+        },
+      ])
+    })
+  })
+
+  context('When the countries are strings', () => {
+    it('should transform the countries into an object', () => {
+      const countries = generateCountries(3)
+
+      const future = countries[0]
+      const exporting = countries[1]
+      const notInterested = countries[2]
+
+      expect(getExportCountries({
+        [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: future,
+        [EXPORT_INTEREST_STATUS.EXPORTING_TO]: exporting,
+        [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: notInterested,
+      })).to.deep.equal([
+        {
+          country: { id: countries[0] },
+          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+        }, {
+          country: { id: countries[1] },
+          status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
+        }, {
+          country: { id: countries[2] },
+          status: EXPORT_INTEREST_STATUS.NOT_INTERESTED,
+        },
+      ])
+    })
+  })
+
+  context('When there are no countries', () => {
+    it('should return an empty array', () => {
+      expect(getExportCountries({})).to.deep.equal([])
+    })
   })
 })

--- a/src/apps/interactions/macros/__test__/map-errors.test.js
+++ b/src/apps/interactions/macros/__test__/map-errors.test.js
@@ -1,0 +1,34 @@
+const faker = require('faker')
+
+const mapErrors = require('../map-errors')
+
+const EXPORT_COUNTRIES = 'export_countries'
+const OUTPUT_FIELD = 'were_countries_discussed'
+
+describe('mapErrors macro', () => {
+  context('When EXPORT_COUNTRIES has an error', () => {
+    it('Should map the error to the future countries of interest', () => {
+      const errorMessage = faker.lorem.words(5)
+      const input = {
+        foo: 'bar',
+        [EXPORT_COUNTRIES]: errorMessage,
+      }
+
+      expect(mapErrors(input)).to.deep.equal({
+        foo: 'bar',
+        [OUTPUT_FIELD]: errorMessage,
+      })
+    })
+  })
+
+  context('When EXPORT_COUNTRIES does not have an error', () => {
+    it('Should return the errors', () => {
+      const input = {
+        foo: 'bar',
+        bar: 'foo',
+      }
+
+      expect(mapErrors(input)).to.deep.equal(input)
+    })
+  })
+})

--- a/src/apps/interactions/macros/can-add-countries.js
+++ b/src/apps/interactions/macros/can-add-countries.js
@@ -1,9 +1,9 @@
 const { THEMES } = require('../constants')
 
-module.exports = (theme, featureFlags) => {
+module.exports = (theme, interaction, featureFlags) => {
   const featureEnabled = featureFlags[ 'interaction-add-countries' ]
 
-  if (!featureEnabled) { return false }
+  if (interaction || !featureEnabled) { return false }
 
   return (theme === THEMES.EXPORT || theme === THEMES.OTHER)
 }

--- a/src/apps/interactions/macros/fields.js
+++ b/src/apps/interactions/macros/fields.js
@@ -3,6 +3,8 @@ const { flattenDeep } = require('lodash')
 const { globalFields } = require('../../macros')
 const canAddCountries = require('./can-add-countries')
 
+const { EXPORT_INTEREST_STATUS } = require('../constants')
+
 module.exports = {
   adviser (advisers) {
     return {
@@ -238,7 +240,7 @@ module.exports = {
         {
           macroName: 'MultipleChoiceField',
           type: 'radio',
-          name: 'was_country_discussed',
+          name: 'were_countries_discussed',
           modifier: 'inline',
           optional: false,
           options: [
@@ -253,16 +255,16 @@ module.exports = {
           ],
         },
         ...[
-          'future_countries',
-          'export_countries',
-          'no_interest_countries',
+          EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+          EXPORT_INTEREST_STATUS.EXPORTING_TO,
+          EXPORT_INTEREST_STATUS.NOT_INTERESTED,
         ].map((name) => ({
           macroName: 'Typeahead',
           name,
           hint: 'Add all that you discussed',
           modifier: 'subfield',
           condition: {
-            name: 'was_country_discussed',
+            name: 'were_countries_discussed',
             value: 'true',
           },
           isAsync: false,

--- a/src/apps/interactions/macros/fields.js
+++ b/src/apps/interactions/macros/fields.js
@@ -3,7 +3,7 @@ const { flattenDeep } = require('lodash')
 const { globalFields } = require('../../macros')
 const canAddCountries = require('./can-add-countries')
 
-const { EXPORT_INTEREST_STATUS } = require('../constants')
+const { EXPORT_INTEREST_STATUS_VALUES } = require('../constants')
 
 module.exports = {
   adviser (advisers) {
@@ -232,52 +232,44 @@ module.exports = {
       options: channels,
     }
   },
-  countriesDiscussed: (theme, featureFlags) => {
-    if (!canAddCountries(theme, featureFlags)) {
-      return []
-    } else {
-      return [
-        {
-          macroName: 'MultipleChoiceField',
-          type: 'radio',
-          name: 'were_countries_discussed',
-          modifier: 'inline',
-          optional: false,
-          options: [
-            {
-              label: 'Yes',
-              value: 'true',
-            },
-            {
-              label: 'No',
-              value: 'false',
-            },
-          ],
-        },
-        ...[
-          EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
-          EXPORT_INTEREST_STATUS.EXPORTING_TO,
-          EXPORT_INTEREST_STATUS.NOT_INTERESTED,
-        ].map((name) => ({
-          macroName: 'Typeahead',
-          name,
-          hint: 'Add all that you discussed',
-          modifier: 'subfield',
-          condition: {
-            name: 'were_countries_discussed',
+  countriesDiscussed: (theme, interaction, featureFlags) => {
+    return !canAddCountries(theme, interaction, featureFlags) ? [] : [
+      {
+        macroName: 'MultipleChoiceField',
+        type: 'radio',
+        name: 'were_countries_discussed',
+        modifier: 'inline',
+        optional: false,
+        options: [
+          {
+            label: 'Yes',
             value: 'true',
           },
-          isAsync: false,
-          isLabelHidden: false,
-          useSubLabel: false,
-          placeholder: 'Search countries',
-          classes: 'c-form-group--no-filter',
-          multipleSelect: true,
-          options: globalFields.countries.options(),
-          target: 'metadata',
-          autoSubmit: false,
-        })),
-      ]
-    }
+          {
+            label: 'No',
+            value: 'false',
+          },
+        ],
+      },
+      ...EXPORT_INTEREST_STATUS_VALUES.map((name) => ({
+        macroName: 'Typeahead',
+        name,
+        hint: 'Add all that you discussed',
+        modifier: 'subfield',
+        condition: {
+          name: 'were_countries_discussed',
+          value: 'true',
+        },
+        isAsync: false,
+        isLabelHidden: false,
+        useSubLabel: false,
+        placeholder: 'Search countries',
+        classes: 'c-form-group--no-filter',
+        multipleSelect: true,
+        options: globalFields.countries.options(),
+        target: 'metadata',
+        autoSubmit: false,
+      })),
+    ]
   },
 }

--- a/src/apps/interactions/macros/get-export-countries.js
+++ b/src/apps/interactions/macros/get-export-countries.js
@@ -1,12 +1,14 @@
+const castCompactArray = require('../../../lib/cast-compact-array')
+
 const { EXPORT_INTEREST_STATUS_VALUES } = require('../constants')
 
 module.exports = (body) => {
   const data = []
 
   EXPORT_INTEREST_STATUS_VALUES.forEach((status) => {
-    const countryIds = body[status]
+    const countryIds = castCompactArray(body[status])
 
-    if (Array.isArray(countryIds) && countryIds.length) {
+    if (countryIds.length) {
       countryIds.forEach((id) => data.push({ country: { id }, status }))
     }
   })

--- a/src/apps/interactions/macros/get-export-countries.js
+++ b/src/apps/interactions/macros/get-export-countries.js
@@ -1,0 +1,15 @@
+const { EXPORT_INTEREST_STATUS_VALUES } = require('../constants')
+
+module.exports = (body) => {
+  const data = []
+
+  EXPORT_INTEREST_STATUS_VALUES.forEach((status) => {
+    const countryIds = body[status]
+
+    if (Array.isArray(countryIds) && countryIds.length) {
+      countryIds.forEach((id) => data.push({ country: { id }, status }))
+    }
+  })
+
+  return data
+}

--- a/src/apps/interactions/macros/get-export-countries.js
+++ b/src/apps/interactions/macros/get-export-countries.js
@@ -13,5 +13,5 @@ module.exports = (body) => {
     }
   })
 
-  return data
+  return data.length ? data : null
 }

--- a/src/apps/interactions/macros/interaction-form.js
+++ b/src/apps/interactions/macros/interaction-form.js
@@ -33,6 +33,7 @@ module.exports = function ({
   types,
   company,
   theme,
+  interaction,
   featureFlags,
 }) {
   return {
@@ -63,7 +64,7 @@ module.exports = function ({
         },
       },
       feedbackPolicyNotes,
-      ...countriesDiscussed(theme, featureFlags),
+      ...countriesDiscussed(theme, interaction, featureFlags),
     ].map(field => {
       return assign(field, {
         label: field.label || labels.interaction[field.name],

--- a/src/apps/interactions/macros/map-errors.js
+++ b/src/apps/interactions/macros/map-errors.js
@@ -1,0 +1,10 @@
+const EXPORT_COUNTRIES = 'export_countries'
+
+module.exports = (errors) => {
+  if (errors.hasOwnProperty(EXPORT_COUNTRIES)) {
+    errors.were_countries_discussed = errors[EXPORT_COUNTRIES]
+    delete errors[EXPORT_COUNTRIES]
+  }
+
+  return errors
+}

--- a/src/apps/interactions/macros/service-delivery-form.js
+++ b/src/apps/interactions/macros/service-delivery-form.js
@@ -36,6 +36,7 @@ module.exports = function ({
   types,
   company,
   theme,
+  interaction,
   featureFlags,
 }) {
   return {
@@ -126,7 +127,7 @@ module.exports = function ({
         },
       },
       feedbackPolicyNotes,
-      ...countriesDiscussed(theme, featureFlags),
+      ...countriesDiscussed(theme, interaction, featureFlags),
     ].map(field => {
       return assign(field, {
         label: field.label || labels.serviceDelivery[field.name],

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -76,7 +76,6 @@ describe('Interaction details middleware', () => {
                 policy_issue_types: [],
                 status: 'complete',
                 were_countries_discussed: null,
-                export_countries: null,
               }
             )
           })
@@ -155,7 +154,6 @@ describe('Interaction details middleware', () => {
                 policy_issue_types: [],
                 status: 'complete',
                 were_countries_discussed: null,
-                export_countries: null,
               }
             )
           })
@@ -337,7 +335,6 @@ describe('Interaction details middleware', () => {
                 [FUTURE_INTEREST]: interactionDataWithCountries[FUTURE_INTEREST],
                 [EXPORTING_TO]: interactionDataWithCountries[EXPORTING_TO],
                 [NOT_INTERESTED]: interactionDataWithCountries[NOT_INTERESTED],
-                export_countries: null,
               }
             )
           })

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -359,6 +359,8 @@ describe('Interaction details middleware', () => {
         before(async () => {
           this.saveInteractionStub = sinon.stub()
           this.getServiceOptionsStub = sinon.stub()
+          this.mapErrorsStub = sinon.stub()
+          this.mapErrorsResponse = { mapErrors: true }
 
           this.middlewareParameters = buildMiddlewareParameters({
             requestBody: { ...interactionData },
@@ -376,7 +378,7 @@ describe('Interaction details middleware', () => {
               '../repos': {
                 saveInteraction: this.saveInteractionStub.rejects({
                   statusCode: 400,
-                  error: 'error',
+                  error: '400-error',
                 }),
               },
               '../../../lib/options': {
@@ -384,6 +386,7 @@ describe('Interaction details middleware', () => {
                   serviceOptionsTransformed
                 ),
               },
+              '../macros/map-errors': this.mapErrorsStub.returns(this.mapErrorsResponse),
             }
           )
 
@@ -402,10 +405,11 @@ describe('Interaction details middleware', () => {
           expect(this.middlewareParameters.resMock.redirect).to.not.be.called
         })
 
-        it('should set errors on locals', () => {
+        it('should map and set the errors on locals', () => {
+          expect(this.mapErrorsStub).to.have.been.calledOnceWithExactly('400-error')
           expect(this.middlewareParameters.resMock.locals.form).to.deep.equal({
             errors: {
-              messages: 'error',
+              messages: this.mapErrorsResponse,
             },
           })
         })

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -75,7 +75,6 @@ describe('Interaction details middleware', () => {
                 policy_areas: [],
                 policy_issue_types: [],
                 status: 'complete',
-                were_countries_discussed: null,
               }
             )
           })
@@ -153,7 +152,6 @@ describe('Interaction details middleware', () => {
                 policy_areas: [],
                 policy_issue_types: [],
                 status: 'complete',
-                were_countries_discussed: null,
               }
             )
           })

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -75,6 +75,7 @@ describe('Interaction details middleware', () => {
                 policy_areas: [],
                 policy_issue_types: [],
                 status: 'complete',
+                were_countries_discussed: null,
                 export_countries: null,
               }
             )
@@ -153,6 +154,7 @@ describe('Interaction details middleware', () => {
                 policy_areas: [],
                 policy_issue_types: [],
                 status: 'complete',
+                were_countries_discussed: null,
                 export_countries: null,
               }
             )

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -12,6 +12,7 @@ const { getDitCompany } = require('../../companies/repos')
 const { joinPaths } = require('../../../lib/path')
 const { getReturnLink } = require('../helpers')
 const canAddCountries = require('../macros/can-add-countries')
+const mapErrors = require('../macros/map-errors')
 
 async function postDetails (req, res, next) {
   try {
@@ -42,7 +43,7 @@ async function postDetails (req, res, next) {
       return next(err)
     }
 
-    set(res.locals, 'form.errors.messages', err.error)
+    set(res.locals, 'form.errors.messages', mapErrors(err.error))
     next()
   }
 }

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -22,8 +22,9 @@ async function postDetails (req, res, next) {
     res.locals.requestBody = transformInteractionFormBodyToApiRequest(
       req.body,
       serviceOptions,
-      canAddCountries(req.params.theme, res.locals.features)
+      canAddCountries(req.params.theme, res.locals.interaction, res.locals.features)
     )
+
     const result = await saveInteraction(
       req.session.token,
       res.locals.requestBody

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -11,6 +11,7 @@ const { getContact } = require('../../contacts/repos')
 const { getDitCompany } = require('../../companies/repos')
 const { joinPaths } = require('../../../lib/path')
 const { getReturnLink } = require('../helpers')
+const canAddCountries = require('../macros/can-add-countries')
 
 async function postDetails (req, res, next) {
   try {
@@ -20,7 +21,8 @@ async function postDetails (req, res, next) {
     })
     res.locals.requestBody = transformInteractionFormBodyToApiRequest(
       req.body,
-      serviceOptions
+      serviceOptions,
+      canAddCountries(req.params.theme, res.locals.features)
     )
     const result = await saveInteraction(
       req.session.token,

--- a/src/apps/interactions/transformers/__test__/interaction-form-body-to-api.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-form-body-to-api.test.js
@@ -9,7 +9,7 @@ const transformInteractionFormBodyToApiRequest = require('../interaction-form-bo
 
 const transformedServices = transformServicesOptions(serviceOptions)
 
-function defaultTests () {
+function defaultTests (addCountries) {
   context('when all fields are populated', function () {
     before(function () {
       this.transformed = transformInteractionFormBodyToApiRequest(
@@ -24,7 +24,7 @@ function defaultTests () {
           service: 'sv1',
         },
         transformedServices,
-        this.addCountries,
+        addCountries,
       )
     })
 
@@ -48,9 +48,15 @@ function defaultTests () {
       expect(this.transformed.policy_issue_types).to.deep.equal(['5555'])
     })
 
-    it('should set countries discussed to null', function () {
-      expect(this.transformed.were_countries_discussed).to.equal(null)
-    })
+    if (addCountries) {
+      it('should set countries discussed to null', function () {
+        expect(this.transformed.were_countries_discussed).to.equal(null)
+      })
+    } else {
+      it('should not include countries discussed', function () {
+        expect(this.transformed.were_countries_discussed).to.be.undefined
+      })
+    }
   })
 
   context('when the optional fields have not been entered', function () {
@@ -183,7 +189,7 @@ describe('#transformInteractionFormBodyToApiRequest', function () {
     before(function () {
       this.addCountries = true
     })
-    defaultTests()
+    defaultTests(true)
 
     context('when countries discussed is false', function () {
       it('should not add export_countries', function () {
@@ -195,6 +201,7 @@ describe('#transformInteractionFormBodyToApiRequest', function () {
           this.addCountries,
         )
 
+        expect(transformed.were_countries_discussed).to.equal('false')
         expect(transformed.export_countries).to.be.undefined
       })
     })
@@ -213,6 +220,7 @@ describe('#transformInteractionFormBodyToApiRequest', function () {
           this.addCountries,
         )
 
+        expect(transformed.were_countries_discussed).to.equal('true')
         expect(transformed.export_countries).to.deep.equal([
           {
             country: { id: futureCountries[ 0 ] },

--- a/src/apps/interactions/transformers/__test__/interaction-form-body-to-api.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-form-body-to-api.test.js
@@ -1,14 +1,17 @@
-const transformInteractionFormBodyToApiRequest = require('../interaction-form-body-to-api')
+const faker = require('faker')
+
+const { transformServicesOptions } = require('../')
+const { EXPORT_INTEREST_STATUS } = require('../../constants')
+
 const serviceOptions = require('../../../../../test/unit/data/interactions/service-options-data.json')
-const {
-  transformServicesOptions,
-} = require('../index')
+
+const transformInteractionFormBodyToApiRequest = require('../interaction-form-body-to-api')
 
 const transformedServices = transformServicesOptions(serviceOptions)
 
-describe('#transformInteractionFormBodyToApiRequest', () => {
-  context('when all fields are populated', () => {
-    beforeEach(() => {
+function defaultTests () {
+  context('when all fields are populated', function () {
+    before(function () {
       this.transformed = transformInteractionFormBodyToApiRequest(
         {
           date_year: '2018',
@@ -20,147 +23,203 @@ describe('#transformInteractionFormBodyToApiRequest', () => {
           policy_issue_types: '5555',
           service: 'sv1',
         },
-        transformedServices
+        transformedServices,
+        this.addCountries,
       )
     })
 
-    it('should set the date', () => {
+    it('should set the date', function () {
       expect(this.transformed.date).to.equal('2018-01-02')
     })
 
-    it('should set the grant amount offered', () => {
+    it('should set the grant amount offered', function () {
       expect(this.transformed.grant_amount_offered).to.equal('1000')
     })
 
-    it('should set the net company receipt', () => {
+    it('should set the net company receipt', function () {
       expect(this.transformed.net_company_receipt).to.equal('500')
     })
 
-    it('converts policy areas to an array', () => {
+    it('converts policy areas to an array', function () {
       expect(this.transformed.policy_areas).to.deep.equal(['4444'])
     })
 
-    it('converts policy issue types to an array', () => {
+    it('converts policy issue types to an array', function () {
       expect(this.transformed.policy_issue_types).to.deep.equal(['5555'])
+    })
+
+    it('should set countries discussed to null', function () {
+      expect(this.transformed.were_countries_discussed).to.equal(null)
     })
   })
 
-  context('when the optional fields have not been entered', () => {
-    beforeEach(() => {
+  context('when the optional fields have not been entered', function () {
+    before(function () {
       this.transformed = transformInteractionFormBodyToApiRequest(
         {
           grant_amount_offered: '',
           net_company_receipt: '',
           service: 'sv1',
         },
-        transformedServices
+        transformedServices,
+        this.addCountries,
       )
     })
 
-    it('should set the grant amount offered to null', () => {
+    it('should set the grant amount offered to null', function () {
       expect(this.transformed.grant_amount_offered).to.be.null
     })
 
-    it('should set the net company receipt to null', () => {
+    it('should set the net company receipt to null', function () {
       expect(this.transformed.net_company_receipt).to.be.null
     })
   })
+}
 
-  context(
-    'when selected service has no interaction questions or sub service',
-    () => {
-      beforeEach(() => {
-        this.expectedServiceId = 'sv1'
-        this.transformed = transformInteractionFormBodyToApiRequest(
-          {
-            service: this.expectedServiceId,
-          },
-          transformedServices
-        )
-      })
+describe('#transformInteractionFormBodyToApiRequest', function () {
+  context('when addCountries is undefined', function () {
+    defaultTests()
 
-      it('should return service id & have no answer options', () => {
-        expect(this.transformed.service).to.equal(this.expectedServiceId)
-        expect(this.transformed.service_answers).to.deep.equal({})
-      })
-    }
-  )
-
-  context(
-    'when selected service has interaction questions and sub service',
-    () => {
-      beforeEach(() => {
-        this.subServiceValues = ['', 'sv2', '']
-        this.expectedServiceLabel = 'Providing Export Advice & Information'
-        this.transformed = transformInteractionFormBodyToApiRequest(
-          {
-            service: this.expectedServiceLabel,
-            subService: this.subServiceValues,
-            'sv2-q1': 'sv2-q1-a1',
-          },
-          transformedServices
-        )
-      })
-
-      it('should return subServiceId as output service id', () => {
-        expect(this.transformed.service).to.equal('sv2')
-      })
-
-      it('should return formated service answers', () => {
-        expect(this.transformed.service_answers).to.deep.equal({
-          'sv2-q1': { 'sv2-q1-a1': {} },
+    context(
+      'when selected service has no interaction questions or sub service',
+      function () {
+        before(function () {
+          this.expectedServiceId = 'sv1'
+          this.transformed = transformInteractionFormBodyToApiRequest(
+            {
+              service: this.expectedServiceId,
+            },
+            transformedServices
+          )
         })
-      })
-    }
-  )
 
-  context(
-    'when selected service has interaction questions and no sub service',
-    () => {
-      beforeEach(() => {
-        this.subServiceValues = ['', 'sv3', '']
-        this.expectedServiceLabel = 'sv3'
-        this.transformed = transformInteractionFormBodyToApiRequest(
-          {
-            service: this.expectedServiceLabel,
-            subService: this.subServiceValues,
-            'sv3-q1': 'sv3-q1-a1',
-          },
-          transformedServices
-        )
-      })
-
-      it('should return subServiceId as output service id', () => {
-        expect(this.transformed.service).to.equal('sv3')
-      })
-
-      it('should return formated service answers', () => {
-        expect(this.transformed.service_answers).to.deep.equal({
-          'sv3-q1': { 'sv3-q1-a1': {} },
+        it('should return service id & have no answer options', function () {
+          expect(this.transformed.service).to.equal(this.expectedServiceId)
+          expect(this.transformed.service_answers).to.deep.equal({})
         })
-      })
-    }
-  )
+      }
+    )
 
-  context(
-    'when no selected service can be found',
-    () => {
-      beforeEach(() => {
-        this.transformed = transformInteractionFormBodyToApiRequest(
+    context(
+      'when selected service has interaction questions and sub service',
+      function () {
+        before(function () {
+          this.subServiceValues = ['', 'sv2', '']
+          this.expectedServiceLabel = 'Providing Export Advice & Information'
+          this.transformed = transformInteractionFormBodyToApiRequest(
+            {
+              service: this.expectedServiceLabel,
+              subService: this.subServiceValues,
+              'sv2-q1': 'sv2-q1-a1',
+            },
+            transformedServices
+          )
+        })
+
+        it('should return subServiceId as output service id', function () {
+          expect(this.transformed.service).to.equal('sv2')
+        })
+
+        it('should return formated service answers', function () {
+          expect(this.transformed.service_answers).to.deep.equal({
+            'sv2-q1': { 'sv2-q1-a1': {} },
+          })
+        })
+      }
+    )
+
+    context(
+      'when selected service has interaction questions and no sub service',
+      function () {
+        before(function () {
+          this.subServiceValues = ['', 'sv3', '']
+          this.expectedServiceLabel = 'sv3'
+          this.transformed = transformInteractionFormBodyToApiRequest(
+            {
+              service: this.expectedServiceLabel,
+              subService: this.subServiceValues,
+              'sv3-q1': 'sv3-q1-a1',
+            },
+            transformedServices
+          )
+        })
+
+        it('should return subServiceId as output service id', function () {
+          expect(this.transformed.service).to.equal('sv3')
+        })
+
+        it('should return formated service answers', function () {
+          expect(this.transformed.service_answers).to.deep.equal({
+            'sv3-q1': { 'sv3-q1-a1': {} },
+          })
+        })
+      }
+    )
+
+    context(
+      'when no selected service can be found',
+      function () {
+        before(function () {
+          this.transformed = transformInteractionFormBodyToApiRequest(
+            {
+              service: undefined,
+            },
+            transformedServices
+          )
+        })
+
+        it('should post a null as service value', function () {
+          expect(this.transformed.service).to.equal(null)
+        })
+
+        it('should return service answers as an empty object', function () {
+          expect(this.transformed.service_answers).to.deep.equal({})
+        })
+      }
+    )
+  })
+
+  context('when addCountries is true', function () {
+    before(function () {
+      this.addCountries = true
+    })
+    defaultTests()
+
+    context('when countries discussed is false', function () {
+      it('should not add export_countries', function () {
+        const transformed = transformInteractionFormBodyToApiRequest(
           {
-            service: undefined,
+            were_countries_discussed: 'false',
           },
-          transformedServices
+          transformedServices,
+          this.addCountries,
         )
-      })
 
-      it('should post a null as service value', () => {
-        expect(this.transformed.service).to.equal(null)
+        expect(transformed.export_countries).to.be.undefined
       })
+    })
 
-      it('should return service answers as an empty object', () => {
-        expect(this.transformed.service_answers).to.deep.equal({})
+    context('when countries discussed is true', function () {
+      it('should add export_countries', function () {
+        const futureCountries = [ faker.random.uuid() ]
+        const transformed = transformInteractionFormBodyToApiRequest(
+          {
+            were_countries_discussed: 'true',
+            [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: futureCountries,
+            [EXPORT_INTEREST_STATUS.EXPORTING_TO]: '',
+            [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: '',
+          },
+          transformedServices,
+          this.addCountries,
+        )
+
+        expect(transformed.export_countries).to.deep.equal([
+          {
+            country: { id: futureCountries[ 0 ] },
+            status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+          },
+        ])
       })
-    }
-  )
+    })
+  })
 })

--- a/src/apps/interactions/transformers/interaction-form-body-to-api.js
+++ b/src/apps/interactions/transformers/interaction-form-body-to-api.js
@@ -50,11 +50,14 @@ function transformInteractionFormBodyToApiRequest (body, services, addCountries)
     policy_areas: castCompactArray(body.policy_areas),
     policy_issue_types: castCompactArray(body.policy_issue_types),
     status: INTERACTION_STATUS.COMPLETE,
-    were_countries_discussed: body.were_countries_discussed || null,
   }
 
-  if (addCountries && body.were_countries_discussed === 'true') {
-    fields.export_countries = getExportCountries(body)
+  if (addCountries) {
+    fields.were_countries_discussed = body.were_countries_discussed || null
+
+    if (body.were_countries_discussed === 'true') {
+      fields.export_countries = getExportCountries(body)
+    }
   }
 
   return omit(

--- a/src/apps/interactions/transformers/interaction-form-body-to-api.js
+++ b/src/apps/interactions/transformers/interaction-form-body-to-api.js
@@ -38,22 +38,27 @@ function transformInteractionFormBodyToApiRequest (body, services, addCountries)
     })
   }
 
+  const fields = {
+    ...body,
+    service,
+    service_answers: serviceAnswers,
+    date: transformDateObjectToDateString('date')(body),
+    grant_amount_offered: body.grant_amount_offered || null,
+    net_company_receipt: body.net_company_receipt || null,
+    contacts: castCompactArray(body.contacts),
+    dit_participants: castCompactArray(body.dit_participants).map(adviser => ({ adviser })),
+    policy_areas: castCompactArray(body.policy_areas),
+    policy_issue_types: castCompactArray(body.policy_issue_types),
+    status: INTERACTION_STATUS.COMPLETE,
+    were_countries_discussed: body.were_countries_discussed || null,
+  }
+
+  if (addCountries && body.were_countries_discussed === 'true') {
+    fields.export_countries = getExportCountries(body)
+  }
+
   return omit(
-    {
-      ...body,
-      service,
-      service_answers: serviceAnswers,
-      date: transformDateObjectToDateString('date')(body),
-      grant_amount_offered: body.grant_amount_offered || null,
-      net_company_receipt: body.net_company_receipt || null,
-      contacts: castCompactArray(body.contacts),
-      dit_participants: castCompactArray(body.dit_participants).map(adviser => ({ adviser })),
-      policy_areas: castCompactArray(body.policy_areas),
-      policy_issue_types: castCompactArray(body.policy_issue_types),
-      status: INTERACTION_STATUS.COMPLETE,
-      were_countries_discussed: body.were_countries_discussed || null,
-      export_countries: (addCountries ? getExportCountries(body) : null),
-    },
+    fields,
     fieldsToOmit
   )
 }

--- a/src/apps/interactions/transformers/interaction-form-body-to-api.js
+++ b/src/apps/interactions/transformers/interaction-form-body-to-api.js
@@ -51,6 +51,7 @@ function transformInteractionFormBodyToApiRequest (body, services, addCountries)
       policy_areas: castCompactArray(body.policy_areas),
       policy_issue_types: castCompactArray(body.policy_issue_types),
       status: INTERACTION_STATUS.COMPLETE,
+      were_countries_discussed: body.were_countries_discussed || null,
       export_countries: (addCountries ? getExportCountries(body) : null),
     },
     fieldsToOmit

--- a/test/functional/cypress/fixtures/company/add-interaction-error.json
+++ b/test/functional/cypress/fixtures/company/add-interaction-error.json
@@ -1,0 +1,4 @@
+{
+  "id": "4e6a4edb-55e3-4461-a88d-84d329ee7eb8",
+  "name": "Error mocked response"
+}

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -17,6 +17,7 @@ module.exports = {
     venusLtd: require('./company/venus-ltd.json'),
     withContacts: require('./company/with-contacts.json'),
     oneListTierDita: require('./company/one-list-tier-d-ita.json'),
+    addInteractionError: require('./company/add-interaction-error.json'),
   },
   contact: {
     deanCox: require('./contact/dean-cox'),

--- a/test/functional/cypress/specs/interaction/add-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/add-interaction-spec.js
@@ -10,39 +10,56 @@ describe('Add Export', () => {
   context('when the add countries feature flag is true', () => {
     context('when adding an export interaction', () => {
       context('when in the context of a company', () => {
-        beforeEach(() => {
-          cy.visit(companies.interactions.createType(fixtures.default.id, 'export', 'interaction'))
-        })
+        context('When the fields have validtion errors', () => {
+          it('Should trigger a validation error', () => {
+            const formSelectors = selectors.interactionForm
+            cy.visit(companies.interactions.createType(fixtures.company.addInteractionError.id, 'export', 'interaction'))
 
-        it('should render breadcrumbs', () => {
-          assertBreadcrumbs({
-            'Home': dashboard(),
-            'Companies': companies.index(),
-            'Add interaction': null,
-          })
-        })
-
-        context('when answering yes to countries discussed', () => {
-          it('should add the interaction', () => {
-            const subject = utils.randomString()
-
-            populateInteractionForm(subject, 'A Specific DIT Export Service or Funding', 'Export Win', { visible: true, discussed: true })
+            populateCountriesDiscussed(formSelectors, true, true)
 
             cy.get(selectors.interactionForm.add).click()
 
-            assertDetails({ subject, flashMessage: 'Interaction created' })
+            cy.get(`${formSelectors.countries.future} .multiselect__tag`).should('contain', 'Albania')
+            cy.get(`${formSelectors.countries.export} .multiselect__tag`).should('contain', 'British Indian Ocean Territory')
+            cy.get(`${formSelectors.countries.noInterest} .multiselect__tag`).should('contain', 'Central African Republic')
           })
         })
 
-        context('when answering no to countries discussed', () => {
-          it('should add the interaction', () => {
-            const subject = utils.randomString()
+        context('When there are no validation errors', () => {
+          beforeEach(() => {
+            cy.visit(companies.interactions.createType(fixtures.default.id, 'export', 'interaction'))
+          })
 
-            populateInteractionForm(subject, 'A Specific DIT Export Service or Funding', 'Export Win', { visible: true, discussed: false })
+          it('should render breadcrumbs', () => {
+            assertBreadcrumbs({
+              'Home': dashboard(),
+              'Companies': companies.index(),
+              'Add interaction': null,
+            })
+          })
 
-            cy.get(selectors.interactionForm.add).click()
+          context('when answering yes to countries discussed', () => {
+            it('should add the interaction', () => {
+              const subject = utils.randomString()
 
-            assertDetails({ subject, flashMessage: 'Interaction created' })
+              populateInteractionForm(subject, 'A Specific DIT Export Service or Funding', 'Export Win', { visible: true, discussed: true })
+
+              cy.get(selectors.interactionForm.add).click()
+
+              assertDetails({ subject, flashMessage: 'Interaction created' })
+            })
+          })
+
+          context('when answering no to countries discussed', () => {
+            it('should add the interaction', () => {
+              const subject = utils.randomString()
+
+              populateInteractionForm(subject, 'A Specific DIT Export Service or Funding', 'Export Win', { visible: true, discussed: false })
+
+              cy.get(selectors.interactionForm.add).click()
+
+              assertDetails({ subject, flashMessage: 'Interaction created' })
+            })
           })
         })
       })

--- a/test/sandbox/fixtures/v3/interaction/interaction-validation-error.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-validation-error.json
@@ -1,0 +1,5 @@
+{
+  "export_countries": [
+      "This field may not be null."
+  ]
+}

--- a/test/sandbox/fixtures/v4/company/company-validation-error.json
+++ b/test/sandbox/fixtures/v4/company/company-validation-error.json
@@ -1,0 +1,124 @@
+{
+  "id":"4e6a4edb-55e3-4461-a88d-84d329ee7eb8",
+  "reference_code":"",
+  "name":"Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+  "trading_name":"",
+  "trading_names":[
+  ],
+  "uk_based":true,
+  "company_number":"BR100000",
+  "vat_number":"",
+  "duns_number":null,
+  "created_on":"2019-01-09T09:45:06.080938Z",
+  "modified_on":"2019-01-09T09:45:06.080969Z",
+  "archived":false,
+  "archived_documents_url_path":"",
+  "archived_on":null,
+  "archived_reason":null,
+  "archived_by":null,
+  "description":"Doloribus accusamus qui non nam et earum inventore.",
+  "transferred_by":null,
+  "transferred_on":null,
+  "transferred_to":null,
+  "transfer_reason":"",
+  "website":"http://jamaal.biz",
+  "business_type":{
+     "name":"UK branch of foreign company (BR)",
+     "id":"b0730fc6-fcce-4071-bdab-ba8de4f4fc98"
+  },
+  "one_list_group_tier":null,
+  "contacts":[
+     {
+        "id":"0e75d636-1d24-416a-aaf0-3fb220d594ce",
+        "title":null,
+        "first_name":"Bob",
+        "last_name":"lawson",
+        "name":"Bob lawson",
+        "job_title":"Magician",
+        "company":{
+           "name":"Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+           "id":"4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+        },
+        "adviser":{
+           "name":"DIT Staff",
+           "first_name":"DIT",
+           "last_name":"Staff",
+           "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+        },
+        "primary":true,
+        "telephone_countrycode":"222",
+        "telephone_number":"3453454",
+        "email":"contact@bob.com",
+        "address_same_as_company":true,
+        "address_1":null,
+        "address_2":null,
+        "address_town":null,
+        "address_county":null,
+        "address_country":null,
+        "address_postcode":null,
+        "telephone_alternative":null,
+        "email_alternative":null,
+        "notes":null,
+        "accepts_dit_email_marketing":false,
+        "archived":false,
+        "archived_documents_url_path":"",
+        "archived_on":null,
+        "archived_reason":null,
+        "archived_by":null,
+        "created_on":"2019-02-04T15:59:14.267412Z",
+        "modified_on":"2019-02-05T13:17:23.112153Z"
+     }
+  ],
+  "employee_range":{
+     "name":"50 to 249",
+     "id":"3fafd8d0-5d95-e211-a939-e4115bead28a"
+  },
+  "number_of_employees":null,
+  "is_number_of_employees_estimated":null,
+  "export_to_countries":[
+
+  ],
+  "future_interest_countries":[
+
+  ],
+  "headquarter_type":null,
+  "one_list_group_global_account_manager":null,
+  "global_headquarters":null,
+  "sector":{
+     "name":"Biotechnology and Pharmaceuticals : Bio and Pharma Marketing and Sales : Bio and Pharma Retail",
+     "id":"70f7ffde-5f95-e211-a939-e4115bead28a"
+  },
+  "turnover_range":{
+     "name":"£1.34 to £6.7M",
+     "id":"784cd12a-6095-e211-a939-e4115bead28a"
+  },
+  "turnover":null,
+  "is_turnover_estimated":null,
+  "uk_region":{
+     "name":"London",
+     "id":"874cd12a-6095-e211-a939-e4115bead28a"
+  },
+  "export_experience_category":null,
+  "address": {
+     "line_1":"3 Priory Court",
+     "line_2":"Kingshill Road",
+     "town":"Dursley",
+     "county":"Gloucestershire",
+     "postcode":"GL11 4DH",
+     "country":{
+        "name":"United Kingdom",
+        "id":"80756b9a-5d95-e211-a939-e4115bead28a"
+     }
+  },
+  "registered_address": {
+     "line_1":"3 Priory Court",
+     "line_2":"Kingshill Road",
+     "town":"Dursley",
+     "county":"Gloucestershire",
+     "postcode":"GL11 4DH",
+     "country":{
+        "name":"United Kingdom",
+        "id":"80756b9a-5d95-e211-a939-e4115bead28a"
+     }
+  }
+}

--- a/test/sandbox/routes/v3/interaction/interaction.js
+++ b/test/sandbox/routes/v3/interaction/interaction.js
@@ -9,6 +9,7 @@ var interactionCancelledMeeting = require('../../../fixtures/v3/interaction/inte
 var interactionCreate = require('../../../fixtures/v3/interaction/interaction-create.json')
 var interactionDraftFutureMeeting = require('../../../fixtures/v3/interaction/interaction-draft-future-meeting.json')
 var interactionDraftPastMeeting = require('../../../fixtures/v3/interaction/interaction-draft-past-meeting.json')
+var interactionValidationError = require('../../../fixtures/v3/interaction/interaction-validation-error.json')
 
 var getInteractions = function (req, res) {
   if (req.query.contact_id) {
@@ -49,6 +50,10 @@ var getInteractionById = function (req, res) {
 }
 
 var createInteraction = function (req, res) {
+  if (req.body.company === '4e6a4edb-55e3-4461-a88d-84d329ee7eb8') {
+    return res.json(400, interactionValidationError)
+  }
+
   if (req.body.subject) {
     state.interaction = {
       subject: req.body.subject,

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -18,6 +18,7 @@ var companyWithInvestment2 = require('../../../fixtures/v4/company/company-with-
 var companyWithContacts = require('../../../fixtures/v4/company/company-with-contacts.json')
 var companyList = require('../../../fixtures/v4/user/company-list.json')
 var companyOneListTierDIta = require('../../../fixtures/v4/company/company-one-list-tier-d-ita.json')
+var companyWithValidationError = require('../../../fixtures/v4/company/company-validation-error.json')
 
 var largeCapitalProfileEmpty = require('../../../fixtures/v4/company/large-capital-profile-empty.json')
 var largeCapitalProfileNew = require('../../../fixtures/v4/company/large-capital-profile-new.json')
@@ -92,6 +93,7 @@ exports.company = function (req, res) {
     'a73efeba-8499-11e6-ae22-56b6b6499611': companyWithInvestment2,
     '0f5216e0-849f-11e6-ae22-56b6b6499622': companyWithContacts,
     'w2c34b41-1d5a-4b4b-7685-7c53ff2868dg': companyOneListTierDIta,
+    '4e6a4edb-55e3-4461-a88d-84d329ee7eb8': companyWithValidationError,
     'not-managed': _.assign({}, company, {
       name: 'Not Managed Company',
       id: 'not-managed',

--- a/test/selectors/interaction-form.js
+++ b/test/selectors/interaction-form.js
@@ -1,4 +1,5 @@
 const typeaheadId = '#group-field-dit_participants'
+const { EXPORT_INTEREST_STATUS } = require('../../src/apps/interactions/constants')
 
 module.exports = {
   subject: '#field-subject',
@@ -37,12 +38,12 @@ module.exports = {
   policyFeedbackNotes: '#field-policy_feedback_notes',
   teamSearch: '#dit_team__typeahead .multiselect__single',
   countriesDiscussed: {
-    yes: 'label[for=field-was_country_discussed-1]',
-    no: 'label[for=field-was_country_discussed-2]',
+    yes: 'label[for=field-were_countries_discussed-1]',
+    no: 'label[for=field-were_countries_discussed-2]',
   },
   countries: {
-    future: '#group-field-future_countries',
-    export: '#group-field-export_countries',
-    noInterest: '#group-field-no_interest_countries',
+    future: ('#group-field-' + EXPORT_INTEREST_STATUS.FUTURE_INTEREST),
+    export: ('#group-field-' + EXPORT_INTEREST_STATUS.EXPORTING_TO),
+    noInterest: ('#group-field-' + EXPORT_INTEREST_STATUS.NOT_INTERESTED),
   },
 }

--- a/test/unit/data/interactions/new-interaction-with-countries.json
+++ b/test/unit/data/interactions/new-interaction-with-countries.json
@@ -1,0 +1,17 @@
+{
+  "contact": "c14f4946-0f8a-45ca-b0e7-830f2ee12ae4",
+  "dit_team": "7eaf1286-b4a0-48fc-9be8-653a2fb04da4",
+  "service": "Providing Export Advice & Information",
+  "subService": ["Providing Export Advice & Information"],
+  "sv2-q1": "sv2-a1",
+  "subject": "subject",
+  "notes": "notes",
+  "date_day": "03",
+  "date_month": "10",
+  "date_year": "2017",
+  "dit_adviser": "10d5efb8-e304-4016-b969-f8a3c9c71b30",
+  "were_countries_discussed": "true",
+  "future_interest": "0cf58a9c-2b5a-4e65-97be-34e0496bfe74",
+  "currently_exporting": "99380ef0-2591-4423-a402-4b65788e743f",
+  "not_interested": "f9c8df84-6480-4c38-87d7-70641e58d49a"
+}


### PR DESCRIPTION
## Description of change

Building on the [part 1 PR](https://github.com/uktrade/data-hub-frontend/pull/2281) this now sends the data to the API and handles error scenarios - **still behind a feature flag**

We have three fields for the countries that are combined into one for the API, so when an error is returned in the 400 response we have to map it to a real field. I have tried several solutions to inject the error message between the "Were countries discussed" question and the three country fields, but each attempt has failed. Therefore I have now just mapped the `export_countries` errors to `were_countries_discussed` so the error gets displayed. This will mean I can implement the rest of the feature and I will come back to the error message when time permits.

**I have not refactored the tests to remove `this` as I want to reduce the noise in this PR, I will make an additional PR to refactor tests**

## Test instructions

When the feature flag is enabled an extra question for "Export" and "Other" interactions to ask "Were countries discussed"
 
## Screenshots
### Before

<img width="726" alt="Screenshot 2019-12-05 at 12 18 03" src="https://user-images.githubusercontent.com/1481883/70234791-55f6fe80-1759-11ea-9e16-32b4fe8cafbd.png">

### After 

<img width="753" alt="Screenshot 2019-12-05 at 12 17 30" src="https://user-images.githubusercontent.com/1481883/70234811-5db6a300-1759-11ea-9ccb-9f71cd969e13.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
