### PR TITLE
Move great.gov url into urls module and remove config from that file

### DIFF
--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -1,23 +1,12 @@
 const faker = require('faker')
-const proxyquire = require('proxyquire')
-
-const modulePath = '../urls'
+const urls = require('../urls')
 
 describe('urls', () => {
-  let urls
-  before(() => {
-    urls = proxyquire(modulePath, {
-      '../config': {
-        greatProfileUrl: 'http://a.b.c.com/path/{id}',
-      },
-    })
-  })
-
   describe('external', () => {
     it('should have the correct urls', () => {
       const companyNumber = faker.random.alphaNumeric(8)
       expect(urls.external.greatProfile(companyNumber)).to.equal(
-        `http://a.b.c.com/path/${companyNumber}`
+        `https://www.great.gov.uk/international/trade/suppliers/${companyNumber}`
       )
 
       expect(urls.external.companiesHouse(companyNumber)).to.equal(

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -1,5 +1,3 @@
-const config = require('../config')
-
 function getTokens(path) {
   const tokens = []
   const parts = path.split('/')
@@ -65,7 +63,8 @@ function createInteractionsSubApp(...mountPoints) {
 
 module.exports = {
   external: {
-    greatProfile: (id) => config.greatProfileUrl.replace('{id}', id),
+    greatProfile: (id) =>
+      `https://www.great.gov.uk/international/trade/suppliers/${id}`,
     companiesHouse: (companyNumber) =>
       `https://beta.companieshouse.gov.uk/company/${companyNumber}`,
     findExporters: () => 'https://find-exporters.datahub.trade.gov.uk/',


### PR DESCRIPTION
## Description of change

Move great.gov url into urls module and remove config from that file. The means you no longer have to have the env variable `GREAT_PROFILE_URL`. 

If the great.gov.uk url changes in future, rather than change the env var, we will need to edit it in the urls module and do a release. However, we now no longer need to import the config file into the urls module and no longer need proxyrequire in unit tests when testing the great profile url. 

## Test instructions

Nothing should change. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
