### PR TITLE
Add DIT region and DIT sector selects to `add Company` journey

### DIFF
--- a/src/apps/companies/apps/add-company/__test__/controllers.test.js
+++ b/src/apps/companies/apps/add-company/__test__/controllers.test.js
@@ -238,6 +238,11 @@ describe('Add company form controllers', () => {
           .post('/v4/dnb/company-create', {
             duns_number: '123',
           })
+          .reply(200, { id: companyCreateResponse.id })
+          .patch(`/v4/company/${companyCreateResponse.id}`, {
+            uk_region: 'abc1',
+            sector: 'xyz1',
+          })
           .reply(200, companyCreateResponse)
 
         middlewareParameters = buildMiddlewareParameters({
@@ -245,6 +250,8 @@ describe('Add company form controllers', () => {
             dnbCompany: {
               duns_number: '123',
             },
+            uk_region: 'abc1',
+            sector: 'xyz1',
           },
         })
 

--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -13,6 +13,7 @@ import { FieldRadios, FieldSelect, Form, Step } from 'data-hub-components'
 import CompanyFoundStep from './CompanyFoundStep'
 import CompanyNotFoundStep from './CompanyNotFoundStep'
 import CompanySearchStep from './CompanySearchStep'
+import CompanyRegionAndSector from './CompanyRegionAndSector'
 import { ISO_CODE } from './constants'
 
 function AddCompanyForm({
@@ -102,6 +103,14 @@ function AddCompanyForm({
 
             {!values.cannotFind && (
               <CompanyFoundStep countryName={countryName} />
+            )}
+
+            {!values.cannotFind && (
+              <CompanyRegionAndSector
+                regions={regions}
+                sectors={sectors}
+                isUK={country.value === ISO_CODE.UK}
+              />
             )}
 
             {values.cannotFind && (

--- a/src/apps/companies/apps/add-company/client/CompanyFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyFoundStep.jsx
@@ -40,7 +40,7 @@ function CompanyFoundStep({ countryName }) {
   const companiesHouseNumber = getCompaniesHouseNumber(dnbCompany)
 
   return (
-    <Step name="companyDetails" forwardButton="Add company">
+    <Step name="companyDetails">
       <H3>Confirm you want to add this company to Data Hub</H3>
 
       <InsetText>

--- a/src/apps/companies/apps/add-company/client/CompanyRegionAndSector.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyRegionAndSector.jsx
@@ -1,0 +1,47 @@
+/* eslint-disable camelcase */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Step, FieldSelect } from 'data-hub-components'
+
+function CompanyRegionAndSector({ regions, sectors, isUK }) {
+  return (
+    <Step name="companyRegionAndSector" forwardButton="Add company">
+      {isUK && (
+        <FieldSelect
+          name="uk_region"
+          label="DIT region"
+          emptyOption="-- Select DIT region --"
+          options={regions}
+          required="Select DIT region"
+        />
+      )}
+
+      <FieldSelect
+        name="sector"
+        label="DIT sector"
+        emptyOption="-- Select DIT sector --"
+        options={sectors}
+        required="Select DIT sector"
+      />
+    </Step>
+  )
+}
+
+CompanyRegionAndSector.propTypes = {
+  regions: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  sectors: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  isUK: PropTypes.bool.isRequired,
+}
+
+export default CompanyRegionAndSector

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -3,9 +3,13 @@
 const { transformCountryToOptionWithIsoCode } = require('../../../transformers')
 const { fetchOrganisationTypes } = require('./repos')
 const { searchDnbCompanies } = require('../../../../modules/search/services')
-const { saveDnbCompany, saveDnbCompanyInvestigation } = require('../../repos')
 const { getOptions } = require('../../../../lib/options')
 const { transformToDnbCompanyInvestigationApi } = require('./transformers')
+const {
+  saveDnbCompany,
+  updateCompany,
+  saveDnbCompanyInvestigation,
+} = require('../../repos')
 
 async function renderAddCompanyForm(req, res, next) {
   try {
@@ -48,11 +52,16 @@ async function postSearchDnbCompanies(req, res, next) {
 }
 
 async function postAddDnbCompany(req, res, next) {
+  const { token } = req.session
+  const { uk_region, sector, dnbCompany } = req.body
+
   try {
-    const result = await saveDnbCompany(
-      req.session.token,
-      req.body.dnbCompany.duns_number
-    )
+    const company = await saveDnbCompany(token, dnbCompany.duns_number)
+    const result = await updateCompany(token, company.id, {
+      uk_region,
+      sector,
+    })
+
     req.flash('success', 'Company added to Data Hub')
     res.json(result)
   } catch (error) {

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -129,6 +129,9 @@ exports.company = function(req, res) {
 }
 
 exports.companyPatched = function(req, res) {
+  if (req.body.sector === '9738cecc-5f95-e211-a939-e4115bead28a') {
+    return res.json(companySomeOtherCompany)
+  }
   res.json(company)
 }
 

--- a/test/selectors/company/add-company.js
+++ b/test/selectors/company/add-company.js
@@ -1,4 +1,5 @@
 module.exports = {
+  title: 'header h1',
   form: 'form',
   continueButton: 'form button:contains("Continue")',
   submitButton: 'form button:contains("Add company")',
@@ -6,6 +7,8 @@ module.exports = {
   subheader: 'form p',
   stepHeader: 'form h3',
   summary: 'form dl',
+  regionSelect: 'form select#uk_region',
+  sectorSelect: 'form select#sector',
   entitySearch: {
     companyNameField: 'input[name="dnbCompanyName"]',
     postalCodeField: 'input[name="dnbPostalCode"]',


### PR DESCRIPTION
## Changes to the "Add company" journey
Previously a user would add a new company and then edit that company to define both region and sector. This improvement enforces them to define one or both as part of the "Add company" journey depending on the company location (UK/Overseas).

1. Enforce users to define both **DIT region** and a **DIT sector** when adding a new **UK company**. 
2. Enforce users to define a **DIT sector** when adding a new **Overseas company**.

## Test instructions
Go to the companies page _/companies_ and click "Add company" or go straight there: _/companies/create_

## Screenshots
### UK
<img width="812" alt="UK" src="https://user-images.githubusercontent.com/964268/74157405-24def280-4c10-11ea-9419-64a63b309bfd.png">

### Overseas
<img width="812" alt="Overseas" src="https://user-images.githubusercontent.com/964268/74157584-6ec7d880-4c10-11ea-912c-d8236a5afd1f.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
