### PR TITLE
Add "Duplicated record" page for D&B company match

### DIFF
--- a/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Link from '@govuk-react/link'
+import InsetText from '@govuk-react/inset-text'
+import styled from 'styled-components'
+
+import urls from '../../../../../lib/urls'
+
+const StyledRoot = styled('div')`
+  p:last-child {
+    margin-bottom: 0;
+  }
+`
+
+function MatchDuplicate({ company, dnbCompany }) {
+  return (
+    <StyledRoot>
+      <p>
+        For some companies there are multiple (duplicate) records. To resolve
+        this, and have this record automatically updated, you can{' '}
+        <Link href={urls.support()}>
+          contact support to request a merge of these records
+        </Link>
+        .
+      </p>
+      <p>
+        Copy and paste the following instructions in the Desciption field of the
+        form:
+      </p>
+      <InsetText>
+        <p>
+          <strong>Company records merge request</strong>
+        </p>
+        <p>
+          Please merge company record {company.name} ({company.id}) with company
+          record {dnbCompany.primary_name} ({dnbCompany.datahub_company_id}).
+        </p>
+      </InsetText>
+
+      <Link href={urls.companies.match.index(company.id)}>
+        Back to search results
+      </Link>
+    </StyledRoot>
+  )
+}
+
+MatchDuplicate.props = {
+  company: PropTypes.shape({
+    name: PropTypes.string,
+  }).isRequired,
+  dnbCompany: PropTypes.shape({
+    primary_name: PropTypes.string,
+    duns_number: PropTypes.string,
+    datahub_company_id: PropTypes.string,
+  }).isRequired,
+}
+
+export default MatchDuplicate

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -69,26 +69,22 @@ async function renderMatchConfirmation(req, res, next) {
     })
 
     const dnbCompany = get(results, 'results[0].dnb_company')
+    const dataHubCompanyId = get(results, 'results[0].datahub_company.id')
 
     res
       .breadcrumb(company.name, urls.companies.detail(company.id))
