### PR TITLE
Refactor transformCompanyToDnbHierarchyList

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^3.2.0",
+    "data-hub-components": "^3.5.0",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/controllers.test.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/controllers.test.js
@@ -157,7 +157,7 @@ describe('D&B Company hierarchy', () => {
           count: 1,
           results: [
             {
-              badges: ['United Kingdom', 'North West'],
+              badges: [{ text: 'United Kingdom' }, { text: 'North West' }],
               headingText: 'Mars Components Ltd',
               headingUrl: '/companies/731bdcc1-f685-4c8e-bd66-b356b2c16995',
               metadata: [

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/transformers.test.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/transformers.test.js
@@ -30,10 +30,10 @@ describe('Edit company form transformers', () => {
       it('should return transformed values', () => {
         const expected = {
           badges: [
-            'Test country',
-            'Test UK region',
-            'Ultimate HQ',
-            'Global HQ',
+            { text: 'Test country' },
+            { text: 'Test UK region' },
+            { text: 'Ultimate HQ' },
+            { text: 'Global HQ' },
           ],
           headingText: 'Test company',
           headingUrl: '/companies/123',

--- a/src/apps/companies/apps/dnb-hierarchy/transformers.js
+++ b/src/apps/companies/apps/dnb-hierarchy/transformers.js
@@ -1,6 +1,4 @@
 /* eslint-disable camelcase */
-const { get } = require('lodash')
-
 const {
   formatAddress,
   formatDateTime,
@@ -34,27 +32,35 @@ function transformCompanyToDnbHierarchyList({
     })
   }
 
-  if (sector) {
+  if (sector && sector.name) {
     metadata.push({
       label: 'Sector',
-      value: get(sector, 'name'),
+      value: sector.name,
     })
   }
 
-  if (address && address.country) {
-    badges.push(get(address, 'country.name'))
+  if (address && address.country && address.country.name) {
+    badges.push({
+      text: address.country.name,
+    })
   }
 
-  if (uk_based) {
-    badges.push(get(uk_region, 'name'))
+  if (uk_based && uk_region && uk_region.name) {
+    badges.push({
+      text: uk_region.name,
+    })
   }
 
   if (is_global_ultimate) {
-    badges.push(labels.companyDetailsLabels.ultimate_hq)
+    badges.push({
+      text: labels.companyDetailsLabels.ultimate_hq,
+    })
   }
 
   if (headquarter_type) {
-    badges.push(labels.hqLabels[get(headquarter_type, 'name')])
+    badges.push({
+      text: labels.hqLabels[headquarter_type.name],
+    })
   }
 
   if (address) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4289,10 +4289,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-3.2.0.tgz#baafc3ac5cf5568798202a883b29580b9a0c6c8b"
-  integrity sha512-NbPGGjj4+Z5G5dDtd+Ls+XSEASOIGOGVfGL1u8YBffwqtq6p6tUU9PJFYZiNHoJMTWu3EyPNhcqf2/iSluItig==
+data-hub-components@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-3.5.0.tgz#a78c8cb157db1d57fbada893fd1b0c0a476dd078"
+  integrity sha512-18aUOoZP+etuEmd4w1v7nAnXeVO6N2pJh23XYbZfYMoJo5cIDmvEWoIrC3aGM3/sR3LTEaTTT2HfIE6JVEm8oA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change

Refactor transformer for dnb hierarchy list to provide badge props as an object with the key of `text`. The allows future passing of a `borderColour` key. Without this change the list would not render because of breaking changes in Data-Hub-Components release 3.5.0

## Test instructions

The dnb hierarchy page should render the same. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
