### PR TITLE
Use the correct field name for export potential

### DIFF
--- a/src/apps/companies/apps/exports/__test__/transformer.test.js
+++ b/src/apps/companies/apps/exports/__test__/transformer.test.js
@@ -76,7 +76,7 @@ describe('transformCompanyToExportDetailsView', () => {
                 name: 'Germany',
               },
             ],
-            export_potential_score: 'low',
+            export_potential: 'low',
           }
 
           const viewRecord = transformCompanyToExportDetailsView(company)

--- a/src/apps/companies/apps/exports/transformer.js
+++ b/src/apps/companies/apps/exports/transformer.js
@@ -63,7 +63,7 @@ module.exports = function transformCompanyToExportDetailsView(
   const viewRecord = {
     exportExperienceCategory: company.export_experience_category || 'None',
     ...getCountriesFields(company, useNewCountries),
-    exportPotential: getExportPotentialLabel(company.export_potential_score),
+    exportPotential: getExportPotentialLabel(company.export_potential),
     greatProfile: getGreatProfileValue(
       company.great_profile_status,
       company.company_number


### PR DESCRIPTION
## Description of change

Use the correct filed name for export potential. It should have been `export_potential`, not `export_potential_score`. This error was accidentally introduced through a conflict merge a little while ago. 

## Test instructions

You should now be able to see the Export Potential on the export page of a company. 

![FireShot Capture 027 - Exports - One List Subsidiary Ltd - Companies - DIT Data Hub - localhost](https://user-images.githubusercontent.com/42253716/73005750-5cbcfc00-3e01-11ea-857f-bfaf2505d047.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
