### PR TITLE
Fix issues with new export countries

### DIFF
--- a/src/apps/companies/apps/exports/views/exports-edit.njk
+++ b/src/apps/companies/apps/exports/views/exports-edit.njk
@@ -7,6 +7,7 @@
 {% block body_main_content %}
 
   {% call Form({
+    errors: errors,
     buttonText: 'Save and return',
     returnText: 'Return without saving',
     returnLink: urls.companies.exports.index(company.id),

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -25,6 +25,8 @@ async function getCompany(req, res, next, id) {
     if (features[NEW_COUNTRIES_FEATURE]) {
       delete company.export_to_countries
       delete company.future_interest_countries
+    } else {
+      delete company.export_countries
     }
 
     res.locals.company = company

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -1,3 +1,4 @@
+const { NEW_COUNTRIES_FEATURE } = require('../../constants')
 const {
   getDitCompany,
   addDitCompanyToList,
@@ -9,6 +10,7 @@ const { isItaTierDAccount } = require('../../../lib/is-tier-type-company')
 
 async function getCompany(req, res, next, id) {
   try {
+    const { features } = res.locals
     const company = await getDitCompany(req.session.token, id)
     company.isItaTierDAccount = isItaTierDAccount(company)
     company.hasAllocatedLeadIta =
@@ -16,14 +18,19 @@ async function getCompany(req, res, next, id) {
     company.hasManagedAccountDetails =
       company.one_list_group_tier && company.hasAllocatedLeadIta
     company.isUltimate =
-      !!company.is_global_ultimate &&
-      res.locals.features['companies-ultimate-hq']
+      !!company.is_global_ultimate && features['companies-ultimate-hq']
     company.isGlobalHQ =
       company.headquarter_type && company.headquarter_type.name === 'ghq'
+
+    if (features[NEW_COUNTRIES_FEATURE]) {
+      delete company.export_to_countries
+      delete company.future_interest_countries
+    }
 
     res.locals.company = company
     next()
   } catch (error) {
+    console.log(error)
     next(error)
   }
 }

--- a/src/apps/constants.js
+++ b/src/apps/constants.js
@@ -3,9 +3,11 @@ const ERROR = {
   ENTER_A_DATE: 'You must enter a date',
 }
 
+// The order here controls the order they are displayed to the user
+// either on a form or when displaying the values
 const EXPORT_INTEREST_STATUS = {
-  FUTURE_INTEREST: 'future_interest',
   EXPORTING_TO: 'currently_exporting',
+  FUTURE_INTEREST: 'future_interest',
   NOT_INTERESTED: 'not_interested',
 }
 

--- a/src/apps/interactions/labels.js
+++ b/src/apps/interactions/labels.js
@@ -2,8 +2,8 @@ const { EXPORT_INTEREST_STATUS } = require('../constants')
 
 const countriesDiscussed = {
   were_countries_discussed: 'Were any countries discussed?',
-  [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: 'Future countries of interest',
   [EXPORT_INTEREST_STATUS.EXPORTING_TO]: 'Countries currently exporting to',
+  [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: 'Future countries of interest',
   [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: 'Countries not interested in',
 }
 

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -221,20 +221,20 @@ describe('Interaction details middleware', () => {
                 policy_issue_types: [],
                 status: 'complete',
                 were_countries_discussed: 'true',
+                [EXPORTING_TO]: interactionDataWithCountries[EXPORTING_TO],
                 [FUTURE_INTEREST]:
                   interactionDataWithCountries[FUTURE_INTEREST],
-                [EXPORTING_TO]: interactionDataWithCountries[EXPORTING_TO],
                 [NOT_INTERESTED]: interactionDataWithCountries[NOT_INTERESTED],
                 export_countries: [
+                  {
+                    country: { id: interactionDataWithCountries[EXPORTING_TO] },
+                    status: EXPORTING_TO,
+                  },
                   {
                     country: {
                       id: interactionDataWithCountries[FUTURE_INTEREST],
                     },
                     status: FUTURE_INTEREST,
-                  },
-                  {
-                    country: { id: interactionDataWithCountries[EXPORTING_TO] },
-                    status: EXPORTING_TO,
                   },
                   {
                     country: {

--- a/src/lib/__test__/get-export-countries.test.js
+++ b/src/lib/__test__/get-export-countries.test.js
@@ -24,20 +24,20 @@ describe('getExportCountries', () => {
         })
       ).to.deep.equal([
         {
-          country: { id: countries[0] },
-          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
-        },
-        {
-          country: { id: countries[1] },
-          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
-        },
-        {
           country: { id: countries[2] },
           status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
         },
         {
           country: { id: countries[3] },
           status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
+        },
+        {
+          country: { id: countries[0] },
+          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
+        },
+        {
+          country: { id: countries[1] },
+          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
         },
         {
           country: { id: countries[4] },
@@ -67,12 +67,12 @@ describe('getExportCountries', () => {
         })
       ).to.deep.equal([
         {
-          country: { id: countries[0] },
-          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
-        },
-        {
           country: { id: countries[1] },
           status: EXPORT_INTEREST_STATUS.EXPORTING_TO,
+        },
+        {
+          country: { id: countries[0] },
+          status: EXPORT_INTEREST_STATUS.FUTURE_INTEREST,
         },
         {
           country: { id: countries[2] },


### PR DESCRIPTION
## Description of change

* Show `non_field_errors` when editing export countries on the export tab
* Change the order of the new country categories to match the old one and be consistent everywhere
* Change company param to delete the old countries fields when the feature flag is on or delete the new countries field when it is not - this stops validation errors on the backend as you can either PATCH with the old or new but not both

## Test instructions

Feature flag: `interaction-add-countries`

### Feature flag off:
* Edit the export tab with the feature flag off and you should still be able to save
### Feature flag on:
* Create a new interaction and the new country fields should be listed in the correct order, the same for the interaction detail page and the export tab itself, the correct order is:
  - Currently exporting to
  - Future countries of interest
  - Countries of no interest
* Edit the export countries on the export tab and enter the same country in at least two fields, you should now see a `non_field_error` saying you cannot do this

## Screenshots
### Before

_Add a screenshot_

### After

<img width="781" alt="Screenshot 2020-01-24 at 19 48 55" src="https://user-images.githubusercontent.com/1481883/73099068-99acef80-3ee2-11ea-839d-0ac8cf8a42f0.png">
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
