### PR TITLE
Fix a bug preventing completion of OMIS orders

### DIFF
--- a/src/apps/omis/apps/edit/fields.js
+++ b/src/apps/omis/apps/edit/fields.js
@@ -10,6 +10,7 @@ const editFields = merge({}, globalFields, {
     label: 'fields.subscribers.label',
     hint: 'fields.subscribers.hint',
     name: 'subscribers',
+    multiple: true,
     children: [
       {
         macroName: 'Typeahead',
@@ -73,6 +74,7 @@ const editFields = merge({}, globalFields, {
     legend: 'fields.assignees.legend',
     label: 'fields.assignees.label',
     hint: 'fields.assignees.hint',
+    multiple: true,
     name: 'assignees',
     children: [
       {
@@ -93,12 +95,14 @@ const editFields = merge({}, globalFields, {
     fieldType: 'TextField',
     label: 'fields.assignee_time.label',
     modifier: ['shorter', 'soft'],
+    multiple: true,
     validate: [duration],
   },
   assignee_actual_time: {
     fieldType: 'TextField',
     label: 'fields.assignee_actual_time.label',
     modifier: ['shorter', 'soft'],
+    multiple: true,
     validate: [arrayrequired, duration],
   },
   vat_status: {


### PR DESCRIPTION
## Description of change

This PR fixes a bug which prevented OMIS orders from being completed.

The bug was introduced when the `hmpo-form-wizard` library was updated: https://github.com/uktrade/data-hub-frontend/pull/2525

There was a BC breaking change introduced to the library meaning that form parameters with multiple values need to be explicitly set as `multiple: true`.  This was manifesting in such a way that any form fields using which depended on multiple values throughout the OMIS frontend code would only save one value and not all the values.