### PR TITLE
Revert "Hotfix to export history count"

### DIFF
--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -35,26 +35,21 @@ const createCountry = (item) => ({
   ],
 })
 
-const transformFullExportHistory = ({ results }, offset) => {
-  const cleanedResults = results.filter((result) =>
-    WHITELISTED_HISTORY_TYPES.includes(result.history_type)
-  )
-
-  return {
-    count: cleanedResults.length + offset,
-    results: cleanedResults.slice(0, 10).map(createCountry),
-  }
-}
+const transformFullExportHistory = ({ count, results }) => ({
+  count,
+  results: results
+    .filter((result) => WHITELISTED_HISTORY_TYPES.includes(result.history_type))
+    .map(createCountry),
+})
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
-export const fetchExportsHistory = ({ companyId, activePage }) => {
-  const offset = activePage * 10 - 10
-  return axios
+export const fetchExportsHistory = ({ companyId, activePage }) =>
+  axios
     .post('/api-proxy/v4/search/export-country-history', {
       company: companyId,
-      offset,
+      limit: 10,
+      offset: activePage * 10 - 10,
     })
     .catch(handleError)
-    .then(({ data }) => transformFullExportHistory(data, offset))
-}
+    .then(({ data }) => transformFullExportHistory(data))

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -378,7 +378,6 @@ describe('Companies Export Countries', () => {
     })
 
     it('should filter out the update', () => {
-      cy.contains('0 results')
       cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
     })
   })

--- a/test/sandbox/fixtures/v4/export/full-export-history-page-1.json
+++ b/test/sandbox/fixtures/v4/export/full-export-history-page-1.json
@@ -180,42 +180,6 @@
       "history_type": "insert",
       "history_date": "2020-02-06T15:41:11.796334+00:00",
       "status": "not_interested"
-    },
-    {
-      "history_user": {
-        "id": "ed5b807d-9674-4424-b954-411f4aac6db1",
-        "name": "DIT Staff"
-      },
-      "country": {
-        "id": "975f66a0-5d95-e211-a939-e4115bead28a",
-        "name": "Andorra"
-      },
-      "company": {
-        "id": "960e1fa9-cc25-478c-a548-a2e2047319bb",
-        "name": "One List Subsidiary Ltd"
-      },
-      "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
-      "history_type": "delete",
-      "history_date": "2020-02-06T15:41:11.802460+00:00",
-      "status": "future_interest"
-    },
-    {
-      "history_user": {
-        "id": "ed5b807d-9674-4424-b954-411f4aac6db1",
-        "name": "DIT Staff"
-      },
-      "country": {
-        "id": "985f66a0-5d95-e211-a939-e4115bead28a",
-        "name": "Angola"
-      },
-      "company": {
-        "id": "960e1fa9-cc25-478c-a548-a2e2047319bb",
-        "name": "One List Subsidiary Ltd"
-      },
-      "id": "3c898164-4df8-4d87-9e0a-8528753e6ad9",
-      "history_type": "insert",
-      "history_date": "2020-02-06T15:41:11.796334+00:00",
-      "status": "not_interested"
     }
   ]
 }


### PR DESCRIPTION
Reverts uktrade/data-hub-frontend#2455

The offset also needs to be moved to the transformer for this to work properly, otherwise the count goes up and down when you change pages on a history with `update` items. 