### PR TITLE
Automate company match requests

### DIFF
--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -103,17 +103,11 @@ function MatchConfirmation({
               find what I'm looking for".
             </Details>
 
-            <H4 as="h2">Requesting verification will:</H4>
+            <H4 as="h2">Linking with verified business will:</H4>
             <StyledList>
               <ListItem>
                 NOT change any recorded activity (interactions, OMIS orders or
                 Investment projects)
-              </ListItem>
-              <ListItem>
-                send a request to the Support Team to verify the details
-              </ListItem>
-              <ListItem>
-                notify you when the Support Team update this record
               </ListItem>
               <ListItem>
                 ensure these business details are updated automatically in the
@@ -121,7 +115,7 @@ function MatchConfirmation({
               </ListItem>
             </StyledList>
             <FormActions>
-              <Button>Request verification</Button>
+              <Button>Link with verified business</Button>
               <Link href={urls.companies.match.index(company.id)}>Back</Link>
             </FormActions>
           </>

--- a/src/apps/companies/apps/match-company/router.js
+++ b/src/apps/companies/apps/match-company/router.js
@@ -5,7 +5,7 @@ const {
   renderFindCompanyForm,
   findDnbCompany,
   renderMatchConfirmation,
-  submitMatchRequest,
+  linkCompanies,
   renderCannotFindMatch,
   submitMergeRequest,
 } = require('./controllers')
@@ -14,7 +14,7 @@ router.get(urls.companies.match.index.route, renderFindCompanyForm)
 router.post(urls.companies.match.index.route, findDnbCompany)
 router.get(urls.companies.match.cannotFind.route, renderCannotFindMatch)
 router.get(urls.companies.match.confirmation.route, renderMatchConfirmation)
-router.post(urls.companies.match.link.route, submitMatchRequest)
+router.post(urls.companies.match.link.route, linkCompanies)
 router.post(urls.companies.match.merge.route, submitMergeRequest)
 
 module.exports = router

--- a/src/apps/companies/apps/match-company/views/match-confirmation.njk
+++ b/src/apps/companies/apps/match-company/views/match-confirmation.njk
@@ -6,7 +6,7 @@
       heading:
         'These verified business details are already being used to verify another Data Hub record'
         if props.dnbCompanyIsMatched
-        else 'Send request for verification',
+        else 'Link company record with verified business details',
       modifier: 'light-banner'
     })
   }}

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -130,6 +130,17 @@ function saveCompanyExportDetails(token, companyId, body) {
   })
 }
 
