### PR TITLE
Add Global Ultimate Duns Number to Edit History

### DIFF
--- a/src/apps/companies/apps/edit-history/constants.js
+++ b/src/apps/companies/apps/edit-history/constants.js
@@ -6,22 +6,18 @@ const NO = 'No'
 const AUTOMATIC_UPDATE = 'automaticUpdate'
 const DEFAULT_ITEMS_PER_PAGE = 10
 
-const EXCLUDED_FIELDS = [
-  'archived_by',
-  'archived_on',
-  'dnb_modified_on',
-  'global_ultimate_duns_number',
-]
+const EXCLUDED_FIELDS = ['archived_by', 'archived_on', 'dnb_modified_on']
 
 const COMPANY_FIELD_NAME_TO_LABEL_MAP = {
   address_1: 'Address line 1',
   address_2: 'Address line 2 (optional)',
+  archived_documents_url_path: 'Archived documents URL path',
   company_number: 'Companies House number',
   description: 'Business description (optional)',
-  archived_documents_url_path: 'Archived documents URL path',
   export_experience_category: 'Export win category',
   export_to_countries: 'Countries currently exporting to',
   future_interest_countries: 'Future countries of interest',
+  global_ultimate_duns_number: 'Global Ultimate Duns Number',
   great_profile_status: 'great.gov.uk business profile',
   is_turnover_estimated: 'Is turnover estimated',
   name: 'Name of company',

--- a/test/functional/cypress/specs/companies/edit-history-spec.js
+++ b/test/functional/cypress/specs/companies/edit-history-spec.js
@@ -238,4 +238,15 @@ describe('Edit History', () => {
       )
     })
   })
+
+  context('when a company becomes a "Global Ultimate"', () => {
+    it('should display the changes to the "Global Ultimate Duns Number"', () => {
+      assertChanges(
+        companyEditHistory.change(5).table(5),
+        'Global Ultimate Duns Number',
+        'Not set',
+        '561652707'
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Description of change
Added the Global Ultimate Duns Number to the Edit History page

Path: _/companies/id/edit-history_

![GUDN](https://user-images.githubusercontent.com/964268/76416877-ce421100-6393-11ea-9b1f-69a051e913f0.png)

## Checklist
[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
