### PR TITLE
Add no-console eslint rule

### DIFF
--- a/.circleci/scripts/local-runner.js
+++ b/.circleci/scripts/local-runner.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 var Nightwatch = require('nightwatch')
 var browserstack = require('browserstack-local')
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,7 @@
     "no-case-declarations": "off",
     "no-prototype-builtins": "off",
     "no-unused-vars": "error",
-    "react/jsx-uses-react": "error",   
+    "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "node/no-deprecated-api": "off",
     "react-hooks/rules-of-hooks": "error",
@@ -59,7 +59,8 @@
         "max": 1
       }
     ],
-    "no-undef": "error"
+    "no-undef": "error",
+    "no-console": ["error", {"allow": ["assert"]}]
   },
   "overrides": [
     {

--- a/assets/javascripts/modules/auto-submit.js
+++ b/assets/javascripts/modules/auto-submit.js
@@ -64,9 +64,8 @@ const AutoSubmit = {
       .then(() => {
         this.isSubmitting = false
       })
-      .catch((error) => {
+      .catch(() => {
         this.isSubmitting = false
-        console.error(`Could not fetch data: ${error}`)
       })
   },
 }

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -24,7 +24,6 @@ async function getCompany(req, res, next, id) {
     res.locals.company = company
     next()
   } catch (error) {
-    console.log(error)
     next(error)
   }
 }

--- a/src/apps/contacts/controllers/__test__/edit.test.js
+++ b/src/apps/contacts/controllers/__test__/edit.test.js
@@ -22,8 +22,7 @@ describe('Contact controller, edit', () => {
   let getContactAsFormDataStub
   let company
   const next = function(error) {
-    console.log(error)
-    throw Error('error')
+    throw error
   }
 
   beforeEach(() => {

--- a/src/apps/investments/middleware/forms/details.js
+++ b/src/apps/investments/middleware/forms/details.js
@@ -143,7 +143,6 @@ async function populateForm(req, res, next) {
 
     next()
   } catch (error) {
-    console.log(error)
     next(error)
   }
 }

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -381,7 +381,6 @@ describe('Company edit', () => {
       cy.contains('Submit').click()
 
       cy.wait('@editCompanyResponse').then((xhr) => {
-        console.log(xhr)
         expect(xhr.request.body.trading_names).to.equal(
           'Test company trading name'
         )

--- a/test/sandbox/routes/v3/contact/contact.js
+++ b/test/sandbox/routes/v3/contact/contact.js
@@ -9,6 +9,7 @@ var contactCreateValidation = require('../../../fixtures/v3/contact/contact-crea
 
 exports.contact = function(req, res) {
   if (req.query.company_id === lambdaPlc.id) {
+    // eslint-disable-next-line no-console
     console.log(
       'BEWARE: Lambda PLC uses contacts-for-referral.json rather than contact.json'
     )

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -42,8 +42,6 @@ var ReferralIds = require('../../../constants/referrals')
 state.investor_description = state.investor_description || ''
 
 exports.largeInvestorProfile = function(req, res) {
-  console.log(req.query.offset)
-  console.log(req)
   if (req.query.investor_company_id === companyOneListCorp.id) {
     return res.json(largeCapitalProfile)
   }

--- a/test/unit/nunjucks.js
+++ b/test/unit/nunjucks.js
@@ -33,6 +33,7 @@ function render(template, options) {
       const { document } = new JSDOM(markup).window
       resolve(document)
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.log(error)
       reject(error)
     }


### PR DESCRIPTION
## Description of change

We should not be checking in code with `console` statement in it, so this adds the eslint rule to stop that from happening and corrects the cases where that has happened in the past

## Test instructions

Run `yarn lint:js` and there should not be any errors

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
