### PR TITLE
Add back no-undef rule to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,8 @@
       {
         "max": 1
       }
-    ]
+    ],
+    "no-undef": "error"
   },
   "overrides": [
     {

--- a/src/apps/companies/apps/exports/__test__/controller.test.js
+++ b/src/apps/companies/apps/exports/__test__/controller.test.js
@@ -19,6 +19,7 @@ describe('Company export controller', () => {
   let middlewareParameters
   let controller
   let metadata
+  let transformerSpy
 
   beforeEach(() => {
     updateCompany = sinon.stub()

--- a/src/apps/companies/middleware/__test__/params.test.js
+++ b/src/apps/companies/middleware/__test__/params.test.js
@@ -53,6 +53,8 @@ describe('Companies form middleware', () => {
   })
 
   describe('getCompany', () => {
+    let expectedCompany
+
     function addFeatureFlag(res) {
       res.locals.features['interaction-add-countries'] = true
       return res


### PR DESCRIPTION
## Description of change

This setting seems to have gotten lost somewhere, adding it back so that our IDEs can flag when we are using undeclared variables.

## Test instructions

Lint tests should pass

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
