### PR TITLE
Group similar export history items

### DIFF
--- a/src/apps/companies/apps/exports/group-history-items.js
+++ b/src/apps/companies/apps/exports/group-history-items.js
@@ -1,0 +1,43 @@
+const GROUP_TIME_DELTA = 1000
+
+const isInteraction = (item) => item.hasOwnProperty('kind')
+
+function isTimeMatch(timestampA, timestampB) {
+  const dateA = Date.parse(timestampA)
+  const dateB = Date.parse(timestampB)
+
+  return Math.abs(dateA - dateB) < GROUP_TIME_DELTA
+}
+
+function isHistoryItemMatch(a, b) {
+  const userMatch = a.history_user.id === b.history_user.id
+  const typeMatch = a.history_type === b.history_type
+  const statusMatch = a.status === b.status
+
+  return userMatch && typeMatch && statusMatch && isTimeMatch(a.date, b.date)
+}
+
+export function groupHistoryItems(results) {
+  const groupedResults = []
+
+  results.forEach((item) => {
+    if (isInteraction(item)) {
+      groupedResults.push(item)
+    } else {
+      const lastItem = groupedResults[groupedResults.length - 1]
+      const canUpdateLastItem = lastItem && !isInteraction(lastItem)
+
+      if (canUpdateLastItem && isHistoryItemMatch(lastItem, item)) {
+        lastItem.countries.push(item.country)
+      } else {
+        const { country, ...rest } = item
+        groupedResults.push({
+          ...rest,
+          countries: [country],
+        })
+      }
+    }
+  })
+
+  return groupedResults
+}

--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -8,6 +8,7 @@ import {
   EXPORT_INTEREST_STATUS,
   EXPORT_INTEREST_STATUS_VALUES,
 } from '../../../constants'
+import { groupHistoryItems } from './group-history-items'
 
 const WHITELISTED_HISTORY_TYPES = ['insert', 'delete']
 
@@ -15,6 +16,7 @@ const COUNTRY_HISTORY_TYPE_TEXT = {
   insert: 'added to',
   delete: 'removed from',
 }
