### PR TITLE
Update css spec to remove warning when starting the app

### DIFF
--- a/assets/stylesheets/elements/_base.scss
+++ b/assets/stylesheets/elements/_base.scss
@@ -1,6 +1,6 @@
-@import "../settings/colours";
-@import "../settings/typography";
-@import "../tools/mixins/addons";
+@import '../settings/colours';
+@import '../settings/typography';
+@import '../tools/mixins/addons';
 
 html {
   font-family: $dit-font-stack;
@@ -9,7 +9,7 @@ html {
 
 a {
   color: $link-colour;
-  text-decoration-skip: ink;
+  text-decoration-skip-ink: auto;
   outline-color: transparent;
 
   &:hover {
@@ -32,7 +32,7 @@ textarea {
 
   &:focus,
   &:focus + label::before {
-    transition: box-shadow .1s, outline-color .1s .1s;
+    transition: box-shadow 0.1s, outline-color 0.1s 0.1s;
     box-shadow: 0 0 0 3px $focus-colour;
     outline-color: $focus-colour;
     text-decoration: none;
@@ -43,4 +43,3 @@ textarea {
 input:focus + label::before {
   outline: none;
 }
-


### PR DESCRIPTION
We recently updated `postcss-loader` and as a result we were getting the below warning in the console when starting the app. I have therefore updated our css in line with the warning and now no warning shows. 

Some of the extra changes, like using single quotes are from prettier. 

<img width="1920" alt="Screenshot 2020-03-24 at 10 05 26" src="https://user-images.githubusercontent.com/42253716/77413757-c3d23f00-6db7-11ea-9d67-a7575b988c28.png"> 