### PR TITLE
ignore .bin script folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ local.log
 # Yalc packages
 .yalc
 yalc.lock
+
+# Ignore bin scripts
+.bin
+


### PR DESCRIPTION
As it says on the tin. 

I moved scripts from the `./bin/sample` folder into my own `./bin` folder and realised git wasn't set up to ignore this. 