### PR TITLE
Add find a matching D&B company record

### DIFF
--- a/src/apps/companies/apps/match-company/__test__/router.test.js
+++ b/src/apps/companies/apps/match-company/__test__/router.test.js
@@ -17,6 +17,10 @@ describe('Match company route', () => {
         methods: ['get'],
       },
       {
+        path: '/:companyId/match',
+        methods: ['post'],
+      },
+      {
         methods: ['get'],
         path: '/:companyId/match/:dunsNumber',
       },

--- a/src/apps/companies/apps/match-company/client/FindCompany.jsx
+++ b/src/apps/companies/apps/match-company/client/FindCompany.jsx
@@ -1,8 +1,32 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { H3 } from '@govuk-react/heading'
+import { companies } from '../../../../../lib/urls'
 
-function FindCompany() {
-  return <H3>Hidden from the user</H3>
+import { Form, FieldDnbCompany } from 'data-hub-components'
+
+function FindCompany({ csrfToken, company }) {
+  function onSubmit(values) {
+    console.log(values) // Intentional
+  }
+
+  return (
+    <Form onSubmit={onSubmit}>
+      <H3>Find the company record in the Dun & Bradstreet database</H3>
+      <FieldDnbCompany
+        apiEndpoint={`${companies.match.index(company.id)}?_csrf=${csrfToken}`}
+        queryParams={{ address_country: 'GB' }}
+        name="dnbCompany"
+      />
+    </Form>
+  )
+}
+
+FindCompany.propTypes = {
+  csrfToken: PropTypes.string.isRequired,
+  company: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }),
 }
 
 export default FindCompany

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -9,21 +9,6 @@ const { searchDnbCompanies } = require('../../../../modules/search/services')
 const ZENDESK_TICKET_TAG_MATCH_REQUEST = 'dnb_match_request'
 const ZENDESK_TICKET_TYPE_TASK = 'task'
 
