### PR TITLE
Add DJANGO_SUPERUSER_SSO_EMAIL_USER_ID to sample env file

### DIFF
--- a/dev-stack.sample.env
+++ b/dev-stack.sample.env
@@ -18,6 +18,7 @@ DJANGO_SECRET_KEY=topSecret
 DJANGO_SETTINGS_MODULE=config.settings.local
 DJANGO_SUPERUSER_EMAIL=choose@you.own.com
 DJANGO_SUPERUSER_PASSWORD=whatEverYouWant
+DJANGO_SUPERUSER_SSO_EMAIL_USER_ID=change.me@id.trade.local
 ES5_URL=http://elasticsearch:9200
 ES_INDEX_PREFIX=test_index
 FIND_EXPORTERS_URL=https://lookInVault.com/


### PR DESCRIPTION
## Description of change

This adds `DJANGO_SUPERUSER_SSO_EMAIL_USER_ID` to the sample env file following https://github.com/uktrade/data-hub-api/pull/2784.

This is used by the back end.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
