### PR TITLE
Show non field errors

### DIFF
--- a/src/apps/builders.js
+++ b/src/apps/builders.js
@@ -1,5 +1,4 @@
 const {
-  assign,
   at,
   castArray,
   get,
@@ -56,12 +55,11 @@ function assignPropsIfFoundInObject(children, sourceObject = {}, propName) {
         return option
       })
     }
-    return assign(
-      {},
-      child,
-      { error: null }, // ensure error is reset if another property is set (e.g. value)
-      { [propName]: sourceObject[child.name] }
-    )
+    return {
+      ...child,
+      error: null, // ensure error is reset if another property is set (e.g. value)
+      [propName]: sourceObject[child.name],
+    }
   })
 }
 
@@ -88,7 +86,7 @@ function buildFormWithErrors(form = {}, errorMessages = {}) {
 
   const children = assignPropsIfFoundInObject(form.children, messages, 'error')
 
-  return assign({}, form, {
+  return Object.assign(form, {
     children,
     errors,
   })
@@ -105,7 +103,7 @@ function buildFormWithState(form = {}, requestBody = {}) {
     'value'
   )
 
-  return assign({}, form, {
+  return Object.assign(form, {
     children,
   })
 }
@@ -180,7 +178,7 @@ async function buildFieldsWithSelectedEntities(token, fields = [], query = {}) {
 
   for (let childIndex = 0; childIndex < fieldsArray.length; childIndex += 1) {
     const child = fieldsArray[childIndex]
-    const newChild = assign({}, child)
+    const newChild = { ...child }
 
     if (child.entity && has(query, child.name)) {
       const id = castArray(get(query, child.name))

--- a/src/apps/interactions/controllers/edit.js
+++ b/src/apps/interactions/controllers/edit.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-const { get, lowerCase, snakeCase, kebabCase } = require('lodash')
+const { get, set, lowerCase, snakeCase, kebabCase } = require('lodash')
 
 const { transformInteractionResponseToForm } = require('../transformers')
 const { transformDateStringToDateObject } = require('../../transformers')
@@ -52,8 +52,7 @@ async function buildForm(req, res, params) {
     featureFlags: res.locals.features,
   }
 
-  const form = formConfigs[kind](formProperties)
-  return form
+  return formConfigs[kind](formProperties)
 }
 
 function setDefaultContact(interaction, contact) {
@@ -139,12 +138,17 @@ async function renderEditPage(req, res, next) {
       kind: validatedKind,
     })
     const errors = get(res.locals, 'form.errors.messages')
+    const nonFieldErrors = get(res.locals, 'form.errors.nonField')
 
     const interactionForm = buildFormWithStateAndErrors(
       form,
       mergedInteractionData,
       errors
     )
+
+    if (nonFieldErrors) {
+      set(interactionForm, 'errors.nonField', nonFieldErrors)
+    }
 
     const forEntityName = res.locals.entityName
       ? ` for ${res.locals.entityName}`

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -47,6 +47,12 @@ async function postDetails(req, res, next) {
       return next(err)
     }
 
+    const nonFieldErrors = get(err.error, 'non_field_errors')
+
+    if (nonFieldErrors) {
+      set(res.locals, 'form.errors.nonField', nonFieldErrors)
+    }
+
     set(res.locals, 'form.errors.messages', mapErrors(err.error))
     next()
   }

--- a/src/templates/_macros/form/error-summary.njk
+++ b/src/templates/_macros/form/error-summary.njk
@@ -3,11 +3,19 @@
  # @param {object} errors - A form error object
  # @param {string} errors.summary - A helpful summary
  # @param {object} errors.messages - A dictionary of errors with field name as key and message as value
+ # @param {object} errors.nonField - An array of non field errros to display
  #}
 {% macro ErrorSummary(errors) %}
-  {% if errors.messages | length or errors.summary %}
+  {% if errors.messages | length or errors.summary or errors.nonField %}
     <div class="c-error-summary js-ErrorSummary" role="alert">
       <h1 class="c-error-summary__heading heading-medium">There was a problem submitting this form</h1>
+      {% if errors.nonField %}
+        <ul class="c-error-summary__non-field">
+          {% for str in errors.nonField %}
+            <li class="c-error-summary__non-field__message">{{ str }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
       {% if errors.summary %}
         <p class="c-error-summary__summary">{{ errors.summary }}</p>
       {% endif %}

--- a/test/functional/cypress/specs/interaction/add-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/add-interaction-spec.js
@@ -30,6 +30,11 @@ describe('Add Export', () => {
 
             cy.get(selectors.interactionForm.add).click()
 
+            cy.get(formSelectors.form).contains(
+              'The export_countries field may not be null.'
+            )
+            cy.get(formSelectors.form).contains('A non field error message')
+
             cy.get(
               `${formSelectors.countries.future} .multiselect__tag`
             ).should('contain', 'Albania')

--- a/test/sandbox/fixtures/v3/interaction/interaction-validation-error.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-validation-error.json
@@ -1,5 +1,8 @@
 {
   "export_countries": [
-      "This field may not be null."
+      "The export_countries field may not be null."
+  ],
+  "non_field_errors": [
+    "A non field error message"
   ]
 }

--- a/test/selectors/interaction-form.js
+++ b/test/selectors/interaction-form.js
@@ -2,6 +2,7 @@ const typeaheadId = '#group-field-dit_participants'
 const { EXPORT_INTEREST_STATUS } = require('../../src/apps/constants')
 
 module.exports = {
+  form: 'form',
   subject: '#field-subject',
   notes: '#field-notes',
   dateOfInteractionYear: '#field-date_year',


### PR DESCRIPTION
## Description of change

Add ability to show non field errors and do so when adding an interaction. Due to the new feature of adding countries discussed with an interaction there is a validation case where a non field error can be returned, this passes that error to the controller which then gets passed to the error-summary component/macro

## Test instructions

**Using the API branch** `feature/interaction_journey_add_countries_validation`

Add an interaction and answer "Were countries discussed" as "Yes", then put the same country in each field and it will return a `non_field_error` in the API which will get displayed in the UI
 
## Screenshots
### Before

No error shown

### After 

<img width="778" alt="Screenshot 2020-01-08 at 07 21 25" src="https://user-images.githubusercontent.com/1481883/71958353-ff616200-31e7-11ea-97a3-e3171f0cb1e6.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
