### PR TITLE
Update e2e tests to use urls from helper

### DIFF
--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -134,7 +134,7 @@ module.exports = {
     type: url('/search', '/:searchPath?'),
   },
   interactions: {
-    index: '/interactions',
+    index: url('/interactions'),
     subapp: createInteractionsSubApp(),
   },
   investments: {

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -116,13 +116,23 @@ module.exports = {
   contacts: {
     index: url('/contacts'),
     contact: url('/contacts', '/:contactId'),
+    create: url('/contacts/create?company=', ':companyId'),
     interactions: createInteractionsSubApp('/contacts', '/:contactId'),
+    contactInteractions: url('/contacts', '/:contactId/interactions'),
+    edit: url('/contacts', '/:contactId/edit'),
+    audit: url('/contacts', '/:contactId/audit'),
+  },
+  events: {
+    index: url('/events'),
+    create: url('/events/create'),
+    details: url('/events', '/:eventId/details'),
   },
   search: {
     index: url('/search'),
     type: url('/search', '/:searchPath?'),
   },
   interactions: {
+    index: '/interactions',
     subapp: createInteractionsSubApp(),
   },
   investments: {

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -115,12 +115,14 @@ module.exports = {
   },
   contacts: {
     index: url('/contacts'),
+    audit: url('/contacts', '/:contactId/audit'),
     contact: url('/contacts', '/:contactId'),
     create: url('/contacts/create?company=', ':companyId'),
-    interactions: createInteractionsSubApp('/contacts', '/:contactId'),
     contactInteractions: url('/contacts', '/:contactId/interactions'),
+    details: url('/contacts', '/:contactId/details'),
+    documents: url('/contacts', '/:contactId/documents'),
     edit: url('/contacts', '/:contactId/edit'),
-    audit: url('/contacts', '/:contactId/audit'),
+    interactions: createInteractionsSubApp('/contacts', '/:contactId'),
   },
   events: {
     index: url('/events'),
@@ -139,6 +141,7 @@ module.exports = {
     index: url('/investments'),
     projects: {
       index: url('/investments', '/projects'),
+      details: url('/investments', '/projects/:projectId/details'),
       documents: url('/investments', '/projects/:projectId/documents'),
       propositions: url('/investments', '/projects/:projectId/propositions'),
       team: url('/investments', '/projects/:projectId/team'),
@@ -152,6 +155,9 @@ module.exports = {
       data: url('/investments', '/profiles/data'),
     },
   },
-  omis: url('/omis/create?company=', ':companyId'),
+  omis: {
+    index: url('/omis'),
+    create: url('/omis/create?company=', ':companyId'),
+  },
   support: url('/support'),
 }

--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -1,4 +1,7 @@
 const selectors = require('../../../../selectors')
+
+const { companies, contacts, investments } = require('../../../../../src/lib/urls')
+
 const { assertCollection } = require('../../support/assertions')
 
 const checkCollection = () => {
@@ -8,7 +11,7 @@ const checkCollection = () => {
 describe('Collection', () => {
   describe('company', () => {
     before(() => {
-      cy.visit('/companies')
+      cy.visit(companies.index())
     })
 
     it('should return the results summary for a company collection', () => {
@@ -18,7 +21,7 @@ describe('Collection', () => {
 
   describe('contact', () => {
     before(() => {
-      cy.visit('/contacts')
+      cy.visit(contacts.index())
     })
 
     it('should return the results summary for a contact collection', () => {
@@ -29,7 +32,7 @@ describe('Collection', () => {
   context('investment', () => {
     describe('projects', () => {
       before(() => {
-        cy.visit('/investments/projects')
+        cy.visit(investments.projects.index())
       })
 
       it('should return the results summary for a investment collection', () => {
@@ -39,7 +42,7 @@ describe('Collection', () => {
 
     describe('interaction', () => {
       before(() => {
-        cy.visit('/investments/projects/e32b3c33-80ac-4589-a8c4-dda305d726ba/interactions')
+        cy.visit(investments.projects.interactionCollection('e32b3c33-80ac-4589-a8c4-dda305d726ba'))
       })
 
       it('should return the results summary for a interaction collection', () => {
@@ -49,7 +52,7 @@ describe('Collection', () => {
 
     describe('proposition', () => {
       before(() => {
-        cy.visit('/investments/projects/e32b3c33-80ac-4589-a8c4-dda305d726ba/propositions')
+        cy.visit(investments.projects.propositions('e32b3c33-80ac-4589-a8c4-dda305d726ba'))
       })
 
       it('should return the results summary for a proposition collection', () => {
@@ -59,7 +62,7 @@ describe('Collection', () => {
 
     describe('team', () => {
       before(() => {
-        cy.visit('/investments/projects/e32b3c33-80ac-4589-a8c4-dda305d726ba/team')
+        cy.visit(investments.projects.team('e32b3c33-80ac-4589-a8c4-dda305d726ba'))
       })
 
       it('should return the investment project team summary', () => {

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -1,10 +1,13 @@
 const selectors = require('../../../../selectors')
+
+const { companies, contacts, dashboard, investments } = require('../../../../../src/lib/urls')
+
 const { assertLocalNav } = require('../../support/assertions')
 
 describe('DA Permission', () => {
   describe('activity', () => {
     before(() => {
-      cy.visit('/companies/375094ac-f79a-43e5-9c88-059a7caa17f0')
+      cy.visit(companies.detail('375094ac-f79a-43e5-9c88-059a7caa17f0'))
     })
 
     it('should display DA only tabs', () => {
@@ -20,7 +23,7 @@ describe('DA Permission', () => {
 
   describe('dashboard', () => {
     before(() => {
-      cy.visit('')
+      cy.visit(dashboard())
     })
 
     it('should display DA only tabs', () => {
@@ -37,7 +40,7 @@ describe('DA Permission', () => {
 
   describe('contact details', () => {
     before(() => {
-      cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/details')
+      cy.visit(contacts.details('9b1138ab-ec7b-497f-b8c3-27fed21694ef'))
     })
 
     it('should display DA only tabs', () => {
@@ -50,7 +53,7 @@ describe('DA Permission', () => {
 
   describe('investment projects', () => {
     before(() => {
-      cy.visit('/investments/projects/e32b3c33-80ac-4589-a8c4-dda305d726ba/details')
+      cy.visit(investments.projects.details('e32b3c33-80ac-4589-a8c4-dda305d726ba'))
     })
 
     it('should display DA only tabs', () => {

--- a/test/end-to-end/cypress/specs/DA/permission-spec.js
+++ b/test/end-to-end/cypress/specs/DA/permission-spec.js
@@ -1,9 +1,11 @@
+const { contacts, events, interactions, search, investments } = require('../../../../../src/lib/urls')
+
 const { assertError } = require('../../support/assertions')
 
 describe('DA Permission', () => {
   describe('event', () => {
     before(() => {
-      cy.visit('/events', { failOnStatusCode: false })
+      cy.visit(events.index(), { failOnStatusCode: false })
     })
 
     it('should prevent DA users from accessing the page', () => {
@@ -14,7 +16,7 @@ describe('DA Permission', () => {
 
   describe('interaction', () => {
     before(() => {
-      cy.visit('/interactions', { failOnStatusCode: false })
+      cy.visit(interactions.index(), { failOnStatusCode: false })
     })
 
     it('should prevent DA users from accessing the page', () => {
@@ -26,7 +28,7 @@ describe('DA Permission', () => {
   context('search', () => {
     describe('interaction', () => {
       before(() => {
-        cy.visit('/search/interactions', { failOnStatusCode: false })
+        cy.visit(search.type('interactions'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing the page', () => {
@@ -37,7 +39,7 @@ describe('DA Permission', () => {
 
     describe('event', () => {
       before(() => {
-        cy.visit('/search/events', { failOnStatusCode: false })
+        cy.visit(search.type('events'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing the page', () => {
@@ -50,7 +52,7 @@ describe('DA Permission', () => {
   context('investment', () => {
     describe('investment document', () => {
       before(() => {
-        cy.visit('/investments/projects/e32b3c33-80ac-4589-a8c4-dda305d726ba/documents', { failOnStatusCode: false })
+        cy.visit(investments.projects.documents('e32b3c33-80ac-4589-a8c4-dda305d726ba'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing the page', () => {
@@ -61,7 +63,7 @@ describe('DA Permission', () => {
 
     describe('interaction', () => {
       before(() => {
-        cy.visit('/investments/projects/ba1f0b14-5fe4-4c36-bf6a-ddf115272977/interactions', { failOnStatusCode: false })
+        cy.visit(investments.projects.interactionCollection('ba1f0b14-5fe4-4c36-bf6a-ddf115272977'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing an interaction they don\'t have access to', () => {
@@ -72,7 +74,7 @@ describe('DA Permission', () => {
 
     describe('proposition', () => {
       before(() => {
-        cy.visit('/investments/projects/ba1f0b14-5fe4-4c36-bf6a-ddf115272977/propositions', { failOnStatusCode: false })
+        cy.visit(investments.projects.propositions('ba1f0b14-5fe4-4c36-bf6a-ddf115272977'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing an interaction they don\'t have access to', () => {
@@ -83,7 +85,7 @@ describe('DA Permission', () => {
 
     describe('team', () => {
       before(() => {
-        cy.visit('/investments/projects/b30dee70-b2d6-48cf-9ce4-b9264854470c/team', { failOnStatusCode: false })
+        cy.visit(investments.projects.team('b30dee70-b2d6-48cf-9ce4-b9264854470c'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing a team they don\'t have access to', () => {
@@ -96,7 +98,7 @@ describe('DA Permission', () => {
   context('contacts', () => {
     describe('documents', () => {
       before(() => {
-        cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/documents', { failOnStatusCode: false })
+        cy.visit(contacts.documents('9b1138ab-ec7b-497f-b8c3-27fed21694ef'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing the page', () => {
@@ -107,7 +109,7 @@ describe('DA Permission', () => {
 
     describe('interactions', () => {
       before(() => {
-        cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/interactions', { failOnStatusCode: false })
+        cy.visit(contacts.contactInteractions('9b1138ab-ec7b-497f-b8c3-27fed21694ef'), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing the page', () => {

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -1,5 +1,7 @@
 const selectors = require('../../../../selectors')
 
+const { companies, contacts } = require('../../../../../src/lib/urls')
+
 const todaysDate = Cypress.moment().format('D MMM YYYY')
 
 describe('Company', () => {
@@ -11,7 +13,7 @@ describe('Company', () => {
     cy.get(selectors.companyAudit.save).click()
     cy.get(selectors.message.successful).should('be.visible')
 
-    cy.visit('/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/audit')
+    cy.visit(companies.edit('0f5216e0-849f-11e6-ae22-56b6b6499611'))
 
     cy.get(selectors.collection.items)
       .should('contain', 'DIT Staff')
@@ -22,14 +24,14 @@ describe('Company', () => {
 
 describe('Contact', () => {
   before(() => {
-    cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/edit')
+    cy.visit(contacts.edit('9b1138ab-ec7b-497f-b8c3-27fed21694ef'))
   })
 
   it('should display name of the person who made contact record changes', () => {
     cy.get(selectors.contactCreate.save).click()
     cy.get(selectors.message.successful).should('be.visible')
 
-    cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/audit')
+    cy.visit(contacts.audit('9b1138ab-ec7b-497f-b8c3-27fed21694ef'))
 
     cy.get(selectors.collection.items)
       .should('contain', 'DIT Staff')

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -6,14 +6,14 @@ const todaysDate = Cypress.moment().format('D MMM YYYY')
 
 describe('Company', () => {
   before(() => {
-    cy.visit('/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/edit')
+    cy.visit(companies.edit('0f5216e0-849f-11e6-ae22-56b6b6499611'))
   })
 
   it('should display name of the person who made company record changes', () => {
     cy.get(selectors.companyAudit.save).click()
     cy.get(selectors.message.successful).should('be.visible')
 
-    cy.visit(companies.edit('0f5216e0-849f-11e6-ae22-56b6b6499611'))
+    cy.visit(companies.audit('0f5216e0-849f-11e6-ae22-56b6b6499611'))
 
     cy.get(selectors.collection.items)
       .should('contain', 'DIT Staff')

--- a/test/end-to-end/cypress/specs/DIT/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/collection-spec.js
@@ -1,7 +1,7 @@
 const selectors = require('../../../../selectors')
 const { assertCollection } = require('../../support/assertions')
 
-const { investments } = require('../../../../../src/lib/urls')
+const { companies, contacts, investments } = require('../../../../../src/lib/urls')
 
 const checkCollection = () => {
   assertCollection(selectors.collection.headerCount, selectors.collection.items)
@@ -10,7 +10,7 @@ const checkCollection = () => {
 describe('Collection', () => {
   describe('contact', () => {
     before(() => {
-      cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/orders')
+      cy.visit(companies.orders('0fb3379c-341c-4da4-b825-bf8d47b26baa'))
     })
 
     it('should return the results summary for orders collection', () => {
@@ -20,7 +20,7 @@ describe('Collection', () => {
 
   describe('contact interaction', () => {
     before(() => {
-      cy.visit('/contacts/952232d2-1d25-4c3a-bcac-2f3a30a94da9/interactions')
+      cy.visit(contacts.contactInteractions('952232d2-1d25-4c3a-bcac-2f3a30a94da9'))
     })
 
     it('should return the results summary for contact interaction collection', () => {

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -1,6 +1,8 @@
 const selectors = require('../../../../selectors')
 const userActions = require('../../support/user-actions')
 
+const { companies, contacts } = require('../../../../../src/lib/urls')
+
 const { assertKeyValueTable } = require('../../support/assertions')
 
 describe('Advisors', () => {
@@ -8,7 +10,7 @@ describe('Advisors', () => {
   const adviserTable = 3
 
   it('should display advisers for a GHQ for a given company', () => {
-    cy.visit('/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/advisers')
+    cy.visit(companies.advisers.index('375094ac-f79a-43e5-9c88-059a7caa17f0'))
 
     cy.get(selectors.collection.contentHeader)
       .should('contain', 'Advisers on the core team')
@@ -39,7 +41,7 @@ describe('Contacts', () => {
   }
 
   it('should create a contact for a given company', () => {
-    cy.visit('/contacts/create?company=0fb3379c-341c-4da4-b825-bf8d47b26baa')
+    cy.visit(contacts.create('0fb3379c-341c-4da4-b825-bf8d47b26baa'))
     userActions.contacts.create(data)
 
     cy.get(selectors.message.successful).should('contain', 'Added new contact')
@@ -54,7 +56,7 @@ describe('Contacts', () => {
   })
 
   it('should display the newly created contact in company contact collection page', () => {
-    cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/activity')
+    cy.visit(companies.activity.index('0fb3379c-341c-4da4-b825-bf8d47b26baa'))
 
     cy.contains('Company contacts').click()
     cy.get(selectors.collection.items)
@@ -67,7 +69,7 @@ describe('Contacts', () => {
 
 describe('Export', () => {
   it('should update export values when edit is made', () => {
-    cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/exports/edit')
+    cy.visit(companies.exports.edit('0fb3379c-341c-4da4-b825-bf8d47b26baa'))
 
     cy.get(selectors.companyExport.winCategory).select('Export growth')
     cy.get(selectors.companyForm.save).click()
@@ -81,7 +83,7 @@ describe('Export', () => {
   })
 
   it('should update export values when edit is made', () => {
-    cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/exports/edit')
+    cy.visit(companies.exports.edit('0fb3379c-341c-4da4-b825-bf8d47b26baa'))
 
     cy.get(selectors.companyExport.winCategory).select('Export growth')
     cy.get(selectors.companyForm.save).click()

--- a/test/end-to-end/cypress/specs/DIT/company-subsidiary-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/company-subsidiary-spec.js
@@ -1,8 +1,10 @@
 const selectors = require('../../../../selectors')
 
+const { companies } = require('../../../../../src/lib/urls')
+
 describe('Company Subsidiary', () => {
   beforeEach(() => {
-    cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/business-details')
+    cy.visit(companies.businessDetails('0fb3379c-341c-4da4-b825-bf8d47b26baa'))
   })
 
   it('should update business hierarchy type to Global HQ', () => {
@@ -43,7 +45,7 @@ describe('Company Subsidiary', () => {
 
 describe('Archived Company Subsidiary', () => {
   beforeEach(() => {
-    cy.visit('/companies/346f78a5-1d23-4213-b4c2-bf48246a13c3/business-details')
+    cy.visit(companies.businessDetails('346f78a5-1d23-4213-b4c2-bf48246a13c3'))
   })
 
   it('should hide subsidiaries links for archived companies', () => {
@@ -57,7 +59,7 @@ describe('Archived Company Subsidiary', () => {
 
 describe('DnB Company Subsidiary', () => {
   beforeEach(() => {
-    cy.visit('/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/business-details')
+    cy.visit(companies.businessDetails('375094ac-f79a-43e5-9c88-059a7caa17f0'))
   })
 
   it('should display subsidiaries links for dnb companies', () => {

--- a/test/end-to-end/cypress/specs/DIT/contacts-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/contacts-spec.js
@@ -1,6 +1,8 @@
 const selectors = require('../../../../selectors')
 const userActions = require('../../support/user-actions')
 
+const { contacts } = require('../../../../../src/lib/urls')
+
 describe('Contacts', () => {
   const data = {
     name: 'NewAddress',
@@ -16,7 +18,7 @@ describe('Contacts', () => {
   }
 
   it('should create a primary contact with a different address to the companies address', () => {
-    cy.visit('/contacts/create?company=0fb3379c-341c-4da4-b825-bf8d47b26baa')
+    cy.visit(contacts.create('0fb3379c-341c-4da4-b825-bf8d47b26baa'))
     userActions.contacts.createWithNewAddress(data)
 
     cy.get(selectors.contactCreate.details)

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -1,5 +1,7 @@
 const selectors = require('../../../../selectors')
 
+const { events } = require('../../../../../src/lib/urls')
+
 const { assertKeyValueTable } = require('../../support/assertions')
 
 const today = Cypress.moment()
@@ -38,7 +40,7 @@ const createEvent = () => {
 describe('Event', () => {
   describe('create', () => {
     beforeEach(() => {
-      cy.visit('/events/create')
+      cy.visit(events.create())
     })
 
     it('should throw validation messages for required fields', () => {
@@ -62,7 +64,7 @@ describe('Event', () => {
     it('should create an attendee on a event', () => {
       createEvent()
 
-      cy.visit('/events')
+      cy.visit(events.index())
       cy.contains('Eventful event').click()
       cy.contains('Attendees').click()
       cy.get(selectors.entityCollection.addAttendee).click()
@@ -78,7 +80,7 @@ describe('Event', () => {
 
   describe('edit', () => {
     before(() => {
-      cy.visit('/events')
+      cy.visit(events.index())
     })
 
     it('should display newly created event in collection page', () => {

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -1,6 +1,6 @@
 const selectors = require('../../../../selectors')
 
-const { companies } = require('../../../../../src/lib/urls')
+const { companies, interactions } = require('../../../../../src/lib/urls')
 
 const today = Cypress.moment().format('D MMMM YYYY')
 
@@ -24,7 +24,7 @@ describe('Interaction', () => {
     cy.get(selectors.interactionForm.add).click()
     cy.get(selectors.message.successful).should('contain', 'Interaction created')
 
-    cy.visit('/interactions')
+    cy.visit(interactions.index())
     cy.get(selectors.filter.interaction.myInteractions).click()
 
     cy.get(selectors.collection.items)
@@ -57,7 +57,7 @@ describe('Service delivery', () => {
     cy.get(selectors.interactionForm.add).click()
     cy.get(selectors.message.successful).should('contain', 'Service delivery created')
 
-    cy.visit('/interactions')
+    cy.visit(interactions.index())
     cy.get(selectors.filter.interaction.myInteractions).click()
 
     cy.get(selectors.collection.items)

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -1,12 +1,12 @@
 const selectors = require('../../../../selectors')
 const { assertLocalNav } = require('../../support/assertions')
 
-const { investments } = require('../../../../../src/lib/urls')
+const { companies, contacts, dashboard, events, investments } = require('../../../../../src/lib/urls')
 
 describe('DIT Permission', () => {
   describe('dashboard', () => {
     before(() => {
-      cy.visit('')
+      cy.visit(dashboard())
     })
 
     it('should display DIT only header nav links', () => {
@@ -25,7 +25,7 @@ describe('DIT Permission', () => {
 
   describe('activity', () => {
     before(() => {
-      cy.visit('/companies/375094ac-f79a-43e5-9c88-059a7caa17f0')
+      cy.visit(companies.detail('375094ac-f79a-43e5-9c88-059a7caa17f0'))
     })
 
     it('should display DIT only tabs', () => {
@@ -42,7 +42,7 @@ describe('DIT Permission', () => {
 
   describe('contact', () => {
     before(() => {
-      cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef')
+      cy.visit(contacts.contact('9b1138ab-ec7b-497f-b8c3-27fed21694ef'))
     })
 
     it('should display DIT only side navs', () => {
@@ -75,7 +75,7 @@ describe('DIT Permission', () => {
 
   describe('event', () => {
     before(() => {
-      cy.visit('/events/b93d4274-36fe-4008-ac40-fbc197910791/details')
+      cy.visit(events.details('b93d4274-36fe-4008-ac40-fbc197910791'))
     })
 
     it('should display DIT only side navs', () => {

--- a/test/end-to-end/cypress/specs/DIT/order-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/order-spec.js
@@ -6,7 +6,7 @@ const today = Cypress.moment().format('D MMM YYYY')
 
 describe('Order', () => {
   beforeEach(() => {
-    cy.visit(omis('0f5216e0-849f-11e6-ae22-56b6b6499611'))
+    cy.visit(omis.create('0f5216e0-849f-11e6-ae22-56b6b6499611'))
   })
 
   it('should create an order', () => {

--- a/test/end-to-end/cypress/specs/DIT/search-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/search-spec.js
@@ -1,8 +1,10 @@
 const selectors = require('../../../../selectors')
 
+const { dashboard } = require('../../../../../src/lib/urls')
+
 describe('Search', () => {
   before(() => {
-    cy.visit('')
+    cy.visit(dashboard())
 
     cy.get(selectors.nav.searchTerm)
       .type('fred')

--- a/test/end-to-end/cypress/specs/LEP/collection-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/collection-spec.js
@@ -1,4 +1,7 @@
 const selectors = require('../../../../selectors')
+
+const { companies, contacts, investments } = require('../../../../../src/lib/urls')
+
 const { assertCollection } = require('../../support/assertions')
 
 const checkCollection = () => {
@@ -8,7 +11,7 @@ const checkCollection = () => {
 describe('Collection', () => {
   describe('company', () => {
     before(() => {
-      cy.visit('/companies')
+      cy.visit(companies.index())
     })
 
     it('should return the results summary for a company collection', () => {
@@ -18,7 +21,7 @@ describe('Collection', () => {
 
   describe('contact', () => {
     before(() => {
-      cy.visit('/contacts')
+      cy.visit(contacts.index())
     })
 
     it('should return the results summary for a contact collection', () => {
@@ -29,7 +32,7 @@ describe('Collection', () => {
   context('investment', () => {
     describe('projects', () => {
       before(() => {
-        cy.visit('/investments/projects')
+        cy.visit(investments.projects.index())
       })
 
       it('should return the results summary for a investment collection', () => {
@@ -39,7 +42,7 @@ describe('Collection', () => {
 
     describe('interaction', () => {
       before(() => {
-        cy.visit('/investments/projects/ba1f0b14-5fe4-4c36-bf6a-ddf115272977/interactions')
+        cy.visit(investments.projects.interactionCollection('ba1f0b14-5fe4-4c36-bf6a-ddf115272977'))
       })
 
       it('should return the results summary for a interaction collection', () => {
@@ -49,7 +52,7 @@ describe('Collection', () => {
 
     describe('proposition', () => {
       before(() => {
-        cy.visit('/investments/projects/ba1f0b14-5fe4-4c36-bf6a-ddf115272977/propositions')
+        cy.visit(investments.projects.interactionCollection('ba1f0b14-5fe4-4c36-bf6a-ddf115272977'))
       })
 
       it('should return the results summary for a proposition collection', () => {
@@ -59,7 +62,7 @@ describe('Collection', () => {
 
     describe('team', () => {
       before(() => {
-        cy.visit('/investments/projects/ba1f0b14-5fe4-4c36-bf6a-ddf115272977/team')
+        cy.visit(investments.projects.team('ba1f0b14-5fe4-4c36-bf6a-ddf115272977'))
       })
 
       it('should return the investment project team summary', () => {

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -7,7 +7,7 @@ const { assertLocalNav } = require('../../support/assertions')
 describe('LEP Permission', () => {
   describe('activity', () => {
     before(() => {
-      cy.visit(companies.details('375094ac-f79a-43e5-9c88-059a7caa17f0'))
+      cy.visit(companies.detail('375094ac-f79a-43e5-9c88-059a7caa17f0'))
     })
 
     it('should display LEP only tabs', () => {

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -1,10 +1,13 @@
 const selectors = require('../../../../selectors')
+
+const { companies, contacts, dashboard, investments } = require('../../../../../src/lib/urls')
+
 const { assertLocalNav } = require('../../support/assertions')
 
 describe('LEP Permission', () => {
   describe('activity', () => {
     before(() => {
-      cy.visit('/companies/375094ac-f79a-43e5-9c88-059a7caa17f0')
+      cy.visit(companies.details('375094ac-f79a-43e5-9c88-059a7caa17f0'))
     })
 
     it('should display LEP only tabs', () => {
@@ -19,7 +22,7 @@ describe('LEP Permission', () => {
 
   describe('dashboard', () => {
     before(() => {
-      cy.visit('')
+      cy.visit(dashboard())
     })
 
     it('should display LEP only tabs', () => {
@@ -33,7 +36,7 @@ describe('LEP Permission', () => {
 
   describe('contact details', () => {
     before(() => {
-      cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/details')
+      cy.visit(contacts.details('9b1138ab-ec7b-497f-b8c3-27fed21694ef'))
     })
 
     it('should display LEP only tabs', () => {
@@ -46,7 +49,7 @@ describe('LEP Permission', () => {
 
   describe('investment projects', () => {
     before(() => {
-      cy.visit('/investments/projects/ba1f0b14-5fe4-4c36-bf6a-ddf115272977/details')
+      cy.visit(investments.projects.details('ba1f0b14-5fe4-4c36-bf6a-ddf115272977'))
     })
 
     it('should display LEP only tabs', () => {

--- a/test/end-to-end/cypress/specs/LEP/permission-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/permission-spec.js
@@ -1,9 +1,11 @@
+const { companies, contacts, events, interactions, omis, search, investments } = require('../../../../../src/lib/urls')
+
 const { assertError } = require('../../support/assertions')
 
 describe('LEP Permission', () => {
   describe('orders', () => {
     before(() => {
-      cy.visit('/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/orders', { failOnStatusCode: false })
+      cy.visit(companies.orders('0fb3379c-341c-4da4-b825-bf8d47b26baa'), { failOnStatusCode: false })
     })
 
     it('should prevent LEP users from accessing the page', () => {
@@ -14,7 +16,7 @@ describe('LEP Permission', () => {
 
   describe('event', () => {
     before(() => {
-      cy.visit('/events', { failOnStatusCode: false })
+      cy.visit(events.index(), { failOnStatusCode: false })
     })
 
     it('should prevent LEP users from accessing the page', () => {
@@ -25,7 +27,7 @@ describe('LEP Permission', () => {
 
   describe('interaction', () => {
     before(() => {
-      cy.visit('/interactions', { failOnStatusCode: false })
+      cy.visit(interactions.index(), { failOnStatusCode: false })
     })
 
     it('should prevent LEP users from accessing the page', () => {
@@ -36,7 +38,7 @@ describe('LEP Permission', () => {
 
   describe('omis', () => {
     before(() => {
-      cy.visit('/omis', { failOnStatusCode: false })
+      cy.visit(omis.index(), { failOnStatusCode: false })
     })
 
     it('should prevent LEP users from accessing the page', () => {
@@ -48,7 +50,7 @@ describe('LEP Permission', () => {
   context('search', () => {
     describe('interaction', () => {
       before(() => {
-        cy.visit('/search/interactions', { failOnStatusCode: false })
+        cy.visit(search.type('interactions'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing the page', () => {
@@ -59,7 +61,7 @@ describe('LEP Permission', () => {
 
     describe('event', () => {
       before(() => {
-        cy.visit('/search/events', { failOnStatusCode: false })
+        cy.visit(search.type('events'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing the page', () => {
@@ -70,7 +72,7 @@ describe('LEP Permission', () => {
 
     describe('omis', () => {
       before(() => {
-        cy.visit('/search/omis', { failOnStatusCode: false })
+        cy.visit(search.type('omis'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing the page', () => {
@@ -83,7 +85,7 @@ describe('LEP Permission', () => {
   context('investment', () => {
     describe('investment document', () => {
       before(() => {
-        cy.visit('/investments/projects/ba1f0b14-5fe4-4c36-bf6a-ddf115272977/documents', { failOnStatusCode: false })
+        cy.visit(investments.projects.documents('ba1f0b14-5fe4-4c36-bf6a-ddf115272977'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing the page', () => {
@@ -94,7 +96,7 @@ describe('LEP Permission', () => {
 
     describe('interaction', () => {
       before(() => {
-        cy.visit('/investments/projects/e32b3c33-80ac-4589-a8c4-dda305d726ba/interactions', { failOnStatusCode: false })
+        cy.visit(investments.projects.interactionCollection('e32b3c33-80ac-4589-a8c4-dda305d726ba'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing an interaction they don\'t have access to', () => {
@@ -105,7 +107,7 @@ describe('LEP Permission', () => {
 
     describe('team', () => {
       before(() => {
-        cy.visit('/investments/projects/b30dee70-b2d6-48cf-9ce4-b9264854470c/team', { failOnStatusCode: false })
+        cy.visit(investments.projects.team('b30dee70-b2d6-48cf-9ce4-b9264854470c'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing a team they don\'t have access to', () => {
@@ -118,7 +120,7 @@ describe('LEP Permission', () => {
   context('contacts', () => {
     describe('documents', () => {
       before(() => {
-        cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/documents', { failOnStatusCode: false })
+        cy.visit(contacts.documents('9b1138ab-ec7b-497f-b8c3-27fed21694ef'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing the page', () => {
@@ -129,7 +131,7 @@ describe('LEP Permission', () => {
 
     describe('interactions', () => {
       before(() => {
-        cy.visit('/contacts/9b1138ab-ec7b-497f-b8c3-27fed21694ef/interactions', { failOnStatusCode: false })
+        cy.visit(contacts.contactInteractions('9b1138ab-ec7b-497f-b8c3-27fed21694ef'), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing the page', () => {


### PR DESCRIPTION
## Description of change

Ensure we use URL helper to navigate throughout our e2e tests

## Test instructions

yarn test:e2e:dit
yarn test:e2e:da
yarn test:e2e:lep
 
- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
