### PR TITLE
Add cannot find DnB company

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -16,7 +16,7 @@ const requiredWebsiteOrPhoneValidator = (
   { values: { website, telephone_number } }
 ) => {
   return !website && !telephone_number
-    ? 'Enter at least a website or a phone number'
+    ? 'Enter a website or phone number'
     : null
 }
 

--- a/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
+++ b/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
@@ -1,23 +1,112 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import axios from 'axios'
+import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
+import { H4 } from '@govuk-react/heading'
+import InsetText from '@govuk-react/inset-text'
+import ErrorSummary from '@govuk-react/error-summary'
 import Paragraph from '@govuk-react/paragraph'
 
 import urls from '../../../../../lib/urls'
+import { WEBSITE_REGEX } from '../../add-company/client/constants'
 
-function CannotFindMatch({ companyId }) {
+import {
+  FormStateful,
+  SummaryList,
+  FormActions,
+  FieldInput,
+} from 'data-hub-components'
+
+const requiredWebsiteOrPhoneValidator = (
+  value,
+  name,
+  { values: { website, telephoneNumber } }
+) => {
+  return !website && !telephoneNumber ? 'Enter a website or phone number' : null
+}
+
+const websiteValidator = (value) => {
+  WEBSITE_REGEX.test(value) ? null : 'Enter a valid website URL'
+}
+
+async function onFormSubmit(values, csrfToken) {
+  const url = urls.companies.match.cannotFind(values.companyId)
+  await axios.post(url, {
+    _csrf: csrfToken,
+    address: values.address,
+    website: values.website,
+    telephoneNumber: values.telephoneNumber,
+  })
+  return urls.companies.detail(values.companyId)
+}
+
+function CannotFindMatch({ company, csrfToken }) {
   return (
-    <>
-      <Paragraph>
-        Thanks for trying to verify the business details on this Data Hub
-        record.
-      </Paragraph>
-      <Paragraph>You can continue to use Data Hub as normal.</Paragraph>
-      <br />
-      <Link href={urls.companies.detail(companyId)}>
-        Return to company record
-      </Link>
-    </>
+    <FormStateful
+      initialValues={{
+        companyId: company.id,
+        address: company.address.join(', '),
+      }}
+      onSubmit={(values) => onFormSubmit(values, csrfToken)}
+    >
+      {({ submissionError }) => (
+        <>
+          {submissionError && (
+            <ErrorSummary
+              heading="There was an error submitting these details"
+              description={submissionError.message}
+              errors={[]}
+            />
+          )}
+          <H4 as="h2">Data Hub business details (un-verified)</H4>
+          <InsetText>
+            <SummaryList
+              rows={[
+                { label: 'Company name', value: company.name },
+                { label: 'Located at', value: company.address.join(', ') },
+              ]}
+            />
+          </InsetText>
+          <H4 as="h2">Contact details of the business for verification</H4>
+          <FieldInput
+            label="Company's website"
+            name="website"
+            type="url"
+            validate={[requiredWebsiteOrPhoneValidator, websiteValidator]}
+          />
+          <FieldInput
+            label="Company's telephone number"
+            hint="If the website of the business does not show the name and address
+              of the business as you want it to appear in Data Hub, it is important
+              to provide a valid phone number, so the company can be contacted when
+              verifying the business details."
+            name="telephoneNumber"
+            type="tel"
+            validate={requiredWebsiteOrPhoneValidator}
+          />
+          <H4 as="h2">What happens next</H4>
+          <Paragraph>
+            These business details will be sent to our third party data
+            suppliers, so it is important you have consent from the business to
+            share these details.
+          </Paragraph>
+          <Paragraph>
+            Our data suppliers might need to contact the company to verify the
+            details, so it is important that the website and phone number are
+            valid.
+          </Paragraph>
+          <Paragraph>
+            It will NOT change any recorded activity (interactions, OMIS orders
+            or Investment projects).
+          </Paragraph>
+          <FormActions>
+            <Button>Send</Button>
+            <Link href={urls.companies.match.index(company.id)}>Back</Link>
+          </FormActions>
+        </>
+      )}
+    </FormStateful>
   )
 }
 

--- a/src/apps/companies/apps/match-company/router.js
+++ b/src/apps/companies/apps/match-company/router.js
@@ -7,12 +7,14 @@ const {
   renderMatchConfirmation,
   linkCompanies,
   renderCannotFindMatch,
+  submitNewDnbRecordRequest,
   submitMergeRequest,
 } = require('./controllers')
 
 router.get(urls.companies.match.index.route, renderFindCompanyForm)
 router.post(urls.companies.match.index.route, findDnbCompany)
 router.get(urls.companies.match.cannotFind.route, renderCannotFindMatch)
+router.post(urls.companies.match.cannotFind.route, submitNewDnbRecordRequest)
 router.get(urls.companies.match.confirmation.route, renderMatchConfirmation)
 router.post(urls.companies.match.link.route, linkCompanies)
 router.post(urls.companies.match.merge.route, submitMergeRequest)

--- a/src/apps/companies/apps/match-company/views/cannot-find-match.njk
+++ b/src/apps/companies/apps/match-company/views/cannot-find-match.njk
@@ -3,7 +3,7 @@
 {% block local_header %}
   {{
     LocalHeader({
-      heading: "I still can't find what I'm looking for",
+      heading: "Send these business details to our third party data supplier for verification",
       modifier: 'light-banner'
     })
   }}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -131,7 +131,9 @@ function App() {
         )}
       </Mount>
       <Mount selector="#cannot-find-match">
