### PR TITLE
Add Edit History API call and translators (2 of 3)

### DIFF
--- a/src/apps/companies/apps/edit-history/__test__/transformers.test.js
+++ b/src/apps/companies/apps/edit-history/__test__/transformers.test.js
@@ -1,0 +1,293 @@
+const { transformCompanyAuditLog } = require('../transformers')
+
+describe('Edit history transformers', () => {
+  it('should return an empty array when there are no changes', () => {
+    const transformed = transformCompanyAuditLog([])
+    expect(transformed).to.deep.equal([])
+  })
+
+  it('should transform an archived company', () => {
+    expect(transformCompanyAuditLog([
+      {
+        id: 236,
+        user: {
+          id: '8b76daf2-0f8a-4887-9b4b-43bbda21c934',
+          first_name: 'Paul',
+          last_name: 'Gain',
+          name: 'Paul Gain',
+          email: 'paul.gain@digital.trade.gov.uk',
+        },
+        timestamp: '2019-12-10T18:07:27.864590Z',
+        comment: '',
+        changes: {
+          archived: [
+            false,
+            true,
+          ],
+          archived_on: [
+            null,
+            '2019-12-10T18:07:27.974000Z',
+          ],
+          archived_reason: [
+            null,
+            'Company is dissolved',
+          ],
+          archived_by: [
+            null,
+            'Paul Gain',
+          ],
+        },
+      },
+    ])).to.deep.equal([
+      {
+        timestamp: '2019-12-10T18:07:27.864590Z',
+        adviserFullName: 'Paul Gain',
+        changes: [
+          {
+            fieldName: 'archived',
+            oldValue: false,
+            newValue: true,
+          },
+          {
+            fieldName: 'archived_on',
+            oldValue: null,
+            newValue: '2019-12-10T18:07:27.974000Z',
+          },
+          {
+            fieldName: 'archived_reason',
+            oldValue: null,
+            newValue: 'Company is dissolved',
+          },
+          {
+            fieldName: 'archived_by',
+            oldValue: null,
+            newValue: 'Paul Gain',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should transform an unarchived company', () => {
+    expect(transformCompanyAuditLog([
+      {
+        id: 237,
+        user: {
+          id: '8b76daf2-0f8a-4887-9b4b-43bbda21c934',
+          first_name: 'Paul',
+          last_name: 'Gain',
+          name: 'Paul Gain',
+          email: 'paul.gain@digital.trade.gov.uk',
+        },
+        timestamp: '2019-12-10T18:12:37.649476Z',
+        comment: '',
+        changes: {
+          archived: [
+            true,
+            false,
+          ],
+          archived_on: [
+            '2019-12-10T18:07:27.974000Z',
+            null,
+          ],
+          archived_reason: [
+            'Company is dissolved',
+            '',
+          ],
+          archived_by: [
+            'Paul Gain',
+            null,
+          ],
+        },
+      },
+    ])).to.deep.equal([
+      {
+        timestamp: '2019-12-10T18:12:37.649476Z',
+        adviserFullName: 'Paul Gain',
+        changes: [
+          {
+            fieldName: 'archived',
+            oldValue: true,
+            newValue: false,
+          },
+          {
+            fieldName: 'archived_on',
+            oldValue: '2019-12-10T18:07:27.974000Z',
+            newValue: null,
+          },
+          {
+            fieldName: 'archived_reason',
+            oldValue: 'Company is dissolved',
+            newValue: '',
+          },
+          {
+            fieldName: 'archived_by',
+            oldValue: 'Paul Gain',
+            newValue: null,
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should transform a company address', () => {
+    expect(transformCompanyAuditLog([
+      {
+        id: 233,
+        user: {
+          id: '8b76daf2-0f8a-4887-9b4b-43bbda21c934',
+          first_name: 'Paul',
+          last_name: 'Gain',
+          name: 'Paul Gain',
+          email: 'paul.gain@digital.trade.gov.uk',
+        },
+        timestamp: '2019-12-10T17:58:59.393078Z',
+        comment: '',
+        changes: {
+          address_1: [
+            '14 Wharf Road',
+            'Her Majesty’s Courts and Tribunals Service - 102 Petty France',
+          ],
+          address_2: [
+            '',
+            'Westminster',
+          ],
+          address_town: [
+            'Brentwood',
+            'London',
+          ],
+          address_county: [
+            'Essex',
+            'Greater London',
+          ],
+          address_postcode: [
+            'CM14 4LQ',
+            'SW1H 9AJ',
+          ],
+        },
+      },
+    ])).to.deep.equal([
+      {
+        timestamp: '2019-12-10T17:58:59.393078Z',
+        adviserFullName: 'Paul Gain',
+        changes: [
+          {
+            fieldName: 'address_1',
+            oldValue: '14 Wharf Road',
+            newValue: 'Her Majesty’s Courts and Tribunals Service - 102 Petty France',
+          },
+          {
+            fieldName: 'address_2',
+            oldValue: '',
+            newValue: 'Westminster',
+          },
+          {
+            fieldName: 'address_town',
+            oldValue: 'Brentwood',
+            newValue: 'London',
+          },
+          {
+            fieldName: 'address_county',
+            oldValue: 'Essex',
+            newValue: 'Greater London',
+          },
+          {
+            fieldName: 'address_postcode',
+            oldValue: 'CM14 4LQ',
+            newValue: 'SW1H 9AJ',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should transform a DnB company', () => {
+    expect(transformCompanyAuditLog([
+      {
+        id: 235,
+        user: {
+          id: '8b76daf2-0f8a-4887-9b4b-43bbda21c934',
+          first_name: 'Paul',
+          last_name: 'Gain',
+          name: 'Paul Gain',
+          email: 'paul.gain@digital.trade.gov.uk',
+        },
+        timestamp: '2019-12-10T18:04:54.287410Z',
+        comment: '',
+        changes: {
+          sector: [
+            'Biotechnology and Pharmaceuticals',
+            'Airports',
+          ],
+          description: [
+            null,
+            'Superior editing services',
+          ],
+          uk_region: [
+            'South East',
+            'London',
+          ],
+        },
+      },
+    ])).to.deep.equal([
+      {
+        timestamp: '2019-12-10T18:04:54.287410Z',
+        adviserFullName: 'Paul Gain',
+        changes: [
+          {
+            fieldName: 'sector',
+            oldValue: 'Biotechnology and Pharmaceuticals',
+            newValue: 'Airports',
+          },
+          {
+            fieldName: 'description',
+            oldValue: null,
+            newValue: 'Superior editing services',
+          },
+          {
+            fieldName: 'uk_region',
+            oldValue: 'South East',
+            newValue: 'London',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should transform a company trading address', () => {
+    expect(transformCompanyAuditLog([
+      {
+        id: 234,
+        user: {
+          id: '8b76daf2-0f8a-4887-9b4b-43bbda21c934',
+          first_name: 'Paul',
+          last_name: 'Gain',
+          name: 'Paul Gain',
+          email: 'paul.gain@digital.trade.gov.uk',
+        },
+        timestamp: '2019-12-10T18:00:52.265115Z',
+        comment: '',
+        changes: {
+          trading_names: [
+            [],
+            [
+              'Edit History Enterprises',
+            ],
+          ],
+        },
+      },
+    ])).to.deep.equal([
+      {
+        timestamp: '2019-12-10T18:00:52.265115Z',
+        adviserFullName: 'Paul Gain',
+        changes: [
+          {
+            fieldName: 'trading_names',
+            oldValue: null,
+            newValue: 'Edit History Enterprises',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/src/apps/companies/apps/edit-history/client/EditHistory.jsx
+++ b/src/apps/companies/apps/edit-history/client/EditHistory.jsx
@@ -1,8 +1,20 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { H3 } from 'govuk-react'
 
-function EditHistory () {
-  return <H3>This page is hidden behind an Express route</H3>
+function EditHistory ({ editHistory }) {
+  return (
+    <>
+      <H3>This page is hidden behind an Express route</H3>
+      {editHistory.map((item, index) => (
+        <pre key={index}>{JSON.stringify(item, null, 2)}</pre>
+      ))}
+    </>
+  )
+}
+
+EditHistory.propTypes = {
+  editHistory: PropTypes.array.isRequired,
 }
 
 export default EditHistory

--- a/src/apps/companies/apps/edit-history/controller.js
+++ b/src/apps/companies/apps/edit-history/controller.js
@@ -1,15 +1,23 @@
 const { companies } = require('../../../../lib/urls')
+const { getCompanyAuditLog } = require('../../repos')
+const { transformCompanyAuditLog } = require('./transformers')
 
 async function renderEditHistory (req, res, next) {
   try {
     const { company } = res.locals
+    const { token } = req.session
+
+    const companyAuditLog = await getCompanyAuditLog(token, company.id)
+    const editHistory = transformCompanyAuditLog(companyAuditLog.results)
 
     res
       .breadcrumb(company.name, companies.detail(company.id))
       .breadcrumb('Business details', companies.businessDetails(company.id))
       .breadcrumb('Edit History')
       .render('companies/apps/edit-history/views/client-container', {
-        props: {},
+        props: {
+          editHistory,
+        },
       })
   } catch (error) {
     next(error)

--- a/src/apps/companies/apps/edit-history/transformers.js
+++ b/src/apps/companies/apps/edit-history/transformers.js
@@ -1,0 +1,39 @@
+/* eslint-disable camelcase */
+const { isArray, isEmpty } = require('lodash')
+
+const unwrapFromArray = change =>
+  isArray(change)
+    ? isEmpty(change)
+      ? null
+      : change.pop()
+    : change
+
+const transformChanges = (changes) => {
+  return Object.keys(changes).map(key => {
+    return {
+      fieldName: key,
+      oldValue: unwrapFromArray(changes[key][0]),
+      newValue: unwrapFromArray(changes[key][1]),
+    }
+  })
+}
+
+const transformCompanyAuditLogItem = ({
+  timestamp,
+  user,
+  changes,
+}) => {
+  return {
+    timestamp,
+    adviserFullName: `${user.first_name} ${user.last_name}`,
+    changes: transformChanges(changes),
+  }
+}
+
+const transformCompanyAuditLog = (audit) => {
+  return audit.map((item) => transformCompanyAuditLogItem(item))
+}
+
+module.exports = {
+  transformCompanyAuditLog,
+}

--- a/test/sandbox/fixtures/v4/company-audit/company-audit.json
+++ b/test/sandbox/fixtures/v4/company-audit/company-audit.json
@@ -1,0 +1,148 @@
+{
+    "count": 5,
+    "next": null,
+    "previous": null,
+    "results": [
+      {
+        "id": 237,
+        "user": {
+          "id": "8b76daf2-0f8a-4887-9b4b-43bbda21c934",
+          "first_name": "Paul",
+          "last_name": "Gain",
+          "name": "Paul Gain",
+          "email": "paul.gain@digital.trade.gov.uk"
+        },
+        "timestamp": "2019-12-10T18:12:37.649476Z",
+        "comment": "",
+        "changes": {
+          "archived": [
+            true,
+            false
+          ],
+          "archived_on": [
+            "2019-12-10T18:07:27.974000Z",
+            null
+          ],
+          "archived_reason": [
+            "Company is dissolved",
+            ""
+          ],
+          "archived_by": [
+            "Paul Gain",
+            null
+          ]
+        }
+      },
+      {
+        "id": 236,
+        "user": {
+          "id": "8b76daf2-0f8a-4887-9b4b-43bbda21c934",
+          "first_name": "Paul",
+          "last_name": "Gain",
+          "name": "Paul Gain",
+          "email": "paul.gain@digital.trade.gov.uk"
+        },
+        "timestamp": "2019-12-10T18:07:27.864590Z",
+        "comment": "",
+        "changes": {
+          "archived": [
+            false,
+            true
+          ],
+          "archived_on": [
+            null,
+            "2019-12-10T18:07:27.974000Z"
+          ],
+          "archived_reason": [
+            null,
+            "Company is dissolved"
+          ],
+          "archived_by": [
+            null,
+            "Paul Gain"
+          ]
+        }
+      },
+      {
+        "id": 235,
+        "user": {
+          "id": "8b76daf2-0f8a-4887-9b4b-43bbda21c934",
+          "first_name": "Paul",
+          "last_name": "Gain",
+          "name": "Paul Gain",
+          "email": "paul.gain@digital.trade.gov.uk"
+        },
+        "timestamp": "2019-12-10T18:04:54.287410Z",
+        "comment": "",
+        "changes": {
+          "sector": [
+            "Biotechnology and Pharmaceuticals",
+            "Airports"
+          ],
+          "description": [
+            null,
+            "Superior editing services"
+          ],
+          "uk_region": [
+            "South East",
+            "London"
+          ]
+        }
+      },
+      {
+        "id": 234,
+        "user": {
+          "id": "8b76daf2-0f8a-4887-9b4b-43bbda21c934",
+          "first_name": "Paul",
+          "last_name": "Gain",
+          "name": "Paul Gain",
+          "email": "paul.gain@digital.trade.gov.uk"
+        },
+        "timestamp": "2019-12-10T18:00:52.265115Z",
+        "comment": "",
+        "changes": {
+          "trading_names": [
+            [],
+            [
+              "Edit History Enterprises"
+            ]
+          ]
+        }
+      },
+      {
+        "id": 233,
+        "user": {
+          "id": "8b76daf2-0f8a-4887-9b4b-43bbda21c934",
+          "first_name": "Paul",
+          "last_name": "Gain",
+          "name": "Paul Gain",
+          "email": "paul.gain@digital.trade.gov.uk"
+        },
+        "timestamp": "2019-12-10T17:58:59.393078Z",
+        "comment": "",
+        "changes": {
+          "address_1": [
+            "14 Wharf Road",
+            "Her Majesty’s Courts and Tribunals Service - 102 Petty France"
+          ],
+          "address_2": [
+            "",
+            "Westminster"
+          ],
+          "address_town": [
+            "Brentwood",
+            "London"
+          ],
+          "address_county": [
+            "Essex",
+            "Greater London"
+          ],
+          "address_postcode": [
+            "CM14 4LQ",
+            "SW1H 9AJ"
+          ]
+        }
+      }
+    ]
+  }
+  

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -418,6 +418,7 @@ Sandbox.define('/v4/company/{companyId}', 'GET', v4Company.company)
 Sandbox.define('/v4/company/{companyId}', 'PATCH', v4Company.companyPatched)
 Sandbox.define('/v4/company', 'GET', v4Company.companies)
 Sandbox.define('/v4/company/{companyId}/{action}-account-manager', 'POST', v4Company.manageAdviser)
+Sandbox.define('/v4/company/{companyId}/audit', 'GET', v4Company.companyAudit)
 
 // V4 DnB
 Sandbox.define('/v4/dnb/company-create', 'POST', v4Dnb.companyCreate)

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -19,6 +19,7 @@ var companyWithContacts = require('../../../fixtures/v4/company/company-with-con
 var companyList = require('../../../fixtures/v4/user/company-list.json')
 var companyOneListTierDIta = require('../../../fixtures/v4/company/company-one-list-tier-d-ita.json')
 var companyWithValidationError = require('../../../fixtures/v4/company/company-validation-error.json')
+var companyAudit = require('../../../fixtures/v4/company-audit/company-audit.json')
 
 var largeCapitalProfileEmpty = require('../../../fixtures/v4/company/large-capital-profile-empty.json')
 var largeCapitalProfileNew = require('../../../fixtures/v4/company/large-capital-profile-new.json')
@@ -135,4 +136,8 @@ exports.getCompanyList = function (req, res) {
 
 exports.manageAdviser = function (req, res) {
   return res.json(204, {})
+}
+
+exports.companyAudit = function (req, res) {
+  res.json(companyAudit)
 }


### PR DESCRIPTION
## Edit History API call and translators (2 of 3)

This PR follows on from https://github.com/uktrade/data-hub-frontend/pull/2315 and makes an API call to the `/v4/company/<id>/audit` endpoint. The response is transformed and passed to a React component (3 of 3).

<img width="1089" alt="edit-history-data" src="https://user-images.githubusercontent.com/964268/70575407-5dc20300-1b9e-11ea-8b21-b390cca52e99.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
