### PR TITLE
Fix no contact bug in referral details

### DIFF
--- a/src/apps/referrals/apps/details/client/ReferralDetails.jsx
+++ b/src/apps/referrals/apps/details/client/ReferralDetails.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { TEXT_COLOUR, GREY_3 } from 'govuk-colours'
 import Details from '@govuk-react/details'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'

--- a/src/apps/referrals/transformer.js
+++ b/src/apps/referrals/transformer.js
@@ -1,7 +1,4 @@
-const { get } = require('lodash')
-
 const transformReferralDetails = ({
-  id,
   subject,
   company,
   contact,
@@ -13,16 +10,16 @@ const transformReferralDetails = ({
   return {
     subject,
     company: company.name,
-    contact: contact.name,
+    contact: contact && contact.name,
     sendingAdviser: {
       name: created_by.name,
-      email: get(created_by, 'contact_email'),
-      team: get(created_by.dit_team, 'name'),
+      email: created_by.contact_email,
+      team: created_by.dit_team && created_by.dit_team.name,
     },
     receivingAdviser: {
       name: recipient.name,
-      email: get(recipient, 'contact_email'),
-      team: get(recipient.dit_team, 'name'),
+      email: recipient.contact_email,
+      team: recipient.dit_team && recipient.dit_team.name,
     },
     date: created_on,
     notes,

--- a/test/functional/cypress/specs/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/referrals/referral-details-spec.js
@@ -1,9 +1,11 @@
 const selectors = require('../../../../selectors')
 const { assertBreadcrumbs } = require('../../support/assertions')
+const {
+  REFERRAL_ID,
+  REFERRAL_ID_NO_CONTACT,
+} = require('../../../../sandbox/constants/referrals')
 
 import urls from '../../../../../src/lib/urls'
-
-const REFERRAL_ID = 'cc5b9953-894c-44b4-a4ac-d0f6a6f6128f'
 
 describe('Referral details', () => {
   context('when viewing referral details', () => {
@@ -76,6 +78,82 @@ describe('Referral details', () => {
         .find('a:nth-child(2)')
         .should('have.text', 'I cannot complete the referral')
         .should('have.attr', 'href', urls.referrals.help(REFERRAL_ID))
+        .parent()
+        .find('a:nth-child(3)')
+        .should('have.text', 'Back')
+    })
+  })
+
+  context('when viewing referral details with no contact', () => {
+    before(() => cy.visit(urls.referrals.details(REFERRAL_ID_NO_CONTACT)))
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: '/',
+        Referral: null,
+      })
+    })
+
+    it('should render the heading', () => {
+      cy.get(selectors.localHeader().heading).should('have.text', 'Referral')
+    })
+
+    it('should render the content and elements in order', () => {
+      cy.get('#referral-details > table')
+        .find('caption')
+        .should('have.text', 'Referral sent - I am a subject')
+        .parents()
+        .find('tbody tr')
+        .as('row')
+        .eq(0)
+        .should('have.text', 'CompanyLambda plc')
+
+      cy.get('@row')
+        .eq(1)
+        .should(
+          'have.text',
+          'Sending adviserIan Leggett, caravans@campervans.com, Advanced Manufacturing Sector'
+        )
+        .find('a')
+        .should('have.attr', 'href', 'mailto:caravans@campervans.com')
+
+      cy.get('@row')
+        .eq(2)
+        .should(
+          'have.text',
+          'Receiving adviserBarry Oling, barry@barry.com, Aberdeen City Council'
+        )
+        .find('a')
+        .should('have.attr', 'href', 'mailto:barry@barry.com')
+
+      cy.get('@row')
+        .eq(3)
+        .should('have.text', 'Date of referral14 Feb 2020')
+
+      cy.get('@row')
+        .eq(4)
+        .should('have.text', 'NotesJust a note about a referral')
+        .parents()
+        .find('summary')
+        .should('have.text', 'Why can I not edit the referral?')
+        .next()
+        .should(
+          'have.text',
+          'This referral has been placed in the "My referrals" section on the Homepage of both the recipient and sender. If necessary contact the receiving adviser directly if any of the information has changed.'
+        )
+        .parents()
+        .find('details')
+        .next()
+        .find('a:first-child')
+        .should('have.text', 'Complete referral')
+        .parent()
+        .find('a:nth-child(2)')
+        .should('have.text', 'I cannot complete the referral')
+        .should(
+          'have.attr',
+          'href',
+          urls.referrals.help(REFERRAL_ID_NO_CONTACT)
+        )
         .parent()
         .find('a:nth-child(3)')
         .should('have.text', 'Back')

--- a/test/sandbox/constants/referrals.js
+++ b/test/sandbox/constants/referrals.js
@@ -1,0 +1,4 @@
+module.exports = {
+  REFERRAL_ID: 'cc5b9953-894c-44b4-a4ac-d0f6a6f6128f',
+  REFERRAL_ID_NO_CONTACT: 'cc5b9953-894c-44b4-a4ac-d0f6a6f6128d',
+}

--- a/test/sandbox/fixtures/v4/referrals/referral-details-no-contact.json
+++ b/test/sandbox/fixtures/v4/referrals/referral-details-no-contact.json
@@ -1,0 +1,34 @@
+{
+  "id": "cc5b9953-894c-44b4-a4ac-d0f6a6f6128f",
+  "closed_by": null,
+  "closed_on": null,
+  "company": {
+    "name": "Lambda plc",
+    "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+  },
+  "completed_by": null,
+  "completed_on": null,
+  "created_by": {
+    "name": "Ian Leggett",
+    "contact_email": "caravans@campervans.com",
+    "dit_team": {
+      "name": "Advanced Manufacturing Sector",
+      "id": "08c14624-2f50-e311-a56a-e4115bead28a"
+    },
+    "id": "0c004222-5626-4ef6-b663-18f99fc67cd6"
+  },
+  "created_on": "2020-02-14T15:07:59.341233Z",
+  "interaction": null,
+  "notes": "Just a note about a referral",
+  "recipient": {
+    "name": "Barry Oling",
+    "contact_email": "barry@barry.com",
+    "dit_team": {
+      "name": "Aberdeen City Council",
+      "id": "cff02898-9698-e211-a939-e4115bead28a"
+    },
+    "id": "a80ff5fd-8904-4940-bf96-fe8047e34be5"
+  },
+  "status": "outstanding",
+  "subject": "I am a subject"
+}

--- a/test/sandbox/routes/v4/referrals/referral-details.js
+++ b/test/sandbox/routes/v4/referrals/referral-details.js
@@ -1,5 +1,10 @@
 var referralDetails = require('../../../fixtures/v4/referrals/referral-details.json')
+var referralDetailsNoContact = require('../../../fixtures/v4/referrals/referral-details-no-contact.json')
+var id = require('../../../constants/referrals')
 
 exports.referralDetails = function(req, res) {
-  res.json(referralDetails)
+  if (req.params.id === id.REFERRAL_ID_NO_CONTACT) {
+    return res.json(referralDetailsNoContact)
+  }
+  return res.json(referralDetails)
 }


### PR DESCRIPTION
## Description of change

This PR guards against the user not adding the optional contact. Previously the referral details page would not render (as per the screenshot below) if there was no contact. 

## Test instructions

Complete a referral without a contact, navigate to `/referrals/:referralId` and you can now view the referral details page. 

## Screenshots
### Before

![Screenshot_2020-02-27_at_17 18 03](https://user-images.githubusercontent.com/42253716/76013481-d91e2100-5f0f-11ea-94f8-89b2384b7266.png)

### After

![FireShot Capture 051 - Referrals - DIT Data Hub - localhost](https://user-images.githubusercontent.com/42253716/76014846-361ad680-5f12-11ea-83b8-6256e0ac8b5b.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
