### PR TITLE
Return to home or company page from referral details depending on previous page

### DIFF
--- a/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
@@ -6,10 +6,11 @@ import Link from '@govuk-react/link'
 import PropTypes from 'prop-types'
 import { SummaryTable, FormActions, DateUtils } from 'data-hub-components'
 import urls from '../../../../../../lib/urls'
+import url from 'url'
+import { ID as STATE_ID } from './state'
 
 import SecondaryButton from '../../../../../../client/components/SecondaryButton'
 import Task from '../../../../../../client/components/Task'
-import { state2props } from './state'
 
 import { REFERRAL_DETAILS } from '../../../../../../client/actions'
 
@@ -31,7 +32,10 @@ AdviserDetails.propTypes = {
   team: PropTypes.string,
 }
 
-export default connect(state2props)(
+export default connect(({ referrerUrl, ...state }) => ({
+  ...state[STATE_ID],
+  referrerUrl,
+}))(
   ({
     subject,
     referralId,
@@ -43,88 +47,104 @@ export default connect(state2props)(
     notes,
     completed,
     interaction,
-  }) => (
-    <Task.Status
-      name="Referral details"
-      id="referralDetails"
-      progressMessage="loading referral details"
-      startOnRender={{
-        payload: referralId,
-        onSuccessDispatch: REFERRAL_DETAILS,
-      }}
-    >
-      {() =>
-        company && (
-          <>
-            <SummaryTable caption={subject}>
-              <SummaryTable.Row heading="Company">
-                <Link href={urls.companies.detail(company.id)}>
-                  {company.name}
-                </Link>
-              </SummaryTable.Row>
-              {contact && (
-                <SummaryTable.Row heading="Contact">
-                  <Link href={urls.contacts.contact(contact.id)}>
-                    {contact.name}
+    referrerUrl,
+  }) => {
+    const cameFromHomePage = url.parse(referrerUrl).pathname === '/'
+
+    return (
+      <Task.Status
+        name="Referral details"
+        id="referralDetails"
+        progressMessage="loading referral details"
+        startOnRender={{
+          payload: referralId,
+          onSuccessDispatch: REFERRAL_DETAILS,
+        }}
+      >
+        {() =>
+          company && (
+            <>
+              <SummaryTable caption={subject}>
+                <SummaryTable.Row heading="Company">
+                  <Link href={urls.companies.detail(company.id)}>
+                    {company.name}
                   </Link>
                 </SummaryTable.Row>
-              )}
-              <SummaryTable.Row heading="Sending adviser">
-                {sendingAdviser && <AdviserDetails {...sendingAdviser} />}
-              </SummaryTable.Row>
-              <SummaryTable.Row heading="Receiving adviser">
-                {receivingAdviser && <AdviserDetails {...receivingAdviser} />}
-              </SummaryTable.Row>
-              <SummaryTable.Row heading="Date of referral">
-                {DateUtils.format(date)}
-              </SummaryTable.Row>
-              <SummaryTable.Row heading="Notes">{notes}</SummaryTable.Row>
-            </SummaryTable>
-            {completed ? (
-              <SummaryTable caption="Referral accepted">
-                <SummaryTable.Row heading="Date">
-                  {DateUtils.format(completed.on)}
+                {contact && (
+                  <SummaryTable.Row heading="Contact">
+                    <Link href={urls.contacts.contact(contact.id)}>
+                      {contact.name}
+                    </Link>
+                  </SummaryTable.Row>
+                )}
+                <SummaryTable.Row heading="Sending adviser">
+                  {sendingAdviser && <AdviserDetails {...sendingAdviser} />}
                 </SummaryTable.Row>
-                <SummaryTable.Row heading="By">
-                  <AdviserDetails {...completed.by} />
+                <SummaryTable.Row heading="Receiving adviser">
+                  {receivingAdviser && <AdviserDetails {...receivingAdviser} />}
                 </SummaryTable.Row>
-                <SummaryTable.Row heading="With interaction">
-                  <Link href={urls.interactions.detail(interaction.id)}>
-                    {interaction.subject}
-                  </Link>
+                <SummaryTable.Row heading="Date of referral">
+                  {DateUtils.format(date)}
                 </SummaryTable.Row>
+                <SummaryTable.Row heading="Notes">{notes}</SummaryTable.Row>
               </SummaryTable>
-            ) : (
-              <>
-                <Details summary="Why can I not edit the referral?">
-                  <p>
-                    For now, you can't edit the referral once it's been sent.
-                  </p>
-                  <p>Contact the recipient if something's changed.</p>
-                </Details>
-                <FormActions>
-                  <Button
-                    as={Link}
-                    href={urls.companies.referrals.interactions.create(
-                      company.id,
-                      referralId
-                    )}
-                  >
-                    Accept referral
-                  </Button>
-                  <SecondaryButton
-                    as={Link}
-                    href={urls.companies.referrals.help(company.id, referralId)}
-                  >
-                    I cannot accept the referral
-                  </SecondaryButton>
-                  <Link href={urls.dashboard()}>Back</Link>
-                </FormActions>
-              </>
-            )}
-          </>
-        )
-      }
-    </Task.Status>
-  )
+              {completed ? (
+                <SummaryTable caption="Referral accepted">
+                  <SummaryTable.Row heading="Date">
+                    {DateUtils.format(completed.on)}
+                  </SummaryTable.Row>
+                  <SummaryTable.Row heading="By">
+                    <AdviserDetails {...completed.by} />
+                  </SummaryTable.Row>
+                  <SummaryTable.Row heading="With interaction">
+                    <Link href={urls.interactions.detail(interaction.id)}>
+                      {interaction.subject}
+                    </Link>
+                  </SummaryTable.Row>
+                </SummaryTable>
+              ) : (
+                <>
+                  <Details summary="Why can I not edit the referral?">
+                    <p>
+                      For now, you can't edit the referral once it's been sent.
+                    </p>
+                    <p>Contact the recipient if something's changed.</p>
+                  </Details>
+                  <FormActions>
+                    <Button
+                      as={Link}
+                      href={urls.companies.referrals.interactions.create(
+                        company.id,
+                        referralId
+                      )}
+                    >
+                      Accept referral
+                    </Button>
+                    <SecondaryButton
+                      as={Link}
+                      href={urls.companies.referrals.help(
+                        company.id,
+                        referralId
+                      )}
+                    >
+                      I cannot accept the referral
+                    </SecondaryButton>
+                    <Link
+                      href={
+                        cameFromHomePage
+                          ? urls.dashboard()
+                          : urls.companies.detail(company.id)
+                      }
+                    >
+                      Back
+                    </Link>
+                  </FormActions>
+                </>
+              )}
+            </>
+          )
+        }
+      </Task.Status>
+    )
+  }
 )

