### PR TITLE
Remove Export tab for non DIT users

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -53,6 +53,7 @@ const LOCAL_NAV = [
   {
     path: 'exports',
     label: 'Export',
+    permissions: ['company.view_companyexportcountry'],
   },
   {
     path: 'orders',

--- a/src/apps/companies/middleware/__test__/local-navigation.test.js
+++ b/src/apps/companies/middleware/__test__/local-navigation.test.js
@@ -31,6 +31,7 @@ describe('Companies local navigation', () => {
             'company.view_contact',
             'investment.view_all_investmentproject',
             'order.view_order',
+            'company.view_companyexportcountry',
           ],
         },
       })
@@ -70,6 +71,7 @@ describe('Companies local navigation', () => {
             'company.view_contact',
             'investment.view_all_investmentproject',
             'order.view_order',
+            'company.view_companyexportcountry',
           ],
         },
       })
@@ -111,6 +113,7 @@ describe('Companies local navigation', () => {
               'company.view_contact',
               'investment.view_all_investmentproject',
               'order.view_order',
+              'company.view_companyexportcountry',
             ],
           },
         })
@@ -147,6 +150,7 @@ describe('Companies local navigation', () => {
             'company.view_contact',
             'investment.view_all_investmentproject',
             'order.view_order',
+            'company.view_companyexportcountry',
           ],
         },
       })

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -20,7 +20,6 @@ describe('DA Permission', () => {
         'Company contacts',
         'Core team',
         'Investment',
-        'Export',
         'Orders',
       ])
     })

--- a/test/end-to-end/cypress/specs/DA/permission-spec.js
+++ b/test/end-to-end/cypress/specs/DA/permission-spec.js
@@ -1,4 +1,5 @@
 const {
+  companies,
   contacts,
   events,
   interactions,
@@ -9,6 +10,24 @@ const {
 const { assertError } = require('../../support/assertions')
 
 describe('DA Permission', () => {
+  describe('companies', () => {
+    describe('exports', () => {
+      before(() => {
+        cy.visit(
+          companies.exports.index('0fb3379c-341c-4da4-b825-bf8d47b26baa'),
+          {
+            failOnStatusCode: false,
+          }
+        )
+      })
+
+      it('should prevent DA users from accessing the page', () => {
+        assertError('You don’t have permission to view this page')
+        assertError('403')
+      })
+    })
+  })
+
   describe('event', () => {
     before(() => {
       cy.visit(events.index(), { failOnStatusCode: false })

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -20,7 +20,6 @@ describe('LEP Permission', () => {
         'Company contacts',
         'Core team',
         'Investment',
-        'Export',
       ])
     })
   })

--- a/test/end-to-end/cypress/specs/LEP/permission-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/permission-spec.js
@@ -11,16 +11,34 @@ const {
 const { assertError } = require('../../support/assertions')
 
 describe('LEP Permission', () => {
-  describe('orders', () => {
-    before(() => {
-      cy.visit(companies.orders('0fb3379c-341c-4da4-b825-bf8d47b26baa'), {
-        failOnStatusCode: false,
+  describe('companies', () => {
+    describe('orders', () => {
+      before(() => {
+        cy.visit(companies.orders('0fb3379c-341c-4da4-b825-bf8d47b26baa'), {
+          failOnStatusCode: false,
+        })
+      })
+
+      it('should prevent LEP users from accessing the page', () => {
+        assertError('You don’t have permission to view this page')
+        assertError('403')
       })
     })
 
-    it('should prevent LEP users from accessing the page', () => {
-      assertError('You don’t have permission to view this page')
-      assertError('403')
+    describe('exports', () => {
+      before(() => {
+        cy.visit(
+          companies.exports.index('0fb3379c-341c-4da4-b825-bf8d47b26baa'),
+          {
+            failOnStatusCode: false,
+          }
+        )
+      })
+
+      it('should prevent LEP users from accessing the page', () => {
+        assertError('You don’t have permission to view this page')
+        assertError('403')
+      })
     })
   })
 

--- a/test/sandbox/fixtures/whoami.json
+++ b/test/sandbox/fixtures/whoami.json
@@ -1,4 +1,4 @@
-{  
+{
     "id":"7d19d407-9aec-4d06-b190-d3f404627f21",
     "name":"DIT Staff",
     "last_login":null,
@@ -7,19 +7,19 @@
     "email":"dit_staff@datahub.com",
     "contact_email":"",
     "telephone_number":"",
-    "dit_team":{  
+    "dit_team":{
        "id":"9010dd28-9798-e211-a939-e4115bead28a",
        "name":"UKTI Team East Midlands - International Trade Team",
        "disabled_on":null,
-       "role":{  
+       "role":{
           "name":"International Trade Team",
           "id":"5e329c18-6095-e211-a939-e4115bead28a"
        },
-       "uk_region":{  
+       "uk_region":{
           "name":"East Midlands",
           "id":"844cd12a-6095-e211-a939-e4115bead28a"
        },
-       "country":{  
+       "country":{
           "name":"United Kingdom",
           "id":"80756b9a-5d95-e211-a939-e4115bead28a"
        }
@@ -88,6 +88,7 @@
                     "company_list.add_companylistitem",
                     "company_list.change_companylistitem",
                     "company_list.delete_companylistitem",
-                    "company.change_regional_account_manager"
+                    "company.change_regional_account_manager",
+                    "company.view_companyexportcountry"
                   ]
  }


### PR DESCRIPTION
## Description of change

As we enrich the data on the Export tab, we need to ensure we only show it to the relevant users. Therefore this tab is only available to users with the DIT permissions.

## Test instructions

As a DIT user you should see the Export tab, as a DA or LEP user you should not

## Screenshots
### Before

<img width="973" alt="Screenshot 2020-01-28 at 20 45 21" src="https://user-images.githubusercontent.com/1481883/73303894-24595b80-420f-11ea-92d7-b4de7e95b4fa.png">

### After
<img width="974" alt="Screenshot 2020-01-28 at 20 44 44" src="https://user-images.githubusercontent.com/1481883/73303919-2e7b5a00-420f-11ea-8ebb-e75bd882ebe3.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
