### PR TITLE
Add the Referral accepted table to ReferralDetails

### DIFF
--- a/src/apps/companies/apps/referrals/__tests__/transformer.test.js
+++ b/src/apps/companies/apps/referrals/__tests__/transformer.test.js
@@ -5,9 +5,15 @@ describe('#transformReferralDetails', () => {
   it('should return details', () => {
     expect(transformReferralDetails(referralDetails)).to.deep.equal({
       subject: 'I am a subject',
-      company: 'Lambda plc',
-      companyId: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
-      contact: 'Johnny Cakeman',
+      completed: false,
+      company: {
+        name: 'Lambda plc',
+        id: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
+      },
+      contact: {
+        name: 'Johnny Cakeman',
+        id: '9b1138ab-ec7b-497f-b8c3-27fed21694ef',
+      },
       sendingAdviser: {
         name: 'Ian Leggett',
         email: 'caravans@ian.com',
@@ -18,6 +24,9 @@ describe('#transformReferralDetails', () => {
         email: 'barry@barry.com',
         team: 'Aberdeen City Council',
       },
+      // We need to have explicit undefined, because deep equal is sensitive
+      // about not existent and set to undefined properties.
+      interaction: undefined,
       date: '2020-02-16T18:24:58.641396Z',
       notes:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',

--- a/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
@@ -12,6 +12,7 @@ import Task from '../../../../../../client/components/Task'
 import { state2props } from './state'
 
 import { REFERRAL_DETAILS } from '../../../../../../client/actions'
+import { interaction } from '../../../../../../../test/sandbox/routes/v3/search/interaction'
 
 export const AdviserDetails = ({ name, email, team }) => (
   <>
@@ -42,6 +43,9 @@ export default connect(state2props)(
     receivingAdviser,
     date,
     notes,
+    status,
+    completed,
+    interaction,
   }) => (
     <Task.Status
       name="Referral details"
@@ -69,28 +73,46 @@ export default connect(state2props)(
               </SummaryTable.Row>
               <SummaryTable.Row heading="Notes">{notes}</SummaryTable.Row>
             </SummaryTable>
-            <Details summary="Why can I not edit the referral?">
-              <p>For now, you can't edit the referral once it's been sent.</p>
-              <p>Contact the recipient if something's changed.</p>
-            </Details>
-            <FormActions>
-              <Button
-                as={Link}
-                href={urls.companies.referrals.interactions.create(
-                  companyId,
-                  referralId
-                )}
-              >
-                Accept referral
-              </Button>
-              <SecondaryButton
-                as={Link}
-                href={urls.companies.referrals.help(companyId, referralId)}
-              >
-                I cannot accept the referral
-              </SecondaryButton>
-              <Link href="/">Back</Link>
-            </FormActions>
+            {completed ? (
+              <SummaryTable caption="Referral accepted">
+                <SummaryTable.Row heading="Date">
+                  {DateUtils.format(completed.on)}
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="By">
+                  <AdviserDetails {...completed.by} />
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="With interaction">
+                  <Link href={urls.interactions.detail(interaction.id)}>
+                    {interaction.subject}
+                  </Link>
+                </SummaryTable.Row>
+              </SummaryTable>
+            ) : (
+              <>
+                <Details summary="Why can I not edit the referral?">
+                  <p>For now, you can't edit the referral once it's been sent.</p>
+                  <p>Contact the recipient if something's changed.</p>
+                </Details>
+                <FormActions>
+                  <Button
+                    as={Link}
+                    href={urls.companies.referrals.interactions.create(
+                      companyId,
+                      referralId
+                    )}
+                  >
+                    Accept referral
+                  </Button>
+                  <SecondaryButton
+                    as={Link}
+                    href={urls.companies.referrals.help(companyId, referralId)}
+                  >
+                    I cannot accept the referral
+                  </SecondaryButton>
+                  <Link href="/">Back</Link>
+                </FormActions>
+              </>
+            )}
           </>
         )
       }

--- a/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
@@ -12,7 +12,6 @@ import Task from '../../../../../../client/components/Task'
 import { state2props } from './state'
 
 import { REFERRAL_DETAILS } from '../../../../../../client/actions'
-import { interaction } from '../../../../../../../test/sandbox/routes/v3/search/interaction'
 
 export const AdviserDetails = ({ name, email, team }) => (
   <>
@@ -37,13 +36,11 @@ export default connect(state2props)(
     subject,
     referralId,
     company,
-    companyId,
     contact,
     sendingAdviser,
     receivingAdviser,
     date,
     notes,
-    status,
     completed,
     interaction,
   }) => (
@@ -60,8 +57,18 @@ export default connect(state2props)(
         company && (
           <>
             <SummaryTable caption={subject}>
-              <SummaryTable.Row heading="Company">{company}</SummaryTable.Row>
-              <SummaryTable.Row heading="Contact">{contact}</SummaryTable.Row>
+              <SummaryTable.Row heading="Company">
+                <Link href={urls.companies.detail(company.id)}>
+                  {company.name}
+                </Link>
+              </SummaryTable.Row>
+              {contact && (
+                <SummaryTable.Row heading="Contact">
+                  <Link href={urls.contacts.contact(contact.id)}>
+                    {contact.name}
+                  </Link>
+                </SummaryTable.Row>
+              )}
               <SummaryTable.Row heading="Sending adviser">
                 {sendingAdviser && <AdviserDetails {...sendingAdviser} />}
               </SummaryTable.Row>
@@ -90,14 +97,16 @@ export default connect(state2props)(
             ) : (
               <>
                 <Details summary="Why can I not edit the referral?">
-                  <p>For now, you can't edit the referral once it's been sent.</p>
+                  <p>
+                    For now, you can't edit the referral once it's been sent.
+                  </p>
                   <p>Contact the recipient if something's changed.</p>
                 </Details>
                 <FormActions>
                   <Button
                     as={Link}
                     href={urls.companies.referrals.interactions.create(
-                      companyId,
+                      company.id,
                       referralId
                     )}
                   >
@@ -105,11 +114,11 @@ export default connect(state2props)(
                   </Button>
                   <SecondaryButton
                     as={Link}
-                    href={urls.companies.referrals.help(companyId, referralId)}
+                    href={urls.companies.referrals.help(company.id, referralId)}
                   >
                     I cannot accept the referral
                   </SecondaryButton>
-                  <Link href="/">Back</Link>
+                  <Link href={urls.dashboard()}>Back</Link>
                 </FormActions>
               </>
             )}

--- a/src/apps/companies/apps/referrals/help/controller.js
+++ b/src/apps/companies/apps/referrals/help/controller.js
@@ -1,18 +1,20 @@
 const urls = require('../../../../../lib/urls')
 
 const renderReferralHelp = ({ params: { referralId } }, res) => {
-  const {
-    company: { name: companyName, id },
-  } = res.locals
+  const { company } = res.locals
 
   res
-    .breadcrumb(companyName, urls.companies.detail(id))
-    .breadcrumb('Referral', urls.companies.referrals.details(id, referralId))
+    .breadcrumb(company.name, urls.companies.detail(company.id))
+    .breadcrumb(
+      'Referral',
+      urls.companies.referrals.details(company.id, referralId)
+    )
     .breadcrumb('I cannot accept this referral')
     .render('companies/apps/referrals/help/views/help-container', {
       heading: 'I cannot accept this referral',
       props: {
         referralId,
+        companyId: company.id,
       },
     })
 }

--- a/src/apps/companies/apps/referrals/transformer.js
+++ b/src/apps/companies/apps/referrals/transformer.js
@@ -1,7 +1,7 @@
 const transformAdviser = ({ name, contact_email, dit_team }) => ({
   name,
   email: contact_email,
-  team: dit_team?.name,
+  team: dit_team && dit_team.name,
 })
 
 const transformReferralDetails = ({

--- a/src/apps/companies/apps/referrals/transformer.js
+++ b/src/apps/companies/apps/referrals/transformer.js
@@ -1,4 +1,4 @@
-const convertAdviser = ({ name, contact_email, dit_team }) => ({
+const transformAdviser = ({ name, contact_email, dit_team }) => ({
   name,
   email: contact_email,
   team: dit_team?.name,
@@ -20,16 +20,15 @@ const transformReferralDetails = ({
   return {
     subject,
     status,
-    company: company.name,
-    companyId: company.id,
-    contact: contact && contact.name,
-    sendingAdviser: convertAdviser(created_by),
-    receivingAdviser: convertAdviser(recipient),
+    company,
+    contact,
+    sendingAdviser: transformAdviser(created_by),
+    receivingAdviser: transformAdviser(recipient),
     date: created_on,
     interaction,
     completed: status === 'complete' && {
       on: completed_on,
-      by: convertAdviser(completed_by),
+      by: transformAdviser(completed_by),
     },
     notes,
   }

--- a/src/apps/companies/apps/referrals/transformer.js
+++ b/src/apps/companies/apps/referrals/transformer.js
@@ -1,3 +1,9 @@
+const convertAdviser = ({ name, contact_email, dit_team }) => ({
+  name,
+  email: contact_email,
+  team: dit_team?.name,
+})
+
 const transformReferralDetails = ({
   subject,
   company,
@@ -6,23 +12,25 @@ const transformReferralDetails = ({
   recipient,
   created_on,
   notes,
+  status,
+  completed_on,
+  completed_by,
+  interaction,
 }) => {
   return {
     subject,
+    status,
     company: company.name,
     companyId: company.id,
     contact: contact && contact.name,
-    sendingAdviser: {
-      name: created_by.name,
-      email: created_by.contact_email,
-      team: created_by.dit_team && created_by.dit_team.name,
-    },
-    receivingAdviser: {
-      name: recipient.name,
-      email: recipient.contact_email,
-      team: recipient.dit_team && recipient.dit_team.name,
-    },
+    sendingAdviser: convertAdviser(created_by),
+    receivingAdviser: convertAdviser(recipient),
     date: created_on,
+    interaction,
+    completed: status === 'complete' && {
+      on: completed_on,
+      by: convertAdviser(completed_by),
+    },
     notes,
   }
 }

--- a/src/apps/companies/apps/referrals/transformer.js
+++ b/src/apps/companies/apps/referrals/transformer.js
@@ -19,7 +19,6 @@ const transformReferralDetails = ({
 }) => {
   return {
     subject,
-    status,
     company,
     contact,
     sendingAdviser: transformAdviser(created_by),

--- a/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
@@ -39,10 +39,22 @@ describe('Referral details', () => {
         .as('row')
         .eq(0)
         .should('have.text', 'CompanyLambda plc')
+        .find('a')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.detail(companyId, REFERRAL_ID)
+        )
 
       cy.get('@row')
         .eq(1)
         .should('have.text', 'ContactHelena Referral')
+        .find('a')
+        .and(
+          'have.attr',
+          'href',
+          urls.contacts.contact('6891d583-7f52-41af-a0d3-d8d527f20d43')
+        )
 
       cy.get('@row')
         .eq(2)
@@ -181,7 +193,7 @@ describe('Referral details', () => {
 
   context('when viewing details of a complete referral', () =>
     it('should display the Referral accepted summary instead of the buttons', () => {
-      cy.visit(urls.companies.referrals.details('any-id-will-do', 'complete'))
+      cy.visit(urls.companies.referrals.details('any-id-will-do', 'completed'))
 
       cy.contains('Complete referral').should('not.exist')
       cy.contains('I cannot complete the referral').should('not.exist')

--- a/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
@@ -31,6 +31,7 @@ describe('Referral details', () => {
 
     it('should render the content and elements in order', () => {
       cy.get('#referral-details > table')
+        .eq(0)
         .find('caption')
         .should('have.text', 'I am a subject')
         .parents()
@@ -117,6 +118,7 @@ describe('Referral details', () => {
 
     it('should render the content and elements in order', () => {
       cy.get('#referral-details > table')
+        .eq(0)
         .find('caption')
         .should('have.text', 'I am a subject')
         .parents()
@@ -176,4 +178,53 @@ describe('Referral details', () => {
         .should('have.text', 'Back')
     })
   })
+
+  context('when viewing details of a complete referral', () =>
+    it('should display the Referral accepted summary instead of the buttons', () => {
+      cy.visit(urls.companies.referrals.details('any-id-will-do', 'complete'))
+
+      cy.contains('Complete referral').should('not.exist')
+      cy.contains('I cannot complete the referral').should('not.exist')
+
+      cy.contains('Referral accepted')
+        .next()
+        .within(() => {
+          cy.get('tr')
+            .as('row')
+            .eq(0)
+            .within(() => {
+              cy.get('th').should('have.text', 'Date')
+              cy.get('td').should('have.text', '19 Mar 2020')
+            })
+
+          cy.get('@row')
+            .eq(1)
+            .within(() => {
+              cy.get('th').should('have.text', 'By')
+              cy.get('td')
+                .should(
+                  'have.text',
+                  'Andy Pipkin, andy.pipkin@little.britain.co.uk, Andy & Lou'
+                )
+                .find('a')
+                .should('have.text', 'andy.pipkin@little.britain.co.uk')
+                .and(
+                  'have.attr',
+                  'href',
+                  'mailto:andy.pipkin@little.britain.co.uk'
+                )
+            })
+
+          cy.get('@row')
+            .eq(2)
+            .within(() => {
+              cy.get('th').should('have.text', 'With interaction')
+              cy.get('td')
+                .find('a')
+                .should('have.text', 'Covert action')
+                .and('have.attr', 'href', '/interactions/foo-bar-baz')
+            })
+        })
+    })
+  )
 })

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -181,5 +181,24 @@ exports.referralDetails = function(req, res) {
   if (req.params.id === ReferralIds.REFERRAL_ID_NO_CONTACT) {
     return res.json(referralDetailsNoContact)
   }
+  if (req.params.id === 'complete') {
+    return res.json(
+      _.merge({}, referralDetailsNoContact, {
+        status: 'complete',
+        completed_on: '2020-03-19T10:38:00.841Z',
+        completed_by: {
+          name: 'Andy Pipkin',
+          contact_email: 'andy.pipkin@little.britain.co.uk',
+          dit_team: {
+            name: 'Andy & Lou',
+          },
+        },
+        interaction: {
+          subject: 'Covert action',
+          id: 'foo-bar-baz',
+        },
+      })
+    )
+  }
   return res.json(referralDetails)
 }

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -181,7 +181,7 @@ exports.referralDetails = function(req, res) {
   if (req.params.id === ReferralIds.REFERRAL_ID_NO_CONTACT) {
     return res.json(referralDetailsNoContact)
   }
-  if (req.params.id === 'complete') {
+  if (req.params.id === 'completed') {
     return res.json(
       _.merge({}, referralDetailsNoContact, {
         status: 'complete',

--- a/test/unit/data/referrals/referralDetails.json
+++ b/test/unit/data/referrals/referralDetails.json
@@ -22,7 +22,6 @@
       "id": "0c004222-5626-4ef6-b663-18f99fc67cd6"
   },
   "created_on": "2020-02-16T18:24:58.641396Z",
-  "interaction": null,
   "notes": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
   "recipient": {
       "name": "Barry Oling",


### PR DESCRIPTION
## Description of change

The _referral details page_ now shows the _Referral accepted_ section instead of the action buttons when the referral is _completed_.

## Test instructions

1. Go to the the _referral details page_ of a _completed_ referral.
2. You should not see the _Complete referral_ and _I cannot complete the referral_.
3. If you visit the same page with an _incomplete_ referral, you should still see the buttons without the _Referral accepted_ section.

## Screenshots
<img width="915" alt="Screen Shot 2020-03-19 at 3 07 10 PM" src="https://user-images.githubusercontent.com/2333157/77081989-5e670280-69f3-11ea-8b50-3f0973ad948d.png">

