### PR TITLE
Replace markets with countries

### DIFF
--- a/src/apps/companies/views/exports-edit.njk
+++ b/src/apps/companies/views/exports-edit.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/template.njk" %}
 
 {% block local_header %}
-  {% call LocalHeader({ heading: 'Edit export markets' }) %}{% endcall %}
+  {% call LocalHeader({ heading: 'Edit export countries' }) %}{% endcall %}
 {% endblock %}
 
 {% block body_main_content %}
@@ -46,14 +46,14 @@
       <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
         <label class="c-form-group__label">
           <span class="c-form-group__label-text">
-            Select a market this company currently exports to (optional)
+            Select a country this company currently exports to (optional)
           </span>
         </label>
 
         {% for country in exportCountries %}
           {{ MultipleChoiceField({
             name: 'export_to_countries',
-            label: 'Select a market this company currently exports to',
+            label: 'Select a country this company currently exports to',
             value: country,
             options: countryOptions,
             initialOption: '-- Select country --',
@@ -70,14 +70,14 @@
       <div class="c-form-group js-AddItems" data-item-selector=".c-form-group--AddItems">
         <label class="c-form-group__label">
           <span class="c-form-group__label-text">
-            Future markets of interest (optional)
+            Future countries of interest (optional)
           </span>
         </label>
 
         {% for country in futureCountries %}
           {{ MultipleChoiceField({
             name: 'future_interest_countries',
-            label: 'Future markets of interest',
+            label: 'Future countries of interest',
             value: country,
             options: countryOptions,
             initialOption: '-- Select country --',

--- a/src/apps/companies/views/exports-view.njk
+++ b/src/apps/companies/views/exports-view.njk
@@ -30,7 +30,7 @@
 
     {% if not company.archived %}
       <p class="actions">
-        <a href="{{ urls.companies.exports.edit(company.id) }}" class="govuk-button govuk-button--secondary">Edit export markets</a>
+        <a href="{{ urls.companies.exports.edit(company.id) }}" class="govuk-button govuk-button--secondary">Edit export countries</a>
       </p>
     {% endif %}
   {% endcall %}

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -150,7 +150,7 @@ describe('Company Collections Filter', () => {
     })
   })
 
-  it('should filter by future markets of interest', () => {
+  it('should filter by future countries of interest', () => {
     const interestedIn = selectors.filter.interestedIn
     const { typeahead } = selectors.filter
 


### PR DESCRIPTION
## Description of change

To use consistent language across the journey replace markets with countries

## Test instructions

View export tab and edit export countries with and without the `interaction-add-countries` feature flag
 
## Screenshots
### Before

<img width="427" alt="Screenshot 2020-01-08 at 07 40 49" src="https://user-images.githubusercontent.com/1481883/71959479-c1197200-31ea-11ea-9311-047592e545f6.png">

With `interaction-add-countries` feature flag
<img width="789" alt="Screenshot 2020-01-08 at 07 41 04" src="https://user-images.githubusercontent.com/1481883/71959491-c7a7e980-31ea-11ea-969a-f19a4b6e92a5.png">

Without feature flag
<img width="779" alt="Screenshot 2020-01-08 at 07 42 44" src="https://user-images.githubusercontent.com/1481883/71959540-e0180400-31ea-11ea-87b5-75c2b6f9022e.png">


### After 

<img width="439" alt="Screenshot 2020-01-08 at 07 40 32" src="https://user-images.githubusercontent.com/1481883/71959552-e73f1200-31ea-11ea-821d-f17fb18e7ea1.png">

With `interaction-add-countries` feature flag
<img width="779" alt="Screenshot 2020-01-08 at 07 41 17" src="https://user-images.githubusercontent.com/1481883/71959567-f0c87a00-31ea-11ea-8f9c-76636d9aed85.png">

Without feature flag
<img width="784" alt="Screenshot 2020-01-08 at 07 42 26" src="https://user-images.githubusercontent.com/1481883/71959581-f8881e80-31ea-11ea-987f-04f7a359911b.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
