### PR TITLE
Only show project value field for projects landing before 01/04/2020

### DIFF
--- a/src/apps/investments/controllers/edit.js
+++ b/src/apps/investments/controllers/edit.js
@@ -1,9 +1,21 @@
+// For projects landing after 01/04/2020, the project value field is not needed
+const valueCutOffDate = new Date('2020-04-01')
+
 function editDetailsGet(req, res) {
   res.breadcrumb('Edit details').render('investments/views/details-edit')
 }
 
 function editValueGet(req, res) {
-  res.breadcrumb('Edit value').render('investments/views/value-edit')
+  const {
+    estimated_land_date: estimatedLandDate,
+    actual_land_date: actualLandDate,
+  } = res.locals.form.state
+
+  res.breadcrumb('Edit value').render('investments/views/value-edit', {
+    projectValueNeeded:
+      (estimatedLandDate || actualLandDate) &&
+      new Date(estimatedLandDate || actualLandDate) < valueCutOffDate,
+  })
 }
 
 function renderRequirementsForm(req, res) {

--- a/src/apps/investments/views/value-edit.njk
+++ b/src/apps/investments/views/value-edit.njk
@@ -99,7 +99,7 @@
       error: errors.messages.number_safeguarded_jobs
     }) }}
 
-    {% if investment.investment_type.name == 'FDI' %}
+    {% if projectValueNeeded and investment.investment_type.name == 'FDI' %}
       {{ MultipleChoiceField({
         name: 'fdi_value',
         label: form.labels.fdi_value,

--- a/test/functional/cypress/fixtures/investment/investment-land-date-after-April-2020.json
+++ b/test/functional/cypress/fixtures/investment/investment-land-date-after-April-2020.json
@@ -1,0 +1,188 @@
+{
+  "id": "6e441b34-1fc8-4638-b4b1-a0922ecf403e",
+  "incomplete_fields": [
+    "associated_non_fdi_r_and_d_project"
+  ],
+  "name": "Project landing after April 2020",
+  "project_code": "DHP-00000010",
+  "description": "This is a dummy investment project for testing",
+  "anonymous_description": "",
+  "allow_blank_estimated_land_date": true,
+  "estimated_land_date": null,
+  "actual_land_date": "2021-10-21",
+  "quotable_as_public_case_study": null,
+  "likelihood_to_land": null,
+  "priority": null,
+  "approved_commitment_to_invest": null,
+  "approved_fdi": null,
+  "approved_good_value": null,
+  "approved_high_value": null,
+  "approved_landed": null,
+  "approved_non_fdi": null,
+  "investment_type": {
+    "name": "FDI",
+    "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+  },
+  "stage": {
+    "name": "Won",
+    "id": "945ea6d1-eee3-4f5b-9144-84a75b71b8e6"
+  },
+  "status": "ongoing",
+  "reason_delayed": null,
+  "reason_abandoned": null,
+  "date_abandoned": null,
+  "reason_lost": null,
+  "date_lost": null,
+  "country_lost_to": null,
+  "investor_company": {
+    "name": "Venus Ltd",
+    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+  },
+  "investor_type": null,
+  "investor_company_country": {
+    "name": "United Kingdom",
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "intermediate_company": null,
+  "level_of_involvement": null,
+  "specific_programme": null,
+  "client_contacts": [
+    {
+      "name": "Dean Cox",
+      "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+    }
+  ],
+  "client_relationship_manager": {
+    "name": "Puck Head",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+  },
+  "client_relationship_manager_team": {
+    "name": "CBBC North EAST",
+    "id": "602b971d-5df6-e511-888e-e4115bead28a"
+  },
+  "referral_source_adviser": {
+    "name": "Puck Head",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+  },
+  "referral_source_activity": {
+    "name": "None",
+    "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+  },
+  "referral_source_activity_website": null,
+  "referral_source_activity_marketing": null,
+  "referral_source_activity_event": null,
+  "fdi_type": {
+    "name": "Creation of new site or activity",
+    "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+  },
+  "sector": {
+    "name": "Renewable Energy : Wind : Onshore",
+    "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+  },
+  "business_activities": [
+    {
+      "name": "Retail",
+      "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+    }
+  ],
+  "other_business_activity": null,
+  "archived": false,
+  "archived_documents_url_path": "",
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "created_on": "2016-01-05T15:00:00Z",
+  "modified_on": "2016-01-05T19:00:00Z",
+  "comments": "",
+  "country_investment_originates_from": null,
+  "level_of_involvement_simplified": "unspecified",
+  "fdi_value": null,
+  "total_investment": "1000000",
+  "foreign_equity_investment": "200000",
+  "government_assistance": true,
+  "some_new_jobs": null,
+  "number_new_jobs": 20,
+  "will_new_jobs_last_two_years": null,
+  "average_salary": {
+    "name": "Below £25,000",
+    "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+  },
+  "number_safeguarded_jobs": 1,
+  "r_and_d_budget": false,
+  "non_fdi_r_and_d_budget": true,
+  "associated_non_fdi_r_and_d_project": null,
+  "new_tech_to_uk": true,
+  "export_revenue": true,
+  "value_complete": false,
+  "client_cannot_provide_total_investment": false,
+  "client_cannot_provide_foreign_investment": false,
+  "client_requirements": "Anywhere",
+  "site_decided": false,
+  "address_1": "10 Northings Road",
+  "address_2": null,
+  "address_town": "London",
+  "address_postcode": "W1 2AB",
+  "competitor_countries": [],
+  "allow_blank_possible_uk_regions": true,
+  "uk_region_locations": [],
+  "actual_uk_regions": [
+    {
+      "name": "North East",
+      "id": "814cd12a-6095-e211-a939-e4115bead28a"
+    }
+  ],
+  "delivery_partners": [
+    {
+      "name": "New Anglia LEP",
+      "id": "cdcc392e-0bf1-e511-8ffa-e4115bead28a"
+    },
+    {
+      "name": "North Eastern LEP",
+      "id": "6e85b4e3-0df1-e511-8ffa-e4115bead28a"
+    }
+  ],
+  "strategic_drivers": [
+    {
+      "name": "Access to market",
+      "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+    }
+  ],
+  "client_considering_other_countries": false,
+  "uk_company_decided": null,
+  "uk_company": {
+    "name": "Mercury Ltd",
+    "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+  },
+  "requirements_complete": true,
+  "project_manager_requested_on": null,
+  "project_manager_request_status": null,
+  "project_manager": {
+    "name": "Michael Wining",
+    "first_name": "Michael",
+    "last_name": "Wining",
+    "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
+  },
+  "project_assurance_adviser": {
+    "name": "Paula Churing",
+    "first_name": "Paula",
+    "last_name": "Churing",
+    "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+  },
+  "project_manager_team": {
+    "name": "Marketing - Marketing Team",
+    "id": "8248318c-9698-e211-a939-e4115bead28a"
+  },
+  "project_assurance_team": {
+    "name": "Marketing - Marketing Team",
+    "id": "8248318c-9698-e211-a939-e4115bead28a"
+  },
+  "team_complete": true,
+  "team_members": [],
+  "project_arrived_in_triage_on": null,
+  "proposal_deadline": null,
+  "stage_log": []
+}

--- a/test/functional/cypress/fixtures/investment/investment-land-date-before-April-2020.json
+++ b/test/functional/cypress/fixtures/investment/investment-land-date-before-April-2020.json
@@ -1,0 +1,188 @@
+{
+  "id": "3e341b34-1fc8-4638-b4b1-a0922ecf403e",
+  "incomplete_fields": [
+    "associated_non_fdi_r_and_d_project"
+  ],
+  "name": "Project landing before April 2020",
+  "project_code": "DHP-00000010",
+  "description": "This is a dummy investment project for testing",
+  "anonymous_description": "",
+  "allow_blank_estimated_land_date": true,
+  "estimated_land_date": null,
+  "actual_land_date": "2020-01-01",
+  "quotable_as_public_case_study": null,
+  "likelihood_to_land": null,
+  "priority": null,
+  "approved_commitment_to_invest": null,
+  "approved_fdi": null,
+  "approved_good_value": null,
+  "approved_high_value": null,
+  "approved_landed": null,
+  "approved_non_fdi": null,
+  "investment_type": {
+    "name": "FDI",
+    "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+  },
+  "stage": {
+    "name": "Won",
+    "id": "945ea6d1-eee3-4f5b-9144-84a75b71b8e6"
+  },
+  "status": "ongoing",
+  "reason_delayed": null,
+  "reason_abandoned": null,
+  "date_abandoned": null,
+  "reason_lost": null,
+  "date_lost": null,
+  "country_lost_to": null,
+  "investor_company": {
+    "name": "Venus Ltd",
+    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+  },
+  "investor_type": null,
+  "investor_company_country": {
+    "name": "United Kingdom",
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "intermediate_company": null,
+  "level_of_involvement": null,
+  "specific_programme": null,
+  "client_contacts": [
+    {
+      "name": "Dean Cox",
+      "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+    }
+  ],
+  "client_relationship_manager": {
+    "name": "Puck Head",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+  },
+  "client_relationship_manager_team": {
+    "name": "CBBC North EAST",
+    "id": "602b971d-5df6-e511-888e-e4115bead28a"
+  },
+  "referral_source_adviser": {
+    "name": "Puck Head",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+  },
+  "referral_source_activity": {
+    "name": "None",
+    "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+  },
+  "referral_source_activity_website": null,
+  "referral_source_activity_marketing": null,
+  "referral_source_activity_event": null,
+  "fdi_type": {
+    "name": "Creation of new site or activity",
+    "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+  },
+  "sector": {
+    "name": "Renewable Energy : Wind : Onshore",
+    "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+  },
+  "business_activities": [
+    {
+      "name": "Retail",
+      "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+    }
+  ],
+  "other_business_activity": null,
+  "archived": false,
+  "archived_documents_url_path": "",
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "created_on": "2016-01-05T15:00:00Z",
+  "modified_on": "2016-01-05T19:00:00Z",
+  "comments": "",
+  "country_investment_originates_from": null,
+  "level_of_involvement_simplified": "unspecified",
+  "fdi_value": null,
+  "total_investment": "1000000",
+  "foreign_equity_investment": "200000",
+  "government_assistance": true,
+  "some_new_jobs": null,
+  "number_new_jobs": 20,
+  "will_new_jobs_last_two_years": null,
+  "average_salary": {
+    "name": "Below £25,000",
+    "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+  },
+  "number_safeguarded_jobs": 1,
+  "r_and_d_budget": false,
+  "non_fdi_r_and_d_budget": true,
+  "associated_non_fdi_r_and_d_project": null,
+  "new_tech_to_uk": true,
+  "export_revenue": true,
+  "value_complete": false,
+  "client_cannot_provide_total_investment": false,
+  "client_cannot_provide_foreign_investment": false,
+  "client_requirements": "Anywhere",
+  "site_decided": false,
+  "address_1": "10 Northings Road",
+  "address_2": null,
+  "address_town": "London",
+  "address_postcode": "W1 2AB",
+  "competitor_countries": [],
+  "allow_blank_possible_uk_regions": true,
+  "uk_region_locations": [],
+  "actual_uk_regions": [
+    {
+      "name": "North East",
+      "id": "814cd12a-6095-e211-a939-e4115bead28a"
+    }
+  ],
+  "delivery_partners": [
+    {
+      "name": "New Anglia LEP",
+      "id": "cdcc392e-0bf1-e511-8ffa-e4115bead28a"
+    },
+    {
+      "name": "North Eastern LEP",
+      "id": "6e85b4e3-0df1-e511-8ffa-e4115bead28a"
+    }
+  ],
+  "strategic_drivers": [
+    {
+      "name": "Access to market",
+      "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+    }
+  ],
+  "client_considering_other_countries": false,
+  "uk_company_decided": null,
+  "uk_company": {
+    "name": "Mercury Ltd",
+    "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+  },
+  "requirements_complete": true,
+  "project_manager_requested_on": null,
+  "project_manager_request_status": null,
+  "project_manager": {
+    "name": "Michael Wining",
+    "first_name": "Michael",
+    "last_name": "Wining",
+    "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
+  },
+  "project_assurance_adviser": {
+    "name": "Paula Churing",
+    "first_name": "Paula",
+    "last_name": "Churing",
+    "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+  },
+  "project_manager_team": {
+    "name": "Marketing - Marketing Team",
+    "id": "8248318c-9698-e211-a939-e4115bead28a"
+  },
+  "project_assurance_team": {
+    "name": "Marketing - Marketing Team",
+    "id": "8248318c-9698-e211-a939-e4115bead28a"
+  },
+  "team_complete": true,
+  "team_members": [],
+  "project_arrived_in_triage_on": null,
+  "proposal_deadline": null,
+  "stage_log": []
+}

--- a/test/functional/cypress/fixtures/investment/investment-no-landing-dates.json
+++ b/test/functional/cypress/fixtures/investment/investment-no-landing-dates.json
@@ -1,0 +1,158 @@
+{
+    "id": "b30dee70-b2d6-48cf-9ce4-b9264854470c",
+    "incomplete_fields": [],
+    "name": "Fancy dress manufacturing",
+    "project_code": "DHP-00000005",
+    "description": "This is a dummy investment project for testing",
+    "anonymous_description": "",
+    "allow_blank_estimated_land_date": false,
+    "estimated_land_date": null,
+    "actual_land_date": null,
+    "quotable_as_public_case_study": null,
+    "likelihood_to_land": null,
+    "priority": null,
+    "approved_commitment_to_invest": null,
+    "approved_fdi": null,
+    "approved_good_value": null,
+    "approved_high_value": null,
+    "approved_landed": null,
+    "approved_non_fdi": null,
+    "investment_type": {
+      "name": "FDI",
+      "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+    },
+    "stage": {
+      "name": "Prospect",
+      "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced"
+    },
+    "status": "ongoing",
+    "reason_delayed": null,
+    "reason_abandoned": null,
+    "date_abandoned": null,
+    "reason_lost": null,
+    "date_lost": null,
+    "country_lost_to": null,
+    "investor_company": {
+      "name": "One List Corp",
+      "id": "375094ac-f79a-43e5-9c88-059a7caa17f0"
+    },
+    "investor_type": null,
+    "investor_company_country": {
+      "name": "France",
+      "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+    },
+    "intermediate_company": null,
+    "level_of_involvement": null,
+    "specific_programme": null,
+    "client_contacts": [
+      {
+        "name": "Mark Halomi",
+        "id": "7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b"
+      }
+    ],
+    "client_relationship_manager": {
+      "name": "Puck Head",
+      "first_name": "Puck",
+      "last_name": "Head",
+      "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+    },
+    "client_relationship_manager_team": {
+      "name": "CBBC North EAST",
+      "id": "602b971d-5df6-e511-888e-e4115bead28a"
+    },
+    "referral_source_adviser": {
+      "name": "Puck Head",
+      "first_name": "Puck",
+      "last_name": "Head",
+      "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+    },
+    "referral_source_activity": {
+      "name": "None",
+      "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+    },
+    "referral_source_activity_website": null,
+    "referral_source_activity_marketing": null,
+    "referral_source_activity_event": null,
+    "fdi_type": {
+      "name": "Creation of new site or activity",
+      "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+    },
+    "sector": {
+      "name": "Renewable Energy : Wind : Onshore",
+      "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+    },
+    "business_activities": [
+      {
+        "name": "Retail",
+        "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+      }
+    ],
+    "other_business_activity": null,
+    "archived": false,
+    "archived_documents_url_path": "",
+    "archived_on": null,
+    "archived_reason": null,
+    "archived_by": null,
+    "created_on": "2017-03-17T15:12:00Z",
+    "modified_on": "2017-06-05T10:00:00Z",
+    "comments": "",
+    "country_investment_originates_from": null,
+    "level_of_involvement_simplified": "unspecified",
+    "fdi_value": null,
+    "total_investment": "1000000",
+    "foreign_equity_investment": "200000",
+    "government_assistance": true,
+    "some_new_jobs": null,
+    "number_new_jobs": 20,
+    "will_new_jobs_last_two_years": null,
+    "average_salary": {
+      "name": "Below £25,000",
+      "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+    },
+    "number_safeguarded_jobs": null,
+    "r_and_d_budget": null,
+    "non_fdi_r_and_d_budget": null,
+    "associated_non_fdi_r_and_d_project": null,
+    "new_tech_to_uk": null,
+    "export_revenue": null,
+    "value_complete": true,
+    "client_cannot_provide_total_investment": false,
+    "client_cannot_provide_foreign_investment": null,
+    "client_requirements": "Anywhere",
+    "site_decided": false,
+    "address_1": null,
+    "address_2": null,
+    "address_town": null,
+    "address_postcode": null,
+    "competitor_countries": [],
+    "allow_blank_possible_uk_regions": false,
+    "uk_region_locations": [
+      {
+        "name": "North East",
+        "id": "814cd12a-6095-e211-a939-e4115bead28a"
+      }
+    ],
+    "actual_uk_regions": [],
+    "delivery_partners": [],
+    "strategic_drivers": [
+      {
+        "name": "Access to market",
+        "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+      }
+    ],
+    "client_considering_other_countries": false,
+    "uk_company_decided": null,
+    "uk_company": null,
+    "requirements_complete": true,
+    "project_manager_requested_on": null,
+    "project_manager_request_status": null,
+    "project_manager": null,
+    "project_assurance_adviser": null,
+    "project_manager_team": null,
+    "project_assurance_team": null,
+    "team_complete": true,
+    "team_members": [],
+    "project_arrived_in_triage_on": null,
+    "proposal_deadline": null,
+    "stage_log": []
+  }

--- a/test/functional/cypress/specs/investment-project/investment-project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investment-project/investment-project-edit-value-spec.js
@@ -1,0 +1,59 @@
+const {
+  assertLocalHeader,
+  assertBreadcrumbs,
+} = require('../../support/assertions')
+const { investments } = require('../../../../../src/lib/urls')
+const projectLandingBeforeApril = require('../../fixtures/investment/investment-land-date-before-April-2020.json')
+const projectLandingAfterApril = require('../../fixtures/investment/investment-land-date-after-April-2020.json')
+const projectNoLandingDates = require('../../fixtures/investment/investment-no-landing-dates.json')
+
+describe('Edit the value details of a project', () => {
+  context(
+    'When either actual or estimated land date is before 01/04/2020 ',
+    () => {
+      before(() => {
+        cy.visit(investments.projects.details(projectLandingBeforeApril.id))
+        cy.contains('Edit value').click()
+      })
+      it('should render the header', () => {
+        assertLocalHeader(projectLandingBeforeApril.name)
+      })
+
+      it('should render breadcrumbs', () => {
+        assertBreadcrumbs({
+          Home: '/',
+          Investments: '/investments',
+          Projects: investments.projects.index(),
+          [projectLandingBeforeApril.name]: investments.projects.project(
+            projectLandingBeforeApril.id
+          ),
+          'Edit value': null,
+        })
+      })
+      it('should display the Project Value field on the edit value page', () => {
+        cy.contains('Project value').should('be.visible')
+      })
+    }
+  )
+  context(
+    'When either actual or estimated land date is after 01/04/2020 ',
+    () => {
+      before(() => {
+        cy.visit(investments.projects.details(projectLandingAfterApril.id))
+        cy.contains('Edit value').click()
+      })
+      it('should not display the Project Value field on the edit value page', () => {
+        cy.contains('label', 'Project value').should('not.be.visible')
+      })
+    }
+  )
+  context('When both land date fields are empty', () => {
+    before(() => {
+      cy.visit(investments.projects.details(projectNoLandingDates.id))
+      cy.contains('Edit value').click()
+    })
+    it('should not display the Project Value field on the edit value page', () => {
+      cy.contains('label', 'Project value').should('not.be.visible')
+    })
+  })
+})

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -1,5 +1,5 @@
 {
-  "count": 12,
+  "count": 14,
   "next": null,
   "previous": null,
   "results": [
@@ -2023,6 +2023,382 @@
       "allow_blank_estimated_land_date": true,
       "estimated_land_date": null,
       "actual_land_date": "2018-01-01",
+      "quotable_as_public_case_study": null,
+      "likelihood_to_land": null,
+      "priority": null,
+      "approved_commitment_to_invest": null,
+      "approved_fdi": null,
+      "approved_good_value": null,
+      "approved_high_value": null,
+      "approved_landed": null,
+      "approved_non_fdi": null,
+      "investment_type": {
+        "name": "FDI",
+        "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+      },
+      "stage": {
+        "name": "Won",
+        "id": "945ea6d1-eee3-4f5b-9144-84a75b71b8e6"
+      },
+      "status": "ongoing",
+      "reason_delayed": null,
+      "reason_abandoned": null,
+      "date_abandoned": null,
+      "reason_lost": null,
+      "date_lost": null,
+      "country_lost_to": null,
+      "investor_company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "investor_type": null,
+      "investor_company_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "intermediate_company": null,
+      "level_of_involvement": null,
+      "specific_programme": null,
+      "client_contacts": [
+        {
+          "name": "Dean Cox",
+          "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+        }
+      ],
+      "client_relationship_manager": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "client_relationship_manager_team": {
+        "name": "CBBC North EAST",
+        "id": "602b971d-5df6-e511-888e-e4115bead28a"
+      },
+      "referral_source_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "referral_source_activity": {
+        "name": "None",
+        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+      },
+      "referral_source_activity_website": null,
+      "referral_source_activity_marketing": null,
+      "referral_source_activity_event": null,
+      "fdi_type": {
+        "name": "Creation of new site or activity",
+        "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+      },
+      "sector": {
+        "name": "Renewable Energy : Wind : Onshore",
+        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+      },
+      "business_activities": [
+        {
+          "name": "Retail",
+          "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+        }
+      ],
+      "other_business_activity": null,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2016-01-05T15:00:00Z",
+      "modified_on": "2016-01-05T19:00:00Z",
+      "comments": "",
+      "country_investment_originates_from": null,
+      "level_of_involvement_simplified": "unspecified",
+      "fdi_value": null,
+      "total_investment": "1000000",
+      "foreign_equity_investment": "200000",
+      "government_assistance": true,
+      "some_new_jobs": null,
+      "number_new_jobs": 20,
+      "will_new_jobs_last_two_years": null,
+      "average_salary": {
+        "name": "Below £25,000",
+        "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+      },
+      "number_safeguarded_jobs": 1,
+      "r_and_d_budget": false,
+      "non_fdi_r_and_d_budget": true,
+      "associated_non_fdi_r_and_d_project": null,
+      "new_tech_to_uk": true,
+      "export_revenue": true,
+      "value_complete": false,
+      "client_cannot_provide_total_investment": false,
+      "client_cannot_provide_foreign_investment": false,
+      "client_requirements": "Anywhere",
+      "site_decided": false,
+      "address_1": "10 Northings Road",
+      "address_2": null,
+      "address_town": "London",
+      "address_postcode": "W1 2AB",
+      "competitor_countries": [],
+      "allow_blank_possible_uk_regions": true,
+      "uk_region_locations": [],
+      "actual_uk_regions": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "delivery_partners": [
+        {
+          "name": "New Anglia LEP",
+          "id": "cdcc392e-0bf1-e511-8ffa-e4115bead28a"
+        },
+        {
+          "name": "North Eastern LEP",
+          "id": "6e85b4e3-0df1-e511-8ffa-e4115bead28a"
+        }
+      ],
+      "strategic_drivers": [
+        {
+          "name": "Access to market",
+          "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+        }
+      ],
+      "client_considering_other_countries": false,
+      "uk_company_decided": null,
+      "uk_company": {
+        "name": "Mercury Ltd",
+        "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+      },
+      "requirements_complete": true,
+      "project_manager_requested_on": null,
+      "project_manager_request_status": null,
+      "project_manager": {
+        "name": "Michael Wining",
+        "first_name": "Michael",
+        "last_name": "Wining",
+        "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
+      },
+      "project_assurance_adviser": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "project_manager_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "project_assurance_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "team_complete": true,
+      "team_members": [],
+      "project_arrived_in_triage_on": null,
+      "proposal_deadline": null,
+      "stage_log": []
+    },
+    {
+      "id": "3e341b34-1fc8-4638-b4b1-a0922ecf403e",
+      "incomplete_fields": [
+        "associated_non_fdi_r_and_d_project"
+      ],
+      "name": "Project landing before April 2020",
+      "project_code": "DHP-00000010",
+      "description": "This is a dummy investment project for testing",
+      "anonymous_description": "",
+      "allow_blank_estimated_land_date": true,
+      "estimated_land_date": null,
+      "actual_land_date": "2020-01-01",
+      "quotable_as_public_case_study": null,
+      "likelihood_to_land": null,
+      "priority": null,
+      "approved_commitment_to_invest": null,
+      "approved_fdi": null,
+      "approved_good_value": null,
+      "approved_high_value": null,
+      "approved_landed": null,
+      "approved_non_fdi": null,
+      "investment_type": {
+        "name": "FDI",
+        "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+      },
+      "stage": {
+        "name": "Won",
+        "id": "945ea6d1-eee3-4f5b-9144-84a75b71b8e6"
+      },
+      "status": "ongoing",
+      "reason_delayed": null,
+      "reason_abandoned": null,
+      "date_abandoned": null,
+      "reason_lost": null,
+      "date_lost": null,
+      "country_lost_to": null,
+      "investor_company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "investor_type": null,
+      "investor_company_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "intermediate_company": null,
+      "level_of_involvement": null,
+      "specific_programme": null,
+      "client_contacts": [
+        {
+          "name": "Dean Cox",
+          "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+        }
+      ],
+      "client_relationship_manager": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "client_relationship_manager_team": {
+        "name": "CBBC North EAST",
+        "id": "602b971d-5df6-e511-888e-e4115bead28a"
+      },
+      "referral_source_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "referral_source_activity": {
+        "name": "None",
+        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+      },
+      "referral_source_activity_website": null,
+      "referral_source_activity_marketing": null,
+      "referral_source_activity_event": null,
+      "fdi_type": {
+        "name": "Creation of new site or activity",
+        "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+      },
+      "sector": {
+        "name": "Renewable Energy : Wind : Onshore",
+        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+      },
+      "business_activities": [
+        {
+          "name": "Retail",
+          "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+        }
+      ],
+      "other_business_activity": null,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2016-01-05T15:00:00Z",
+      "modified_on": "2016-01-05T19:00:00Z",
+      "comments": "",
+      "country_investment_originates_from": null,
+      "level_of_involvement_simplified": "unspecified",
+      "fdi_value": null,
+      "total_investment": "1000000",
+      "foreign_equity_investment": "200000",
+      "government_assistance": true,
+      "some_new_jobs": null,
+      "number_new_jobs": 20,
+      "will_new_jobs_last_two_years": null,
+      "average_salary": {
+        "name": "Below £25,000",
+        "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+      },
+      "number_safeguarded_jobs": 1,
+      "r_and_d_budget": false,
+      "non_fdi_r_and_d_budget": true,
+      "associated_non_fdi_r_and_d_project": null,
+      "new_tech_to_uk": true,
+      "export_revenue": true,
+      "value_complete": false,
+      "client_cannot_provide_total_investment": false,
+      "client_cannot_provide_foreign_investment": false,
+      "client_requirements": "Anywhere",
+      "site_decided": false,
+      "address_1": "10 Northings Road",
+      "address_2": null,
+      "address_town": "London",
+      "address_postcode": "W1 2AB",
+      "competitor_countries": [],
+      "allow_blank_possible_uk_regions": true,
+      "uk_region_locations": [],
+      "actual_uk_regions": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "delivery_partners": [
+        {
+          "name": "New Anglia LEP",
+          "id": "cdcc392e-0bf1-e511-8ffa-e4115bead28a"
+        },
+        {
+          "name": "North Eastern LEP",
+          "id": "6e85b4e3-0df1-e511-8ffa-e4115bead28a"
+        }
+      ],
+      "strategic_drivers": [
+        {
+          "name": "Access to market",
+          "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+        }
+      ],
+      "client_considering_other_countries": false,
+      "uk_company_decided": null,
+      "uk_company": {
+        "name": "Mercury Ltd",
+        "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+      },
+      "requirements_complete": true,
+      "project_manager_requested_on": null,
+      "project_manager_request_status": null,
+      "project_manager": {
+        "name": "Michael Wining",
+        "first_name": "Michael",
+        "last_name": "Wining",
+        "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
+      },
+      "project_assurance_adviser": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "project_manager_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "project_assurance_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "team_complete": true,
+      "team_members": [],
+      "project_arrived_in_triage_on": null,
+      "proposal_deadline": null,
+      "stage_log": []
+    },
+    {
+      "id": "6e441b34-1fc8-4638-b4b1-a0922ecf403e",
+      "incomplete_fields": [
+        "associated_non_fdi_r_and_d_project"
+      ],
+      "name": "Project landing after April 2020",
+      "project_code": "DHP-00000010",
+      "description": "This is a dummy investment project for testing",
+      "anonymous_description": "",
+      "allow_blank_estimated_land_date": true,
+      "estimated_land_date": null,
+      "actual_land_date": "2021-10-21",
       "quotable_as_public_case_study": null,
       "likelihood_to_land": null,
       "priority": null,


### PR DESCRIPTION
## Description of change

Due to the way DIT measures the value of an investment project changing from 01/04/2020 onwards, the 'Project Value' field is no longer required for projects with an estimated or actual land date after this date. 

This PR adds a check in the edit-value controller to determine whether the field should be displayed or not, and passes a boolean to the 'edit-value' template. If the project is both FDI and has an actual or estimated land date before 01/04/2020, the field will be displayed. 

**Future work**
Once the investment verification team has carried out all checks on projects which landed before 01/04/2020, this field can be removed completely from the front end. 

## Test instructions

1. Go to an investment project with an estimated or actual land date before 01/04/200 (can use the filters on the investments tab)
2. Click 'Edit/Add value'
3. Check that the project value field appears

1. Go to a project with an estimated or actual land date after 01/04/2020
2. Click 'Edit/Add value'
3. Check that the project value field doe not appear

## Screenshots
### Before

![Screenshot 2020-04-27 at 16 58 53](https://user-images.githubusercontent.com/22460823/80393431-62b2f500-88a8-11ea-9ac1-c38cf5e3cc92.png)

### After

![Screenshot 2020-04-27 at 16 59 40](https://user-images.githubusercontent.com/22460823/80393513-7eb69680-88a8-11ea-87db-4faf9f8df0dd.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