--- a/src/apps/companies/apps/referrals/details/client/state.js
+++ b/src/apps/companies/apps/referrals/details/client/state.js
@@ -1,3 +1,1 @@
 export const ID = 'referralDetails'
-
-export const state2props = (state) => state[ID]

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -67,7 +67,10 @@ const store = createStore(
     ...TabNav.reducerSpread,
     ...ReferralList.reducerSpread,
     [EXPORTS_WINS_ID]: exportWinsReducer,
+    // A reducer is required to be able to set a preloadedState parameter
+    referrerUrl: (state = {}) => state,
   }),
+  { referrerUrl: window.document.referrer },
   composeWithDevTools(applyMiddleware(sagaMiddleware))
 )
 

--- a/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
@@ -239,4 +239,28 @@ describe('Referral details', () => {
         })
     })
   )
+  context('When you come to the details page from the homepage', () => {
+    it('should take you to the homepage when you click "back"', () => {
+      cy.visit(urls.dashboard())
+      cy.contains('My referrals').click()
+      cy.contains('Andy to Lou').click()
+      cy.contains('Back').click()
+      cy.location('pathname').should('eq', urls.dashboard())
+    })
+  })
+  context(
+    'When you come to the details page from anywhere but the homepage',
+    () => {
+      it('should take you to the company page when you click "back"', () => {
+        cy.visit(
+          urls.companies.referrals.details(companyId, REFERRAL_ID_NO_CONTACT)
+        )
+        cy.contains('Back').click()
+        cy.location('pathname').should(
+          'eq',
+          urls.companies.activity.index(companyId)
+        )
+      })
+    }
+  )
 })


### PR DESCRIPTION
## Description of change

You can get to a referral's details page from either the activity feed or the homepage, however the back link currently only returns you to the homepage. 

For a smoother user journey, this PR checks the path of the referrer and if it was the homepage it will return them there, otherwise it will return them to the activity feed. 

To keep the ReferralDetails component pure, 'referrerUrl' is passed to the createStore function as the preLoadedState. As stated in the [redux docs](https://redux.js.org/api/createstore), as we're using combinedReducers, for anything in preloadedState there needs to be a corresponding reducer - hence the simple in-line reducer. 

As the PR for showing referrals on the homepage (#2499) will be the last one we merge for MVP going live, a test will be added to the referral details spec for returning to the homepage once this is merged ([trello card](https://trello.com/c/vDXs5AU8/1176-once-show-my-referrals-on-homepage-is-merged-add-test-for-back-button-in-referral-details-spec)).

## Test instructions

As referrals aren't currently visible on the homepage, you can: 

- Add a link to [this referral which is on dev](http://localhost:3000/companies/346f78a5-1d23-4213-b4c2-bf48246a13c3/referrals/6fc68b2b-ee76-4135-9d25-0ef5e3540970) to dashboard.njk
`<a href="http://localhost:3000/companies/346f78a5-1d23-4213-b4c2-bf48246a13c3/referrals/6fc68b2b-ee76-4135-9d25-0ef5e3540970">Referral</a>`
- Follow the link
- Click back on the referral details page
- It should take you back to the homepage

Then:
- Go to [the referral](http://localhost:3000/companies/346f78a5-1d23-4213-b4c2-bf48246a13c3/referrals/6fc68b2b-ee76-4135-9d25-0ef5e3540970) from any other page 
- Click back
- It should take you to the company's activity feed

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
