### PR TITLE
Add USD to GBP conversion with rounding

### DIFF
--- a/src/apps/companies/apps/business-details/transformers.js
+++ b/src/apps/companies/apps/business-details/transformers.js
@@ -1,8 +1,7 @@
 /* eslint-disable camelcase */
-
 const { get, pick, compact, omitBy } = require('lodash')
 const { hqLabels } = require('../../labels')
-const config = require('../../../../config')
+const { convertUSDToGBP } = require('../../../../common/currency')
 
 const transformGlobalAccountManager = ({ dit_team, name }) => {
   const region = get(dit_team, 'uk_region.name')
@@ -41,8 +40,7 @@ const transformCompanyToBusinessDetails = (company) => {
         'headquarter_type',
         'is_global_ultimate',
       ]),
-      turnover:
-        company.turnover && company.turnover * config.currencyRate.usdToGbp,
+      turnover: convertUSDToGBP(company.turnover),
       business_type: get(company.business_type, 'name'),
       turnover_range: get(company.turnover_range, 'name'),
       employee_range: get(company.employee_range, 'name'),

--- a/src/apps/companies/apps/edit-history/client/EditHistoryChangeList.jsx
+++ b/src/apps/companies/apps/edit-history/client/EditHistoryChangeList.jsx
@@ -6,6 +6,7 @@ import moment from 'moment'
 import styled from 'styled-components'
 import { SummaryTable, DateUtils, NumberUtils } from 'data-hub-components'
 import { ARCHIVED, NOT_ARCHIVED, NOT_SET, YES, NO } from '../constants'
+import { convertUSDToGBP } from '../../../../../common/currency'
 
 const StyledSummaryTable = styled(SummaryTable)`
   caption {
@@ -63,7 +64,7 @@ function getValue(value, field) {
 
   if (isNumber(value)) {
     return CURRENCY_FIELDS.includes(field)
-      ? NumberUtils.currencyUSD(value)
+      ? NumberUtils.currencyGBP(convertUSDToGBP(value))
       : value.toString()
   }
 

--- a/src/common/currency.js
+++ b/src/common/currency.js
@@ -1,0 +1,20 @@
+const { isNumber } = require('lodash')
+const { currencyRate } = require('../config')
+
+const convertUSDToGBP = (usd) => {
+  if (!isNumber(usd)) {
+    return usd
+  }
+
+  const gbp = usd * currencyRate.usdToGbp
+
+  if (usd === 1) {
+    return gbp
+  }
+
+  return gbp ? Math.round(gbp) : gbp
+}
+
+module.exports = {
+  convertUSDToGBP,
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -113,7 +113,7 @@ const config = {
     email: process.env.ONE_LIST_EMAIL || 'one.list@example.com',
   },
   currencyRate: {
-    usdToGbp: 0.770032,
+    usdToGbp: 0.76755,
   },
   activityFeed: {
     paginationSize: 20,

--- a/src/lib/__test__/currency.test.js
+++ b/src/lib/__test__/currency.test.js
@@ -1,0 +1,40 @@
+const { convertUSDToGBP } = require(`../../common/currency`)
+const { currencyRate } = require('../../config/index')
+
+function getExpectedValue(value) {
+  return Math.round(currencyRate.usdToGbp * value)
+}
+
+describe('Currency test', () => {
+  describe('USD to GBP', () => {
+    it('should handle null', () => {
+      expect(convertUSDToGBP(null)).to.equal(null)
+    })
+
+    it('should handle undefined', () => {
+      expect(convertUSDToGBP(undefined)).to.equal(undefined)
+    })
+
+    it('should handle NaN', () => {
+      expect(convertUSDToGBP(NaN)).to.deep.equal(NaN)
+    })
+
+    it('should convert zero', () => {
+      expect(convertUSDToGBP(0)).to.equal(0)
+    })
+
+    it('should convert negative values -$100', () => {
+      const expected = getExpectedValue(-100)
+      expect(convertUSDToGBP(-100)).to.equal(expected)
+    })
+
+    it('should convert $1', () => {
+      expect(convertUSDToGBP(1)).to.equal(currencyRate.usdToGbp)
+    })
+
+    it('should convert $1M', () => {
+      const expected = getExpectedValue(1000000)
+      expect(convertUSDToGBP(1000000)).to.equal(expected)
+    })
+  })
+})

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -399,7 +399,7 @@ describe('Companies business details', () => {
           content: {
             'Trading names': 'DnBD&B',
             'Annual turnover':
-              '£770,032This is an estimated numberWhat does that mean?Actual turnover is not available for this business. The number has been modelled by Dun & Bradstreet, based on similar businesses.',
+              '£767,550This is an estimated numberWhat does that mean?Actual turnover is not available for this business. The number has been modelled by Dun & Bradstreet, based on similar businesses.',
             'Number of employees':
               '95This is an estimated numberWhat does that mean?Actual number of employees is not available for this business. The number has been modelled by Dun & Bradstreet, based on similar businesses.',
             Website: 'Not set',

--- a/test/functional/cypress/specs/companies/edit-history-spec.js
+++ b/test/functional/cypress/specs/companies/edit-history-spec.js
@@ -155,8 +155,8 @@ describe('Edit History', () => {
       assertChanges(
         companyEditHistory.change(5).table(2),
         'Turnover',
-        '$110,008',
-        '$83,257'
+        '£84,437',
+        '£63,904'
       )
     })
 


### PR DESCRIPTION
## Description of change

A simple currency conversion from USD to GBP with rounding. This fixes an issue on the business details page where the turnover is displayed with _n_ decimal places.

## Test instructions
https://www.datahub.dev.uktrade.io/companies/0d8154f7-f74c-408b-90b1-a6efe0871347/business-details

## Screenshots
### Before
<img width="1262" alt="business-details-page" src="https://user-images.githubusercontent.com/964268/72507830-90fe4e80-383c-11ea-8aef-381cb2c77c55.png">

### After
<img width="1262" alt="business-details-page-fixed" src="https://user-images.githubusercontent.com/964268/72508629-ec7d0c00-383d-11ea-8367-8fb4e08408e5.png">

**Edit history**
We can apply the same conversion to the Edit history page.
<img width="1216" alt="edit-history" src="https://user-images.githubusercontent.com/964268/72508004-d884da80-383c-11ea-9790-c82909b94cfd.png">

## Checklist
[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)