### PR TITLE
Add "Find a company record" boilerplate

### DIFF
--- a/src/apps/companies/apps/match-company/__test__/controllers.test.js
+++ b/src/apps/companies/apps/match-company/__test__/controllers.test.js
@@ -1,0 +1,69 @@
+const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
+const companyMock = require('../../../../../../test/unit/data/companies/company-v4.json')
+const urls = require('../../../../../../src/lib/urls')
+
+const { renderFindCompanyForm } = require('../controllers')
+
+describe('Finding a company', () => {
+  context('when "renderFindCompanyForm" renders successfully', () => {
+    let middlewareParams
+    beforeEach(async () => {
+      middlewareParams = buildMiddlewareParameters({
+        company: companyMock,
+      })
+      await renderFindCompanyForm(
+        middlewareParams.reqMock,
+        middlewareParams.resMock,
+        middlewareParams.nextSpy
+      )
+    })
+
+    it('should render the find a company form template with fields', () => {
+      expect(middlewareParams.resMock.render).to.be.calledOnceWithExactly(
+        'companies/apps/match-company/views/find-company',
+        {
+          props: {},
+        }
+      )
+    })
+
+    it('should add 2 breadcrumbs', () => {
+      expect(middlewareParams.resMock.breadcrumb.args).to.deep.equal([
+        [
+          'Mercury Ltd',
+          urls.companies.detail('a73efeba-8499-11e6-ae22-56b6b6499611'),
+        ],
+        ['Find this company record'],
+      ])
+    })
+
+    it('should not call next() with an error', () => {
+      expect(middlewareParams.nextSpy).to.not.have.been.called
+    })
+  })
+
+  context('when "renderFindCompanyForm" errors', async () => {
+    let middlewareParams
+
+    before(async () => {
+      middlewareParams = buildMiddlewareParameters({
+        company: companyMock,
+      })
+      middlewareParams.resMock.render.throws()
+
+      await renderFindCompanyForm(
+        middlewareParams.reqMock,
+        middlewareParams.resMock,
+        middlewareParams.nextSpy
+      )
+    })
+
+    it('should not call render', () => {
+      expect(middlewareParams.resMock.render).to.be.thrown
+    })
+
+    it('should call next in the catch', () => {
+      expect(middlewareParams.nextSpy).to.be.calledOnce
+    })
+  })
+})

--- a/src/apps/companies/apps/match-company/__test__/router.test.js
+++ b/src/apps/companies/apps/match-company/__test__/router.test.js
@@ -1,0 +1,21 @@
+const router = require('../router')
+
+describe('Match company route', () => {
+  it('should define an "Match company" route', () => {
+    const paths = router.stack
+      .filter((r) => r.route)
+      .map((r) => {
+        return {
+          path: r.route.path,
+          methods: Object.keys(r.route.methods).map((method) => method),
+        }
+      })
+
+    expect(paths).to.deep.equal([
+      {
+        path: '/:companyId/match',
+        methods: ['get'],
+      },
+    ])
+  })
+})

--- a/src/apps/companies/apps/match-company/client/FindCompany.jsx
+++ b/src/apps/companies/apps/match-company/client/FindCompany.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { H3 } from '@govuk-react/heading'
+
+function FindCompany() {
+  return <H3>Hidden from the user</H3>
+}
+
+export default FindCompany

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -1,0 +1,20 @@
+const { companies } = require('../../../../lib/urls')
+
+async function renderFindCompanyForm(req, res, next) {
+  try {
+    const { company } = res.locals
+
+    res
+      .breadcrumb(company.name, companies.detail(company.id))
+      .breadcrumb('Find this company record')
+      .render('companies/apps/match-company/views/find-company', {
+        props: {},
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderFindCompanyForm,
+}

--- a/src/apps/companies/apps/match-company/router.js
+++ b/src/apps/companies/apps/match-company/router.js
@@ -1,0 +1,8 @@
+const router = require('express').Router()
+const urls = require('../../../../lib/urls')
+
+const { renderFindCompanyForm } = require('./controllers')
+
+router.get(urls.companies.match.index.route, renderFindCompanyForm)
+
+module.exports = router

--- a/src/apps/companies/apps/match-company/views/find-company.njk
+++ b/src/apps/companies/apps/match-company/views/find-company.njk
@@ -1,0 +1,9 @@
+{% extends "_layouts/template.njk" %}
+
+{% block body_main_content %}
+  {% component 'react-slot', {
+    id: 'find-company',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -75,6 +75,7 @@ const activityFeedRouter = require('./apps/activity-feed/router')
 const dnbHierarchyRouter = require('./apps/dnb-hierarchy/router')
 const businessDetailsRouter = require('./apps/business-details/router')
 const editHistoryRouter = require('./apps/edit-history/router')
+const matchCompanyRouter = require('./apps/match-company/router')
 
 const investmentsRouter = require('./apps/investments/router')
 const matchingRouter = require('./apps/matching/router')
@@ -185,5 +186,7 @@ router.use(activityFeedRouter)
 router.use(dnbHierarchyRouter)
 
 router.use(businessDetailsRouter)
+
+router.use(matchCompanyRouter)
 
 module.exports = router

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -7,6 +7,7 @@ import { ActivityFeedApp } from 'data-hub-components'
 import AddCompanyForm from '../apps/companies/apps/add-company/client/AddCompanyForm'
 import EditCompanyForm from '../apps/companies/apps/edit-company/client/EditCompanyForm'
 import EditHistory from '../apps/companies/apps/edit-history/client/EditHistory'
+import FindCompany from '../apps/companies/apps/match-company/client/FindCompany'
 import DeleteCompanyList from '../apps/company-lists/client/DeleteCompanyList'
 import CompanyLists from '../apps/dashboard/client/CompanyLists'
 import companyLists, {
@@ -64,6 +65,11 @@ function App() {
       <Mount selector="#edit-history">
         {(props) => (
           <EditHistory csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#find-company">
+        {(props) => (
+          <FindCompany csrfToken={globalProps.csrfToken} {...props} />
         )}
       </Mount>
       <Mount selector="#activity-feed-app">

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -133,6 +133,9 @@ module.exports = {
         '/:companyId/investments/large-capital-profile'
       ),
     },
+    match: {
+      index: url('/companies', '/:companyId/match'),
+    },
     subsidiaries: {
       index: url('/companies', '/:companyId/subsidiaries'),
       link: url('/companies', '/:companyId/subsidiaries/link'),

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -1,0 +1,27 @@
+const {
+  assertLocalHeader,
+  assertBreadcrumbs,
+} = require('../../support/assertions')
+const fixtures = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+
+describe('Match a company', () => {
+  context('when viewing "Find this company record" page', () => {
+    before(() => {
+      cy.visit(urls.companies.match.index(fixtures.company.venusLtd.id))
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Find this company record')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        'Venus Ltd': urls.companies.detail(fixtures.company.venusLtd.id),
+        'Find this company record': null,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
Boilerplate for matching a Data Hub company with a D&B company.

**/companies/id/match**

<img width="1233" alt="find-a-company" src="https://user-images.githubusercontent.com/964268/72167572-43f52500-33c3-11ea-9a37-94e4f32279ed.png">


## Checklist
[//]: # "When submitting a PR make sure the code review guidelines have been satisfied. 
https://github.com/uktrade/data-hub-frontend/blob/develop/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
