### PR TITLE
Fix: use new api for company exports

### DIFF
--- a/src/apps/companies/__test__/repos.test.js
+++ b/src/apps/companies/__test__/repos.test.js
@@ -1,15 +1,20 @@
 /* eslint prefer-promise-reject-errors: 0 */
 const proxyquire = require('proxyquire')
+const faker = require('faker')
 
 const companyData = require('../../../../test/unit/data/company.json')
 const companyV4Data = require('../../../../test/unit/data/companies/company-v4.json')
 const myCompanyListData = require('../../../../test/unit/data/companies/my-company-list.json')
 const config = require('../../../config')
+const {
+  generateExportCountries,
+} = require('../../../../test/unit/helpers/generate-export-countries')
 
 const {
   getDitCompany,
   saveDnbCompany,
   saveDnbCompanyInvestigation,
+  saveCompanyExportDetails,
 } = require('../repos')
 
 function makeRepositoryWithAuthRequest(authorisedRequestStub) {
@@ -159,6 +164,26 @@ describe('Company repository', () => {
       const actual = await saveDnbCompanyInvestigation('1234', { name: 'name' })
 
       expect(actual).to.deep.equal({ hello: true })
+    })
+  })
+
+  describe('#saveCompanyExportDetails', () => {
+    it('should respond successfully', async () => {
+      const companyId = companyV4Data.id
+      const { exportCountries } = generateExportCountries()
+      const details = {
+        export_countries: exportCountries,
+      }
+
+      nock(config.apiRoot)
+        .patch(`/v4/company/${companyId}/export-detail`, details)
+        .reply(200, {
+          countries: true,
+        })
+
+      const actual = await saveCompanyExportDetails('1234', companyId, details)
+
+      expect(actual).to.deep.equal({ countries: true })
     })
   })
 })

