### PR TITLE
Add config options to control request logging

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -65,6 +65,8 @@ const config = {
   },
   assetsHost: process.env.ASSETS_HOST,
   logLevel: process.env.LOG_LEVEL || (isDev ? 'debug' : 'error'),
+  logResponses: process.env.LOG_RESPONSES === 'true',
+  logRequests: process.env.LOG_REQUESTS === 'true',
   zen: {
     ticketsURL: process.env.ZEN_TICKETS_URL,
     token: process.env.ZEN_TOKEN,


### PR DESCRIPTION
## Description of change

To enable easier debugging this enables us to see the request and response data in the console and easily turn it on/off via env vars

Only request method and url are logged by default, additional log output can be added by using the following env vars:

`LOG_RESPONSES` - Log the response data from a request
`LOG_REQUESTS` - Log the request info made to `request` (`headers`, `body`, `qs`)

This also allows us to control the data logged in deployed builds, for example we can turn on debug logging without exposing request tokens

## Test instructions

The log messages in the console should be less noisy unless you turn these on when you should see the request data and/or the response data

### Before

```bash
debug:   Send authorised request:  Authorization=Bearer myToken , json=true, method=GET, proxy=undefined, url=http://localhost:8000/v3/feature-flag
```

### After
Default

```
debug:   Sending GET to http://localhost:8000/v3/feature-flag
```
`LOG_REQUESTS=true`
```
debug:   Sending GET to http://localhost:8000/v3/feature-flag
debug:   with request data: {
  "headers": {
    "Authorization": "Bearer myToken "
  }
}
```
`LOG_RESPONSES=true`
```
debug:   Sending GET to http://localhost:8000/v3/feature-flag
debug:   with request data: {
  "headers": {
    "Authorization": "Bearer myToken "
  }
}
debug:   Response for GET to http://localhost:8000/v3/feature-flag: [
  {
    "code": "companies-advisers",
    "is_active": true
  },
  {
    "code": "interaction-add-countries",
    "is_active": true
  }
]
```

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
