### PR TITLE
Update target branch for Dependabot to use master (default)

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,7 +5,6 @@ update_configs:
   - package_manager: javascript
     directory: "/"
     update_schedule: live
-    target_branch: develop
     default_reviewers:
       - datahub-fed
     allowed_updates:
@@ -15,7 +14,6 @@ update_configs:
   - package_manager: javascript
     directory: "/"
     update_schedule: weekly
-    target_branch: develop
     version_requirement_updates: increase_versions
     default_reviewers:
       - datahub-fed


### PR DESCRIPTION
## Description of change

Update target branch for Dependabot so it's using the default Github branch (master).