### PR TITLE
Add link to exports history from export tab

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportsIndex.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsIndex.jsx
@@ -84,6 +84,9 @@ const ExportsIndex = ({
       </Details>
 
       <H3>Export countries information</H3>
+      <Link href={urls.companies.exports.history(companyId)}>
+        View full export countries history
+      </Link>
       <StyledSummaryTable>
         {exportCountriesInformation.map(({ name, value }) => (
           <SummaryTable.Row heading={name} key={name}>
@@ -132,16 +135,10 @@ ExportsIndex.propTypes = {
     name: PropTypes.string,
     value: PropTypes.string,
   }).isRequired,
-  exportDetails: PropTypes.arrayOf(
+  exportCountriesInformation: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
-      value: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.shape({
-          url: PropTypes.string,
-          text: PropTypes.string,
-        }),
-      ]),
+      value: PropTypes.string,
     })
   ).isRequired,
   exportPotentials: PropTypes.arrayOf(
@@ -151,7 +148,11 @@ ExportsIndex.propTypes = {
     })
   ).isRequired,
   companyId: PropTypes.string.isRequired,
-  companyNumber: PropTypes.string.isRequired,
+  companyNumber: PropTypes.string,
+}
+
+ExportsIndex.defaultProps = {
+  companyNumber: null,
 }
 
 export default ExportsIndex

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -70,6 +70,14 @@ describe('Companies Export', () => {
           .should('have.text', 'Export countries information')
       })
 
+      it('should render the link to exports history', () => {
+        cy.contains('View full export countries history').should(
+          'have.attr',
+          'href',
+          urls.companies.exports.history(fixtures.company.dnbCorp.id)
+        )
+      })
+
       it('should render the "Exports countries information" table', () => {
         cy.get('th')
           .eq(3)
@@ -175,6 +183,20 @@ describe('Companies Export', () => {
           .should('have.text', 'Medium')
       })
 
+      it('should render the "Export countries information header', () => {
+        cy.get('h3')
+          .first()
+          .should('have.text', 'Export countries information')
+      })
+
+      it('should render the link to exports history', () => {
+        cy.contains('View full export countries history').should(
+          'have.attr',
+          'href',
+          urls.companies.exports.history(fixtures.company.dnbLtd.id)
+        )
+      })
+
       it('should render the "Exports countries information" table', () => {
         cy.get('th')
           .eq(3)
@@ -203,7 +225,7 @@ describe('Companies Export', () => {
       cy.visit(urls.companies.exports.index(fixtures.company.archivedLtd.id))
     })
 
-    it('the edit expor countries button should not exist', () => {
+    it('the edit export countries button should not exist', () => {
       cy.contains('Edit export countries').should('not.exist')
     })
   })


### PR DESCRIPTION
## Description of change

Add link to exports history from export tab and update functional test.

## Test instructions

A link to `View full export countries history`

## Screenshots
### Before

![FireShot Capture 039 - Exports - Hitachi Ltd  - Companies - DIT Data Hub - www datahub trade gov uk](https://user-images.githubusercontent.com/42253716/74732391-05fce380-5242-11ea-95d5-29ea6df42333.png)

### After

![FireShot Capture 040 - Exports - One List Subsidiary Ltd - Companies - DIT Data Hub - localhost](https://user-images.githubusercontent.com/42253716/74732415-1614c300-5242-11ea-9797-aa1146abbfce.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
