### PR TITLE
Fix docker setup for clean working directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ COPY yarn.lock ./
 RUN yarn
 
 COPY . .
+RUN yarn build
 
 CMD ["yarn", "develop"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,11 @@ services:
     build:
       context: .
     volumes:
-      - .:/usr/src/app
+      - ./assets:/usr/src/app/assets
+      - ./scripts:/usr/src/app/scripts
+      - ./src:/usr/src/app/src
+      - ./test:/usr/src/app/test
+      - ./visual-screenshots:/usr/src/app/visual-screenshots
     ports:
       - 3000:3000
       - 9229:9229


### PR DESCRIPTION
## Description of change

This change is needed for the following reasons:
- We do away with mounting the whole app directory from host -> container.  This was causing a problem where an empty `node_modules` directory was being mounted to the container which meant that the container was running without any dependencies.  This change means that specific source directories are mounted on the container only.
- Running `yarn build` in the Dockerfile after copying the host's application directory over means that a `manifest.json` is properly created on the container and means that assets etc can be loaded properly in the app.