### PR TITLE
Fix a bug when Redux devtools leaked into production

### DIFF
--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -28,8 +28,8 @@ const store = createStore(
     companyLists: resolvePreloadedCompanyListsData(),
   },
   process.env.NODE_ENV === 'production'
-    ? require('redux-devtools-extension').devToolsEnhancer()
-    : undefined,
+    ? undefined
+    : require('redux-devtools-extension').devToolsEnhancer(),
 )
 
 const appWrapper = document.getElementById('react-app')


### PR DESCRIPTION
## Description of change

Inverted the condition when Redux devtools were included.

## Test instructions

Redux dev tools should:

* Say "No store detected" when `NODE_ENV === 'production'`
* Show the state and actions otherwise
 
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
