### PR TITLE
Better task error handling & apiTaskFactory

### DIFF
--- a/src/apps/companies/apps/add-company/client/tasks.js
+++ b/src/apps/companies/apps/add-company/client/tasks.js
@@ -1,9 +1,8 @@
 import axios from 'axios'
-
-const handleError = (e) => Promise.reject(Error(e.response.data.detail))
+import { catchApiError } from '../../../../../client/components/Task/utils'
 
 export default (postcode) =>
   axios
     .get(`/api/postcode-to-region-lookup/${postcode}`)
-    .catch(handleError)
+    .catch(catchApiError)
     .then(({ data }) => data)

--- a/src/apps/companies/apps/edit-one-list/client/tasks.js
+++ b/src/apps/companies/apps/edit-one-list/client/tasks.js
@@ -1,5 +1,4 @@
-import axios from 'axios'
-
+import { apiProxyAxios } from '../../../../../client/components/Task/utils'
 import { SAVED, API_ERROR } from './state'
 import {
   NONE,
@@ -10,8 +9,8 @@ import {
 
 export function saveOneListDetails({ values, companyId }) {
   function assignOneListTierandGlobalManagerRequest() {
-    return axios.post(
-      `/api-proxy/v4/company/${companyId}/assign-one-list-tier-and-global-account-manager`,
+    return apiProxyAxios.post(
+      `v4/company/${companyId}/assign-one-list-tier-and-global-account-manager`,
       {
         [ACCOUNT_MANAGER_FIELD_NAME]: values[ACCOUNT_MANAGER_FIELD_NAME].value,
         [TIER_FIELD_NAME]: values[TIER_FIELD_NAME],
@@ -20,7 +19,7 @@ export function saveOneListDetails({ values, companyId }) {
   }
 
   function removeFromOneList() {
-    return axios.post(`/api-proxy/v4/company/${companyId}/remove-from-one-list`)
+    return apiProxyAxios.post(`v4/company/${companyId}/remove-from-one-list`)
   }
 
   function assignCoreTeamRequest() {
@@ -28,8 +27,8 @@ export function saveOneListDetails({ values, companyId }) {
       adviser: member.value,
     }))
 
-    return axios.patch(
-      `/api-proxy/v4/company/${companyId}/update-one-list-core-team`,
+    return apiProxyAxios.patch(
+      `v4/company/${companyId}/update-one-list-core-team`,
       {
         [ONE_LIST_TEAM_FIELD_NAME]: one_list_team,
       }
@@ -37,8 +36,8 @@ export function saveOneListDetails({ values, companyId }) {
   }
 
   function removeCoreTeamRequest() {
-    return axios.patch(
-      `/api-proxy/v4/company/${companyId}/update-one-list-core-team`,
+    return apiProxyAxios.patch(
+      `v4/company/${companyId}/update-one-list-core-team`,
       {
         [ONE_LIST_TEAM_FIELD_NAME]: [],
       }

--- a/src/apps/companies/apps/exports/client/ExportCountriesEdit/tasks.js
+++ b/src/apps/companies/apps/exports/client/ExportCountriesEdit/tasks.js
@@ -21,11 +21,9 @@ export function saveExportCountries({ values, companyId }) {
       const is400 = e?.response?.status === 400
       const nonFieldMessages = is400 && e.response.data?.non_field_errors
       if (nonFieldMessages?.length) {
-        return Promise.reject({
-          message: { [API_ERROR]: nonFieldMessages.join(', ') },
-        })
+        return Promise.reject({ [API_ERROR]: nonFieldMessages.join(', ') })
       } else {
-        return Promise.reject({ message: { [API_WARN]: e.message } })
+        return Promise.reject({ [API_WARN]: e.message })
       }
     })
     .then(() => ({ [SAVED]: urls.companies.exports.index(companyId) }))

--- a/src/apps/companies/apps/exports/client/ExportWins/tasks.js
+++ b/src/apps/companies/apps/exports/client/ExportWins/tasks.js
@@ -77,13 +77,11 @@ export function fetchExportWins({ companyId, companyName, activePage }) {
 
       if ([404, 500, 502].includes(e.response?.status)) {
         return Promise.reject(
-          new Error(
-            `We were unable to lookup Export Wins for ${companyName}, please try again later.`
-          )
+          `We were unable to lookup Export Wins for ${companyName}, please try again later.`
         )
       }
 
-      return Promise.reject(new Error(e.message))
+      return Promise.reject(e.message)
     })
     .then((response) => {
       if (response[NOT_IMPLEMENTED]) {

--- a/src/apps/companies/apps/exports/client/ExportsHistory/tasks.js
+++ b/src/apps/companies/apps/exports/client/ExportsHistory/tasks.js
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { formatWithTime } from '../../../../../../client/utils/date-utils'
 import { GREEN } from 'govuk-colours'
 
@@ -9,6 +8,7 @@ import {
   EXPORT_INTEREST_STATUS_VALUES,
 } from '../../../../../constants'
 import { groupHistoryItems } from '../group-history-items'
+import { apiProxyAxios } from '../../../../../../client/components/Task/utils'
 
 const WHITELISTED_HISTORY_TYPES = ['insert', 'delete', 'update']
 
@@ -123,17 +123,11 @@ function transformFullExportHistory({ results }, activePage) {
   }
 }
 
-function handleError(e) {
-  const message = e?.response?.data?.detail || 'An unknown error occured'
-  return Promise.reject(new Error(message))
-}
-
 export function fetchExportsHistory({ companyId, countryId, activePage }) {
-  return axios
-    .post('/api-proxy/v4/search/export-country-history', {
+  return apiProxyAxios
+    .post('v4/search/export-country-history', {
       company: companyId,
       country: countryId,
     })
-    .catch(handleError)
     .then(({ data }) => transformFullExportHistory(data, activePage))
 }

--- a/src/apps/companies/apps/referrals/details/client/tasks.js
+++ b/src/apps/companies/apps/referrals/details/client/tasks.js
@@ -1,10 +1,8 @@
-const axios = require('axios')
+import { apiProxyAxios } from '../../../../../../client/components/Task/utils'
+
 const transformReferralDetails = require('../../transformer')
 
-const handleError = (e) => Promise.reject(Error(e.response.data.detail))
-
 export const fetchReferralDetails = (id) =>
-  axios
-    .get(`/api-proxy/v4/company-referral/${id}`)
-    .catch(handleError)
+  apiProxyAxios
+    .get(`v4/company-referral/${id}`)
     .then(({ data }) => transformReferralDetails(data))

--- a/src/apps/companies/apps/referrals/send-referral/client/tasks.js
+++ b/src/apps/companies/apps/referrals/send-referral/client/tasks.js
@@ -1,6 +1,6 @@
-import axios from 'axios'
 import { ID as STORE_ID } from './state'
 import getContactFromQuery from '../../../../../../client/utils/getContactFromQuery'
+import { apiProxyAxios } from '../../../../../../client/components/Task/utils'
 
 export function openContactForm({ values, url }) {
   window.sessionStorage.setItem(
@@ -36,7 +36,7 @@ export async function saveReferral({ values, companyId }) {
   window.sessionStorage.removeItem(STORE_ID)
 
   const { adviser, subject, notes, contact } = values
-  await axios.post('/api-proxy/v4/company-referral', {
+  await apiProxyAxios.post('v4/company-referral', {
     company: companyId,
     recipient: adviser.value,
     subject,

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { omit, pick } from 'lodash'
 
 import urls from '../../../../../lib/urls'
+import { catchApiError } from '../../../../../client/components/Task/utils'
 import getContactFromQuery from '../../../../../client/utils/getContactFromQuery'
 import { INTERACTION_STATUS } from '../../../constants'
 import { EXPORT_INTEREST_STATUS_VALUES, OPTION_NO } from '../../../../constants'
@@ -146,13 +147,11 @@ export function saveInteraction({ values, companyId, referralId }) {
   return request(
     values.id ? `${endpoint}/${values.id}` : endpoint,
     omit(payload, FIELDS_TO_OMIT)
-  )
+  ).catch(catchApiError)
 }
-
-const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
 export const fetchActiveEvents = () =>
   axios
     .get(urls.interactions.activeEventsData())
-    .catch(handleError)
+    .catch(catchApiError)
     .then(({ data }) => data)

--- a/src/apps/investments/views/admin/client/tasks.js
+++ b/src/apps/investments/views/admin/client/tasks.js
@@ -1,9 +1,12 @@
-const axios = require('axios')
+import { apiProxyAxios } from '../../../../../client/components/Task/utils'
 
 export function updateProjectStage({ values, projectId }) {
-  return axios.post(`/api-proxy/v3/investment/${projectId}/update-stage`, {
-    stage: {
-      id: values.projectStageId,
-    },
-  })
+  return apiProxyAxios.post(
+    `/api-proxy/v3/investment/${projectId}/update-stage`,
+    {
+      stage: {
+        id: values.projectStageId,
+      },
+    }
+  )
 }

--- a/src/apps/my-pipeline/client/api.js
+++ b/src/apps/my-pipeline/client/api.js
@@ -1,58 +1,26 @@
-import axios from 'axios'
+import { apiProxyAxios } from '../../../client/components/Task/utils'
 
-const endpoint = '/api-proxy/v4/pipeline-item'
+const endpoint = 'v4/pipeline-item'
 
-function handleSuccess(result) {
-  return result
-}
+const getPipelineItems = (filter) =>
+  apiProxyAxios.get(`${endpoint}`, { params: filter })
 
-function handleError(error) {
-  const message = error?.response?.data?.detail || error.message
-  return Promise.reject({
-    message,
-    ...error,
-  })
-}
+const getPipelineItem = (pipelineItemId) =>
+  apiProxyAxios.get(`${endpoint}/${pipelineItemId}`)
 
-function getPipelineItems(filter) {
-  return axios
-    .get(`${endpoint}`, { params: filter })
-    .then(handleSuccess, handleError)
-}
+const createPipelineItem = (values) => apiProxyAxios.post(`${endpoint}`, values)
 
-function getPipelineItem(pipelineItemId) {
-  return axios
-    .get(`${endpoint}/${pipelineItemId}`)
-    .then(handleSuccess, handleError)
-}
+const updatePipelineItem = (pipelineItemId, values) =>
+  apiProxyAxios.patch(`${endpoint}/${pipelineItemId}`, values)
 
-function createPipelineItem(values) {
-  return axios.post(`${endpoint}`, values).then(handleSuccess, handleError)
-}
+const archivePipelineItem = (pipelineItemId, values) =>
+  apiProxyAxios.post(`${endpoint}/${pipelineItemId}/archive`, values)
 
-function updatePipelineItem(pipelineItemId, values) {
-  return axios
-    .patch(`${endpoint}/${pipelineItemId}`, values)
-    .then(handleSuccess, handleError)
-}
+const unarchivePipelineItem = (pipelineItemId) =>
+  apiProxyAxios.post(`${endpoint}/${pipelineItemId}/unarchive`)
 
-function archivePipelineItem(pipelineItemId, values) {
-  return axios
-    .post(`${endpoint}/${pipelineItemId}/archive`, values)
-    .then(handleSuccess, handleError)
-}
-
-function unarchivePipelineItem(pipelineItemId) {
-  return axios
-    .post(`${endpoint}/${pipelineItemId}/unarchive`)
-    .then(handleSuccess, handleError)
-}
-
-function deletePipelineItem(pipelineItemId) {
-  return axios
-    .delete(`${endpoint}/${pipelineItemId}`)
-    .then(handleSuccess, handleError)
-}
+const deletePipelineItem = (pipelineItemId) =>
+  apiProxyAxios.delete(`${endpoint}/${pipelineItemId}`)
 
 const pipelineApi = {
   list: getPipelineItems,

--- a/src/client/components/CompanyLists/tasks.js
+++ b/src/client/components/CompanyLists/tasks.js
@@ -1,37 +1,29 @@
 import { get, pick } from 'lodash'
-import axios from 'axios'
-
-const handleError = (e) => Promise.reject(Error(e.response.data.detail))
+import { apiProxyAxios } from '../Task/utils'
 
 export const fetchCompanyLists = () =>
-  axios
-    .get('/api-proxy/v4/company-list')
-    .catch(handleError)
-    .then((res) =>
-      res.data.results.reduce(
-        (acc, { id, name }) => ({
-          ...acc,
-          [id]: name,
-        }),
-        {}
-      )
+  apiProxyAxios.get('v4/company-list').then((res) =>
+    res.data.results.reduce(
+      (acc, { id, name }) => ({
+        ...acc,
+        [id]: name,
+      }),
+      {}
     )
+  )
 
 export const fetchCompanyList = (id) =>
-  axios
-    .get(`/api-proxy/v4/company-list/${id}/item`)
-    .catch(handleError)
-    .then((res) =>
-      res.data.results.map(({ company: { id, name }, latest_interaction }) => ({
-        id,
-        name,
-        ...pick(latest_interaction, ['date', 'subject']),
-        interactionId: get(latest_interaction, 'id'),
-        ditParticipants: get(latest_interaction, 'dit_participants', []).map(
-          (x) => ({
-            name: get(x, 'adviser.name'),
-            team: get(x, 'team.name'),
-          })
-        ),
-      }))
-    )
+  apiProxyAxios.get(`v4/company-list/${id}/item`).then((res) =>
+    res.data.results.map(({ company: { id, name }, latest_interaction }) => ({
+      id,
+      name,
+      ...pick(latest_interaction, ['date', 'subject']),
+      interactionId: get(latest_interaction, 'id'),
+      ditParticipants: get(latest_interaction, 'dit_participants', []).map(
+        (x) => ({
+          name: get(x, 'adviser.name'),
+          team: get(x, 'team.name'),
+        })
+      ),
+    }))
+  )

--- a/src/client/components/ReferralList/task.js
+++ b/src/client/components/ReferralList/task.js
@@ -1,8 +1,5 @@
-import axios from 'axios'
-
+import { apiProxyAxios } from '../../components/Task/utils'
 import { SENT, RECEIVED } from './constants'
-
-const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
 const convertAdviser = ({ name, contact_email, dit_team }) => ({
   name,
@@ -12,20 +9,18 @@ const convertAdviser = ({ name, contact_email, dit_team }) => ({
 
 export default () =>
   Promise.all([
-    axios.get('/api-proxy/v4/company-referral'),
-    axios.get('/api-proxy/whoami/'),
-  ])
-    .catch(handleError)
-    .then(([{ data: { results } }, { data: { id } }]) =>
-      results.map((referral) => ({
-        companyId: referral.company.id,
-        id: referral.id,
-        subject: referral.subject,
-        companyName: referral.company.name,
-        date: referral.created_on,
-        dateAccepted: referral.completed_on,
-        sender: convertAdviser(referral.created_by),
-        recipient: convertAdviser(referral.recipient),
-        direction: referral.created_by.id === id ? SENT : RECEIVED,
-      }))
-    )
+    apiProxyAxios.get('v4/company-referral'),
+    apiProxyAxios.get('whoami/'),
+  ]).then(([{ data: { results } }, { data: { id } }]) =>
+    results.map((referral) => ({
+      companyId: referral.company.id,
+      id: referral.id,
+      subject: referral.subject,
+      companyName: referral.company.name,
+      date: referral.created_on,
+      dateAccepted: referral.completed_on,
+      sender: convertAdviser(referral.created_by),
+      recipient: convertAdviser(referral.recipient),
+      direction: referral.created_by.id === id ? SENT : RECEIVED,
+    }))
+  )

--- a/src/client/components/Task/index.jsx
+++ b/src/client/components/Task/index.jsx
@@ -52,7 +52,10 @@ const startOnRenderPropTypes = {
 /**
  * Enables starting and reading states of _registered tasks_. A _task_ is a
  * function which takes a _payload_ as its only argument and returns a
- * {Promise}. _Tasks_ are registered by passing a map of names to _tasks_ to the
+ * {Promise}. If the promise rejects with a value which is not an instance of
+ * {Error}, it will be rendered as the error message in {Task.Status}. If it
+ * rejects with an {Error} instance, the error will be rethrown.
+ * _Tasks_ are registered by passing a map of names to _tasks_ to the
  * `tasksSagaFactory` function and plugging in the resulting saga e.g.
  * To register a task that always succeeds with the value `123` under the name
  * `'foo'` you can do:

--- a/src/client/components/Task/saga.js
+++ b/src/client/components/Task/saga.js
@@ -24,13 +24,17 @@ function* taskSaga(task, action) {
     }
     yield put({ type: TASK__CLEAR, id, name })
   } catch (error) {
-    const { id, name } = action
-    yield put({
-      type: TASK__ERROR,
-      id,
-      name,
-      errorMessage: error.message,
-    })
+    if (error instanceof Error) {
+      throw error
+    } else {
+      const { id, name } = action
+      yield put({
+        type: TASK__ERROR,
+        id,
+        name,
+        errorMessage: error,
+      })
+    }
   }
 }
 

--- a/src/client/components/Task/utils.js
+++ b/src/client/components/Task/utils.js
@@ -1,4 +1,5 @@
-import { curry } from 'lodash'
+import axios from 'axios'
+import { curry, identity } from 'lodash'
 
 /**
  * A curried function which Decorates a task so, that it's progress will take
@@ -16,4 +17,23 @@ export const delay = curry((duration, task, payload) =>
     task(payload),
     new Promise((resolve) => setTimeout(resolve, duration)),
   ]).then(([result]) => result)
+)
+
+export const catchApiError = ({ response: { data } }) =>
+  Promise.reject(data.detail || data)
+
+/**
+ * A custom Axios instance for easy access to the `/api-proxy` endpoint.
+ * It has its {baseURL} set to `/api-proxy/` so you should omit that part of the
+ * path from the {url} of your request. It also handles API errors so that
+ * if used in a task of the {Task} component, the correct error message will be
+ * displayed in the {Task.Status}.
+ */
+export const apiProxyAxios = axios.create()
+apiProxyAxios.interceptors.request.use(({ url, ...config }) => ({
+  ...config,
+  url: url.startsWith('/api-proxy') ? url : url.replace(/^\/?/, '/api-proxy/'),
+}))
+apiProxyAxios.interceptors.response.use(identity, ({ response }) =>
+  Promise.reject(response.data.detail || response.statusText)
 )

--- a/test/functional/cypress/specs/pipeline/my-pipeline-archive-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-archive-spec.js
@@ -57,7 +57,7 @@ describe('Archive pipeline item form', () => {
 
     it('should render a 404 error message', () => {
       cy.contains('There is a problem')
-      cy.contains('Request failed with status code 404')
+      cy.contains('Not Found')
     })
   })
 

--- a/test/functional/cypress/specs/pipeline/my-pipeline-delete-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-delete-spec.js
@@ -38,7 +38,7 @@ describe('Delete pipeline item form', () => {
 
     it('should render a 404 error message', () => {
       cy.contains('There is a problem')
-      cy.contains('Request failed with status code 404')
+      cy.contains('Not Found')
     })
   })
 

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
@@ -36,7 +36,7 @@ describe('Pipeline edit form', () => {
 
     it('should render 404 error message', () => {
       cy.contains('There is a problem')
-      cy.contains('Request failed with status code 404')
+      cy.contains('Not Found')
     })
   })
 

--- a/test/functional/cypress/specs/pipeline/my-pipeline-unarchive-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-unarchive-spec.js
@@ -38,7 +38,7 @@ describe('Unarchive pipeline item form', () => {
 
     it('should render a 404 error message', () => {
       cy.contains('There is a problem')
-      cy.contains('Request failed with status code 404')
+      cy.contains('Not Found')
     })
   })
 


### PR DESCRIPTION
## Description of change

Improved the way `Task` component handles errors. Because of the nature of error handling in promisses, JavaScript errors were caught in the underlying saga, leaving no stack trace in the console and being displayed in the UI.

Now only promises that reject with ~string~ an instance of Error are treated like failed state, all other rejections will be rethrown. So if you want the task to end up in a UI error message, the promise must reject with a string which will be used as the error message in the UI:

```js
// These won't be caught and will log a stack trace in the console
const errorTask1 = () => undefined.foo
const errorTask2 = () => {throw Error()}
const errorTask3 = () => Promise.reject(Error())

// These will be caught in the saga and "Error message" will be rendered in the UI
const failingTask1 = () => {throw 'Error message'}
const failingTask2 = () => Promise.reject('Error message')
const failingTask2 = () => Promise.reject(123)
const failingTask2 = () => Promise.reject({toString: () => 'Error message'})
```
<img width="623" alt="Screen Shot 2020-02-21 at 12 25 46 PM" src="https://user-images.githubusercontent.com/2333157/75034607-73f51500-54a5-11ea-9fc3-dbe78de51eaf.png">

Axios requests should thus transform the axios error with:
```js
const axiosTask = () => axios.get('/api-endpoint/v4/company-lists')
  .catch(e => Promise.reject(e.response.data.detail))
```

NOTE: The `apiTaskFactory` mentioned in some of the comments was removed from this PR. Instead there is a custom `apiProxyAxios` Axios instance added which has the error handling built in.

