### PR TITLE
Update helpcentre urls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,9 @@ aliases:
     OAUTH2_CLIENT_SECRET: youAintSeenMyRight
     OAUTH2_CLIENT_ID: randomClientId
     SESSION_SECRET: theStrongestAvenger
-    HELP_CENTRE_URL: https://datahub-helpcentre.london.cloudapps.digital
-    HELP_CENTRE_ANNOUNCMENTS_URL: https://datahub-helpcentre.london.cloudapps.digital/updates/announcements
-    HELP_CENTRE_API_FEED: https://datahub-helpcentre.london.cloudapps.digital/api/feeds/announcements
+    HELP_CENTRE_URL: https://data-services-help.trade.gov.uk/data-hub/
+    HELP_CENTRE_ANNOUNCMENTS_URL: https://data-services-help.trade.gov.uk/data-hub/updates/announcements/
+    HELP_CENTRE_API_FEED: https://data-services-help.trade.gov.uk/api/feeds/data-hub/updates
     DATA_HUB_BACKEND_ACCESS_KEY_ID: frontend-key-id
     DATA_HUB_BACKEND_SECRET_ACCESS_KEY: frontend-key
     ZEN_TICKETS_URL: http://zendesk.example.com
@@ -356,7 +356,6 @@ jobs:
       - store_artifacts:
           path: cypress/screenshots
       - *store_artifacts_cypress_video
-   
 
   # Run e2e tests for LEP staff
   lep_staff_e2e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       OAUTH2_CLIENT_ID: randomClientId
       OAUTH2_DEV_TOKEN: ditStaffToken
       CACHE_ASSETS: 'true'
-      HELP_CENTRE_URL: https://datahub-helpcentre.london.cloudapps.digital
-      HELP_CENTRE_ANNOUNCMENTS_URL: https://datahub-helpcentre.london.cloudapps.digital/updates/announcements
+      HELP_CENTRE_URL: https://data-services-help.trade.gov.uk/data-hub/
+      HELP_CENTRE_ANNOUNCMENTS_URL: https://data-services-help.trade.gov.uk/data-hub/updates/announcements/
       HELP_CENTRE_API_FEED: http://mock-backend:8001/help-centre/announcement
       HELP_CENTRE_FEED_API_TOKEN: apiToken
       SESSION_SECRET: foobarbaz

--- a/docker-visual-regression.yml
+++ b/docker-visual-regression.yml
@@ -40,8 +40,8 @@ services:
       OAUTH2_CLIENT_ID: randomClientId
       OAUTH2_DEV_TOKEN: ditStaffToken
       CACHE_ASSETS: "true"
-      HELP_CENTRE_URL: https://datahub-helpcentre.london.cloudapps.digital
-      HELP_CENTRE_ANNOUNCMENTS_URL: https://datahub-helpcentre.london.cloudapps.digital/updates/announcements
+      HELP_CENTRE_URL: https://data-services-help.trade.gov.uk/data-hub/
+      HELP_CENTRE_ANNOUNCMENTS_URL: https://data-services-help.trade.gov.uk/data-hub/updates/announcements/
       HELP_CENTRE_API_FEED: http://sandbox:8001/help-centre/announcement
       HELP_CENTRE_FEED_API_TOKEN: apiToken
       SESSION_SECRET: foobarbaz


### PR DESCRIPTION
Update helpcentre url in configs. I already updated the url in the environment variables, but there are areas where this isn't used. Shortly the old `datahub-helpcentre` url will be turned off. 

In the future we should look into how to better manage external urls. Some are managed through the urls module, but this is one that changes depending on the environment and therefore wouldn't work well with how that module is currently configured. 