### PR TITLE
Handle missing export wins data

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportWins/tasks.js
+++ b/src/apps/companies/apps/exports/client/ExportWins/tasks.js
@@ -46,8 +46,11 @@ function getMetadata(win) {
     ['Type of win', win.name_of_export],
     ['Country exported to', win.country],
     ['Sector', win.sector],
-    ['Company type', win.business_potential],
   ]
+
+  if (win.business_potential) {
+    metadata.push(['Company type', win.business_potential])
+  }
 
   if (win.response?.confirmed) {
     metadata.push(['Date confirmed', DateUtils.format(win.response.date)])

--- a/src/apps/companies/apps/exports/client/ExportWins/tasks.js
+++ b/src/apps/companies/apps/exports/client/ExportWins/tasks.js
@@ -44,7 +44,7 @@ function getMetadata(win) {
       }),
     ],
     ['Type of win', win.name_of_export],
-    ['Country exported to', win.country],
+    ['Country exported to', win.country || 'Unknown'],
     ['Sector', win.sector],
   ]
 

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -245,7 +245,7 @@ describe('Company Export tab', () => {
           .should('contain', 'Type of export quis qui consequuntur')
           .should('contain', 'Total export value £36,300')
           .should('contain', 'Type of win et quisquam voluptatem')
-          .should('contain', 'Country exported to Guam')
+          .should('contain', 'Country exported to Unknown')
           .should('contain', 'Sector voluptates molestiae cupiditate')
           .should('not.contain', 'Company type')
           .should('not.contain', 'Date confirmed')

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -139,7 +139,7 @@ describe('Company Export tab', () => {
       })
 
       it('should render the list of Export Wins without pagination', () => {
-        const LIST_ALIAS = 'export-wins-colleciton-list'
+        const LIST_ALIAS = 'export-wins-collection-list'
 
         cy.contains('8 results')
           .parent()

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -224,6 +224,32 @@ describe('Company Export tab', () => {
           .should('contain', 'Company type veritatis non ullam')
           .should('not.contain', 'Date confirmed')
           .should('contain', 'HVC name E198: quidem accusamus velit')
+
+        // company without a business_potential - this was added in Jun 2018
+        cy.contains(
+          'Labore quibusdam ut hic deleniti et harum ducimus repellendus.'
+        )
+          .siblings()
+          .should('contain', 'Won on 11 Mar 2019')
+          .should('contain', 'HVC')
+          .should('not.contain', 'Confirmed')
+          .should(
+            'contain',
+            'Lead officer Elias Hamill (nostrum quaerat maxime fugiat voluptatum quo)'
+          )
+          .should(
+            'contain',
+            'Company contact Damian Daugherty (qui minus quo - Georgianna78@gmail.com)'
+          )
+          .should('contain', 'Customer explicabo iusto quo')
+          .should('contain', 'Type of export quis qui consequuntur')
+          .should('contain', 'Total export value £36,300')
+          .should('contain', 'Type of win et quisquam voluptatem')
+          .should('contain', 'Country exported to Guam')
+          .should('contain', 'Sector voluptates molestiae cupiditate')
+          .should('not.contain', 'Company type')
+          .should('not.contain', 'Date confirmed')
+          .should('contain', 'HVC name E188: sed culpa saepe')
       })
     }
   )

--- a/test/sandbox/fixtures/v4/company-export-wins/export-wins.json
+++ b/test/sandbox/fixtures/v4/company-export-wins/export-wins.json
@@ -200,7 +200,7 @@
       "date": "2019-03-11T12:44:54.750Z",
       "country": "Guam",
       "sector": "voluptates molestiae cupiditate",
-      "business_potential": "et a ut",
+      "business_potential": null,
       "business_type": "quis qui consequuntur",
       "name_of_export": "et quisquam voluptatem",
       "customer": "explicabo iusto quo",

--- a/test/sandbox/fixtures/v4/company-export-wins/export-wins.json
+++ b/test/sandbox/fixtures/v4/company-export-wins/export-wins.json
@@ -198,7 +198,7 @@
       "title": "Labore quibusdam ut hic deleniti et harum ducimus repellendus.",
       "created": "2019-11-18T18:37:43.091Z",
       "date": "2019-03-11T12:44:54.750Z",
-      "country": "Guam",
+      "country": null,
       "sector": "voluptates molestiae cupiditate",
       "business_potential": null,
       "business_type": "quis qui consequuntur",


### PR DESCRIPTION
## Description of change

Now that we have real data for Export Wins in Data Hub it has shown some fields can be `null` so this handles the missing data correctly

## Test instructions

Use sandbox and view the Export tab for DnB Corp (cc7e2f19-7251-4a41-a27a-f98437720531) and look at the details for the 4th win in the list "Labore quibusdam ut hic deleniti et harum ducimus repellendus.". You should see that "Country exported to" is "Unknown" and the "Company type" field has been removed.

## Screenshots
### Before

<img width="952" alt="Screenshot 2020-04-21 at 08 40 59" src="https://user-images.githubusercontent.com/1481883/79839416-65937e80-83ac-11ea-8208-3605a4e0d835.png">


### After

<img width="952" alt="Screenshot 2020-04-21 at 08 40 18" src="https://user-images.githubusercontent.com/1481883/79839438-6c21f600-83ac-11ea-8fa4-8244e3b7160b.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
