### PR TITLE
Add company local header component to companies app

### DIFF
--- a/src/apps/companies/client/CompanyLocalHeader.jsx
+++ b/src/apps/companies/client/CompanyLocalHeader.jsx
@@ -1,0 +1,240 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import pluralize from 'pluralize'
+import GridCol from '@govuk-react/grid-col'
+import GridRow from '@govuk-react/grid-row'
+import Link from '@govuk-react/link'
+import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
+import { GREY_3 } from 'govuk-colours'
+import Details from '@govuk-react/details'
+import Main from '@govuk-react/main'
+import { Badge, StatusMessage, DateUtils } from 'data-hub-components'
+
+import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
+import LocalHeaderHeading from '../../../client/components/LocalHeader/LocalHeaderHeading'
+import SecondaryButton from '../../../client/components/SecondaryButton.jsx'
+import formatAddress from '../../../client/utils/formatAddress'
+import { companies } from '../../../lib/urls'
+
+const StyledAddress = styled('p')`
+  margin-top: ${SPACING.SCALE_2};
+  margin-bottom: ${SPACING.SCALE_2};
+`
+
+const BadgeText = styled('span')`
+  font-weight: 600;
+  font-size: ${FONT_SIZE.SIZE_16};
+`
+
+const TypeWrapper = styled('div')`
+  @media (min-width: ${BREAKPOINTS.TABLET}) {
+    display: table-row;
+  }
+`
+
+const BadgeWrapper = styled('div')`
+  @media (min-width: ${BREAKPOINTS.TABLET}) {
+    display: table-cell;
+  }
+`
+
+const StyledDetails = styled(Details)`
+  @media (min-width: ${BREAKPOINTS.TABLET}) {
+    margin: 0 0 0 ${SPACING.SCALE_3};
+  }
+  span,
+  div {
+    font-size: ${FONT_SIZE.SIZE_16};
+  }
+`
+
+const StyledDescription = styled('div')`
+  padding: ${SPACING.SCALE_2};
+  background-color: ${GREY_3};
+
+  * + & {
+    margin-top: ${SPACING.SCALE_3};
+  }
+
+  p {
+    margin-top: 0;
+    margin-bottom: 0;
+
+    &:not(:last-child) {
+      margin-bottom: ${SPACING.SCALE_2};
+    }
+  }
+
+  & + * {
+    margin-top: ${SPACING.SCALE_3};
+  }
+`
+
+const StyledMain = styled(Main)`
+  padding-top: ${SPACING.SCALE_1};
+  div {
+    font-size: ${FONT_SIZE.SIZE_20};
+  }
+`
+
+const CompanyLocalHeader = ({
+  breadcrumbs,
+  flashMessages,
+  company,
+  dnbRelatedCompaniesCount,
+  returnUrl,
+}) => {
+  const queryString = returnUrl ? `${returnUrl}` : `/companies/${company.id}`
+
+  return (
+    <>
+      <LocalHeader breadcrumbs={breadcrumbs} flashMessages={flashMessages}>
+        <GridRow>
+          <GridCol setWidth="two-thirds">
+            <LocalHeaderHeading data-auto-id="heading">
+              {company.name}
+            </LocalHeaderHeading>
+            <StyledAddress data-auto-id="address">
+              {formatAddress([
+                company.address.line_1,
+                company.address.line_2,
+                company.address.town,
+                company.address.county,
+                company.address.postcode,
+                company.address.country.name,
+              ])}
+            </StyledAddress>
+          </GridCol>
+          <GridCol setWith="one-third">
+            <SecondaryButton
+              as={Link}
+              href={`/companies/${company.id}/lists/add-remove?returnUrl=${queryString}`}
+            >
+              Add to or remove from lists
+            </SecondaryButton>
+          </GridCol>
+        </GridRow>
+        {(company.isUltimate || company.isGlobalHQ) && (
+          <TypeWrapper>
+            <BadgeWrapper>
+              <Badge>
+                <BadgeText data-auto-id="badge">
+                  {company.isUltimate ? 'Ultimate HQ' : 'Global HQ'}
+                </BadgeText>
+              </Badge>
+            </BadgeWrapper>
+            {company.isUltimate && (
+              <StyledDetails
+                summary="What does this mean?"
+                data-auto-id="metaList"
+              >
+                This HQ is in control of all related company records for{' '}
+                {company.name}.
+              </StyledDetails>
+            )}
+          </TypeWrapper>
+        )}
+        {(dnbRelatedCompaniesCount || company.hasManagedAccountDetails) && (
+          <StyledDescription data-auto-id="description">
+            {dnbRelatedCompaniesCount && (
+              <p>
+                Data Hub contains{' '}
+                <a href={companies.dnbHierarchy.index(company.id)}>
+                  {dnbRelatedCompaniesCount} other company{' '}
+                  {pluralize('record', dnbRelatedCompaniesCount)}
+                </a>{' '}
+                related to this company
+              </p>
+            )}
+            {company.hasManagedAccountDetails && (
+              <>
+                <p>
+                  This is an account managed company (One List{' '}
+                  {company.one_list_group_tier.name})
+                </p>
+                <p>
+                  {company.isItaTierDAccount
+                    ? 'Lead ITA'
+                    : 'Global Account Manager'}
+                  : {company.one_list_group_global_account_manager.name}{' '}
+                  <a href={companies.advisers.index(company.id)}>
+                    {company.isItaTierDAccount
+                      ? 'View Lead adviser'
+                      : 'View core team'}
+                  </a>
+                </p>
+              </>
+            )}
+          </StyledDescription>
+        )}
+        <p>
+          <a href={companies.businessDetails(company.id)}>
+            View full business details
+          </a>
+        </p>
+      </LocalHeader>
+
+      {company.archived && (
+        <StyledMain>
+          <StatusMessage>
+            {company.archived_by
+              ? `This company was archived on ${DateUtils.format(
+                  company.archived_on
+                )} by ${company.archived_by.first_name} ${
+                  company.archived_by.last_name
+                }.`
+              : `This company was automatically archived on ${DateUtils.format(
+                  company.archived_on
+                )}.`}
+            <br />
+            <strong>Reason:</strong> {company.archived_reason}
+            <br />
+            <br />
+            <a href={companies.unarchive(company.id)}>Unarchive</a>
+          </StatusMessage>
+        </StyledMain>
+      )}
+
+      {company.pending_dnb_investigation && (
+        <StyledMain>
+          This company record is based on information that has not yet been
+          validated. This information is currently being checked by the Data Hub
+          support team.
+        </StyledMain>
+      )}
+    </>
+  )
+}
+
+CompanyLocalHeader.propTypes = {
+  breadcrumbs: PropTypes.arrayOf(
+    PropTypes.shape({
+      link: PropTypes.string,
+      text: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  flashMessages: PropTypes.shape({
+    type: PropTypes.oneOfType([
+      PropTypes.arrayOf(
+        PropTypes.shape({
+          body: PropTypes.string.isRequired,
+          heading: PropTypes.string.isRequired,
+          id: PropTypes.string,
+        })
+      ),
+      PropTypes.arrayOf(PropTypes.string).isRequired,
+    ]),
+  }),
+  company: PropTypes.object.isRequired,
+  dnbRelatedCompaniesCount: PropTypes.number,
+  returnUrl: PropTypes.string,
+}
+
+CompanyLocalHeader.defaultProps = {
+  flashMessages: null,
+  dnbRelatedCompaniesCount: null,
+  returnUrl: null,
+}
+
+export default CompanyLocalHeader

--- a/src/apps/companies/client/__stories__/CompanyLocalHeader.stories.jsx
+++ b/src/apps/companies/client/__stories__/CompanyLocalHeader.stories.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import dnBGlobalUltimate from '../../../../../test/sandbox/fixtures/v4/company/company-dnb-global-ultimate.json'
+import { companies, dashboard } from '../../../../lib/urls'
+import CompanyLocalHeader from '../CompanyLocalHeader'
+import exampleReadme from './example.md'
+import usageReadme from './usage.md'
+
+storiesOf('Company Local Header', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <CompanyLocalHeader
+      breadcrumbs={[
+        { link: dashboard(), text: 'Home' },
+        { link: companies.index(), text: 'Companies' },
+        {
+          link: companies.detail(dnBGlobalUltimate.id),
+          text: dnBGlobalUltimate.name,
+        },
+        { text: 'Activity Feed' },
+      ]}
+      flashMessages={{
+        'success:with-body': [
+          {
+            heading: 'Business details verified.',
+            body:
+              'Thanks for helping to improve the quality of records on Data Hub!',
+            id: 'message-company-matched',
+          },
+        ],
+      }}
+      company={{
+        ...dnBGlobalUltimate,
+        ...{
+          hasManagedAccountDetails: true,
+          archived: true,
+          pending_dnb_investigation: true,
+          isUltimate: true,
+          archived_on: '2019-06-12T14:19:05.473413Z',
+          archived_reason: 'Client cancelled',
+        },
+      }}
+      dnbRelatedCompaniesCount={3}
+    />
+  ))

--- a/src/apps/companies/client/__stories__/example.md
+++ b/src/apps/companies/client/__stories__/example.md
@@ -1,0 +1,7 @@
+### Import
+
+```js
+import CompanyLocalHeader from 'CompanyLocalHeader'
+```
+
+### Output

--- a/src/apps/companies/client/__stories__/usage.md
+++ b/src/apps/companies/client/__stories__/usage.md
@@ -1,0 +1,53 @@
+# CompanyLocalHeader
+
+### Description
+
+Implementation of the company local header in React, extending the LocalHeader component.
+
+### Usage
+
+```jsx
+<CompanyLocalHeader
+  breadcrumbs={[
+    { link: dashboard(), text: 'Home' },
+    { link: companies.index(), text: 'Companies' },
+    {
+      link: companies.detail(dnBGlobalUltimate.id),
+      text: dnBGlobalUltimate.name,
+    },
+    { text: 'Activity Feed' },
+  ]}
+  flashMessages={{
+    'success:with-body': [
+      {
+        heading: 'Business details verified.',
+        body:
+          'Thanks for helping to improve the quality of records on Data Hub!',
+        id: 'message-company-matched',
+      },
+    ],
+  }}
+  company={{
+    ...dnBGlobalUltimate,
+    ...{
+      hasManagedAccountDetails: true,
+      archived: true,
+      pending_dnb_investigation: true,
+      isUltimate: true,
+      archived_on: '2019-06-12T14:19:05.473413Z',
+      archived_reason: 'Client cancelled',
+    },
+  }}
+  dnbRelatedCompaniesCount={3}
+/>
+```
+
+### Properties
+
+| Prop                       | Required | Default                                                                                                                                                                                                                                                                            | Type   | Description                                                                                                        |
+| :------------------------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----- | :----------------------------------------------------------------------------------------------------------------- |
+| `breadcrumbs`              | true     | `` | Array | Array of breadcrumbs                                                                                                                                                                                                                                                  |
+| `flashMessages`            | false    | null                                                                                                                                                                                                                                                                               | Object | Contains the flash messages. Will show none if null.                                                               |
+| `company`                  | true     | `` | Object | Contains all of the company information provided by `res.locals`. The component will conditionally show the badge, details dropdown, parts of the description, the archive message and the pending investigation message depending on the information provided here. |
+| `dnbRelatedCompaniesCount` | false    | null                                                                                                                                                                                                                                                                               | Number | Number of related companies. If provided it shows that information in the description section.                     |
+| `returnUrl`                | false    | null                                                                                                                                                                                                                                                                               | String | Provides the return url for the `Add to or remove from lists` pages. Not needed on the default activity feed page. |

--- a/src/client/utils/formatAddress.js
+++ b/src/client/utils/formatAddress.js
@@ -1,0 +1,4 @@
+// strips undefined values and formats address
+const formatAddress = (address) => address.filter(Boolean).join(', ')
+
+export default formatAddress


### PR DESCRIPTION
## Description of change

Add company local header component to the companies app. 

This component holds all of the conditional logic needed for the company local header. I envisage that each of the apps that has complex requirements around the local header, e.g. omis and investment, will have their own implementation component of the local header like this one. Apps with simpler requirements will be able to use the base `LocalHeader` component to show the breadcrumbs, header and flash messages. 

This is the second of three PRs to rebuild the company local header into React. 
The first PR converted the flash messages to React - https://github.com/uktrade/data-hub-frontend/pull/2647
The third will implement the component in this PR into the companies app. With this will come the accompanying functional tests. 

## Test instructions

Open storybook, `yarn start-storybook`, and you will see an example of the company local header. This example shows all of the conditional elements. Depending on the data passed, particularly through the `company` prop, you will see fewer elements. 

## Screenshots

![image](https://user-images.githubusercontent.com/42253716/80956303-db5e0800-8df8-11ea-806e-9b0749c59725.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