+function linkDataHubCompanyToDnBCompany(token, companyId, dunsNumber) {
+  return authorisedRequest(token, {
+    body: {
+      company_id: companyId,
+      duns_number: dunsNumber,
+    },
+    url: `${config.apiRoot}/v4/dnb/company-link`,
+    method: 'POST',
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
@@ -146,4 +157,5 @@ module.exports = {
   saveDnbCompany,
   saveDnbCompanyInvestigation,
   saveCompanyExportDetails,
+  linkDataHubCompanyToDnBCompany,
 }

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -200,7 +200,7 @@ describe('Match a company', () => {
       })
 
       it('should render the header', () => {
-        assertLocalHeader('Send request for verification')
+        assertLocalHeader('Link company record with verified business details')
       })
 
       it('should render breadcrumbs', () => {
@@ -254,11 +254,11 @@ describe('Match a company', () => {
           )
           .parent()
           .next()
-          .should('have.text', 'Requesting verification will:')
+          .should('have.text', 'Linking with verified business will:')
           .and('match', 'h2')
           .next()
           .children()
-          .should('have.length', 4)
+          .should('have.length', 2)
           .first()
           .should(
             'have.text',
@@ -267,21 +267,11 @@ describe('Match a company', () => {
           .next()
           .should(
             'have.text',
-            'send a request to the Support Team to verify the details'
-          )
-          .next()
-          .should(
-            'have.text',
-            'notify you when the Support Team update this record'
-          )
-          .next()
-          .should(
-            'have.text',
             'ensure these business details are updated automatically in the future'
           )
           .parent()
           .next()
-          .contains('Request verification')
+          .contains('Link with verified business')
           .and('match', 'button')
           .next()
           .contains('Back')
@@ -302,7 +292,7 @@ describe('Match a company', () => {
           DUNS_NUMBER_NOT_MATCHED
         )
       )
-      cy.contains('Request verification').click()
+      cy.contains('Link with verified business').click()
     })
 
     it('should redirect to the company page', () => {
@@ -312,10 +302,10 @@ describe('Match a company', () => {
       )
     })
 
-    it('displays the "Verification requested" flash message and the ID used in GA', () => {
+    it('displays the "Business details verified" flash message and the ID used in GA', () => {
       cy.contains(
-        'Verification requested.Some business details may be wrong. ' +
-          'Once verified, the warning message will disappear.'
+        'Business details verified.Thanks for helping to improve ' +
+          'the quality of records on Data Hub!'
       ).should('have.attr', 'id', 'message-company-matched')
     })
   })

--- a/test/sandbox/fixtures/v4/dnb/company-link.json
+++ b/test/sandbox/fixtures/v4/dnb/company-link.json
@@ -1,0 +1,133 @@
+{
+  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+  "reference_code": "ORG-10096257",
+  "name": "Venus Ltd",
+  "trading_names": [],
+  "uk_based": true,
+  "company_number": null,
+  "vat_number": "",
+  "duns_number": "11111111",
+  "created_on": "2016-06-15T10:00:00Z",
+  "modified_on": "2016-07-15T10:00:00Z",
+  "archived": false,
+  "archived_documents_url_path": "/documents/123",
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "description": "This is a dummy company for testing",
+  "transferred_by": null,
+  "transferred_on": null,
+  "transferred_to": null,
+  "transfer_reason": "",
+  "website": null,
+  "business_type": {
+    "name": "Company",
+    "id": "98d14e94-5d95-e211-a939-e4115bead28a"
+  },
+  "one_list_group_tier": {
+    "name": "Tier A - Strategic Account",
+    "id": "b91bf800-8d53-e311-aef3-441ea13961e2"
+  },
+  "contacts": [
+    {
+      "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef",
+      "title": null,
+      "first_name": "Johnny",
+      "last_name": "Cakeman",
+      "name": "Johnny Cakeman",
+      "job_title": null,
+      "company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "adviser": null,
+      "primary": false,
+      "telephone_countrycode": "44",
+      "telephone_number": "67890123432",
+      "email": "johnny@cakeman.com",
+      "address_same_as_company": false,
+      "address_1": "82 Ramsgate Rd",
+      "address_2": null,
+      "address_town": "Willington",
+      "address_county": null,
+      "address_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "address_postcode": "NE28 5JB",
+      "telephone_alternative": null,
+      "email_alternative": null,
+      "notes": "This is a dummy contact for testing",
+      "accepts_dit_email_marketing": false,
+      "archived": false,
+      "archived_documents_url_path": "/documents/123",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-02-28T15:00:00Z",
+      "modified_on": "2017-06-05T00:00:00Z"
+    }
+  ],
+  "employee_range": null,
+  "number_of_employees": null,
+  "is_number_of_employees_estimated": null,
+  "export_to_countries": [],
+  "future_interest_countries": [],
+  "headquarter_type": null,
+  "one_list_group_global_account_manager": {
+    "name": "Travis Greene",
+    "first_name": "Travis",
+    "last_name": "Greene",
+    "dit_team": {
+      "name": "IST - Sector Advisory Services",
+      "uk_region": {
+        "name": "London",
+        "id": "874cd12a-6095-e211-a939-e4115bead28a"
+      },
+      "country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "id": "fc3a6667-cfe9-e511-8ffa-e4115bead28a"
+    },
+    "id": "8eefe6b4-2816-4e47-94b5-a13409dcef70"
+  },
+  "global_headquarters": {
+    "name": "Archived Ltd",
+    "id": "346f78a5-1d23-4213-b4c2-bf48246a13c3"
+  },
+  "sector": {
+    "name": "Retail",
+    "id": "355f977b-8ac3-e211-a646-e4115bead28a"
+  },
+  "turnover_range": null,
+  "turnover": null,
+  "is_turnover_estimated": null,
+  "uk_region": {
+    "name": "North West",
+    "id": "824cd12a-6095-e211-a939-e4115bead28a"
+  },
+  "export_experience_category": null,
+  "address": {
+    "line_1": "66 Marcham Road",
+    "line_2": "",
+    "town": "Bordley",
+    "county": "",
+    "postcode": "BD23 8RZ",
+    "country": {
+      "name": "United Kingdom",
+      "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
+  },
+  "registered_address": {
+    "line_1": "66 Marcham Road",
+    "line_2": "",
+    "town": "Bordley",
+    "county": "",
+    "postcode": "BD23 8RZ",
+    "country": {
+      "name": "United Kingdom",
+      "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+    }
+  }
+}

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -438,6 +438,7 @@ Sandbox.define(
   v4Dnb.companyCreateInvestigation
 )
 Sandbox.define('/v4/dnb/company-search', 'POST', v4Dnb.companySearch)
+Sandbox.define('/v4/dnb/company-link', 'POST', v4Dnb.companyLink)
 
 // V4 legacy company list
 Sandbox.define(

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -1,5 +1,6 @@
 var companyCreate = require('../../../fixtures/v4/dnb/company-create.json')
 var companySearch = require('../../../fixtures/v4/dnb/company-search.json')
+var companyLink = require('../../../fixtures/v4/dnb/company-link.json')
 var companySearchMatched = require('../../../fixtures/v4/dnb/company-search-matched.json')
 var companySearchNotMatched = require('../../../fixtures/v4/dnb/company-search-not-matched.json')
 var companyCreateInvestigation = require('../../../fixtures/v4/dnb/company-create-investigation.json')
@@ -21,4 +22,8 @@ exports.companySearch = function(req, res) {
 
 exports.companyCreateInvestigation = function(req, res) {
   res.json(companyCreateInvestigation)
+}
+
+exports.companyLink = function(req, res) {
+  res.json(companyLink)
 }


### PR DESCRIPTION
## Description of change
When a user verifies a Data Hub company against a D&B company a Zendesk ticket is generated and subsequently processed by the team. The next stage is automating that process by sending the request to the API instead of Zendesk.

## Test instructions
Find a company that has a black box on the company detail page asking a user to verify the business details.

**Dev:** _/companies/731bdcc1-f685-4c8e-bd66-b356b2c16995/activity_

Go through the journey until you land back on the company details page only this time the company has been matched against a D&B company, the black box has been removed with the following changes to the Data Hub company record:

1. The Data Hub company record now has a unique D&B duns number
2. Data is pulled from D&B record and updates/overwrites the Data Hub company record

## Screenshots
### Before

![1 before](https://user-images.githubusercontent.com/964268/75665087-83294f00-5c6b-11ea-956b-c6090f93ac3e.png)

### After

_Add a screenshot_

![1 after](https://user-images.githubusercontent.com/964268/75665103-87ee0300-5c6b-11ea-9670-2708a80e194a.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
