### PR TITLE
Replace basic anchor tag with React version for opening a new window

### DIFF
--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -15,7 +15,8 @@ import {
   SEND_REFERRAL_FORM__CONTACT_CHANGE,
   SEND_REFERRAL_FORM__TEXTAREA_CHANGE,
 } from '../../../../../../client/actions'
-import { FormActions, Typeahead } from 'data-hub-components'
+
+import { NewWindowLink, FormActions, Typeahead } from 'data-hub-components'
 import {
   H4,
   Label,
@@ -86,9 +87,9 @@ const SendReferralForm = ({
         <HintText>
           This can be an adviser at post, a sector specialist or an
           international trade advisor. If you're not sure, you can{' '}
-          <a href="https://people.trade.gov.uk/teams/department-for-international-trade">
+          <NewWindowLink href="https://people.trade.gov.uk/teams/department-for-international-trade">
             find the right team and person on Digital Workspace
-          </a>
+          </NewWindowLink>
           .
         </HintText>
         <Typeahead

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -43,14 +43,33 @@ describe('Send a referral form', () => {
 
       it('should display the headings and four fields', () => {
         cy.get(selectors.companySendReferral.form)
+          .find('h4')
+          .should('contain', 'Who do you want to refer this company to?')
+          .next()
           .should('contain', 'Adviser')
-          .and('contain', 'Subject')
-          .and('contain', 'Notes')
-          .and('contain', 'Company contact (optional')
-        cy.get(selectors.companySendReferral.adviserField).should('be.visible')
-        cy.get(selectors.companySendReferral.subjectField).should('be.visible')
-        cy.get(selectors.companySendReferral.notesField).should('be.visible')
-        cy.get(selectors.companySendReferral.contactField).should('be.visible')
+          .should(
+            'contain',
+            "This can be an adviser at post, a sector specialist or an international trade advisor. If you're not sure, you can find the right team and person on Digital Workspace (opens in a new window or tab)."
+          )
+          .find('a')
+          .should('have.attr', 'href', urls.external.digitalWorkspace.teams)
+          .parent()
+          .parent()
+          .next()
+          .next()
+          .should('contain', 'Referral notes')
+          .next()
+          .should('contain', 'Subject')
+          .next()
+          .next()
+          .should('contain', 'Notes')
+          .and(
+            'contain',
+            "Include reasons you're referring this company and any specific opportunities."
+          )
+          .next()
+          .next()
+          .should('contain', 'Company contact (optional')
       })
 
       it('should display "Continue" button', () => {


### PR DESCRIPTION
## Description of change
We need to change an anchor tag in the "Send referral" form so that it opens in a new window.

# Solution
Replace the anchor tag with our React component `NewWindowLink` which is more accessible (includes content - Opens in a new window). 

## Test instructions

Go to a company page and click on "Refer this company"

## Screenshots
### Before

![Screenshot 2020-04-01 at 16 18 03](https://user-images.githubusercontent.com/10154302/78155132-fa056380-7434-11ea-9dbc-664b95213589.png)

### After

![Screenshot 2020-04-01 at 16 17 46](https://user-images.githubusercontent.com/10154302/78155147-ff62ae00-7434-11ea-9a59-ee5ca0a831b7.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
