### PR TITLE
Make workspace links open in new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^5.1.0",
+    "data-hub-components": "^5.1.2",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/referrals/help/client/ReferralHelp.jsx
+++ b/src/apps/companies/apps/referrals/help/client/ReferralHelp.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import Link from '@govuk-react/link'
 import { H2 } from '@govuk-react/heading'
 import { LEVEL_SIZE } from '@govuk-react/constants'
+import { NewWindowLink } from 'data-hub-components'
 import urls from '../../../../../../lib/urls'
 
 import Task from '../../../../../../client/components/Task'
@@ -54,9 +55,9 @@ export default connect(state2props)(
               </p>
               <p>
                 Or{' '}
-                <Link href={urls.external.digitalWorkspace.teams}>
+                <NewWindowLink href={urls.external.digitalWorkspace.teams}>
                   find their contact details on Digital Workspace
-                </Link>
+                </NewWindowLink>
               </p>
               <H2 size={LEVEL_SIZE[3]}>I'm not the right adviser for this</H2>
 

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { throttle } from 'lodash'
 import axios from 'axios'
 
+import urls from '../../../../../../lib/urls'
 import SendReferralConfirmation from './SendReferralConfirmation.jsx'
 import ValidatedInput from '../../../../../../client/components/ValidatedInput.jsx'
 import styled from 'styled-components'
@@ -15,7 +16,7 @@ import {
   SEND_REFERRAL_FORM__ADVISER_CHANGE,
   SEND_REFERRAL_FORM__CONTACT_CHANGE,
 } from '../../../../../../client/actions'
-import { FormActions, Typeahead } from 'data-hub-components'
+import { FormActions, Typeahead, NewWindowLink } from 'data-hub-components'
 import {
   H4,
   TextArea,
@@ -90,9 +91,9 @@ const SendReferralForm = ({
         <HintText>
           This can be an adviser at post, a sector specialist or an
           international trade advisor. If you're not sure, you can{' '}
-          <a href="https://people.trade.gov.uk/teams/department-for-international-trade">
+          <NewWindowLink href="https://people.trade.gov.uk/teams/department-for-international-trade">
             find the right team and person on Digital Workspace
-          </a>
+          </NewWindowLink>
           .
         </HintText>
         <StyledTypeahead

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -332,7 +332,7 @@ describe('Companies business details', () => {
           dataAutoId: 'documentsDetailsContainer',
           heading: 'Documents from CDMS',
           showEditLink: false,
-          content: ['View files and documents (Opens in a new window)'],
+          content: ['View files and documents (opens in a new window or tab)'],
         })
       })
 

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -122,7 +122,7 @@ describe('Company Export tab - Edit exports', () => {
         assertReadOnlyItems([
           {
             label: 'great.gov.uk business profile',
-            value: '"Find a supplier" profile (Opens in a new window)',
+            value: '"Find a supplier" profile (opens in a new window or tab)',
           },
           { label: 'Export potential', value: 'Medium' },
         ])

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -219,7 +219,7 @@ describe('Company Export tab', () => {
           { label: 'Export win category', value: 'Increasing export turnover' },
           {
             label: 'great.gov.uk business profile',
-            value: '"Find a supplier" profile (Opens in a new window)',
+            value: '"Find a supplier" profile (opens in a new window or tab)',
           },
 
           { label: 'Export potential', value: 'Medium' },

--- a/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
@@ -64,5 +64,12 @@ describe('Referral help', () => {
         )
         .should('have.text', 'Back to the referral')
     })
+    it("should link to digital workspace's people finder", () => {
+      cy.contains('Digital Workspace').should(
+        'have.attr',
+        'href',
+        urls.external.digitalWorkspace.teams
+      )
+    })
   })
 })

--- a/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
@@ -41,7 +41,7 @@ describe('Referral help', () => {
         .next()
         .should(
           'have.text',
-          'Or find their contact details on Digital Workspace'
+          'Or find their contact details on Digital Workspace (opens in a new window or tab)'
         )
         .next()
         .should('have.prop', 'tagName', 'H2')

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -41,6 +41,16 @@ describe('Send a referral form', () => {
         assertLocalHeader('Send a referral')
       })
 
+      it('should display link to digital workspace', () => {
+        cy.contains(
+          'find the right team and person on Digital Workspace (opens in a new window or tab)'
+        ).within(() =>
+          cy
+            .get('a')
+            .should('have.attr', 'href', urls.external.digitalWorkspace.teams)
+        )
+      })
+
       it('should display the headings and four fields', () => {
         cy.get(selectors.companySendReferral.form)
           .should('contain', 'Adviser')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4827,10 +4827,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.1.0.tgz#f742848ea3fab2ff9b29cf1019094d1d7b3e7392"
-  integrity sha512-lzc6v23cl7E3rT++cONFlbnWSXEmJGECF4fFcgKEsu3VxPpYxPJgF/KltiJo/hbwZPkyeQq5izpmvUnUfU7h5Q==
+data-hub-components@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.1.2.tgz#d3fb9a39775660644fbaa366f495ce9d6e0309fc"
+  integrity sha512-iOxT0ERtWaVxd4k9SZkUOl976FBSrSJEuPs9sZsOrZQHAkxVdDv5X8cgNgjaMW3tyqumhymosR9DH+QdgpJslA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change

This PR makes the links to digital workspace open in new tabs and adds text to the links to inform users of this. 

## Test instructions

1. On send referral form

- Go to companies/:companyId/send-referral
- Check the digital workspace link opens in a tab


2) On help page

- Create a referral with the form above, it will appear in the activity feed
- click on the referral in the activity feed
- click 'I cannot complete this referral' 
- check the workspace link opens in a new tab

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
