### PR TITLE
Update wavy check to include sass files

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "circle:acceptance:da-staff": "yarn circle:acceptance --tag da --skiptags ignore",
     "heroku-postbuild": "yarn cache clean && npm rebuild && npm run build",
     "lint-staged": "lint-staged",
-    "wavy-check": "grep -rlE \"(proxyquire|rewire|require).*?\\(.*?~\" test src | wc -l | { read count; if [ $count -gt 0 ]; then echo \"wavy dependency still in use by $count files\"; else echo '🎉 wavy dependency can be removed 🎉'; fi; }"
+    "wavy-check": "grep -rlE \"((proxyquire|rewire|require).*?\\(|@import).*?~\" test src assets/stylesheets | wc -l | { read count; if [ $count -gt 0 ]; then echo \"wavy dependency still in use by $count files\"; else echo '🎉 wavy dependency can be removed 🎉'; fi; }"
   },
   "pre-commit": "lint-staged, wavy-check",
   "lint-staged": {


### PR DESCRIPTION
## Description of change

As @debitan tried to remove `wavy` and got an error because the SASS files are using it, this updates the checks to include the SASS files.

## Test instructions

`yarn wavy-check`
Should now say it is in use by 4 files

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
