### PR TITLE
Create a D&B investigation (user cannot verify a DH company)

### DIFF
--- a/src/apps/companies/apps/match-company/__test__/transformers.test.js
+++ b/src/apps/companies/apps/match-company/__test__/transformers.test.js
@@ -1,0 +1,40 @@
+const { transformToDnbInvestigation } = require('../transformers')
+
+describe('#transformToDnbInvestigation', () => {
+  it('should transform the request body', () => {
+    expect(
+      transformToDnbInvestigation(
+        {
+          id: 'id',
+          name: 'name',
+          address: {
+            line_1: 'line_1',
+            line_2: 'line_2',
+            town: 'town',
+            county: 'county',
+            postcode: 'postcode',
+            country: {
+              name: 'United Kingdom',
+              id: 'countryId',
+            },
+          },
+        },
+        'website',
+        'telephone'
+      )
+    ).to.deep.equal({
+      company: 'id',
+      name: 'name',
+      website: 'website',
+      telephone_number: 'telephone',
+      address: {
+        line_1: 'line_1',
+        line_2: 'line_2',
+        town: 'town',
+        county: 'county',
+        postcode: 'postcode',
+        country: 'countryId',
+      },
+    })
+  })
+})

--- a/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
+++ b/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
@@ -34,9 +34,8 @@ async function onFormSubmit(values, csrfToken) {
   const url = urls.companies.match.cannotFind(values.companyId)
   await axios.post(url, {
     _csrf: csrfToken,
-    address: values.address,
     website: values.website,
-    telephoneNumber: values.telephoneNumber,
+    telephone_number: values.telephoneNumber,
   })
   return urls.companies.detail(values.companyId)
 }

--- a/src/apps/companies/apps/match-company/transformers.js
+++ b/src/apps/companies/apps/match-company/transformers.js
@@ -1,0 +1,22 @@
+const { omit } = require('lodash')
+
+const transformToDnbInvestigation = (
+  { id, name, address },
+  website,
+  telephone_number
+) => {
+  return {
+    company: id,
+    name,
+    website,
+    telephone_number,
+    address: {
+      ...omit(address, 'country'),
+      country: address.country.id,
+    },
+  }
+}
+
+module.exports = {
+  transformToDnbInvestigation,
+}

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -300,8 +300,7 @@ describe('Match a company', () => {
 
         cy.get(selectors.localHeader().flash).should(
           'contain.text',
-          'Verification request sent.Once verified, the below message' +
-            ' asking you to verify the business details will disappear.'
+          'Verification request sent for third party review'
         )
       })
     }


### PR DESCRIPTION
## Description of change
Create a D&B investigation after a user cannot verify (unsuccessful search) a Data Hub company against a D&B company. Previously we created a Zendesk ticket which the Support Team picked up, now we make an API call that is proxied through to the [dnb-service](https://github.com/uktrade/dnb-service). After a period of time spreadsheets are generated and emailed to the Support Team.

## Test instructions
**_Dev environment:_**

1. Go to _/companies/8543474b-4470-4f5a-bcd8-fed19ed7f6dc/activity_
2. Select `Verify business details`
3. Select `Find company`
4. Select `I can't find what I'm looking for`
5. Select `I still can't find what I'm looking for`
6. Select `Send` after entering both `website` and `telephone number`

## Screenshots
### Before
<img width="991" alt="1" src="https://user-images.githubusercontent.com/964268/80375450-3d19f180-8890-11ea-8e3c-94640892361f.png">

### After
<img width="991" alt="3" src="https://user-images.githubusercontent.com/964268/80375476-4b680d80-8890-11ea-9c4c-65e1d6db3d28.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