--- a/src/apps/companies/__test__/repos.test.js
+++ b/src/apps/companies/__test__/repos.test.js
@@ -23,20 +23,23 @@ function makeRepositoryWithAuthRequest(authorisedRequestStub) {
 describe('Company repository', () => {
   describe('Save company', () => {
     describe('Make correct call to API', () => {
+      let authorisedRequestStub
+      let repo
+
       beforeEach(() => {
-        this.authorisedRequestStub = sinon.stub().resolves({
+        authorisedRequestStub = sinon.stub().resolves({
           id: 'TEST_TOKEN',
           name: 'fred',
         })
-        this.repo = makeRepositoryWithAuthRequest(this.authorisedRequestStub)
+        repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
       })
 
       it('should call the API with a PATCH if an ID is provided.', async () => {
-        await this.repo.saveCompany('TEST_TOKEN', {
+        await repo.saveCompany('TEST_TOKEN', {
           id: 'TEST_TOKEN',
           name: 'fred',
         })
-        expect(this.authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+        expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
           body: { id: 'TEST_TOKEN', name: 'fred' },
           method: 'PATCH',
           url: `${config.apiRoot}/v4/company/TEST_TOKEN`,
@@ -44,8 +47,8 @@ describe('Company repository', () => {
       })
 
       it('should call the API with a POST if no ID is provided.', async () => {
-        await this.repo.saveCompany('TEST_TOKEN', { name: 'fred' })
-        expect(this.authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+        await repo.saveCompany('TEST_TOKEN', { name: 'fred' })
+        expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
           body: { name: 'fred' },
           method: 'POST',
           url: `${config.apiRoot}/v4/company`,
@@ -55,47 +58,44 @@ describe('Company repository', () => {
   })
 
   describe('Update company', () => {
-    beforeEach(() => {
-      this.authorisedRequestStub = sinon.stub().resolves(companyData)
-      this.repo = makeRepositoryWithAuthRequest(this.authorisedRequestStub)
-    })
-
     it('should make the correct call to the API', async () => {
-      await this.repo.updateCompany('TEST_TOKEN', '999', {
+      const authorisedRequestStub = sinon.stub().resolves(companyData)
+      const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
+
+      await repo.updateCompany('TEST_TOKEN', '999', {
         global_headquarters: '1',
       })
-      expect(this.authorisedRequestStub).to.be.calledOnceWithExactly(
-        'TEST_TOKEN',
-        {
-          url: `${config.apiRoot}/v4/company/999`,
-          method: 'PATCH',
-          body: {
-            global_headquarters: '1',
-          },
-        }
-      )
+
+      expect(authorisedRequestStub).to.be.calledOnceWithExactly('TEST_TOKEN', {
+        url: `${config.apiRoot}/v4/company/999`,
+        method: 'PATCH',
+        body: {
+          global_headquarters: '1',
+        },
+      })
     })
   })
 
   describe('#getDitCompany', () => {
-    beforeEach(() => {
+    it('should return company', async () => {
       nock(config.apiRoot)
         .get(`/v4/company/${companyV4Data.id}`)
         .reply(200, companyV4Data)
-    })
 
-    it('should return company', async () => {
       const company = await getDitCompany('TEST_TOKEN', companyV4Data.id)
+
       expect(company).to.deep.equal(companyV4Data)
     })
   })
 
   describe('#getDitCompanyFromList', () => {
     it('should call the API with a GET to see if the company exists in the list', async () => {
-      this.authorisedRequestStub = sinon.stub()
-      this.repo = makeRepositoryWithAuthRequest(this.authorisedRequestStub)
-      await this.repo.getDitCompanyFromList('TEST_TOKEN', myCompanyListData.id)
-      expect(this.authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+      const authorisedRequestStub = sinon.stub()
+      const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
+
+      await repo.getDitCompanyFromList('TEST_TOKEN', myCompanyListData.id)
+
+      expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
         method: 'GET',
         url: `${config.apiRoot}/v4/user/company-list/${myCompanyListData.id}`,
       })
@@ -104,10 +104,12 @@ describe('Company repository', () => {
 
   describe('#addDitCompanyToList', () => {
     it('should call the API with a PUT to add company to the list', async () => {
-      this.authorisedRequestStub = sinon.stub()
-      this.repo = makeRepositoryWithAuthRequest(this.authorisedRequestStub)
-      await this.repo.addDitCompanyToList('TEST_TOKEN', myCompanyListData.id)
-      expect(this.authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+      const authorisedRequestStub = sinon.stub()
+      const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
+
+      await repo.addDitCompanyToList('TEST_TOKEN', myCompanyListData.id)
+
+      expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
         method: 'PUT',
         url: `${config.apiRoot}/v4/user/company-list/${myCompanyListData.id}`,
       })
@@ -116,13 +118,12 @@ describe('Company repository', () => {
 
   describe('#removeDitCompanyToList', () => {
     it('should call the API with a DELETE to remove company from the list', async () => {
-      this.authorisedRequestStub = sinon.stub()
-      this.repo = makeRepositoryWithAuthRequest(this.authorisedRequestStub)
-      await this.repo.removeDitCompanyFromList(
-        'TEST_TOKEN',
-        myCompanyListData.id
-      )
-      expect(this.authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+      const authorisedRequestStub = sinon.stub()
+      const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
+
+      await repo.removeDitCompanyFromList('TEST_TOKEN', myCompanyListData.id)
+
+      expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
         method: 'DELETE',
         url: `${config.apiRoot}/v4/user/company-list/${myCompanyListData.id}`,
       })
@@ -130,7 +131,7 @@ describe('Company repository', () => {
   })
 
   describe('#saveDnbCompany', () => {
-    beforeEach(async () => {
+    it('should respond successfully', async () => {
       nock(config.apiRoot)
         .post('/v4/dnb/company-create', {
           duns_number: '123',
@@ -139,16 +140,14 @@ describe('Company repository', () => {
           hello: true,
         })
 
-      this.actual = await saveDnbCompany('1234', '123')
-    })
+      const actual = await saveDnbCompany('1234', '123')
 
-    it('should respond successfully', () => {
-      expect(this.actual).to.deep.equal({ hello: true })
+      expect(actual).to.deep.equal({ hello: true })
     })
   })
 
   describe('#saveDnbCompanyInvestigation', () => {
-    beforeEach(async () => {
+    it('should respond successfully', async () => {
       nock(config.apiRoot)
         .post('/v4/dnb/company-create-investigation', {
           name: 'name',
@@ -157,11 +156,9 @@ describe('Company repository', () => {
           hello: true,
         })
 
-      this.actual = await saveDnbCompanyInvestigation('1234', { name: 'name' })
-    })
+      const actual = await saveDnbCompanyInvestigation('1234', { name: 'name' })
 
-    it('should respond successfully', () => {
-      expect(this.actual).to.deep.equal({ hello: true })
+      expect(actual).to.deep.equal({ hello: true })
     })
   })
 })

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -122,6 +122,14 @@ function saveDnbCompanyInvestigation(token, company) {
   })
 }
 
+function saveCompanyExportDetails(token, companyId, body) {
+  return authorisedRequest(token, {
+    body,
+    url: `${config.apiRoot}/v4/company/${companyId}/export-detail`,
+    method: 'PATCH',
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
@@ -137,4 +145,5 @@ module.exports = {
   getOneListGroupCoreTeam,
   saveDnbCompany,
   saveDnbCompanyInvestigation,
+  saveCompanyExportDetails,
 }


### PR DESCRIPTION
## Description of change

- API has changed based on feedback on the BE PR, this is to reflect those changes
- refactor the controller to stop sending the whole company back to the API
- refactor the tests to remove `this`

## Test instructions

Feature flag: `interaction-add-countries`

### Feature flag off:
No change

### Feature flag on
Edit the export countries of a company and save. The changes should be reflected after a save and no errors should be thrown, apart from when you try and add the same county to more than one category

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
