### PR TITLE
Exp/api endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "history": "^4.7.2",
     "hmpo-form-wizard": "^9.9.0",
     "html5shiv": "^3.7.3",
+    "http-proxy-middleware": "^0.20.0",
     "image-webpack-loader": "^4.0.0",
     "lodash": "^4.17.13",
     "markdown-it": "^8.4.0",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -43,6 +43,7 @@ const config = {
   noCache: process.env.CACHE_ASSETS ? false : isDev,
   port: process.env.PORT || 3000,
   apiRoot: process.env.API_ROOT || 'http://localhost:8000',
+  apiProxyWhitelist: ['/v4/company-list', '/v4/company-list/:id/item'],
   api: {
     authUrl: '/token/',
   },

--- a/src/server.js
+++ b/src/server.js
@@ -120,10 +120,10 @@ app.use(store())
 app.use(csrf())
 app.use(csrfToken())
 
-app.use(proxy('/api', {
+app.use(proxy('/api-proxy', {
   target: config.apiRoot,
   pathRewrite: {
-    '^/api': '/',
+    '^/api-proxy': '/',
   },
   onProxyReq: (req, res) =>
     req.setHeader('authorization', `Bearer ${res.session.token}`),

--- a/src/server.js
+++ b/src/server.js
@@ -120,14 +120,17 @@ app.use(store())
 app.use(csrf())
 app.use(csrfToken())
 
-app.use(proxy('/api-proxy', {
-  target: config.apiRoot,
-  pathRewrite: {
-    '^/api-proxy': '/',
-  },
-  onProxyReq: (req, res) =>
-    req.setHeader('authorization', `Bearer ${res.session.token}`),
-}))
+const API_PROXY_PATH = '/api-proxy'
+app.use(
+  proxy(config.apiProxyWhitelist.map((pth) => path.join(API_PROXY_PATH, pth)), {
+    target: config.apiRoot,
+    pathRewrite: {
+      ['^' + API_PROXY_PATH]: '/',
+    },
+    onProxyReq: (proxyReq, req) =>
+      proxyReq.setHeader('authorization', `Bearer ${req.session.token}`),
+  })
+)
 
 // routing
 app.use(slashify())

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ const enforce = require('express-sslify')
 const favicon = require('serve-favicon')
 const cookieParser = require('cookie-parser')
 const minifyHTML = require('express-minify-html')
+var proxy = require('http-proxy-middleware')
 
 const config = require('./config')
 const title = require('./middleware/title')
@@ -118,6 +119,15 @@ app.use(headers)
 app.use(store())
 app.use(csrf())
 app.use(csrfToken())
+
+app.use(proxy('/api', {
+  target: config.apiRoot,
+  pathRewrite: {
+    '^/api': '/',
+  },
+  onProxyReq: (req, res) =>
+    req.setHeader('authorization', `Bearer ${res.session.token}`),
+}))
 
 // routing
 app.use(slashify())

--- a/src/server.js
+++ b/src/server.js
@@ -12,7 +12,7 @@ const enforce = require('express-sslify')
 const favicon = require('serve-favicon')
 const cookieParser = require('cookie-parser')
 const minifyHTML = require('express-minify-html')
-var proxy = require('http-proxy-middleware')
+const proxy = require('http-proxy-middleware')
 
 const config = require('./config')
 const title = require('./middleware/title')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4387,7 +4387,7 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.1.0, debug@^3.2.6:
+debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -5653,6 +5653,11 @@ eventemitter3@1.x.x:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
   integrity sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
 
+eventemitter3@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
+  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
+
 events@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
@@ -6303,6 +6308,13 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
+
+follow-redirects@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
+  integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
+  dependencies:
+    debug "^3.0.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -7320,6 +7332,16 @@ http-proxy-agent@1, http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
+http-proxy-middleware@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.20.0.tgz#5b128f7207985c4ea91b53fab8ad897a48c690d6"
+  integrity sha512-dNJAk71nEJhPiAczQH9hGvE/MT9kEs+zn2Dh+Hi94PGZe1GluQirC7mw5rdREUtWx6qGS1Gu0bZd4qEAg+REgw==
+  dependencies:
+    http-proxy "^1.17.0"
+    is-glob "^4.0.1"
+    lodash "^4.17.14"
+    micromatch "^4.0.2"
+
 http-proxy@1.15.2:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.15.2.tgz#642fdcaffe52d3448d2bda3b0079e9409064da31"
@@ -7327,6 +7349,15 @@ http-proxy@1.15.2:
   dependencies:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
+
+http-proxy@^1.17.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
+  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -9626,6 +9657,14 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -11099,6 +11138,11 @@ picomatch@^2.0.4:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.0.tgz#0fd042f568d08b1ad9ff2d3ec0f0bfb3cb80e177"
   integrity sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw==
 
+picomatch@^2.0.5:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
+  integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
+
 pidtree@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
@@ -12283,7 +12327,7 @@ require-uncached@^1.0.2, require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requires-port@1.x.x:
+requires-port@1.x.x, requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,7 +2723,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==


### PR DESCRIPTION
This is a resurection of PR #2242, which has been closed, probably when we moved from `develop` to `master` and which can't be reopened because the target branch `develop` doesn't exist anymore.

## Description of change

Added the `/api-proxy` endpoint, which proxies all requests to **whitelisted** routes to `config.apiRoot` with added `authorization: Bearer <session.token>` header. The `/api-proxy` prefix is stripped from the requests, e.g a request to `localhost:3000/api-proxy/v4/company-list` will be proxied to `<apiRoot>/v4/company-list`.

## Test instructions

* You should be able to access the API from `/api-proxy` without the need to use the access token.
* You should not be able to access the API from `/api-proxy` if you are not logged in.
* You should only be able to access whitelisted routes, which at the moment are `/v4/company-list` and `/v4/company-list/:id/item`

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
