### PR TITLE
Add message to exports history results

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportsHistory/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsHistory/index.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { H2 } from '@govuk-react/heading'
 import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
+import InsetText from '@govuk-react/inset-text'
 import { CollectionList } from 'data-hub-components'
 import { connect } from 'react-redux'
 
@@ -48,6 +49,10 @@ export default connect(state2props, (dispatch) => ({
         >
           {() => (
             <>
+              <InsetText>
+                You can only see the history of countries that were added or
+                edited after 6th February 2020
+              </InsetText>
               <H2 size={LEVEL_SIZE[3]}>{pageTitle}</H2>
               <CollectionList
                 itemName="result"

--- a/test/functional/cypress/specs/companies/export/history-spec.js
+++ b/test/functional/cypress/specs/companies/export/history-spec.js
@@ -40,6 +40,12 @@ describe('Company Export tab - Export countries history', () => {
         })
       })
 
+      it('renders the help message', () => {
+        cy.contains(
+          'You can only see the history of countries that were added or edited after 6th February 2020'
+        )
+      })
+
       it('renders the title', () => {
         cy.contains('Export countries history')
       })
@@ -53,6 +59,12 @@ describe('Company Export tab - Export countries history', () => {
     context('when there is history with multiple pages', () => {
       before(() => {
         visitHistory(fixtures.company.dnbCorp.id)
+      })
+
+      it('renders the help message', () => {
+        cy.contains(
+          'You can only see the history of countries that were added or edited after 6th February 2020'
+        )
       })
 
       it('renders the title', () => {
@@ -159,6 +171,12 @@ describe('Company Export tab - Export countries history', () => {
         visitHistory(fixtures.company.dnbGlobalUltimate.id)
       })
 
+      it('renders the help message', () => {
+        cy.contains(
+          'You can only see the history of countries that were added or edited after 6th February 2020'
+        )
+      })
+
       it('renders the title', () => {
         cy.contains('Export countries history')
       })
@@ -232,6 +250,12 @@ describe('Company Export tab - Export countries history', () => {
           visitHistory(fixtures.company.marsExportsLtd.id)
         })
 
+        it('renders the help message', () => {
+          cy.contains(
+            'You can only see the history of countries that were added or edited after 6th February 2020'
+          )
+        })
+
         it('renders the title', () => {
           cy.contains('Export countries history')
         })
@@ -253,6 +277,12 @@ describe('Company Export tab - Export countries history', () => {
       context('With grouped history items', () => {
         before(() => {
           visitHistory(fixtures.company.minimallyMinimalLtd.id)
+        })
+
+        it('renders the help message', () => {
+          cy.contains(
+            'You can only see the history of countries that were added or edited after 6th February 2020'
+          )
         })
 
         it('renders the title', () => {
@@ -309,6 +339,12 @@ describe('Company Export tab - Export countries history', () => {
     context('when viewing a company with interactions in the history', () => {
       before(() => {
         visitHistory(fixtures.company.investigationLimited.id)
+      })
+
+      it('renders the help message', () => {
+        cy.contains(
+          'You can only see the history of countries that were added or edited after 6th February 2020'
+        )
       })
 
       it('renders the title', () => {
@@ -466,6 +502,12 @@ describe('Company Export tab - Export countries history', () => {
         Exports: urls.companies.exports.index(fixtures.company.dnbCorp.id),
         'Andorra exports history': null,
       })
+    })
+
+    it('renders the help message', () => {
+      cy.contains(
+        'You can only see the history of countries that were added or edited after 6th February 2020'
+      )
     })
 
     it('renders the title', () => {


### PR DESCRIPTION
## Description of change

Add a message to the top of exports history pages to say that 'You can only see the history of countries that were added or edited after 6th February 2020'

## Test instructions

Navigate to any exports history page and you will see the message. 

## Screenshots

![FireShot Capture 060 - Export countries history - Exports - Lambda plc - Companies - DIT Dat_ - localhost](https://user-images.githubusercontent.com/42253716/78020270-0f9d5f00-7349-11ea-89a3-17e77d6b4798.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
