### PR TITLE
Add company match confirmation page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ aliases:
     SESSION_SECRET: theStrongestAvenger
     DATA_HUB_BACKEND_ACCESS_KEY_ID: frontend-key-id
     DATA_HUB_BACKEND_SECRET_ACCESS_KEY: frontend-key
+    ZEN_TICKETS_URL: http://localhost:8001/zendesk/tickets
 
   # Data hub base docker container
   - &docker_data_hub_base

--- a/app.json
+++ b/app.json
@@ -14,7 +14,10 @@
     "OAUTH2_DEV_TOKEN": { "required": true },
     "OAUTH2_BYPASS_SSO": { "required": true },
     "POSTCODE_KEY": { "required": true },
-    "SESSION_SECRET": { "required": true }
+    "SESSION_SECRET": { "required": true },
+    "ZEN_TICKETS_URL": { "required": true },
+    "ZEN_EMAIL": { "required": true },
+    "ZEN_TOKEN": { "required": true }
   },
   "addons":["heroku-redis"]
 }

--- a/sample.env
+++ b/sample.env
@@ -11,7 +11,7 @@ REDIS_HOST=localhost
 
 # Not necessary but if using feedback you will need these
 ZEN_TOKEN=
-ZEN_DOMAIN=
+ZEN_TICKETS_URL="https://ORGANISATION-NAME.zendesk.com/api/v2/tickets.json"
 ZEN_EMAIL=
 ZEN_BROWSER=
 ZEN_IMPACT=

--- a/src/apps/companies/apps/match-company/__test__/router.test.js
+++ b/src/apps/companies/apps/match-company/__test__/router.test.js
@@ -16,6 +16,14 @@ describe('Match company route', () => {
         path: '/:companyId/match',
         methods: ['get'],
       },
+      {
+        methods: ['get'],
+        path: '/:companyId/match/:dunsNumber',
+      },
+      {
+        methods: ['post'],
+        path: '/:companyId/match/:dunsNumber',
+      },
     ])
   })
 })

