### PR TITLE
Hotfix: defend against update items in export history

### DIFF
--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -35,7 +35,9 @@ const createCountry = (item) => ({
 
 const transformFullExportHistory = ({ count, results }) => ({
   count,
-  results: results.map(createCountry),
+  results: results
+    .filter((result) => result.history_type === 'insert' || 'delete')
+    .map(createCountry),
 })
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))

--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -1,6 +1,11 @@
 import axios from 'axios'
 import { DateUtils } from 'data-hub-components'
 
+const WHITELISTED_HISTORY_TYPES = {
+  insert: 'insert',
+  delete: 'delete',
+}
+
 const COUNTRY_HISTORY_TYPE_TEXT = {
   insert: 'added to',
   delete: 'removed from',
@@ -36,7 +41,7 @@ const createCountry = (item) => ({
 const transformFullExportHistory = ({ count, results }) => ({
   count,
   results: results
-    .filter((result) => result.history_type === 'insert' || 'delete')
+    .filter((result) => WHITELISTED_HISTORY_TYPES.includes(result.history_type))
     .map(createCountry),
 })
 

--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -1,10 +1,7 @@
 import axios from 'axios'
 import { DateUtils } from 'data-hub-components'
 
-const WHITELISTED_HISTORY_TYPES = {
-  insert: 'insert',
-  delete: 'delete',
-}
+const WHITELISTED_HISTORY_TYPES = ['insert', 'delete']
 
 const COUNTRY_HISTORY_TYPE_TEXT = {
   insert: 'added to',

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -377,8 +377,7 @@ describe('Companies Export Countries', () => {
       )
     })
 
-    it('should filter out the update and show 0 results', () => {
-      cy.contains('0 results')
+    it('should filter out the update', () => {
       cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
     })
   })

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -369,4 +369,17 @@ describe('Companies Export Countries', () => {
         .should('contain', 'Date 6 Feb 2020, 3:41pm')
     })
   })
+
+  context('when the only item is an "update" item', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.exports.history(fixtures.company.dnbSubsidiary.id)
+      )
+    })
+
+    it('should filter out the update and show 0 results', () => {
+      cy.contains('0 results')
+      cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
+    })
+  })
 })

--- a/test/sandbox/fixtures/v4/export/update-only-export-history.json
+++ b/test/sandbox/fixtures/v4/export/update-only-export-history.json
@@ -1,0 +1,20 @@
+{
+  "count": 1,
+  "results": [
+    {
+      "history_user": null,
+      "country": {
+        "id": "975f66a0-5d95-e211-a939-e4115bead28a",
+        "name": "Andorra"
+      },
+      "company": {
+        "id": "960e1fa9-cc25-478c-a548-a2e2047319bb",
+        "name": "One List Subsidiary Ltd"
+      },
+      "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
+      "history_type": "update",
+      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "status": "future_interest"
+    }
+  ]
+}

--- a/test/sandbox/routes/v4/search/export.js
+++ b/test/sandbox/routes/v4/search/export.js
@@ -2,8 +2,10 @@ var fullExportHistoryPage1 = require('../../../fixtures/v4/export/full-export-hi
 var fullExportHistoryPage2 = require('../../../fixtures/v4/export/full-export-history-page-2.json')
 var emptyFullExportHistory = require('../../../fixtures/v4/export/empty-full-export-history.json')
 var unkownUserExportHistory = require('../../../fixtures/v4/export/unkown-user-export-history.json')
+var updateOnlyExportHistory = require('../../../fixtures/v4/export/update-only-export-history.json')
 var dnbCorp = require('../../../fixtures/v4/company/company-dnb-corp.json')
 var marsExportsLtd = require('../../../fixtures/v4/company/company-mars-exports-ltd.json')
+var dnbSubsidiary = require('../../../fixtures/v4/company/company-dnb-subsidiary.json')
 
 exports.fetchFullExportHistory = function(req, res) {
   if (req.body.company === dnbCorp.id) {
@@ -14,6 +16,9 @@ exports.fetchFullExportHistory = function(req, res) {
   }
   if (req.body.company === marsExportsLtd.id) {
     return res.json(unkownUserExportHistory)
+  }
+  if (req.body.company === dnbSubsidiary.id) {
+    return res.json(updateOnlyExportHistory)
   }
   return res.json(emptyFullExportHistory)
 }


### PR DESCRIPTION
## Description of change

This is a hotfix to filter out export history items that have a `history_type` of `update`. These are not meant to appear in the api and there is a ticket to fix that root problem. 

I can't fix the count number, however. That will still show the total number of items across all pages, including the updates. As I only get a maximum of ten results back at a time I can't accurately work out how many to reduce the count by. This will only be rectified when the backend fix is put in place. 

## Test instructions

You should no longer see any export history items that do not say either 'added to' or 'removed from'. 

Previously `update` items were leaking through to the frontend would appear as, for example, `Andorra currently exporting to`, i.e. without one of the verbs above. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
