### PR TITLE
Complete referral with interaction

### DIFF
--- a/src/apps/companies/apps/referrals/details/client/InteractionReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/details/client/InteractionReferralDetails.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { SummaryTable, DateUtils } from 'data-hub-components'
+import { SPACING_POINTS } from '@govuk-react/constants'
+import { Link } from 'govuk-react'
+import styled from 'styled-components'
+
+import urls from '../../../../../../lib/urls'
+
+const StyledSummaryTable = styled(SummaryTable)({
+  'margin-top': SPACING_POINTS[8],
+})
+
+const InteractionReferralDetails = ({
+  id,
+  subject,
+  created_by,
+  recipient,
+  created_on,
+  companyId,
+}) => {
+  return (
+    <StyledSummaryTable
+      caption="This interaction is linked to a referral"
+      data-auto-id="interactionDetailsContainer"
+    >
+      <SummaryTable.Row heading="Subject">
+        <Link href={urls.companies.referrals.details(companyId, id)}>
+          {subject}
+        </Link>
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Sent on">
+        {DateUtils.format(created_on)}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="By">{created_by.name}</SummaryTable.Row>
+      <SummaryTable.Row heading="To">{recipient.name}</SummaryTable.Row>
+    </StyledSummaryTable>
+  )
+}
+
+export default InteractionReferralDetails

