### PR TITLE
Update Docker set-up instructions following SSO integration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,7 @@ and be provided with a back end server to provide the API, data storage and sear
 
 4. Run `docker-compose build --parallel && docker-compose -p dev up --abort-on-container-exit`. This is provided for you in the `dev-stack` file in the `.bin/sample` folder. Feel free to move it to your own `.bin` file. Alternatively, if you already have yarn installed globally on your machine, you can run `yarn dev-stack`.
 
-5. Once the process has completed you will need to set up an access token. Login into the Django admin at `http://localhost:8000/admin/` with the superuser username and password in your `dev-stack.env` file.
-
-6. Navigate to access tokens, find your superuser account, add `ditStaffToken` as the access token. Set an expiry time and date for your token. The easiest way to do this is to just click today and now and then increase the year by one. Finally, define the scope as `data-hub:internal-front-end`
-
-7. You can now access the frontend at `http://localhost:3000` and the api at `http://localhost:8000`.
+5. Once the process has completed you can access the frontend at `http://localhost:3000` and the api at `http://localhost:8000`.
 
 #### Option 2 (the mock stack - using the sandbox api for running functional tests)
 

--- a/dev-stack.sample.env
+++ b/dev-stack.sample.env
@@ -42,6 +42,7 @@ REDIS_URL=redis://redis:6379
 RESOURCE_SERVER_INTROSPECTION_URL=http://mock-sso:8080/o/introspect
 SESSION_SECRET=lookInVault
 SSO_ENABLED=false
+SUPERUSER_ACCESS_TOKEN=ditStaffToken
 WEB_CONCURRENCY=2
 ZEN_EMAIL=look@in.vault.com
 ZEN_TICKETS_URL=https://lookInVault.com/


### PR DESCRIPTION
## Description of change

This updates the README following uktrade/data-hub-api#2818 to reflect the fact that the API Docker start-up script automatically creates an access token using the `SUPERUSER_ACCESS_TOKEN` environment variable.

## Test instructions

1. Check out this branch and also the latest `develop` in `data-hub-api`.
2. Make sure `DJANGO_SUPERUSER_SSO_EMAIL_USER_ID` and `SUPERUSER_ACCESS_TOKEN` are set in `dev-stack.env`.
3. If you have an existing database, make sure the existing superuser has an SSO email user ID set in Django admin to whatever's in `DJANGO_SUPERUSER_SSO_EMAIL_USER_ID`.
4. Bring up the full Docker stack using the instructions from option 1, step 4 in the README.
5. The FE should come up successfully and work.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
