### PR TITLE
Add refer this company button to activity feed

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -421,8 +421,6 @@ describe('Activity feed controllers', () => {
           {
             props: {
               companyId: 'dcdabbc9-1781-e411-8955-e4115bead28a',
-              contentLink: companies.interactions.create(companyId),
-              contentText: 'Add interaction',
               activityTypeFilter: FILTER_KEYS.dataHubActivity,
               activityTypeFilters: FILTER_ITEMS,
               apiEndpoint: companies.activity.data(companyId),
@@ -479,8 +477,6 @@ describe('Activity feed controllers', () => {
           {
             props: {
               companyId: 'dcdabbc9-1781-e411-8955-e4115bead28a',
-              contentLink: companies.interactions.create(companyId),
-              contentText: 'Add interaction',
               activityTypeFilter: FILTER_KEYS.dataHubActivity,
               activityTypeFilters: FILTER_ITEMS,
               apiEndpoint: companies.activity.data(companyId),

--- a/src/apps/companies/apps/activity-feed/client/ActivityFeedApp.jsx
+++ b/src/apps/companies/apps/activity-feed/client/ActivityFeedApp.jsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { ActivityFeed } from 'data-hub-components'
+import PropTypes from 'prop-types'
+import axios from 'axios'
+
+export default class ActivityFeedApp extends React.Component {
+  static propTypes = {
+    actions: PropTypes.node,
+    activityTypeFilter: PropTypes.string,
+    activityTypeFilters: PropTypes.object,
+    apiEndpoint: PropTypes.string.isRequired,
+    isGlobalUltimate: PropTypes.bool,
+    dnbHierarchyCount: PropTypes.number,
+    isTypeFilterFlagEnabled: PropTypes.bool,
+    isGlobalUltimateFlagEnabled: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    activityTypeFilter: null,
+    activityTypeFilters: {},
+    actions: null,
+    isGlobalUltimate: false,
+    dnbHierarchyCount: null,
+    isTypeFilterFlagEnabled: false,
+    isGlobalUltimateFlagEnabled: false,
+  }
+
+  constructor(props) {
+    super(props)
+
+    const { activityTypeFilter } = props
+
+    this.state = {
+      activities: [],
+      error: false,
+      hasMore: true,
+      isLoading: true,
+      from: 0,
+      total: 0,
+      queryParams: {
+        activityTypeFilter,
+        showDnbHierarchy: false,
+      },
+    }
+
+    this.onLoadMore = this.onLoadMore.bind(this)
+    this.setQueryParams = this.setQueryParams.bind(this)
+  }
+
+  async componentDidMount() {
+    await this.onLoadMore()
+  }
+
+  setQueryParams(queryParams) {
+    this.setState(
+      {
+        from: 0,
+        activities: [],
+        queryParams,
+      },
+      this.onLoadMore
+    )
+  }
+
+  async onLoadMore() {
+    const { activities, queryParams, from } = this.state
+    const { apiEndpoint } = this.props
+    const size = 20
+
+    this.setState({
+      isLoading: true,
+    })
+
+    try {
+      const {
+        activities: newActivities,
+        total,
+      } = await ActivityFeedApp.fetchActivities(
+        apiEndpoint,
+        from,
+        size,
+        queryParams
+      )
+
+      const allActivities = activities.concat(newActivities)
+
+      this.setState({
+        activities: allActivities,
+        isLoading: false,
+        hasMore: total > allActivities.length,
+        from: from + size,
+        total,
+      })
+    } catch (e) {
+      this.setState({
+        isLoading: false,
+        hasMore: false,
+        error: true,
+      })
+    }
+  }
+
+  static async fetchActivities(apiEndpoint, from, size, queryParams) {
+    const { activityTypeFilter, showDnbHierarchy } = queryParams
+
+    const params = {
+      from,
+      size,
+      activityTypeFilter,
+      showDnbHierarchy,
+    }
+
+    const { data } = await axios.get(apiEndpoint, { params })
+
+    const { total, hits } = data.hits
+
+    return {
+      total,
+      activities: hits.map((hit) => hit._source),
+    }
+  }
+
+  render() {
+    const { activities, isLoading, hasMore, error, total } = this.state
+    const {
+      activityTypeFilters,
+      actions,
+      isGlobalUltimate,
+      dnbHierarchyCount,
+      isTypeFilterFlagEnabled,
+      isGlobalUltimateFlagEnabled,
+    } = this.props
+
+    const isEmptyFeed = activities.length === 0 && !hasMore
+
+    return (
+      <ActivityFeed
+        activities={activities}
+        activityTypeFilters={activityTypeFilters}
+        actions={actions}
+        isLoading={isLoading}
+        hasMore={hasMore}
+        onLoadMore={this.onLoadMore}
+        sendQueryParams={this.setQueryParams}
+        totalActivities={total}
+        isGlobalUltimate={isGlobalUltimate}
+        dnbHierarchyCount={dnbHierarchyCount}
+        isTypeFilterFlagEnabled={isTypeFilterFlagEnabled}
+        isGlobalUltimateFlagEnabled={isGlobalUltimateFlagEnabled}
+      >
+        {isEmptyFeed && !error && <div>There are no activities to show.</div>}
+        {error && <div>Error occurred while loading activities.</div>}
+      </ActivityFeed>
+    )
+  }
+}

--- a/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
+++ b/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
@@ -3,59 +3,81 @@ import PropTypes from 'prop-types'
 import { Button, Details, Paragraph, WarningText } from 'govuk-react'
 import { BLACK } from 'govuk-colours'
 import styled from 'styled-components'
+import { ActivityFeedAction, StatusMessage } from 'data-hub-components'
 
-import {
-  ActivityFeedApp,
-  ActivityFeedAction,
-  StatusMessage,
-} from 'data-hub-components'
-import urls from '../../../../../lib/urls'
+import ActivityFeedApp from './ActivityFeedApp'
+import { companies } from '../../../../../lib/urls'
 
 const StyledLink = styled('a')`
   margin-bottom: 0;
 `
 
-const CompanyActivityFeed = ({ companyId, showMatchingPrompt, ...rest }) => (
-  <>
-    {showMatchingPrompt && (
-      <StatusMessage colour={BLACK} id="ga-company-details-matching-prompt">
-        <WarningText>
-          Business details on this company record have not been verified and
-          could be wrong.
-        </WarningText>
-        <Details summary="Why verify?">
-          <Paragraph>
-            Using verified business details from a trusted third-party supplier
-            means we can keep certain information up to date automatically. This
-            helps reduce duplicate records, provide a shared view of complex
-            companies and make it more likely we can link other data sources
-            together.
-          </Paragraph>
-          <Paragraph>
-            Verification can often be done in just 4 clicks.
-          </Paragraph>
-        </Details>
-        <Button as={StyledLink} href={urls.companies.match.index(companyId)}>
-          Verify business details
-        </Button>
-      </StatusMessage>
-    )}
-    <ActivityFeedApp
-      actions={
-        <ActivityFeedAction
-          text="Add interaction"
-          link={urls.companies.interactions.create(companyId)}
-        />
-      }
-      {...rest}
-    />
-  </>
-)
+const CompanyActivityFeed = ({
+  companyId,
+  showMatchingPrompt,
+  activityTypeFilter,
+  activityTypeFilters,
+  isGlobalUltimate,
+  dnbHierarchyCount,
+  isTypeFilterFlagEnabled,
+  isGlobalUltimateFlagEnabled,
+  apiEndpoint,
+}) => {
+  const actions = (
+    <>
+      <ActivityFeedAction
+        text="Refer this company"
+        link={companies.referrals.send(companyId)}
+      />
+      <ActivityFeedAction
+        text="Add interaction"
+        link={companies.interactions.create(companyId)}
+      />
+    </>
+  )
+
+  return (
+    <>
+      {showMatchingPrompt && (
+        <StatusMessage colour={BLACK} id="ga-company-details-matching-prompt">
+          <WarningText>
+            Business details on this company record have not been verified and
+            could be wrong.
+          </WarningText>
+          <Details summary="Why verify?">
+            <Paragraph>
+              Using verified business details from a trusted third-party
+              supplier means we can keep certain information up to date
+              automatically. This helps reduce duplicate records, provide a
+              shared view of complex companies and make it more likely we can
+              link other data sources together.
+            </Paragraph>
+            <Paragraph>
+              Verification can often be done in just 4 clicks.
+            </Paragraph>
+          </Details>
+          <Button as={StyledLink} href={companies.match.index(companyId)}>
+            Verify business details
+          </Button>
+        </StatusMessage>
+      )}
+      <ActivityFeedApp
+        actions={companyId && actions}
+        activityTypeFilter={activityTypeFilter}
+        activityTypeFilters={activityTypeFilters}
+        isGlobalUltimate={isGlobalUltimate}
+        dnbHierarchyCount={dnbHierarchyCount}
+        isTypeFilterFlagEnabled={isTypeFilterFlagEnabled}
+        isGlobalUltimateFlagEnabled={isGlobalUltimateFlagEnabled}
+        apiEndpoint={apiEndpoint}
+      />
+    </>
+  )
+}
 
 CompanyActivityFeed.propTypes = {
-  companyId: PropTypes.string.isRequired,
-  contentLink: PropTypes.string,
-  contentText: PropTypes.string,
+  companyId: PropTypes.string,
+  actions: PropTypes.node,
   activityTypeFilter: PropTypes.string,
   activityTypeFilters: PropTypes.object,
   apiEndpoint: PropTypes.string.isRequired,
@@ -67,10 +89,10 @@ CompanyActivityFeed.propTypes = {
 }
 
 CompanyActivityFeed.defaultProps = {
+  companyId: null,
   activityTypeFilter: null,
   activityTypeFilters: {},
-  contentLink: null,
-  contentText: null,
+  actions: null,
   isGlobalUltimate: false,
   dnbHierarchyCount: null,
   isTypeFilterFlagEnabled: false,

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -13,8 +13,6 @@ async function renderActivityFeed(req, res, next) {
       ? {}
       : {
           companyId: company.id,
-          contentText: 'Add interaction',
-          contentLink: companies.interactions.create(company.id),
           activityTypeFilter: FILTER_KEYS.dataHubActivity,
           activityTypeFilters: FILTER_ITEMS,
           isGlobalUltimate: company.is_global_ultimate,

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -84,6 +84,14 @@ describe('Company activity feed', () => {
       ).should('have.text', 'Add interaction')
     })
 
+    it('should display "Refer this company" button', () => {
+      cy.get(
+        selectors
+          .companyCollection()
+          .interaction.referButton(fixtures.company.venusLtd.id)
+      ).should('have.text', 'Refer this company')
+    })
+
     it('should not display the activity feed', () => {
       cy.get(selectors.companyActivity.activityFeed.item(1)).should(
         'not.be.visible'
@@ -138,11 +146,11 @@ describe('Company activity feed', () => {
     })
 
     it('should not display the "Add interaction" button', () => {
-      cy.get(
-        selectors
-          .companyCollection()
-          .interaction.addButton(fixtures.company.archivedLtd.id)
-      ).should('not.exist')
+      cy.contains('Add interaction').should('not.exist')
+    })
+
+    it('should not display "Refer this company" button', () => {
+      cy.contains('Refer this company').should('not.exist')
     })
 
     it('should display the activity feed', () => {

--- a/test/selectors/company/company-collection.js
+++ b/test/selectors/company/company-collection.js
@@ -1,18 +1,30 @@
+const urls = require('../../../src/lib/urls')
+
 module.exports = () => {
   const bodyMainContentSelector = '[data-auto-id="bodyMainContent"]'
 
   return {
     interaction: {
       addButton: (companyId) =>
-        `${bodyMainContentSelector} [href="/companies/${companyId}/interactions/create"]`,
+        `${bodyMainContentSelector} [href="${urls.companies.interactions.create(
+          companyId
+        )}"]`,
+      referButton: (companyId) =>
+        `${bodyMainContentSelector} [href="${urls.companies.referrals.send(
+          companyId
+        )}"]`,
     },
     contact: {
       addButton: (companyId) =>
-        `${bodyMainContentSelector} [href="/contacts/create?company=${companyId}"]`,
+        `${bodyMainContentSelector} [href="${urls.contacts.create(
+          companyId
+        )}"]`,
     },
     export: {
       editButton: (companyId) =>
-        `${bodyMainContentSelector} [href="/companies/${companyId}/exports/edit"]`,
+        `${bodyMainContentSelector} [href="${urls.companies.exports.edit(
+          companyId
+        )}"]`,
     },
     heading: `${bodyMainContentSelector} h2`,
     archivedSummary: `${bodyMainContentSelector} .details__summary`,


### PR DESCRIPTION
## Description of change

This PR:
1. brings in the component library `v4.0.0`
2. moves the `ActivityFeedApp` implementation layer into the frontend. This is a straight up copy and paste of the current implementation from the component library. We can work to refactor this in future PRs. 
3. refactors the `ActivityFeed` to pass multiple JSX buttons
4. fixes a false positive test where the buttons display even when the company is archived

## Test instructions

Navigate to a company page and you will see the new `Refer this company` button at the top of the ActivityFeed which takes you to the `send-referral` page.

## Screenshots
### Before

![FireShot Capture 054 - Activity Feed - LAMBDA COMMUNICATIONS LTD - Companies - DIT Data Hub_ - www datahub dev uktrade io](https://user-images.githubusercontent.com/42253716/76679264-05eccb00-65d7-11ea-98f4-1fe0b54284d1.png)

### After

![FireShot Capture 055 - Activity Feed - Lambda plc - Companies - DIT Data Hub - localhost](https://user-images.githubusercontent.com/42253716/76679278-1f8e1280-65d7-11ea-9aac-b50edf796035.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
