### PR TITLE
Add new API environment variables to CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,8 @@ aliases:
       SSO_ENABLED: 'True'
       RESOURCE_SERVER_INTROSPECTION_URL: http://localhost:8080/o/introspect # required but not used as user with token has been created in backend setup script
       RESOURCE_SERVER_AUTH_TOKEN: sso-token
+      STAFF_SSO_BASE_URL: http://localhost:8080/
+      STAFF_SSO_AUTH_TOKEN: sso-token
       WEB_CONCURRENCY: 2
       ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
       ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret


### PR DESCRIPTION
## Description of change

The adds new API environment variables that will be required following https://github.com/uktrade/data-hub-api/pull/2695.

## Test instructions

The CircleCI build should pass.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
