### PR TITLE
Sort export country names alphabetically

### DIFF
--- a/src/apps/companies/apps/exports/__test__/transformer.test.js
+++ b/src/apps/companies/apps/exports/__test__/transformer.test.js
@@ -230,7 +230,10 @@ describe('transformCompanyToExportDetailsView', () => {
       }
 
       function getCountryText(countries) {
-        return countries.map(([, name]) => name).join(', ')
+        return countries
+          .map(([, name]) => name)
+          .sort((a, b) => a.localeCompare(b))
+          .join(', ')
       }
 
       const viewRecord = transformCompanyToExportDetailsView(company)

--- a/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
@@ -13,7 +13,10 @@ const urls = require('../../../../lib/urls')
 config.archivedDocumentsBaseUrl = 'http://base'
 
 function getCountryNames(countries) {
-  return countries.map(([, name]) => name).join(', ')
+  return countries
+    .map(([, name]) => name)
+    .sort((a, b) => a.localeCompare(b))
+    .join(', ')
 }
 
 describe('#transformInteractionResponsetoViewRecord', () => {

--- a/src/lib/group-export-countries.js
+++ b/src/lib/group-export-countries.js
@@ -15,6 +15,12 @@ module.exports = (countries) => {
         bucket.push(item.country)
       }
     })
+
+    EXPORT_INTEREST_STATUS_VALUES.forEach((status) => {
+      buckets[status] = buckets[status].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      )
+    })
   }
 
   return buckets


### PR DESCRIPTION
## Description of change

Ensure that lists of country names are display alphabetically on the export tab and interaction detail page

## Test instructions

All tests pass

## Screenshots
### Before

<img width="944" alt="Screenshot 2020-02-10 at 09 12 09" src="https://user-images.githubusercontent.com/1481883/74136133-77ef8000-4be5-11ea-9ed4-8d00f814e5bf.png">

### After

<img width="946" alt="Screenshot 2020-02-10 at 09 11 51" src="https://user-images.githubusercontent.com/1481883/74136145-7cb43400-4be5-11ea-9b4f-cfd405644643.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
