### PR TITLE
Remove back link from interaction details template

### DIFF
--- a/src/apps/interactions/views/details.njk
+++ b/src/apps/interactions/views/details.njk
@@ -23,8 +23,6 @@
         classes: 'govuk-button govuk-button--secondary'
       }) }}
     {% endif %}
-
-    <a href="{{ returnLink }}">Back</a>
   </div>
 
   {% if referral %}

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -63,7 +63,7 @@ describe('Interaction details', () => {
         selectors.interaction.details.interaction.actions.completeInteraction(
           params
         )
-      ).should('have.text', 'Complete interaction ')
+      ).should('have.text', 'Complete interaction')
     })
 
     it('should not render the "Edit interaction" button', () => {
@@ -74,15 +74,6 @@ describe('Interaction details', () => {
           'service-delivery'
         )
       ).should('not.be.visible')
-    })
-
-    it('should render the "Back" link', () => {
-      cy.get(
-        selectors.interaction.details.interaction.actions.back(params)
-      ).should('be.visible')
-      cy.get(
-        selectors.interaction.details.interaction.actions.back(params)
-      ).should('have.text', 'Back')
     })
 
     it('should not render the "Why can I not complete this interaction?" details summary', () => {
@@ -152,15 +143,6 @@ describe('Interaction details', () => {
       ).should('not.be.visible')
     })
 
-    it('should render the "Back" link', () => {
-      cy.get(
-        selectors.interaction.details.interaction.actions.back(params)
-      ).should('be.visible')
-      cy.get(
-        selectors.interaction.details.interaction.actions.back(params)
-      ).should('have.text', 'Back')
-    })
-
     it('should render the "Why can I not complete this interaction?" details summary', () => {
       cy.get(
         selectors.interaction.details.interaction.whyCanINotComplete
@@ -226,15 +208,6 @@ describe('Interaction details', () => {
           'service-delivery'
         )
       ).should('not.be.visible')
-    })
-
-    it('should render the "Back" link', () => {
-      cy.get(
-        selectors.interaction.details.interaction.actions.back(params)
-      ).should('be.visible')
-      cy.get(
-        selectors.interaction.details.interaction.actions.back(params)
-      ).should('have.text', 'Back')
     })
 
     it('should not render the "Why can I not complete this interaction?" details summary', () => {
@@ -307,15 +280,7 @@ describe('Interaction details', () => {
         'service-delivery'
       )
       cy.get(editInteraction).should('be.visible')
-      cy.get(editInteraction).should('have.text', 'Edit service delivery ')
-    })
-
-    it('should render the "Back" link', () => {
-      const back = selectors.interaction.details.interaction.actions.back(
-        params
-      )
-      cy.get(back).should('be.visible')
-      cy.get(back).should('have.text', 'Back')
+      cy.get(editInteraction).should('have.text', 'Edit service delivery')
     })
 
     it('should not render the "Why can I not complete this interaction?" details summary', () => {
@@ -389,15 +354,7 @@ describe('Interaction details', () => {
         'interaction'
       )
       cy.get(editInteraction).should('be.visible')
-      cy.get(editInteraction).should('have.text', 'Edit interaction ')
-    })
-
-    it('should render the "Back" link', () => {
-      const back = selectors.interaction.details.interaction.actions.back(
-        params
-      )
-      cy.get(back).should('be.visible')
-      cy.get(back).should('have.text', 'Back')
+      cy.get(editInteraction).should('have.text', 'Edit interaction')
     })
 
     it('should not render the "Why can I not complete this interaction?" details summary', () => {

--- a/test/selectors/interaction/details.js
+++ b/test/selectors/interaction/details.js
@@ -4,7 +4,6 @@ exports.interaction = {
       `[href="/companies/${companyId}/interactions/${interactionId}/complete"]`,
     editInteraction: ({ companyId, interactionId }, theme, kind) =>
       `[href="/companies/${companyId}/interactions/${interactionId}/edit/${theme}/${kind}"]`,
-    back: ({ companyId }) => `[href="/companies/${companyId}/interactions/"]`,
   },
   whyCanINotComplete: '[data-auto-id="interactionDetailsWhyCanINotComplete"]',
   referralDetails: '#interaction-referral-details',


### PR DESCRIPTION
## Description of change

This PR removes the back link from the interaction details template. As a result, the checks that the back link has been rendered have been removed from the interaction details functional test. 

This came about from a bug that Rogier noticed when completing an interaction from a referral, as the back link on that interaction page threw an error. 

Rogier advised that we should just remove the back link from the interaction details template all together, as it adds no value and often doesn't return the user to a logical place. 

## Test instructions

- Go to any interaction page
- The back link should not appear

## Screenshots
### Before

![Screenshot 2020-04-01 at 15 57 10](https://user-images.githubusercontent.com/22460823/78152249-74cc7f80-7431-11ea-92f0-4ea46032ef83.png)


### After

![Screenshot 2020-04-01 at 15 56 07](https://user-images.githubusercontent.com/22460823/78152126-4fd80c80-7431-11ea-9468-c833eebb9233.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