-      .breadcrumb('Confirm update')
+      .breadcrumb(dataHubCompanyId ? 'Duplicated record' : 'Confirm update')
       .render('companies/apps/match-company/views/match-confirmation', {
         props: {
-          urls: {
-            companyDetail: urls.companies.detail(company.id),
-            match: urls.companies.match.index(company.id),
-            matchConfirmation: urls.companies.match.confirmation(
-              company.id,
-              dunsNumber
-            ),
-          },
+          dnbCompanyIsMatched: !!dataHubCompanyId,
           company: {
+            ...pick(company, ['id', 'name', 'trading_names']),
             ...pick(company, ['name']),
             address: parseAddress(company.address, countries),
           },
           dnbCompany: {
             ...pick(dnbCompany, ['primary_name', 'duns_number']),
+            datahub_company_id: dataHubCompanyId,
             address: parseAddress(dnbCompany, countries, 'address_'),
             registered_address: parseAddress(
               dnbCompany,

--- a/src/apps/companies/apps/match-company/views/match-confirmation.njk
+++ b/src/apps/companies/apps/match-company/views/match-confirmation.njk
@@ -1,5 +1,17 @@
 {% extends "_layouts/template.njk" %}
 
+{% block local_header %}
+  {{
+    LocalHeader({
+      heading:
+        'This verified third party record has already been matched to a different Data Hub company record'
+        if props.dnbCompanyIsMatched
+        else 'Update the company record',
+      modifier: 'light-banner'
+    })
+  }}
+{% endblock %}
+
 {% block body_main_content %}
   {% component 'react-slot', {
     id: 'match-confirmation',

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -162,12 +162,10 @@ describe('Add company form', () => {
             })
 
             context(
-              'when the first company is clicked that does not exist on Data Hub',
+              'when a company is clicked that does not exist on Data Hub',
               () => {
                 before(() => {
-                  cy.get(
-                    selectors.companyAdd.entitySearch.results.someOtherCompany
-                  ).click()
+                  cy.contains('Some unmatched company').click()
                 })
 
                 it('should display "Confirm you want to add this company to Data Hub" subheader', () => {
@@ -184,7 +182,7 @@ describe('Add company form', () => {
                   )
                   cy.get(selectors.companyAdd.summary).should(
                     'contain',
-                    'Some other company'
+                    'Some unmatched company'
                   )
                 })
 

--- a/test/sandbox/fixtures/v4/dnb/company-create.json
+++ b/test/sandbox/fixtures/v4/dnb/company-create.json
@@ -20,7 +20,7 @@
   "contacts": [],
   "created_on": "2019-09-03T15:50:37.892394Z",
   "description": null,
-  "duns_number": "291332174",
+  "duns_number": "11111111",
   "employee_range": null,
   "export_experience_category": null,
   "export_to_countries": [],

--- a/test/sandbox/fixtures/v4/dnb/company-search-matched.json
+++ b/test/sandbox/fixtures/v4/dnb/company-search-matched.json
@@ -1,53 +1,9 @@
 {
-  "total_matches": 271,
-  "total_returned": 2,
+  "total_matches": 1,
+  "total_returned": 1,
   "page_size": 2,
   "page_number": 1,
   "results": [
-    {
-      "dnb_company": {
-        "duns_number": "11111111",
-        "primary_name": "Some unmatched company",
-        "trading_names": [
-          "Some unmatched company trading name"
-        ],
-        "registration_numbers": [
-          {
-            "registration_type": "uk_companies_house_number",
-            "registration_number": "00016033"
-          }
-        ],
-        "global_ultimate_duns_number": "319999999",
-        "global_ultimate_primary_name": "Some other company parent",
-        "domain": "example.co.uk",
-        "is_out_of_business": false,
-        "address_line_1": "123 ABC Road",
-        "address_line_2": "",
-        "address_town": "Brighton",
-        "address_county": "",
-        "address_postcode": "BN2 9QB",
-        "address_country": "GB",
-        "registered_address_line_1": "",
-        "registered_address_line_2": "",
-        "registered_address_town": "Brighton",
-        "registered_address_county": "",
-        "registered_address_postcode": "BN2 9QB",
-        "registered_address_country": "GB",
-        "annual_sales": 1999999999,
-        "annual_sales_currency": "USD",
-        "is_annual_sales_estimated": null,
-        "employee_number": 300,
-        "is_employees_number_estimated": true,
-        "industry_codes": [
-          {
-            "usSicV4": "3799",
-            "usSicV4Description": "Mfg transportation equipment"
-          }
-        ],
-        "legal_status": "corporation"
-      },
-      "datahub_company": null
-    },
     {
       "dnb_company": {
         "duns_number": "22222222",

--- a/test/sandbox/fixtures/v4/dnb/company-search-not-matched.json
+++ b/test/sandbox/fixtures/v4/dnb/company-search-not-matched.json
@@ -1,0 +1,52 @@
+{
+  "total_matches": 1,
+  "total_returned": 1,
+  "page_size": 2,
+  "page_number": 1,
+  "results": [
+    {
+      "dnb_company": {
+        "duns_number": "11111111",
+        "primary_name": "Some unmatched company",
+        "trading_names": [
+          "Some unmatched company trading name"
+        ],
+        "registration_numbers": [
+          {
+            "registration_type": "uk_companies_house_number",
+            "registration_number": "00016033"
+          }
+        ],
+        "global_ultimate_duns_number": "319999999",
+        "global_ultimate_primary_name": "Some other company parent",
+        "domain": "example.co.uk",
+        "is_out_of_business": false,
+        "address_line_1": "123 ABC Road",
+        "address_line_2": "",
+        "address_town": "Brighton",
+        "address_county": "",
+        "address_postcode": "BN2 9QB",
+        "address_country": "GB",
+        "registered_address_line_1": "",
+        "registered_address_line_2": "",
+        "registered_address_town": "Brighton",
+        "registered_address_county": "",
+        "registered_address_postcode": "BN2 9QB",
+        "registered_address_country": "GB",
+        "annual_sales": 1999999999,
+        "annual_sales_currency": "USD",
+        "is_annual_sales_estimated": null,
+        "employee_number": 300,
+        "is_employees_number_estimated": true,
+        "industry_codes": [
+          {
+            "usSicV4": "3799",
+            "usSicV4Description": "Mfg transportation equipment"
+          }
+        ],
+        "legal_status": "corporation"
+      },
+      "datahub_company": null
+    }
+  ]
+}

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -1,15 +1,22 @@
 var companyCreate = require('../../../fixtures/v4/dnb/company-create.json')
 var companySearch = require('../../../fixtures/v4/dnb/company-search.json')
+var companySearchMatched = require('../../../fixtures/v4/dnb/company-search-matched.json')
+var companySearchNotMatched = require('../../../fixtures/v4/dnb/company-search-not-matched.json')
 var companyCreateInvestigation = require('../../../fixtures/v4/dnb/company-create-investigation.json')
 
 exports.companyCreate = function(req, res) {
-  if (req.body.duns_number === '291332174') {
+  if (req.body.duns_number === '11111111') {
     res.json(companyCreate)
   }
 }
 
 exports.companySearch = function(req, res) {
-  res.json(companySearch)
+  if (req.body.duns_number === '11111111') {
+    return res.json(companySearchNotMatched)
+  } else if (req.body.duns_number === '22222222') {
+    return res.json(companySearchMatched)
+  }
+  return res.json(companySearch)
 }
 
 exports.companyCreateInvestigation = function(req, res) {

--- a/test/unit/data/companies/dnb/company-create.json
+++ b/test/unit/data/companies/dnb/company-create.json
@@ -20,7 +20,7 @@
   "contacts": [],
   "created_on": "2019-09-03T15:50:37.892394Z",
   "description": null,
-  "duns_number": "291332174",
+  "duns_number": "11111111",
   "employee_range": null,
   "export_experience_category": null,
   "export_to_countries": [],


### PR DESCRIPTION
## Test instructions

1. Go to the D&B company matching form at `companies/COMPANY_ID/match`
2. Search for a company
3. Click `Some matched company` from the search results
4. You should be redirected to a page titled `This Dun & Bradstreet company record has already been matched to a different Data Hub company record`

## Screenshots

![image](https://user-images.githubusercontent.com/4199239/73194857-bb95b480-4124-11ea-8936-7b24d949e39c.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
