### PR TITLE
Feature/edit export countries on export tab

### DIFF
--- a/src/apps/companies/__test__/router.test.js
+++ b/src/apps/companies/__test__/router.test.js
@@ -1,4 +1,5 @@
 const router = require('../router')
+const urls = require('../../../lib/urls')
 
 describe('Company router', () => {
   it('should define all routes', () => {
@@ -6,7 +7,8 @@ describe('Company router', () => {
     expect(paths).to.deep.equal([
       '/',
       '/export',
-      '/:companyId/exports/edit',
+      urls.companies.exports.index.route,
+      urls.companies.exports.edit.route,
       '/:companyId/archive',
       '/:companyId/unarchive',
       '/:companyId',
@@ -18,7 +20,6 @@ describe('Company router', () => {
       '/:companyId/hierarchies/subsidiaries/search',
       '/:companyId/hierarchies/subsidiaries/:subsidiaryCompanyId/add',
       '/:companyId/contacts',
-      '/:companyId/exports',
       '/:companyId/orders',
       '/:companyId/audit',
       '/:companyId/documents',

--- a/src/apps/companies/controllers/__test__/exports.test.js
+++ b/src/apps/companies/controllers/__test__/exports.test.js
@@ -206,7 +206,7 @@ describe('Company export controller', () => {
       })
 
       it('should redirect to exports routes', () => {
-        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(urls.companies.exports(companyMock.id))
+        expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(urls.companies.exports.index(companyMock.id))
         expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
       })
 

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { assign, filter, flatten } = require('lodash')
+const { filter, flatten } = require('lodash')
 
 const metadataRepo = require('../../../lib/metadata')
 const urls = require('../../../lib/urls')
@@ -29,7 +29,7 @@ function populateExportForm (req, res, next) {
     export_experience_category,
   } = res.locals.company
 
-  res.locals.formData = assign({}, {
+  res.locals.formData = Object.assign({
     export_experience_category,
     export_to_countries: export_to_countries.map(country => country.id),
     future_interest_countries: future_interest_countries.map(country => country.id),
@@ -56,7 +56,7 @@ async function handleEditFormPost (req, res, next) {
   const exportToCountries = flatten([req.body.export_to_countries])
   const futureInterestCountries = flatten([req.body.future_interest_countries])
 
-  const data = assign({}, res.locals.company, {
+  const data = Object.assign({}, res.locals.company, {
     export_experience_category: req.body.export_experience_category,
     export_to_countries: filter(exportToCountries),
     future_interest_countries: filter(futureInterestCountries),

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -3,12 +3,27 @@ const { filter, flatten } = require('lodash')
 
 const metadataRepo = require('../../../lib/metadata')
 const urls = require('../../../lib/urls')
+const groupExportCountries = require('../../../lib/group-export-countries')
+
 const { saveCompany } = require('../repos')
 const { transformObjectToOption } = require('../../transformers')
 const { transformCompanyToExportDetailsView } = require('../transformers')
 const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
 
-const { NEW_COUNTRIES_FEATURE } = require('../../constants')
+const { NEW_COUNTRIES_FEATURE, EXPORT_INTEREST_STATUS, EXPORT_INTEREST_STATUS_VALUES } = require('../../constants')
+
+function getId (obj) {
+  return obj.id
+}
+
+function getExportCountries (countries) {
+  const buckets = groupExportCountries(countries)
+  EXPORT_INTEREST_STATUS_VALUES.forEach((status) => {
+    buckets[ status ] = buckets[ status ].map(transformObjectToOption)
+  })
+
+  return buckets
+}
 
 function renderExports (req, res) {
   const { company, features } = res.locals
@@ -28,19 +43,27 @@ function populateExportForm (req, res, next) {
     export_to_countries,
     future_interest_countries,
     export_experience_category,
+    export_countries,
   } = res.locals.company
 
-  res.locals.formData = Object.assign({
-    export_experience_category,
-    export_to_countries: export_to_countries.map(country => country.id),
-    future_interest_countries: future_interest_countries.map(country => country.id),
-  }, req.body)
+  if (res.locals.features[ NEW_COUNTRIES_FEATURE ]) {
+    res.locals.formData = Object.assign({
+      export_experience_category,
+      ...getExportCountries(export_countries),
+    }, req.body)
+  } else {
+    res.locals.formData = Object.assign({
+      export_experience_category,
+      export_to_countries: export_to_countries.map(getId),
+      future_interest_countries: future_interest_countries.map(getId),
+    }, req.body)
+  }
 
   next()
 }
 
 function renderExportEdit (req, res) {
-  const { company } = res.locals
+  const { company, features } = res.locals
 
   res
     .breadcrumb(company.name, urls.companies.detail(company.id))
@@ -50,6 +73,12 @@ function renderExportEdit (req, res) {
       exportDetailsLabels,
       exportExperienceCategories: metadataRepo.exportExperienceCategory.map(transformObjectToOption),
       countryOptions: metadataRepo.countryOptions.map(transformObjectToOption),
+      useNewCountries: features[ NEW_COUNTRIES_FEATURE ],
+      countriesFields: {
+        [EXPORT_INTEREST_STATUS.EXPORTING_TO]: exportDetailsLabels.exportToCountries,
+        [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: exportDetailsLabels.futureInterestCountries,
+        [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: exportDetailsLabels.noInterestCountries,
+      },
     })
 }
 

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -8,10 +8,11 @@ const { transformObjectToOption } = require('../../transformers')
 const { transformCompanyToExportDetailsView } = require('../transformers')
 const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
 
+const { NEW_COUNTRIES_FEATURE } = require('../../constants')
+
 function renderExports (req, res) {
   const { company, features } = res.locals
-  const useNewCountries = features['interaction-add-countries']
-  const exportDetails = transformCompanyToExportDetailsView(company, useNewCountries)
+  const exportDetails = transformCompanyToExportDetailsView(company, features[NEW_COUNTRIES_FEATURE])
 
   res
     .breadcrumb(company.name, urls.companies.detail(company.id))

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -17,7 +17,7 @@ function getId (obj) {
   return obj.id
 }
 
-function getExportCountryGroups (countries) {
+function getExportCountryGroups (countries = []) {
   const buckets = groupExportCountries(countries)
 
   EXPORT_INTEREST_STATUS_VALUES.forEach((status) => {

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -85,14 +85,13 @@ function renderExportEdit (req, res) {
 }
 
 async function handleEditFormPost (req, res, next) {
-  let data = Object.assign({}, res.locals.company, {
+  const data = {
+    ...res.locals.company,
     export_experience_category: req.body.export_experience_category,
-  })
+  }
 
   if (res.locals.features[ NEW_COUNTRIES_FEATURE ]) {
-    Object.assign(data, {
-      export_countries: getExportCountries(req.body),
-    })
+    data.export_countries = getExportCountries(req.body) || []
   } else {
     const exportToCountries = flatten([req.body.export_to_countries])
     const futureInterestCountries = flatten([req.body.future_interest_countries])

--- a/src/apps/companies/controllers/exports.js
+++ b/src/apps/companies/controllers/exports.js
@@ -43,7 +43,7 @@ function renderExportEdit (req, res) {
 
   res
     .breadcrumb(company.name, urls.companies.detail(company.id))
-    .breadcrumb('Exports', urls.companies.exports(company.id))
+    .breadcrumb('Exports', urls.companies.exports.index(company.id))
     .breadcrumb('Edit')
     .render('companies/views/exports-edit', {
       exportDetailsLabels,
@@ -65,7 +65,7 @@ async function handleEditFormPost (req, res, next) {
   try {
     const save = await saveCompany(req.session.token, data)
 
-    res.redirect(urls.companies.exports(save.id))
+    res.redirect(urls.companies.exports.index(save.id))
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -93,8 +93,9 @@ router.use('/:companyId/lists', companyListsRouter)
 router.use('/:companyId/edit', editCompanyFormRouter)
 router.use('/:companyId/edit-history', editHistoryRouter)
 
+router.get(urls.companies.exports.index.route, renderExports)
 router
-  .route('/:companyId/exports/edit')
+  .route(urls.companies.exports.edit.route)
   .get(populateExportForm, renderExportEdit)
   .post(populateExportForm, handleEditFormPost, renderExportEdit)
 
@@ -120,8 +121,6 @@ router.get('/:companyId/contacts',
   getCompanyContactCollection,
   renderContacts
 )
-
-router.get(urls.companies.exports.route, renderExports)
 
 router.get('/:companyId/orders', renderOrders)
 router.get('/:companyId/audit', renderAuditLog)

--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -9,7 +9,7 @@
   {% call Form({
     buttonText: 'Save and return',
     returnText: 'Return without saving',
-    returnLink: '/companies/' + company.id + '/exports',
+    returnLink: urls.companies.exports.index(company.id),
     hiddenFields: {
       id: company.id
     }

--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -23,52 +23,71 @@
       optional: true
     }) }}
 
-    {# TODO: Make these work without JavaScript #}
-    {% set exportCountries = formData.export_to_countries if formData.export_to_countries.length else ['']%}
-    <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
-      <label class="c-form-group__label">
-        <span class="c-form-group__label-text">
-          Select a market this company currently exports to (optional)
-        </span>
-      </label>
-
-      {% for country in exportCountries %}
-        {{ MultipleChoiceField({
-          name: 'export_to_countries',
-          label: 'Select a market this company currently exports to',
-          value: country,
+    {% if useNewCountries and countriesFields %}
+      {% for name, label in countriesFields %}
+        {{ Typeahead({
+          name: name,
+          label: label,
+          isAsync: false,
+          isLabelHidden: false,
+          useSubLabel: false,
+          placeholder: 'Search countries',
+          classes: 'c-form-group--no-filter',
+          multipleSelect: true,
           options: countryOptions,
-          initialOption: '-- Select country --',
-          idSuffix: loop.index,
-          optional: true,
-          isLabelHidden: true,
-          modifier: ['compact', 'AddItems']
+          target: 'metadata',
+          autoSubmit: false,
+          selectedOptions: formData[name]
         }) }}
       {% endfor %}
-    </div>
+    {% else %}
+      {# TODO: Make these work without JavaScript #}
+      {% set exportCountries = formData.export_to_countries if formData.export_to_countries.length else ['']%}
+      <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
+        <label class="c-form-group__label">
+          <span class="c-form-group__label-text">
+            Select a market this company currently exports to (optional)
+          </span>
+        </label>
 
-    {# TODO: Make these work without JavaScript #}
-    {% set futureCountries = formData.future_interest_countries if formData.future_interest_countries.length else ['']%}
-    <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
-      <label class="c-form-group__label">
-        <span class="c-form-group__label-text">
-          Future markets of interest (optional)
-        </span>
-      </label>
+        {% for country in exportCountries %}
+          {{ MultipleChoiceField({
+            name: 'export_to_countries',
+            label: 'Select a market this company currently exports to',
+            value: country,
+            options: countryOptions,
+            initialOption: '-- Select country --',
+            idSuffix: loop.index,
+            optional: true,
+            isLabelHidden: true,
+            modifier: ['compact', 'AddItems']
+          }) }}
+        {% endfor %}
+      </div>
 
-      {% for country in futureCountries %}
-        {{ MultipleChoiceField({
-          name: 'future_interest_countries',
-          label: 'Future markets of interest',
-          value: country,
-          options: countryOptions,
-          initialOption: '-- Select country --',
-          idSuffix: loop.index,
-          optional: true,
-          isLabelHidden: true,
-          modifier: ['compact', 'AddItems']
-        }) }}
-      {% endfor %}
-    </div>
+      {# TODO: Make these work without JavaScript #}
+      {% set futureCountries = formData.future_interest_countries if formData.future_interest_countries.length else ['']%}
+      <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
+        <label class="c-form-group__label">
+          <span class="c-form-group__label-text">
+            Future markets of interest (optional)
+          </span>
+        </label>
+
+        {% for country in futureCountries %}
+          {{ MultipleChoiceField({
+            name: 'future_interest_countries',
+            label: 'Future markets of interest',
+            value: country,
+            options: countryOptions,
+            initialOption: '-- Select country --',
+            idSuffix: loop.index,
+            optional: true,
+            isLabelHidden: true,
+            modifier: ['compact', 'AddItems']
+          }) }}
+        {% endfor %}
+      </div>
+    {% endif %}
   {% endcall %}
 {% endblock %}

--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -30,7 +30,7 @@
 
     {% if not company.archived %}
       <p class="actions">
-        <a href="/companies/{{company.id}}/exports/edit" class="govuk-button govuk-button--secondary">Edit export markets</a>
+        <a href="{{ urls.companies.exports.edit(company.id) }}" class="govuk-button govuk-button--secondary">Edit export markets</a>
       </p>
     {% endif %}
   {% endcall %}

--- a/src/apps/constants.js
+++ b/src/apps/constants.js
@@ -9,8 +9,11 @@ const EXPORT_INTEREST_STATUS = {
   NOT_INTERESTED: 'not_interested',
 }
 
+const NEW_COUNTRIES_FEATURE = 'interaction-add-countries'
+
 module.exports = {
   ERROR,
   EXPORT_INTEREST_STATUS,
   EXPORT_INTEREST_STATUS_VALUES: Object.values(EXPORT_INTEREST_STATUS),
+  NEW_COUNTRIES_FEATURE,
 }

--- a/src/apps/interactions/macros/can-add-countries.js
+++ b/src/apps/interactions/macros/can-add-countries.js
@@ -1,7 +1,8 @@
 const { THEMES } = require('../constants')
+const { NEW_COUNTRIES_FEATURE } = require('../../constants')
 
 module.exports = (theme, interaction, featureFlags) => {
-  const featureEnabled = featureFlags[ 'interaction-add-countries' ]
+  const featureEnabled = featureFlags[ NEW_COUNTRIES_FEATURE ]
 
   if (interaction || !featureEnabled) { return false }
 

--- a/src/apps/interactions/transformers/interaction-form-body-to-api.js
+++ b/src/apps/interactions/transformers/interaction-form-body-to-api.js
@@ -2,7 +2,7 @@ const { omit } = require('lodash')
 
 const castCompactArray = require('../../../lib/cast-compact-array')
 const { transformDateObjectToDateString } = require('../../transformers')
-const getExportCountries = require('../macros/get-export-countries')
+const getExportCountries = require('../../../lib/get-export-countries')
 
 const { INTERACTION_STATUS } = require('../constants')
 

--- a/src/lib/__test__/get-export-countries.test.js
+++ b/src/lib/__test__/get-export-countries.test.js
@@ -1,6 +1,6 @@
 const faker = require('faker')
 
-const { EXPORT_INTEREST_STATUS } = require('../../../constants')
+const { EXPORT_INTEREST_STATUS } = require('../../apps/constants')
 const getExportCountries = require('../get-export-countries')
 
 function generateCountries (length) {

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -73,9 +73,11 @@ describe('urls', () => {
       expect(urls.companies.dnbHierarchy.data.route).to.equal('/:companyId/dnb-hierarchy/data')
       expect(urls.companies.dnbHierarchy.data(companyId)).to.equal(`/companies/${companyId}/dnb-hierarchy/data`)
 
-      expect(urls.companies.exports.route).to.equal('/:companyId/exports')
-      expect(urls.companies.exports(companyId)).to.equal(`/companies/${companyId}/exports`)
-      expect(urls.companies.exports.route).to.equal('/:companyId/exports')
+      expect(urls.companies.exports.index.route).to.equal('/:companyId/exports')
+      expect(urls.companies.exports.index(companyId)).to.equal(`/companies/${companyId}/exports`)
+
+      expect(urls.companies.exports.edit.route).to.equal('/:companyId/exports/edit')
+      expect(urls.companies.exports.edit(companyId)).to.equal(`/companies/${companyId}/exports/edit`)
 
       expect(urls.companies.subsidiaries.index(companyId)).to.equal(`/companies/${companyId}/subsidiaries`)
       expect(urls.companies.subsidiaries.index.route).to.equal('/:companyId/subsidiaries')

--- a/src/lib/get-export-countries.js
+++ b/src/lib/get-export-countries.js
@@ -1,6 +1,6 @@
-const castCompactArray = require('../../../lib/cast-compact-array')
+const castCompactArray = require('./cast-compact-array')
 
-const { EXPORT_INTEREST_STATUS_VALUES } = require('../../constants')
+const { EXPORT_INTEREST_STATUS_VALUES } = require('../apps/constants')
 
 module.exports = (body) => {
   const data = []

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -90,7 +90,10 @@ module.exports = {
       index: url('/companies', '/:companyId/dnb-hierarchy'),
       data: url('/companies', '/:companyId/dnb-hierarchy/data'),
     },
-    exports: url('/companies', '/:companyId/exports'),
+    exports: {
+      index: url('/companies', '/:companyId/exports'),
+      edit: url('/companies', '/:companyId/exports/edit'),
+    },
     hierarchies: {
       ghq: {
         add: url('/companies', '/:companyId/hierarchies/ghq/:globalHqId/add'),

--- a/test/selectors/investment/proposition.js
+++ b/test/selectors/investment/proposition.js
@@ -1,8 +1,8 @@
 module.exports = {
   name: '#field-name',
   scope: '#field-scope',
-  day: '#field-deadline_month',
-  month: '#field-deadline_day',
+  day: '#field-deadline_day',
+  month: '#field-deadline_month',
   year: '#field-deadline_year',
   button: '.c-form-actions > button',
   details: '#field-details',


### PR DESCRIPTION
## Description of change

View the export tab for a company, add the feature flag interaction-add-countries and it should change to show the new fields. A migration will be happening on the backend PR but until that happens the fields will display None

This is the Edit feature mentioned in this PR: https://github.com/uktrade/data-hub-frontend/pull/2318

You should be able to edit the countries currently on the Export Tab
 
## Screenshots
### Before

https://user-images.githubusercontent.com/1481883/70545635-ce006280-1b65-11ea-821f-fa7a0d505494.png

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
