### PR TITLE
Corrections and enhancements to the Healthcheck endpoints

### DIFF
--- a/src/apps/healthcheck/__test__/controllers.test.js
+++ b/src/apps/healthcheck/__test__/controllers.test.js
@@ -58,12 +58,12 @@ const getMicroserviceHealthcheck = async (dependencies) => {
   return callNamedHandler('getMicroserviceHealthcheck', dependencies)
 }
 
-const renderPingdomXml = async (dependencies) => {
-  return callNamedHandler('renderPingdomXml', dependencies)
+const getPingdomFailures = async (dependencies) => {
+  return callNamedHandler('getPingdomFailures', dependencies)
 }
 
-const renderPingdomWarningXml = async (dependencies) => {
-  return callNamedHandler('renderPingdomWarningXml', dependencies)
+const getPingdomWarnings = async (dependencies) => {
+  return callNamedHandler('getPingdomWarnings', dependencies)
 }
 
 describe('Health check controller', () => {
@@ -126,9 +126,9 @@ describe('Health check controller', () => {
     })
   })
 
-  describe('#renderPingdomXml with healthy service dependencies', () => {
+  describe('#getPingdomFailures with healthy service dependencies', () => {
     it('should set content type and cache control', async () => {
-      const { res } = await renderPingdomXml(successDependencies)
+      const { res } = await getPingdomFailures(successDependencies)
 
       expect(res.set).to.be.calledWith({
         'Content-Type': 'text/xml',
@@ -138,29 +138,29 @@ describe('Health check controller', () => {
     })
 
     it('should return a 200 status code', async () => {
-      const { res } = await renderPingdomXml(successDependencies)
+      const { res } = await getPingdomFailures(successDependencies)
 
       expect(res.status).to.be.calledWith(200)
       expect(res.status).to.have.been.calledOnce
     })
 
     it('should return OK', async () => {
-      const { res } = await renderPingdomXml(successDependencies)
+      const { res } = await getPingdomFailures(successDependencies)
 
       expect(res.status().send.args[0][0]).to.contain('OK')
       expect(res.status().send.args[0][0]).to.not.contain('Service Unavailable')
     })
 
     it('should not call the logger', async () => {
-      const { logger } = await renderPingdomXml(successDependencies)
+      const { logger } = await getPingdomFailures(successDependencies)
 
       expect(logger.error.notCalled).to.be.true
     })
   })
 
-  describe('#renderPingdomXml with unhealthy service dependencies', () => {
+  describe('#getPingdomFailures with unhealthy service dependencies', () => {
     it('should set content type and cache control', async () => {
-      const { res } = await renderPingdomXml(failureDependencies)
+      const { res } = await getPingdomFailures(failureDependencies)
 
       expect(res.set).to.be.calledWith({
         'Content-Type': 'text/xml',
@@ -170,21 +170,21 @@ describe('Health check controller', () => {
     })
 
     it('should return a 503 status code', async () => {
-      const { res } = await renderPingdomXml(failureDependencies)
+      const { res } = await getPingdomFailures(failureDependencies)
 
       expect(res.status).to.be.calledWith(503)
       expect(res.status).to.have.been.calledOnce
     })
 
     it('should return Service Unavailable', async () => {
-      const { res } = await renderPingdomXml(failureDependencies)
+      const { res } = await getPingdomFailures(failureDependencies)
 
       expect(res.status().send.args[0][0]).to.contain('Service Unavailable')
       expect(res.status().send.args[0][0]).to.not.contain('OK')
     })
 
     it('should call the logger', async () => {
-      const { logger } = await renderPingdomXml(failureDependencies)
+      const { logger } = await getPingdomFailures(failureDependencies)
 
       expect(logger.error.calledOnce)
       expect(logger.error.calledWith(
@@ -194,9 +194,9 @@ describe('Health check controller', () => {
     })
   })
 
-  describe('#renderPingdomXml with unhealthy "warning only" service dependencies', () => {
+  describe('#getPingdomFailures with unhealthy "warning only" service dependencies', () => {
     it('should set content type and cache control', async () => {
-      const { res } = await renderPingdomXml(warningDependencies)
+      const { res } = await getPingdomFailures(warningDependencies)
 
       expect(res.set).to.be.calledWith({
         'Content-Type': 'text/xml',
@@ -206,29 +206,29 @@ describe('Health check controller', () => {
     })
 
     it('should return a 200 status code', async () => {
-      const { res } = await renderPingdomXml(warningDependencies)
+      const { res } = await getPingdomFailures(warningDependencies)
 
       expect(res.status).to.be.calledWith(200)
       expect(res.status).to.have.been.calledOnce
     })
 
     it('should return OK', async () => {
-      const { res } = await renderPingdomXml(warningDependencies)
+      const { res } = await getPingdomFailures(warningDependencies)
 
       expect(res.status().send.args[0][0]).to.contain('OK')
       expect(res.status().send.args[0][0]).to.not.contain('Service Unavailable')
     })
 
     it('should not call the logger', async () => {
-      const { logger } = await renderPingdomXml(warningDependencies)
+      const { logger } = await getPingdomFailures(warningDependencies)
 
       expect(logger.error.notCalled).to.be.true
     })
   })
 
-  describe('#renderPingdomWarningXml with unhealthy "warning only" service dependencies', () => {
+  describe('#getPingdomWarnings with unhealthy "warning only" service dependencies', () => {
     it('should set content type and cache control', async () => {
-      const { res } = await renderPingdomWarningXml(warningDependencies)
+      const { res } = await getPingdomWarnings(warningDependencies)
 
       expect(res.set).to.be.calledWith({
         'Content-Type': 'text/xml',
@@ -238,21 +238,21 @@ describe('Health check controller', () => {
     })
 
     it('should return a 503 status code', async () => {
-      const { res } = await renderPingdomWarningXml(warningDependencies)
+      const { res } = await getPingdomWarnings(warningDependencies)
 
       expect(res.status).to.be.calledWith(503)
       expect(res.status).to.have.been.calledOnce
     })
 
     it('should return Service Unavailable', async () => {
-      const { res } = await renderPingdomWarningXml(warningDependencies)
+      const { res } = await getPingdomWarnings(warningDependencies)
 
       expect(res.status().send.args[0][0]).to.contain('Service Unavailable')
       expect(res.status().send.args[0][0]).to.not.contain('OK')
     })
 
     it('should call the logger', async () => {
-      const { logger } = await renderPingdomWarningXml(warningDependencies)
+      const { logger } = await getPingdomWarnings(warningDependencies)
 
       expect(logger.error.calledOnce)
       expect(logger.error.calledWith(
@@ -262,10 +262,10 @@ describe('Health check controller', () => {
     })
   })
 
-  describe('#renderPingdomWarningXml with unhealthy primary service dependencies', () => {
+  describe('#getPingdomWarnings with unhealthy primary service dependencies', () => {
     // "primary" denoting NOT "warning only"
     it('should set content type and cache control', async () => {
-      const { res } = await renderPingdomWarningXml(failureDependencies)
+      const { res } = await getPingdomWarnings(failureDependencies)
 
       expect(res.set).to.be.calledWith({
         'Content-Type': 'text/xml',
@@ -275,21 +275,21 @@ describe('Health check controller', () => {
     })
 
     it('should return a 200 status code', async () => {
-      const { res } = await renderPingdomWarningXml(failureDependencies)
+      const { res } = await getPingdomWarnings(failureDependencies)
 
       expect(res.status).to.be.calledWith(200)
       expect(res.status).to.have.been.calledOnce
     })
 
     it('should return OK', async () => {
-      const { res } = await renderPingdomWarningXml(failureDependencies)
+      const { res } = await getPingdomWarnings(failureDependencies)
 
       expect(res.status().send.args[0][0]).to.contain('OK')
       expect(res.status().send.args[0][0]).to.not.contain('Service Unavailable')
     })
 
     it('should not call the logger', async () => {
-      const { logger } = await renderPingdomWarningXml(failureDependencies)
+      const { logger } = await getPingdomWarnings(failureDependencies)
 
       expect(logger.error.notCalled).to.be.true
     })

--- a/src/apps/healthcheck/__test__/controllers.test.js
+++ b/src/apps/healthcheck/__test__/controllers.test.js
@@ -82,6 +82,7 @@ describe('Health check controller', () => {
     })
   })
 
+  // getMicroserviceHealthcheck() ought NOT check dependencies
   describe('#getMicroserviceHealthcheck with unhealthy service dependencies', () => {
     it('should set cache control', async () => {
       const { res } = await getMicroserviceHealthcheck(failureDependencies)
@@ -90,28 +91,24 @@ describe('Health check controller', () => {
       expect(res.set).to.have.been.calledOnce
     })
 
-    it('should return a 503 status code', async () => {
+    it('should return a 200 status code', async () => {
       const { res } = await getMicroserviceHealthcheck(failureDependencies)
 
-      expect(res.status).to.be.calledWith(503)
+      expect(res.status).to.be.calledWith(200)
       expect(res.status).to.have.been.calledOnce
     })
 
-    it('should return Service Unavailable', async () => {
+    it('should return OK', async () => {
       const { res } = await getMicroserviceHealthcheck(failureDependencies)
 
-      expect(res.status().send).to.be.calledWith('Service Unavailable')
+      expect(res.status().send).to.be.calledWith('OK')
       expect(res.status().send).to.have.been.calledOnce
     })
 
-    it('should call the logger', async () => {
+    it('should not call the logger', async () => {
       const { logger } = await getMicroserviceHealthcheck(failureDependencies)
 
-      expect(logger.error.calledOnce)
-      expect(logger.error.calledWith(
-        `${serviceDependencyError.name} health check failed`,
-        serviceDependencyError.error
-      ))
+      expect(logger.error.notCalled).to.be.true
     })
   })
 

--- a/src/apps/healthcheck/__test__/controllers.test.js
+++ b/src/apps/healthcheck/__test__/controllers.test.js
@@ -1,231 +1,197 @@
 const proxyquire = require('proxyquire')
+const successDependencies = [
+  {
+    name: 'success',
+    healthCheck: () => {
+      return Promise.resolve({ statusText: 'OK' })
+    },
+  },
+]
+
+const serviceDependencyError = {
+  name: 'example service dependency',
+  error: Error('example error'),
+}
+
+const failureDependencies = [
+  {
+    name: 'failure',
+    healthCheck: () => {
+      return Promise.resolve(serviceDependencyError)
+    },
+  },
+]
+
+const getMicroserviceHealthcheck = async (dependencies) => {
+  const logger = { error: sinon.spy() }
+  const controller = proxyquire.noCallThru().load('../controllers', {
+    './serviceDependencies': dependencies,
+    '../../../config/logger': logger,
+  })
+  const req = {}
+  const res = {
+    set: sinon.spy(),
+    status: sinon.stub().returns({
+      send: sinon.spy(),
+    }),
+  }
+  const next = sinon.spy()
+  await controller.getMicroserviceHealthcheck(req, res, next)
+  return {
+    logger,
+    res,
+  }
+}
+
+const renderPingdomXml = async (dependencies) => {
+  const logger = { error: sinon.spy() }
+  const controller = proxyquire.noCallThru().load('../controllers', {
+    './serviceDependencies': dependencies,
+    '../../../config/logger': logger,
+  })
+  const req = {}
+  const res = {
+    set: sinon.spy(),
+    status: sinon.stub().returns({
+      send: sinon.spy(),
+    }),
+  }
+  const next = sinon.spy()
+  await controller.renderPingdomXml(req, res, next)
+  return {
+    logger,
+    res,
+  }
+}
 
 describe('Health check controller', () => {
   describe('#getMicroserviceHealthcheck with healthy service dependencies', () => {
-    beforeEach(() => {
-      this.serviceDependencies = [
-        {
-          name: 'success',
-          healthCheck: () => {
-            return Promise.resolve({ statusText: 'OK' })
-          },
-        },
-      ]
-      this.logger = sinon.stub().returns({ error: sinon.spy() })
-      this.controller = proxyquire.noCallThru().load('../controllers', {
-        './serviceDependencies': this.serviceDependencies,
-        '../../../config/logger': this.logger,
-      })
-      this.req = {}
-      this.res = {
-        set: sinon.spy(),
-        status: sinon.stub().returns({
-          send: sinon.spy(),
-        }),
-      }
-      this.next = sinon.spy()
-    })
-
     it('should set cache control', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { res } = await getMicroserviceHealthcheck(successDependencies)
 
-      expect(this.res.set).to.be.calledWith('Cache-Control', 'no-cache, no-store, must-revalidate')
-      expect(this.res.set).to.have.been.calledOnce
+      expect(res.set).to.be.calledWith('Cache-Control', 'no-cache, no-store, must-revalidate')
+      expect(res.set).to.have.been.calledOnce
     })
 
     it('should return a 200 status code', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { res } = await getMicroserviceHealthcheck(successDependencies)
 
-      expect(this.res.status).to.be.calledWith(200)
-      expect(this.res.status).to.have.been.calledOnce
+      expect(res.status).to.be.calledWith(200)
+      expect(res.status).to.have.been.calledOnce
     })
 
     it('should return OK', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { res } = await getMicroserviceHealthcheck(successDependencies)
 
-      expect(this.res.status().send).to.be.calledWith('OK')
-      expect(this.res.status().send).to.have.been.calledOnce
+      expect(res.status().send).to.be.calledWith('OK')
+      expect(res.status().send).to.have.been.calledOnce
     })
 
     it('should not call the logger', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { logger } = await getMicroserviceHealthcheck(successDependencies)
 
-      expect(this.logger().error.notCalled).to.be.true
+      expect(logger.error.notCalled).to.be.true
     })
   })
 
   describe('#getMicroserviceHealthcheck with unhealthy service dependencies', () => {
-    beforeEach(() => {
-      this.serviceDependencyError = { name: 'example service dependency', error: Error('example error') }
-      this.serviceDependencies = [
-        {
-          name: 'failure',
-          healthCheck: () => {
-            return Promise.resolve(this.serviceDependencyError)
-          },
-        },
-      ]
-      this.logger = { error: sinon.spy() }
-      this.controller = proxyquire.noCallThru().load('../controllers', {
-        './serviceDependencies': this.serviceDependencies,
-        '../../config/logger': this.logger,
-      })
-      this.req = {}
-      this.res = {
-        set: sinon.spy(),
-        status: sinon.stub().returns({
-          send: sinon.spy(),
-        }),
-      }
-      this.next = sinon.spy()
-    })
-
     it('should set cache control', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { res } = await getMicroserviceHealthcheck(failureDependencies)
 
-      expect(this.res.set).to.be.calledWith('Cache-Control', 'no-cache, no-store, must-revalidate')
-      expect(this.res.set).to.have.been.calledOnce
+      expect(res.set).to.be.calledWith('Cache-Control', 'no-cache, no-store, must-revalidate')
+      expect(res.set).to.have.been.calledOnce
     })
 
     it('should return a 503 status code', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { res } = await getMicroserviceHealthcheck(failureDependencies)
 
-      expect(this.res.status).to.be.calledWith(503)
-      expect(this.res.status).to.have.been.calledOnce
+      expect(res.status).to.be.calledWith(503)
+      expect(res.status).to.have.been.calledOnce
     })
 
     it('should return Service Unavailable', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { res } = await getMicroserviceHealthcheck(failureDependencies)
 
-      expect(this.res.status().send).to.be.calledWith('Service Unavailable')
-      expect(this.res.status().send).to.have.been.calledOnce
+      expect(res.status().send).to.be.calledWith('Service Unavailable')
+      expect(res.status().send).to.have.been.calledOnce
     })
 
     it('should call the logger', async () => {
-      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
+      const { logger } = await getMicroserviceHealthcheck(failureDependencies)
 
-      expect(this.logger.error).to.have.been.calledOnce
-      expect(this.logger.error).to.be.calledWith(
-        `${this.serviceDependencyError.name} health check failed`,
-        this.serviceDependencyError.error
-      )
+      expect(logger.error.calledOnce)
+      expect(logger.error.calledWith(
+        `${serviceDependencyError.name} health check failed`,
+        serviceDependencyError.error
+      ))
     })
   })
 
   describe('#renderPingdomXml with healthy service dependencies', () => {
-    beforeEach(() => {
-      this.serviceDependencies = [
-        {
-          name: 'success',
-          healthCheck: () => {
-            return Promise.resolve({ statusText: 'OK' })
-          },
-        },
-      ]
-      this.logger = sinon.stub().returns({ error: sinon.spy() })
-      this.controller = proxyquire.noCallThru().load('../controllers', {
-        './serviceDependencies': this.serviceDependencies,
-        '../../../config/logger': this.logger,
-      })
-      this.req = {}
-      this.res = {
-        set: sinon.spy(),
-        status: sinon.stub().returns({
-          send: sinon.spy(),
-        }),
-      }
-      this.next = sinon.spy()
-    })
-
     it('should set content type and cache control', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { res } = await renderPingdomXml(successDependencies)
 
-      expect(this.res.set).to.be.calledWith({
+      expect(res.set).to.be.calledWith({
         'Content-Type': 'text/xml',
         'Cache-Control': 'no-cache, no-store, must-revalidate',
       })
-      expect(this.res.set).to.have.been.calledOnce
+      expect(res.set).to.have.been.calledOnce
     })
 
     it('should return a 200 status code', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { res } = await renderPingdomXml(successDependencies)
 
-      expect(this.res.status).to.be.calledWith(200)
-      expect(this.res.status).to.have.been.calledOnce
+      expect(res.status).to.be.calledWith(200)
+      expect(res.status).to.have.been.calledOnce
     })
 
     it('should return OK', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { res } = await renderPingdomXml(successDependencies)
 
-      expect(this.res.status().send.args[0][0]).to.contain('OK')
-      expect(this.res.status().send.args[0][0]).to.not.contain('Service Unavailable')
+      expect(res.status().send.args[0][0]).to.contain('OK')
+      expect(res.status().send.args[0][0]).to.not.contain('Service Unavailable')
     })
 
     it('should not call the logger', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { logger } = await renderPingdomXml(successDependencies)
 
-      expect(this.logger().error.notCalled).to.be.true
+      expect(logger.error.notCalled).to.be.true
     })
   })
 
   describe('#renderPingdomXml with unhealthy service dependencies', () => {
-    beforeEach(() => {
-      this.serviceDependencyError = { name: 'example service dependency', error: Error('example error') }
-      this.serviceDependencies = [
-        {
-          name: 'failure',
-          healthCheck: () => {
-            return Promise.resolve(this.serviceDependencyError)
-          },
-        },
-      ]
-      this.logger = { error: sinon.spy() }
-      this.controller = proxyquire.noCallThru().load('../controllers', {
-        './serviceDependencies': this.serviceDependencies,
-        '../../config/logger': this.logger,
-      })
-      this.req = {}
-      this.res = {
-        set: sinon.spy(),
-        status: sinon.stub().returns({
-          send: sinon.spy(),
-        }),
-      }
-      this.next = sinon.spy()
-    })
-
     it('should set content type and cache control', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { res } = await renderPingdomXml(failureDependencies)
 
-      expect(this.res.set).to.be.calledWith({
+      expect(res.set).to.be.calledWith({
         'Content-Type': 'text/xml',
         'Cache-Control': 'no-cache, no-store, must-revalidate',
       })
-      expect(this.res.set).to.have.been.calledOnce
+      expect(res.set).to.have.been.calledOnce
     })
 
     it('should return a 503 status code', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { res } = await renderPingdomXml(failureDependencies)
 
-      expect(this.res.status).to.be.calledWith(503)
-      expect(this.res.status).to.have.been.calledOnce
+      expect(res.status).to.be.calledWith(503)
+      expect(res.status).to.have.been.calledOnce
     })
 
     it('should return Service Unavailable', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { res } = await renderPingdomXml(failureDependencies)
 
-      expect(this.res.status().send.args[0][0]).to.contain('Service Unavailable')
-      expect(this.res.status().send.args[0][0]).to.not.contain('OK')
+      expect(res.status().send.args[0][0]).to.contain('Service Unavailable')
+      expect(res.status().send.args[0][0]).to.not.contain('OK')
     })
 
     it('should call the logger', async () => {
-      await this.controller.renderPingdomXml(this.req, this.res, this.next)
+      const { logger } = await renderPingdomXml(failureDependencies)
 
-      expect(this.logger.error).to.have.been.calledOnce
-      expect(this.logger.error).to.be.calledWith(
-        `${this.serviceDependencyError.name} health check failed`,
-        this.serviceDependencyError.error
-      )
+      expect(logger.error.calledOnce)
+      expect(logger.error.calledWith(
+        `${serviceDependencyError.name} health check failed`,
+        serviceDependencyError.error
+      ))
     })
   })
 })

--- a/src/apps/healthcheck/__test__/controllers.test.js
+++ b/src/apps/healthcheck/__test__/controllers.test.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire')
 
 describe('Health check controller', () => {
-  describe('#getHandler with healthy service dependencies', () => {
+  describe('#getMicroserviceHealthcheck with healthy service dependencies', () => {
     beforeEach(() => {
       this.serviceDependencies = [
         {
@@ -27,34 +27,34 @@ describe('Health check controller', () => {
     })
 
     it('should set cache control', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.res.set).to.be.calledWith('Cache-Control', 'no-cache, no-store, must-revalidate')
       expect(this.res.set).to.have.been.calledOnce
     })
 
     it('should return a 200 status code', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.res.status).to.be.calledWith(200)
       expect(this.res.status).to.have.been.calledOnce
     })
 
     it('should return OK', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.res.status().send).to.be.calledWith('OK')
       expect(this.res.status().send).to.have.been.calledOnce
     })
 
     it('should not call the logger', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.logger().error.notCalled).to.be.true
     })
   })
 
-  describe('#getHandler with unhealthy service dependencies', () => {
+  describe('#getMicroserviceHealthcheck with unhealthy service dependencies', () => {
     beforeEach(() => {
       this.serviceDependencyError = { name: 'example service dependency', error: Error('example error') }
       this.serviceDependencies = [
@@ -81,28 +81,28 @@ describe('Health check controller', () => {
     })
 
     it('should set cache control', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.res.set).to.be.calledWith('Cache-Control', 'no-cache, no-store, must-revalidate')
       expect(this.res.set).to.have.been.calledOnce
     })
 
     it('should return a 503 status code', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.res.status).to.be.calledWith(503)
       expect(this.res.status).to.have.been.calledOnce
     })
 
     it('should return Service Unavailable', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.res.status().send).to.be.calledWith('Service Unavailable')
       expect(this.res.status().send).to.have.been.calledOnce
     })
 
     it('should call the logger', async () => {
-      await this.controller.getHandler(this.req, this.res, this.next)
+      await this.controller.getMicroserviceHealthcheck(this.req, this.res, this.next)
 
       expect(this.logger.error).to.have.been.calledOnce
       expect(this.logger.error).to.be.calledWith(

--- a/src/apps/healthcheck/__test__/controllers.test.js
+++ b/src/apps/healthcheck/__test__/controllers.test.js
@@ -22,7 +22,7 @@ const failureDependencies = [
   },
 ]
 
-const getMicroserviceHealthcheck = async (dependencies) => {
+const callNamedHandler = async (handlerName, dependencies) => {
   const logger = { error: sinon.spy() }
   const controller = proxyquire.noCallThru().load('../controllers', {
     './serviceDependencies': dependencies,
@@ -36,32 +36,20 @@ const getMicroserviceHealthcheck = async (dependencies) => {
     }),
   }
   const next = sinon.spy()
-  await controller.getMicroserviceHealthcheck(req, res, next)
+  const handler = controller[handlerName]
+  await handler(req, res, next)
   return {
     logger,
     res,
   }
 }
 
+const getMicroserviceHealthcheck = async (dependencies) => {
+  return callNamedHandler('getMicroserviceHealthcheck', dependencies)
+}
+
 const renderPingdomXml = async (dependencies) => {
-  const logger = { error: sinon.spy() }
-  const controller = proxyquire.noCallThru().load('../controllers', {
-    './serviceDependencies': dependencies,
-    '../../../config/logger': logger,
-  })
-  const req = {}
-  const res = {
-    set: sinon.spy(),
-    status: sinon.stub().returns({
-      send: sinon.spy(),
-    }),
-  }
-  const next = sinon.spy()
-  await controller.renderPingdomXml(req, res, next)
-  return {
-    logger,
-    res,
-  }
+  return callNamedHandler('renderPingdomXml', dependencies)
 }
 
 describe('Health check controller', () => {

--- a/src/apps/healthcheck/controllers.js
+++ b/src/apps/healthcheck/controllers.js
@@ -36,7 +36,7 @@ function healthCheckWarningsOnly (allDependencies) {
   return Promise.all(promiseArray)
 }
 
-function renderPingdomXml (req, res, next) {
+function getPingdomFailures (req, res, next) {
   return healthCheckFailuresOnly(serviceDependencies)
     .then((results) => {
       return results.filter((result) => result.statusText !== 'OK')
@@ -64,7 +64,7 @@ function renderPingdomXml (req, res, next) {
     .catch(next)
 }
 
-function renderPingdomWarningXml (req, res, next) {
+function getPingdomWarnings (req, res, next) {
   return healthCheckWarningsOnly(serviceDependencies)
     .then((results) => {
       return results.filter((result) => result.statusText !== 'OK')
@@ -101,6 +101,6 @@ function getMicroserviceHealthcheck (req, res, next) {
 
 module.exports = {
   getMicroserviceHealthcheck,
-  renderPingdomXml,
-  renderPingdomWarningXml,
+  getPingdomFailures,
+  getPingdomWarnings,
 }

--- a/src/apps/healthcheck/controllers.js
+++ b/src/apps/healthcheck/controllers.js
@@ -1,5 +1,7 @@
 const logger = require('../../config/logger')
 const serviceDependencies = require('./serviceDependencies')
+const failureDependencies = serviceDependencies.filter((dependency) => (!dependency.warningOnly))
+const warningDependencies = serviceDependencies.filter((dependency) => (dependency.warningOnly))
 
 function pingdomTemplate (statusMessage) {
   return `
@@ -10,9 +12,8 @@ function pingdomTemplate (statusMessage) {
   `.trim()
 }
 
-function healthCheckFailuresOnly (allDependencies) {
-  const failureDependencies = allDependencies.filter((dependency) => (!dependency.warningOnly))
-  const promiseArray = failureDependencies.map((dependency) => {
+function healthCheck (dependencies) {
+  const promiseArray = dependencies.map((dependency) => {
     return dependency.healthCheck()
       .then((result) => result)
       .catch((error) => {
@@ -23,73 +24,40 @@ function healthCheckFailuresOnly (allDependencies) {
   return Promise.all(promiseArray)
 }
 
-function healthCheckWarningsOnly (allDependencies) {
-  const failureDependencies = allDependencies.filter((dependency) => (dependency.warningOnly))
-  const promiseArray = failureDependencies.map((dependency) => {
-    return dependency.healthCheck()
-      .then((result) => result)
-      .catch((error) => {
-        return { name: dependency.name, error }
+function renderPingdomXml (req, res, next, dependencies) {
+  return healthCheck(dependencies)
+    .then((results) => {
+      return results.filter((result) => result.statusText !== 'OK')
+    })
+    .then((errors) => {
+      res.set({
+        'Content-Type': 'text/xml',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
       })
-  })
 
-  return Promise.all(promiseArray)
+      if (errors.length) {
+        errors.forEach((dependency) => {
+          logger.error(`${dependency.name} health check failed`, dependency.error)
+        })
+
+        return res
+          .status(503)
+          .send(pingdomTemplate('Service Unavailable'))
+      }
+
+      return res
+        .status(200)
+        .send(pingdomTemplate('OK'))
+    })
+    .catch(next)
 }
 
 function getPingdomFailures (req, res, next) {
-  return healthCheckFailuresOnly(serviceDependencies)
-    .then((results) => {
-      return results.filter((result) => result.statusText !== 'OK')
-    })
-    .then((errors) => {
-      res.set({
-        'Content-Type': 'text/xml',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-      })
-
-      if (errors.length) {
-        errors.forEach((dependency) => {
-          logger.error(`${dependency.name} health check failed`, dependency.error)
-        })
-
-        return res
-          .status(503)
-          .send(pingdomTemplate('Service Unavailable'))
-      }
-
-      return res
-        .status(200)
-        .send(pingdomTemplate('OK'))
-    })
-    .catch(next)
+  return renderPingdomXml(req, res, next, failureDependencies)
 }
 
 function getPingdomWarnings (req, res, next) {
-  return healthCheckWarningsOnly(serviceDependencies)
-    .then((results) => {
-      return results.filter((result) => result.statusText !== 'OK')
-    })
-    .then((errors) => {
-      res.set({
-        'Content-Type': 'text/xml',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-      })
-
-      if (errors.length) {
-        errors.forEach((dependency) => {
-          logger.error(`${dependency.name} health check failed`, dependency.error)
-        })
-
-        return res
-          .status(503)
-          .send(pingdomTemplate('Service Unavailable'))
-      }
-
-      return res
-        .status(200)
-        .send(pingdomTemplate('OK'))
-    })
-    .catch(next)
+  return renderPingdomXml(req, res, next, warningDependencies)
 }
 
 function getMicroserviceHealthcheck (req, res, next) {

--- a/src/apps/healthcheck/controllers.js
+++ b/src/apps/healthcheck/controllers.js
@@ -23,8 +23,49 @@ function healthCheckFailuresOnly (allDependencies) {
   return Promise.all(promiseArray)
 }
 
+function healthCheckWarningsOnly (allDependencies) {
+  const failureDependencies = allDependencies.filter((dependency) => (dependency.warningOnly))
+  const promiseArray = failureDependencies.map((dependency) => {
+    return dependency.healthCheck()
+      .then((result) => result)
+      .catch((error) => {
+        return { name: dependency.name, error }
+      })
+  })
+
+  return Promise.all(promiseArray)
+}
+
 function renderPingdomXml (req, res, next) {
   return healthCheckFailuresOnly(serviceDependencies)
+    .then((results) => {
+      return results.filter((result) => result.statusText !== 'OK')
+    })
+    .then((errors) => {
+      res.set({
+        'Content-Type': 'text/xml',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+      })
+
+      if (errors.length) {
+        errors.forEach((dependency) => {
+          logger.error(`${dependency.name} health check failed`, dependency.error)
+        })
+
+        return res
+          .status(503)
+          .send(pingdomTemplate('Service Unavailable'))
+      }
+
+      return res
+        .status(200)
+        .send(pingdomTemplate('OK'))
+    })
+    .catch(next)
+}
+
+function renderPingdomWarningXml (req, res, next) {
+  return healthCheckWarningsOnly(serviceDependencies)
     .then((results) => {
       return results.filter((result) => result.statusText !== 'OK')
     })
@@ -61,4 +102,5 @@ function getMicroserviceHealthcheck (req, res, next) {
 module.exports = {
   getMicroserviceHealthcheck,
   renderPingdomXml,
+  renderPingdomWarningXml,
 }

--- a/src/apps/healthcheck/controllers.js
+++ b/src/apps/healthcheck/controllers.js
@@ -51,26 +51,10 @@ function renderPingdomXml (req, res, next) {
 }
 
 function getMicroserviceHealthcheck (req, res, next) {
-  return healthCheck(serviceDependencies)
-    .then((results) => results.filter((result) => result.statusText !== 'OK'))
-    .then((errors) => {
-      res.set('Cache-Control', 'no-cache, no-store, must-revalidate')
-
-      if (errors.length) {
-        errors.forEach((dependency) => {
-          logger.error(`${dependency.name} health check failed`, dependency.error)
-        })
-
-        return res
-          .status(503)
-          .send('Service Unavailable')
-      }
-
-      return res
-        .status(200)
-        .send('OK')
-    })
-    .catch(next)
+  res.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+  return res
+    .status(200)
+    .send('OK')
 }
 
 module.exports = {

--- a/src/apps/healthcheck/controllers.js
+++ b/src/apps/healthcheck/controllers.js
@@ -10,8 +10,9 @@ function pingdomTemplate (statusMessage) {
   `.trim()
 }
 
-function healthCheck (dependencies) {
-  const promiseArray = dependencies.map((dependency) => {
+function healthCheckFailuresOnly (allDependencies) {
+  const failureDependencies = allDependencies.filter((dependency) => (!dependency.warningOnly))
+  const promiseArray = failureDependencies.map((dependency) => {
     return dependency.healthCheck()
       .then((result) => result)
       .catch((error) => {
@@ -23,7 +24,7 @@ function healthCheck (dependencies) {
 }
 
 function renderPingdomXml (req, res, next) {
-  return healthCheck(serviceDependencies)
+  return healthCheckFailuresOnly(serviceDependencies)
     .then((results) => {
       return results.filter((result) => result.statusText !== 'OK')
     })

--- a/src/apps/healthcheck/controllers.js
+++ b/src/apps/healthcheck/controllers.js
@@ -50,7 +50,7 @@ function renderPingdomXml (req, res, next) {
     .catch(next)
 }
 
-function getHandler (req, res, next) {
+function getMicroserviceHealthcheck (req, res, next) {
   return healthCheck(serviceDependencies)
     .then((results) => results.filter((result) => result.statusText !== 'OK'))
     .then((errors) => {
@@ -74,6 +74,6 @@ function getHandler (req, res, next) {
 }
 
 module.exports = {
-  getHandler,
+  getMicroserviceHealthcheck,
   renderPingdomXml,
 }

--- a/src/apps/healthcheck/router.js
+++ b/src/apps/healthcheck/router.js
@@ -1,11 +1,11 @@
 const router = require('express').Router()
 
-const { renderPingdomXml, renderPingdomWarningXml, getMicroserviceHealthcheck } = require('./controllers')
+const { getPingdomFailures, getPingdomWarnings, getMicroserviceHealthcheck } = require('./controllers')
 
 router.get('/', getMicroserviceHealthcheck)
 
-router.get('/ping.xml', renderPingdomXml)
+router.get('/ping.xml', getPingdomFailures)
 
-router.get('/warning/ping.xml', renderPingdomWarningXml)
+router.get('/warning/ping.xml', getPingdomWarnings)
 
 module.exports = router

--- a/src/apps/healthcheck/router.js
+++ b/src/apps/healthcheck/router.js
@@ -1,9 +1,11 @@
 const router = require('express').Router()
 
-const { renderPingdomXml, getMicroserviceHealthcheck } = require('./controllers')
+const { renderPingdomXml, renderPingdomWarningXml, getMicroserviceHealthcheck } = require('./controllers')
 
 router.get('/', getMicroserviceHealthcheck)
 
 router.get('/ping.xml', renderPingdomXml)
+
+router.get('/warning/ping.xml', renderPingdomWarningXml)
 
 module.exports = router

--- a/src/apps/healthcheck/router.js
+++ b/src/apps/healthcheck/router.js
@@ -1,8 +1,8 @@
 const router = require('express').Router()
 
-const { renderPingdomXml, getHandler } = require('./controllers')
+const { renderPingdomXml, getMicroserviceHealthcheck } = require('./controllers')
 
-router.get('/', getHandler)
+router.get('/', getMicroserviceHealthcheck)
 
 router.get('/ping.xml', renderPingdomXml)
 

--- a/src/apps/healthcheck/serviceDependencies.js
+++ b/src/apps/healthcheck/serviceDependencies.js
@@ -25,6 +25,7 @@ module.exports = [
   },
   {
     name: 'getaddress postcode lookup',
+    warningOnly: true,
     healthCheck: () =>
       axios.get(
         `https://api.getaddress.io/usage?api-key=${


### PR DESCRIPTION
## Description of change

This PR addresses a few things:

1. Pingdom needs to be able to call _two_ healthcheck points per service. One for critical failures (P1); the other for less critical "warning only" level problems (P2)
2. The recurrent "getaddress postcode lookup" check should be relegated to a P2 check
3. The basic microservice healthcheck _should not_ check dependencies. It is there only to allow CF components to verify that _this_ service has mounted its router and is available to serve requests, regardless of the health of its dependencies.
4. Removal of `this` and the `beforeEach()` antipattern from unit tests

- [X] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
