### PR TITLE
Prepopulate company match search form with company data

### DIFF
--- a/src/apps/companies/apps/match-company/client/FindCompany.jsx
+++ b/src/apps/companies/apps/match-company/client/FindCompany.jsx
@@ -13,7 +13,12 @@ import {
 
 function FindCompany({ company, csrfToken }) {
   return (
-    <Form>
+    <Form
+      initialValues={{
+        dnbCompanyName: company.name,
+        dnbPostalCode: company.postcode,
+      }}
+    >
       <H4 as="h2">Existing Data Hub company record</H4>
       <InsetText>
         <SummaryList
@@ -58,6 +63,7 @@ FindCompany.propTypes = {
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     address: PropTypes.arrayOf(PropTypes.string),
+    postcode: PropTypes.string.isRequired,
     countryCode: PropTypes.string.isRequired,
   }),
 }

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -179,6 +179,7 @@ async function renderFindCompanyForm(req, res, next) {
           company: {
             ...pick(company, ['id', 'name']),
             address: parseAddress(company.address, countries),
+            postcode: get(company, 'address.postcode'),
             countryCode: getCountryCode(company, countries),
           },
         },

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -10,7 +10,9 @@ const {
 const DUNS_NUMBER = '111222333'
 
 const performSearch = (companyName = 'some company') => {
-  cy.get(selectors.companyMatch.find.companyNameInput).type(companyName)
+  cy.get(selectors.companyMatch.find.companyNameInput)
+    .clear()
+    .type(companyName)
   cy.get(selectors.companyMatch.find.button).click()
 }
 
@@ -67,6 +69,19 @@ describe('Match a company', () => {
         .contains('Find company')
         .and('have.prop', 'tagName', 'BUTTON')
     })
+
+    it('should prepopulate company name and postcode text fields', () => {
+      cy.get(selectors.companyMatch.find.companyNameInput).should(
+        'have.attr',
+        'value',
+        fixtures.company.venusLtd.name
+      )
+      cy.get(selectors.companyMatch.find.postcodeField).should(
+        'have.attr',
+        'value',
+        fixtures.company.venusLtd.address.postcode
+      )
+    })
   })
 
   context(
@@ -77,6 +92,7 @@ describe('Match a company', () => {
       })
 
       it('should display error message', () => {
+        cy.get(selectors.companyMatch.find.companyNameInput).clear()
         cy.get(selectors.companyMatch.find.button)
           .click()
           .get(selectors.companyMatch.form)
@@ -99,10 +115,7 @@ describe('Match a company', () => {
     () => {
       before(() => {
         cy.visit(urls.companies.match.index(fixtures.company.venusLtd.id))
-        cy.get(selectors.companyMatch.find.companyNameInput).type(
-          'some company'
-        )
-        cy.get(selectors.companyMatch.find.button).click()
+        performSearch()
       })
 
       it('should display the company search results', () => {
@@ -119,8 +132,7 @@ describe('Match a company', () => {
   context('when one of the search results is clicked', () => {
     before(() => {
       cy.visit(urls.companies.match.index(fixtures.company.dnbCorp.id))
-      cy.get(selectors.companyMatch.find.companyNameInput).type('some company')
-      cy.get(selectors.companyMatch.find.button).click()
+      performSearch()
       cy.get(selectors.companyMatch.find.results.someCompany).click()
     })
 


### PR DESCRIPTION
## Description of change

So the user doesn't have to type the company name and the postcode.

## Test instructions

1. Go to the "Add company form"
2. Check if the company name and postcode were populated on the company search form