### PR TITLE
Handle unknown users for grouped history

### DIFF
--- a/src/apps/companies/apps/exports/group-history-items.js
+++ b/src/apps/companies/apps/exports/group-history-items.js
@@ -10,7 +10,7 @@ function isTimeMatch(timestampA, timestampB) {
 }
 
 function isHistoryItemMatch(a, b) {
-  const userMatch = a.history_user.id === b.history_user.id
+  const userMatch = a.history_user?.id === b.history_user?.id
   const typeMatch = a.history_type === b.history_type
   const statusMatch = a.status === b.status
 

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -615,32 +615,70 @@ describe('Company History', () => {
           ],
         ])
       })
+
       it('should not display the pagination', () => {
         cy.get('#company-export-full-history ul').should('not.exist')
       })
     })
 
     context('when the user is unknown', () => {
-      before(() => {
-        cy.visit(
-          urls.companies.exports.history.index(
-            fixtures.company.marsExportsLtd.id
+      context('With a single history item', () => {
+        before(() => {
+          cy.visit(
+            urls.companies.exports.history.index(
+              fixtures.company.marsExportsLtd.id
+            )
           )
-        )
+        })
+
+        it('renders the title', () => {
+          cy.contains('Export countries history')
+        })
+
+        it('renders the collection list with the one result', () => {
+          cy.contains('1 result')
+          cy.get(countrySelectors.listItemHeadings).should('have.length', 1)
+
+          checkListItems([
+            [
+              'Andorra removed from future countries of interest',
+              'By unknown',
+              'Date 6 Feb 2020, 3:41pm',
+            ],
+          ])
+        })
       })
 
-      it('renders the title', () => {
-        cy.contains('Export countries history')
-      })
+      context('With grouped history items', () => {
+        before(() => {
+          cy.visit(
+            urls.companies.exports.history.index(
+              fixtures.company.minimallyMinimalLtd.id
+            )
+          )
+        })
 
-      it('renders the collection list with the one result', () => {
-        cy.contains('1 result')
-        cy.get(countrySelectors.listItemHeadings).should('have.length', 1)
+        it('renders the title', () => {
+          cy.contains('Export countries history')
+        })
 
-        cy.contains('Andorra removed from future countries of interest')
-          .siblings()
-          .should('contain', 'By unknown')
-          .should('contain', 'Date 6 Feb 2020, 3:41pm')
+        it('renders the collection list with the two results', () => {
+          cy.contains('2 results')
+          cy.get(countrySelectors.listItemHeadings).should('have.length', 2)
+
+          checkListItems([
+            [
+              'Maldives, Gibraltar, Andorra added to currently exporting',
+              'By unknown',
+              'Date 6 Feb 2020, 5:07pm',
+            ],
+            [
+              'Kiribati, Hong Kong, Czechia, Angola added to future countries of interest',
+              'By unknown',
+              'Date 6 Feb 2020, 5:06pm',
+            ],
+          ])
+        })
       })
     })
 

--- a/test/sandbox/fixtures/v4/export/history-groups-null-users.json
+++ b/test/sandbox/fixtures/v4/export/history-groups-null-users.json
@@ -1,0 +1,133 @@
+{
+  "count": 8,
+  "results": [
+      {
+          "history_user": null,
+          "country": {
+              "id": "0650bdb8-5d95-e211-a939-e4115bead28a",
+              "name": "Maldives"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "033e3537-6c33-48ad-8e39-e817ddce440a",
+          "date": "2020-02-06T17:07:12.630612+00:00",
+          "status": "currently_exporting",
+          "history_date": "2020-02-06T17:07:12.630612+00:00",
+          "history_type": "insert"
+      },
+      {
+          "history_user": null,
+          "country": {
+              "id": "e2f682ac-5d95-e211-a939-e4115bead28a",
+              "name": "Gibraltar"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "5621d6e8-915e-44ca-b8f2-4748dab2600d",
+          "date": "2020-02-06T17:07:12.627606+00:00",
+          "status": "currently_exporting",
+          "history_date": "2020-02-06T17:07:12.627606+00:00",
+          "history_type": "insert"
+      },
+      {
+          "history_user": null,
+          "country": {
+              "id": "985f66a0-5d95-e211-a939-e4115bead28a",
+              "name": "Angola"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "b9879b82-9fc2-4d54-859f-59d757ac92c9",
+          "date": "2020-02-06T17:07:12.624890+00:00",
+          "status": "currently_exporting",
+          "history_date": "2020-02-06T17:07:12.624890+00:00",
+          "history_type": "update"
+      },
+      {
+          "history_user": null,
+          "country": {
+              "id": "975f66a0-5d95-e211-a939-e4115bead28a",
+              "name": "Andorra"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "5a6ca1c7-c749-4668-9ea6-bd0976976667",
+          "date": "2020-02-06T17:07:12.619582+00:00",
+          "status": "currently_exporting",
+          "history_date": "2020-02-06T17:07:12.619582+00:00",
+          "history_type": "insert"
+      },
+      {
+          "history_user": null,
+          "country": {
+              "id": "7a6a9ab2-5d95-e211-a939-e4115bead28a",
+              "name": "Kiribati"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "67957788-2708-4546-b75d-7c9cbabe30dd",
+          "date": "2020-02-06T17:06:53.701816+00:00",
+          "status": "future_interest",
+          "history_date": "2020-02-06T17:06:53.701816+00:00",
+          "history_type": "insert"
+      },
+      {
+          "history_user": null,
+          "country": {
+              "id": "f0f682ac-5d95-e211-a939-e4115bead28a",
+              "name": "Hong Kong"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "52f34e7d-06b5-4966-99ef-45062d89d8b2",
+          "date": "2020-02-06T17:06:53.697971+00:00",
+          "status": "future_interest",
+          "history_date": "2020-02-06T17:06:53.697971+00:00",
+          "history_type": "insert"
+      },
+      {
+          "history_user": null,
+          "country": {
+              "id": "6faf72a6-5d95-e211-a939-e4115bead28a",
+              "name": "Czechia"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "98c60ab1-d441-4a05-8bb7-b5e37065d520",
+          "date": "2020-02-06T17:06:53.694367+00:00",
+          "status": "future_interest",
+          "history_date": "2020-02-06T17:06:53.694367+00:00",
+          "history_type": "insert"
+      },
+      {
+          "history_user": null,
+          "country": {
+              "id": "985f66a0-5d95-e211-a939-e4115bead28a",
+              "name": "Angola"
+          },
+          "company": {
+              "id": "5bb239e4-b227-4a84-bc2e-3420fc129447",
+              "name": "Alphabet Inc."
+          },
+          "id": "2ff687fc-f671-47a2-9ef4-83b180df9294",
+          "date": "2020-02-06T17:06:53.691071+00:00",
+          "status": "future_interest",
+          "history_date": "2020-02-06T17:06:53.691071+00:00",
+          "history_type": "insert"
+      }
+  ]
+}

--- a/test/sandbox/routes/v4/search/export.js
+++ b/test/sandbox/routes/v4/search/export.js
@@ -5,12 +5,14 @@ var updateOnlyExportHistory = require('../../../fixtures/v4/export/update-only-e
 var countryExportHistory = require('../../../fixtures/v4/export/country-export-history.json')
 var exportHistoryWithInteractions = require('../../../fixtures/v4/export/history-with-interactions.json')
 var exportHistoryGroups = require('../../../fixtures/v4/export/history-groups.json')
+var historyGroupsWithNullUsers = require('../../../fixtures/v4/export/history-groups-null-users.json')
 
 var dnbCorp = require('../../../fixtures/v4/company/company-dnb-corp.json')
 var marsExportsLtd = require('../../../fixtures/v4/company/company-mars-exports-ltd.json')
 var dnbSubsidiary = require('../../../fixtures/v4/company/company-dnb-subsidiary.json')
 var investigationLtd = require('../../../fixtures/v4/company/company-investigation-ltd.json')
 var globalUltimate = require('../../../fixtures/v4/company/company-dnb-global-ultimate.json')
+var minimallyMinimal = require('../../../fixtures/v4/company/company-minimally-minimal.json')
 
 exports.fetchExportHistory = function(req, res) {
   var companyId = req.body.company
@@ -33,6 +35,9 @@ exports.fetchExportHistory = function(req, res) {
   }
   if (companyId === globalUltimate.id) {
     return res.json(exportHistoryGroups)
+  }
+  if (companyId === minimallyMinimal.id) {
+    return res.json(historyGroupsWithNullUsers)
   }
 
   return res.json(emptyFullExportHistory)


### PR DESCRIPTION
## Description of change

The `history_user` can be `null` sometimes so this handles that scenario for grouping history items

## Test instructions

The functional tests only had one `null` user which meant the code passed the tests, so this adds a scenario with multiple history items with unknown users.

Use Sandbox and view the Minimally Minimal Ltd company (149475d4-13a0-e511-88b6-e4115bead28a) and go to the Export tab and click "View full export countries history"

## Screenshots
### Before

<img width="982" alt="Screenshot 2020-03-09 at 08 37 49" src="https://user-images.githubusercontent.com/1481883/76196123-94c9a400-61e1-11ea-9d0c-e9dad47576bb.png">

### After

<img width="978" alt="Screenshot 2020-03-09 at 08 38 06" src="https://user-images.githubusercontent.com/1481883/76196134-985d2b00-61e1-11ea-95a5-9d8c1b2d2f0a.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
