### PR TITLE
Check the value of a global account manager before it is transformed

### DIFF
--- a/src/apps/companies/apps/business-details/__test__/transformers.test.js
+++ b/src/apps/companies/apps/business-details/__test__/transformers.test.js
@@ -65,6 +65,17 @@ describe('Company business details transformers', () => {
 
         expect(actual).to.deep.equal(expected)
       })
+
+      it('should not error when the "One list account owner" is not set', () => {
+        const company = {
+          one_list_group_tier: { name: 'Tier A - Strategic Account' },
+          one_list_group_global_account_manager: null,
+        }
+        const actual = transformCompanyToBusinessDetails(company)
+        expect(actual).to.deep.equal({
+          one_list_group_tier: 'Tier A - Strategic Account',
+        })
+      })
     })
 
     context('when called without any fields', () => {

--- a/src/apps/companies/apps/business-details/transformers.js
+++ b/src/apps/companies/apps/business-details/transformers.js
@@ -3,11 +3,14 @@ const { get, pick, compact, omitBy } = require('lodash')
 const { hqLabels } = require('../../labels')
 const { convertUsdToGbp } = require('../../../../common/currency')
 
-const transformGlobalAccountManager = ({ dit_team, name }) => {
+const transformGlobalAccountManager = (globalAccountManager) => {
+  if (!globalAccountManager) {
+    return null
+  }
+  const { dit_team, name } = globalAccountManager
   const region = get(dit_team, 'uk_region.name')
   const country = get(dit_team, 'country.name')
   const items = compact([name, get(dit_team, 'name'), region || country])
-
   return items.length ? items : 'Not set'
 }
 
@@ -48,11 +51,9 @@ const transformCompanyToBusinessDetails = (company) => {
       uk_region: get(company.uk_region, 'name'),
       global_headquarters: get(company.global_headquarters, 'name'),
       one_list_group_tier: get(company.one_list_group_tier, 'name'),
-      one_list_group_global_account_manager:
-        company.one_list_group_tier &&
-        transformGlobalAccountManager(
-          company.one_list_group_global_account_manager
-        ),
+      one_list_group_global_account_manager: transformGlobalAccountManager(
+        company.one_list_group_global_account_manager
+      ),
       headquarter_type_label:
         company.headquarter_type && hqLabels[company.headquarter_type.name],
     },

--- a/src/apps/companies/apps/business-details/transformers.js
+++ b/src/apps/companies/apps/business-details/transformers.js
@@ -11,7 +11,7 @@ const transformGlobalAccountManager = (globalAccountManager) => {
   const region = get(dit_team, 'uk_region.name')
   const country = get(dit_team, 'country.name')
   const items = compact([name, get(dit_team, 'name'), region || country])
-  return items.length ? items : 'Not set'
+  return items.length ? items : null
 }
 
 const transformCompanyToBusinessDetails = (company) => {


### PR DESCRIPTION
## Description of change

This PR fixes a bug that causes Data Hub to hang and eventually leads to a 504 error when a user clicks on ‘View full business details’ on affected one list companies (this also appears in Sentry). An example of this can be found [here](https://www.datahub.staging.uktrade.io/companies/f1c4ae9e-2ec3-4f3e-b4d2-3e82c0707058/activity) - an error message should appear in the 'data-hub-sentry' channel after the link is clicked.

The bug is caused if someone using Django Admin changes a company to the one list tier but does not set the one list account owner. In the code, the translator always expects `one_list_global_account_manager` to be defined and throws an unexpected error when encountering 'null'

This PR allows the transformer to check the value of `one_list_global_account_manager` before the transformation process starts, and returns a value of ‘not set’ if the variable hasn’t been set beforehand.

## Test instructions

Go the the company identified above in the Heroku app and the business details page should appear normally

## Screenshots
### Before

![Screenshot 2020-03-05 at 09 49 28](https://user-images.githubusercontent.com/36161814/75969297-a439ac00-5ec6-11ea-9cee-e0a2dd545b1a.png)

### After

A normal business details page should appear

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
