### PR TITLE
Change Edit export countries button to a link

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportsIndex.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsIndex.jsx
@@ -5,14 +5,19 @@ import Details from '@govuk-react/details'
 import Link from '@govuk-react/link'
 import { H3 } from '@govuk-react/heading'
 import { SummaryTable } from 'data-hub-components'
+import { SPACING } from '@govuk-react/constants'
 
-import SecondaryButton from '../../../../../client/components/SecondaryButton'
 import urls from '../../../../../lib/urls'
 import ExportWins from './ExportWins/'
 import GreatProfile from './GreatProfile'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin-top: 0;
+`
+
+const StyledLink = styled(Link)`
+  display: inline-block;
+  margin-bottom: ${SPACING.SCALE_5};
 `
 
 const ExportsIndex = ({
@@ -79,11 +84,19 @@ const ExportsIndex = ({
         <a href={urls.support()}>support channel</a>.
       </Details>
 
-      <H3>Export countries information</H3>
-      <Link href={urls.companies.exports.history.index(companyId)}>
-        View full export countries history
-      </Link>
-      <StyledSummaryTable>
+      <StyledSummaryTable
+        caption="Export countries information"
+        actions={
+          !isArchived && (
+            <Link
+              href={urls.companies.exports.editCountries(companyId)}
+              data-test-id="edit-export-countries"
+            >
+              Edit
+            </Link>
+          )
+        }
+      >
         {exportCountriesInformation.map(({ name, values }) => (
           <SummaryTable.Row heading={name} key={name}>
             <>
@@ -110,15 +123,9 @@ const ExportsIndex = ({
         ))}
       </StyledSummaryTable>
 
-      {isArchived ? null : (
-        <SecondaryButton
-          as={Link}
-          href={urls.companies.exports.editCountries(companyId)}
-          data-test-id="editExportCountriesButton"
-        >
-          Edit export countries
-        </SecondaryButton>
-      )}
+      <StyledLink href={urls.companies.exports.history.index(companyId)}>
+        View full export countries history
+      </StyledLink>
 
       <H3>Export wins</H3>
       <p>


### PR DESCRIPTION
## Description of change

To have a consistent style and re-use components this PR removes the button and uses the actions of the SummaryTable component. This means moving the View full export countries history link below the table as well

_Document what the PR does and why the change is needed_

View the Export tab of a company, if it is not archived then there should be a link to Edit the Export countries information instead of a button below

_What should I see?_

## Screenshots

<img width="852" alt="Screenshot 2020-03-24 at 12 58 18" src="https://user-images.githubusercontent.com/1481883/77427996-4c100e80-6dcf-11ea-8cb9-6156a1a0b2a3.png">

_Add a screenshot_

<img width="844" alt="Screenshot 2020-03-24 at 12 57 54" src="https://user-images.githubusercontent.com/1481883/77428007-50d4c280-6dcf-11ea-8786-26f708696dcd.png">


_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
