### PR TITLE
Confirm referral details and send referral

### DIFF
--- a/src/apps/companies/__test__/router.test.js
+++ b/src/apps/companies/__test__/router.test.js
@@ -23,6 +23,7 @@ describe('Company router', () => {
       '/:companyId/subsidiaries',
       '/:companyId/subsidiaries/link',
       '/:companyId/send-referral',
+      '/:companyId/send-referral',
     ])
   })
 })

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -74,7 +74,10 @@ const investmentsRouter = require('./apps/investments/router')
 const interactionsRouter = require('../interactions/router.sub-app')
 const companyListsRouter = require('../company-lists/router')
 const advisersRouter = require('./apps/advisers/router')
-const renderSendReferralForm = require('../referrals/apps/send-referral/controllers')
+const {
+  renderSendReferralForm,
+  submitSendReferralForm,
+} = require('../referrals/apps/send-referral/controllers')
 
 const {
   setCompanyHierarchyLocalNav,
@@ -168,6 +171,7 @@ router.get(urls.companies.subsidiaries.index.route, renderSubsidiaries)
 router.get(urls.companies.subsidiaries.link.route, renderLinkSubsidiary)
 
 router.get(urls.companies.sendReferral.route, renderSendReferralForm)
+router.post(urls.companies.sendReferral.route, submitSendReferralForm)
 
 router.use(activityFeedRouter)
 

--- a/src/apps/referrals/apps/send-referral/client/SendReferralConfirmation.jsx
+++ b/src/apps/referrals/apps/send-referral/client/SendReferralConfirmation.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+import { SummaryTable, FormActions } from 'data-hub-components'
+import { H4, Button, Link } from 'govuk-react'
+import SecondaryButton from '../../../../../client/components/SecondaryButton'
+
+const StyledParagraph = styled('p')`
+  font-size: 16px;
+`
+
+const SendReferralConfirmation = ({
+  companyName,
+  companyId,
+  adviser,
+  subject,
+  contact,
+  notes,
+  cancelUrl,
+  onBack,
+  csrfToken,
+}) => {
+  return (
+    <>
+      <SummaryTable caption="Check referral details">
+        <SummaryTable.Row heading="Send this company record to">
+          {adviser.name}
+        </SummaryTable.Row>
+        <SummaryTable.Row heading="Subject">{subject}</SummaryTable.Row>
+        <SummaryTable.Row heading="Notes">
+          {notes || 'No notes added'}
+        </SummaryTable.Row>
+        <SummaryTable.Row heading="Company contact">
+          {contact?.name || 'No contact added'}
+        </SummaryTable.Row>
+      </SummaryTable>
+      <SecondaryButton onClick={onBack}>Edit referral</SecondaryButton>
+      <H4>What happens next</H4>
+      <StyledParagraph>
+        <p>
+          <p>
+            Clicking “Send referral” will show the referral in the activity of{' '}
+            {companyName}, as well as in the Referrals section on both your Data
+            Hub Homepage and the Homepage of the recipient.
+          </p>
+          <p>It might take up to 24 hours for the referral to appear.</p>
+          <p>You will not be able to edit the referral after this point.</p>
+        </p>
+      </StyledParagraph>
+      <form method="post">
+        <input name="recipient" value={adviser.id} type="hidden"></input>
+        <input name="subject" value={subject} type="hidden"></input>
+        <input name="notes" value={notes} type="hidden"></input>
+        <input name="contact" value={contact?.id} type="hidden"></input>
+        <input name="company" value={companyId} type="hidden"></input>
+        <input name="_csrf" value={csrfToken} type="hidden"></input>
+        <FormActions>
+          <Button>Send referral</Button>
+          <Link href={cancelUrl}>Cancel</Link>
+        </FormActions>
+      </form>
+    </>
+  )
+}
+
+SendReferralConfirmation.propTypes = {
+  companyId: PropTypes.string.isRequired,
+  companyName: PropTypes.string.isRequired,
+  cancelUrl: PropTypes.string.isRequired,
+  csrfToken: PropTypes.string.isRequired,
+}
+
+export default SendReferralConfirmation

--- a/src/apps/referrals/apps/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/referrals/apps/send-referral/client/SendReferralForm.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { throttle } from 'lodash'
 import axios from 'axios'
 
+import SendReferralConfirmation from './SendReferralConfirmation.jsx'
 import ValidatedInput from '../../../../../client/components/ValidatedInput.jsx'
 import styled from 'styled-components'
 import {
@@ -118,7 +119,7 @@ const SendReferralForm = ({
                   results
                     .filter((adviser) => adviser?.name.trim().length)
                     .map(({ id, name, dit_team }) => ({
-                      label: `${name} ${dit_team ? ', ' + dit_team.name : ''}`,
+                      label: `${name}${dit_team ? ', ' + dit_team.name : ''}`,
                       value: id,
                     }))
                 ),
@@ -246,9 +247,7 @@ export default connect(
   })
 )(({ confirm, ...props }) =>
   confirm ? (
-    <div>
-      Confirmation Page <button onClick={props.onBack}>Go back</button>
-    </div>
+    <SendReferralConfirmation {...props} />
   ) : (
     <SendReferralForm {...props} />
   )

--- a/src/apps/referrals/apps/send-referral/controllers.js
+++ b/src/apps/referrals/apps/send-referral/controllers.js
@@ -1,4 +1,7 @@
 const urls = require('../../../../lib/urls')
+const { authorisedRequest } = require('../../../../lib/authorised-request')
+const { omit } = require('lodash')
+const config = require('../../../../config/index')
 
 function renderSendReferralForm(req, res) {
   const {
@@ -15,8 +18,29 @@ function renderSendReferralForm(req, res) {
       heading: 'Send a referral',
       props: {
         companyContacts,
+        companyName: name,
+        companyId: id,
         cancelUrl: urls.companies.detail(id),
       },
     })
 }
-module.exports = renderSendReferralForm
+
+async function submitSendReferralForm(req, res, next) {
+  try {
+    await authorisedRequest(req.session.token, {
+      method: 'POST',
+      url: `${config.apiRoot}/v4/company-referral`,
+      body: omit(req.body, '_csrf'),
+    })
+    req.flashWithBody(
+      'success',
+      'Referral sent',
+      `You can <a href="${urls.dashboard()}">find your referrals on the Homepage</a>.`
+    )
+    res.redirect(urls.companies.detail(res.locals.company.id))
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = { renderSendReferralForm, submitSendReferralForm }

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -161,7 +161,9 @@ function App() {
         {(props) => <ExportsIndex {...props} />}
       </Mount>
       <Mount selector="#send-referral-form">
-        {(props) => <SendReferralForm {...props} />}
+        {(props) => (
+          <SendReferralForm {...props} csrfToken={globalProps.csrfToken} />
+        )}
       </Mount>
       <Mount selector="#company-export-full-history">
         {(props) => <ExportsHistory {...props} />}

--- a/test/functional/cypress/specs/companies/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/send-referral-spec.js
@@ -152,55 +152,131 @@ describe('Send a referral form', () => {
               .type('Example subject')
               .get(selectors.companySendReferral.continueButton)
               .click()
-            cy.get(selectors.companySendReferral.confirmationComponent).should(
-              'contain.text',
-              'Confirmation Page'
-            )
+            cy.contains('Check referral details').should('be.visible')
           })
         }
       )
-
-    context(
-      'when "Continue" button is clicked after all fields filled in',
-      () => {
-        it('should display confirmation component and persist the form values', () => {
-          cy.visit(
-            urls.companies.sendReferral(fixtures.company.withContacts.id)
-          )
-          selectTypeahead('Adviser', 'S', 3)
-          cy.get(selectors.companySendReferral.subjectField)
-            .click()
-            .type('Example subject')
-            .get(selectors.companySendReferral.notesField)
-            .click()
-            .type('Example notes')
-          selectTypeahead('Company contact', 'J', 2)
-            .get(selectors.companySendReferral.continueButton)
-            .click()
-          cy.get(selectors.companySendReferral.confirmationComponent).should(
-            'contain.text',
-            'Confirmation Page'
-          )
-          cy.get(selectors.companySendReferral.backButton).click()
-          cy.get(selectors.companySendReferral.adviserField).should(
-            'contain',
-            'Shawn Cohen'
-          )
-          cy.get(selectors.companySendReferral.subjectField).should(
-            'have.attr',
-            'value',
-            'Example subject'
-          )
-          cy.get(selectors.companySendReferral.notesField).should(
-            'have.text',
-            'Example notes'
-          )
-          cy.get(selectors.companySendReferral.contactField).should(
-            'contain',
-            'Johnny Cakeman'
-          )
-        })
-      }
-    )
   })
+
+  context(
+    'when "Continue" button is clicked after all fields filled in',
+    () => {
+      it('should display the confirmation component with the values just input', () => {
+        cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
+        selectTypeahead('Adviser', 'S', 3)
+        cy.get(selectors.companySendReferral.subjectField)
+          .click()
+          .type('Example subject')
+          .get(selectors.companySendReferral.notesField)
+          .click()
+          .type('Example notes')
+        selectTypeahead('Company contact', 'J', 2)
+          .get(selectors.companySendReferral.continueButton)
+          .click()
+        cy.get('table')
+          .should('contain', 'Shawn Cohen')
+          .and('contain', 'Example subject')
+          .and('contain', 'Example notes')
+          .and('contain', 'Johnny Cakeman')
+        cy.contains('Edit referral').should('be.visible')
+        cy.get('h4').should('contain', 'What happens next')
+        cy.get('p')
+          .eq(2)
+          .should(
+            'have.text',
+            'Clicking “Send referral” will show the referral in the activity of Venus Ltd, as well as in the Referrals section on both your Data Hub' +
+              ' Homepage and the Homepage of the recipient.' +
+              'It might take up to 24 hours for the referral to appear.' +
+              'You will not be able to edit the referral after this point.'
+          )
+        cy.get('button')
+          .eq(2)
+          .should('be.visible')
+        cy.contains('Cancel').should('be.visible')
+      })
+    }
+  )
+
+  context(
+    'when "Continue" button is clicked after all fields filled in',
+    () => {
+      it('the input data should appear in the form when "Edit referral" is clicked', () => {
+        cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
+        selectTypeahead('Adviser', 'S', 3)
+        cy.get(selectors.companySendReferral.subjectField)
+          .click()
+          .type('Example subject')
+          .get(selectors.companySendReferral.notesField)
+          .click()
+          .type('Example notes')
+        selectTypeahead('Company contact', 'J', 2)
+          .get(selectors.companySendReferral.continueButton)
+          .click()
+        cy.contains('Edit referral').click()
+        cy.get(selectors.companySendReferral.adviserField).should(
+          'contain',
+          'Shawn Cohen'
+        )
+        cy.get(selectors.companySendReferral.subjectField).should(
+          'have.attr',
+          'value',
+          'Example subject'
+        )
+        cy.get(selectors.companySendReferral.notesField).should(
+          'have.text',
+          'Example notes'
+        )
+        cy.get(selectors.companySendReferral.contactField).should(
+          'contain',
+          'Johnny Cakeman'
+        )
+      })
+    }
+  )
+
+  context(
+    'When the "Cancel" link is clicked from the confirmation component',
+    () => {
+      it('should return to the company page', () => {
+        selectTypeahead('Adviser', 'S', 3)
+        cy.get(selectors.companySendReferral.subjectField)
+          .click()
+          .type('Example subject')
+          .get(selectors.companySendReferral.continueButton)
+          .click()
+        cy.contains('Cancel').click()
+        cy.url().should(
+          'contain',
+          urls.companies.activity.index(fixtures.company.withContacts.id)
+        )
+      })
+    }
+  )
+
+  context(
+    'When the "Send referral" button is clicked from the confirmation component',
+    () => {
+      before(() => {
+        cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
+      })
+      it('should take user to the company page, display flash message and link to the homepage', () => {
+        selectTypeahead('Adviser', 'S', 3)
+        cy.get(selectors.companySendReferral.subjectField)
+          .click()
+          .type('Example subject')
+          .get(selectors.companySendReferral.continueButton)
+          .click()
+        cy.get('button')
+          .eq(2)
+          .click() //Fix reference to send referral button
+        cy.url().should(
+          'contain',
+          urls.companies.activity.index(fixtures.company.withContacts.id)
+        )
+        cy.get(selectors.localHeader().flash).should('contain', 'Referral sent')
+        cy.contains('find your referrals on the Homepage').click()
+        cy.url().should('contain', urls.dashboard())
+      })
+    }
+  )
 })

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -37,6 +37,12 @@ Sandbox.define(
   'GET',
   v4referralDetails.referralDetails
 )
