### PR TITLE
Create Zendesk tickets when user requests to merge companies

### DIFF
--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -30,10 +30,7 @@ const StyledList = styled(UnorderedList)`
 
 async function onMatchSubmit({ company, dnbCompany, csrfToken }) {
   await axios.post(
-    `${urls.companies.match.confirmation(
-      company.id,
-      dnbCompany.duns_number
-    )}?_csrf=${csrfToken}`,
+    `${urls.companies.match.link(company.id)}?_csrf=${csrfToken}`,
     {
       dnbCompany,
     }
@@ -48,7 +45,13 @@ function MatchConfirmation({
   csrfToken,
 }) {
   if (dnbCompanyIsMatched) {
-    return <MatchDuplicate company={company} dnbCompany={dnbCompany} />
+    return (
+      <MatchDuplicate
+        company={company}
+        dnbCompany={dnbCompany}
+        csrfToken={csrfToken}
+      />
+    )
   }
 
   return (

--- a/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
@@ -1,50 +1,74 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import axios from 'axios'
 import Link from '@govuk-react/link'
-import InsetText from '@govuk-react/inset-text'
+import ListItem from '@govuk-react/list-item'
+import { H4 } from '@govuk-react/heading'
 import styled from 'styled-components'
 import Button from '@govuk-react/button'
-import { FormActions } from 'data-hub-components'
+import { ErrorSummary, UnorderedList } from 'govuk-react'
+import { SPACING } from '@govuk-react/constants'
+import { Form, FormActions } from 'data-hub-components'
 
 import urls from '../../../../../lib/urls'
 
-const StyledRoot = styled('div')`
-  p:last-child {
-    margin-bottom: 0;
-  }
+// TODO: Reset all styles to defaults for HTML within react-slot.
+const StyledList = styled(UnorderedList)`
+  list-style-type: initial;
+  margin-bottom: ${SPACING.SCALE_6};
 `
 
