### PR TITLE
Update data-hub-components which introduced stateless forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^3.14.1",
+    "data-hub-components": "^5.0.0",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
+++ b/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
@@ -4,7 +4,11 @@ import { Button, Details, Paragraph, WarningText } from 'govuk-react'
 import { BLACK } from 'govuk-colours'
 import styled from 'styled-components'
 
-import { ActivityFeedApp, StatusMessage } from 'data-hub-components'
+import {
+  ActivityFeedApp,
+  ActivityFeedAction,
+  StatusMessage,
+} from 'data-hub-components'
 import urls from '../../../../../lib/urls'
 
 const StyledLink = styled('a')`
@@ -36,7 +40,15 @@ const CompanyActivityFeed = ({ companyId, showMatchingPrompt, ...rest }) => (
         </Button>
       </StatusMessage>
     )}
-    <ActivityFeedApp {...rest} />
+    <ActivityFeedApp
+      actions={
+        <ActivityFeedAction
+          text="Add interaction"
+          link={urls.companies.interactions.create(companyId)}
+        />
+      }
+      {...rest}
+    />
   </>
 )
 

--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -8,7 +8,12 @@ import axios from 'axios'
 import { get } from 'lodash'
 import { H3 } from '@govuk-react/heading'
 
-import { FieldRadios, FieldSelect, Form, Step } from 'data-hub-components'
+import {
+  FieldRadios,
+  FieldSelect,
+  FormStateful,
+  Step,
+} from 'data-hub-components'
 
 import CompanyFoundStep from './CompanyFoundStep'
 import CompanyNotFoundStep from './CompanyNotFoundStep'
@@ -68,7 +73,7 @@ function AddCompanyForm({
   }
 
   return (
-    <Form
+    <FormStateful
       onSubmit={onSubmit}
       onExit={() => 'Changes that you made will not be saved.'}
     >
@@ -124,7 +129,7 @@ function AddCompanyForm({
           </>
         )
       }}
-    </Form>
+    </FormStateful>
   )
 }
 

--- a/src/apps/companies/apps/business-details/client/SectionArchive.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionArchive.jsx
@@ -9,7 +9,7 @@ import axios from 'axios'
 
 import {
   ButtonLink,
-  Form,
+  FormStateful,
   FormActions,
   FieldRadios,
   FieldInput,
@@ -43,7 +43,7 @@ const SectionArchive = ({ isArchived, isDnbCompany, urls }) => {
       <p>Archive this company if it is no longer required or active.</p>
 
       {formIsOpen && (
-        <Form onSubmit={archiveSubmitCallback} scrollToTop={false}>
+        <FormStateful onSubmit={archiveSubmitCallback} scrollToTop={false}>
           <FieldRadios
             label="Archive reason"
             name="archived_reason"
@@ -64,7 +64,7 @@ const SectionArchive = ({ isArchived, isDnbCompany, urls }) => {
             <Button>Archive</Button>
             <ButtonLink onClick={() => setFormIsOpen(false)}>Cancel</ButtonLink>
           </FormActions>
-        </Form>
+        </FormStateful>
       )}
 
       {!formIsOpen && (

--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -4,7 +4,7 @@ import axios from 'axios'
 
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
-import { Form, FormActions, StatusMessage } from 'data-hub-components'
+import { FormStateful, FormActions, StatusMessage } from 'data-hub-components'
 
 import urls from '../../../../../lib/urls'
 import CompanyMatched from './CompanyMatched'
@@ -31,7 +31,7 @@ function EditCompanyForm({
 
   // TODO: Support nested form values to avoid transformation
   return (
-    <Form onSubmit={onSubmit} initialValues={formInitialValues}>
+    <FormStateful onSubmit={onSubmit} initialValues={formInitialValues}>
       {({ submissionError }) => (
         <>
           {submissionError && (
@@ -71,7 +71,7 @@ function EditCompanyForm({
           </FormActions>
         </>
       )}
-    </Form>
+    </FormStateful>
   )
 }
 

--- a/src/apps/companies/apps/match-company/client/FindCompany.jsx
+++ b/src/apps/companies/apps/match-company/client/FindCompany.jsx
@@ -7,13 +7,13 @@ import urls from '../../../../../lib/urls'
 import {
   EntityListItem,
   FieldDnbCompany,
-  Form,
+  FormStateful,
   SummaryList,
 } from 'data-hub-components'
 
 function FindCompany({ company, csrfToken }) {
   return (
-    <Form
+    <FormStateful
       initialValues={{
         dnbCompanyName: company.name,
         dnbPostalCode: company.postcode,
@@ -56,7 +56,7 @@ function FindCompany({ company, csrfToken }) {
          company. You'll be given a chance to review the new business details
           before you verify."
       />
-    </Form>
+    </FormStateful>
   )
 }
 

--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -12,7 +12,7 @@ import { SPACING } from '@govuk-react/constants'
 import ErrorSummary from '@govuk-react/error-summary'
 import Details from '@govuk-react/details'
 
-import { Form, FormActions, SummaryList } from 'data-hub-components'
+import { FormStateful, FormActions, SummaryList } from 'data-hub-components'
 import urls from '../../../../../lib/urls'
 import MatchDuplicate from './MatchDuplicate'
 
@@ -56,7 +56,9 @@ function MatchConfirmation({
 
   return (
     <StyledRoot>
-      <Form onSubmit={() => onMatchSubmit({ company, dnbCompany, csrfToken })}>
+      <FormStateful
+        onSubmit={() => onMatchSubmit({ company, dnbCompany, csrfToken })}
+      >
         {({ submissionError }) => (
           <>
             {submissionError && (
@@ -120,7 +122,7 @@ function MatchConfirmation({
             </FormActions>
           </>
         )}
-      </Form>
+      </FormStateful>
     </StyledRoot>
   )
 }

--- a/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import Button from '@govuk-react/button'
 import { ErrorSummary, UnorderedList } from 'govuk-react'
 import { SPACING } from '@govuk-react/constants'
-import { Form, FormActions } from 'data-hub-components'
+import { FormStateful, FormActions } from 'data-hub-components'
 
 import urls from '../../../../../lib/urls'
 
@@ -30,7 +30,9 @@ async function onFormSubmit({ company, dnbCompany, csrfToken }) {
 
 function MatchDuplicate({ company, dnbCompany, csrfToken }) {
   return (
-    <Form onSubmit={() => onFormSubmit({ company, dnbCompany, csrfToken })}>
+    <FormStateful
+      onSubmit={() => onFormSubmit({ company, dnbCompany, csrfToken })}
+    >
       {({ submissionError }) => (
         <>
           {submissionError && (
@@ -68,7 +70,7 @@ function MatchDuplicate({ company, dnbCompany, csrfToken }) {
           </FormActions>
         </>
       )}
-    </Form>
+    </FormStateful>
   )
 }
 

--- a/src/apps/company-lists/client/EditCompanyList.jsx
+++ b/src/apps/company-lists/client/EditCompanyList.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import axios from 'axios'
 import { get } from 'lodash'
 import PropTypes from 'prop-types'
-import { Form, FieldInput, FormActions } from 'data-hub-components'
+import { FormStateful, FieldInput, FormActions } from 'data-hub-components'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import ErrorSummary from '@govuk-react/error-summary'
@@ -44,7 +44,7 @@ function EditCompanyList({
           errors={[]}
         />
       )}
-      <Form onSubmit={onSubmitHandler} initialValues={{ listName }}>
+      <FormStateful onSubmit={onSubmitHandler} initialValues={{ listName }}>
         <FieldInput
           name="listName"
           type="text"
@@ -61,7 +61,7 @@ function EditCompanyList({
           <Button>Save</Button>
           <Link href={cancelUrl}>Cancel</Link>
         </FormActions>
-      </Form>
+      </FormStateful>
     </>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,10 +4745,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-3.14.1.tgz#8cbbeaa2996819560d07e5287d879d4cf9f93695"
-  integrity sha512-g+RM4uhWRBEcYhs3vvNv/9KKWeZ2LDF2kQtiSXxKKtyqWCQdNzGjvMcnV9eWK0p6zzzQDNjhoNt9vNDhLpWSuQ==
+data-hub-components@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.0.0.tgz#ebd03122c16c9ff2d560079e1e08a91635da78d6"
+  integrity sha512-QN3UYBa60B+tE0MgyEHtVQvFAeuFNpeH+NSlnDIzQgcMQ18Y0Z5SkXlWzGQ3KNESzS3ODRA8iqXbVNxhLb3t4w==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change

Update the component library which makes the `Form` component stateless and introduce a new component `FormSateteful` which handles the state internally.

## Test instructions

Everything should work as before.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
