### PR TITLE
Show interactions in export history

### DIFF
--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -1,5 +1,13 @@
 import axios from 'axios'
 import { DateUtils } from 'data-hub-components'
+import { GREEN } from 'govuk-colours'
+
+import urls from '../../../../lib/urls'
+import groupExportCountries from '../../../../lib/group-export-countries'
+import {
+  EXPORT_INTEREST_STATUS,
+  EXPORT_INTEREST_STATUS_VALUES,
+} from '../../../constants'
 
 const WHITELISTED_HISTORY_TYPES = ['insert', 'delete']
 
@@ -13,47 +21,114 @@ const COUNTRY_TYPE_TEXT = {
   not_interested: 'countries of no interest',
 }
 
-const getCountryText = (country, historyType, status) => {
+const COUNTRY_TYPE_LABEL = {
+  [EXPORT_INTEREST_STATUS.EXPORTING_TO]: 'Countries currently exporting to',
+  [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: 'Future countries of interest',
+  [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: 'Countries not intersted in',
+}
+
+function getCountryText(country, historyType, status) {
   const historyTypeText = COUNTRY_HISTORY_TYPE_TEXT[historyType]
   const typeText = COUNTRY_TYPE_TEXT[status]
 
   return [country, historyTypeText, typeText].join(' ')
 }
 
-const createCountry = (item) => ({
-  headingText: getCountryText(
-    item.country.name,
-    item.history_type,
-    item.status
-  ),
-  metadata: [
-    {
-      label: 'By',
-      value: item.history_user?.name ?? 'unknown',
-    },
-    { label: 'Date', value: DateUtils.formatWithTime(item.history_date) },
-  ],
-})
+function createHistory(item) {
+  return {
+    headingText: getCountryText(
+      item.country.name,
+      item.history_type,
+      item.status
+    ),
+    metadata: [
+      {
+        label: 'By',
+        value: item.history_user?.name ?? 'unknown',
+      },
+      { label: 'Date', value: DateUtils.formatWithTime(item.history_date) },
+    ],
+  }
+}
 
-const transformFullExportHistory = ({ results }, activePage) => {
+const isInteraction = (item) => item.hasOwnProperty('kind')
+
+function getAdvisersText(items) {
+  return items
+    .map((item) => `${item.adviser.name} (${item.team.name})`)
+    .join(', ')
+}
+
+function createInteraction(item) {
+  const countryBuckets = groupExportCountries(item.export_countries)
+  const metadata = [
+    {
+      label: 'Company contact' + (item.contacts.length > 1 ? 's' : ''),
+      value: item.contacts.map((contact) => contact.name).join(', '),
+    },
+    {
+      label: 'Adviser' + (item.dit_participants.length > 1 ? 's' : ''),
+      value: getAdvisersText(item.dit_participants),
+    },
+    {
+      label: 'Service',
+      value: item.service.name,
+    },
+  ]
+
+  EXPORT_INTEREST_STATUS_VALUES.forEach((status) => {
+    const countries = countryBuckets[status]
+    if (countries?.length) {
+      metadata.push({
+        label: COUNTRY_TYPE_LABEL[status],
+        value: countries.map((country) => country.name).join(', '),
+      })
+    }
+  })
+
+  return {
+    headingText: item.subject,
+    headingUrl: urls.interactions.detail(item.id),
+    subheading: `Created ${DateUtils.formatWithTime(item.date)}`,
+    badges: [
+      {
+        text: 'Interaction',
+        borderColour: GREEN,
+      },
+    ],
+    metadata,
+  }
+}
+
+function transformFullExportHistory({ results }, activePage) {
   const offset = activePage * 10 - 10
-  const cleanedResults = results.filter((result) =>
-    WHITELISTED_HISTORY_TYPES.includes(result.history_type)
+  const cleanedResults = results.filter(
+    (item) =>
+      isInteraction(item) ||
+      WHITELISTED_HISTORY_TYPES.includes(item.history_type)
   )
 
   return {
     count: cleanedResults.length,
-    results: cleanedResults.slice(offset, offset + 10).map(createCountry),
+    results: cleanedResults
+      .slice(offset, offset + 10)
+      .map((item) =>
+        isInteraction(item) ? createInteraction(item) : createHistory(item)
+      ),
   }
 }
 
-const handleError = (e) => Promise.reject(Error(e.response.data.detail))
+function handleError(e) {
+  const message = e?.response?.data?.detail || 'An unknown error occured'
+  return Promise.reject(new Error(message))
+}
 
-export const fetchExportsHistory = ({ companyId, countryId, activePage }) =>
-  axios
+export function fetchExportsHistory({ companyId, countryId, activePage }) {
+  return axios
     .post('/api-proxy/v4/search/export-country-history', {
       company: companyId,
       country: countryId,
     })
     .catch(handleError)
     .then(({ data }) => transformFullExportHistory(data, activePage))
+}

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -41,4 +41,7 @@ module.exports = {
     oneDayExhibition: require('./event/one-day-exhibition'),
     teddyBearExpo: require('./event/teddy-bear-expo'),
   },
+  export: {
+    historyWithInteractions: require('../../../sandbox/fixtures/v4/export/history-with-interactions.json'),
+  },
 }

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -385,6 +385,142 @@ describe('Companies Export Countries', () => {
       cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
     })
   })
+
+  context('when viewing a company with interactions in the history', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.exports.history.index(
+          fixtures.company.investigationLimited.id
+        )
+      )
+    })
+
+    it('renders the title', () => {
+      cy.contains('Export countries history')
+    })
+
+    it('renders the collection list with 5 results', () => {
+      const historyItems = fixtures.export.historyWithInteractions.results
+
+      function checkInteraction(assertions, index) {
+        const item = historyItems[index]
+        const interaction = 'interaction' + index
+        const link = 'interactionLink' + index
+        const subHeading = 'interactionSubHeading' + index
+        const assertionTasks = []
+
+        assertions.forEach(([assertion, values]) => {
+          values.forEach((value) => {
+            assertionTasks.push({ assertion, value })
+          })
+        })
+
+        cy.contains(item.subject)
+          .as(link)
+          .parent()
+          .siblings('h4')
+          .as(subHeading)
+          .parent()
+          .as(interaction)
+
+        cy.get('@' + link).should(
+          'have.attr',
+          'href',
+          urls.interactions.detail(item.id)
+        )
+
+        cy.get('@' + interaction)
+          .find('div span')
+          .should('contain', 'Interaction')
+
+        assertionTasks.reduce(($details, { assertion, value }) => {
+          return $details.should(assertion, value)
+        }, cy.get('@' + interaction).find('details'))
+      }
+
+      cy.contains('5 results')
+      cy.get(countrySelectors.listItemHeadings).should('have.length', 5)
+
+      const interactionDetails = [
+        [
+          [
+            'contain',
+            [
+              'Company contacts Stephan Padberg, Stephanie Stokes',
+              'Advisers Mr. Genesis Kub (et nihil repudiandae), Solon Lynch (ea est totam), Dr. Meda Mraz (fuga corporis architecto)',
+              'Service Deserunt magni sapiente soluta praesentium sapiente.',
+              'Countries currently exporting to Benin',
+              'Future countries of interest Brunei Darussalam, French Polynesia',
+            ],
+          ],
+          ['not.contain', ['Countries not intersted in']],
+        ],
+        [
+          [
+            'contain',
+            [
+              'Company contact Justus Simonis',
+              'Adviser Carolanne Langworth (sit delectus recusandae)',
+              'Service Ipsa dicta omnis pariatur.',
+              'Countries currently exporting to Christmas Island, Indonesia, Martinique',
+              'Countries not intersted in Serbia',
+            ],
+          ],
+          ['not.contain', ['Future countries of interest']],
+        ],
+        [
+          [
+            'contain',
+            [
+              'Company contacts Karen Mayer Jr., Ari Von',
+              'Adviser Horace Orn (nisi ipsa quisquam)',
+              'Service Architecto suscipit et aliquam architecto.',
+              'Countries currently exporting to Burkina Faso',
+              'Future countries of interest Kyrgyz Republic, Trinidad and Tobago',
+            ],
+          ],
+          ['not.contain', ['Countries not intersted in']],
+        ],
+        [
+          [
+            'contain',
+            [
+              'Company contact Leonie Deckow',
+              'Advisers Napoleon Powlowski (veritatis temporibus unde), Giovanna Anderson (delectus repellendus ducimus), Tessie Hane (perferendis nihil nam)',
+              'Service Repellat quia fugiat velit delectus expedita omnis doloribus.',
+              'Countries currently exporting to Bolivia, Cameroon',
+              'Future countries of interest Bolivia, Qatar',
+              'Countries not intersted in Australia, Greenland',
+            ],
+          ],
+        ],
+      ]
+
+      interactionDetails.forEach(checkInteraction)
+
+      cy.get('@interactionSubHeading0').should(
+        'contain',
+        'Created 8 Jun 2019, 7:24am'
+      )
+      cy.get('@interactionSubHeading1').should(
+        'contain',
+        'Created 21 Jun 2019, 5:07am'
+      )
+      cy.get('@interactionSubHeading2').should(
+        'contain',
+        'Created 17 Sep 2019, 12:13am'
+      )
+      cy.get('@interactionSubHeading3').should(
+        'contain',
+        'Created 5 Jan 2020, 1:27pm'
+      )
+
+      cy.contains('Belarus added to countries of no interest')
+        .siblings()
+        .should('contain', 'By DIT Staff')
+        .should('contain', 'Date 11 Feb 2020, 10:47am')
+    })
+  })
 })
 
 describe('Country Export History', () => {

--- a/test/sandbox/fixtures/v4/export/history-with-interactions.json
+++ b/test/sandbox/fixtures/v4/export/history-with-interactions.json
@@ -1,0 +1,281 @@
+{
+    "count": 5,
+    "results": [
+        {
+            "id": "467a488e-8a0d-40d6-af22-0c0257ca1f5a",
+            "date": "2019-06-08T06:24:48.910Z",
+            "subject": "Voluptatem occaecati molestiae mollitia ratione cupiditate.",
+            "service": {
+              "id": "f1f70483-0fc2-4c6b-ab70-4c89e3bf0e5c",
+              "name": "Deserunt magni sapiente soluta praesentium sapiente."
+            },
+            "kind": "service_delivery",
+            "export_countries": [
+                {
+                    "country": {
+                        "id": "2eb1f7a8-7212-4eca-8caf-f95082668874",
+                        "name": "Benin"
+                    },
+                    "status": "currently_exporting"
+                },
+                {
+                    "country": {
+                        "id": "6c153527-720d-41b9-99f5-df2801510843",
+                        "name": "French Polynesia"
+                    },
+                    "status": "future_interest"
+                },
+                {
+                    "country": {
+                        "id": "f256ed03-4739-4299-90f4-490219bf0075",
+                        "name": "Brunei Darussalam"
+                    },
+                    "status": "future_interest"
+                }
+            ],
+            "contacts": [
+                {
+                    "name": "Stephan Padberg"
+                },
+                {
+                    "name": "Stephanie Stokes"
+                }
+            ],
+            "dit_participants": [
+                {
+                    "adviser": {
+                        "name": "Mr. Genesis Kub"
+                    },
+                    "team": {
+                        "name": "et nihil repudiandae"
+                    }
+                },
+                {
+                    "adviser": {
+                        "name": "Solon Lynch"
+                    },
+                    "team": {
+                        "name": "ea est totam"
+                    }
+                },
+                {
+                    "adviser": {
+                        "name": "Dr. Meda Mraz"
+                    },
+                    "team": {
+                        "name": "fuga corporis architecto"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "1a18ce0e-d474-4c5b-a335-455254647f4c",
+            "date": "2019-06-21T04:07:08.511Z",
+            "subject": "Aperiam dolores perferendis eaque vel qui voluptatum sed quia doloribus.",
+            "service": {
+              "id": "eaf392a7-cbe3-4d2d-833d-deeb190c4bb8",
+              "name": "Ipsa dicta omnis pariatur."
+            },
+            "kind": "interaction",
+            "export_countries": [
+                {
+                    "country": {
+                        "id": "d414474c-cb93-49f1-bcad-c482f9e3b3c2",
+                        "name": "Serbia"
+                    },
+                    "status": "not_interested"
+                },
+                {
+                    "country": {
+                        "id": "a36c2917-59c9-40ee-83f8-0bf3a6125194",
+                        "name": "Christmas Island"
+                    },
+                    "status": "currently_exporting"
+                },
+                {
+                    "country": {
+                        "id": "59c2e6ed-3b08-456f-97df-d35e0c8dad71",
+                        "name": "Martinique"
+                    },
+                    "status": "currently_exporting"
+                },
+                {
+                    "country": {
+                        "id": "f2637422-11dc-4a49-bf24-83527fb7b65a",
+                        "name": "Indonesia"
+                    },
+                    "status": "currently_exporting"
+                }
+            ],
+            "contacts": [
+                {
+                    "name": "Justus Simonis"
+                }
+            ],
+            "dit_participants": [
+                {
+                    "adviser": {
+                        "name": "Carolanne Langworth"
+                    },
+                    "team": {
+                        "name": "sit delectus recusandae"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "9f7399b7-3296-4e25-9d88-f7c917dd8416",
+            "date": "2019-09-16T23:13:50.781Z",
+            "subject": "Nisi doloribus inventore facere labore rerum.",
+            "service": {
+              "id": "337abc4d-29f3-40d7-a7cc-3d37be4aba1e",
+              "name": "Architecto suscipit et aliquam architecto."
+            },
+            "kind": "service_delivery",
+            "export_countries": [
+                {
+                    "country": {
+                        "id": "0cb5c189-0106-4be4-b487-62f817a58ab8",
+                        "name": "Trinidad and Tobago"
+                    },
+                    "status": "future_interest"
+                },
+                {
+                    "country": {
+                        "id": "9d6084bf-6bbd-454e-9fa3-d05aed500d72",
+                        "name": "Kyrgyz Republic"
+                    },
+                    "status": "future_interest"
+                },
+                {
+                    "country": {
+                        "id": "2f12e1a9-56b0-47d7-8757-9d49700aca43",
+                        "name": "Burkina Faso"
+                    },
+                    "status": "currently_exporting"
+                }
+            ],
+            "contacts": [
+                {
+                    "name": "Karen Mayer Jr."
+                },
+                {
+                    "name": "Ari Von"
+                }
+            ],
+            "dit_participants": [
+                {
+                    "adviser": {
+                        "name": "Horace Orn"
+                    },
+                    "team": {
+                        "name": "nisi ipsa quisquam"
+                    }
+                }
+            ]
+        },
+        {
+          "id": "22e6b1e8-4518-4e35-8306-05daaa1ee67c",
+          "date": "2020-01-05T13:27:49.888Z",
+          "subject": "Velit praesentium voluptas neque fuga nostrum.",
+          "service": {
+            "id": "7fadc1b6-5153-4a06-8e6a-91a55642160d",
+            "name": "Repellat quia fugiat velit delectus expedita omnis doloribus."
+          },
+          "kind": "service_delivery",
+          "export_countries": [
+            {
+              "country": {
+                "id": "787e7381-b5df-4889-ab20-595c28f38f1a",
+                "name": "Qatar"
+              },
+              "status": "future_interest"
+            },
+            {
+              "country": {
+                "id": "8da2226e-96fb-4c62-a7cd-0af69a593090",
+                "name": "Australia"
+              },
+              "status": "not_interested"
+            },
+            {
+              "country": {
+                "id": "1b1db85c-fe10-4e15-810d-28499d067753",
+                "name": "Bolivia"
+              },
+              "status": "currently_exporting"
+            },
+            {
+              "country": {
+                "id": "d0f70662-be58-4144-bc9d-38a92f777e55",
+                "name": "Bolivia"
+              },
+              "status": "future_interest"
+            },
+            {
+              "country": {
+                "id": "1b39e8e6-5cff-4386-a9dc-1358eb9f5f12",
+                "name": "Greenland"
+              },
+              "status": "not_interested"
+            },
+            {
+              "country": {
+                "id": "fd540a86-9a57-4fc9-8deb-e52596a1f187",
+                "name": "Cameroon"
+              },
+              "status": "currently_exporting"
+            }
+          ],
+          "contacts": [
+            {
+              "name": "Leonie Deckow"
+            }
+          ],
+          "dit_participants": [
+            {
+              "adviser": {
+                "name": "Napoleon Powlowski"
+              },
+              "team": {
+                "name": "veritatis temporibus unde"
+              }
+            },
+            {
+              "adviser": {
+                "name": "Giovanna Anderson"
+              },
+              "team": {
+                "name": "delectus repellendus ducimus"
+              }
+            },
+            {
+              "adviser": {
+                "name": "Tessie Hane"
+              },
+              "team": {
+                "name": "perferendis nihil nam"
+              }
+            }
+          ]
+        },
+        {
+            "history_user": {
+                "id": "ed5b807d-9674-4424-b954-411f4aac6db1",
+                "name": "DIT Staff"
+            },
+            "country": {
+                "id": "a65f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Belarus"
+            },
+            "company": {
+                "id": "960e1fa9-cc25-478c-a548-a2e2047319bb",
+                "name": "One List Subsidiary Ltd"
+            },
+            "id": "9e37e956-bc37-4a29-946f-4a6375d2fdd2",
+            "status": "not_interested",
+            "history_type": "insert",
+            "history_date": "2020-02-11T10:47:33.657731+00:00"
+        }
+    ]
+}

--- a/test/sandbox/routes/v4/search/export.js
+++ b/test/sandbox/routes/v4/search/export.js
@@ -3,22 +3,32 @@ var emptyFullExportHistory = require('../../../fixtures/v4/export/empty-full-exp
 var unkownUserExportHistory = require('../../../fixtures/v4/export/unkown-user-export-history.json')
 var updateOnlyExportHistory = require('../../../fixtures/v4/export/update-only-export-history.json')
 var countryExportHistory = require('../../../fixtures/v4/export/country-export-history.json')
+var exportHistoryWithInteractions = require('../../../fixtures/v4/export/history-with-interactions.json')
+
 var dnbCorp = require('../../../fixtures/v4/company/company-dnb-corp.json')
 var marsExportsLtd = require('../../../fixtures/v4/company/company-mars-exports-ltd.json')
 var dnbSubsidiary = require('../../../fixtures/v4/company/company-dnb-subsidiary.json')
+var investigationLtd = require('../../../fixtures/v4/company/company-investigation-ltd.json')
 
 exports.fetchExportHistory = function(req, res) {
+  var companyId = req.body.company
+
   if (req.body.country === '975f66a0-5d95-e211-a939-e4115bead28a') {
     return res.json(countryExportHistory)
   }
-  if (req.body.company === dnbCorp.id) {
+
+  if (companyId === dnbCorp.id) {
     return res.json(fullExportHistoryPage1)
   }
-  if (req.body.company === marsExportsLtd.id) {
+  if (companyId === marsExportsLtd.id) {
     return res.json(unkownUserExportHistory)
   }
-  if (req.body.company === dnbSubsidiary.id) {
+  if (companyId === dnbSubsidiary.id) {
     return res.json(updateOnlyExportHistory)
   }
+  if (companyId === investigationLtd.id) {
+    return res.json(exportHistoryWithInteractions)
+  }
+
   return res.json(emptyFullExportHistory)
 }


### PR DESCRIPTION
## Description of change

Show interactions in the export history for a company - when available in the API

## Test instructions

Currently available using a branch on the API or via Sandbox

- Sandbox: view the export tab for INVESTIGATION LIMITED (ca8fae21-2895-47cf-90ba-9273c94dab81) and click "View full export countries history"
- API: In branch `feature/search-api-include-interactions-to-export-countries` it requires two commands to be run as well
    - `./manage.py migrate_es`
    - `./manage.py sync_es`
  then add an interaction and answer "Were any countries discussed" as "Yes" and add some countries. Now view the export tab and click "View full export countries history"

## Screenshots
### Before

No interactions shown

### After

<img width="980" alt="Screenshot 2020-03-02 at 22 31 29" src="https://user-images.githubusercontent.com/1481883/75724511-742bb680-5cd6-11ea-9d68-1b5ddc79ec77.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
