### PR TITLE
Add the referrals to the ES keys

### DIFF
--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -8,6 +8,7 @@ const ES_KEYS = {
   omis: 'dit:OMISOrder',
   type: 'object.type',
   attributedTo: 'object.attributedTo.id',
+  companyReferral: 'dit:CompanyReferral',
 }
 
 const ES_KEYS_GROUPED = {
@@ -19,6 +20,7 @@ const ES_KEYS_GROUPED = {
     ES_KEYS.serviceDelivery, // Interaction
     ES_KEYS.investmentProject,
     ES_KEYS.omis,
+    ES_KEYS.companyReferral,
   ],
 
   externalActivity: [
@@ -32,6 +34,7 @@ const ES_KEYS_GROUPED = {
     ES_KEYS.serviceDelivery, // Interaction
     ES_KEYS.investmentProject,
     ES_KEYS.omis,
+    ES_KEYS.companyReferral,
   ],
 }
 


### PR DESCRIPTION
## Description of change

After updating the Activity Feed in Data Hub Components we now just need to add the referral ES key that is used to retrieve the referrals.

## Test instructions

Run this against the dev API and select the company "VENUS SOLUTIONS LIMITED" you should then see referrals pulling through the activity feed.

## Screenshots
![Screenshot 2020-03-09 at 16 35 22](https://user-images.githubusercontent.com/10154302/76236918-4e963400-6225-11ea-8acd-6ce6285e649d.png)



## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
