### PR TITLE
Remove the optional label for event in the interaction form

### DIFF
--- a/src/apps/interactions/macros/service-delivery-form.js
+++ b/src/apps/interactions/macros/service-delivery-form.js
@@ -90,7 +90,6 @@ module.exports = function({
         macroName: 'MultipleChoiceField',
         type: 'radio',
         name: 'is_event',
-        optional: true,
         modifier: 'inline',
         options: [
           {

--- a/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
+++ b/test/functional/cypress/specs/interaction/service-delivery-form-spec.js
@@ -24,6 +24,10 @@ describe('Service delivery form', () => {
     cy.get(selectors.interactionForm.ditAdviserTypeahead.fieldset).should(
       'to.exist'
     )
+    cy.get(selectors.interactionForm.eventLabel).should(
+      'have.text',
+      'Is this an event?'
+    )
     cy.get(selectors.interactionForm.eventYes).should('be.visible')
     cy.get(selectors.interactionForm.eventNo).should('be.visible')
     cy.get(selectors.interactionForm.event).should('not.be.visible')

--- a/test/selectors/interaction-form.js
+++ b/test/selectors/interaction-form.js
@@ -25,6 +25,7 @@ module.exports = {
     secondTypeaheadRemoveLink: `${typeaheadId} .c-form-group__inner .c-form-group--AddItems:nth-child(2) .js-AddItems__remove`,
   },
   communicationChannel: '#field-communication_channel',
+  eventLabel: '#group-field-is_event legend',
   eventYes: 'label[for=field-is_event-1]',
   eventNo: 'label[for=field-is_event-2]',
   event: '#field-event',


### PR DESCRIPTION
## Description of change

When adding a service delivery interaction the "Events" radio options should not be optional so they shouldn't have an optional label attached to them.

## Test instructions

Go to add a service delivery interaction via - Add interaction > other > A service that you have provided

## Screenshots
### Before
![Screenshot 2020-01-21 at 16 31 50](https://user-images.githubusercontent.com/10154302/72823541-ca372400-3c6b-11ea-9a1c-83000ed95fc1.png)


### After
![Screenshot 2020-01-21 at 16 31 17](https://user-images.githubusercontent.com/10154302/72823554-cefbd800-3c6b-11ea-9273-4dc2a12ee55a.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
