### PR TITLE
Show new countries fields on export tab

### DIFF
--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -9,8 +9,9 @@ const { transformCompanyToExportDetailsView } = require('../transformers')
 const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
 
 function renderExports (req, res) {
-  const { company } = res.locals
-  const exportDetails = transformCompanyToExportDetailsView(company)
+  const { company, features } = res.locals
+  const useNewCountries = features['interaction-add-countries']
+  const exportDetails = transformCompanyToExportDetailsView(company, useNewCountries)
 
   res
     .breadcrumb(company.name, urls.companies.detail(company.id))

--- a/src/apps/companies/labels.js
+++ b/src/apps/companies/labels.js
@@ -56,6 +56,7 @@ const exportDetailsLabels = {
   exportExperienceCategory: 'Export win category',
   exportToCountries: 'Currently exporting to',
   futureInterestCountries: 'Future countries of interest',
+  noInterestCountries: 'Countries of no interest',
   greatProfile: 'great.gov.uk business profile',
   exportPotential: 'Export potential',
 }

--- a/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
@@ -1,9 +1,37 @@
 const proxyquire = require('proxyquire')
 const faker = require('faker')
+
+const { EXPORT_INTEREST_STATUS } = require('../../../constants')
+
 const minimalCompany = require('../../../../../test/unit/data/companies/minimal-company.json')
 
 const transformerPath = '../company-to-export-details-view'
 const EXPORT_POTENTIAL_LABEL = 'Export potential'
+
+function generateCountries (length) {
+  return Array.from({ length }).map(() => [faker.random.uuid(), faker.address.country()])
+}
+
+function createExportCountry (status) {
+  return ([id, name]) => ({ country: { id, name }, status })
+}
+
+function generateExportCountries () {
+  const future = generateCountries(2)
+  const current = generateCountries(2)
+  const noInterest = generateCountries(2)
+
+  return {
+    future,
+    current,
+    noInterest,
+    exportCountries: [
+      ...future.map(createExportCountry(EXPORT_INTEREST_STATUS.FUTURE_INTEREST)),
+      ...current.map(createExportCountry(EXPORT_INTEREST_STATUS.EXPORTING_TO)),
+      ...noInterest.map(createExportCountry(EXPORT_INTEREST_STATUS.NOT_INTERESTED)),
+    ],
+  }
+}
 
 describe('transformCompanyToExportDetailsView', () => {
   let transformCompanyToExportDetailsView
@@ -21,160 +49,190 @@ describe('transformCompanyToExportDetailsView', () => {
       '../../../lib/urls': urls,
     })
   })
-  context('when no export market information has been entered', () => {
-    beforeEach(() => {
-      const company = {
-        ...minimalCompany,
-        export_experience_category: null,
-        export_to_countries: [],
-        future_interest_countries: [],
-      }
 
-      this.viewRecord = transformCompanyToExportDetailsView(company)
-    })
+  context('when there is no feature flag', () => {
+    context('when no export market information has been entered', () => {
+      beforeEach(() => {
+        const company = {
+          ...minimalCompany,
+          export_experience_category: null,
+          export_to_countries: [],
+          future_interest_countries: [],
+        }
 
-    it('should show the country currently exporting to', () => {
-      expect(this.viewRecord).to.have.property('Currently exporting to', 'None')
-    })
-
-    it('should not show the country the company wants to export to', () => {
-      expect(this.viewRecord).to.have.property('Future countries of interest', 'None')
-    })
-
-    it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win category', 'None')
-    })
-
-    it('should show the export potential', () => {
-      expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'No score given')
-    })
-  })
-
-  context('when single values have been selected for drop down fields', () => {
-    beforeEach(() => {
-      this.exportExperienceCategory = {
-        id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
-        name: 'Increasing export markets',
-      }
-      const company = {
-        ...minimalCompany,
-        export_experience_category: this.exportExperienceCategory,
-        export_to_countries: [{
-          id: '1234',
-          name: 'France',
-        }],
-        future_interest_countries: [{
-          id: '4321',
-          name: 'Germany',
-        }],
-        export_potential_score: 'low',
-      }
-
-      this.viewRecord = transformCompanyToExportDetailsView(company)
-    })
-
-    it('should show the country currently exporting to', () => {
-      expect(this.viewRecord).to.have.property('Currently exporting to', 'France')
-    })
-
-    it('should not show the country the company wants to export to', () => {
-      expect(this.viewRecord).to.have.property('Future countries of interest', 'Germany')
-    })
-
-    it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
-    })
-
-    it('should show the export potential', () => {
-      expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'Low')
-    })
-  })
-
-  context('when multiple values have been selected for drop down fields', () => {
-    beforeEach(() => {
-      this.exportExperienceCategory = {
-        id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
-        name: 'Increasing export markets',
-      }
-      const company = {
-        ...minimalCompany,
-        export_experience_category: this.exportExperienceCategory,
-        export_to_countries: [{
-          id: '1234',
-          name: 'France',
-        }, {
-          id: '5511',
-          name: 'Spain',
-        }],
-        future_interest_countries: [{
-          id: '4321',
-          name: 'Germany',
-        }, {
-          id: '4123',
-          name: 'Sweden',
-        }],
-      }
-
-      this.viewRecord = transformCompanyToExportDetailsView(company)
-    })
-
-    it('should show the country currently exporting to', () => {
-      expect(this.viewRecord).to.have.property('Currently exporting to', 'France, Spain')
-    })
-
-    it('should not show the country the company wants to export to', () => {
-      expect(this.viewRecord).to.have.property('Future countries of interest', 'Germany, Sweden')
-    })
-
-    it('should show the export win category', () => {
-      expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
-    })
-  })
-
-  describe('great profile', () => {
-    const GREAT_LABEL = 'great.gov.uk business profile'
-    let companiesHouseNumber
-
-    function createRecord (props) {
-      return transformCompanyToExportDetailsView({
-        ...minimalCompany,
-        export_experience_category: null,
-        export_to_countries: [],
-        future_interest_countries: [],
-        company_number: companiesHouseNumber,
-        ...props,
+        this.viewRecord = transformCompanyToExportDetailsView(company)
       })
-    }
 
-    beforeEach(() => {
-      companiesHouseNumber = faker.random.alphaNumeric(8)
-    })
+      it('should show the country currently exporting to', () => {
+        expect(this.viewRecord).to.have.property('Currently exporting to', 'None')
+      })
 
-    context('when a profile is published', () => {
-      it('should return the data to link to the profile', () => {
-        const viewRecord = createRecord({ great_profile_status: 'published' })
-        const data = viewRecord[GREAT_LABEL]
+      it('should not show the country the company wants to export to', () => {
+        expect(this.viewRecord).to.have.property('Future countries of interest', 'None')
+      })
 
-        expect(data).to.have.property('url', greatUrlProfileResponse)
-        expect(data).to.have.property('newWindow', true)
-        expect(data).to.have.property('name', '"Find a supplier" profile')
-        expect(data).to.have.property('hint', '(opens in a new window)')
+      it('should show the export win category', () => {
+        expect(this.viewRecord).to.have.property('Export win category', 'None')
+      })
 
-        expect(urls.external.greatProfile).to.have.been.calledWith(companiesHouseNumber)
+      it('should show the export potential', () => {
+        expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'No score given')
+      })
+
+      it('should not have the new label of countries of no interest', () => {
+        expect(this.viewRecord).not.to.have.property('Countries of no interest')
       })
     })
 
-    context('when a profile is unpublished', () => {
-      it('should return the label and data', () => {
-        const viewRecord = createRecord({ great_profile_status: 'unpublished' })
-        expect(viewRecord).to.have.property(GREAT_LABEL, 'Profile not published')
+    context('when single values have been selected for drop down fields', () => {
+      beforeEach(() => {
+        this.exportExperienceCategory = {
+          id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
+          name: 'Increasing export markets',
+        }
+        const company = {
+          ...minimalCompany,
+          export_experience_category: this.exportExperienceCategory,
+          export_to_countries: [{
+            id: '1234',
+            name: 'France',
+          }],
+          future_interest_countries: [{
+            id: '4321',
+            name: 'Germany',
+          }],
+          export_potential_score: 'low',
+        }
+
+        this.viewRecord = transformCompanyToExportDetailsView(company)
+      })
+
+      it('should show the country currently exporting to', () => {
+        expect(this.viewRecord).to.have.property('Currently exporting to', 'France')
+      })
+
+      it('should not show the country the company wants to export to', () => {
+        expect(this.viewRecord).to.have.property('Future countries of interest', 'Germany')
+      })
+
+      it('should show the export win category', () => {
+        expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
+      })
+
+      it('should show the export potential', () => {
+        expect(this.viewRecord).to.have.property(EXPORT_POTENTIAL_LABEL, 'Low')
       })
     })
 
-    context('without a profile', () => {
-      it('should return the label and data', () => {
-        const viewRecord = createRecord({ great_profile_status: null })
-        expect(viewRecord).to.have.property(GREAT_LABEL, 'No profile')
+    context('when multiple values have been selected for drop down fields', () => {
+      beforeEach(() => {
+        this.exportExperienceCategory = {
+          id: '8b05e8c7-1812-46bf-bab7-a0096ab5689f',
+          name: 'Increasing export markets',
+        }
+        const company = {
+          ...minimalCompany,
+          export_experience_category: this.exportExperienceCategory,
+          export_to_countries: [{
+            id: '1234',
+            name: 'France',
+          }, {
+            id: '5511',
+            name: 'Spain',
+          }],
+          future_interest_countries: [{
+            id: '4321',
+            name: 'Germany',
+          }, {
+            id: '4123',
+            name: 'Sweden',
+          }],
+        }
+
+        this.viewRecord = transformCompanyToExportDetailsView(company)
+      })
+
+      it('should show the country currently exporting to', () => {
+        expect(this.viewRecord).to.have.property('Currently exporting to', 'France, Spain')
+      })
+
+      it('should not show the country the company wants to export to', () => {
+        expect(this.viewRecord).to.have.property('Future countries of interest', 'Germany, Sweden')
+      })
+
+      it('should show the export win category', () => {
+        expect(this.viewRecord).to.have.property('Export win category', this.exportExperienceCategory)
+      })
+    })
+
+    describe('great profile', () => {
+      const GREAT_LABEL = 'great.gov.uk business profile'
+      let companiesHouseNumber
+
+      function createRecord (props) {
+        return transformCompanyToExportDetailsView({
+          ...minimalCompany,
+          export_experience_category: null,
+          export_to_countries: [],
+          future_interest_countries: [],
+          company_number: companiesHouseNumber,
+          ...props,
+        })
+      }
+
+      beforeEach(() => {
+        companiesHouseNumber = faker.random.alphaNumeric(8)
+      })
+
+      context('when a profile is published', () => {
+        it('should return the data to link to the profile', () => {
+          const viewRecord = createRecord({ great_profile_status: 'published' })
+          const data = viewRecord[GREAT_LABEL]
+
+          expect(data).to.have.property('url', greatUrlProfileResponse)
+          expect(data).to.have.property('newWindow', true)
+          expect(data).to.have.property('name', '"Find a supplier" profile')
+          expect(data).to.have.property('hint', '(opens in a new window)')
+
+          expect(urls.external.greatProfile).to.have.been.calledWith(companiesHouseNumber)
+        })
+      })
+
+      context('when a profile is unpublished', () => {
+        it('should return the label and data', () => {
+          const viewRecord = createRecord({ great_profile_status: 'unpublished' })
+          expect(viewRecord).to.have.property(GREAT_LABEL, 'Profile not published')
+        })
+      })
+
+      context('without a profile', () => {
+        it('should return the label and data', () => {
+          const viewRecord = createRecord({ great_profile_status: null })
+          expect(viewRecord).to.have.property(GREAT_LABEL, 'No profile')
+        })
+      })
+    })
+  })
+
+  context('when the interaction-add-countries feature flag is true', () => {
+    context('when multiple countries have been added', () => {
+      it('should show the countries', () => {
+        const { future, current, noInterest, exportCountries } = generateExportCountries()
+
+        const company = {
+          ...minimalCompany,
+          export_countries: exportCountries,
+        }
+
+        function getCountryText (countries) {
+          return countries.map(([, name]) => name).join(', ')
+        }
+
+        const viewRecord = transformCompanyToExportDetailsView(company, true)
+
+        expect(viewRecord).to.have.property('Currently exporting to', getCountryText(current))
+        expect(viewRecord).to.have.property('Future countries of interest', getCountryText(future))
+        expect(viewRecord).to.have.property('Countries of no interest', getCountryText(noInterest))
       })
     })
   })

--- a/src/apps/companies/transformers/company-to-export-details-view.js
+++ b/src/apps/companies/transformers/company-to-export-details-view.js
@@ -23,9 +23,8 @@ function getGreatProfileValue (profileStatus, companiesHouseNumber) {
       name: '"Find a supplier" profile',
       hint: '(opens in a new window)',
     }
-  } else {
-    return (profileStatus === 'unpublished' ? 'Profile not published' : 'No profile')
   }
+  return (profileStatus === 'unpublished' ? 'Profile not published' : 'No profile')
 }
 
 module.exports = function transformCompanyToExportDetailsView ({

--- a/src/apps/companies/transformers/company-to-export-details-view.js
+++ b/src/apps/companies/transformers/company-to-export-details-view.js
@@ -4,6 +4,8 @@ const { flatMap } = require('lodash')
 const { getDataLabels } = require('../../../lib/controller-utils')
 const urls = require('../../../lib/urls')
 const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
+const { EXPORT_INTEREST_STATUS } = require('../../constants')
+const groupExportCountries = require('../../../lib/group-export-countries')
 
 function getCountries (data) {
   return flatMap(data, ({ name }) => (name || null)).join(', ') || 'None'
@@ -27,21 +29,39 @@ function getGreatProfileValue (profileStatus, companiesHouseNumber) {
   return (profileStatus === 'unpublished' ? 'Profile not published' : 'No profile')
 }
 
-module.exports = function transformCompanyToExportDetailsView ({
-  export_experience_category,
-  export_to_countries,
-  future_interest_countries,
-  export_potential_score,
-  great_profile_status,
-  company_number,
-}) {
+function getCountriesFields (company, useNewCountries) {
+  if (useNewCountries) {
+    const buckets = groupExportCountries(company.export_countries)
+
+    return {
+      exportToCountries: getCountries(buckets[EXPORT_INTEREST_STATUS.EXPORTING_TO]),
+      futureInterestCountries: getCountries(buckets[EXPORT_INTEREST_STATUS.FUTURE_INTEREST]),
+      noInterestCountries: getCountries(buckets[EXPORT_INTEREST_STATUS.NOT_INTERESTED]),
+    }
+  }
+  return {
+    exportToCountries: getCountries(company.export_to_countries),
+    futureInterestCountries: getCountries(company.future_interest_countries),
+  }
+}
+
+module.exports = function transformCompanyToExportDetailsView (company, useNewCountries) {
+  const labels = {
+    ...exportDetailsLabels,
+  }
   const viewRecord = {
-    exportExperienceCategory: export_experience_category || 'None',
-    exportToCountries: getCountries(export_to_countries),
-    futureInterestCountries: getCountries(future_interest_countries),
-    exportPotential: getExportPotentialLabel(export_potential_score),
-    greatProfile: getGreatProfileValue(great_profile_status, company_number),
+    exportExperienceCategory: company.export_experience_category || 'None',
+    ...getCountriesFields(company, useNewCountries),
+    exportPotential: getExportPotentialLabel(company.export_potential_score),
+    greatProfile: getGreatProfileValue(company.great_profile_status, company.company_number),
   }
 
-  return getDataLabels(viewRecord, exportDetailsLabels)
+  // Whilst we have the feature flag we have to delete the new label
+  // Otherwise a new field will be displayed with no value
+  // @TODO remove this when the feature flag is removed
+  if (!useNewCountries) {
+    delete labels.noInterestCountries
+  }
+
+  return getDataLabels(viewRecord, labels)
 }

--- a/src/apps/constants.js
+++ b/src/apps/constants.js
@@ -3,6 +3,14 @@ const ERROR = {
   ENTER_A_DATE: 'You must enter a date',
 }
 
+const EXPORT_INTEREST_STATUS = {
+  FUTURE_INTEREST: 'future_interest',
+  EXPORTING_TO: 'currently_exporting',
+  NOT_INTERESTED: 'not_interested',
+}
+
 module.exports = {
   ERROR,
+  EXPORT_INTEREST_STATUS,
+  EXPORT_INTEREST_STATUS_VALUES: Object.values(EXPORT_INTEREST_STATUS),
 }

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -118,12 +118,6 @@ const KINDS = {
   SERVICE_DELIVERY: 'service-delivery',
 }
 
-const EXPORT_INTEREST_STATUS = {
-  FUTURE_INTEREST: 'future_interest',
-  EXPORTING_TO: 'currently_exporting',
-  NOT_INTERESTED: 'not_interested',
-}
-
 module.exports = {
   QUERY_FIELDS,
   QUERY_DATE_FIELDS,
@@ -138,6 +132,4 @@ module.exports = {
   INTERACTION_CONTEXTS,
   THEMES,
   KINDS,
-  EXPORT_INTEREST_STATUS,
-  EXPORT_INTEREST_STATUS_VALUES: Object.values(EXPORT_INTEREST_STATUS),
 }

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -11,7 +11,8 @@ const { joinPaths } = require('../../../lib/path')
 const isValidTheme = require('../macros/is-valid-theme')
 const canAddCountries = require('../macros/can-add-countries')
 
-const { KINDS, THEMES, EXPORT_INTEREST_STATUS_VALUES } = require('../constants')
+const { KINDS, THEMES } = require('../constants')
+const { EXPORT_INTEREST_STATUS_VALUES } = require('../../constants')
 
 const formConfigs = {
   [KINDS.INTERACTION]: interactionForm,

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -1,4 +1,4 @@
-const { EXPORT_INTEREST_STATUS } = require('./constants')
+const { EXPORT_INTEREST_STATUS } = require('../constants')
 
 const countriesDiscussed = {
   were_countries_discussed: 'Were any countries discussed?',

--- a/src/apps/interactions/macros/__test__/get-export-countries.test.js
+++ b/src/apps/interactions/macros/__test__/get-export-countries.test.js
@@ -1,6 +1,6 @@
 const faker = require('faker')
 
-const { EXPORT_INTEREST_STATUS } = require('../../constants')
+const { EXPORT_INTEREST_STATUS } = require('../../../constants')
 const getExportCountries = require('../get-export-countries')
 
 function generateCountries (length) {

--- a/src/apps/interactions/macros/fields.js
+++ b/src/apps/interactions/macros/fields.js
@@ -3,7 +3,7 @@ const { flattenDeep } = require('lodash')
 const { globalFields } = require('../../macros')
 const canAddCountries = require('./can-add-countries')
 
-const { EXPORT_INTEREST_STATUS_VALUES } = require('../constants')
+const { EXPORT_INTEREST_STATUS_VALUES } = require('../../constants')
 
 module.exports = {
   adviser (advisers) {

--- a/src/apps/interactions/macros/get-export-countries.js
+++ b/src/apps/interactions/macros/get-export-countries.js
@@ -1,6 +1,6 @@
 const castCompactArray = require('../../../lib/cast-compact-array')
 
-const { EXPORT_INTEREST_STATUS_VALUES } = require('../constants')
+const { EXPORT_INTEREST_STATUS_VALUES } = require('../../constants')
 
 module.exports = (body) => {
   const data = []

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -5,7 +5,7 @@ const interactionData = require('../../../../../test/unit/data/interactions/new-
 const interactionDataWithCountries = require('../../../../../test/unit/data/interactions/new-interaction-with-countries')
 const serviceOptions = require('../../../../../test/unit/data/interactions/service-options-data')
 
-const { EXPORT_INTEREST_STATUS } = require('../../constants')
+const { EXPORT_INTEREST_STATUS } = require('../../../constants')
 
 const { transformServicesOptions } = require('../../transformers')
 

--- a/src/apps/interactions/transformers/__test__/interaction-form-body-to-api.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-form-body-to-api.test.js
@@ -1,7 +1,7 @@
 const faker = require('faker')
 
 const { transformServicesOptions } = require('../')
-const { EXPORT_INTEREST_STATUS } = require('../../constants')
+const { EXPORT_INTEREST_STATUS } = require('../../../constants')
 
 const serviceOptions = require('../../../../../test/unit/data/interactions/service-options-data.json')
 

--- a/src/lib/__test__/group-export-countries.test.js
+++ b/src/lib/__test__/group-export-countries.test.js
@@ -1,0 +1,70 @@
+const faker = require('faker')
+
+const { EXPORT_INTEREST_STATUS } = require('../../apps/constants')
+
+function generateCountries (length) {
+  return Array.from({ length }).map(() => [faker.random.uuid(), faker.address.country()])
+}
+
+function createExportCountry (status) {
+  return ([id, name]) => ({ country: { id, name }, status })
+}
+
+function generateExportCountries () {
+  const future = generateCountries(2)
+  const current = generateCountries(2)
+  const noInterest = generateCountries(2)
+
+  return {
+    future,
+    current,
+    noInterest,
+    exportCountries: [
+      ...future.map(createExportCountry(EXPORT_INTEREST_STATUS.FUTURE_INTEREST)),
+      ...current.map(createExportCountry(EXPORT_INTEREST_STATUS.EXPORTING_TO)),
+      ...noInterest.map(createExportCountry(EXPORT_INTEREST_STATUS.NOT_INTERESTED)),
+    ],
+  }
+}
+
+function convertToObjects (countries) {
+  return countries.map(([id, name]) => ({ id, name }))
+}
+
+const groupExportCountries = require('../group-export-countries')
+
+describe('groupExportCountries', () => {
+  context('With no countries', () => {
+    it('Should return an empty object', () => {
+      expect(groupExportCountries()).to.deep.equal({})
+    })
+  })
+
+  context('With countries for each status', () => {
+    it('Should separate out the countries', () => {
+      const { future, current, noInterest, exportCountries } = generateExportCountries()
+
+      const buckets = groupExportCountries(exportCountries)
+
+      expect(buckets[EXPORT_INTEREST_STATUS.FUTURE_INTEREST]).to.deep.equal(convertToObjects(future))
+      expect(buckets[EXPORT_INTEREST_STATUS.EXPORTING_TO]).to.deep.equal(convertToObjects(current))
+      expect(buckets[EXPORT_INTEREST_STATUS.NOT_INTERESTED]).to.deep.equal(convertToObjects(noInterest))
+    })
+  })
+
+  context('With unexpected statuses', () => {
+    it('Should only return the known statuses', () => {
+      const FAKE_STATUS = 'fake-status'
+      const { future, current, noInterest, exportCountries } = generateExportCountries()
+
+      exportCountries.push(...generateCountries(2).map(createExportCountry(FAKE_STATUS)))
+
+      const buckets = groupExportCountries(exportCountries)
+
+      expect(buckets[EXPORT_INTEREST_STATUS.FUTURE_INTEREST]).to.deep.equal(convertToObjects(future))
+      expect(buckets[EXPORT_INTEREST_STATUS.EXPORTING_TO]).to.deep.equal(convertToObjects(current))
+      expect(buckets[EXPORT_INTEREST_STATUS.NOT_INTERESTED]).to.deep.equal(convertToObjects(noInterest))
+      expect(buckets[FAKE_STATUS]).to.be.undefined
+    })
+  })
+})

--- a/src/lib/group-export-countries.js
+++ b/src/lib/group-export-countries.js
@@ -1,0 +1,21 @@
+const { EXPORT_INTEREST_STATUS_VALUES } = require('../apps/constants')
+
+module.exports = (countries) => {
+  const buckets = {}
+
+  if (Array.isArray(countries)) {
+    EXPORT_INTEREST_STATUS_VALUES.forEach((status) => {
+      buckets[ status ] = []
+    }, {})
+
+    countries.forEach((item) => {
+      const bucket = buckets[item.status]
+
+      if (bucket) {
+        bucket.push(item.country)
+      }
+    })
+  }
+
+  return buckets
+}

--- a/test/selectors/interaction-form.js
+++ b/test/selectors/interaction-form.js
@@ -1,5 +1,5 @@
 const typeaheadId = '#group-field-dit_participants'
-const { EXPORT_INTEREST_STATUS } = require('../../src/apps/interactions/constants')
+const { EXPORT_INTEREST_STATUS } = require('../../src/apps/constants')
 
 module.exports = {
   subject: '#field-subject',


### PR DESCRIPTION
## Description of change

To add more features for the adding countries on an interaction, this now shows the three new fields on the export tab for a country - **behind a feature flag**

## Test instructions

View the export tab for a company, add the feature flag `interaction-add-countries` and it should change to show the new fields. A migration will be happening on the backed PR but until that happens the fields will display `None`

You cannot edit these countries as part of this PR, that is the next one...

Also, please excuse the lack of test refactoring as that will come in a subsequent PR
 
## Screenshots
### Before

<img width="870" alt="Screenshot 2019-12-10 at 15 56 35" src="https://user-images.githubusercontent.com/1481883/70545621-c6d95480-1b65-11ea-9ca6-09ec62d528fe.png">

### After 

<img width="872" alt="Screenshot 2019-12-10 at 15 56 51" src="https://user-images.githubusercontent.com/1481883/70545635-ce006280-1b65-11ea-821f-fa7a0d505494.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
