### PR TITLE
Add start script for more than one backend

### DIFF
--- a/.bin.sample/start
+++ b/.bin.sample/start
@@ -1,0 +1,14 @@
+envName='local'
+
+if [ $# -gt 0 ]; then
+  if [ -f .bin/envs/$1.env ]; then
+      source .bin/envs/$1.env
+      envName=$1
+    else
+      echo 'Env not found'
+      exit 1
+    fi
+fi
+
+echo "Starting $envName server with $API_ROOT"
+yarn run develop


### PR DESCRIPTION
## Description of change

Add a sample script to enable easy switching of backends. Simply create an `envs` folder inside your `.bin` folder (the assumed folder name) and then add any file ending with `.env` which contains required env variable overrides from your base `.env` file to talk to a different backend. For example, add a `dev.env` file and then this script can be used by simply stating the name of the env, so: `start dev`. This will overwrite any existing env values specified in your base `.env` file with any specified in the `dev.env` file - you do not need the `export` keyword just assign the value to the env.

example `dev.env` contents:
```bash
API_ROOT=https://path-to-dev.uktrade.io
OAUTH2_BYPASS_SSO=true
OAUTH2_DEV_TOKEN=a-dev-token
DATA_HUB_BACKEND_ACCESS_KEY_ID=a-key
DATA_HUB_BACKEND_SECRET_ACCESS_KEY=a-secret
```

You can add as many files as you like, I have added `sandbox.env`, `dev.env` and `staging.env` then to switch environments I simply run 

`start sandbox`
`start dev`
`start staging`

If you run `start` without an argument it will use the default envs, which in my case means using my local API

This assumes you have installed and setup [direnv](https://direnv.net/), if not you will need to run the commands with the path added: `.bin/start dev` etc

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