-async function renderFindCompanyForm(req, res, next) {
-  try {
-    const { company } = res.locals
-
-    res
-      .breadcrumb(company.name, urls.companies.detail(company.id))
-      .breadcrumb('Find this company record')
-      .render('companies/apps/match-company/views/find-company', {
-        props: {},
-      })
-  } catch (error) {
-    next(error)
-  }
-}
-
 function parseCountry(country, countries) {
   return get(
     typeof country === 'string'
@@ -163,8 +148,39 @@ async function submitMatchRequest(req, res) {
   }
 }
 
+async function renderFindCompanyForm(req, res, next) {
+  try {
+    const { company } = res.locals
+
+    res
+      .breadcrumb(company.name, urls.companies.detail(company.id))
+      .breadcrumb('Find this company record')
+      .render('companies/apps/match-company/views/find-company', {
+        props: {
+          company: pick(company, ['id']),
+        },
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+async function findDnbCompany(req, res, next) {
+  try {
+    const results = await searchDnbCompanies({
+      token: req.session.token,
+      requestBody: req.body,
+    })
+
+    res.json(results)
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
-  renderFindCompanyForm,
   renderMatchConfirmation,
   submitMatchRequest,
+  renderFindCompanyForm,
+  findDnbCompany,
 }

--- a/src/apps/companies/apps/match-company/router.js
+++ b/src/apps/companies/apps/match-company/router.js
@@ -3,11 +3,13 @@ const router = require('express').Router()
 const urls = require('../../../../lib/urls')
 const {
   renderFindCompanyForm,
+  findDnbCompany,
   renderMatchConfirmation,
   submitMatchRequest,
 } = require('./controllers')
 
 router.get(urls.companies.match.index.route, renderFindCompanyForm)
+router.post(urls.companies.match.index.route, findDnbCompany)
 router.get(urls.companies.match.confirmation.route, renderMatchConfirmation)
 router.post(urls.companies.match.confirmation.route, submitMatchRequest)
 

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -1,11 +1,11 @@
+const fixtures = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+const { companyMatch, localHeader } = require('../../../../selectors')
 const {
   assertLocalHeader,
   assertBreadcrumbs,
   assertSummaryList,
 } = require('../../support/assertions')
-const fixtures = require('../../fixtures')
-const urls = require('../../../../../src/lib/urls')
-const selectors = require('../../../../selectors')
 
 const DUNS_NUMBER = '111222333'
 
@@ -27,7 +27,71 @@ describe('Match a company', () => {
         'Find this company record': null,
       })
     })
+
+    it('should render the sub header', () => {
+      cy.get(companyMatch.subHeader).should(
+        'have.text',
+        'Find the company record in the Dun & Bradstreet database'
+      )
+    })
+
+    it('should render a "Company name" label', () => {
+      cy.get(companyMatch.find.companyNameLabel).should(
+        'have.text',
+        'Company name'
+      )
+    })
+
+    it('should render a "Company postcode (optional)" label', () => {
+      cy.get(companyMatch.find.postcodeLabel).should(
+        'have.text',
+        'Company postcode (optional)'
+      )
+    })
+
+    it('should display a "Find company" button', () => {
+      cy.get(companyMatch.find.button).should('be.visible')
+    })
   })
+
+  context(
+    'when the "Find company" button is clicked without providing a company name',
+    () => {
+      before(() => {
+        cy.visit(urls.companies.match.index(fixtures.company.venusLtd.id))
+      })
+
+      it('should display error message', () => {
+        cy.get(companyMatch.find.button)
+          .click()
+          .get(companyMatch.form)
+          .contains('Enter company name')
+      })
+
+      it('should not display the search results', () => {
+        cy.get(companyMatch.find.results.someCompany).should('not.be.visible')
+        cy.get(companyMatch.find.results.someOtherCompany).should(
+          'not.be.visible'
+        )
+      })
+    }
+  )
+
+  context(
+    'when the "Find company" button is clicked providing a company name',
+    () => {
+      before(() => {
+        cy.visit(urls.companies.match.index(fixtures.company.venusLtd.id))
+        cy.get(companyMatch.find.companyNameInput).type('some company')
+        cy.get(companyMatch.find.button).click()
+      })
+
+      it('should display the company search results', () => {
+        cy.get(companyMatch.find.results.someCompany).should('be.visible')
+        cy.get(companyMatch.find.results.someOtherCompany).should('be.visible')
+      })
+    }
+  )
 
   context('when company matching is confirmed', () => {
     before(() => {
@@ -48,7 +112,7 @@ describe('Match a company', () => {
     })
 
     it('displays the "Company record update request sent" flash message', () => {
-      cy.get(selectors.localHeader().flash).should(
+      cy.get(localHeader().flash).should(
         'contain.text',
         'Company record update request sent'
       )

--- a/test/selectors/company/match-company.js
+++ b/test/selectors/company/match-company.js
@@ -1,0 +1,16 @@
+module.exports = {
+  form: 'form',
+  subHeader: 'form h3',
+  find: {
+    companyNameLabel: 'label[for="dnbCompanyName"]',
+    companyNameInput: 'input[name="dnbCompanyName"]',
+    companyNameError: '#field-dnbCompanyName > div > span',
+    postcodeLabel: 'label[for="dnbPostalCode"]',
+    postcodeField: 'input[name="dnbPostalCode"]',
+    button: 'form button:contains("Find company")',
+    results: {
+      someCompany: 'form ol li:nth-child(1)',
+      someOtherCompany: 'form ol li:nth-child(2)',
+    },
+  },
+}

--- a/test/selectors/index.js
+++ b/test/selectors/index.js
@@ -1,5 +1,6 @@
 exports.collection = require('./collection')
 exports.companyAdd = require('./company/add-company')
+exports.companyMatch = require('./company/match-company')
 exports.companyActivity = require('./company/activity')
 exports.companyAudit = require('./company/audit')
 exports.companyEditHistory = require('./company/edit-history')


### PR DESCRIPTION
## Find a matching D&B company record

Allow users to match a Data Hub record with a Dunn & Bradstreet record by performing a search. This PR only deals with the searching of companies. The next PR includes company selection from the list of results. 

## Test instructions
_/companies/id/match_
Define a search term and click **_Find company_**

## Screenshots
### Before
<img width="1233" alt="find-a-company" src="https://user-images.githubusercontent.com/964268/72167572-43f52500-33c3-11ea-9a37-94e4f32279ed.png">

### After -  still hidden from the user
![match-company-record](https://user-images.githubusercontent.com/964268/72434368-4ffe2f80-3793-11ea-91b2-2724d0094237.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
