### PR TITLE
Fix typo for countries not interested in

### DIFF
--- a/src/apps/companies/apps/exports/tasks.js
+++ b/src/apps/companies/apps/exports/tasks.js
@@ -26,7 +26,7 @@ const COUNTRY_TYPE_TEXT = {
 const COUNTRY_TYPE_LABEL = {
   [EXPORT_INTEREST_STATUS.EXPORTING_TO]: 'Countries currently exporting to',
   [EXPORT_INTEREST_STATUS.FUTURE_INTEREST]: 'Future countries of interest',
-  [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: 'Countries not intersted in',
+  [EXPORT_INTEREST_STATUS.NOT_INTERESTED]: 'Countries not interested in',
 }
 
 function getCountryText(countries, historyType, status) {

--- a/test/functional/cypress/specs/companies/export-spec.js
+++ b/test/functional/cypress/specs/companies/export-spec.js
@@ -763,7 +763,7 @@ describe('Company History', () => {
                 'Future countries of interest Brunei Darussalam, French Polynesia',
               ],
             ],
-            ['not.contain', ['Countries not intersted in']],
+            ['not.contain', ['Countries not interested in']],
           ],
           [
             [
@@ -773,7 +773,7 @@ describe('Company History', () => {
                 'Adviser Carolanne Langworth (sit delectus recusandae)',
                 'Service Ipsa dicta omnis pariatur.',
                 'Countries currently exporting to Christmas Island, Indonesia, Martinique',
-                'Countries not intersted in Serbia',
+                'Countries not interested in Serbia',
               ],
             ],
             ['not.contain', ['Future countries of interest']],
@@ -789,7 +789,7 @@ describe('Company History', () => {
                 'Future countries of interest Kyrgyz Republic, Trinidad and Tobago',
               ],
             ],
-            ['not.contain', ['Countries not intersted in']],
+            ['not.contain', ['Countries not interested in']],
           ],
           [
             [
@@ -800,7 +800,7 @@ describe('Company History', () => {
                 'Service Repellat quia fugiat velit delectus expedita omnis doloribus.',
                 'Countries currently exporting to Bolivia, Cameroon',
                 'Future countries of interest Bolivia, Qatar',
-                'Countries not intersted in Australia, Greenland',
+                'Countries not interested in Australia, Greenland',
               ],
             ],
           ],


### PR DESCRIPTION
## Description of change

@reupen noticed a typo in the label for the countries not interested field

## Test instructions

Functional test assertions updated so all test should pass.
Use sandbox and view the export history for Investigation Limited (ca8fae21-2895-47cf-90ba-9273c94dab81) 

## Screenshots
### Before

<img width="950" alt="Screenshot 2020-03-12 at 06 38 27" src="https://user-images.githubusercontent.com/1481883/76494225-507e1400-642c-11ea-8800-6ee48983d6ea.png">

### After

<img width="953" alt="Screenshot 2020-03-12 at 06 38 01" src="https://user-images.githubusercontent.com/1481883/76494235-53790480-642c-11ea-9cff-733d77488bf9.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