--- a/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
@@ -74,7 +74,13 @@ export default connect(state2props)(
               <p>Contact the recipient if something's changed.</p>
             </Details>
             <FormActions>
-              <Button as={Link} href="/">
+              <Button
+                as={Link}
+                href={urls.companies.referrals.interactions.create(
+                  companyId,
+                  referralId
+                )}
+              >
                 Accept referral
               </Button>
               <SecondaryButton

--- a/src/apps/companies/apps/referrals/index.js
+++ b/src/apps/companies/apps/referrals/index.js
@@ -1,8 +1,0 @@
-const router = require('./router')
-const urls = require('../../lib/urls')
-
-module.exports = {
-  displayName: 'Referrals',
-  mountpath: urls.referrals.index.mountPoint,
-  router,
-}

--- a/src/apps/companies/apps/referrals/middleware/interactions.js
+++ b/src/apps/companies/apps/referrals/middleware/interactions.js
@@ -1,0 +1,43 @@
+const { getReferral } = require('../repos')
+const urls = require('../../../../../lib/urls')
+
+async function setCompanyDetails(req, res, next) {
+  try {
+    const referral = await getReferral(req.session.token, req.params.referralId)
+    res.locals.company = referral.company
+    res.locals.contact = referral.contact
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
+function setInteractionsDetails(req, res, next) {
+  const { referralId } = req.params
+  const { company } = res.locals
+  res.locals.interactions = {
+    returnLink: urls.companies.referrals.interactionsIndex(
+      company.id,
+      referralId
+    ),
+    referralId: referralId,
+    canAdd: true,
+    showCompany: true,
+  }
+  res.breadcrumb([
+    {
+      text: `${company.name}`,
+      href: urls.companies.detail(company.id),
+    },
+    {
+      text: 'Referral',
+      href: urls.companies.referrals.details(company.id, referralId),
+    },
+  ]),
+    next()
+}
+
+module.exports = {
+  setInteractionsDetails,
+  setCompanyDetails,
+}

--- a/src/apps/companies/apps/referrals/repos.js
+++ b/src/apps/companies/apps/referrals/repos.js
@@ -1,0 +1,11 @@
+const { authorisedRequest } = require('../../../../lib/authorised-request')
+const config = require('../../../../config/index')
+
+function getReferral(token, referralId) {
+  return authorisedRequest(
+    token,
+    `${config.apiRoot}/v4/company-referral/${referralId}`
+  )
+}
+
+module.exports = { getReferral }

--- a/src/apps/companies/apps/referrals/router.js
+++ b/src/apps/companies/apps/referrals/router.js
@@ -7,10 +7,23 @@ const {
   renderSendReferralForm,
   submitSendReferralForm,
 } = require('./send-referral/controllers')
+const interactionsRouter = require('../../../interactions/router.sub-app')
+const {
+  setCompanyDetails,
+  setInteractionsDetails,
+} = require('./middleware/interactions')
 
 router.get(urls.companies.referrals.details.route, renderReferralDetails)
 router.get(urls.companies.referrals.help.route, renderReferralHelp)
 router.get(urls.companies.referrals.send.route, renderSendReferralForm)
 router.post(urls.companies.referrals.send.route, submitSendReferralForm)
 
+// Adding an interaction to complete a referral
+// This mounts the interactions sub app on the details route
+router.use(
+  urls.companies.referrals.details.route,
+  setCompanyDetails,
+  setInteractionsDetails,
+  interactionsRouter
+)
 module.exports = router

--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -12,6 +12,10 @@ function renderDetailsPage(req, res, next) {
       interaction,
       isComplete
     )
+    const referral = interaction.company_referral
+    if (referral) {
+      referral.companyId = interaction.company.id
+    }
     const canComplete =
       interaction.status === INTERACTION_STATUS.DRAFT &&
       new Date(interaction.date) < new Date() &&
@@ -24,6 +28,7 @@ function renderDetailsPage(req, res, next) {
         interactionViewRecord,
         canComplete,
         canEdit: isComplete,
+        referral,
       })
   } catch (error) {
     next(error)

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -17,6 +17,8 @@ const { FUTURE_INTEREST, EXPORTING_TO, NOT_INTERESTED } = EXPORT_INTEREST_STATUS
 
 const serviceOptionsTransformed = transformServicesOptions(serviceOptions)
 
+let referralId
+
 describe('Interaction details middleware', () => {
   describe('#postDetails', () => {
     let formBodyToApiRequestResponse
@@ -72,7 +74,8 @@ describe('Interaction details middleware', () => {
           it('should POST to the API', () => {
             expect(this.saveInteractionStub).to.have.been.calledOnceWithExactly(
               this.middlewareParameters.reqMock.session.token,
-              formBodyToApiRequestResponse
+              formBodyToApiRequestResponse,
+              referralId
             )
           })
 
@@ -142,7 +145,8 @@ describe('Interaction details middleware', () => {
           it('should PATCH to the API', () => {
             expect(this.saveInteractionStub).to.have.been.calledOnceWithExactly(
               this.middlewareParameters.reqMock.session.token,
-              formBodyToApiRequestResponse
+              formBodyToApiRequestResponse,
+              referralId
             )
           })
 
@@ -218,7 +222,8 @@ describe('Interaction details middleware', () => {
                 this.saveInteractionStub
               ).to.have.been.calledOnceWithExactly(
                 this.middlewareParameters.reqMock.session.token,
-                formBodyToApiRequestResponse
+                formBodyToApiRequestResponse,
+                referralId
               )
             })
 
@@ -300,7 +305,8 @@ describe('Interaction details middleware', () => {
                 this.saveInteractionStub
               ).to.have.been.calledOnceWithExactly(
                 this.middlewareParameters.reqMock.session.token,
-                formBodyToApiRequestResponse
+                formBodyToApiRequestResponse,
+                referralId
               )
             })
 
@@ -370,7 +376,8 @@ describe('Interaction details middleware', () => {
           it('should PATCH to the API without export_countries', () => {
             expect(this.saveInteractionStub).to.have.been.calledOnceWithExactly(
               this.middlewareParameters.reqMock.session.token,
-              formBodyToApiRequestResponse
+              formBodyToApiRequestResponse,
+              referralId
             )
           })
 

--- a/src/apps/interactions/repos.js
+++ b/src/apps/interactions/repos.js
@@ -8,9 +8,12 @@ function fetchInteraction(token, interactionId) {
   )
 }
 
-function saveInteraction(token, interaction) {
+function saveInteraction(token, interaction, referralId) {
   const options = {
-    url: `${config.apiRoot}/v3/interaction`,
+    url:
+      referralId && !interaction.id
+        ? `${config.apiRoot}/v4/company-referral/${referralId}/complete`
+        : `${config.apiRoot}/v3/interaction`,
     method: 'POST',
     body: interaction,
   }

--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -27,6 +27,13 @@
     <a href="{{ returnLink }}">Back</a>
   </div>
 
+  {% if referral %}
+    {% component 'react-slot', {
+      id: 'interaction-referral-details',
+      props: referral
+    } %}
+  {% endif %}
+
   {% if not canComplete and not canEdit and not interaction.archived %}
     {{ govukDetails({
       summaryText: 'Why can I not complete this interaction?',

--- a/src/client/components/ReferralList/Referral.jsx
+++ b/src/client/components/ReferralList/Referral.jsx
@@ -41,7 +41,9 @@ const Referral = ({
   <Card>
     <CardHeader
       company={{ name: companyName }}
-      heading={<Link href={urls.referrals.details(id)}>{subject}</Link>}
+      heading={
+        <Link href={urls.companies.referrals.details(id)}>{subject}</Link>
+      }
       startTime={date}
       badge={{
         text: `${capitalize(status)} referral`,

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -29,6 +29,7 @@ import ReferralHelp from '../apps/companies/apps/referrals/help/client/ReferralH
 import ValidatedInput from './components/ValidatedInput'
 import SendReferralForm from '../apps/companies/apps/referrals/send-referral/client/SendReferralForm'
 import sendReferral from '../apps/companies/apps/referrals/send-referral/client/reducer'
+import InteractionReferralDetails from '../apps/companies/apps/referrals/details/client/InteractionReferralDetails.jsx'
 
 import tasksSaga from './components/Task/saga'
 import tasks from './components/Task/reducer'
@@ -191,6 +192,9 @@ function App() {
       </Mount>
       <Mount selector="#company-exports-edit">
         {(props) => <ExportsEdit {...props} />}
+      </Mount>
+      <Mount selector="#interaction-referral-details">
+        {(props) => <InteractionReferralDetails {...props} />}
       </Mount>
     </Provider>
   )

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -96,6 +96,14 @@ module.exports = {
       send: url('/companies', '/:companyId/send-referral'),
       details: url('/companies', '/:companyId/referrals/:referralId'),
       help: url('/companies', '/:companyId/referrals/:referralId/help'),
+      interactions: createInteractionsSubApp(
+        '/companies',
+        '/:companyId/referrals/:referralId'
+      ),
+      interactionsIndex: url(
+        '/companies',
+        '/:companyId/referrals/:referralId/interactions'
+      ),
     },
     activity: {
       index: url('/companies', '/:companyId/activity'),

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -9,6 +9,7 @@ const WHITELIST = [
   '/v4/search/export-country-history',
   '/v4/company-referral/',
   '/v4/company-referral/:id',
+  '/v4/company-referral/:id/complete',
   '/adviser/',
   '/v4/company/:id/export-win',
   '/v4/company/:id',

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -31,6 +31,7 @@ module.exports = {
     draftPastMeeting: require('./interaction/draft-past-meeting'),
     withNoLink: require('./interaction/with-no-link.json'),
     withLink: require('./interaction/with-link.json'),
+    withReferral: require('../../../sandbox/fixtures/v3/interaction/interaction-with-referral.json'),
   },
   investment: {
     investmentWithNoLink: require('./investment/investment-with-no-link.json'),
@@ -43,5 +44,8 @@ module.exports = {
   },
   export: {
     historyWithInteractions: require('../../../sandbox/fixtures/v4/export/history-with-interactions.json'),
+  },
+  referrals: {
+    referalDetails: require('../../../sandbox/fixtures/v4/referrals/referral-details.json'),
   },
 }

--- a/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
@@ -41,7 +41,7 @@ describe('Referral details', () => {
 
       cy.get('@row')
         .eq(1)
-        .should('have.text', 'ContactJohnny Cakeman')
+        .should('have.text', 'ContactHelena Referral')
 
       cy.get('@row')
         .eq(2)

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -4,6 +4,11 @@ const {
   assertKeyValueTable,
   assertBreadcrumbs,
 } = require('../../support/assertions')
+const { interactions, companies } = require('../../../../../src/lib/urls')
+
+const {
+  interaction: { withReferral: interactionWithReferral },
+} = fixtures
 
 describe('Interaction details', () => {
   context('Past draft interaction', () => {
@@ -399,6 +404,38 @@ describe('Interaction details', () => {
       cy.get(
         selectors.interaction.details.interaction.whyCanINotComplete
       ).should('not.be.visible')
+    })
+  })
+
+  context('When an interaction is created from a referral', () => {
+    it('should display the linked referral on the interaction detail page', () => {
+      cy.visit(interactions.detail(interactionWithReferral.id))
+      cy.contains('This interaction is linked to a referral').should(
+        'be.visible'
+      )
+      cy.get('table')
+        .eq(1)
+        .should('contain', 'Subject')
+        .and('contain', interactionWithReferral.company_referral.subject)
+        .and('contain', 'Sent on')
+        .and('contain', '14 Feb 2020')
+        .and('contain', 'By')
+        .and(
+          'contain',
+          interactionWithReferral.company_referral.created_by.name
+        )
+        .and('contain', 'To')
+        .and('contain', interactionWithReferral.company_referral.recipient.name)
+    })
+    it('should take you to the referral details page when you click on the subject', () => {
+      cy.contains(interactionWithReferral.company_referral.subject).click()
+      cy.url().should(
+        'contain',
+        companies.referrals.details(
+          interactionWithReferral.company.id,
+          interactionWithReferral.company_referral.id
+        )
+      )
     })
   })
 })

--- a/test/sandbox/fixtures/v3/contact/contacts-for-referral.json
+++ b/test/sandbox/fixtures/v3/contact/contacts-for-referral.json
@@ -1,0 +1,29 @@
+{
+    "count": 2,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": "6891d583-7f52-41af-a0d3-d8d527f20d43",
+            "first_name": "Helena",
+            "last_name": "Referral",
+            "name": "Helena Referral",
+            "company": {
+              "name": "Lambda plc",
+              "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+            }
+
+          },
+          {
+            "id": "5d43k9a2-868f-4d85-8e5f-631e5a8c9a3b",
+            "first_name": "Joseph Woof,",
+            "last_name": "Dog master",
+            "name": "Joseph Woof, Dog master",
+            "company": {
+              "name": "Lambda plc",
+              "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+            }
+           
+          }
+    ]
+}

--- a/test/sandbox/fixtures/v3/interaction/interaction-with-referral.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-with-referral.json
@@ -1,0 +1,126 @@
+{  
+    "id":"65e984ad-1ad5-4d89-9b12-71cdff5f412d",
+    "company":{  
+       "name":"Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+       "id":"4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+    },
+    "contact":{  
+       "name":"Bob lawson",
+       "first_name":"Bob",
+       "last_name":"lawson",
+       "job_title":"Magician",
+       "id":"0e75d636-1d24-416a-aaf0-3fb220d594ce"
+    },
+    "contacts":[  
+       {  
+          "name":"Bob lawson",
+          "first_name":"Bob",
+          "last_name":"lawson",
+          "job_title":"Magician",
+          "id":"0e75d636-1d24-416a-aaf0-3fb220d594ce"
+       }
+    ],
+    "created_on":"2019-02-07T15:54:01.435652Z",
+    "created_by":{  
+       "name":"DIT Staff",
+       "first_name":"DIT",
+       "last_name":"Staff",
+       "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+    },
+    "event":null,
+    "is_event":null,
+    "status": "complete",
+    "kind":"interaction",
+    "modified_by":{  
+       "name":"DIT Staff",
+       "first_name":"DIT",
+       "last_name":"Staff",
+       "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+    },
+    "modified_on":"2019-02-07T15:54:01.435681Z",
+    "date":"2019-02-07",
+    "dit_adviser":{
+      "name":"DIT Staff",
+      "first_name":"DIT",
+      "last_name":"Staff",
+      "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+    },
+    "dit_team":{
+      "name":"UKTI Team East Midlands - International Trade Team",
+      "id":"9010dd28-9798-e211-a939-e4115bead28a"
+    },
+    "company_referral": {
+        "id": "cc5b9953-894c-44b4-a4ac-d0f6a6f6128f",
+        "closed_by": null,
+        "closed_on": null,
+        "company": {
+            "name": "Lambda plc",
+            "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+        },
+        "completed_by": null,
+        "completed_on": null,
+        "contact": {
+            "name": "Johnny Cakeman",
+            "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef"
+        },
+        "created_by": {
+            "name": "Ian Leggett",
+            "contact_email": "caravans@campervans.com",
+            "dit_team": {
+                "name": "Advanced Manufacturing Sector",
+                "id": "08c14624-2f50-e311-a56a-e4115bead28a"
+            },
+            "id": "0c004222-5626-4ef6-b663-18f99fc67cd6"
+        },
+        "created_on": "2020-02-14T15:07:59.341233Z",
+        "interaction": null,
+        "notes": "Just a note about a referral",
+        "recipient": {
+            "name": "Barry Oling",
+            "contact_email": "barry@barry.com",
+            "dit_team": {
+                "name": "Aberdeen City Council",
+                "id": "cff02898-9698-e211-a939-e4115bead28a"
+            },
+            "id": "a80ff5fd-8904-4940-bf96-fe8047e34be5"
+        },
+        "status": "outstanding",
+        "subject": "I am a subject"
+      },
+    "dit_participants": [
+      {
+        "adviser": {
+          "name":"DIT Staff",
+          "first_name":"DIT",
+          "last_name":"Staff",
+          "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+        },
+        "team": {
+          "name":"UKTI Team East Midlands - International Trade Team",
+          "id":"9010dd28-9798-e211-a939-e4115bead28a"
+        }
+      }],
+    "communication_channel":{  
+       "name":"Social Media",
+       "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
+    },
+    "grant_amount_offered":null,
+    "investment_project":null,
+    "net_company_receipt":null,
+    "service":{  
+       "name":"Account Managment: Northern Powerhouse",
+       "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
+    },
+    "service_delivery_status":null,
+    "subject":"This is an automated interaction",
+    "notes":"Sandbox",
+    "archived_documents_url_path":"",
+    "policy_areas":[  
+  
+    ],
+    "policy_feedback_notes":"",
+    "policy_issue_types":[  
+  
+    ],
+    "was_policy_feedback_provided":false
+  }

--- a/test/sandbox/fixtures/v4/referrals/referral-details.json
+++ b/test/sandbox/fixtures/v4/referrals/referral-details.json
@@ -9,8 +9,8 @@
   "completed_by": null,
   "completed_on": null,
   "contact": {
-      "name": "Johnny Cakeman",
-      "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef"
+      "name": "Helena Referral",
+      "id": "6891d583-7f52-41af-a0d3-d8d527f20d43"
   },
   "created_by": {
       "name": "Ian Leggett",

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -35,6 +35,13 @@ Sandbox.define('/v4/company-referral/{id}', 'GET', v4Company.referralDetails)
 // Send a referral
 Sandbox.define('/v4/company-referral', 'POST', v4Company.referralDetails)
 
+// Complete referral
+Sandbox.define(
+  '/v4/company-referral/{id}/complete',
+  'POST',
+  v3Interaction.createInteraction
+)
+
 // Adviser endpoint
 Sandbox.define('/adviser/', 'GET', adviser.advisers)
 Sandbox.define('/adviser/{id}/', 'GET', adviser.singleAdviser)

--- a/test/sandbox/routes/v3/contact/contact.js
+++ b/test/sandbox/routes/v3/contact/contact.js
@@ -1,12 +1,21 @@
 var contact = require('../../../fixtures/v3/contact/contact.json')
 var contactById = require('../../../fixtures/v3/contact/contact-by-id.json')
 var contactByIdWithNoDocument = require('../../../fixtures/v3/contact/contact-by-id-with-no-document.json')
+var contactsForReferral = require('../../../fixtures/v3/contact/contacts-for-referral.json')
 
+var lambdaPlc = require('../../../fixtures/v4/company/company-lambda-plc.json')
 var contactCreate = require('../../../fixtures/v3/contact/contact-create.json')
 var contactCreateValidation = require('../../../fixtures/v3/contact/contact-create-validation.json')
 
 exports.contact = function(req, res) {
-  res.json(contact)
+  if (req.query.company_id === lambdaPlc.id) {
+    console.log(
+      'BEWARE: Lambda PLC uses contacts-for-referral.json rather than contact.json'
+    )
+    return res.json(contactsForReferral)
+  } else {
+    res.json(contact)
+  }
 }
 
 exports.contactCreate = function(req, res) {

--- a/test/sandbox/routes/v3/interaction/interaction.js
+++ b/test/sandbox/routes/v3/interaction/interaction.js
@@ -10,6 +10,7 @@ var interactionCreate = require('../../../fixtures/v3/interaction/interaction-cr
 var interactionDraftFutureMeeting = require('../../../fixtures/v3/interaction/interaction-draft-future-meeting.json')
 var interactionDraftPastMeeting = require('../../../fixtures/v3/interaction/interaction-draft-past-meeting.json')
 var interactionValidationError = require('../../../fixtures/v3/interaction/interaction-validation-error.json')
+var interactionWithReferral = require('../../../fixtures/v3/interaction/interaction-with-referral.json')
 
 var getInteractions = function(req, res) {
   if (req.query.contact_id) {
@@ -36,6 +37,7 @@ var getInteractionById = function(req, res) {
     '57a0b5ea-ad56-49c9-b70e-0542153ea673': interactionCancelledMeeting,
     '999c12ee-91db-4964-908e-0f18ce823096': interactionDraftFutureMeeting,
     '888c12ee-91db-4964-908e-0f18ce823096': interactionDraftPastMeeting,
+    '65e984ad-1ad5-4d89-9b12-71cdff5f412d': interactionWithReferral,
   }
 
   var interactionResponse =


### PR DESCRIPTION
## Description of change

This change allows users to 'accept' a referral by completing an interaction to show they have done what was requested of them in the referral.

This creates a new interaction sub app connected to referrals. After clicking 'complete referral' on a referral details page, a user will be taken into the create interaction flow. The contact from the referral is brought through and pre-populates the interaction form. Once the interaction is created, the linked referral appears on that interaction's details page. 

I created a new InteractionReferralDetails component rather than reusing the ReferralDetails component as what we need to display in the interaction details page is sufficiently different to the referral details page. 

There are multiple combinations of flash messages, given the possibility of countries being discussed as well, so there are quite a few test cases to reflect this.

## Test instructions

- Go to companies/:companyId/referrals/:referralId
- Click complete a referral 
- Create the interaction
- Check the referral appears on the interaction details page

Getting a referral Id: 
- you will need to create a new referral using postman, as you can't add an interaction to a referral which is already 'accepted'
- POST to  ​/v4​/company-referral, body requirements on [swagger](https://api.datahub.dev.uktrade.io/docs)


## Screenshots

### After
![Screenshot 2020-03-17 at 15 59 32](https://user-images.githubusercontent.com/22460823/76876286-9fcba680-6869-11ea-9fd1-302b7b16630f.png)

![Screenshot 2020-03-17 at 16 08 35](https://user-images.githubusercontent.com/22460823/76876253-92162100-6869-11ea-9bb5-9ec1087e5d53.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
