### PR TITLE
Move exports transformer into exports folder

### DIFF
--- a/src/apps/companies/apps/exports/__test__/controller.test.js
+++ b/src/apps/companies/apps/exports/__test__/controller.test.js
@@ -19,7 +19,7 @@ describe('Company export controller', () => {
     saveCompany = sinon.stub()
     transformerSpy = sinon.spy()
 
-    controller = proxyquire('../exports', {
+    controller = proxyquire('../controller', {
       '../../repos': {
         saveCompany,
       },
@@ -37,9 +37,7 @@ describe('Company export controller', () => {
           },
         ],
       },
-      '../../transformers': {
-        transformCompanyToExportDetailsView: transformerSpy,
-      },
+      './transformer': transformerSpy,
     })
   })
 

--- a/src/apps/companies/apps/exports/__test__/transformer.test.js
+++ b/src/apps/companies/apps/exports/__test__/transformer.test.js
@@ -1,14 +1,14 @@
 const proxyquire = require('proxyquire')
 const faker = require('faker')
 
-const minimalCompany = require('../../../../../test/unit/data/companies/minimal-company.json')
+const minimalCompany = require('../../../../../../test/unit/data/companies/minimal-company.json')
 
-const transformerPath = '../company-to-export-details-view'
+const transformerPath = '../transformer'
 const EXPORT_POTENTIAL_LABEL = 'Export potential'
 
 const {
   generateExportCountries,
-} = require('../../../../../test/unit/helpers/generate-export-countries')
+} = require('../../../../../../test/unit/helpers/generate-export-countries')
 
 describe('transformCompanyToExportDetailsView', () => {
   let transformCompanyToExportDetailsView
@@ -23,7 +23,7 @@ describe('transformCompanyToExportDetailsView', () => {
       },
     }
     transformCompanyToExportDetailsView = proxyquire(transformerPath, {
-      '../../../lib/urls': urls,
+      '../../../../lib/urls': urls,
     })
   })
 

--- a/src/apps/companies/apps/exports/controller.js
+++ b/src/apps/companies/apps/exports/controller.js
@@ -8,7 +8,7 @@ const getExportCountries = require('../../../../lib/get-export-countries')
 
 const { saveCompany } = require('../../repos')
 const { transformObjectToOption } = require('../../../transformers')
-const { transformCompanyToExportDetailsView } = require('../../transformers')
+const transformCompanyToExportDetailsView = require('./transformer')
 const { exportDetailsLabels, exportPotentialLabels } = require('../../labels')
 
 const {

--- a/src/apps/companies/apps/exports/router.js
+++ b/src/apps/companies/apps/exports/router.js
@@ -9,7 +9,7 @@ const {
   populateExportForm,
   renderExportEdit,
   handleEditFormPost,
-} = require('./exports')
+} = require('./controller')
 
 router.get(urls.companies.exports.index.route, setReturnUrl, renderExports)
 

--- a/src/apps/companies/apps/exports/transformer.js
+++ b/src/apps/companies/apps/exports/transformer.js
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 const { flatMap } = require('lodash')
 
-const { getDataLabels } = require('../../../lib/controller-utils')
-const urls = require('../../../lib/urls')
-const { exportDetailsLabels, exportPotentialLabels } = require('../labels')
-const { EXPORT_INTEREST_STATUS } = require('../../constants')
-const groupExportCountries = require('../../../lib/group-export-countries')
+const { getDataLabels } = require('../../../../lib/controller-utils')
+const urls = require('../../../../lib/urls')
+const { exportDetailsLabels, exportPotentialLabels } = require('../../labels')
+const { EXPORT_INTEREST_STATUS } = require('../../../constants')
+const groupExportCountries = require('../../../../lib/group-export-countries')
 
 function getCountries(data) {
   return flatMap(data, ({ name }) => name || null).join(', ') || 'None'

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -1,10 +1,8 @@
-const transformCompanyToExportDetailsView = require('./company-to-export-details-view')
 const transformCompanyToListItem = require('./company-to-list-item')
 const transformCompanyToSubsidiaryListItem = require('./company-to-subsidiary-list-item')
 const transformCoreTeamToCollection = require('./one-list-core-team-to-collection')
 
 module.exports = {
-  transformCompanyToExportDetailsView,
   transformCompanyToListItem,
   transformCompanyToSubsidiaryListItem,
   transformCoreTeamToCollection,


### PR DESCRIPTION
## Description of change

Move exports transformer into exports folder. This brings all exports related files into the export folder. 

## Test instructions

Nothing should change.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
