### PR TITLE
Fix typeahead text outline 

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "^5.3.3",
+    "data-hub-components": "^5.3.4",
     "date-fns": "^1.29.0",
     "del-cli": "^2.0.0",
     "dotenv": "^5.0.0",

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -38,14 +38,6 @@ const StyledTextArea = styled(TextArea)({
   },
 })
 
-// Override the unecessary outlining of text within the input
-
-const StyledTypeahead = styled(Typeahead)`
-  input:focus {
-    box-shadow: none;
-  }
-`
-
 const SendReferralForm = ({
   companyContacts,
   cancelUrl,
@@ -99,7 +91,7 @@ const SendReferralForm = ({
           </a>
           .
         </HintText>
-        <StyledTypeahead
+        <Typeahead
           onChange={(event) =>
             onAdviserChange({
               name: event.label,
@@ -159,7 +151,7 @@ const SendReferralForm = ({
       <Label>
         <LabelText>Company contact (optional)</LabelText>
         <HintText>Who should the recipient of the referral talk to?</HintText>
-        <StyledTypeahead
+        <Typeahead
           isMulti={false}
           isClearable={true}
           name="contact"


### PR DESCRIPTION
## Description of change

We have a global style which gives inputs a box-shadow, which for the typeahead component means the input text is outlined in yellow. This is now fixed at the component level in [this PR](url) so the overriding style added to the Typeahead component in the send referral form can now be removed. 

This PR also bumps the component library version to include this change.  

## Test instructions

There are no visible changes to the send referral form.

As a result of the component library change:

- Go to /interactions/create?company_id=companyId
- Check that there is no yellow outline on the typeaheads' input text

## Screenshots
### Before


![](https://user-images.githubusercontent.com/22460823/77757380-0fd7ea80-7029-11ea-99c2-e31edd30ade7.png)

### After

![](https://user-images.githubusercontent.com/22460823/77757399-16666200-7029-11ea-883e-08170307c9e5.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