-function MatchDuplicate({ company, dnbCompany }) {
-  return (
-    <StyledRoot>
-      <p>
-        This can happen when there are duplicate company records in Data Hub. To
-        resolve this, you can ask the Support Team to merge these duplicates
-        into one record.
-      </p>
-      <p>
-        You can copy and paste the following instructions in the Description
-        field of the form:
-      </p>
-      <InsetText>
-        <p>
-          <strong>Company records merge request</strong>
-        </p>
-        <p>
-          Please merge company record {company.name} ({company.id}) with company
-          record {dnbCompany.primary_name} ({dnbCompany.datahub_company_id}).
-        </p>
-      </InsetText>
+async function onFormSubmit({ company, dnbCompany, csrfToken }) {
+  await axios.post(
+    `${urls.companies.match.merge(company.id)}?_csrf=${csrfToken}`,
+    {
+      dnbCompany,
+    }
+  )
+  return urls.companies.detail(company.id)
+}
 
-      <FormActions>
-        <Button as="a" href={urls.support()}>
-          Request merge
-        </Button>
-        <Link href={urls.companies.match.index(company.id)}>
-          Back to search results
-        </Link>
-      </FormActions>
-    </StyledRoot>
+function MatchDuplicate({ company, dnbCompany, csrfToken }) {
+  return (
+    <Form onSubmit={() => onFormSubmit({ company, dnbCompany, csrfToken })}>
+      {({ submissionError }) => (
+        <>
+          {submissionError && (
+            <ErrorSummary
+              heading="There was an error merging this company"
+              description={submissionError.message}
+              errors={[]}
+            />
+          )}
+
+          <p>
+            This can happen when there are duplicate company records in Data
+            Hub. To resolve this, you can ask the Support Team to merge these
+            duplicates into one record.
+          </p>
+
+          <H4 as="h2">Requesting records merge will:</H4>
+          <StyledList>
+            <ListItem>
+              send a request to the Support Team to merge these records
+            </ListItem>
+            <ListItem>
+              preserve all recorded activity (interactions, OMIS Orders and
+              Investment Projects) and contacts from BOTH records and link them
+              to the merged record
+            </ListItem>
+            <ListItem>
+              ensure the business details are automatically updated in the
+              future
+            </ListItem>
+          </StyledList>
+          <FormActions>
+            <Button>Request merge</Button>
+            <Link href={urls.companies.match.index(company.id)}>Back</Link>
+          </FormActions>
+        </>
+      )}
+    </Form>
   )
 }
 

--- a/src/apps/companies/apps/match-company/router.js
+++ b/src/apps/companies/apps/match-company/router.js
@@ -7,12 +7,14 @@ const {
   renderMatchConfirmation,
   submitMatchRequest,
   renderCannotFindMatch,
+  submitMergeRequest,
 } = require('./controllers')
 
 router.get(urls.companies.match.index.route, renderFindCompanyForm)
 router.post(urls.companies.match.index.route, findDnbCompany)
 router.get(urls.companies.match.cannotFind.route, renderCannotFindMatch)
 router.get(urls.companies.match.confirmation.route, renderMatchConfirmation)
-router.post(urls.companies.match.confirmation.route, submitMatchRequest)
+router.post(urls.companies.match.link.route, submitMatchRequest)
+router.post(urls.companies.match.merge.route, submitMergeRequest)
 
 module.exports = router

--- a/src/apps/companies/apps/match-company/views/match-confirmation.njk
+++ b/src/apps/companies/apps/match-company/views/match-confirmation.njk
@@ -4,7 +4,7 @@
   {{
     LocalHeader({
       heading:
-        'These verified business details have already been matched to another company record'
+        'These verified business details are already being used to verify another Data Hub record'
         if props.dnbCompanyIsMatched
         else 'Send request for verification',
       modifier: 'light-banner'

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -137,6 +137,8 @@ module.exports = {
     match: {
       index: url('/companies', '/:companyId/match'),
       confirmation: url('/companies', '/:companyId/match/:dunsNumber'),
+      link: url('/companies', '/:companyId/match/link'),
+      merge: url('/companies', '/:companyId/match/merge'),
       cannotFind: url('/companies', '/:companyId/match/cannot-find'),
     },
     subsidiaries: {

--- a/test/sandbox/fixtures/v4/dnb/company-create.json
+++ b/test/sandbox/fixtures/v4/dnb/company-create.json
@@ -20,7 +20,7 @@
   "contacts": [],
   "created_on": "2019-09-03T15:50:37.892394Z",
   "description": null,
-  "duns_number": "11111111",
+  "duns_number": "111111111",
   "employee_range": null,
   "export_experience_category": null,
   "export_to_countries": [],

--- a/test/sandbox/fixtures/v4/dnb/company-search-matched.json
+++ b/test/sandbox/fixtures/v4/dnb/company-search-matched.json
@@ -6,7 +6,7 @@
   "results": [
     {
       "dnb_company": {
-        "duns_number": "22222222",
+        "duns_number": "222222222",
         "primary_name": "Some matched company",
         "trading_names": [
           "Some matched company trading name"

--- a/test/sandbox/fixtures/v4/dnb/company-search-not-matched.json
+++ b/test/sandbox/fixtures/v4/dnb/company-search-not-matched.json
@@ -6,7 +6,7 @@
   "results": [
     {
       "dnb_company": {
-        "duns_number": "11111111",
+        "duns_number": "111111111",
         "primary_name": "Some unmatched company",
         "trading_names": [
           "Some unmatched company trading name"

--- a/test/sandbox/fixtures/v4/dnb/company-search.json
+++ b/test/sandbox/fixtures/v4/dnb/company-search.json
@@ -6,7 +6,7 @@
   "results": [
     {
       "dnb_company": {
-        "duns_number": "11111111",
+        "duns_number": "111111111",
         "primary_name": "Some unmatched company",
         "trading_names": [
           "Some unmatched company trading name"
@@ -50,7 +50,7 @@
     },
     {
       "dnb_company": {
-        "duns_number": "22222222",
+        "duns_number": "222222222",
         "primary_name": "Some matched company",
         "trading_names": [
           "Some matched company trading name"

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -5,15 +5,15 @@ var companySearchNotMatched = require('../../../fixtures/v4/dnb/company-search-n
 var companyCreateInvestigation = require('../../../fixtures/v4/dnb/company-create-investigation.json')
 
 exports.companyCreate = function(req, res) {
-  if (req.body.duns_number === '11111111') {
+  if (req.body.duns_number === '111111111') {
     res.json(companyCreate)
   }
 }
 
 exports.companySearch = function(req, res) {
-  if (req.body.duns_number === '11111111') {
+  if (req.body.duns_number === '111111111') {
     return res.json(companySearchNotMatched)
-  } else if (req.body.duns_number === '22222222') {
+  } else if (req.body.duns_number === '222222222') {
     return res.json(companySearchMatched)
   }
   return res.json(companySearch)

--- a/test/unit/data/companies/dnb/company-create.json
+++ b/test/unit/data/companies/dnb/company-create.json
@@ -20,7 +20,7 @@
   "contacts": [],
   "created_on": "2019-09-03T15:50:37.892394Z",
   "description": null,
-  "duns_number": "11111111",
+  "duns_number": "111111111",
   "employee_range": null,
   "export_experience_category": null,
   "export_to_countries": [],


### PR DESCRIPTION
## Description of change

Create Zendesk tickets when users request to merge two companies. Before they had to send a support request via web form.

## Test instructions

1. Navigate to an unmatched company
2. Click "Verify business details"
3. Select a company that already exists on DH
4. Click "Request merge" on the next page
5. A Zendesk ticket should be created on our Zendesk staging env

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/4199239/75255185-6f986700-57d9-11ea-9ba3-5b6f737955a0.png)

### After

![image](https://user-images.githubusercontent.com/4199239/75255200-745d1b00-57d9-11ea-935f-0a4dd4c2c08f.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
