### PR TITLE
Hotfix to export history count

### DIFF
--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -35,21 +35,27 @@ const createCountry = (item) => ({
   ],
 })
 
-const transformFullExportHistory = ({ count, results }) => ({
-  count,
-  results: results
-    .filter((result) => WHITELISTED_HISTORY_TYPES.includes(result.history_type))
-    .map(createCountry),
-})
+const transformFullExportHistory = ({ results }, offset) => {
+  const cleanedResults = results.filter((result) =>
+    WHITELISTED_HISTORY_TYPES.includes(result.history_type)
+  )
+  const count = cleanedResults.length + offset
+
+  return {
+    count,
+    results: cleanedResults.slice(0, 10).map(createCountry),
+  }
+}
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
-export const fetchExportsHistory = ({ companyId, activePage }) =>
-  axios
+export const fetchExportsHistory = ({ companyId, activePage }) => {
+  const offset = activePage * 10 - 10
+  return axios
     .post('/api-proxy/v4/search/export-country-history', {
       company: companyId,
-      limit: 10,
-      offset: activePage * 10 - 10,
+      offset,
     })
     .catch(handleError)
-    .then(({ data }) => transformFullExportHistory(data))
+    .then(({ data }) => transformFullExportHistory(data, offset))
+}

--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -39,10 +39,9 @@ const transformFullExportHistory = ({ results }, offset) => {
   const cleanedResults = results.filter((result) =>
     WHITELISTED_HISTORY_TYPES.includes(result.history_type)
   )
-  const count = cleanedResults.length + offset
 
   return {
-    count,
+    count: cleanedResults.length + offset,
     results: cleanedResults.slice(0, 10).map(createCountry),
   }
 }

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -378,6 +378,7 @@ describe('Companies Export Countries', () => {
     })
 
     it('should filter out the update', () => {
+      cy.contains('0 results')
       cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
     })
   })

--- a/test/sandbox/fixtures/v4/export/full-export-history-page-1.json
+++ b/test/sandbox/fixtures/v4/export/full-export-history-page-1.json
@@ -180,6 +180,42 @@
       "history_type": "insert",
       "history_date": "2020-02-06T15:41:11.796334+00:00",
       "status": "not_interested"
+    },
+    {
+      "history_user": {
+        "id": "ed5b807d-9674-4424-b954-411f4aac6db1",
+        "name": "DIT Staff"
+      },
+      "country": {
+        "id": "975f66a0-5d95-e211-a939-e4115bead28a",
+        "name": "Andorra"
+      },
+      "company": {
+        "id": "960e1fa9-cc25-478c-a548-a2e2047319bb",
+        "name": "One List Subsidiary Ltd"
+      },
+      "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
+      "history_type": "delete",
+      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "status": "future_interest"
+    },
+    {
+      "history_user": {
+        "id": "ed5b807d-9674-4424-b954-411f4aac6db1",
+        "name": "DIT Staff"
+      },
+      "country": {
+        "id": "985f66a0-5d95-e211-a939-e4115bead28a",
+        "name": "Angola"
+      },
+      "company": {
+        "id": "960e1fa9-cc25-478c-a548-a2e2047319bb",
+        "name": "One List Subsidiary Ltd"
+      },
+      "id": "3c898164-4df8-4d87-9e0a-8528753e6ad9",
+      "history_type": "insert",
+      "history_date": "2020-02-06T15:41:11.796334+00:00",
+      "status": "not_interested"
     }
   ]
 }


### PR DESCRIPTION
This is a follow up PR to https://github.com/uktrade/data-hub-frontend/pull/2454

I didn't think I could fix the count while waiting for the backend fix, but there is this slightly convoluted way to do it. 

This code is temporary and will be removed when the backend fix is ready. 