-        {(props) => <CannotFindMatch {...props} />}
+        {(props) => (
+          <CannotFindMatch csrfToken={globalProps.csrfToken} {...props} />
+        )}
       </Mount>
       <Mount selector="#find-company">
         {(props) => (

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -376,7 +376,7 @@ describe('Add company form', () => {
             )
             cy.get(selectors.companyAdd.form).contains('Enter name')
             cy.get(selectors.companyAdd.form).contains(
-              'Enter at least a website or a phone number'
+              'Enter a website or phone number'
             )
             cy.get(selectors.companyAdd.form).contains('Enter address line 1')
             cy.get(selectors.companyAdd.form).contains('Enter town or city')


### PR DESCRIPTION
## Description of change
Currently if a user is unable to match a D&B company to a Data Hub company they come to a dead end.

**In dev:**
1.  /companies/731bdcc1-f685-4c8e-bd66-b356b2c16995/activity
2. Select the green "Verify business details" button
3. Select the green "Find company" button 
4. Select the  "I can't find what I'm looking for" link
5. Select the "I still can't find what I'm looking for"

## Current dead end
<img width="1040" alt="deadend" src="https://user-images.githubusercontent.com/964268/78135689-35deff80-741a-11ea-8156-2707462fa07d.png">

## New functionality (the same five steps as above)
A user completes either field (or both) and submits their business details. Subsequently a Zendesk ticket is generated where a member of the team picks this request up. The next iteration would be to automate the process.

<img width="1258" alt="new" src="https://user-images.githubusercontent.com/964268/78135828-6b83e880-741a-11ea-9b51-bbd617ee031d.png">

## Validation error
<img width="1258" alt="validation-errors" src="https://user-images.githubusercontent.com/964268/78136591-cff37780-741b-11ea-87ab-5589bacbc64f.png">

## Network error
<img width="1239" alt="404" src="https://user-images.githubusercontent.com/964268/78136565-c10cc500-741b-11ea-93d5-42b2f34fd3d4.png">

## Zendesk ticket
<img width="1610" alt="zendesk" src="https://user-images.githubusercontent.com/964268/78136954-5e67f900-741c-11ea-8699-140250c6e6bd.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
