### PR TITLE
Add the existing DH record to the "Find this company record" form

### DIFF
--- a/src/apps/companies/apps/match-company/client/FindCompany.jsx
+++ b/src/apps/companies/apps/match-company/client/FindCompany.jsx
@@ -1,14 +1,30 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { H3 } from '@govuk-react/heading'
+import { H4 } from '@govuk-react/heading'
+import InsetText from '@govuk-react/inset-text'
 
 import urls from '../../../../../lib/urls'
-import { EntityListItem, FieldDnbCompany, Form } from 'data-hub-components'
+import {
+  EntityListItem,
+  FieldDnbCompany,
+  Form,
+  SummaryList,
+} from 'data-hub-components'
 
 function FindCompany({ company, csrfToken }) {
   return (
     <Form>
-      <H3>Find the company record in the Dun & Bradstreet database</H3>
+      <H4 as="h2">Existing Data Hub company record</H4>
+      <InsetText>
+        <SummaryList
+          rows={[
+            { label: 'Company name', value: company.name },
+            { label: 'Located at', value: company.address.join(', ') },
+          ]}
+        />
+      </InsetText>
+
+      <H4 as="h2">Find the verified third party company record</H4>
       <FieldDnbCompany
         apiEndpoint={`${urls.companies.match.index(
           company.id
@@ -40,6 +56,8 @@ FindCompany.propTypes = {
   csrfToken: PropTypes.string.isRequired,
   company: PropTypes.shape({
     id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    address: PropTypes.arrayOf(PropTypes.string),
     countryCode: PropTypes.string.isRequired,
   }),
 }

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -177,7 +177,8 @@ async function renderFindCompanyForm(req, res, next) {
       .render('companies/apps/match-company/views/find-company', {
         props: {
           company: {
-            ...pick(company, ['id']),
+            ...pick(company, ['id', 'name']),
+            address: parseAddress(company.address, countries),
             countryCode: getCountryCode(company, countries),
           },
         },

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -20,10 +20,6 @@ describe('Match a company', () => {
       cy.visit(urls.companies.match.index(fixtures.company.venusLtd.id))
     })
 
-    it('should render the header', () => {
-      assertLocalHeader('Find this company record')
-    })
-
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
@@ -33,29 +29,43 @@ describe('Match a company', () => {
       })
     })
 
-    it('should render the sub header', () => {
-      cy.get(selectors.companyMatch.subHeader).should(
-        'have.text',
-        'Find the company record in the Dun & Bradstreet database'
-      )
+    it('should render the header', () => {
+      assertLocalHeader('Find this company record')
     })
 
-    it('should render a "Company name" label', () => {
-      cy.get(selectors.companyMatch.find.companyNameLabel).should(
-        'have.text',
-        'Company name'
-      )
+    it('should render the Data Hub record', () => {
+      cy.contains('Existing Data Hub company record')
+        .should('have.prop', 'tagName', 'H2')
+        .next()
+        .find('dl')
+        .then(($el) =>
+          assertSummaryList($el, {
+            'Company name': 'Venus Ltd',
+            'Located at': '66 Marcham Road, Bordley, BD23 8RZ, United Kingdom',
+          })
+        )
     })
 
-    it('should render a "Company postcode (optional)" label', () => {
-      cy.get(selectors.companyMatch.find.postcodeLabel).should(
-        'have.text',
-        'Company postcode (optional)'
-      )
-    })
-
-    it('should display a "Find company" button', () => {
-      cy.get(selectors.companyMatch.find.button).should('be.visible')
+    it('should render both search input fields and a button', () => {
+      cy.contains('Find the verified third party company record')
+        .and('have.prop', 'tagName', 'H2')
+        .next()
+        .children()
+        .first()
+        .should('have.text', 'Company name')
+        .find('input')
+        .should('have.attr', 'type', 'search')
+        .parent()
+        .parent()
+        .next()
+        .should('have.text', 'Company postcode (optional)')
+        .find('input')
+        .should('have.attr', 'type', 'search')
+        .parent()
+        .parent()
+        .next()
+        .contains('Find company')
+        .and('have.prop', 'tagName', 'BUTTON')
     })
   })
 


### PR DESCRIPTION
## Update the form to include the DH record.
This adds the existing Data Hub record to the "Find this company record" form.

## Test instructions
_/companies/id/match_

## Screenshots
### Before

<img width="1002" alt="before" src="https://user-images.githubusercontent.com/964268/73545739-d5d8d680-4433-11ea-9f63-0e7a3f5fc6d1.png">

### After
<img width="915" alt="after" src="https://user-images.githubusercontent.com/964268/73545743-d7a29a00-4433-11ea-980d-9ee89ba4cdb8.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
