### PR TITLE
Fix: stop caching node modules in docker compose

### DIFF
--- a/docker-compose.mock.yml
+++ b/docker-compose.mock.yml
@@ -5,7 +5,6 @@ services:
       context: .
     volumes:
       - .:/usr/src/app
-      - /usr/src/app/node_modules
     ports:
       - 3001:3000
       - 9230:9229

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       context: .
     volumes:
       - .:/usr/src/app
-      - /usr/src/app/node_modules
     ports:
       - 3000:3000
       - 9229:9229


### PR DESCRIPTION
Don't mount node_modules folder to prevent caching of node modules when running in the app in docker. 