+// Send a referral
+Sandbox.define(
+  '/v4/company-referral',
+  'POST',
+  v4referralDetails.referralDetails
+)
 
 // Adviser endpoint
 Sandbox.define('/adviser/', 'GET', adviser.advisers)

--- a/test/selectors/company/send-referral.js
+++ b/test/selectors/company/send-referral.js
@@ -9,6 +9,4 @@ module.exports = {
     '#send-referral-form > form > label:nth-child(9) > div > div > div',
   continueButton: '#send-referral-form > form > div > button',
   cancelLink: '#send-referral-form > form > div > a',
-  confirmationComponent: '#send-referral-form > div',
-  backButton: '#send-referral-form > div > button',
 }


### PR DESCRIPTION
## Description of change
Following a PR which captures referral details in a form (#2418), this change adds a confirmation component which displays the user's input data. They can then go back and edit the referral in the form, or click 'Send referral' which will post that referral to the API. 

They will then be redirected back to the company page they started from, and a flash message with a link to see 'My referrals' on the homepage appears. The 'My referrals' tab will be added to the homepage in an upcoming PR.
 
The confirmation page is a react component, rendered when the 'confirm' prop is true. This is toggled with an onSubmit action on the form component. 

The API post request is made using the traditional express router, rather than the task component. This is because a redirect after the request promise is fulfilled is not yet possible using the task component.

## Test instructions

- Go to companies/:companyId/send-referral
- Enter an adviser and a subject (currently only required fields)
- Click continue to see the confirmation page

## Screenshots
### After

![Screenshot 2020-03-04 at 12 16 16](https://user-images.githubusercontent.com/22460823/75878736-f66cc580-5e11-11ea-8123-48251d8de8dc.png)

![Screenshot 2020-03-04 at 12 17 22](https://user-images.githubusercontent.com/22460823/75878823-1bf9cf00-5e12-11ea-9b3e-0d5bf86be21f.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
