### PR TITLE
Add cypress recording capability to functionals and e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ aliases:
       name: Wait for api sandbox
       command: dockerize -wait ${API_ROOT}/ping.xml -timeout 120s
 
+  - &store_artifacts_cypress_video
+    store_artifacts:
+      path: cypress/videos
+
   # Data hub base environment variables
   - &data_hub_base_envs
     NODE_ENV: development
@@ -293,6 +297,7 @@ jobs:
           when: always
       - store_artifacts:
           path: cypress/screenshots
+      - *store_artifacts_cypress_video
 
   # Run visual tests
   visual_tests:
@@ -348,6 +353,8 @@ jobs:
           command: yarn test:e2e:dit --browser chrome
       - store_artifacts:
           path: cypress/screenshots
+      - *store_artifacts_cypress_video
+   
 
   # Run e2e tests for LEP staff
   lep_staff_e2e:
@@ -377,6 +384,7 @@ jobs:
           command: yarn test:e2e:lep --browser chrome
       - store_artifacts:
           path: cypress/screenshots
+      - *store_artifacts_cypress_video
 
   # Run e2e tests for DA staff
   da_staff_e2e:
@@ -406,6 +414,7 @@ jobs:
           command: yarn test:e2e:da --browser chrome
       - store_artifacts:
           path: cypress/screenshots
+      - *store_artifacts_cypress_video
 
 # CircleCI workflows
 workflows:

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,8 @@
 {
   "integrationFolder": "test/functional/cypress/specs",
   "baseUrl": "http://localhost:3001",
-  "video": false,
+  "video": true,
+  "videoUploadOnPasses": false,
   "screenshotOnRunFailure": false,
   "pluginsFile": false,
   "defaultCommandTimeout": 10000,

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -61,7 +61,7 @@ describe('Service delivery', () => {
     )
   })
 
