### PR TITLE
Change referral send url

### DIFF
--- a/src/apps/companies/apps/referrals/router.js
+++ b/src/apps/companies/apps/referrals/router.js
@@ -13,10 +13,13 @@ const {
   setInteractionsDetails,
 } = require('./middleware/interactions')
 
+router
+  .route(urls.companies.referrals.send.route)
+  .get(renderSendReferralForm)
+  .post(submitSendReferralForm)
+// the details route needs to go below the send route so that it does not try to handle the send route
 router.get(urls.companies.referrals.details.route, renderReferralDetails)
 router.get(urls.companies.referrals.help.route, renderReferralHelp)
-router.get(urls.companies.referrals.send.route, renderSendReferralForm)
-router.post(urls.companies.referrals.send.route, submitSendReferralForm)
 
 // Adding an interaction to complete a referral
 // This mounts the interactions sub app on the details route

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -194,6 +194,29 @@ describe('urls', () => {
         `/companies/${companyId}/orders`
       )
       expect(urls.companies.orders.route).to.equal('/:companyId/orders')
+
+      const referralId = faker.random.uuid()
+      expect(urls.companies.referrals.send(companyId)).to.equal(
+        `/companies/${companyId}/referrals/send`
+      )
+
+      expect(urls.companies.referrals.details(companyId, referralId)).to.equal(
+        `/companies/${companyId}/referrals/${referralId}`
+      )
+
+      expect(urls.companies.referrals.help(companyId, referralId)).to.equal(
+        `/companies/${companyId}/referrals/${referralId}/help`
+      )
+
+      expect(
+        urls.companies.referrals.interactions.create(companyId, referralId)
+      ).to.equal(
+        `/companies/${companyId}/referrals/${referralId}/interactions/create`
+      )
+
+      expect(
+        urls.companies.referrals.interactionsIndex(companyId, referralId)
+      ).to.equal(`/companies/${companyId}/referrals/${referralId}/interactions`)
     })
   })
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -93,7 +93,7 @@ module.exports = {
     interactions: createInteractionsSubApp('/companies', '/:companyId'),
     manageCompanyList: url('/companies', '/:companyId/manage-company-list'),
     referrals: {
-      send: url('/companies', '/:companyId/send-referral'),
+      send: url('/companies', '/:companyId/referrals/send'),
       details: url('/companies', '/:companyId/referrals/:referralId'),
       help: url('/companies', '/:companyId/referrals/:referralId/help'),
       interactions: createInteractionsSubApp(


### PR DESCRIPTION
## Description of change

This PR changes the url for sending a referral from `/send-referral` to `referrals/send`. This improves the consistency with other urls both in and outside of the referrals module. 

I have also added tests for the referrals urls in the urls module as these were missing up to this point. 

## Test instructions

Navigate to `/companies/:companyId/referrals/send` and you will see the send referral form. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