--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import axios from 'axios'
+import { H4 } from '@govuk-react/heading'
+import UnorderedList from '@govuk-react/unordered-list'
+import Button from '@govuk-react/button'
+import Link from '@govuk-react/link'
+import ListItem from '@govuk-react/list-item'
+import InsetText from '@govuk-react/inset-text'
+import { SPACING } from '@govuk-react/constants'
+import ErrorSummary from '@govuk-react/error-summary'
+
+import { Form, FormActions, SummaryList } from 'data-hub-components'
+
+const StyledRoot = styled('div')`
+  h2:not(:first-child) {
+    margin-top: ${SPACING.SCALE_6};
+  }
+`
+
+// TODO: Reset all styles to defaults for HTML within react-slot.
+const StyledList = styled(UnorderedList)`
+  list-style-type: initial;
+  margin-bottom: ${SPACING.SCALE_6};
+`
+
+async function onMatchSubmit({ dnbCompany, urls, csrfToken }) {
+  await axios.post(`${urls.matchConfirmation}?_csrf=${csrfToken}`, {
+    dnbCompany,
+  })
+  return urls.companyDetail
+}
+
+function MatchConfirmation({ company, dnbCompany, urls, csrfToken }) {
+  return (
+    <StyledRoot>
+      <Form onSubmit={() => onMatchSubmit({ dnbCompany, urls, csrfToken })}>
+        {({ submissionError }) => (
+          <>
+            {submissionError && (
+              <ErrorSummary
+                heading="There was an error matching this company"
+                description={submissionError.message}
+                errors={[]}
+              />
+            )}
+
+            <H4 as="h2">
+              Confirm you want to update this Data Hub company record
+            </H4>
+            <InsetText>
+              <SummaryList
+                rows={[
+                  { label: 'Registered company name', value: company.name },
+                  { label: 'Trading name(s)', value: company.trading_names },
+                  {
+                    label: 'Located at',
+                    value: company.address.join(', '),
+                  },
+                  {
+                    label: 'Registered address',
+                    value: company.registered_address.join(', '),
+                  },
+                ]}
+              />
+            </InsetText>
+
+            <H4 as="h2">
+              With the information from this Dun &amp; Bradstreet company record
+            </H4>
+            <InsetText>
+              <SummaryList
+                rows={[
+                  {
+                    label: 'Registered company name',
+                    value: dnbCompany.primary_name,
+                  },
+                  {
+                    label: 'Trading name(s)',
+                    value: dnbCompany.trading_names,
+                  },
+                  {
+                    label: 'Located at',
+                    value: dnbCompany.address.join(', '),
+                  },
+                  {
+                    label: 'Registered address',
+                    value: dnbCompany.registered_address.join(', '),
+                  },
+                ]}
+              />
+            </InsetText>
+
+            <H4 as="h2">What happens next</H4>
+            <StyledList>
+              <ListItem>
+                This will send a request to the Support Team to update the
+                business details for this company record, including any future
+                changes to this information.
+              </ListItem>
+              <ListItem>
+                This will NOT change any recorded activity (Interactions, OMIS
+                orders or Investments projects) for this company record.
+              </ListItem>
+            </StyledList>
+            <FormActions>
+              <Button>Send update request</Button>
+              <Link href={urls.match}>Back</Link>
+            </FormActions>
+          </>
+        )}
+      </Form>
+    </StyledRoot>
+  )
+}
+
+MatchConfirmation.props = {
+  company: PropTypes.shape({
+    name: PropTypes.string,
+    trading_names: PropTypes.string,
+    address: PropTypes.arrayOf(PropTypes.string),
+    registered_address: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+  dnbCompany: PropTypes.shape({
+    primary_name: PropTypes.string,
+    trading_names: PropTypes.string,
+    duns_number: PropTypes.string,
+    address: PropTypes.arrayOf(PropTypes.string),
+    registered_address: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+  urls: PropTypes.shape({
+    companyDetail: PropTypes.string,
+    match: PropTypes.string,
+    matchConfirmation: PropTypes.string,
+  }).isRequired,
+  csrfToken: PropTypes.string.isRequired,
+}
+
+export default MatchConfirmation

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -1,11 +1,20 @@
-const { companies } = require('../../../../lib/urls')
+const { get, isEmpty, pick } = require('lodash')
+const url = require('url')
+
+const urls = require('../../../../lib/urls')
+const { postToZenDesk } = require('../../../support/services')
+const { getOptions } = require('../../../../lib/options')
+const { searchDnbCompanies } = require('../../../../modules/search/services')
+
+const ZENDESK_TICKET_TAG_MATCH_REQUEST = 'dnb_match_request'
+const ZENDESK_TICKET_TYPE_TASK = 'task'
 
 async function renderFindCompanyForm(req, res, next) {
   try {
     const { company } = res.locals
 
     res
-      .breadcrumb(company.name, companies.detail(company.id))
+      .breadcrumb(company.name, urls.companies.detail(company.id))
       .breadcrumb('Find this company record')
       .render('companies/apps/match-company/views/find-company', {
         props: {},
@@ -15,6 +24,147 @@ async function renderFindCompanyForm(req, res, next) {
   }
 }
 
+function parseCountry(country, countries) {
+  return get(
+    typeof country === 'string'
+      ? countries.find((c) => c.iso_alpha2_code === country)
+      : country,
+    'name'
+  )
+}
+
+function parseAddress(dnbCompany, countries, prefix = '') {
+  return Object.values(
+    pick(
+      {
+        ...dnbCompany,
+        [`${prefix}country`]: parseCountry(
+          get(dnbCompany, `${prefix}country`),
+          countries
+        ),
+      },
+      [
+        `${prefix}line_1`,
+        `${prefix}line_2`,
+        `${prefix}town`,
+        `${prefix}postcode`,
+        `${prefix}country`,
+      ]
+    )
+  ).filter((v) => !isEmpty(v))
+}
+
+async function renderMatchConfirmation(req, res, next) {
+  try {
+    const { company } = res.locals
+    const { token } = req.session
+    const { dunsNumber } = req.params
+
+    const countries = await getOptions(token, 'country', {
+      transformer: ({ name, iso_alpha2_code }) => ({ name, iso_alpha2_code }),
+    })
+
+    const results = await searchDnbCompanies({
+      token,
+      requestBody: {
+        duns_number: dunsNumber,
+      },
+    })
+
+    const dnbCompany = get(results, 'results[0].dnb_company')
+
+    res
+      .breadcrumb(company.name, urls.companies.detail(company.id))
+      .breadcrumb('Confirm update')
+      .render('companies/apps/match-company/views/match-confirmation', {
+        props: {
+          urls: {
+            companyDetail: urls.companies.detail(company.id),
+            match: urls.companies.match.index(company.id),
+            matchConfirmation: urls.companies.match.confirmation(
+              company.id,
+              dunsNumber
+            ),
+          },
+          company: {
+            ...pick(company, ['name', 'trading_names']),
+            address: parseAddress(company.address, countries),
+            registered_address: parseAddress(
+              company.registered_address,
+              countries
+            ),
+          },
+          dnbCompany: {
+            ...pick(dnbCompany, [
+              'primary_name',
+              'trading_names',
+              'duns_number',
+            ]),
+            address: parseAddress(dnbCompany, countries, 'address_'),
+            registered_address: parseAddress(
+              dnbCompany,
+              countries,
+              'registered_address_'
+            ),
+          },
+        },
+      })
+  } catch (error) {
+    next(error)
+  }
+}
+
+function createMatchRequestMessage(req, res) {
+  const { company, user } = res.locals
+  const { dnbCompany } = req.body
+  const companyUrl = url.format({
+    protocol: req.protocol,
+    host: req.get('host'),
+    pathname: urls.companies.detail(company.id),
+  })
+
+  const messageBody =
+    `User ${user.name} requested a match of ${company.name}` +
+    `(${companyUrl}) with the following D&B company:\n` +
+    `Registered company name: ${dnbCompany.primary_name}\n` +
+    `Trading name(s): ${
+      !isEmpty(company.trading_names) ? company.trading_names.join(', ') : 'N/A'
+    }\n` +
+    `Located at: ${dnbCompany.address.join(', ')}\n` +
+    `Registered address: ${dnbCompany.registered_address.join(', ')}\n` +
+    `DUNS number: ${dnbCompany.duns_number}`
+
+  // See Zendesk API docs: https://developer.zendesk.com/rest_api/docs/support/tickets
+  return {
+    type: ZENDESK_TICKET_TYPE_TASK,
+    requester: {
+      name: `Data Hub user - ${user.name}`,
+      email: user.email,
+    },
+    subject: `D&B company match request for ${company.name}`,
+    comment: {
+      body: messageBody,
+    },
+    tags: [ZENDESK_TICKET_TAG_MATCH_REQUEST],
+  }
+}
+
+async function submitMatchRequest(req, res) {
+  try {
+    const ticket = createMatchRequestMessage(req, res)
+    const result = await postToZenDesk(ticket)
+
+    req.flash('success', 'Company record update request sent')
+    res.json({ message: 'OK', ticket: get(result, 'data.ticket.id') })
+  } catch (error) {
+    const statusCode = get(error, 'response.status', 500)
+    const message = get(error, 'response.data.description')
+    res.status(statusCode).json({ message })
+  }
+}
+
 module.exports = {
   renderFindCompanyForm,
+  renderMatchConfirmation,
+  submitMatchRequest,
 }

--- a/src/apps/companies/apps/match-company/router.js
+++ b/src/apps/companies/apps/match-company/router.js
@@ -1,8 +1,14 @@
 const router = require('express').Router()
-const urls = require('../../../../lib/urls')
 
-const { renderFindCompanyForm } = require('./controllers')
+const urls = require('../../../../lib/urls')
+const {
+  renderFindCompanyForm,
+  renderMatchConfirmation,
+  submitMatchRequest,
+} = require('./controllers')
 
 router.get(urls.companies.match.index.route, renderFindCompanyForm)
+router.get(urls.companies.match.confirmation.route, renderMatchConfirmation)
+router.post(urls.companies.match.confirmation.route, submitMatchRequest)
 
 module.exports = router

--- a/src/apps/companies/apps/match-company/views/match-confirmation.njk
+++ b/src/apps/companies/apps/match-company/views/match-confirmation.njk
@@ -1,0 +1,9 @@
+{% extends "_layouts/template.njk" %}
+
+{% block body_main_content %}
+  {% component 'react-slot', {
+    id: 'match-confirmation',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -77,7 +77,6 @@ const dnbHierarchyRouter = require('./apps/dnb-hierarchy/router')
 const businessDetailsRouter = require('./apps/business-details/router')
 const editHistoryRouter = require('./apps/edit-history/router')
 const matchCompanyRouter = require('./apps/match-company/router')
-
 const investmentsRouter = require('./apps/investments/router')
 const matchingRouter = require('./apps/matching/router')
 const interactionsRouter = require('../interactions/router.sub-app')

--- a/src/apps/support/services.js
+++ b/src/apps/support/services.js
@@ -33,7 +33,7 @@ function createZenDeskMessage({
 
 function postToZenDesk(ticket) {
   return axios.post(
-    config.zen.url,
+    config.zen.ticketsURL,
     { ticket },
     {
       auth: {

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -9,6 +9,7 @@ import EditCompanyForm from '../apps/companies/apps/edit-company/client/EditComp
 import EditHistory from '../apps/companies/apps/edit-history/client/EditHistory'
 import FindCompany from '../apps/companies/apps/match-company/client/FindCompany'
 import DeleteCompanyList from '../apps/company-lists/client/DeleteCompanyList'
+import MatchConfirmation from '../apps/companies/apps/match-company/client/MatchConfirmation'
 import CompanyLists from '../apps/dashboard/client/CompanyLists'
 import companyLists, {
   resolvePreloadedData as resolvePreloadedCompanyListsData,
@@ -65,6 +66,11 @@ function App() {
       <Mount selector="#edit-history">
         {(props) => (
           <EditHistory csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#match-confirmation">
+        {(props) => (
+          <MatchConfirmation csrfToken={globalProps.csrfToken} {...props} />
         )}
       </Mount>
       <Mount selector="#find-company">

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -65,9 +65,7 @@ const config = {
   assetsHost: process.env.ASSETS_HOST,
   logLevel: process.env.LOG_LEVEL || (isDev ? 'debug' : 'error'),
   zen: {
-    // TODO tidy up the configuration of zendesk URLs
-    url: `https://${process.env.ZEN_DOMAIN}.zendesk.com/api/v2/tickets.json`,
-    announcementsURL: process.env.ZEN_ANNOUNCEMENT_URL,
+    ticketsURL: process.env.ZEN_TICKETS_URL,
     token: process.env.ZEN_TOKEN,
     email: process.env.ZEN_EMAIL,
     browser: process.env.ZEN_BROWSER,

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -135,6 +135,7 @@ module.exports = {
     },
     match: {
       index: url('/companies', '/:companyId/match'),
+      confirmation: url('/companies', '/:companyId/match/:dunsNumber'),
     },
     subsidiaries: {
       index: url('/companies', '/:companyId/subsidiaries'),

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -1,9 +1,13 @@
 const {
   assertLocalHeader,
   assertBreadcrumbs,
+  assertSummaryList,
 } = require('../../support/assertions')
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
+const selectors = require('../../../../selectors')
+
+const DUNS_NUMBER = '111222333'
 
 describe('Match a company', () => {
   context('when viewing "Find this company record" page', () => {
@@ -22,6 +26,118 @@ describe('Match a company', () => {
         'Venus Ltd': urls.companies.detail(fixtures.company.venusLtd.id),
         'Find this company record': null,
       })
+    })
+  })
+
+  context('when company matching is confirmed', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.match.confirmation(
+          fixtures.company.venusLtd.id,
+          DUNS_NUMBER
+        )
+      )
+      cy.contains('Send update request').click()
+    })
+
+    it('should redirect to the company page', () => {
+      cy.location('pathname').should(
+        'eq',
+        urls.companies.activity.index(fixtures.company.venusLtd.id)
+      )
+    })
+
+    it('displays the "Company record update request sent" flash message', () => {
+      cy.get(selectors.localHeader().flash).should(
+        'contain.text',
+        'Company record update request sent'
+      )
+    })
+  })
+
+  context('when viewing "Confirm update" page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.match.confirmation(
+          fixtures.company.dnbCorp.id,
+          DUNS_NUMBER
+        )
+      )
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Confirm update')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.dnbCorp.name]: urls.companies.detail(
+          fixtures.company.dnbCorp.id
+        ),
+        'Confirm update': null,
+      })
+    })
+
+    it('should display matching confirmation details', () => {
+      cy.contains('Confirm you want to update this Data Hub company record')
+        .should('have.prop', 'tagName', 'H2')
+        .next()
+        .find('dl')
+        .then(($el) =>
+          assertSummaryList($el, {
+            'Registered company name': 'DnB Corp',
+            'Trading name(s)': 'DnB, D&B',
+            'Located at': '1 Main Road, Rome, 001122, Italy',
+            'Registered address': '1 Main Road, Rome, 001122, Italy',
+          })
+        )
+        .parent()
+        .parent()
+        .next()
+        .should(
+          'have.text',
+          'With the information from this Dun & Bradstreet company record'
+        )
+        .and('have.prop', 'tagName', 'H2')
+        .next()
+        .find('dl')
+        .then(($el) =>
+          assertSummaryList($el, {
+            'Registered company name': 'Some company name',
+            'Trading name(s)': 'Some trading name',
+            'Located at': '123 Fake Street, Brighton, BN1 4SE, United Kingdom',
+            'Registered address': 'Brighton, BN1 4SE, United Kingdom',
+          })
+        )
+        .parent()
+        .parent()
+        .next()
+        .should('have.text', 'What happens next')
+        .and('have.prop', 'tagName', 'H2')
+        .next()
+        .children()
+        .should('have.length', 2)
+        .and(
+          'contain',
+          'This will send a request to the Support Team to update the business details for this company record, including any future changes to this information.'
+        )
+        .and(
+          'contain',
+          'This will NOT change any recorded activity (Interactions, OMIS orders or Investments projects) for this company record.'
+        )
+        .parent()
+        .next()
+        .contains('Send update request')
+        .and('have.prop', 'tagName', 'BUTTON')
+        .next()
+        .contains('Back')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.match.index(fixtures.company.dnbCorp.id)
+        )
     })
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -118,6 +118,22 @@ const assertTabbedLocalNav = (nav) => {
   cy.get(selectors.tabbedLocalNav).contains(nav)
 }
 
+const assertSummaryList = (listElement, specs) => {
+  const entries = Object.entries(specs)
+  cy.wrap(listElement)
+    .children()
+    .should('have.length', entries.length)
+    .each((x, i) => {
+      const [expectedLabel, expectedValue] = entries[i]
+      cy.get(x)
+        .find('dt')
+        .should('have.text', expectedLabel)
+      cy.get(x)
+        .find('dd')
+        .should('have.text', expectedValue)
+    })
+}
+
 module.exports = {
   assertKeyValueTable,
   assertValueTable,
@@ -127,4 +143,5 @@ module.exports = {
   assertFieldUneditable,
   assertLocalHeader,
   assertTabbedLocalNav,
+  assertSummaryList,
 }

--- a/test/sandbox/fixtures/zendesk/tickets.json
+++ b/test/sandbox/fixtures/zendesk/tickets.json
@@ -1,0 +1,189 @@
+{
+  "ticket": {
+    "url": "https://org-name.zendesk.com/api/v2/tickets/123.json",
+    "id": 123,
+    "external_id": null,
+    "via": {
+      "channel": "api",
+      "source": {
+        "from": {},
+        "to": {},
+        "rel": null
+      }
+    },
+    "created_at": "2020-01-15T12:39:47Z",
+    "updated_at": "2020-01-15T12:39:47Z",
+    "type": "task",
+    "subject": "D&B company match request for Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+    "raw_subject": "D&B company match request for Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+    "description": "User DIT Staff requested a match of Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978(http://localhost:3000/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018) with the following D&B company:\nRegistered company name: Some company name\nTrading name(s): N/A\nLocated at: 123 Fake Street, Brighton, BN1 4SE, United Kingdom\nRegistered address: Brighton, BN1 4SE, United Kingdom\nDUNS number: 12345678",
+    "priority": null,
+    "status": "new",
+    "recipient": null,
+    "requester_id": 369561342717,
+    "submitter_id": 369561342717,
+    "assignee_id": null,
+    "organization_id": null,
+    "group_id": null,
+    "collaborator_ids": [],
+    "follower_ids": [],
+    "email_cc_ids": [],
+    "forum_topic_id": null,
+    "problem_id": null,
+    "has_incidents": false,
+    "is_public": true,
+    "due_at": null,
+    "tags": [
+      "dnb_match_request"
+    ],
+    "custom_fields": [
+      {
+        "id": 44394765,
+        "value": false
+      },
+      {
+        "id": 44394785,
+        "value": null
+      },
+      {
+        "id": 44379689,
+        "value": null
+      },
+      {
+        "id": 44394805,
+        "value": null
+      },
+      {
+        "id": 44394825,
+        "value": false
+      },
+      {
+        "id": 44394845,
+        "value": null
+      },
+      {
+        "id": 44394605,
+        "value": null
+      },
+      {
+        "id": 44380149,
+        "value": null
+      }
+    ],
+    "satisfaction_rating": null,
+    "sharing_agreement_ids": [],
+    "fields": [
+      {
+        "id": 44394765,
+        "value": false
+      },
+      {
+        "id": 44394785,
+        "value": null
+      },
+      {
+        "id": 44379689,
+        "value": null
+      },
+      {
+        "id": 44394805,
+        "value": null
+      },
+      {
+        "id": 44394825,
+        "value": false
+      },
+      {
+        "id": 44394845,
+        "value": null
+      },
+      {
+        "id": 44394605,
+        "value": null
+      },
+      {
+        "id": 44380149,
+        "value": null
+      }
+    ],
+    "followup_ids": [],
+    "brand_id": 3155849,
+    "allow_channelback": false,
+    "allow_attachments": true
+  },
+  "audit": {
+    "id": 572858735358,
+    "ticket_id": 123,
+    "created_at": "2020-01-15T12:39:47Z",
+    "author_id": 10361731669,
+    "metadata": {
+      "system": {
+        "client": "axios/0.18.1",
+        "ip_address": "82.2.101.70",
+        "location": "London, ENG, United Kingdom",
+        "latitude": 51.4647,
+        "longitude": -0.0509
+      },
+      "custom": {}
+    },
+    "events": [
+      {
+        "id": 572858735438,
+        "type": "Comment",
+        "author_id": 369561342717,
+        "body": "User DIT Staff requested a match of Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978(http://localhost:3000/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018) with the following D&B company:\nRegistered company name: Some company name\nTrading name(s): N/A\nLocated at: 123 Fake Street, Brighton, BN1 4SE, United Kingdom\nRegistered address: Brighton, BN1 4SE, United Kingdom\nDUNS number: 12345678",
+        "html_body": "<div class=\"zd-comment\" dir=\"auto\"><p dir=\"auto\">User DIT Staff requested a match of Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978(<a href=\"http://localhost:3000/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018\" target=\"_blank\" rel=\"nofollow noreferrer\">http://localhost:3000/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018</a>) with the following D&amp;B company:\n<br>Registered company name: Some company name\n<br>Trading name(s): N/A\n<br>Located at: 123 Fake Street, Brighton, BN1 4SE, United Kingdom\n<br>Registered address: Brighton, BN1 4SE, United Kingdom\n<br>DUNS number: 12345678</p></div>",
+        "plain_body": "User DIT Staff requested a match of Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978(http://localhost:3000/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018) with the following D&amp;B company:\n\nRegistered company name: Some company name\n\nTrading name(s): N/A\n\nLocated at: 123 Fake Street, Brighton, BN1 4SE, United Kingdom\n\nRegistered address: Brighton, BN1 4SE, United Kingdom\n\nDUNS number: 12345678",
+        "public": true,
+        "attachments": [],
+        "audit_id": 572858735358
+      },
+      {
+        "id": 572858735498,
+        "type": "Create",
+        "value": "369561342717",
+        "field_name": "requester_id"
+      },
+      {
+        "id": 572858735558,
+        "type": "Create",
+        "value": "D&B company match request for Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+        "field_name": "subject"
+      },
+      {
+        "id": 572858735618,
+        "type": "Create",
+        "value": [
+          "dnb_match_request"
+        ],
+        "field_name": "tags"
+      },
+      {
+        "id": 572858735658,
+        "type": "Create",
+        "value": "task",
+        "field_name": "type"
+      },
+      {
+        "id": 572858735718,
+        "type": "Create",
+        "value": "new",
+        "field_name": "status"
+      },
+      {
+        "id": 572858735758,
+        "type": "Create",
+        "value": null,
+        "field_name": "priority"
+      }
+    ],
+    "via": {
+      "channel": "api",
+      "source": {
+        "from": {},
+        "to": {},
+        "rel": null
+      }
+    }
+  }
+}

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -16,6 +16,7 @@ var v3SearchInvestmentProject = require('./routes/v3/search/investment-project.j
 var v3SearchOrder = require('./routes/v3/search/order.js')
 var v3SearchInteraction = require('./routes/v3/search/interaction.js')
 var helpCentre = require('./routes/helpCentre.js')
+var zendesk = require('./routes/zendesk.js')
 
 // V4
 var v4ActivityFeed = require('./routes/v4/activity-feed/activity-feed.js')
@@ -492,3 +493,6 @@ Sandbox.define('/whoami/', 'GET', user.whoami)
 
 // Help centre endpoint
 Sandbox.define('/help-centre/announcement', 'GET', helpCentre.announcement)
+
+// Zendesk tickets endpoint
+Sandbox.define('/zendesk/tickets', 'POST', zendesk.tickets)

--- a/test/sandbox/routes/zendesk.js
+++ b/test/sandbox/routes/zendesk.js
@@ -1,0 +1,5 @@
+var zendeskTickets = require('../fixtures/zendesk/tickets.json')
+
+exports.tickets = function(req, res) {
+  res.json(201, JSON.stringify(zendeskTickets))
+}


### PR DESCRIPTION
## Description of change

Add a page used to match Data Hub companies with D&B records, this page is a second step for a form created in https://github.com/uktrade/data-hub-frontend/pull/2365

## Test instructions

1. Go to `/companies/COMPANY_ID/match/DUNS_NUMBER`
2. Check if the page displays information for both Data Hub and D&B records
3. Clicking the `Update company record` button should create a zendesk ticket (use the staging Zendesk account) and redirect user to the company page

## Screenshots
![image](https://user-images.githubusercontent.com/4199239/72435200-6efdc100-3795-11ea-8546-30abfa28b5cc.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
