### PR TITLE
Fix adding an event attendee

### DIFF
--- a/src/apps/events/attendees/controllers/__test__/create.test.js
+++ b/src/apps/events/attendees/controllers/__test__/create.test.js
@@ -1,12 +1,16 @@
 const config = require('../../../../../config')
 const { createAttendee } = require('../create')
+
+const { NEW_COUNTRIES_FEATURE } = require('../../../../constants')
+
 const attendeesData = require('../../../../../../test/unit/data/interactions/attendees.json')
 const event = require('../../../../../../test/unit/data/events/event-data.json')
 const contact = require('../../../../../../test/unit/data/contacts/contact.json')
 
 describe('Create attendee controller', () => {
+  let req, res, next
   beforeEach(() => {
-    this.req = {
+    req = {
       params: {},
       query: {},
       session: {
@@ -18,22 +22,24 @@ describe('Create attendee controller', () => {
       flash: sinon.spy(),
     }
 
-    this.res = {
+    res = {
       breadcrumb: sinon.stub().returnsThis(),
       render: sinon.spy(),
       redirect: sinon.spy(),
-      locals: {},
+      locals: {
+        features: {},
+      },
     }
 
-    this.nextSpy = sinon.spy()
+    next = sinon.spy()
   })
 
   context(
     'when the controller is called with a valid contact and event',
     () => {
-      beforeEach(async () => {
-        this.req.params.contactId = '59c815d1-91d0-4d1f-b980-1d04157a298f'
-        this.res.locals.event = event
+      beforeEach(() => {
+        req.params.contactId = '59c815d1-91d0-4d1f-b980-1d04157a298f'
+        res.locals.event = event
 
         nock(config.apiRoot)
           .get(
@@ -45,43 +51,98 @@ describe('Create attendee controller', () => {
           })
           .get('/v3/contact/59c815d1-91d0-4d1f-b980-1d04157a298f')
           .reply(200, contact)
-          .post('/v3/interaction', {
-            contacts: ['59c815d1-91d0-4d1f-b980-1d04157a298f'],
-            company: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
-            date: '2017-11-10',
-            dit_participants: [{ adviser: '999' }],
-            event: '31a9f8bd-7796-4af4-8f8c-25450860e2d1',
-            is_event: true,
-            kind: 'service_delivery',
-            theme: 'other',
-            service: '9484b82b-3499-e211-a939-e4115bead28a',
-            subject: 'Attended A United Kingdom Get together',
-            was_policy_feedback_provided: false,
+      })
+
+      context(
+        'When the interaction-add-countries feature flag is NOT set',
+        () => {
+          beforeEach(async () => {
+            nock(config.apiRoot)
+              .post('/v3/interaction', {
+                contacts: ['59c815d1-91d0-4d1f-b980-1d04157a298f'],
+                company: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
+                date: '2017-11-10',
+                dit_participants: [{ adviser: '999' }],
+                event: '31a9f8bd-7796-4af4-8f8c-25450860e2d1',
+                is_event: true,
+                kind: 'service_delivery',
+                theme: 'other',
+                service: '9484b82b-3499-e211-a939-e4115bead28a',
+                subject: 'Attended A United Kingdom Get together',
+                was_policy_feedback_provided: false,
+              })
+              .reply(200, {})
+
+            await createAttendee(req, res, next)
           })
-          .reply(200, {})
 
-        await createAttendee(this.req, this.res, this.nextSpy)
-      })
+          it('should save an interaction', () => {
+            expect(nock.isDone()).to.be.true
+          })
 
-      it('should save an interaction', () => {
-        expect(nock.isDone()).to.be.true
-      })
+          it('should set a flash message to tell the user that the record was created', () => {
+            expect(req.flash).to.be.calledWith(
+              'success',
+              'Event attendee added - This has created a service delivery record. If required, you can view or edit the service delivery directly from the attendee record.'
+            )
+          })
 
-      it('should set a flash message to tell the user that the record was created', () => {
-        expect(this.req.flash).to.be.calledWith(
-          'success',
-          'Event attendee added - This has created a service delivery record. If required, you can view or edit the service delivery directly from the attendee record.'
-        )
-      })
+          it('should redirect the user to the attendee list', () => {
+            expect(res.redirect).to.be.calledWith(
+              '/events/31a9f8bd-7796-4af4-8f8c-25450860e2d1/attendees'
+            )
+          })
 
-      it('should redirect the user to the attendee list', () => {
-        expect(this.res.redirect).to.be.calledWith(
-          '/events/31a9f8bd-7796-4af4-8f8c-25450860e2d1/attendees'
-        )
-      })
+          it('should not call next', () => {
+            expect(next).to.not.be.called
+          })
+        }
+      )
 
-      it('should not call next', () => {
-        expect(this.nextSpy).to.not.be.called
+      context('When the interaction-add-countries feature flag is set', () => {
+        beforeEach(async () => {
+          nock(config.apiRoot)
+            .post('/v3/interaction', {
+              contacts: ['59c815d1-91d0-4d1f-b980-1d04157a298f'],
+              company: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
+              date: '2017-11-10',
+              dit_participants: [{ adviser: '999' }],
+              event: '31a9f8bd-7796-4af4-8f8c-25450860e2d1',
+              is_event: true,
+              kind: 'service_delivery',
+              theme: 'other',
+              service: '9484b82b-3499-e211-a939-e4115bead28a',
+              subject: 'Attended A United Kingdom Get together',
+              was_policy_feedback_provided: false,
+              were_countries_discussed: false,
+            })
+            .reply(200, {})
+
+          res.locals.features[NEW_COUNTRIES_FEATURE] = true
+
+          await createAttendee(req, res, next)
+        })
+
+        it('should save an interaction', () => {
+          expect(nock.isDone()).to.be.true
+        })
+
+        it('should set a flash message to tell the user that the record was created', () => {
+          expect(req.flash).to.be.calledWith(
+            'success',
+            'Event attendee added - This has created a service delivery record. If required, you can view or edit the service delivery directly from the attendee record.'
+          )
+        })
+
+        it('should redirect the user to the attendee list', () => {
+          expect(res.redirect).to.be.calledWith(
+            '/events/31a9f8bd-7796-4af4-8f8c-25450860e2d1/attendees'
+          )
+        })
+
+        it('should not call next', () => {
+          expect(next).to.not.be.called
+        })
       })
     }
   )
@@ -89,14 +150,13 @@ describe('Create attendee controller', () => {
   context(
     'when the controller is called with a valid contact but no event',
     () => {
-      beforeEach(async () => {
-        this.req.params.contactId = '59c815d1-91d0-4d1f-b980-1d04157a298f'
-        await createAttendee(this.req, this.res, this.nextSpy)
-      })
+      it('should call next', async () => {
+        req.params.contactId = '59c815d1-91d0-4d1f-b980-1d04157a298f'
 
-      it('should call next', () => {
-        expect(this.nextSpy).to.be.calledOnce
-        expect(this.nextSpy).to.be.calledWith(
+        await createAttendee(req, res, next)
+
+        expect(next).to.be.calledOnce
+        expect(next).to.be.calledWith(
           sinon.match({
             message: 'Missing eventId or contactId',
           })
@@ -108,14 +168,13 @@ describe('Create attendee controller', () => {
   context(
     'when the controller is called with a valid event but no contact',
     () => {
-      beforeEach(async () => {
-        this.res.locals.event = event
-        await createAttendee(this.req, this.res, this.nextSpy)
-      })
+      it('should call next', async () => {
+        res.locals.event = event
 
-      it('should call next', () => {
-        expect(this.nextSpy).to.be.calledOnce
-        expect(this.nextSpy).to.be.calledWith(
+        await createAttendee(req, res, next)
+
+        expect(next).to.be.calledOnce
+        expect(next).to.be.calledWith(
           sinon.match({
             message: 'Missing eventId or contactId',
           })
@@ -127,9 +186,9 @@ describe('Create attendee controller', () => {
   context(
     'when the controller is called with a valid event but an existing attendee',
     () => {
-      beforeEach(async () => {
-        this.req.params.contactId = '9b1138ab-ec7b-497f-b8c3-27fed21694ef'
-        this.res.locals.event = event
+      it('should set a flash message to tell the user that the attendee already exists', async () => {
+        req.params.contactId = '9b1138ab-ec7b-497f-b8c3-27fed21694ef'
+        res.locals.event = event
 
         nock(config.apiRoot)
           .get(
@@ -137,11 +196,9 @@ describe('Create attendee controller', () => {
           )
           .reply(200, attendeesData)
 
-        await createAttendee(this.req, this.res, this.nextSpy)
-      })
+        await createAttendee(req, res, next)
 
-      it('should set a flash message to tell the user that the attendee already exists', () => {
-        expect(this.req.flash).to.be.calledWith(
+        expect(req.flash).to.be.calledWith(
           'failure',
           'Event attendee not added - This contact has already been added as an event attendee'
         )

--- a/src/apps/events/attendees/controllers/create.js
+++ b/src/apps/events/attendees/controllers/create.js
@@ -1,5 +1,6 @@
 const { get } = require('lodash')
 
+const { NEW_COUNTRIES_FEATURE } = require('../../../constants')
 const { saveInteraction } = require('../../../interactions/repos')
 const { getContact } = require('../../../contacts/repos')
 const { fetchEventAttendees } = require('../repos')
@@ -8,7 +9,7 @@ async function createAttendee(req, res, next) {
   try {
     const { user: adviser, token } = req.session
     const contactId = req.params.contactId
-    const event = res.locals.event
+    const { event, features } = res.locals
 
     if (!event || !contactId) {
       throw new Error('Missing eventId or contactId')
@@ -19,6 +20,7 @@ async function createAttendee(req, res, next) {
       contactId,
       eventId: event.id,
     })
+
     if (attendees.count > 0) {
       req.flash(
         'failure',
@@ -45,6 +47,10 @@ async function createAttendee(req, res, next) {
       service: get(event, 'service.id'),
       subject: `Attended ${event.name}`,
       was_policy_feedback_provided: false,
+    }
+
+    if (features[NEW_COUNTRIES_FEATURE]) {
+      serviceDelivery.were_countries_discussed = false
     }
 
     await saveInteraction(token, serviceDelivery)


### PR DESCRIPTION
Add were_countries_discussed when the feature flag is on
If this is not set then the API will return a 400 as it will fail validation

## Description of change

This fixes an issue in production where attendees cannot be added to an event

## Test instructions

Go to an event and select "Attendees" and then search for one and click it. The attendee should now be added to the event. Previously this generated a 400 error

## Screenshots
### Before

<img width="877" alt="Screenshot 2020-02-10 at 14 04 38" src="https://user-images.githubusercontent.com/1481883/74156479-50f97400-4c0e-11ea-9dc1-bd90e159c905.png">


### After

<img width="982" alt="Screenshot 2020-02-10 at 14 03 26" src="https://user-images.githubusercontent.com/1481883/74156490-5656be80-4c0e-11ea-8776-2c13994f12b9.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
