### PR TITLE
Fix CircleCI build following Python 3.8 update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,8 @@ aliases:
       DATA_HUB_FRONTEND_ACCESS_KEY_ID: frontend-key-id
       DATA_HUB_FRONTEND_SECRET_ACCESS_KEY: frontend-key
       ADMIN_OAUTH2_ENABLED: 'False'
+      # Workaround for Docker/CircleCI compatibility problem with Python 3.8
+      COLUMNS: 80
 
   - &docker_data_hub_backend_api
     <<: *docker_data_hub_backend_base


### PR DESCRIPTION
## Description of change

There was a change to how Python gets the terminal width which has problems under Docker in some circumstances.

This adds a workaround for this.

## Test instructions

The CircleCI build should pass.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
