### PR TITLE
Fix for broken 'Company One List Group Tier' filter CSV download

### DIFF
--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -21,6 +21,7 @@ const QUERY_FIELDS = [
   'policy_areas',
   'policy_issue_types',
   'dit_participants__adviser',
+  'company_one_list_group_tier',
 ]
 
 const QUERY_DATE_FIELDS = ['date_after', 'date_before']


### PR DESCRIPTION
## Description of change
Fixes an issue when downloading a subset of Interactions in `.csv` format.

When applying a "Company One List Group Tier" filter to Interactions and then subsequently downloading the subset of data you are left with the entire dataset after opening the file. This fix addresses that shortcoming.

![interactions-csv-download](https://user-images.githubusercontent.com/964268/70262024-7475ed80-178b-11ea-93fe-1995bc3ab183.gif)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
