### PR TITLE
Revert company turnover back to GBP

### DIFF
--- a/src/apps/companies/apps/business-details/client/SectionAbout.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAbout.jsx
@@ -69,7 +69,7 @@ const SectionAbout = ({ businessDetails, isDnbCompany, isArchived, urls }) => (
     <SummaryTable.Row heading="Annual turnover">
       {businessDetails.turnover && (
         <>
-          {NumberUtils.currencyUSD(businessDetails.turnover)}
+          {NumberUtils.currencyGBP(businessDetails.turnover)}
 
           {businessDetails.is_turnover_estimated && (
             <TableDetails>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -113,7 +113,7 @@ const config = {
     email: process.env.ONE_LIST_EMAIL || 'one.list@example.com',
   },
   currencyRate: {
-    usdToGbp: 0.750148,
+    usdToGbp: 0.770032,
   },
   activityFeed: {
     paginationSize: 20,

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -399,7 +399,7 @@ describe('Companies business details', () => {
           content: {
             'Trading names': 'DnBD&B',
             'Annual turnover':
-              '$750,148This is an estimated numberWhat does that mean?Actual turnover is not available for this business. The number has been modelled by Dun & Bradstreet, based on similar businesses.',
+              '£770,032This is an estimated numberWhat does that mean?Actual turnover is not available for this business. The number has been modelled by Dun & Bradstreet, based on similar businesses.',
             'Number of employees':
               '95This is an estimated numberWhat does that mean?Actual number of employees is not available for this business. The number has been modelled by Dun & Bradstreet, based on similar businesses.',
             Website: 'Not set',


### PR DESCRIPTION
## Bug
Company turnover should be in GBP not USD

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
