### PR TITLE
Rename the Audit trail HTML link to Edit history

### DIFF
--- a/src/apps/companies/apps/business-details/__test__/controllers.test.js
+++ b/src/apps/companies/apps/business-details/__test__/controllers.test.js
@@ -87,7 +87,9 @@ describe('Company business details', () => {
                   companyMock.id
                 )}?_csrf=csrf`,
                 companyAdvisers: urls.companies.advisers.index(companyMock.id),
-                companyAudit: urls.companies.audit(companyMock.id),
+                companyEditHistory: urls.companies.editHistory.index(
+                  companyMock.id
+                ),
                 support: urls.support(),
                 subsidiaries: urls.companies.subsidiaries.index(companyMock.id),
                 linkSubsidiary: urls.companies.subsidiaries.link(

--- a/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
+++ b/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
@@ -49,7 +49,7 @@ const CompanyBusinessDetails = ({
         other businesses.
         <br />
         Changes made to this information can be found on the{' '}
-        <Link href={urls.companyAudit}>Audit trail page</Link>.
+        <Link href={urls.companyEditHistory}>Edit history page</Link>.
         {lastUpdated && (
           <>
             <br />
@@ -84,7 +84,7 @@ const CompanyBusinessDetails = ({
             </Link>
             . This is an external and verified source. The information is
             automatically updated.{' '}
-            <Link href={urls.companyAudit}>View the audit history</Link>.
+            <Link href={urls.companyEditHistory}>View the edit history</Link>.
           </p>
           <p>
             If you think the information is incomplete or incorrect,{' '}

--- a/src/apps/companies/apps/business-details/controllers.js
+++ b/src/apps/companies/apps/business-details/controllers.js
@@ -42,7 +42,7 @@ async function renderBusinessDetails(req, res) {
             company.id
           )}?_csrf=${csrfToken}`,
           companyAdvisers: urls.companies.advisers.index(company.id),
-          companyAudit: urls.companies.audit(company.id),
+          companyEditHistory: urls.companies.editHistory.index(company.id),
           support: urls.support(),
           subsidiaries: urls.companies.subsidiaries.index(company.id),
           linkSubsidiary: urls.companies.subsidiaries.link(company.id),


### PR DESCRIPTION
## Update HTML link name & URL
This pull request simply renames the **Audit trail page** link to **Edit history page** and updates the URL exposing the new implementation to users.

<dl>
  <dt>URL from:</dt>
  <dd>/companies/id/audit</dd>

  <dt>URL to:</dt>
  <dd>/companies/id/edit-history</dd>
</dl>

## Test instructions
Click the link to view the new Edit history page.

## Screenshots
### Before

<img width="1262" alt="audit-history-link" src="https://user-images.githubusercontent.com/964268/72511729-55b34e00-3843-11ea-9ccd-33960a84bd85.png">

### After
<img width="1262" alt="edit-history-link" src="https://user-images.githubusercontent.com/964268/72511907-65cb2d80-3843-11ea-873a-543d836db953.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
