### PR TITLE
Feature/new countries fields on interaction detail

### DIFF
--- a/src/apps/companies/controllers/__test__/exports.test.js
+++ b/src/apps/companies/controllers/__test__/exports.test.js
@@ -356,6 +356,11 @@ describe('Company export controller', () => {
           expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
         })
 
+        it('should redirect to exports routes', () => {
+          expect(this.middlewareParameters.resMock.redirect).to.have.been.calledWith(urls.companies.exports.index(companyMock.id))
+          expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
+        })
+
         it('next should not have been called', () => {
           expect(this.middlewareParameters.nextSpy).not.to.have.been.called
         })

--- a/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
+++ b/src/apps/companies/transformers/__test__/company-to-export-details-view.test.js
@@ -1,37 +1,12 @@
 const proxyquire = require('proxyquire')
 const faker = require('faker')
 
-const { EXPORT_INTEREST_STATUS } = require('../../../constants')
-
 const minimalCompany = require('../../../../../test/unit/data/companies/minimal-company.json')
 
 const transformerPath = '../company-to-export-details-view'
 const EXPORT_POTENTIAL_LABEL = 'Export potential'
 
-function generateCountries (length) {
-  return Array.from({ length }).map(() => [faker.random.uuid(), faker.address.country()])
-}
-
-function createExportCountry (status) {
-  return ([id, name]) => ({ country: { id, name }, status })
-}
-
-function generateExportCountries () {
-  const future = generateCountries(2)
-  const current = generateCountries(2)
-  const noInterest = generateCountries(2)
-
-  return {
-    future,
-    current,
-    noInterest,
-    exportCountries: [
-      ...future.map(createExportCountry(EXPORT_INTEREST_STATUS.FUTURE_INTEREST)),
-      ...current.map(createExportCountry(EXPORT_INTEREST_STATUS.EXPORTING_TO)),
-      ...noInterest.map(createExportCountry(EXPORT_INTEREST_STATUS.NOT_INTERESTED)),
-    ],
-  }
-}
+const { generateExportCountries } = require('../../../../../test/unit/helpers/generate-export-countries')
 
 describe('transformCompanyToExportDetailsView', () => {
   let transformCompanyToExportDetailsView

--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -5,13 +5,15 @@ const {
 
 const { transformInteractionResponseToViewRecord } = require('../transformers')
 const { INTERACTION_STATUS } = require('../constants')
+const { NEW_COUNTRIES_FEATURE } = require('../../constants')
 
 function renderDetailsPage (req, res, next) {
   try {
-    const { interaction } = res.locals
+    const { interaction, features } = res.locals
     const breadcrumb = capitalize(lowerCase(interaction.kind))
     const isComplete = interaction.status === INTERACTION_STATUS.COMPLETE
-    const interactionViewRecord = transformInteractionResponseToViewRecord(interaction, isComplete)
+    const useNewCountries = features[ NEW_COUNTRIES_FEATURE ]
+    const interactionViewRecord = transformInteractionResponseToViewRecord(interaction, isComplete, useNewCountries)
     const canComplete = interaction.status === INTERACTION_STATUS.DRAFT &&
       new Date(interaction.date) < new Date() &&
       !interaction.archived

--- a/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
@@ -6,6 +6,7 @@ const mockInteraction = require('../../../../../test/unit/data/interactions/inte
 const mockInteractionWithPolicyFeedback = require('../../../../../test/unit/data/interactions/interaction-with-feedback.json')
 
 const { generateExportCountries } = require('../../../../../test/unit/helpers/generate-export-countries')
+const urls = require('../../../../lib/urls')
 
 config.archivedDocumentsBaseUrl = 'http://base'
 
@@ -17,12 +18,12 @@ describe('#transformInteractionResponsetoViewRecord', () => {
   context('when the interaction-add-countries feature flag is true', () => {
     const transformedMockInteraction = {
       Company: {
-        url: '/companies/0f5216e0-849f-11e6-ae22-56b6b6499611',
+        url: urls.companies.detail('0f5216e0-849f-11e6-ae22-56b6b6499611'),
         name: 'Venus Ltd',
       },
       'Contact(s)': [
         {
-          url: '/contacts/7701587b-e88f-4f39-874f-0bd06321f7df',
+          url: urls.contacts.contact('7701587b-e88f-4f39-874f-0bd06321f7df'),
           name: 'Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5',
         },
       ],
@@ -47,7 +48,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
       },
       'Adviser(s)': ['Bob Lawson, The test team'],
       'Investment project': {
-        url: '/investments/projects/bac18331-ca4d-4501-960e-a1bd68b5d47e',
+        url: urls.investments.projects.project('bac18331-ca4d-4501-960e-a1bd68b5d47e'),
         name: 'Test project',
       },
       'Communication channel': {

--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -5,7 +5,7 @@ const config = require('../../../config')
 const labels = require('../labels')
 const { getDataLabels } = require('../../../lib/controller-utils')
 
-const transformEntityLink = (entity, entityPath, noLinkText = null) => {
+function transformEntityLink (entity, entityPath, noLinkText = null) {
   return entity
     ? {
       url: `/${entityPath}/${entity.id}`,
@@ -14,7 +14,7 @@ const transformEntityLink = (entity, entityPath, noLinkText = null) => {
     : noLinkText
 }
 
-const transformDocumentsLink = archived_documents_url_path => {
+function transformDocumentsLink (archived_documents_url_path) {
   if (archived_documents_url_path) {
     return {
       url: config.archivedDocumentsBaseUrl + archived_documents_url_path,
@@ -25,6 +25,54 @@ const transformDocumentsLink = archived_documents_url_path => {
   }
 
   return { name: 'There are no files or documents' }
+}
+
+function formatParticipantName (participant) {
+  return get(participant, 'team')
+    ? `${participant.adviser.name}, ${participant.team.name}`
+    : participant.adviser.name
+}
+
+const excludedServiceStrings = [
+  'A Specific DIT Export Service or Funding',
+  'A Specific Service',
+  'Enquiry or Referral Received',
+  'Enquiry Received',
+]
+
+function getServiceValues (service) {
+  if (!service) return
+
+  const splitServiceName = service.name.split(' : ')
+  const serviceName =
+    splitServiceName[1] &&
+    excludedServiceStrings.includes(splitServiceName[0])
+      ? splitServiceName[1]
+      : service.name
+
+  return {
+    ...service,
+    name: serviceName,
+  }
+}
+
+function getName (obj) {
+  return obj.name
+}
+
+function getNames (arr = []) {
+  return arr.map(getName).join(', ')
+}
+
+function getCurrency (item) {
+  if (item) {
+    return {
+      type: 'currency',
+      name: item,
+    }
+  }
+
+  return null
 }
 
 function transformInteractionResponseToViewRecord (
@@ -51,67 +99,17 @@ function transformInteractionResponseToViewRecord (
 ) {
   const defaultEventText = kind === 'service_delivery' ? 'No' : null
   const kindLabels = labels[camelCase(kind)]
-  const formattedPolicyAreas = (policy_areas || [])
-    .map(policy_area => policy_area.name)
-    .join(', ')
-  const formattedPolicyTypes = (policy_issue_types || [])
-    .map(policy_type => policy_type.name)
-    .join(', ')
-
-  const formatParticipantName = participant =>
-    get(participant, 'team')
-      ? `${participant.adviser.name}, ${participant.team.name}`
-      : participant.adviser.name
-
-  const formattedParticipants = (dit_participants || []).map(participant =>
-    formatParticipantName(participant)
-  )
-
-  const getServiceValues = () => {
-    if (!service) return
-    const excludedServiceStrings = [
-      'A Specific DIT Export Service or Funding',
-      'A Specific Service',
-      'Enquiry or Referral Received',
-      'Enquiry Received',
-    ]
-
-    const splitServiceName = service.name.split(' : ')
-    const serviceName =
-      splitServiceName[1] &&
-      excludedServiceStrings.includes(splitServiceName[0])
-        ? splitServiceName[1]
-        : service.name
-
-    return {
-      ...service,
-      name: serviceName,
-    }
-  }
 
   const viewRecord = {
     company: transformEntityLink(company, 'companies'),
     contacts: contacts.map(contact => transformEntityLink(contact, 'contacts')),
-    service: getServiceValues(),
+    service: getServiceValues(service),
     service_delivery_status,
-    grant_amount_offered: grant_amount_offered
-      ? {
-        type: 'currency',
-        name: grant_amount_offered,
-      }
-      : null,
-    net_company_receipt: net_company_receipt
-      ? {
-        type: 'currency',
-        name: net_company_receipt,
-      }
-      : null,
+    grant_amount_offered: getCurrency(grant_amount_offered),
+    net_company_receipt: getCurrency(net_company_receipt),
     notes: notes,
-    date: {
-      type: 'date',
-      name: date,
-    },
-    dit_participants: formattedParticipants,
+    date: { type: 'date', name: date },
+    dit_participants: (dit_participants || []).map(formatParticipantName),
     investment_project: transformEntityLink(
       investment_project,
       'investments/projects'
@@ -121,8 +119,8 @@ function transformInteractionResponseToViewRecord (
     documents: canShowDocuments
       ? transformDocumentsLink(archived_documents_url_path)
       : null,
-    policy_issue_types: formattedPolicyTypes,
-    policy_areas: formattedPolicyAreas,
+    policy_issue_types: getNames(policy_issue_types),
+    policy_areas: getNames(policy_areas),
     policy_feedback_notes: policy_feedback_notes,
   }
 

--- a/src/lib/__test__/group-export-countries.test.js
+++ b/src/lib/__test__/group-export-countries.test.js
@@ -1,31 +1,6 @@
-const faker = require('faker')
-
 const { EXPORT_INTEREST_STATUS } = require('../../apps/constants')
 
-function generateCountries (length) {
-  return Array.from({ length }).map(() => [faker.random.uuid(), faker.address.country()])
-}
-
-function createExportCountry (status) {
-  return ([id, name]) => ({ country: { id, name }, status })
-}
-
-function generateExportCountries () {
-  const future = generateCountries(2)
-  const current = generateCountries(2)
-  const noInterest = generateCountries(2)
-
-  return {
-    future,
-    current,
-    noInterest,
-    exportCountries: [
-      ...future.map(createExportCountry(EXPORT_INTEREST_STATUS.FUTURE_INTEREST)),
-      ...current.map(createExportCountry(EXPORT_INTEREST_STATUS.EXPORTING_TO)),
-      ...noInterest.map(createExportCountry(EXPORT_INTEREST_STATUS.NOT_INTERESTED)),
-    ],
-  }
-}
+const { generateExportCountries, generateCountries, createExportCountry } = require('../../../test/unit/helpers/generate-export-countries')
 
 function convertToObjects (countries) {
   return countries.map(([id, name]) => ({ id, name }))

--- a/test/unit/helpers/generate-export-countries.js
+++ b/test/unit/helpers/generate-export-countries.js
@@ -1,0 +1,34 @@
+const faker = require('faker')
+
+const { EXPORT_INTEREST_STATUS } = require('../../../src/apps/constants')
+
+function generateCountries (length) {
+  return Array.from({ length }).map(() => [faker.random.uuid(), faker.address.country()])
+}
+
+function createExportCountry (status) {
+  return ([id, name]) => ({ country: { id, name }, status })
+}
+
+function generateExportCountries () {
+  const future = generateCountries(2)
+  const current = generateCountries(2)
+  const noInterest = generateCountries(2)
+
+  return {
+    future,
+    current,
+    noInterest,
+    exportCountries: [
+      ...future.map(createExportCountry(EXPORT_INTEREST_STATUS.FUTURE_INTEREST)),
+      ...current.map(createExportCountry(EXPORT_INTEREST_STATUS.EXPORTING_TO)),
+      ...noInterest.map(createExportCountry(EXPORT_INTEREST_STATUS.NOT_INTERESTED)),
+    ],
+  }
+}
+
+module.exports = {
+  generateCountries,
+  createExportCountry,
+  generateExportCountries,
+}


### PR DESCRIPTION
## Description of change

View the export tab for a company, add the feature flag interaction-add-countries and it should change to show the new fields. A migration will be happening on the backend PR but until that happens the fields will display None

Third and final PR for this feature
 
## Screenshots
### Before

https://user-images.githubusercontent.com/1481883/70545635-ce006280-1b65-11ea-821f-fa7a0d505494.png

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
