### PR TITLE
Matching interface content change

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^3.7.1",
+    "data-hub-components": "^3.7.2",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -52,41 +52,26 @@ function MatchConfirmation({ company, dnbCompany, urls, csrfToken }) {
             <InsetText>
               <SummaryList
                 rows={[
-                  { label: 'Registered company name', value: company.name },
-                  { label: 'Trading name(s)', value: company.trading_names },
+                  { label: 'Company name', value: company.name },
                   {
                     label: 'Located at',
                     value: company.address.join(', '),
-                  },
-                  {
-                    label: 'Registered address',
-                    value: company.registered_address.join(', '),
                   },
                 ]}
               />
             </InsetText>
 
-            <H4 as="h2">
-              With the information from this Dun &amp; Bradstreet company record
-            </H4>
+            <H4 as="h2">With this verified third party company information</H4>
             <InsetText>
               <SummaryList
                 rows={[
                   {
-                    label: 'Registered company name',
+                    label: 'Company name',
                     value: dnbCompany.primary_name,
-                  },
-                  {
-                    label: 'Trading name(s)',
-                    value: dnbCompany.trading_names,
                   },
                   {
                     label: 'Located at',
                     value: dnbCompany.address.join(', '),
-                  },
-                  {
-                    label: 'Registered address',
-                    value: dnbCompany.registered_address.join(', '),
                   },
                 ]}
               />
@@ -118,13 +103,10 @@ function MatchConfirmation({ company, dnbCompany, urls, csrfToken }) {
 MatchConfirmation.props = {
   company: PropTypes.shape({
     name: PropTypes.string,
-    trading_names: PropTypes.string,
     address: PropTypes.arrayOf(PropTypes.string),
-    registered_address: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   dnbCompany: PropTypes.shape({
     primary_name: PropTypes.string,
-    trading_names: PropTypes.string,
     duns_number: PropTypes.string,
     address: PropTypes.arrayOf(PropTypes.string),
     registered_address: PropTypes.arrayOf(PropTypes.string),

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -84,19 +84,11 @@ async function renderMatchConfirmation(req, res, next) {
             ),
           },
           company: {
-            ...pick(company, ['name', 'trading_names']),
+            ...pick(company, ['name']),
             address: parseAddress(company.address, countries),
-            registered_address: parseAddress(
-              company.registered_address,
-              countries
-            ),
           },
           dnbCompany: {
-            ...pick(dnbCompany, [
-              'primary_name',
-              'trading_names',
-              'duns_number',
-            ]),
+            ...pick(dnbCompany, ['primary_name', 'duns_number']),
             address: parseAddress(dnbCompany, countries, 'address_'),
             registered_address: parseAddress(
               dnbCompany,

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -255,10 +255,8 @@ describe('Match a company', () => {
         .find('dl')
         .then(($el) =>
           assertSummaryList($el, {
-            'Registered company name': 'DnB Corp',
-            'Trading name(s)': 'DnB, D&B',
+            'Company name': 'DnB Corp',
             'Located at': '1 Main Road, Rome, 001122, Italy',
-            'Registered address': '1 Main Road, Rome, 001122, Italy',
           })
         )
         .parent()
@@ -266,17 +264,15 @@ describe('Match a company', () => {
         .next()
         .should(
           'have.text',
-          'With the information from this Dun & Bradstreet company record'
+          'With this verified third party company information'
         )
         .and('have.prop', 'tagName', 'H2')
         .next()
         .find('dl')
         .then(($el) =>
           assertSummaryList($el, {
-            'Registered company name': 'Some company name',
-            'Trading name(s)': 'Some trading name',
+            'Company name': 'Some company name',
             'Located at': '123 Fake Street, Brighton, BN1 4SE, United Kingdom',
-            'Registered address': 'Brighton, BN1 4SE, United Kingdom',
           })
         )
         .parent()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4333,10 +4333,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-3.7.1.tgz#9f8cf2636cbd8c70627a308ea5c24d5544369df3"
-  integrity sha512-H7/iA32p5hcR6EmNrKaXiiiFdn1iuZC6RmgIaXe/k1o7hpGuVHCqRfYZZmA3mb5Q2V10SHIgabFOGsST0iBCVA==
+data-hub-components@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-3.7.2.tgz#0320d13610b417d4ed98f8b969a82512b506fdc7"
+  integrity sha512-gTAQmh8xFWD10C3ycI6eUAtKvBREJQ7e7biWPLs+7IKgO/zelGIGKDlIyT88eA1NDdm1EQMqX4rHVgXAw7lOTQ==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Matching interface content changes - Confirm update page

Simplified the _Confirm update_ page by removing both the **Registered address** and the **Trading name(s)**. The **Registered company name** was renamed to **Company name**

**Bump Data Hub Components to 3.7.2**

## Test instructions

_/companies/id/match/dunnsNumber

## Screenshots
### Before
<img width="888" alt="before" src="https://user-images.githubusercontent.com/964268/73551629-a7142d80-443e-11ea-857c-a1ebc0bdaedd.png">

### After
<img width="888" alt="after" src="https://user-images.githubusercontent.com/964268/73551636-aa0f1e00-443e-11ea-8704-cb4c1bad01ac.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
