### PR TITLE
Change log message and only calculate max age once

### DIFF
--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -1,14 +1,14 @@
 const logger = require('../config/logger')
 
+const STS_MAX_AGE = 180 * 24 * 60 * 60
+
 module.exports = function headers(req, res, next) {
   if (
     req.url.indexOf('/css') === -1 &&
     req.url.indexOf('/javascripts') === -1 &&
     req.url.indexOf('/images') === -1
   ) {
-    logger.debug('adding headers')
-
-    const STS_MAX_AGE = 180 * 24 * 60 * 60
+    logger.debug('Headers middleware -> Adding response headers')
 
     res.set('Cache-Control', 'no-cache, no-store, must-revalidate, private')
     res.set('Pragma', 'no-cache')


### PR DESCRIPTION
## Description of change

Add more information to the log message as I didn't know where it was coming from. Also there is no need to calculate the max age repeatedly so moved it out of the function.

## Test instructions

When reviewing the console output after a page is viewed the message should be visible when debug messages are shown.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
