### PR TITLE
Update dependabot config to update all packages and fix conflict

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,16 +7,3 @@ update_configs:
     update_schedule: live
     default_reviewers:
       - datahub-fed
-    allowed_updates:
-      - match:
-          update_type: "security"
-
-  - package_manager: javascript
-    directory: "/"
-    update_schedule: weekly
-    version_requirement_updates: increase_versions
-    default_reviewers:
-      - datahub-fed
-    allowed_updates:
-      - match:
-          dependency_name: "data-hub-components"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,3 +7,7 @@ update_configs:
     update_schedule: live
     default_reviewers:
       - datahub-fed
+    ignored_updates:
+      - match:
+        dependency_name: "govuk-frontend"
+        dependency_name: "govuk-colours"


### PR DESCRIPTION
There are currently two issues open regarding our dependabot config. 

https://github.com/uktrade/data-hub-frontend/issues/2361
https://github.com/uktrade/data-hub-frontend/issues/2496

One says it cannot find our default branch 'develop'. I've checked and the default branch is now master. Hopefully updating the conflict in the config will also resolve this issue. 

This new config _should_ also create pull requests to update all of our packages, helping us keep up to date. 

I have checked this config using the dependabot config validator - https://dependabot.com/docs/config-file/validator/