### PR TITLE
Referral details help button

### DIFF
--- a/src/apps/referrals/apps/details/client/ReferralDetails.jsx
+++ b/src/apps/referrals/apps/details/client/ReferralDetails.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { TEXT_COLOUR, GREY_3 } from 'govuk-colours'
 import Details from '@govuk-react/details'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import { SummaryTable, FormActions, DateUtils } from 'data-hub-components'
+import urls from '../../../../../lib/urls'
 
 import Task from '../../../../../client/components/Task'
 import { state2props } from './state'
@@ -70,6 +72,14 @@ export default connect(state2props)(
             <FormActions>
               <Button as={Link} href="/">
                 Complete referral
+              </Button>
+              <Button
+                buttonColour={GREY_3}
+                buttonTextColour={TEXT_COLOUR}
+                as={Link}
+                href={urls.referrals.help(id)}
+              >
+                I cannot complete the referral
               </Button>
               <Link href="/">Back</Link>
             </FormActions>

--- a/src/apps/referrals/apps/details/client/ReferralDetails.jsx
+++ b/src/apps/referrals/apps/details/client/ReferralDetails.jsx
@@ -7,6 +7,7 @@ import Link from '@govuk-react/link'
 import { SummaryTable, FormActions, DateUtils } from 'data-hub-components'
 import urls from '../../../../../lib/urls'
 
+import SecondaryButton from '../../../../../client/components/SecondaryButton'
 import Task from '../../../../../client/components/Task'
 import { state2props } from './state'
 
@@ -73,14 +74,9 @@ export default connect(state2props)(
               <Button as={Link} href="/">
                 Complete referral
               </Button>
-              <Button
-                buttonColour={GREY_3}
-                buttonTextColour={TEXT_COLOUR}
-                as={Link}
-                href={urls.referrals.help(id)}
-              >
+              <SecondaryButton as={Link} href={urls.referrals.help(id)}>
                 I cannot complete the referral
-              </Button>
+              </SecondaryButton>
               <Link href="/">Back</Link>
             </FormActions>
           </>

--- a/test/functional/cypress/specs/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/referrals/referral-details-spec.js
@@ -7,9 +7,7 @@ const REFERRAL_ID = 'cc5b9953-894c-44b4-a4ac-d0f6a6f6128f'
 
 describe('Referral details', () => {
   context('when viewing referral details', () => {
-    before(() => {
-      cy.visit(`/referrals/${REFERRAL_ID}`)
-    })
+    before(() => cy.visit(urls.referrals.details(REFERRAL_ID)))
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
@@ -31,11 +29,10 @@ describe('Referral details', () => {
         .as('row')
         .eq(0)
         .should('have.text', 'CompanyLambda plc')
-        .parents()
-        .find('tbody tr')
+
+      cy.get('@row')
         .eq(1)
         .should('have.text', 'ContactJohnny Cakeman')
-        .parents()
 
       cy.get('@row')
         .eq(2)

--- a/test/functional/cypress/specs/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/referrals/referral-details-spec.js
@@ -18,93 +18,68 @@ describe('Referral details', () => {
       cy.get(selectors.localHeader().heading).should('have.text', 'Referral')
     })
 
-    it('should render a caption', () => {
-      cy.get(selectors.referralDetails.table)
+    it('should render the content and elements in order', () => {
+      cy.get('#referral-details > table')
         .find('caption')
         .should('have.text', 'Referral sent - I am a subject')
-    })
-
-    it('should render company details', () => {
-      cy.get(selectors.referralDetails.table)
+        .parents()
         .find('tbody tr')
         .eq(0)
         .should('have.text', 'CompanyLambda plc')
-    })
-    it('should render contact details', () => {
-      cy.get(selectors.referralDetails.table)
+        .parents()
         .find('tbody tr')
         .eq(1)
         .should('have.text', 'ContactJohnny Cakeman')
-    })
-    it('should render sending adviser details', () => {
-      cy.get(selectors.referralDetails.table)
+        .parents()
         .find('tbody tr')
         .eq(2)
         .should(
           'have.text',
           'Sending adviserIan Leggett, caravans@campervans.com, Advanced Manufacturing Sector'
         )
-    })
-    it('should render the sending advisers email as a link', () => {
-      cy.get(selectors.referralDetails.table)
-        .find('tbody tr')
-        .eq(2)
         .find('a')
         .should('have.attr', 'href', 'mailto:caravans@campervans.com')
-    })
-    it('should render receiving adviser details', () => {
-      cy.get(selectors.referralDetails.table)
+        .parents()
         .find('tbody tr')
         .eq(3)
         .should(
           'have.text',
           'Receiving adviserBarry Oling, barry@barry.com, Aberdeen City Council'
         )
-    })
-    it('should render the receiving advisers email as a link', () => {
-      cy.get(selectors.referralDetails.table)
-        .find('tbody tr')
-        .eq(3)
         .find('a')
         .should('have.attr', 'href', 'mailto:barry@barry.com')
-    })
-    it('should render the date of the referral', () => {
-      cy.get(selectors.referralDetails.table)
+        .parents()
         .find('tbody tr')
         .eq(4)
         .should('have.text', 'Date of referral14 Feb 2020')
-    })
-    it('should render the referral notes', () => {
-      cy.get(selectors.referralDetails.table)
+        .parents()
         .find('tbody tr')
         .eq(5)
         .should('have.text', 'NotesJust a note about a referral')
-    })
-    it('should render a details section', () => {
-      cy.get(selectors.referralDetails.details)
+        .parents()
         .find('summary')
         .should('have.text', 'Why can I not edit the referral?')
-      cy.get(selectors.referralDetails.details)
-        .find('div')
+        .next()
         .should(
           'have.text',
           'This referral has been placed in the "My referrals" section on the Homepage of both the recipient and sender. If necessary contact the receiving adviser directly if any of the information has changed.'
         )
-    })
-    it('should render a button for completing a referral', () => {
-      cy.get(selectors.referralDetails.button).should(
-        'have.text',
-        'Complete referral'
-      )
-      cy.get(selectors.referralDetails.button).should('have.attr', 'href', '/')
-    })
-    it('should render a back button', () => {
-      cy.get(selectors.referralDetails.backLink).should('have.text', 'Back')
-      cy.get(selectors.referralDetails.backLink).should(
-        'have.attr',
-        'href',
-        '/'
-      )
+        .parents()
+        .find('details')
+        .next()
+        .find('a:first-child')
+        .should('have.text', 'Complete referral')
+        .parent()
+        .find('a:nth-child(2)')
+        .should('have.text', 'I cannot complete the referral')
+        .should(
+          'have.attr',
+          'href',
+          '/referrals/cc5b9953-894c-44b4-a4ac-d0f6a6f6128f/help'
+        )
+        .parent()
+        .find('a:nth-child(3)')
+        .should('have.text', 'Back')
     })
   })
 })

--- a/test/functional/cypress/specs/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/referrals/referral-details-spec.js
@@ -1,10 +1,14 @@
 const selectors = require('../../../../selectors')
 const { assertBreadcrumbs } = require('../../support/assertions')
 
+import urls from '../../../../../src/lib/urls'
+
+const REFERRAL_ID = 'cc5b9953-894c-44b4-a4ac-d0f6a6f6128f'
+
 describe('Referral details', () => {
   context('when viewing referral details', () => {
     before(() => {
-      cy.visit('/referrals/cc5b9953-894c-44b4-a4ac-d0f6a6f6128f')
+      cy.visit(`/referrals/${REFERRAL_ID}`)
     })
 
     it('should render breadcrumbs', () => {
@@ -24,6 +28,7 @@ describe('Referral details', () => {
         .should('have.text', 'Referral sent - I am a subject')
         .parents()
         .find('tbody tr')
+        .as('row')
         .eq(0)
         .should('have.text', 'CompanyLambda plc')
         .parents()
@@ -31,7 +36,8 @@ describe('Referral details', () => {
         .eq(1)
         .should('have.text', 'ContactJohnny Cakeman')
         .parents()
-        .find('tbody tr')
+
+      cy.get('@row')
         .eq(2)
         .should(
           'have.text',
@@ -39,8 +45,8 @@ describe('Referral details', () => {
         )
         .find('a')
         .should('have.attr', 'href', 'mailto:caravans@campervans.com')
-        .parents()
-        .find('tbody tr')
+
+      cy.get('@row')
         .eq(3)
         .should(
           'have.text',
@@ -48,12 +54,12 @@ describe('Referral details', () => {
         )
         .find('a')
         .should('have.attr', 'href', 'mailto:barry@barry.com')
-        .parents()
-        .find('tbody tr')
+
+      cy.get('@row')
         .eq(4)
         .should('have.text', 'Date of referral14 Feb 2020')
-        .parents()
-        .find('tbody tr')
+
+      cy.get('@row')
         .eq(5)
         .should('have.text', 'NotesJust a note about a referral')
         .parents()
@@ -72,11 +78,7 @@ describe('Referral details', () => {
         .parent()
         .find('a:nth-child(2)')
         .should('have.text', 'I cannot complete the referral')
-        .should(
-          'have.attr',
-          'href',
-          '/referrals/cc5b9953-894c-44b4-a4ac-d0f6a6f6128f/help'
-        )
+        .should('have.attr', 'href', urls.referrals.help(REFERRAL_ID))
         .parent()
         .find('a:nth-child(3)')
         .should('have.text', 'Back')


### PR DESCRIPTION
## Description of change

This is an iteration on the referrals details page #2432. Now I am adding a button for the unhappy path which is when the user is having trouble completing a referral.

Note: This button currently doesn't link to any help page. There is another PR that when merged I will be able to add the links, this is because the urls module has been modified on the other PR.

## Test instructions

You will need to visit a referral, you should then see a button with text - I cannot complete this referral

## Screenshots
![Screenshot 2020-02-27 at 14 12 13](https://user-images.githubusercontent.com/10154302/75453656-23316080-596c-11ea-838d-0759d1fc8aad.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
