### PR TITLE
Add more interaction e2e tests

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -137,4 +137,23 @@ describe('Event', () => {
       })
     })
   })
+
+  describe('Add attendee', () => {
+    it('Should add an interaction with the attendee', () => {
+      cy.visit(events.index())
+
+      cy.contains('One-day exhibition').click()
+      cy.contains('a', 'Attendees').click()
+      cy.contains('Add attendee').click()
+
+      cy.get('input').type('John')
+      cy.contains('button', 'Search').click()
+
+      cy.get('main li > a')
+        .should('contain', 'Johnny Cakeman')
+        .click()
+
+      cy.contains('Event attendee added')
+    })
+  })
 })

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -101,6 +101,30 @@ describe('Interaction', () => {
           .and('contain', 'Countries of no interestSpain')
       })
     })
+
+    context('The same country is added to two categories', () => {
+      it('should get an error saving the interaction', () => {
+        const subject = 'Some interesting interaction about countries'
+        const formSelectors = selectors.interactionForm
+
+        cy.get(formSelectors.service).select('Export Win')
+        cy.get(formSelectors.contact).select('Johnny Cakeman')
+        cy.get(formSelectors.communicationChannel).select('Email/Website')
+        cy.get(formSelectors.subject).type(subject)
+        cy.get(formSelectors.notes).type(
+          'Conversation with potential client about countries'
+        )
+        cy.get(formSelectors.policyFeedbackNo).click()
+        cy.get(formSelectors.countriesDiscussed.yes).click()
+        selectCountry(formSelectors.countries.export, 'Fran')
+        selectCountry(formSelectors.countries.future, 'Fran')
+
+        cy.get(selectors.interactionForm.add).click()
+        cy.contains(
+          'A country that was discussed cannot be entered in multiple fields.'
+        )
+      })
+    })
   })
 })
 

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -125,6 +125,26 @@ describe('Interaction', () => {
         )
       })
     })
+
+    context('The no countries are added to any categories', () => {
+      it('should get an error saving the interaction', () => {
+        const subject = 'Some interesting interaction about countries'
+        const formSelectors = selectors.interactionForm
+
+        cy.get(formSelectors.service).select('Export Win')
+        cy.get(formSelectors.contact).select('Johnny Cakeman')
+        cy.get(formSelectors.communicationChannel).select('Email/Website')
+        cy.get(formSelectors.subject).type(subject)
+        cy.get(formSelectors.notes).type(
+          'Conversation with potential client about countries'
+        )
+        cy.get(formSelectors.policyFeedbackNo).click()
+        cy.get(formSelectors.countriesDiscussed.yes).click()
+
+        cy.get(selectors.interactionForm.add).click()
+        cy.contains('Were any countries discussed?This field may not be null.')
+      })
+    })
   })
 })
 


### PR DESCRIPTION
## Description of change

There are some e2e tests missing for the export countries of an interaction. This PR adds the missing test scenarios

## Test instructions

e2e tests should pass

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
