### PR TITLE
Change dependabot to weekly

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,9 +4,7 @@ version: 1
 update_configs:
   - package_manager: javascript
     directory: '/'
-    update_schedule: live
-    default_reviewers:
-      - datahub-fed
+    update_schedule: weekly
     ignored_updates:
       - match:
           dependency_name: 'govuk-frontend'


### PR DESCRIPTION
Also fix the `default_reviewers`. I'm trying to add `datahub-front-end` twice as we need two reviews from the team.