### PR TITLE
Move proxy to middleware and change how whitelist is applied

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -52,13 +52,6 @@ const config = {
   noCache: envVars.CACHE_ASSETS ? false : isDev,
   port: envVars.PORT,
   apiRoot: envVars.API_ROOT,
-  apiProxyWhitelist: [
-    '/v4/company-list',
-    '/v4/company-list/:id/item',
-    '/v4/search/export-country-history',
-    '/v4/company-referral/',
-    '/v4/company-referral/:id',
-  ],
   api: {
     authUrl: '/token/',
   },

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -1,0 +1,38 @@
+const proxy = require('http-proxy-middleware')
+
+const config = require('../config/')
+
+const API_PROXY_PATH = '/api-proxy'
+const WHITELIST = [
+  '/v4/company-list',
+  '/v4/company-list/:id/item',
+  '/v4/search/export-country-history',
+  '/v4/company-referral/',
+  '/v4/company-referral/:id',
+]
+
+module.exports = (app) => {
+  app.use(
+    WHITELIST.map((apiPath) => API_PROXY_PATH + apiPath),
+    proxy('/', {
+      changeOrigin: true,
+      target: config.apiRoot,
+      pathRewrite: {
+        ['^' + API_PROXY_PATH]: '',
+      },
+      onProxyReq: (proxyReq, req) => {
+        proxyReq.setHeader('authorization', `Bearer ${req.session.token}`)
+        // this is required to be able to handle POST requests and avoid a conflict with bodyParser
+        // issue here -> https://github.com/chimurai/http-proxy-middleware/issues/320
+        if (req.body) {
+          let bodyData = JSON.stringify(req.body)
+          // incase if content-type is application/x-www-form-urlencoded -> we need to change to application/json
+          proxyReq.setHeader('Content-Type', 'application/json')
+          proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData))
+          // stream the content
+          proxyReq.write(bodyData)
+        }
+      },
+    })
+  )
+}


### PR DESCRIPTION
## Description of change

Move the proxy to a separate file in middleware and bring the config to that file too. This should make it clearer where to edit anything with the proxy

Changed the routes to use Express for the whitelist filtering which allows us to use Express path syntax - I was having issues adding a new route with a UUID in it

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
