### PR TITLE
Update components package to 3.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^3.11.2",
+    "data-hub-components": "^3.11.4",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,10 +4745,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^3.11.2:
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-3.11.2.tgz#68b3263d3361653859ca672c1bb945ebc7dedb4c"
-  integrity sha512-qTADNlqvMOT4v04N8zder4U7vTXy2ItkeSqoKu+O6wjM/PZZ24LFW2CNYOzRgpAPbRXeLy7tppJeyJ8UWGugkQ==
+data-hub-components@^3.11.4:
+  version "3.11.4"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-3.11.4.tgz#b66fe2cc7ab15f569fa53f0960499e696deebe9e"
+  integrity sha512-vvBfjtBx8wxUkCYN/60hmliAHMnu84D0Q9FzX/6TznD2VZzaNNzUQeE1s+mJedg1QVbYXqb08i0NqqujlnzrQg==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change

Update components package to 3.11.4. This brings in the fix for pagination erroneously showing on pages with 0 results. 

## Test instructions

Navigate to a collectionList (e.g. export history) where there are no results and you will no longer see any pagination. 

## Screenshots
### Before

![FireShot Capture 052 - Export countries history - Exports - SOCIETE DE CONSULTING TESTING EN_ - www datahub dev uktrade io](https://user-images.githubusercontent.com/42253716/76090999-96625480-5fb4-11ea-85f0-a7222db3e4ae.png)

### After

![FireShot Capture 053 - Export countries history - Exports - SOCIETE DE CONSULTING TESTING EN_ - localhost](https://user-images.githubusercontent.com/42253716/76091055-bf82e500-5fb4-11ea-9c2e-34f455369d49.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
