### PR TITLE
Add a prompt to match company

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -420,6 +420,7 @@ describe('Activity feed controllers', () => {
           'companies/apps/activity-feed/views/client-container',
           {
             props: {
+              companyId: 'dcdabbc9-1781-e411-8955-e4115bead28a',
               contentLink: companies.interactions.create(companyId),
               contentText: 'Add interaction',
               activityTypeFilter: FILTER_KEYS.dataHubActivity,
@@ -429,6 +430,7 @@ describe('Activity feed controllers', () => {
               isTypeFilterFlagEnabled: undefined,
               isGlobalUltimateFlagEnabled: undefined,
               dnbHierarchyCount: undefined,
+              showMatchingPrompt: undefined,
             },
           }
         )
@@ -476,6 +478,7 @@ describe('Activity feed controllers', () => {
           'companies/apps/activity-feed/views/client-container',
           {
             props: {
+              companyId: 'dcdabbc9-1781-e411-8955-e4115bead28a',
               contentLink: companies.interactions.create(companyId),
               contentText: 'Add interaction',
               activityTypeFilter: FILTER_KEYS.dataHubActivity,
@@ -485,6 +488,7 @@ describe('Activity feed controllers', () => {
               dnbHierarchyCount: 123,
               isTypeFilterFlagEnabled: undefined,
               isGlobalUltimateFlagEnabled: undefined,
+              showMatchingPrompt: undefined,
             },
           }
         )

--- a/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
+++ b/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { WarningText, Button } from 'govuk-react'
+import { BLACK } from 'govuk-colours'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
+
+import { ActivityFeedApp, StatusMessage } from 'data-hub-components'
+import urls from '../../../../../lib/urls'
+
+const StyledLink = styled('a')`
+  margin-bottom: 0;
+`
+
+const StyledExtraMessage = styled('div')`
+  margin-top: ${SPACING.SCALE_3};
+  margin-bottom: ${SPACING.SCALE_3};
+`
+
+const CompanyActivityFeed = ({ companyId, showMatchingPrompt, ...rest }) => (
+  <>
+    {showMatchingPrompt && (
+      <StatusMessage colour={BLACK}>
+        <WarningText>
+          There might be wrong information on this company page because it
+          doesn't get updated automatically.
+        </WarningText>
+        <StyledExtraMessage>
+          You can make sure it has the right information by selecting the
+          "update this record" button below.
+        </StyledExtraMessage>
+        <Button as={StyledLink} href={urls.companies.match.index(companyId)}>
+          Update this record
+        </Button>
+      </StatusMessage>
+    )}
+    <ActivityFeedApp {...rest} />
+  </>
+)
+
+CompanyActivityFeed.propTypes = {
+  companyId: PropTypes.string.isRequired,
+  contentLink: PropTypes.string,
+  contentText: PropTypes.string,
+  activityTypeFilter: PropTypes.string,
+  activityTypeFilters: PropTypes.object,
+  apiEndpoint: PropTypes.string.isRequired,
+  isGlobalUltimate: PropTypes.bool,
+  dnbHierarchyCount: PropTypes.number,
+  isTypeFilterFlagEnabled: PropTypes.bool,
+  isGlobalUltimateFlagEnabled: PropTypes.bool,
+  showMatchingPrompt: PropTypes.bool,
+}
+
+CompanyActivityFeed.defaultProps = {
+  activityTypeFilter: null,
+  activityTypeFilters: {},
+  contentLink: null,
+  contentText: null,
+  isGlobalUltimate: false,
+  dnbHierarchyCount: null,
+  isTypeFilterFlagEnabled: false,
+  isGlobalUltimateFlagEnabled: false,
+  showMatchingPrompt: false,
+}
+
+export default CompanyActivityFeed

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -12,6 +12,7 @@ async function renderActivityFeed(req, res, next) {
     const contentProps = company.archived
       ? {}
       : {
+          companyId: company.id,
           contentText: 'Add interaction',
           contentLink: companies.interactions.create(company.id),
           activityTypeFilter: FILTER_KEYS.dataHubActivity,
@@ -21,6 +22,10 @@ async function renderActivityFeed(req, res, next) {
           isTypeFilterFlagEnabled:
             features['activity-feed-type-filter-enabled'],
           isGlobalUltimateFlagEnabled: features['companies-ultimate-hq'],
+          showMatchingPrompt:
+            features['companies-matching'] &&
+            !company.duns_number &&
+            !company.pending_dnb_investigation,
         }
 
     const props = {

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -5,8 +5,8 @@ import { createStore, combineReducers, applyMiddleware } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly'
 import createSagaMiddleware from 'redux-saga'
 
-import { ActivityFeedApp } from 'data-hub-components'
 import AddCompanyForm from '../apps/companies/apps/add-company/client/AddCompanyForm'
+import CompanyActivityFeed from '../apps/companies/apps/activity-feed/client/CompanyActivityFeed'
 import EditCompanyForm from '../apps/companies/apps/edit-company/client/EditCompanyForm'
 import EditHistory from '../apps/companies/apps/edit-history/client/EditHistory'
 import FindCompany from '../apps/companies/apps/match-company/client/FindCompany'
@@ -94,7 +94,7 @@ function App() {
         )}
       </Mount>
       <Mount selector="#activity-feed-app">
-        {(props) => <ActivityFeedApp {...props} />}
+        {(props) => <CompanyActivityFeed {...props} />}
       </Mount>
       <Mount selector="#my-companies">
         <CompanyLists />

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -1,6 +1,6 @@
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
-const { companyMatch, localHeader } = require('../../../../selectors')
+const selectors = require('../../../../selectors')
 const {
   assertLocalHeader,
   assertBreadcrumbs,
@@ -10,8 +10,8 @@ const {
 const DUNS_NUMBER = '111222333'
 
 const performSearch = (companyName = 'some company') => {
-  cy.get(companyMatch.find.companyNameInput).type(companyName)
-  cy.get(companyMatch.find.button).click()
+  cy.get(selectors.companyMatch.find.companyNameInput).type(companyName)
+  cy.get(selectors.companyMatch.find.button).click()
 }
 
 describe('Match a company', () => {
@@ -34,28 +34,28 @@ describe('Match a company', () => {
     })
 
     it('should render the sub header', () => {
-      cy.get(companyMatch.subHeader).should(
+      cy.get(selectors.companyMatch.subHeader).should(
         'have.text',
         'Find the company record in the Dun & Bradstreet database'
       )
     })
 
     it('should render a "Company name" label', () => {
-      cy.get(companyMatch.find.companyNameLabel).should(
+      cy.get(selectors.companyMatch.find.companyNameLabel).should(
         'have.text',
         'Company name'
       )
     })
 
     it('should render a "Company postcode (optional)" label', () => {
-      cy.get(companyMatch.find.postcodeLabel).should(
+      cy.get(selectors.companyMatch.find.postcodeLabel).should(
         'have.text',
         'Company postcode (optional)'
       )
     })
 
     it('should display a "Find company" button', () => {
-      cy.get(companyMatch.find.button).should('be.visible')
+      cy.get(selectors.companyMatch.find.button).should('be.visible')
     })
   })
 
@@ -67,15 +67,17 @@ describe('Match a company', () => {
       })
 
       it('should display error message', () => {
-        cy.get(companyMatch.find.button)
+        cy.get(selectors.companyMatch.find.button)
           .click()
-          .get(companyMatch.form)
+          .get(selectors.companyMatch.form)
           .contains('Enter company name')
       })
 
       it('should not display the search results', () => {
-        cy.get(companyMatch.find.results.someCompany).should('not.be.visible')
-        cy.get(companyMatch.find.results.someOtherCompany).should(
+        cy.get(selectors.companyMatch.find.results.someCompany).should(
+          'not.be.visible'
+        )
+        cy.get(selectors.companyMatch.find.results.someOtherCompany).should(
           'not.be.visible'
         )
       })
@@ -87,12 +89,19 @@ describe('Match a company', () => {
     () => {
       before(() => {
         cy.visit(urls.companies.match.index(fixtures.company.venusLtd.id))
-        performSearch()
+        cy.get(selectors.companyMatch.find.companyNameInput).type(
+          'some company'
+        )
+        cy.get(selectors.companyMatch.find.button).click()
       })
 
       it('should display the company search results', () => {
-        cy.get(companyMatch.find.results.someCompany).should('be.visible')
-        cy.get(companyMatch.find.results.someOtherCompany).should('be.visible')
+        cy.get(selectors.companyMatch.find.results.someCompany).should(
+          'be.visible'
+        )
+        cy.get(selectors.companyMatch.find.results.someOtherCompany).should(
+          'be.visible'
+        )
       })
     }
   )
@@ -100,8 +109,9 @@ describe('Match a company', () => {
   context('when one of the search results is clicked', () => {
     before(() => {
       cy.visit(urls.companies.match.index(fixtures.company.dnbCorp.id))
-      performSearch()
-      cy.get(companyMatch.find.results.someCompany).click()
+      cy.get(selectors.companyMatch.find.companyNameInput).type('some company')
+      cy.get(selectors.companyMatch.find.button).click()
+      cy.get(selectors.companyMatch.find.results.someCompany).click()
     })
 
     it('should redirect to the the match confirmation page', () => {
@@ -182,7 +192,7 @@ describe('Match a company', () => {
     })
 
     it('displays the "Company record update request sent" flash message', () => {
-      cy.get(localHeader().flash).should(
+      cy.get(selectors.localHeader().flash).should(
         'contain.text',
         'Company record update request sent'
       )

--- a/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+++ b/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
@@ -42,5 +42,9 @@
   {
     "code": "interaction-add-countries",
     "is_active": true
+  },
+  {
+    "code": "companies-matching",
+    "is_active": true
   }
 ]

--- a/test/sandbox/fixtures/v4/company/company-investigation-ltd.json
+++ b/test/sandbox/fixtures/v4/company/company-investigation-ltd.json
@@ -20,7 +20,7 @@
   "contacts": [],
   "created_on": "2019-09-03T15:50:37.892394Z",
   "description": null,
-  "duns_number": "291332174",
+  "duns_number": null,
   "employee_range": null,
   "export_experience_category": null,
   "export_to_countries": [],


### PR DESCRIPTION
## Description of change

Add a message to the company page encouraging user to match a company with D&B records.

## Test instructions

1. Go to the company page which hasn't been matched yet
2. Message box should appear above the activity feed

## Screenshots

![image](https://user-images.githubusercontent.com/4199239/73387192-13b8ec00-42c8-11ea-9037-0bc8ebeeda01.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
