### PR TITLE
Add Edit History boilerplate

### DIFF
--- a/src/apps/companies/apps/edit-history/__test__/controller.test.js
+++ b/src/apps/companies/apps/edit-history/__test__/controller.test.js
@@ -1,0 +1,65 @@
+const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
+const companyMock = require('../../../../../../test/unit/data/companies/company-v4.json')
+const urls = require('../../../../../../src/lib/urls')
+
+const { renderEditHistory } = require('../controller')
+
+describe('rendering Edit History', () => {
+  context('when "Edit History" renders successfully', () => {
+    let middlewareParams
+    beforeEach(async () => {
+      middlewareParams = buildMiddlewareParameters({
+        company: companyMock,
+      })
+      await renderEditHistory(
+        middlewareParams.reqMock,
+        middlewareParams.resMock,
+        middlewareParams.nextSpy,
+      )
+    })
+
+    it('should render the add company form template with fields', () => {
+      const expectedTemplate = 'companies/apps/edit-history/views/client-container'
+      expect(middlewareParams.resMock.render).to.be.calledOnceWithExactly(expectedTemplate, {
+        props: {},
+      })
+    })
+
+    it('should add 3 breadcrumbs', () => {
+      expect(middlewareParams.resMock.breadcrumb.args).to.deep.equal([
+        ['Mercury Ltd', urls.companies.detail('a73efeba-8499-11e6-ae22-56b6b6499611')],
+        ['Business details', urls.companies.businessDetails('a73efeba-8499-11e6-ae22-56b6b6499611')],
+        ['Edit History'],
+      ])
+    })
+
+    it('should not call next() with an error', () => {
+      expect(middlewareParams.nextSpy).to.not.have.been.called
+    })
+  })
+
+  context('when "Edit History" errors', async () => {
+    let middlewareParams
+
+    before(async () => {
+      middlewareParams = buildMiddlewareParameters({
+        company: companyMock,
+      })
+      middlewareParams.resMock.render.throws()
+
+      await renderEditHistory(
+        middlewareParams.reqMock,
+        middlewareParams.resMock,
+        middlewareParams.nextSpy
+      )
+    })
+
+    it('should not call render', () => {
+      expect(middlewareParams.resMock.render).to.be.thrown
+    })
+
+    it('should call next in the catch', () => {
+      expect(middlewareParams.nextSpy).to.be.calledOnce
+    })
+  })
+})

--- a/src/apps/companies/apps/edit-history/__test__/router.test.js
+++ b/src/apps/companies/apps/edit-history/__test__/router.test.js
@@ -1,0 +1,19 @@
+const router = require('../router')
+
+describe('Edit history route', () => {
+  it('should define an "Edit history" route', () => {
+    const paths = router.stack.filter(r => r.route).map(r => {
+      return {
+        path: r.route.path,
+        methods: Object.keys(r.route.methods).map(method => method),
+      }
+    })
+
+    expect(paths).to.deep.equal([
+      {
+        'path': '/',
+        'methods': [ 'get' ],
+      },
+    ])
+  })
+})

--- a/src/apps/companies/apps/edit-history/client/EditHistory.jsx
+++ b/src/apps/companies/apps/edit-history/client/EditHistory.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { H3 } from 'govuk-react'
+
+function EditHistory () {
+  return <H3>This page is hidden behind an Express route</H3>
+}
+
+export default EditHistory

