### PR TITLE
Add explanation why the D&B hierarchy might have fewer records

### DIFF
--- a/src/apps/companies/apps/dnb-hierarchy/__test__/controllers.test.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/controllers.test.js
@@ -12,6 +12,7 @@ const companyMock = {
   id: '1',
   name: 'Test company',
   global_ultimate_duns_number: '999999',
+  isGlobalHQ: false,
 }
 
 describe('D&B Company hierarchy', () => {
@@ -40,6 +41,7 @@ describe('D&B Company hierarchy', () => {
           'companies/apps/dnb-hierarchy/views/client-container', {
             heading: 'Company records related to Test company',
             props: {
+              isGlobalHQ: false,
               dataEndpoint: urls.companies.dnbHierarchy.data('1'),
             },
           })

--- a/src/apps/companies/apps/dnb-hierarchy/client/DnbHierarchy.jsx
+++ b/src/apps/companies/apps/dnb-hierarchy/client/DnbHierarchy.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import { useSearchParam } from 'react-use'
 import { CollectionList } from 'data-hub-components'
 import axios from 'axios'
-import { LoadingBox } from 'govuk-react'
+import { Details, LoadingBox } from 'govuk-react'
 
-const DnbHierarchy = ({ dataEndpoint }) => {
+const DnbHierarchy = ({ dataEndpoint, isGlobalHQ }) => {
   const [companies, setCompanies] = useState([])
   const [totalItems, setTotalItems] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
@@ -41,6 +41,15 @@ const DnbHierarchy = ({ dataEndpoint }) => {
     <>
       <p>This hierarchy information from Dun & Bradstreet cannot be edited.</p>
 
+      {isGlobalHQ &&
+        <Details summary="Why aren't all manually linked subsidiaries listed here?">
+          This does not mean that Dun & Bradstreet does not know about those subsidiaries.<br />
+          The Dun & Bradstreet hierarchy information can only show the company records in Data Hub that have been matched
+          to a verified Dun & Bradstreet record. This matching process is ongoing and more related company records will appear
+          in the future.
+        </Details>
+      }
+
       <LoadingBox loading={isLoading}>
         <CollectionList
           itemName="related company record"
@@ -57,6 +66,7 @@ const DnbHierarchy = ({ dataEndpoint }) => {
 
 DnbHierarchy.propTypes = {
   dataEndpoint: PropTypes.string.isRequired,
+  isGlobalHQ: PropTypes.bool.isRequired,
 }
 
 export default DnbHierarchy

--- a/src/apps/companies/apps/dnb-hierarchy/controllers.js
+++ b/src/apps/companies/apps/dnb-hierarchy/controllers.js
@@ -24,6 +24,7 @@ async function renderDnbHierarchy (req, res, next) {
         heading: `Company records related to ${company.name}`,
         props: {
           dataEndpoint: urls.companies.dnbHierarchy.data(company.id),
+          isGlobalHQ: company.isGlobalHQ,
         },
       })
   } catch (error) {

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-spec.js
@@ -35,6 +35,11 @@ describe('D&B Company hierarchy', () => {
         .and('contain', 'DnB Global Ultimate')
         .and('contain', 'DnB Global Ultimate subsidiary')
     })
+
+    it('should now show explanation why the D&B hierarchy might have fewer records than manual one', () => {
+      cy.contains("Why aren't all manually linked subsidiaries listed here?")
+        .should('not.be.visible')
+    })
   })
 
   context('when viewing hierarchy for a D&B Global Ultimate which is also Global HQ', () => {
@@ -68,6 +73,17 @@ describe('D&B Company hierarchy', () => {
         'Dun & Bradstreet hierarchy',
         'Manually linked subsidiaries',
       ])
+    })
+
+    it('should show explanation why the D&B hierarchy might have fewer records than manual one', () => {
+      cy.get('details:contains("Why aren\'t all manually linked subsidiaries listed here?")')
+        .should('have.text', '' +
+        'Why aren\'t all manually linked subsidiaries listed here?This does not' +
+        ' mean that Dun & Bradstreet does not know about those subsidiaries.The' +
+        ' Dun & Bradstreet hierarchy information can only show the company records' +
+        ' in Data Hub that have been matched to a verified Dun & Bradstreet record.' +
+        ' This matching process is ongoing and more related company records will' +
+        ' appear in the future.')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Add explanation why the D&B hierarchy might have fewer records than manually created one.

https://trello.com/c/oR8Gwj8y/563-explain-fewer-db-records

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/4199239/70912561-1909f200-200c-11ea-8d66-6ccb0532cd4c.png)


### After 

![image](https://user-images.githubusercontent.com/4199239/70912534-08597c00-200c-11ea-91ca-984d34f6537f.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
