### PR TITLE
Refactor LocalHeader component to take children rather than props

### DIFF
--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralConfirmation.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralConfirmation.jsx
@@ -5,6 +5,7 @@ import { SummaryTable, FormActions } from 'data-hub-components'
 import { H4, Button, Link, Main } from 'govuk-react'
 import UnorderedList from '@govuk-react/unordered-list'
 import ListItem from '@govuk-react/list-item'
+
 import SecondaryButton from '../../../../../../client/components/SecondaryButton'
 import LocalHeader from '../../../../../../client/components/LocalHeader'
 import { companies, dashboard } from '../../../../../../lib/urls'

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -3,19 +3,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { throttle } from 'lodash'
 import axios from 'axios'
-
-import SendReferralConfirmation from './SendReferralConfirmation'
-import LocalHeader from '../../../../../../client/components/LocalHeader.jsx'
 import styled from 'styled-components'
-import {
-  SEND_REFERRAL_FORM__CONTINUE,
-  SEND_REFERRAL_FORM__BACK,
-  SEND_REFERRAL_FORM__ERROR,
-  SEND_REFERRAL_FORM__SUBJECT_CHANGE,
-  SEND_REFERRAL_FORM__ADVISER_CHANGE,
-  SEND_REFERRAL_FORM__CONTACT_CHANGE,
-  SEND_REFERRAL_FORM__TEXTAREA_CHANGE,
-} from '../../../../../../client/actions'
 
 import { NewWindowLink, FormActions, Typeahead } from 'data-hub-components'
 import {
@@ -30,9 +18,20 @@ import {
   Main,
   InputField,
 } from 'govuk-react'
-import { companies, dashboard } from '../../../../../../lib/urls'
-
 import { MEDIA_QUERIES } from '@govuk-react/constants'
+
+import {
+  SEND_REFERRAL_FORM__CONTINUE,
+  SEND_REFERRAL_FORM__BACK,
+  SEND_REFERRAL_FORM__ERROR,
+  SEND_REFERRAL_FORM__SUBJECT_CHANGE,
+  SEND_REFERRAL_FORM__ADVISER_CHANGE,
+  SEND_REFERRAL_FORM__CONTACT_CHANGE,
+  SEND_REFERRAL_FORM__TEXTAREA_CHANGE,
+} from '../../../../../../client/actions'
+import SendReferralConfirmation from './SendReferralConfirmation'
+import LocalHeader from '../../../../../../client/components/LocalHeader'
+import { companies, dashboard } from '../../../../../../lib/urls'
 
 const StyledTextArea = styled(TextArea)({
   textarea: {
@@ -73,6 +72,7 @@ const SendReferralForm = ({
           { text: 'Send a referral' },
         ]}
       />
+
       <Main>
         <form
           onSubmit={(event) => {

--- a/src/client/components/LocalHeader.jsx
+++ b/src/client/components/LocalHeader.jsx
@@ -1,59 +1,66 @@
 import React from 'react'
-import Breadcrumbs from '@govuk-react/breadcrumbs'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { typography } from '@govuk-react/lib'
-import { SPACING } from '@govuk-react/constants'
 import { GREY_4 } from 'govuk-colours'
-
-const StyledBreadcrumbs = styled(Breadcrumbs)`
-   {
-    margin-bottom: ${SPACING.SCALE_5};
-    margin-top: 0;
-  }
-`
-const StyledH1 = styled('h1')`
-   {
-    ${typography.font({ size: 36, weight: 'bold' })};
-  }
-`
+import { SPACING } from '@govuk-react/constants'
+import Main from '@govuk-react/main'
+import Breadcrumbs from '@govuk-react/breadcrumbs'
+import { typography } from '@govuk-react/lib'
 
 const StyledHeader = styled('header')`
-   {
-    padding-bottom: ${SPACING.SCALE_5};
-    background-color: ${GREY_4};
-    padding-top: ${SPACING.SCALE_3};
-  }
+  padding-bottom: ${SPACING.SCALE_5};
+  background-color: ${GREY_4};
+  padding-top: ${SPACING.SCALE_3};
 `
 
-const LocalHeader = ({ breadcrumbs, heading }) => {
-  const breadcrumbItems = breadcrumbs.map((breadcrumb) =>
-    breadcrumb.link ? (
-      <Breadcrumbs.Link key={breadcrumb.link} href={breadcrumb.link}>
-        {breadcrumb.text}
-      </Breadcrumbs.Link>
-    ) : (
-      breadcrumb.text
-    )
-  )
-  return (
-    <StyledHeader aria-label="local header" data-auto-id="localHeader">
-      <div className=" govuk-width-container">
-        <StyledBreadcrumbs>{breadcrumbItems}</StyledBreadcrumbs>
-        <StyledH1>{heading}</StyledH1>
-      </div>
-    </StyledHeader>
-  )
-}
+const StyledMain = styled(Main)`
+  padding-top: 0;
+`
+
+const BreadcrumbsWrapper = styled(Breadcrumbs)`
+  margin-bottom: ${SPACING.SCALE_5};
+  margin-top: 0;
+`
+
+const StyledH1 = styled('h1')`
+  ${typography.font({ size: 36, weight: 'bold' })};
+`
+
+const LocalHeader = ({ breadcrumbs, heading, children }) => (
+  <StyledHeader aria-label="local header" data-auto-id="localHeader">
+    <StyledMain>
+      <BreadcrumbsWrapper>
+        {breadcrumbs?.map((breadcrumb) =>
+          breadcrumb.link ? (
+            <Breadcrumbs.Link key={breadcrumb.link} href={breadcrumb.link}>
+              {breadcrumb.text}
+            </Breadcrumbs.Link>
+          ) : (
+            breadcrumb.text
+          )
+        )}
+      </BreadcrumbsWrapper>
+      {heading && <StyledH1>{heading}</StyledH1>}
+      {children}
+    </StyledMain>
+  </StyledHeader>
+)
 
 LocalHeader.propTypes = {
   breadcrumbs: PropTypes.arrayOf(
     PropTypes.shape({
       link: PropTypes.string,
       text: PropTypes.string.isRequired,
-    }).isRequired
+    })
   ),
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.string,
+  children: PropTypes.node,
+}
+
+LocalHeader.defaultProps = {
+  breadcrumbs: null,
+  heading: null,
+  children: null,
 }
 
 export default LocalHeader

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -37,7 +37,6 @@ import ReferralHelp from '../apps/companies/apps/referrals/help/client/ReferralH
 import SendReferralForm from '../apps/companies/apps/referrals/send-referral/client/SendReferralForm'
 import sendReferral from '../apps/companies/apps/referrals/send-referral/client/reducer'
 import InteractionReferralDetails from '../apps/companies/apps/referrals/details/client/InteractionReferralDetails.jsx'
-import LocalHeader from './components/LocalHeader.jsx'
 
 import tasksSaga from './components/Task/saga'
 import tasks from './components/Task/reducer'
@@ -253,9 +252,6 @@ function App() {
         </Mount>
         <Mount selector="#company-export-countries-edit">
           {(props) => <ExportCountriesEdit {...props} />}
-        </Mount>
-        <Mount selector="#local-header">
-          {(props) => <LocalHeader {...props} />}
         </Mount>
       </ConnectedRouter>
     </Provider>


### PR DESCRIPTION
## Description of change

This PR refactors the LocalHeader component to take children rather than props. This allows the component to be more flexible in anticipation of its use on more complex pages. 

The reason for this is because I need to add a new action dropdown as per the screenshot below on the company page header. This is all currently rewritten in nunjucks and this PR is the first part of refactoring this to React. 

![image](https://user-images.githubusercontent.com/42253716/80234368-f473f580-864f-11ea-89b2-711d16d81504.png)


## Test instructions

Nothing should change. On navigating to the send referral page and the send referral confirmation page you should see the local header as before with no functional or styling changes. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