--- a/src/apps/companies/apps/edit-history/controller.js
+++ b/src/apps/companies/apps/edit-history/controller.js
@@ -1,0 +1,21 @@
+const { companies } = require('../../../../lib/urls')
+
+async function renderEditHistory (req, res, next) {
+  try {
+    const { company } = res.locals
+
+    res
+      .breadcrumb(company.name, companies.detail(company.id))
+      .breadcrumb('Business details', companies.businessDetails(company.id))
+      .breadcrumb('Edit History')
+      .render('companies/apps/edit-history/views/client-container', {
+        props: {},
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderEditHistory,
+}

--- a/src/apps/companies/apps/edit-history/router.js
+++ b/src/apps/companies/apps/edit-history/router.js
@@ -1,0 +1,9 @@
+const router = require('express').Router()
+
+const {
+  renderEditHistory,
+} = require('./controller')
+
+router.get('/', renderEditHistory)
+
+module.exports = router

--- a/src/apps/companies/apps/edit-history/views/client-container.njk
+++ b/src/apps/companies/apps/edit-history/views/client-container.njk
@@ -1,0 +1,9 @@
+{% extends "_layouts/template.njk" %}
+
+{% block body_main_content %}
+  {% component 'react-slot', {
+    id: 'edit-history',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -54,6 +54,7 @@ const editCompanyFormRouter = require('./apps/edit-company/router')
 const activityFeedRouter = require('./apps/activity-feed/router')
 const dnbHierarchyRouter = require('./apps/dnb-hierarchy/router')
 const businessDetailsRouter = require('./apps/business-details/router')
+const editHistoryRouter = require('./apps/edit-history/router')
 
 const investmentsRouter = require('./apps/investments/router')
 const matchingRouter = require('./apps/matching/router')
@@ -90,6 +91,7 @@ router.get('/export',
 router.use('/create', addCompanyFormRouter)
 router.use('/:companyId/lists', companyListsRouter)
 router.use('/:companyId/edit', editCompanyFormRouter)
+router.use('/:companyId/edit-history', editHistoryRouter)
 
 router
   .route('/:companyId/exports/edit')

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import { ActivityFeedApp } from 'data-hub-components'
 import AddCompanyForm from './apps/companies/apps/add-company/client/AddCompanyForm'
 import EditCompanyForm from './apps/companies/apps/edit-company/client/EditCompanyForm'
+import EditHistory from './apps/companies/apps/edit-history/client/EditHistory'
 import DeleteCompanyList from './apps/company-lists/client/DeleteCompanyList'
 import MyCompanies from './apps/dashboard/client/MyCompanies.jsx'
 import CreateListFormSection from './apps/company-lists/client/CreateListFormSection'
@@ -40,6 +41,9 @@ function App () {
       </Mount>
       <Mount selector="#edit-company-form">
         {props => <EditCompanyForm csrfToken={globalProps.csrfToken} {...props} />}
+      </Mount>
+      <Mount selector="#edit-history">
+        {props => <EditHistory csrfToken={globalProps.csrfToken} {...props} />}
       </Mount>
       <Mount selector="#activity-feed-app">
         {props => <ActivityFeedApp {...props} />}

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -80,6 +80,7 @@ module.exports = {
       remove: url('/companies', '/:companyId/advisers/remove'),
     },
     audit: url('/companies', '/:companyId/audit'),
+    editHistory: url('/companies', '/:companyId/edit-history'),
     businessDetails: url('/companies', '/:companyId/business-details'),
     detail: url('/companies', '/:companyId'),
     edit: url('/companies', '/:companyId/edit'),

--- a/test/functional/cypress/specs/companies/edit-history-spec.js
+++ b/test/functional/cypress/specs/companies/edit-history-spec.js
@@ -1,0 +1,25 @@
+const { assertLocalHeader, assertBreadcrumbs } = require('../../support/assertions')
+const fixtures = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+
+describe('Edit History', () => {
+  context('when viewing the "Edit History" page', () => {
+    before(() => {
+      cy.visit(urls.companies.editHistory(fixtures.company.venusLtd.id))
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Edit History')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        'Home': urls.dashboard(),
+        'Companies': urls.companies.index(),
+        'Venus Ltd': urls.companies.detail(fixtures.company.venusLtd.id),
+        'Business details': urls.companies.businessDetails(fixtures.company.venusLtd.id),
+        'Edit History': null,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Edit History boilerplate (1 of 3)
http://localhost:3000/companies/5bb239e4-b227-4a84-bc2e-3420fc129447/edit-history

This PR is 1 of 3 and purely sets up the boilerplate for viewing the `Edit history` of a company, which will eventually replace the `Audit history` which remains in place until we're in a position to swap over the implementations. 

`Edit History` is a significant improvement over the old `Audit history`:
 https://drive.google.com/file/d/1nEYW4eIcpuTN7wyrfI4Ns3S8Mti3QOJU/view

![edit-history](https://user-images.githubusercontent.com/964268/70436045-4ee52e80-1a80-11ea-8d57-64fc61b31030.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
