### PR TITLE
Correctly format currency fields

### DIFF
--- a/src/apps/companies/apps/edit-history/client/EditHistoryChangeList.jsx
+++ b/src/apps/companies/apps/edit-history/client/EditHistoryChangeList.jsx
@@ -58,14 +58,14 @@ function getValue(value, field) {
     return getValueFromBoolean(value, field)
   }
 
-  if (isDate(value)) {
-    return DateUtils.formatWithTime(value)
-  }
-
   if (isNumber(value)) {
     return CURRENCY_FIELDS.includes(field)
       ? NumberUtils.currencyGBP(convertUSDToGBP(value))
       : value.toString()
+  }
+
+  if (isDate(value)) {
+    return DateUtils.formatWithTime(value)
   }
 
   return value || NOT_SET

--- a/test/functional/cypress/specs/companies/edit-history-spec.js
+++ b/test/functional/cypress/specs/companies/edit-history-spec.js
@@ -155,8 +155,8 @@ describe('Edit History', () => {
       assertChanges(
         companyEditHistory.change(5).table(2),
         'Turnover',
-        '£84,437',
-        '£63,904'
+        '£1,828,928',
+        '£1,387,800'
       )
     })
 

--- a/test/sandbox/fixtures/v4/company-audit/company-audit.json
+++ b/test/sandbox/fixtures/v4/company-audit/company-audit.json
@@ -103,8 +103,8 @@
         "comment": "Updated from D&B [celery:get_company_updates:ddf50721-d4bf-4482-84f1-74f4c78c46aa]",
         "changes": {
             "turnover": [
-                110008,
-                83257
+                2382813,
+                1808091
             ],
             "is_turnover_estimated": [
                 true,


### PR DESCRIPTION
## Description of change
Change the order in which field values are being evaluated and formatted as some values can be construed as dates when in fact they're a number.

Fixes a **Turnover** Prod issue (currently not exposed to users)
https://www.datahub.trade.gov.uk/companies/9108e5de-3c5a-452f-8a8a-2cca240877f8/edit-history

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
