### PR TITLE
Improve docker setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,31 @@ and be provided with a back end server to provide the API, data storage and sear
 
 1.  Go to the project root.
 
-2.  Start the server:
+2.  Create a `.env` file with `cp docker.sample.env .env`.
+
+3.  By default, the frontend container will use the mock-sso instance specified
+    in `docker-compose.yml`.  To use this, you will also need to specify the `MOCK_SSO_USERNAME`
+    environment variable in `.env`.
+    This value should correspond with an `Advisor.email` value in the Data Hub backend
+
+4.  Optionally, you can point the frontend to a different backend by specifying
+    an `API_ROOT` in `.env`. e.g. To connect the frontend docker container to the
+    shared dev environment backend.
+
+    If you want to point `API_ROOT` to a data-hub-api docker container, ensure
+    that both containers are running under docker-compose with the same
+    `COMPOSE_PROJECT_NAME` specified in each `.env` file. This will make sure
+    that the containers share a network. The following snippet in `.env` should then
+    do the trick:
+
+    ```
+    API_ROOT=http://api:8000
+    ```
+  
+5.  Start the server:
 
     ```bash
-    docker-compose up
+    docker-compose up frontend
     ```
 
     The server will start in developer mode, which means that when you make local changes it will auto-compile assets, and will restart nodejs.
@@ -50,16 +71,6 @@ and be provided with a back end server to provide the API, data storage and sear
     You can access the server on port 3000,
     [http://localhost:3000](http://localhost:3000). You can also run a remote
     debug session over port 9229 if using webstorm/Intellij or Visual Studio Code.
-
-3.  Optionally, you can point the frontend to a different backend:
-
-    ```bash
-    API_ROOT=example.com docker-compose up frontend
-    ```
-
-    If using the mock-sso instance specified in `docker-compose.yml`, you will
-    also need to specify the `MOCK_SSO_USERNAME` environment variable in `.env`.
-    This value should correspond with an `Advisor.email` value in the Data Hub backend
 
 ### Running project natively
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and be provided with a back end server to provide the API, data storage and sear
 3.  By default, the frontend container will use the mock-sso instance specified
     in `docker-compose.yml`.  To use this, you will also need to specify the `MOCK_SSO_USERNAME`
     environment variable in `.env`.
-    This value should correspond with an `Advisor.email` value in the Data Hub backend
+    This value should correspond with an `Advisor.email` value in the Data Hub backend.
 
 4.  Optionally, you can point the frontend to a different backend by specifying
     an `API_ROOT` in `.env`. e.g. To connect the frontend docker container to the

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ and be provided with a back end server to provide the API, data storage and sear
 
 ### Running project within Docker
 
+**Note for Mac Users:** By default, docker on Mac will restrict itself to using just 2GB of memory. This [should be increased](https://docs.docker.com/docker-for-mac/#resources) to at least 4GB to avoid running in to unexpected problems.
+
 1.  Go to the project root.
 
 2.  Create a `.env` file with `cp docker.sample.env .env`.

--- a/docker.sample.env
+++ b/docker.sample.env
@@ -1,0 +1,3 @@
+#API_ROOT=http://api:8000
+MOCK_SSO_USERNAME=some.person@example.net
+COMPOSE_PROJECT_NAME=data-hub


### PR DESCRIPTION
## Description of change
This PR improves the docker instructions in the README.  The hope is that new developers wanting to set up both FE and BE under docker have enough instructions available to do so.

From the meeting the other day, it seems like everybody has a different workflow for setting up local copies so this has tried to be informative without being opinionated.  This does mean that there's lots of "optional" steps which IMO could be confusing.

Also, this adds a trimmed down `docker.sample.env` file to avoid reusing the bloated existing `sample.env` file.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
