### PR TITLE
Handle 404 for Export Wins

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportWins/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportWins/index.jsx
@@ -20,7 +20,14 @@ function ExportWins(state) {
     return null
   }
 
-  const { count, results, onPageClick, activePage, companyId } = state
+  const {
+    count,
+    results,
+    onPageClick,
+    activePage,
+    companyId,
+    companyName,
+  } = state
 
   return (
     <Wrapper>
@@ -29,7 +36,7 @@ function ExportWins(state) {
         id="exportWins"
         progressMessage="Loading Exports Wins..."
         startOnRender={{
-          payload: { companyId, activePage },
+          payload: { companyId, companyName, activePage },
           onSuccessDispatch: EXPORT_WINS__LOADED,
         }}
       >

--- a/src/apps/companies/apps/exports/client/ExportWins/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportWins/index.jsx
@@ -15,16 +15,7 @@ const Wrapper = styled('div')`
   margin-top: ${SPACING.SCALE_3};
 `
 
-export default connect(state2props, (dispatch) => ({
-  onPageClick: (page, event) => {
-    event.target.blur()
-    event.preventDefault()
-    dispatch({
-      type: EXPORT_WINS__SELECT_PAGE,
-      page,
-    })
-  },
-}))((state) => {
+function ExportWins(state) {
   if (state[NOT_IMPLEMENTED]) {
     return null
   }
@@ -54,4 +45,15 @@ export default connect(state2props, (dispatch) => ({
       </Task.Status>
     </Wrapper>
   )
-})
+}
+
+export default connect(state2props, (dispatch) => ({
+  onPageClick: (page, event) => {
+    event.target.blur()
+    event.preventDefault()
+    dispatch({
+      type: EXPORT_WINS__SELECT_PAGE,
+      page,
+    })
+  },
+}))(ExportWins)

--- a/src/apps/companies/apps/exports/client/ExportWins/tasks.js
+++ b/src/apps/companies/apps/exports/client/ExportWins/tasks.js
@@ -60,16 +60,23 @@ function getMetadata(win) {
   return metadata.map(([label, value]) => ({ label, value }))
 }
 
-export function fetchExportWins({ companyId, activePage }) {
+export function fetchExportWins({ companyId, companyName, activePage }) {
   const offset = activePage * 10 - 10
   const param = offset ? '?offset=' + offset : ''
 
   return axios
     .get(`/api-proxy/v4/company/${companyId}/export-win${param}`)
     .catch((e) => {
-      // @TODO: Remove the 404 and handle separatly once API is in place to return a 501
-      if (e.response?.status === 501 || e.response?.status == 404) {
+      if (e.response?.status === 501) {
         return { [NOT_IMPLEMENTED]: true }
+      }
+
+      if (e.response?.status === 404) {
+        return Promise.reject(
+          new Error(
+            `We were unable to lookup Export Wins for ${companyName}, please try again later.`
+          )
+        )
       }
 
       return Promise.reject(new Error(e.message))

--- a/src/apps/companies/apps/exports/client/ExportsIndex.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsIndex.jsx
@@ -28,6 +28,7 @@ const ExportsIndex = ({
   exportCountriesInformation,
   exportPotentials,
   companyId,
+  companyName,
   companyNumber,
 }) => {
   return (
@@ -152,7 +153,7 @@ const ExportsIndex = ({
           measures export activity.
         </p>
       </Details>
-      <ExportWins companyId={companyId}></ExportWins>
+      <ExportWins companyId={companyId} companyName={companyName}></ExportWins>
     </>
   )
 }

--- a/src/apps/companies/apps/exports/controllers.js
+++ b/src/apps/companies/apps/exports/controllers.js
@@ -70,6 +70,7 @@ function renderExports(req, res) {
         exportPotentials: Object.values(exportPotentialLabels),
         companyId: company.id,
         companyNumber: company.company_number,
+        companyName: company.name,
       },
     })
 }

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -317,7 +317,13 @@ describe('Company Export tab', () => {
       it('should show an error message', () => {
         cy.contains('8 results').should('not.exist')
         cy.contains('0 results').should('not.exist')
-        cy.contains('Could not load Export wins').should('not.exist')
+        cy.contains('Could not load Export wins')
+          .should('exist')
+          .siblings()
+          .should(
+            'contain',
+            'We were unable to lookup Export Wins for One List Corp, please try again later.'
+          )
       })
     })
 


### PR DESCRIPTION
## Description of change

Now that the API is configured to return a 501 for `/export-win` whilst it is being developed this PR handles the 404 correctly by showing an error message

## Test instructions

Use sandbox and visit the Export tab for One List Corp (375094ac-f79a-43e5-9c88-059a7caa17f0), scroll down the page and you should see an error message for Export Wins.

A 404 in this context means that we were unable to get a match id from the company matching service and therefore we were unable to perform a lookup from Export Wins

## Screenshots
### Before

<img width="953" alt="Screenshot 2020-04-08 at 14 18 22" src="https://user-images.githubusercontent.com/1481883/78790099-f4180100-79a5-11ea-8657-c9eec53f5a7e.png">

### After

<img width="949" alt="Screenshot 2020-04-08 at 14 18 02" src="https://user-images.githubusercontent.com/1481883/78790117-fb3f0f00-79a5-11ea-85bd-dc0c6869a7f6.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
