### PR TITLE
Automation of company change requests

### DIFF
--- a/src/apps/companies/apps/edit-company/transformers.js
+++ b/src/apps/companies/apps/edit-company/transformers.js
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-
 const { castArray, get, isEmpty, omitBy, pick, isUndefined } = require('lodash')
 
 const UNMATCHED_COMPANY_EDITABLE_FIELDS = [
@@ -93,8 +92,49 @@ const transformFormToZendesk = (company, formValues) => {
   )
 }
 
+const transformFormToDnbChangeRequest = (company, formValues) => {
+  const obj = transformFormToZendesk(company, formValues)
+  const address = omitBy(
+    {
+      line_1: obj.address1,
+      line_2: obj.address2,
+      town: obj.city,
+      county: obj.county,
+      postcode: obj.postcode,
+    },
+    (fieldValue) => isEmpty(fieldValue)
+  )
+
+  delete obj.address1
+  delete obj.address2
+  delete obj.city
+  delete obj.county
+  delete obj.postcode
+
+  const tradingNames = omitBy(
+    {
+      trading_names: obj.trading_names ? castArray(obj.trading_names) : [],
+    },
+    (fieldValue) => isEmpty(fieldValue)
+  )
+
+  delete obj.trading_names
+
+  const dnbChangeRequest = {
+    ...obj,
+    ...tradingNames,
+  }
+
+  if (!isEmpty(address)) {
+    dnbChangeRequest.address = address
+  }
+
+  return dnbChangeRequest
+}
+
 module.exports = {
   transformCompanyToForm,
   transformFormToApi,
   transformFormToZendesk,
+  transformFormToDnbChangeRequest,
 }

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -141,6 +141,17 @@ function linkDataHubCompanyToDnBCompany(token, companyId, dunsNumber) {
   })
 }
 
+function createDnbChangeRequest(token, dunsNumber, changes) {
+  return authorisedRequest(token, {
+    body: {
+      duns_number: dunsNumber,
+      changes,
+    },
+    url: `${config.apiRoot}/v4/dnb/company-change-request`,
+    method: 'POST',
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
@@ -158,4 +169,5 @@ module.exports = {
   saveDnbCompanyInvestigation,
   saveCompanyExportDetails,
   linkDataHubCompanyToDnBCompany,
+  createDnbChangeRequest,
 }

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -354,9 +354,9 @@ describe('Company edit', () => {
       )
     })
 
-    it('displays the "Update sent for review" flash message and the ID used in GA', () => {
+    it('displays the "Update sent for third party review" flash message and the ID used in GA', () => {
       cy.contains(
-        'Update sent for review.Thanks for keeping Data Hub running smoothly.'
+        'Update sent for third party review.Thanks for keeping Data Hub running smoothly.'
       ).should('have.attr', 'id', 'message-company-change-request')
     })
   })

--- a/test/sandbox/fixtures/v4/dnb/company-change-request.json
+++ b/test/sandbox/fixtures/v4/dnb/company-change-request.json
@@ -1,0 +1,15 @@
+{
+  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+  "duns_number": "218882442",
+  "changes": {
+      "domain": "example.com",
+      "address_line_1": "23 Code Street",
+      "address_line_2": "6th Floor, Amp House",
+      "address_town": "CROYDON",
+      "address_county": "",
+      "address_country": "GB",
+      "address_postcode": "CR0 2LX"
+  },
+  "status": "pending",
+  "created_on": "2020-03-26T16:11:54.593785Z"
+}

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -450,6 +450,11 @@ Sandbox.define(
 )
 Sandbox.define('/v4/dnb/company-search', 'POST', v4Dnb.companySearch)
 Sandbox.define('/v4/dnb/company-link', 'POST', v4Dnb.companyLink)
+Sandbox.define(
+  '/v4/dnb/company-change-request',
+  'POST',
+  v4Dnb.companyChangeRequest
+)
 
 // V4 legacy company list
 Sandbox.define(

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -1,6 +1,7 @@
 var companyCreate = require('../../../fixtures/v4/dnb/company-create.json')
 var companySearch = require('../../../fixtures/v4/dnb/company-search.json')
 var companyLink = require('../../../fixtures/v4/dnb/company-link.json')
+var companyChangeRequest = require('../../../fixtures/v4/dnb/company-change-request.json')
 var companySearchMatched = require('../../../fixtures/v4/dnb/company-search-matched.json')
 var companySearchNotMatched = require('../../../fixtures/v4/dnb/company-search-not-matched.json')
 var companyCreateInvestigation = require('../../../fixtures/v4/dnb/company-create-investigation.json')
@@ -26,4 +27,8 @@ exports.companyCreateInvestigation = function(req, res) {
 
 exports.companyLink = function(req, res) {
   res.json(companyLink)
+}
+
+exports.companyChangeRequest = function(req, res) {
+  res.json(companyChangeRequest)
 }


### PR DESCRIPTION
## Description of change
Allows users to edit a D&B company, the subsequent change request is sent to D&B for approval.

Technical high-level overview of what occurs when a user makes a company change request

**Frontend:**
- The first call is to the Zendesk API where a ticket is generated - a member of the team picks this up (current functionality)

- The second call is to the DH API, the user’s change request (the diff) is part of the payload

**DH API**
- The endpoint validates the payload (number 2 above) as part of the request

- The API makes a call to the dnb-service passing the validated payload

**D&B Service**
- The payload from the DH API request is stored in a model

- A service batches all requests from the model into tasks

- Tasks are run nightly, CSVs are generated and emailed to D&B

**D&B Investigator**
- D&B accept the changes, the business is updated, changes can be seen in the Edit History after approximately 2 weeks
- D&B reject the changes, a team member receives an email (unhappy path)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
