### PR TITLE
Add flash messages to react local header

### DIFF
--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralConfirmation.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralConfirmation.jsx
@@ -7,7 +7,7 @@ import UnorderedList from '@govuk-react/unordered-list'
 import ListItem from '@govuk-react/list-item'
 
 import SecondaryButton from '../../../../../../client/components/SecondaryButton'
-import LocalHeader from '../../../../../../client/components/LocalHeader'
+import LocalHeader from '../../../../../../client/components/LocalHeader/LocalHeader'
 import { companies, dashboard } from '../../../../../../lib/urls'
 
 const SendReferralConfirmation = ({

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -30,7 +30,7 @@ import {
   SEND_REFERRAL_FORM__TEXTAREA_CHANGE,
 } from '../../../../../../client/actions'
 import SendReferralConfirmation from './SendReferralConfirmation'
-import LocalHeader from '../../../../../../client/components/LocalHeader'
+import LocalHeader from '../../../../../../client/components/LocalHeader/LocalHeader'
 import { companies, dashboard } from '../../../../../../lib/urls'
 
 const StyledTextArea = styled(TextArea)({

--- a/src/client/components/LocalHeader/FlashMessages.jsx
+++ b/src/client/components/LocalHeader/FlashMessages.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import { ERROR_COLOUR, BLUE, BUTTON_COLOUR, ORANGE, BLACK } from 'govuk-colours'
+import { FONT_WEIGHTS } from '@govuk-react/constants/lib/typography'
+import { FONT_SIZE } from '@govuk-react/constants'
+import { StatusMessage } from 'data-hub-components'
+
+const StyledBody = styled('p')`
+  margin-bottom: 0;
+  font-weight: ${FONT_WEIGHTS.bold};
+`
+
+const StyledHeading = styled('h2')`
+  font-size: ${FONT_SIZE.SIZE_20};
+  font-weight: ${FONT_WEIGHTS.bold};
+  margin-top: 0;
+`
+
+const StyledMessage = styled('p')`
+  margin: 0;
+  font-size: ${FONT_SIZE.SIZE_20};
+`
+
+const messageColours = {
+  info: BLUE,
+  success: BUTTON_COLOUR,
+  warning: ORANGE,
+  error: ERROR_COLOUR,
+  muted: BLACK,
+}
+
+const FlashMessages = ({ flashMessages }) =>
+  Object.entries(flashMessages).map(([type, message]) => {
+    const parts = String(type).split(':')
+    return parts.length > 1 ? (
+      message.map((message) => (
+        <StatusMessage colour={messageColours[parts[0]]} key={message.body}>
+          <StyledHeading>{message.heading}</StyledHeading>
+          <StyledBody>{message.body}</StyledBody>
+        </StatusMessage>
+      ))
+    ) : (
+      <StatusMessage colour={messageColours[type]} key={message}>
+        <StyledMessage>{message}</StyledMessage>
+      </StatusMessage>
+    )
+  })
+
+FlashMessages.propTypes = {
+  flashMessages: PropTypes.shape({
+    type: PropTypes.oneOfType([
+      PropTypes.arrayOf(
+        PropTypes.shape({
+          body: PropTypes.string.isRequired,
+          heading: PropTypes.string.isRequired,
+          id: PropTypes.string,
+        })
+      ),
+      PropTypes.arrayOf(PropTypes.string).isRequired,
+    ]),
+  }).isRequired,
+}
+
+export default FlashMessages

--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -5,7 +5,9 @@ import { GREY_4 } from 'govuk-colours'
 import { SPACING } from '@govuk-react/constants'
 import Main from '@govuk-react/main'
 import Breadcrumbs from '@govuk-react/breadcrumbs'
-import { typography } from '@govuk-react/lib'
+
+import LocalHeaderHeading from './LocalHeaderHeading'
+import FlashMessages from './FlashMessages'
 
 const StyledHeader = styled('header')`
   padding-bottom: ${SPACING.SCALE_5};
@@ -21,12 +23,7 @@ const BreadcrumbsWrapper = styled(Breadcrumbs)`
   margin-bottom: ${SPACING.SCALE_5};
   margin-top: 0;
 `
-
-const StyledH1 = styled('h1')`
-  ${typography.font({ size: 36, weight: 'bold' })};
-`
-
-const LocalHeader = ({ breadcrumbs, heading, children }) => (
+const LocalHeader = ({ breadcrumbs, flashMessages, heading, children }) => (
   <StyledHeader aria-label="local header" data-auto-id="localHeader">
     <StyledMain>
       <BreadcrumbsWrapper>
@@ -40,7 +37,8 @@ const LocalHeader = ({ breadcrumbs, heading, children }) => (
           )
         )}
       </BreadcrumbsWrapper>
-      {heading && <StyledH1>{heading}</StyledH1>}
+      {flashMessages && <FlashMessages flashMessages={flashMessages} />}
+      {heading && <LocalHeaderHeading>{heading}</LocalHeaderHeading>}
       {children}
     </StyledMain>
   </StyledHeader>
@@ -53,6 +51,18 @@ LocalHeader.propTypes = {
       text: PropTypes.string.isRequired,
     })
   ),
+  flashMessages: PropTypes.shape({
+    type: PropTypes.oneOfType([
+      PropTypes.arrayOf(
+        PropTypes.shape({
+          body: PropTypes.string.isRequired,
+          heading: PropTypes.string.isRequired,
+          id: PropTypes.string,
+        })
+      ),
+      PropTypes.arrayOf(PropTypes.string).isRequired,
+    ]),
+  }),
   heading: PropTypes.string,
   children: PropTypes.node,
 }

--- a/src/client/components/LocalHeader/LocalHeaderHeading.jsx
+++ b/src/client/components/LocalHeader/LocalHeaderHeading.jsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+import { typography } from '@govuk-react/lib'
+
+const LocalHeaderHeading = styled('h1')`
+  ${typography.font({ size: 36, weight: 'bold' })};
+`
+
+export default LocalHeaderHeading

--- a/src/client/components/LocalHeader/__stories__/FlashMessages.stories.jsx
+++ b/src/client/components/LocalHeader/__stories__/FlashMessages.stories.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import FlashMessages from '../FlashMessages'
+import exampleReadme from './example.md'
+import usageReadme from './usage.md'
+
+storiesOf('Flash Messages', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <FlashMessages
+      flashMessages={{
+        'success:with-body': [
+          {
+            heading: 'Success message heading',
+            body: 'Success message body',
+          },
+        ],
+        'info:with-body': [
+          {
+            heading: 'Info message heading',
+            body: 'Info message body',
+          },
+        ],
+        error: ['Error test message'],
+        warning: ['Warning test message'],
+        muted: ['Muted test message'],
+      }}
+    />
+  ))

--- a/src/client/components/LocalHeader/__stories__/example.md
+++ b/src/client/components/LocalHeader/__stories__/example.md
@@ -1,0 +1,7 @@
+### Import
+
+```js
+import FlashMessages from 'FlashMessages'
+```
+
+### Output

--- a/src/client/components/LocalHeader/__stories__/usage.md
+++ b/src/client/components/LocalHeader/__stories__/usage.md
@@ -1,0 +1,35 @@
+# Panel
+
+### Description
+
+Flash messages for users in different colours depending on the message
+
+### Usage
+
+```jsx
+<FlashMessages
+  flashMessages={{
+    'success:with-body': [
+      {
+        heading: 'Success message heading',
+        body: 'Success message body',
+      },
+    ],
+    'info:with-body': [
+      {
+        heading: 'Info message heading',
+        body: 'Info message body',
+      },
+    ],
+    error: ['Error test message'],
+    warning: ['Warning test message'],
+    muted: ['Muted test message'],
+  }}
+/>
+```
+
+### Properties
+
+| Prop            | Required | Default                                   | Type | Description |
+| :-------------- | :------- | :---------------------------------------- | :--- | :---------- |
+| `flashMessages` | true     | `` | Object | Contains the flash messages |


### PR DESCRIPTION
## Description of change

Add flash messages to the react local header in preparation for its use in the company local header.

The flash messages are generated by `req.flash` and `req.flashWithBody` and get passed through to the component as an object. 

Functional tests covering an implementation of this will be in another PR when this new functionality is used for the first time. 

There will be another PR following this one showing how the flash messages work in the company header.

## Test instructions

Open storybook, `yarn start-storybook`, and you will see an example of the different flash message types.

## Screenshots

![image](https://user-images.githubusercontent.com/42253716/80816560-a61ea380-8bc7-11ea-8ad9-3796d9431928.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