+
 const COUNTRY_TYPE_TEXT = {
   future_interest: 'future countries of interest',
   currently_exporting: 'currently exporting',
@@ -27,26 +29,23 @@ const COUNTRY_TYPE_LABEL = {
   [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: 'Countries not intersted in',
 }
 
-function getCountryText(country, historyType, status) {
+function getCountryText(countries, historyType, status) {
   const historyTypeText = COUNTRY_HISTORY_TYPE_TEXT[historyType]
   const typeText = COUNTRY_TYPE_TEXT[status]
+  const countryText = countries.map((country) => country.name).join(', ')
 
-  return [country, historyTypeText, typeText].join(' ')
+  return [countryText, historyTypeText, typeText].join(' ')
 }
 
 function createHistory(item) {
   return {
-    headingText: getCountryText(
-      item.country.name,
-      item.history_type,
-      item.status
-    ),
+    headingText: getCountryText(item.countries, item.history_type, item.status),
     metadata: [
       {
         label: 'By',
         value: item.history_user?.name ?? 'unknown',
       },
-      { label: 'Date', value: DateUtils.formatWithTime(item.history_date) },
+      { label: 'Date', value: DateUtils.formatWithTime(item.date) },
     ],
   }
 }
@@ -102,10 +101,12 @@ function createInteraction(item) {
 
 function transformFullExportHistory({ results }, activePage) {
   const offset = activePage * 10 - 10
-  const cleanedResults = results.filter(
-    (item) =>
-      isInteraction(item) ||
-      WHITELISTED_HISTORY_TYPES.includes(item.history_type)
+  const cleanedResults = groupHistoryItems(
+    results.filter(
+      (item) =>
+        isInteraction(item) ||
+        WHITELISTED_HISTORY_TYPES.includes(item.history_type)
+    )
   )
 
   return {

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -399,11 +399,409 @@ describe('Companies Export', () => {
   })
 })
 
-describe('Companies Export Countries', () => {
-  context('when there is no history', () => {
+describe('Company History', () => {
+  function checkListItems(items) {
+    items.forEach(([text, by, date]) => {
+      cy.contains(text)
+        .siblings()
+        .should('contain', by)
+        .should('contain', date)
+    })
+  }
+
+  describe('Full history', () => {
+    context('when there is no history', () => {
+      before(() => {
+        cy.visit(
+          urls.companies.exports.history.index(fixtures.company.lambdaPlc.id)
+        )
+      })
+
+      it('should render breadcrumbs', () => {
+        assertBreadcrumbs({
+          Home: urls.dashboard(),
+          Companies: urls.companies.index(),
+          [fixtures.company.lambdaPlc.name]: urls.companies.detail(
+            fixtures.company.lambdaPlc.id
+          ),
+          Exports: urls.companies.exports.index(fixtures.company.lambdaPlc.id),
+          'Export countries history': null,
+        })
+      })
+
+      it('renders the title', () => {
+        cy.contains('Export countries history')
+      })
+
+      it('renders the collection list with the 0 results', () => {
+        cy.contains('0 results')
+        cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
+      })
+    })
+
+    context('when there is history with multiple pages', () => {
+      before(() => {
+        cy.visit(
+          urls.companies.exports.history.index(fixtures.company.dnbCorp.id)
+        )
+      })
+
+      it('renders the title', () => {
+        cy.contains('Export countries history')
+      })
+
+      it('renders the collection list with 10 of the 12 results', () => {
+        cy.contains('12 results')
+        cy.get(countrySelectors.listItemHeadings).should('have.length', 10)
+
+        checkListItems([
+          [
+            'Belarus added to countries of no interest',
+            'By DIT Staff',
+            'Date 11 Feb 2020, 10:47am',
+          ],
+          [
+            'Botswana added to future countries of interest',
+            'By DIT Staff',
+            'Date 11 Feb 2020, 10:47am',
+          ],
+          [
+            'Georgia added to currently exporting',
+            'By DIT Staff',
+            'Date 11 Feb 2020, 10:48am',
+          ],
+          [
+            'France added to currently exporting',
+            'By DIT Staff',
+            'Date 11 Feb 2020, 10:47am',
+          ],
+          [
+            'Fiji added to currently exporting',
+            'By DIT Staff',
+            'Date 11 Feb 2020, 10:46am',
+          ],
+          [
+            'Argentina added to currently exporting',
+            'By DIT Staff',
+            'Date 6 Feb 2020, 4:06pm',
+          ],
+          [
+            'Andorra added to currently exporting',
+            'By DIT Staff',
+            'Date 6 Feb 2020, 4:05pm',
+          ],
+          [
+            'Afghanistan added to future countries of interest',
+            'By DIT Staff',
+            'Date 6 Feb 2020, 3:42pm',
+          ],
+          [
+            'Andorra removed from future countries of interest',
+            'By DIT Staff',
+            'Date 6 Feb 2020, 3:41pm',
+          ],
+          [
+            'Angola added to countries of no interest',
+            'By DIT Staff',
+            'Date 6 Feb 2020, 3:41pm',
+          ],
+        ])
+      })
+
+      it('should display the next button', () => {
+        cy.get('ul:last li a:last').should('have.text', 'Next')
+      })
+
+      it('should not display the previous button', () => {
+        cy.get('ul:last li a:first').should('not.have.text', 'Previous')
+      })
+
+      it('the second page renders the collection list with 2 of the 12 results', () => {
+        cy.get('a')
+          .contains('2')
+          .click()
+        cy.get(countrySelectors.listItemHeadings).should('have.length', 2)
+
+        checkListItems([
+          [
+            'Andorra removed from future countries of interest',
+            'By DIT Staff',
+            'Date 6 Feb 2020, 3:41pm',
+          ],
+          [
+            'Angola added to countries of no interest',
+            'By DIT Staff',
+            'Date 6 Feb 2020, 3:41pm',
+          ],
+        ])
+      })
+
+      it('should not display the next button', () => {
+        cy.get('ul:last li a:last').should('not.have.text', 'Next')
+      })
+
+      it('should display the previous button', () => {
+        cy.get('ul:last li a:first').should('have.text', 'Previous')
+      })
+    })
+
+    context('when there is history that can be grouped', () => {
+      before(() => {
+        cy.visit(
+          urls.companies.exports.history.index(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      })
+
+      it('renders the title', () => {
+        cy.contains('Export countries history')
+      })
+
+      it('renders the collection list with 10 results', () => {
+        cy.contains('10 results')
+        cy.get(countrySelectors.listItemHeadings).should('have.length', 10)
+
+        checkListItems([
+          [
+            'Barbados, Bangladesh, Bahrain, Afghanistan added to countries of no interest',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 4:33pm',
+          ],
+          [
+            'France removed from future countries of interest',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 4:33pm',
+          ],
+          [
+            'Spain added to currently exporting',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 4:33pm',
+          ],
+          [
+            'Albania, Brazil, Gibraltar removed from currently exporting',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 8:55am',
+          ],
+          [
+            'France added to future countries of interest',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 8:55am',
+          ],
+          [
+            'Albania, Gibraltar, Brazil added to currently exporting',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 8:55am',
+          ],
+          [
+            'Germany, Spain removed from future countries of interest',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 8:54am',
+          ],
+          [
+            'France removed from currently exporting',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 8:54am',
+          ],
+          [
+            'Germany, Spain added to future countries of interest',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 8:54am',
+          ],
+          [
+            'France added to currently exporting',
+            'By Stephan Padberg',
+            'Date 4 Mar 2020, 8:53am',
+          ],
+        ])
+      })
+      it('should not display the pagination', () => {
+        cy.get('#company-export-full-history ul').should('not.exist')
+      })
+    })
+
+    context('when the user is unknown', () => {
+      before(() => {
+        cy.visit(
+          urls.companies.exports.history.index(
+            fixtures.company.marsExportsLtd.id
+          )
+        )
+      })
+
+      it('renders the title', () => {
+        cy.contains('Export countries history')
+      })
+
+      it('renders the collection list with the one result', () => {
+        cy.contains('1 result')
+        cy.get(countrySelectors.listItemHeadings).should('have.length', 1)
+
+        cy.contains('Andorra removed from future countries of interest')
+          .siblings()
+          .should('contain', 'By unknown')
+          .should('contain', 'Date 6 Feb 2020, 3:41pm')
+      })
+    })
+
+    context('when the only item is an "update" item', () => {
+      before(() => {
+        cy.visit(
+          urls.companies.exports.history.index(
+            fixtures.company.dnbSubsidiary.id
+          )
+        )
+      })
+
+      it('should filter out the update', () => {
+        cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
+      })
+    })
+
+    context('when viewing a company with interactions in the history', () => {
+      before(() => {
+        cy.visit(
+          urls.companies.exports.history.index(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      it('renders the title', () => {
+        cy.contains('Export countries history')
+      })
+
+      it('renders the collection list with 5 results', () => {
+        const historyItems = fixtures.export.historyWithInteractions.results
+
+        function checkInteraction(assertions, index) {
+          const item = historyItems[index]
+          const interaction = 'interaction' + index
+          const link = 'interactionLink' + index
+          const subHeading = 'interactionSubHeading' + index
+          const assertionTasks = []
+
+          assertions.forEach(([assertion, values]) => {
+            values.forEach((value) => {
+              assertionTasks.push({ assertion, value })
+            })
+          })
+
+          cy.contains(item.subject)
+            .as(link)
+            .parent()
+            .siblings('h4')
+            .as(subHeading)
+            .parent()
+            .as(interaction)
+
+          cy.get('@' + link).should(
+            'have.attr',
+            'href',
+            urls.interactions.detail(item.id)
+          )
+
+          cy.get('@' + interaction)
+            .find('div span')
+            .should('contain', 'Interaction')
+
+          assertionTasks.reduce(($details, { assertion, value }) => {
+            return $details.should(assertion, value)
+          }, cy.get('@' + interaction).find('details'))
+        }
+
+        cy.contains('5 results')
+        cy.get(countrySelectors.listItemHeadings).should('have.length', 5)
+
+        const interactionDetails = [
+          [
+            [
+              'contain',
+              [
+                'Company contacts Stephan Padberg, Stephanie Stokes',
+                'Advisers Mr. Genesis Kub (et nihil repudiandae), Solon Lynch (ea est totam), Dr. Meda Mraz (fuga corporis architecto)',
+                'Service Deserunt magni sapiente soluta praesentium sapiente.',
+                'Countries currently exporting to Benin',
+                'Future countries of interest Brunei Darussalam, French Polynesia',
+              ],
+            ],
+            ['not.contain', ['Countries not intersted in']],
+          ],
+          [
+            [
+              'contain',
+              [
+                'Company contact Justus Simonis',
+                'Adviser Carolanne Langworth (sit delectus recusandae)',
+                'Service Ipsa dicta omnis pariatur.',
+                'Countries currently exporting to Christmas Island, Indonesia, Martinique',
+                'Countries not intersted in Serbia',
+              ],
+            ],
+            ['not.contain', ['Future countries of interest']],
+          ],
+          [
+            [
+              'contain',
+              [
+                'Company contacts Karen Mayer Jr., Ari Von',
+                'Adviser Horace Orn (nisi ipsa quisquam)',
+                'Service Architecto suscipit et aliquam architecto.',
+                'Countries currently exporting to Burkina Faso',
+                'Future countries of interest Kyrgyz Republic, Trinidad and Tobago',
+              ],
+            ],
+            ['not.contain', ['Countries not intersted in']],
+          ],
+          [
+            [
+              'contain',
+              [
+                'Company contact Leonie Deckow',
+                'Advisers Napoleon Powlowski (veritatis temporibus unde), Giovanna Anderson (delectus repellendus ducimus), Tessie Hane (perferendis nihil nam)',
+                'Service Repellat quia fugiat velit delectus expedita omnis doloribus.',
+                'Countries currently exporting to Bolivia, Cameroon',
+                'Future countries of interest Bolivia, Qatar',
+                'Countries not intersted in Australia, Greenland',
+              ],
+            ],
+          ],
+        ]
+
+        interactionDetails.forEach(checkInteraction)
+
+        cy.get('@interactionSubHeading0').should(
+          'contain',
+          'Created 8 Jun 2019, 7:24am'
+        )
+        cy.get('@interactionSubHeading1').should(
+          'contain',
+          'Created 21 Jun 2019, 5:07am'
+        )
+        cy.get('@interactionSubHeading2').should(
+          'contain',
+          'Created 17 Sep 2019, 12:13am'
+        )
+        cy.get('@interactionSubHeading3').should(
+          'contain',
+          'Created 5 Jan 2020, 1:27pm'
+        )
+
+        cy.contains('Belarus added to countries of no interest')
+          .siblings()
+          .should('contain', 'By DIT Staff')
+          .should('contain', 'Date 11 Feb 2020, 10:47am')
+      })
+    })
+  })
+
+  describe('Country specific history', () => {
     before(() => {
       cy.visit(
-        urls.companies.exports.history.index(fixtures.company.lambdaPlc.id)
+        urls.companies.exports.history.country(
+          fixtures.company.dnbCorp.id,
+          '975f66a0-5d95-e211-a939-e4115bead28a'
+        )
       )
     })
 
@@ -411,321 +809,34 @@ describe('Companies Export Countries', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
         Companies: urls.companies.index(),
-        [fixtures.company.lambdaPlc.name]: urls.companies.detail(
-          fixtures.company.lambdaPlc.id
+        [fixtures.company.dnbCorp.name]: urls.companies.detail(
+          fixtures.company.dnbCorp.id
         ),
-        Exports: urls.companies.exports.index(fixtures.company.lambdaPlc.id),
-        'Export countries history': null,
+        Exports: urls.companies.exports.index(fixtures.company.dnbCorp.id),
+        'Andorra exports history': null,
       })
     })
 
     it('renders the title', () => {
-      cy.contains('Export countries history')
+      cy.contains('Andorra exports history')
     })
 
-    it('renders the collection list with the 0 results', () => {
-      cy.contains('0 results')
-      cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
-    })
-  })
-
-  context('when there is history', () => {
-    before(() => {
-      cy.visit(
-        urls.companies.exports.history.index(fixtures.company.dnbCorp.id)
-      )
-    })
-
-    it('renders the title', () => {
-      cy.contains('Export countries history')
-    })
-
-    it('renders the collection list with 10 of the 12 results', () => {
-      cy.contains('12 results')
-      cy.get(countrySelectors.listItemHeadings).should('have.length', 10)
-
-      cy.contains('Belarus added to countries of no interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 11 Feb 2020, 10:47am')
-      cy.contains('Botswana added to future countries of interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 11 Feb 2020, 10:47am')
-      cy.contains('Georgia added to currently exporting')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 11 Feb 2020, 10:47am')
-      cy.contains('France added to currently exporting')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 11 Feb 2020, 10:47am')
-      cy.contains('Fiji added to currently exporting')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 11 Feb 2020, 10:47am')
-      cy.contains('Argentina added to currently exporting')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 6 Feb 2020, 4:06pm')
-      cy.contains('Andorra added to currently exporting')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 6 Feb 2020, 4:06pm')
-      cy.contains('Afghanistan added to future countries of interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', '6 Feb 2020, 3:42pm')
-      cy.contains('Andorra removed from future countries of interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 6 Feb 2020, 3:41pm')
-      cy.contains('Angola added to countries of no interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 6 Feb 2020, 3:41pm')
-    })
-
-    it('should display the next button', () => {
-      cy.get('ul:last li a:last').should('have.text', 'Next')
-    })
-
-    it('should not display the previous button', () => {
-      cy.get('ul:last li a:first').should('not.have.text', 'Previous')
-    })
-
-    it('the second page renders the collection list with 2 of the 12 results', () => {
-      cy.get('a')
-        .contains('2')
-        .click()
+    it('renders the collection list with 2 results', () => {
+      cy.contains('2 results')
       cy.get(countrySelectors.listItemHeadings).should('have.length', 2)
-      cy.contains('Andorra removed from future countries of interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 6 Feb 2020, 3:41pm')
-      cy.contains('Angola added to countries of no interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 6 Feb 2020, 3:41pm')
-    })
 
-    it('should not display the next button', () => {
-      cy.get('ul:last li a:last').should('not.have.text', 'Next')
-    })
-
-    it('should display the previous button', () => {
-      cy.get('ul:last li a:first').should('have.text', 'Previous')
-    })
-  })
-
-  context('when the user is unknown', () => {
-    before(() => {
-      cy.visit(
-        urls.companies.exports.history.index(fixtures.company.marsExportsLtd.id)
-      )
-    })
-
-    it('renders the title', () => {
-      cy.contains('Export countries history')
-    })
-
-    it('renders the collection list with the one result', () => {
-      cy.contains('1 result')
-      cy.get(countrySelectors.listItemHeadings).should('have.length', 1)
-
-      cy.contains('Andorra removed from future countries of interest')
-        .siblings()
-        .should('contain', 'By unknown')
-        .should('contain', 'Date 6 Feb 2020, 3:41pm')
-    })
-  })
-
-  context('when the only item is an "update" item', () => {
-    before(() => {
-      cy.visit(
-        urls.companies.exports.history.index(fixtures.company.dnbSubsidiary.id)
-      )
-    })
-
-    it('should filter out the update', () => {
-      cy.get(countrySelectors.listItemHeadings).should('have.length', 0)
-    })
-  })
-
-  context('when viewing a company with interactions in the history', () => {
-    before(() => {
-      cy.visit(
-        urls.companies.exports.history.index(
-          fixtures.company.investigationLimited.id
-        )
-      )
-    })
-
-    it('renders the title', () => {
-      cy.contains('Export countries history')
-    })
-
-    it('renders the collection list with 5 results', () => {
-      const historyItems = fixtures.export.historyWithInteractions.results
-
-      function checkInteraction(assertions, index) {
-        const item = historyItems[index]
-        const interaction = 'interaction' + index
-        const link = 'interactionLink' + index
-        const subHeading = 'interactionSubHeading' + index
-        const assertionTasks = []
-
-        assertions.forEach(([assertion, values]) => {
-          values.forEach((value) => {
-            assertionTasks.push({ assertion, value })
-          })
-        })
-
-        cy.contains(item.subject)
-          .as(link)
-          .parent()
-          .siblings('h4')
-          .as(subHeading)
-          .parent()
-          .as(interaction)
-
-        cy.get('@' + link).should(
-          'have.attr',
-          'href',
-          urls.interactions.detail(item.id)
-        )
-
-        cy.get('@' + interaction)
-          .find('div span')
-          .should('contain', 'Interaction')
-
-        assertionTasks.reduce(($details, { assertion, value }) => {
-          return $details.should(assertion, value)
-        }, cy.get('@' + interaction).find('details'))
-      }
-
-      cy.contains('5 results')
-      cy.get(countrySelectors.listItemHeadings).should('have.length', 5)
-
-      const interactionDetails = [
+      checkListItems([
         [
-          [
-            'contain',
-            [
-              'Company contacts Stephan Padberg, Stephanie Stokes',
-              'Advisers Mr. Genesis Kub (et nihil repudiandae), Solon Lynch (ea est totam), Dr. Meda Mraz (fuga corporis architecto)',
-              'Service Deserunt magni sapiente soluta praesentium sapiente.',
-              'Countries currently exporting to Benin',
-              'Future countries of interest Brunei Darussalam, French Polynesia',
-            ],
-          ],
-          ['not.contain', ['Countries not intersted in']],
+          'Andorra added to currently exporting',
+          'By DIT Staff',
+          'Date 6 Feb 2020, 4:06pm',
         ],
         [
-          [
-            'contain',
-            [
-              'Company contact Justus Simonis',
-              'Adviser Carolanne Langworth (sit delectus recusandae)',
-              'Service Ipsa dicta omnis pariatur.',
-              'Countries currently exporting to Christmas Island, Indonesia, Martinique',
-              'Countries not intersted in Serbia',
-            ],
-          ],
-          ['not.contain', ['Future countries of interest']],
+          'Andorra removed from future countries of interest',
+          'By DIT Staff',
+          'Date 6 Feb 2020, 3:41pm',
         ],
-        [
-          [
-            'contain',
-            [
-              'Company contacts Karen Mayer Jr., Ari Von',
-              'Adviser Horace Orn (nisi ipsa quisquam)',
-              'Service Architecto suscipit et aliquam architecto.',
-              'Countries currently exporting to Burkina Faso',
-              'Future countries of interest Kyrgyz Republic, Trinidad and Tobago',
-            ],
-          ],
-          ['not.contain', ['Countries not intersted in']],
-        ],
-        [
-          [
-            'contain',
-            [
-              'Company contact Leonie Deckow',
-              'Advisers Napoleon Powlowski (veritatis temporibus unde), Giovanna Anderson (delectus repellendus ducimus), Tessie Hane (perferendis nihil nam)',
-              'Service Repellat quia fugiat velit delectus expedita omnis doloribus.',
-              'Countries currently exporting to Bolivia, Cameroon',
-              'Future countries of interest Bolivia, Qatar',
-              'Countries not intersted in Australia, Greenland',
-            ],
-          ],
-        ],
-      ]
-
-      interactionDetails.forEach(checkInteraction)
-
-      cy.get('@interactionSubHeading0').should(
-        'contain',
-        'Created 8 Jun 2019, 7:24am'
-      )
-      cy.get('@interactionSubHeading1').should(
-        'contain',
-        'Created 21 Jun 2019, 5:07am'
-      )
-      cy.get('@interactionSubHeading2').should(
-        'contain',
-        'Created 17 Sep 2019, 12:13am'
-      )
-      cy.get('@interactionSubHeading3').should(
-        'contain',
-        'Created 5 Jan 2020, 1:27pm'
-      )
-
-      cy.contains('Belarus added to countries of no interest')
-        .siblings()
-        .should('contain', 'By DIT Staff')
-        .should('contain', 'Date 11 Feb 2020, 10:47am')
+      ])
     })
-  })
-})
-
-describe('Country Export History', () => {
-  before(() => {
-    cy.visit(
-      urls.companies.exports.history.country(
-        fixtures.company.dnbCorp.id,
-        '975f66a0-5d95-e211-a939-e4115bead28a'
-      )
-    )
-  })
-
-  it('should render breadcrumbs', () => {
-    assertBreadcrumbs({
-      Home: urls.dashboard(),
-      Companies: urls.companies.index(),
-      [fixtures.company.dnbCorp.name]: urls.companies.detail(
-        fixtures.company.dnbCorp.id
-      ),
-      Exports: urls.companies.exports.index(fixtures.company.dnbCorp.id),
-      'Andorra exports history': null,
-    })
-  })
-
-  it('renders the title', () => {
-    cy.contains('Andorra exports history')
-  })
-
-  it('renders the collection list with 2 results', () => {
-    cy.contains('2 results')
-    cy.get(countrySelectors.listItemHeadings).should('have.length', 2)
-
-    cy.contains('Andorra added to currently exporting')
-      .siblings()
-      .should('contain', 'By DIT Staff')
-      .should('contain', 'Date 6 Feb 2020, 4:06pm')
-    cy.contains('Andorra removed from future countries of interest')
-      .siblings()
-      .should('contain', 'By DIT Staff')
-      .should('contain', 'Date 6 Feb 2020, 3:41pm')
   })
 })

--- a/test/sandbox/fixtures/v4/export/country-export-history.json
+++ b/test/sandbox/fixtures/v4/export/country-export-history.json
@@ -16,7 +16,7 @@
       },
       "id": "f3824d00-dcb9-405e-8160-128723a4f234",
       "history_type": "insert",
-      "history_date": "2020-02-06T16:06:30.472874+00:00",
+      "date": "2020-02-06T16:06:30.472874+00:00",
       "status": "currently_exporting"
     },
     {
@@ -34,7 +34,7 @@
       },
       "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
       "history_type": "delete",
-      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "date": "2020-02-06T15:41:11.802460+00:00",
       "status": "future_interest"
     }
   ]

--- a/test/sandbox/fixtures/v4/export/full-export-history-page-1.json
+++ b/test/sandbox/fixtures/v4/export/full-export-history-page-1.json
@@ -17,7 +17,7 @@
       "id": "9e37e956-bc37-4a29-946f-4a6375d2fdd2",
       "status": "not_interested",
       "history_type": "insert",
-      "history_date": "2020-02-11T10:47:33.657731+00:00"
+      "date": "2020-02-11T10:47:33.657731+00:00"
     },
     {
       "history_user": {
@@ -35,7 +35,7 @@
       "id": "c28b5a48-5740-4572-b5b6-ce9a64125a6f",
       "status": "future_interest",
       "history_type": "insert",
-      "history_date": "2020-02-11T10:47:33.651790+00:00"
+      "date": "2020-02-11T10:47:33.651790+00:00"
     },
     {
       "history_user": {
@@ -53,7 +53,7 @@
       "id": "582a4b45-33e5-4331-9a1b-5f8051925e71",
       "status": "currently_exporting",
       "history_type": "insert",
-      "history_date": "2020-02-11T10:47:33.633742+00:00"
+      "date": "2020-02-11T10:48:33.633742+00:00"
     },
     {
       "history_user": {
@@ -71,7 +71,7 @@
       "id": "4e102d2d-e014-4c58-ae2c-af0d1d1829c5",
       "status": "currently_exporting",
       "history_type": "insert",
-      "history_date": "2020-02-11T10:47:33.629904+00:00"
+      "date": "2020-02-11T10:47:33.629904+00:00"
     },
     {
       "history_user": {
@@ -89,7 +89,7 @@
       "id": "6702fff9-7b63-4742-813c-4a8cc7cdfb56",
       "status": "currently_exporting",
       "history_type": "insert",
-      "history_date": "2020-02-11T10:47:33.618209+00:00"
+      "date": "2020-02-11T10:46:33.618209+00:00"
     },
     {
       "history_user": {
@@ -106,7 +106,7 @@
       },
       "id": "355c5a71-670c-4969-8c83-b0b117558635",
       "history_type": "insert",
-      "history_date": "2020-02-06T16:06:30.477414+00:00",
+      "date": "2020-02-06T16:06:30.477414+00:00",
       "status": "currently_exporting"
     },
     {
@@ -124,7 +124,7 @@
       },
       "id": "f3824d00-dcb9-405e-8160-128723a4f234",
       "history_type": "insert",
-      "history_date": "2020-02-06T16:06:30.472874+00:00",
+      "date": "2020-02-06T16:05:30.472874+00:00",
       "status": "currently_exporting"
     },
     {
@@ -142,7 +142,7 @@
       },
       "id": "c5171cb4-00d3-4e91-9f9b-c31c4ec9837a",
       "history_type": "insert",
-      "history_date": "2020-02-06T15:42:08.713400+00:00",
+      "date": "2020-02-06T15:42:08.713400+00:00",
       "status": "future_interest"
     },
     {
@@ -160,7 +160,7 @@
       },
       "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
       "history_type": "delete",
-      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "date": "2020-02-06T15:41:11.802460+00:00",
       "status": "future_interest"
     },
     {
@@ -178,7 +178,7 @@
       },
       "id": "3c898164-4df8-4d87-9e0a-8528753e6ad9",
       "history_type": "insert",
-      "history_date": "2020-02-06T15:41:11.796334+00:00",
+      "date": "2020-02-06T15:41:11.796334+00:00",
       "status": "not_interested"
     },
     {
@@ -196,7 +196,7 @@
       },
       "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
       "history_type": "delete",
-      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "date": "2020-02-06T15:41:11.802460+00:00",
       "status": "future_interest"
     },
     {
@@ -214,7 +214,7 @@
       },
       "id": "3c898164-4df8-4d87-9e0a-8528753e6ad9",
       "history_type": "insert",
-      "history_date": "2020-02-06T15:41:11.796334+00:00",
+      "date": "2020-02-06T15:41:11.796334+00:00",
       "status": "not_interested"
     }
   ]

--- a/test/sandbox/fixtures/v4/export/full-export-history-page-2.json
+++ b/test/sandbox/fixtures/v4/export/full-export-history-page-2.json
@@ -16,7 +16,7 @@
       },
       "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
       "history_type": "delete",
-      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "date": "2020-02-06T15:41:11.802460+00:00",
       "status": "future_interest"
     },
     {
@@ -34,7 +34,7 @@
       },
       "id": "3c898164-4df8-4d87-9e0a-8528753e6ad9",
       "history_type": "insert",
-      "history_date": "2020-02-06T15:41:11.796334+00:00",
+      "date": "2020-02-06T15:41:11.796334+00:00",
       "status": "not_interested"
     }
   ]

--- a/test/sandbox/fixtures/v4/export/history-groups.json
+++ b/test/sandbox/fixtures/v4/export/history-groups.json
@@ -1,0 +1,366 @@
+{
+    "count": 19,
+    "results": [
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "a55f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Barbados"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "766eece6-57dc-4a2a-892b-ce0007309f1c",
+            "date": "2020-03-04T16:33:57.438445+00:00",
+            "history_date": "2020-03-04T16:33:57.438445+00:00",
+            "status": "not_interested",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "a45f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Bangladesh"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "79febf69-6d6e-4664-bf3e-21d854ee725b",
+            "date": "2020-03-04T16:33:57.434436+00:00",
+            "history_date": "2020-03-04T16:33:57.434436+00:00",
+            "status": "not_interested",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "a35f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Bahrain"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "5a224916-3198-40e6-9a42-d961ab8ad36a",
+            "date": "2020-03-04T16:33:57.430419+00:00",
+            "history_date": "2020-03-04T16:33:57.430419+00:00",
+            "status": "not_interested",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "87756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "Afghanistan"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "f17cdd60-da10-4cff-abe0-1e5e0e3e2808",
+            "date": "2020-03-04T16:33:57.425813+00:00",
+            "history_date": "2020-03-04T16:33:57.425813+00:00",
+            "status": "not_interested",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "82756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "France"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "e01a4b2d-58be-4c3d-965c-d72c5e71ec67",
+            "date": "2020-03-04T16:33:11.387354+00:00",
+            "history_date": "2020-03-04T16:33:11.387354+00:00",
+            "status": "future_interest",
+            "history_type": "delete"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "86756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "Spain"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "ce9bce4f-2f7a-4e71-8baa-3451a2616906",
+            "date": "2020-03-04T16:33:05.940300+00:00",
+            "history_date": "2020-03-04T16:33:05.940300+00:00",
+            "status": "currently_exporting",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "945f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Albania"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "fb2908ee-7dcd-434c-83fd-7bbb5116e667",
+            "date": "2020-03-04T08:55:49.061948+00:00",
+            "history_date": "2020-03-04T08:55:49.061948+00:00",
+            "status": "currently_exporting",
+            "history_type": "delete"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "b05f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Brazil"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "d7446c97-4866-429d-8beb-215ced89c69a",
+            "date": "2020-03-04T08:55:49.058041+00:00",
+            "history_date": "2020-03-04T08:55:49.058041+00:00",
+            "status": "currently_exporting",
+            "history_type": "delete"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "e2f682ac-5d95-e211-a939-e4115bead28a",
+                "name": "Gibraltar"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "8a5641fe-f38c-4438-834a-c49f0aeee861",
+            "date": "2020-03-04T08:55:49.054282+00:00",
+            "history_date": "2020-03-04T08:55:49.054282+00:00",
+            "status": "currently_exporting",
+            "history_type": "delete"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "82756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "France"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "cd29598a-aace-4a4c-bced-380506102041",
+            "date": "2020-03-04T08:55:49.048400+00:00",
+            "history_date": "2020-03-04T08:55:49.048400+00:00",
+            "status": "future_interest",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "945f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Albania"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "e753a3eb-edee-4cac-8881-e5394d7f621d",
+            "date": "2020-03-04T08:55:06.094737+00:00",
+            "history_date": "2020-03-04T08:55:06.094737+00:00",
+            "status": "currently_exporting",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "e2f682ac-5d95-e211-a939-e4115bead28a",
+                "name": "Gibraltar"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "264ccd2c-539d-41f2-be71-f2955e5cf8fd",
+            "date": "2020-03-04T08:55:06.090659+00:00",
+            "history_date": "2020-03-04T08:55:06.090659+00:00",
+            "status": "currently_exporting",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "b05f66a0-5d95-e211-a939-e4115bead28a",
+                "name": "Brazil"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "f8aa97cf-8d45-43ab-8809-c4f61f86dc46",
+            "date": "2020-03-04T08:55:06.086296+00:00",
+            "history_date": "2020-03-04T08:55:06.086296+00:00",
+            "status": "currently_exporting",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "83756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "Germany"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "22a8bd9c-b1fe-4407-85e3-cc06096e1bfa",
+            "date": "2020-03-04T08:54:53.350140+00:00",
+            "history_date": "2020-03-04T08:54:53.350140+00:00",
+            "status": "future_interest",
+            "history_type": "delete"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "86756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "Spain"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "bb488da7-7101-4776-97c1-40670fc8ceb3",
+            "date": "2020-03-04T08:54:53.345805+00:00",
+            "history_date": "2020-03-04T08:54:53.345805+00:00",
+            "status": "future_interest",
+            "history_type": "delete"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "82756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "France"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "5e62036d-393b-4e7b-9ae0-ec8781125f60",
+            "date": "2020-03-04T08:54:42.806088+00:00",
+            "history_date": "2020-03-04T08:54:42.806088+00:00",
+            "status": "currently_exporting",
+            "history_type": "delete"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "83756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "Germany"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "e36e551f-88b6-4abd-a068-87c27e190345",
+            "date": "2020-03-04T08:54:42.800708+00:00",
+            "history_date": "2020-03-04T08:54:42.800708+00:00",
+            "status": "future_interest",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "86756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "Spain"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "281f9aa5-9f40-41c4-83aa-4390e0b52858",
+            "date": "2020-03-04T08:54:42.795073+00:00",
+            "history_date": "2020-03-04T08:54:42.795073+00:00",
+            "status": "future_interest",
+            "history_type": "insert"
+        },
+        {
+            "history_user": {
+                "id": "f4ba3387-4853-4ebf-be5f-e4088daefa16",
+                "name": "Stephan Padberg"
+            },
+            "country": {
+                "id": "82756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "France"
+            },
+            "company": {
+                "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+                "name": "Lambda plc"
+            },
+            "id": "b713615c-eeba-4ff5-a3fd-de2fa6098262",
+            "date": "2020-03-04T08:53:19.444496+00:00",
+            "history_date": "2020-03-04T08:53:19.444496+00:00",
+            "status": "currently_exporting",
+            "history_type": "insert"
+        }
+    ]
+}

--- a/test/sandbox/fixtures/v4/export/history-with-interactions.json
+++ b/test/sandbox/fixtures/v4/export/history-with-interactions.json
@@ -275,7 +275,7 @@
             "id": "9e37e956-bc37-4a29-946f-4a6375d2fdd2",
             "status": "not_interested",
             "history_type": "insert",
-            "history_date": "2020-02-11T10:47:33.657731+00:00"
+            "date": "2020-02-11T10:47:33.657731+00:00"
         }
     ]
 }

