### PR TITLE
Add DnB company investigations

### DIFF
--- a/src/apps/companies/apps/add-company/__test__/controllers.test.js
+++ b/src/apps/companies/apps/add-company/__test__/controllers.test.js
@@ -326,24 +326,39 @@ describe('Add company form controllers', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
           .post('/v4/dnb/company-create-investigation', {
+            name: 'name',
+            telephone_number: '123',
+            website: 'website',
+            business_type: '1',
+            sector: '3',
+            uk_region: '2',
             address: {
+              line_1: 'line 1',
+              line_2: '',
+              town: 'town',
+              county: '',
+              postcode: 'postcode',
               country: {
                 id: 'country',
               },
-              county: '',
-              line_1: 'line 1',
-              line_2: '',
-              postcode: 'postcode',
-              town: 'town',
             },
-            business_type: '1',
-            name: 'name',
-            sector: '3',
-            telephone_number: '123',
-            uk_region: '2',
-            website: 'website',
           })
           .reply(200, companyCreateInvestigationResponse)
+          .post('/v4/dnb/company-investigation', {
+            company: 'ca8fae21-2895-47cf-90ba-9273c94dab81',
+            name: 'name',
+            website: 'website',
+            telephone_number: '123',
+            address: {
+              line_1: 'line 1',
+              line_2: '',
+              town: 'town',
+              county: '',
+              postcode: 'postcode',
+              country: 'country',
+            },
+          })
+          .reply(200, {})
 
         middlewareParameters = buildMiddlewareParameters({
           requestBody: {

--- a/src/apps/companies/apps/add-company/__test__/transformers.test.js
+++ b/src/apps/companies/apps/add-company/__test__/transformers.test.js
@@ -1,12 +1,15 @@
-const { transformToDnbCompanyInvestigationApi } = require('../transformers')
+const {
+  transformToSaveDnBCompanyInvestigation,
+  transformToCreateDnbCompanyInvestigation,
+} = require('../transformers')
 
 describe('Companies add company transformers', () => {
-  describe('#transformToDnbCompanyInvestigationApi', () => {
+  describe('#transformToSaveDnBCompanyInvestigation', () => {
     context('when all fields are populated', () => {
       let actual
 
       beforeEach(() => {
-        actual = transformToDnbCompanyInvestigationApi({
+        actual = transformToSaveDnBCompanyInvestigation({
           business_type: '1',
           name: 'name',
           website: 'website',
@@ -48,7 +51,7 @@ describe('Companies add company transformers', () => {
       let actual
 
       beforeEach(() => {
-        actual = transformToDnbCompanyInvestigationApi({
+        actual = transformToSaveDnBCompanyInvestigation({
           business_type: '1',
           name: 'name',
           website: 'website',
@@ -82,6 +85,46 @@ describe('Companies add company transformers', () => {
           telephone_number: '123',
           uk_region: '2',
           website: 'website',
+        })
+      })
+    })
+  })
+
+  describe('#transformToCreateDnbCompanyInvestigation', () => {
+    context('when all fields are populated', () => {
+      let actual
+
+      beforeEach(() => {
+        actual = transformToCreateDnbCompanyInvestigation(
+          {
+            name: 'name',
+            website: 'website',
+            telephone_number: '123',
+            address1: 'line 1',
+            address2: 'line 2',
+            city: 'town',
+            county: 'county',
+            postcode: 'postcode',
+            country: 'country',
+          },
+          '123'
+        )
+      })
+
+      it('should transform the request body', () => {
+        expect(actual).to.deep.equal({
+          company: '123',
+          name: 'name',
+          website: 'website',
+          telephone_number: '123',
+          address: {
+            line_1: 'line 1',
+            line_2: 'line 2',
+            town: 'town',
+            county: 'county',
+            postcode: 'postcode',
+            country: 'country',
+          },
         })
       })
     })

--- a/src/apps/companies/apps/add-company/__test__/transformers.test.js
+++ b/src/apps/companies/apps/add-company/__test__/transformers.test.js
@@ -92,24 +92,20 @@ describe('Companies add company transformers', () => {
 
   describe('#transformToCreateDnbCompanyInvestigation', () => {
     context('when all fields are populated', () => {
-      let actual
-
-      beforeEach(() => {
-        actual = transformToCreateDnbCompanyInvestigation(
-          {
-            name: 'name',
-            website: 'website',
-            telephone_number: '123',
-            address1: 'line 1',
-            address2: 'line 2',
-            city: 'town',
-            county: 'county',
-            postcode: 'postcode',
-            country: 'country',
-          },
-          '123'
-        )
-      })
+      let actual = transformToCreateDnbCompanyInvestigation(
+        {
+          name: 'name',
+          website: 'website',
+          telephone_number: '123',
+          address1: 'line 1',
+          address2: 'line 2',
+          city: 'town',
+          county: 'county',
+          postcode: 'postcode',
+          country: 'country',
+        },
+        '123'
+      )
 
       it('should transform the request body', () => {
         expect(actual).to.deep.equal({

--- a/src/apps/companies/apps/add-company/transformers.js
+++ b/src/apps/companies/apps/add-company/transformers.js
@@ -1,20 +1,19 @@
 /* eslint-disable camelcase */
-const transformToDnbCompanyInvestigationApi = ({
-  business_type,
-  name,
-  website,
-  telephone_number,
-  address1,
-  address2,
-  city,
-  county,
-  postcode,
-  country,
-  uk_region,
-  sector,
-}) => {
+const transformFormData = (
+  {
+    name,
+    website,
+    telephone_number,
+    address1,
+    address2,
+    city,
+    county,
+    postcode,
+    country,
+  },
+  countryAsObject = true
+) => {
   return {
-    business_type,
     name,
     website,
     telephone_number,
@@ -24,15 +23,28 @@ const transformToDnbCompanyInvestigationApi = ({
       town: city,
       county: county || '',
       postcode: postcode,
-      country: {
-        id: country,
-      },
+      country: countryAsObject ? { id: country } : country,
     },
-    sector,
-    uk_region,
+  }
+}
+
+const transformToSaveDnBCompanyInvestigation = (formData) => {
+  return {
+    ...transformFormData(formData),
+    business_type: formData.business_type,
+    uk_region: formData.uk_region,
+    sector: formData.sector,
+  }
+}
+
+const transformToCreateDnbCompanyInvestigation = (formData, companyId) => {
+  return {
+    ...transformFormData(formData, false),
+    company: companyId,
   }
 }
 
 module.exports = {
-  transformToDnbCompanyInvestigationApi,
+  transformToSaveDnBCompanyInvestigation,
+  transformToCreateDnbCompanyInvestigation,
 }

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -122,6 +122,14 @@ function saveDnbCompanyInvestigation(token, company) {
   })
 }
 
+function createDnbCompanyInvestigation(token, body) {
+  return authorisedRequest(token, {
+    body,
+    url: `${config.apiRoot}/v4/dnb/company-investigation`,
+    method: 'POST',
+  })
+}
+
 function saveCompanyExportDetails(token, companyId, body) {
   return authorisedRequest(token, {
     body,
@@ -167,6 +175,7 @@ module.exports = {
   getOneListGroupCoreTeam,
   saveDnbCompany,
   saveDnbCompanyInvestigation,
+  createDnbCompanyInvestigation,
   saveCompanyExportDetails,
   linkDataHubCompanyToDnBCompany,
   createDnbChangeRequest,

--- a/test/sandbox/fixtures/v4/dnb/company-investigation.json
+++ b/test/sandbox/fixtures/v4/dnb/company-investigation.json
@@ -1,0 +1,16 @@
+{
+  "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+  "status": "pending",
+  "created_on": "2020-01-05T11:00:00",
+  "company_details": {
+      "primary_name": "INVESTIGATION LIMITED",
+      "domain": "www.investigationlimited.com", 
+      "telephone_number": "123456789",
+      "address_line_1": "Unit 10, Ockham Drive",
+      "address_line_2": "",
+      "address_town": "GREENFORD",
+      "address_county": "",
+      "address_postcode": "UB6 0F2",
+      "address_country": "GB"
+  }
+}

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -453,6 +453,11 @@ Sandbox.define(
   'POST',
   v4Dnb.companyCreateInvestigation
 )
+Sandbox.define(
+  '/v4/dnb/company-investigation',
+  'POST',
+  v4Dnb.companyInvestigation
+)
 Sandbox.define('/v4/dnb/company-search', 'POST', v4Dnb.companySearch)
 Sandbox.define('/v4/dnb/company-link', 'POST', v4Dnb.companyLink)
 Sandbox.define(

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -5,6 +5,7 @@ var companyChangeRequest = require('../../../fixtures/v4/dnb/company-change-requ
 var companySearchMatched = require('../../../fixtures/v4/dnb/company-search-matched.json')
 var companySearchNotMatched = require('../../../fixtures/v4/dnb/company-search-not-matched.json')
 var companyCreateInvestigation = require('../../../fixtures/v4/dnb/company-create-investigation.json')
+var companyInvestigation = require('../../../fixtures/v4/dnb/company-investigation.json')
 
 exports.companyCreate = function(req, res) {
   if (req.body.duns_number === '111111111') {
@@ -23,6 +24,10 @@ exports.companySearch = function(req, res) {
 
 exports.companyCreateInvestigation = function(req, res) {
   res.json(companyCreateInvestigation)
+}
+
+exports.companyInvestigation = function(req, res) {
+  res.json(companyInvestigation)
 }
 
 exports.companyLink = function(req, res) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,6 +87,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
+"@babel/generator@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
+  integrity sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==
+  dependencies:
+    "@babel/types" "^7.9.5"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz#60bc0bc657f63a0924ff9a4b4a0b24a13cf4deee"
@@ -1188,6 +1198,21 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
+"@babel/traverse@^7.0.0":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.5.tgz#6e7c56b44e2ac7011a948c21e283ddd9d9db97a2"
+  integrity sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.5"
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.0", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
@@ -1356,7 +1381,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.1", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1418,7 +1443,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.0", "@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -6653,6 +6678,15 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
+css-to-react-native@^2.2.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
+  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
+
 css-to-react-native@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
@@ -11555,6 +11589,11 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
+is-what@^3.3.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.8.0.tgz#610bc46a524355f2424eb85eedc6ebbbf7e1ff8c"
+  integrity sha512-UKeBoQfV8bjlM4pmx1FLDHdxslW/1mTksEs8ReVsilPmUv5cORd4+2/wFcviI3cUjrLybxCjzc8DnodAzJ/Wrg==
+
 is-whitespace-character@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz#b3ad9546d916d7d3ffa78204bca0c26b56257fac"
@@ -13067,6 +13106,13 @@ meow@^5.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
     yargs-parser "^10.0.0"
+
+merge-anything@^2.2.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.4.tgz#6226b2ac3d3d3fc5fb9e8d23aa400df25f98fdf0"
+  integrity sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==
+  dependencies:
+    is-what "^3.3.1"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -15455,7 +15501,7 @@ promise@^8.0.3:
   dependencies:
     asap "~2.0.6"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -18390,6 +18436,25 @@ style-loader@^1.0.0:
     loader-utils "^2.0.0"
     schema-utils "^2.6.5"
 
+styled-components@^4.2.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
+  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
 styled-components@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.0.tgz#2e3985b54f461027e1c91af3229e1c2530872a4e"
@@ -18406,10 +18471,20 @@ styled-components@^5.1.0:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
 stylis@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
   integrity sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 subarg@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,16 +87,6 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/generator@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
-  integrity sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==
-  dependencies:
-    "@babel/types" "^7.9.5"
-    jsesc "^2.5.1"
-    lodash "^4.17.13"
-    source-map "^0.5.0"
-
 "@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz#60bc0bc657f63a0924ff9a4b4a0b24a13cf4deee"
@@ -1198,21 +1188,6 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.0.0":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.5.tgz#6e7c56b44e2ac7011a948c21e283ddd9d9db97a2"
-  integrity sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==
-  dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.5"
-    "@babel/helper-function-name" "^7.9.5"
-    "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/parser" "^7.9.0"
-    "@babel/types" "^7.9.5"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.13"
-
 "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.0", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
@@ -1381,7 +1356,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.1", "@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1443,7 +1418,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.0", "@emotion/unitless@^0.7.4":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -6678,15 +6653,6 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-to-react-native@^2.2.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
-  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^3.3.0"
-
 css-to-react-native@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
@@ -11589,11 +11555,6 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-what@^3.3.1:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.8.0.tgz#610bc46a524355f2424eb85eedc6ebbbf7e1ff8c"
-  integrity sha512-UKeBoQfV8bjlM4pmx1FLDHdxslW/1mTksEs8ReVsilPmUv5cORd4+2/wFcviI3cUjrLybxCjzc8DnodAzJ/Wrg==
-
 is-whitespace-character@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz#b3ad9546d916d7d3ffa78204bca0c26b56257fac"
@@ -13106,13 +13067,6 @@ meow@^5.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
     yargs-parser "^10.0.0"
-
-merge-anything@^2.2.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.4.tgz#6226b2ac3d3d3fc5fb9e8d23aa400df25f98fdf0"
-  integrity sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==
-  dependencies:
-    is-what "^3.3.1"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -15501,7 +15455,7 @@ promise@^8.0.3:
   dependencies:
     asap "~2.0.6"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -18436,25 +18390,6 @@ style-loader@^1.0.0:
     loader-utils "^2.0.0"
     schema-utils "^2.6.5"
 
-styled-components@^4.2.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
-  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.8.1"
-    "@emotion/unitless" "^0.7.0"
-    babel-plugin-styled-components ">= 1"
-    css-to-react-native "^2.2.2"
-    memoize-one "^5.0.0"
-    merge-anything "^2.2.4"
-    prop-types "^15.5.4"
-    react-is "^16.6.0"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
-    supports-color "^5.5.0"
-
 styled-components@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.0.tgz#2e3985b54f461027e1c91af3229e1c2530872a4e"
@@ -18471,20 +18406,10 @@ styled-components@^5.1.0:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-stylis-rule-sheet@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
-
 stylis@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
   integrity sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==
-
-stylis@^3.5.0:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
-  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 subarg@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description of change
**No UI visual changes**

When a user cannot find a D&B company (via Add company) after performing a search we currently create a stubbed Data Hub record and send a single notification to request an investigation.

This piece of work takes the company details and creates an investigation via the dnb-service which subsequently generates spreadsheets and mailed to our support team.

## Checklist
[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