-  it('should add the service delivery', () => {
+  it('should create the service delivery', () => {
     const subject = 'Some interesting service delivery'
 
     const formSelectors = selectors.interactionForm
@@ -79,11 +79,14 @@ describe('Service delivery', () => {
       'contain',
       'Service delivery created'
     )
+  })
 
+  it('should display newly created service delivery', () => {
     cy.visit(interactions.index())
     cy.get(selectors.filter.interaction.myInteractions).click()
 
-    cy.get(selectors.collection.items)
+    cy.reload()
+      .get(selectors.collection.items)
       .should('contain', 'Johnny Cakeman')
       .and('contain', 'Some interesting service delivery')
       .and('contain', 'Venus Ltd')

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -85,8 +85,7 @@ describe('Service delivery', () => {
     cy.visit(interactions.index())
     cy.get(selectors.filter.interaction.myInteractions).click()
 
-    cy.reload()
-      .get(selectors.collection.items)
+    cy.get(selectors.collection.items)
       .should('contain', 'Johnny Cakeman')
       .and('contain', 'Some interesting service delivery')
       .and('contain', 'Venus Ltd')

--- a/test/functional/cypress/specs/companies/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/send-referral-spec.js
@@ -6,7 +6,7 @@ const {
   assertBreadcrumbs,
 } = require('../../support/assertions')
 
-const selectTypeahead = (fieldName, input, spanNumber) =>
+const selectTypeahead = (fieldName, input) =>
   cy.contains(fieldName).within(() => {
     cy.server()
     cy.route('/api-proxy/adviser/?*').as('adviserResults')

--- a/test/functional/cypress/specs/companies/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/send-referral-spec.js
@@ -11,11 +11,7 @@ const selectTypeahead = (fieldName, input, spanNumber) =>
     cy.get('div')
       .eq(0)
       .type(input)
-      .within(() => {
-        cy.get('span')
-          .eq(spanNumber)
-          .click()
-      })
+      .type('{enter}')
   })
 
 describe('Send a referral form', () => {
@@ -106,7 +102,7 @@ describe('Send a referral form', () => {
       'when "Continue" button is clicked without specifying a subject',
       () => {
         it('should display error message', () => {
-          selectTypeahead('Adviser', 'S', 3)
+          selectTypeahead('Adviser', 'Shawn')
           cy.get(selectors.companySendReferral.continueButton).click()
           cy.get(selectors.companySendReferral.form).contains(
             'Enter a subject for the referral'
@@ -146,7 +142,7 @@ describe('Send a referral form', () => {
         'when "Continue" button is clicked with just mandatory fields filled in',
         () => {
           it('should display confirmation component', () => {
-            selectTypeahead('Adviser', 'S', 3)
+            selectTypeahead('Adviser', 'Shawn')
             cy.get(selectors.companySendReferral.subjectField)
               .click()
               .type('Example subject')
@@ -163,14 +159,14 @@ describe('Send a referral form', () => {
     () => {
       it('should display the confirmation component with the values just input', () => {
         cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
-        selectTypeahead('Adviser', 'S', 3)
+        selectTypeahead('Adviser', 'Shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')
           .get(selectors.companySendReferral.notesField)
           .click()
           .type('Example notes')
-        selectTypeahead('Company contact', 'J', 2)
+        selectTypeahead('Company contact', 'Johnny')
           .get(selectors.companySendReferral.continueButton)
           .click()
         cy.get('table')
@@ -202,14 +198,14 @@ describe('Send a referral form', () => {
     () => {
       it('the input data should appear in the form when "Edit referral" is clicked', () => {
         cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
-        selectTypeahead('Adviser', 'S', 3)
+        selectTypeahead('Adviser', 'Shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')
           .get(selectors.companySendReferral.notesField)
           .click()
           .type('Example notes')
-        selectTypeahead('Company contact', 'J', 2)
+        selectTypeahead('Company contact', 'Johnny')
           .get(selectors.companySendReferral.continueButton)
           .click()
         cy.contains('Edit referral').click()
@@ -238,7 +234,7 @@ describe('Send a referral form', () => {
     'When the "Cancel" link is clicked from the confirmation component',
     () => {
       it('should return to the company page', () => {
-        selectTypeahead('Adviser', 'S', 3)
+        selectTypeahead('Adviser', 'Shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')
@@ -260,7 +256,7 @@ describe('Send a referral form', () => {
         cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
       })
       it('should take user to the company page, display flash message and link to the homepage', () => {
-        selectTypeahead('Adviser', 'S', 3)
+        selectTypeahead('Adviser', 'Shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')

--- a/test/functional/cypress/specs/companies/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/send-referral-spec.js
@@ -8,10 +8,13 @@ const {
 
 const selectTypeahead = (fieldName, input, spanNumber) =>
   cy.contains(fieldName).within(() => {
+    cy.server()
+    cy.route('/api-proxy/adviser/?*').as('adviserResults')
     cy.get('div')
       .eq(0)
       .type(input)
-      .type('{enter}')
+    cy.wait('@adviserResults')
+    cy.get('[class*="MenuList"] > div > span').click()
   })
 
 describe('Send a referral form', () => {
@@ -102,9 +105,10 @@ describe('Send a referral form', () => {
       'when "Continue" button is clicked without specifying a subject',
       () => {
         it('should display error message', () => {
-          selectTypeahead('Adviser', 'Shawn')
+          selectTypeahead('Adviser', 'shawn')
           cy.get(selectors.companySendReferral.continueButton).click()
-          cy.get(selectors.companySendReferral.form).contains(
+          cy.get(selectors.companySendReferral.form).should(
+            'contain',
             'Enter a subject for the referral'
           )
         })
@@ -120,7 +124,8 @@ describe('Send a referral form', () => {
             .type(
               'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris nec interdum velit. Nulla facilisi. In ultricies sed ex at malesuada. Proin quis faucibus felis, iaculis malesuada sem. Maecenas semper elit magna, tincidunt consectetur risus volutpat at. Sed'
             )
-          cy.get(selectors.companySendReferral.form).contains(
+          cy.get(selectors.companySendReferral.form).should(
+            'contain',
             'Subject must be 255 characters or less'
           )
         })
@@ -133,7 +138,8 @@ describe('Send a referral form', () => {
           .click()
           .type('example subject')
         cy.get(selectors.companySendReferral.subjectField).clear()
-        cy.get(selectors.companySendReferral.form).contains(
+        cy.get(selectors.companySendReferral.form).should(
+          'contain',
           'Enter a subject for the referral'
         )
       })
@@ -142,7 +148,7 @@ describe('Send a referral form', () => {
         'when "Continue" button is clicked with just mandatory fields filled in',
         () => {
           it('should display confirmation component', () => {
-            selectTypeahead('Adviser', 'Shawn')
+            selectTypeahead('Adviser', 'shawn')
             cy.get(selectors.companySendReferral.subjectField)
               .click()
               .type('Example subject')
@@ -159,14 +165,14 @@ describe('Send a referral form', () => {
     () => {
       it('should display the confirmation component with the values just input', () => {
         cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
-        selectTypeahead('Adviser', 'Shawn')
+        selectTypeahead('Adviser', 'shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')
           .get(selectors.companySendReferral.notesField)
           .click()
           .type('Example notes')
-        selectTypeahead('Company contact', 'Johnny')
+        selectTypeahead('Company contact', 'johnny')
           .get(selectors.companySendReferral.continueButton)
           .click()
         cy.get('table')
@@ -198,14 +204,14 @@ describe('Send a referral form', () => {
     () => {
       it('the input data should appear in the form when "Edit referral" is clicked', () => {
         cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
-        selectTypeahead('Adviser', 'Shawn')
+        selectTypeahead('Adviser', 'shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')
           .get(selectors.companySendReferral.notesField)
           .click()
           .type('Example notes')
-        selectTypeahead('Company contact', 'Johnny')
+        selectTypeahead('Company contact', 'johnny')
           .get(selectors.companySendReferral.continueButton)
           .click()
         cy.contains('Edit referral').click()
@@ -234,7 +240,7 @@ describe('Send a referral form', () => {
     'When the "Cancel" link is clicked from the confirmation component',
     () => {
       it('should return to the company page', () => {
-        selectTypeahead('Adviser', 'Shawn')
+        selectTypeahead('Adviser', 'shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')
@@ -256,7 +262,7 @@ describe('Send a referral form', () => {
         cy.visit(urls.companies.sendReferral(fixtures.company.withContacts.id))
       })
       it('should take user to the company page, display flash message and link to the homepage', () => {
-        selectTypeahead('Adviser', 'Shawn')
+        selectTypeahead('Adviser', 'shawn')
         cy.get(selectors.companySendReferral.subjectField)
           .click()
           .type('Example subject')

--- a/test/functional/cypress/specs/companies/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/send-referral-spec.js
@@ -14,7 +14,7 @@ const selectTypeahead = (fieldName, input, spanNumber) =>
       .eq(0)
       .type(input)
     cy.wait('@adviserResults')
-    cy.get('[class*="MenuList"] > div > span').click()
+    cy.get('[class*="menu"] > div').click()
   })
 
 describe('Send a referral form', () => {


### PR DESCRIPTION
## Description of change

Add video capability for failing tests and enhance current flaky tests due to chrome upgrade

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
