### PR TITLE
Clarify “Ultimate HQ” label on the company business details page

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -43,6 +43,21 @@
 
   .c-meta-list {
     @include core-font(16);
+    @include media(tablet) {
+      display: table-row;
+    }
+  }
+
+  .c-meta-list__item {
+    @include media(tablet) {
+      display: table-cell;
+    }
+  }
+
+  .govuk-details--inline {
+    @include media(tablet) {
+      margin-left: $default-spacing-unit;
+    }
   }
 
   .c-entity-search__aggregations {

--- a/assets/stylesheets/elements/_details.scss
+++ b/assets/stylesheets/elements/_details.scss
@@ -87,3 +87,10 @@ details {
     }
   }
 }
+
+.govuk-details--inline {
+  margin-bottom: 0;
+  .govuk-details__summary-text, .govuk-details__text {
+    font-size: initial;
+  }
+}

--- a/src/apps/companies/views/template.njk
+++ b/src/apps/companies/views/template.njk
@@ -1,3 +1,5 @@
+{% from "details/macro.njk" import govukDetails %}
+
 {% extends "_layouts/template.njk" %}
 
 {% set action %}
@@ -20,6 +22,15 @@
       <div class="c-meta-list">
         <div class="c-meta-list__item">
           <span class="c-badge">{{ "Ultimate" if company.isUltimate else "Global" }} HQ</span>
+        </div>
+        <div class="c-meta-list__item">
+          {% if company.isUltimate %}
+            {{ govukDetails({
+              summaryText: 'What does this mean?',
+              text: 'This HQ is in control of all related company records for ' + company.name + '.',
+              classes: 'govuk-details--inline'
+            }) }}
+          {% endif %}
         </div>
       </div>
     {% endif %}

--- a/test/functional/cypress/specs/companies/company-global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/company-global-ultimate-spec.js
@@ -12,6 +12,12 @@ describe('Company Global Ultimate HQ', () => {
       cy.get(selectors.localHeader().badge(1)).should('be.visible')
     })
 
+    it('should display an "What does this mean?" details', () => {
+      cy.get(selectors.localHeader().metaList)
+        .should('contain', 'What does this mean?')
+        .should('contain', 'This HQ is in control of all related company records for DnB Global Ultimate')
+    })
+
     it('should display a single subsidiary', () => {
       const expected = 'Data Hub contains 1 other company record related to this company'
       cy.get(selectors.localHeader().description.paragraph(1)).should('have.text', expected)

--- a/test/selectors/local-header.js
+++ b/test/selectors/local-header.js
@@ -1,6 +1,7 @@
 module.exports = () => {
   const localHeaderSelector = '[data-auto-id="localHeader"]'
   return {
+    metaList: `${localHeaderSelector} .c-meta-list`,
     heading: `${localHeaderSelector} h1.c-local-header__heading`,
     headingAfter: `${localHeaderSelector} p.c-local-header__heading-after`,
     badge: (number) => `${localHeaderSelector} span.c-badge:nth-child(${number})`,


### PR DESCRIPTION
## Description of change

Add explanation of the new `Ultimate HQ` label to the company local header.

## Test instructions

1. Go to the company page for Global Ultimate
2. Check if the details element is displayed next to the `Ultimate HQ` label.
 
## Screenshots
### Before

![image](https://user-images.githubusercontent.com/4199239/70789249-9292ad80-1d8a-11ea-89ac-6f54f33d8d2b.png)


### After 

![image](https://user-images.githubusercontent.com/4199239/70789228-86a6eb80-1d8a-11ea-8aac-10787e60b186.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