--- a/test/sandbox/fixtures/v4/export/unkown-user-export-history.json
+++ b/test/sandbox/fixtures/v4/export/unkown-user-export-history.json
@@ -13,7 +13,7 @@
       },
       "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
       "history_type": "delete",
-      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "date": "2020-02-06T15:41:11.802460+00:00",
       "status": "future_interest"
     }
   ]

--- a/test/sandbox/fixtures/v4/export/update-only-export-history.json
+++ b/test/sandbox/fixtures/v4/export/update-only-export-history.json
@@ -13,7 +13,7 @@
       },
       "id": "15ea74cf-e384-4002-a5d9-8d13ea30ca2e",
       "history_type": "update",
-      "history_date": "2020-02-06T15:41:11.802460+00:00",
+      "date": "2020-02-06T15:41:11.802460+00:00",
       "status": "future_interest"
     }
   ]

--- a/test/sandbox/routes/v4/search/export.js
+++ b/test/sandbox/routes/v4/search/export.js
@@ -4,11 +4,13 @@ var unkownUserExportHistory = require('../../../fixtures/v4/export/unkown-user-e
 var updateOnlyExportHistory = require('../../../fixtures/v4/export/update-only-export-history.json')
 var countryExportHistory = require('../../../fixtures/v4/export/country-export-history.json')
 var exportHistoryWithInteractions = require('../../../fixtures/v4/export/history-with-interactions.json')
+var exportHistoryGroups = require('../../../fixtures/v4/export/history-groups.json')
 
 var dnbCorp = require('../../../fixtures/v4/company/company-dnb-corp.json')
 var marsExportsLtd = require('../../../fixtures/v4/company/company-mars-exports-ltd.json')
 var dnbSubsidiary = require('../../../fixtures/v4/company/company-dnb-subsidiary.json')
 var investigationLtd = require('../../../fixtures/v4/company/company-investigation-ltd.json')
+var globalUltimate = require('../../../fixtures/v4/company/company-dnb-global-ultimate.json')
 
 exports.fetchExportHistory = function(req, res) {
   var companyId = req.body.company
@@ -28,6 +30,9 @@ exports.fetchExportHistory = function(req, res) {
   }
   if (companyId === investigationLtd.id) {
     return res.json(exportHistoryWithInteractions)
+  }
+  if (companyId === globalUltimate.id) {
+    return res.json(exportHistoryGroups)
   }
 
   return res.json(emptyFullExportHistory)


### PR DESCRIPTION
## Description of change

This is a temporary FE fix to group the API data to reduce items in the list. The API is expected to do this in the future at which point this code will be removed.

It will group export history country changes to show the same actions on the same line. Currently if you add two countries they will show as two line items when it should be one.

## Test instructions

Edit the export countries either on the export tab or by adding an interaction with "Were countries discussed" as "Yes" and then click on "View full export countries history" and then countries added to the same category should appear in the same line

## Screenshots
### Before

![exports_before](https://user-images.githubusercontent.com/1481883/76093044-46858c80-5fb8-11ea-8fc3-f62d93ecb0b3.png)

### After

![export_after](https://user-images.githubusercontent.com/1481883/76093078-51402180-5fb8-11ea-86db-412f1420a983.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
