### PR TITLE
Move urls from nunjucks config

### DIFF
--- a/src/apps/companies/apps/exports/controller.js
+++ b/src/apps/companies/apps/exports/controller.js
@@ -44,6 +44,8 @@ function renderExports(req, res) {
     .render('companies/apps/exports/views/exports-view', {
       exportDetails,
       exportPotentials: Object.values(exportPotentialLabels),
+      findExportersUrl: urls.external.findExporters(),
+      feedbackLink: urls.support(),
     })
 }
 

--- a/src/apps/global-nav-items.js
+++ b/src/apps/global-nav-items.js
@@ -3,6 +3,7 @@ const path = require('path')
 const { compact, sortBy, concat, includes } = require('lodash')
 
 const config = require('../config')
+const urls = require('../lib/urls')
 
 const subApps = fs.readdirSync(__dirname)
 
@@ -33,7 +34,7 @@ const GLOBAL_NAV_ITEMS = concat(
     key: 'datahub-mi',
   },
   {
-    path: config.findExportersUrl,
+    path: urls.external.findExporters(),
     label: 'Find exporters',
     key: 'find-exporters',
   }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -86,7 +86,6 @@ const config = {
   paginationMaxResults: 10000,
   paginationDefaultSize: 10,
   performanceDashboardsUrl: process.env.PERFORMANCE_DASHBOARDS_URL,
-  findExportersUrl: process.env.FIND_EXPORTERS_URL,
   archivedDocumentsBaseUrl: process.env.ARCHIVED_DOCUMENTS_BASE_URL,
   oauth: {
     url: process.env.OAUTH2_AUTH_URL,

--- a/src/config/nunjucks/globals.js
+++ b/src/config/nunjucks/globals.js
@@ -9,9 +9,6 @@ module.exports = {
   projectPhase: config.projectPhase,
   description:
     'Data Hub is a customer relationship, project management and analytical tool for Department for International Trade.',
-  feedbackLink: '/support',
-  findExportersUrl: config.findExportersUrl,
-
   assign,
   urls,
 

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -23,6 +23,10 @@ describe('urls', () => {
       expect(urls.external.companiesHouse(companyNumber)).to.equal(
         `https://beta.companieshouse.gov.uk/company/${companyNumber}`
       )
+
+      expect(urls.external.findExporters()).to.equal(
+        'https://find-exporters.datahub.trade.gov.uk/'
+      )
     })
   })
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -68,6 +68,7 @@ module.exports = {
     greatProfile: (id) => config.greatProfileUrl.replace('{id}', id),
     companiesHouse: (companyNumber) =>
       `https://beta.companieshouse.gov.uk/company/${companyNumber}`,
+    findExporters: () => 'https://find-exporters.datahub.trade.gov.uk/',
   },
   dashboard: url('/'),
   companies: {


### PR DESCRIPTION
## Description of change

Move the find exporters and support link from the global config and instead pass through the controller where needed using the urls module. This is in preparation for replacing the export page with react, which won't have access to nunjucks globals. 

## Test instructions

Nothing should change.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
