### PR TITLE
Fix parsing of VCAP_SERVICES which comes as JSON string

### DIFF
--- a/src/config/__test__/envSchema.test.js
+++ b/src/config/__test__/envSchema.test.js
@@ -1,0 +1,24 @@
+const envSchema = require('../envSchema')
+
+describe('envSchema', () => {
+  it('should parse VCAP_SERVICES from a JSON string', () => {
+    const jsonString = '{"str":"ing","numb":1,"bol":false,"obj":{},"arr":[]}'
+    const { value } = envSchema.validate(
+      {
+        VCAP_SERVICES: jsonString,
+      },
+      {
+        allowUnknown: true,
+        abortEarly: false,
+      }
+    )
+
+    expect(value.VCAP_SERVICES).to.deep.equal({
+      str: 'ing',
+      numb: 1,
+      bol: false,
+      obj: {},
+      arr: [],
+    })
+  })
+})

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -1,5 +1,20 @@
 const Joi = require('@hapi/joi')
 
+const ExtendedJoi = Joi.extend((joi) => ({
+  type: 'json',
+  base: joi.object(),
+  messages: {
+    'json.invalid': '"{{#label}}" has invalid JSON format',
+  },
+  coerce(value, helpers) {
+    try {
+      return { value: JSON.parse(value) }
+    } catch (ignoreErr) {
+      return { value, errors: helpers.error('json.invalid') }
+    }
+  },
+}))
+
 /* eslint-disable prettier/prettier */
 const OAUTH2_STR = Joi.string()
   .when('OAUTH2_BYPASS_SSO', { is: false, then: Joi.required() })
@@ -131,7 +146,7 @@ const envSchema = Joi.object({
   SESSION_TTL: Joi.number().integer().default(2 * 60 * 60 * 1000),
 
   // Configuration object (JSON) of Cloud Foundry services
-  VCAP_SERVICES: Joi.object().default({}),
+  VCAP_SERVICES: ExtendedJoi.json().default({}),
 
   // Zendesk field ID used to capture user's browser
   ZEN_BROWSER: Joi.string(),


### PR DESCRIPTION
## Description of change

Fixes an error when validating `VCAP_SERVIES` which are passed as a JSON string and not as object.

This functionality was working in the previous versions of Joi but was removed in [v16](https://github.com/hapijs/joi/issues/2037).

This bug was introduced in https://github.com/uktrade/data-hub-frontend/pull/2395