### PR TITLE
Add Dropdown contextual menu 

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { addDecorator, configure } from '@storybook/react'
+import { addDecorator, configure, addParameters } from '@storybook/react'
 import { addReadme } from 'storybook-readme'
 import { FONT_SIZE, FONT_STACK, MEDIA_QUERIES } from '@govuk-react/constants'
 import { createGlobalStyle } from 'styled-components'
@@ -15,9 +15,14 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 `
+
+addParameters({
+  options: {
+    theme: {}
+  },
+})
+
 addDecorator(addReadme)
 addDecorator(s => <><GlobalStyle />{s()}</>)
 
-const loadStories = () => req.keys().forEach(filename => req(filename))
-
-configure(loadStories, module)
+configure(req, module);

--- a/src/client/components/DropdownMenu/DropdownMenu.jsx
+++ b/src/client/components/DropdownMenu/DropdownMenu.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Button from '@govuk-react/button'
+import { GREY_3, BLACK, GREY_2 } from 'govuk-colours'
+import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
+import { spacing } from '@govuk-react/lib'
+import styled from 'styled-components'
+
+import trianglePng from '../../../../assets/images/icon-triangle.svg'
+
+const DropdownMenuContainer = styled.div`
+  position: relative;
+`
+
+const DropdownMenuGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: ${SPACING.SCALE_3};
+  background-color: ${GREY_2};
+  ${spacing.responsive({
+    size: -5,
+    property: 'margin-top',
+  })}
+  ${MEDIA_QUERIES.TABLET} {
+    position: absolute;
+  }
+`
+
+const Icon = styled.img`
+  transform: ${({ active }) => (active ? 'rotate(0deg)' : 'rotate(-90deg)')};
+  margin-left: ${SPACING.SCALE_3};
+  transition: transform 300ms ease;
+  transform-origin: center;
+`
+
+const DropdownToggleButton = styled(Button)`
+  font-weight: Bold;
+`
+
+export const DropdownButton = styled(Button)`
+  ${spacing.responsive({
+    size: 3,
+    property: 'margin-bottom',
+  })}
+  &:last-child {
+    margin-bottom: 0;
+  }
+`
+
+const DropdownMenu = ({ label, children, closedLabel, onClick, open }) => {
+  return (
+    <DropdownMenuContainer>
+      <DropdownToggleButton
+        buttonShadowColour="transparent"
+        buttonColour={GREY_3}
+        buttonTextColour={BLACK}
+        onClick={() => onClick(!open)}
+        icon={<Icon src={trianglePng} active={open} />}
+        aria-haspopup={true}
+        aria-expanded={open}
+      >
+        {(open ? closedLabel : label) || label}
+      </DropdownToggleButton>
+      {open && <DropdownMenuGroup>{children}</DropdownMenuGroup>}
+    </DropdownMenuContainer>
+  )
+}
+
+DropdownMenu.propTypes = {
+  label: PropTypes.string.isRequired,
+  closedLabel: PropTypes.string,
+  children: PropTypes.node,
+  onClick: PropTypes.func.isRequired,
+  open: PropTypes.bool,
+}
+
+export default DropdownMenu

--- a/src/client/components/DropdownMenu/__stories__/DropdownMenu.stories.jsx
+++ b/src/client/components/DropdownMenu/__stories__/DropdownMenu.stories.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { GREY_3, BLACK } from 'govuk-colours'
+
+import DropdownMenu, { DropdownButton } from '../DropdownMenu'
+import defaultReadme from './default.md'
+import noCloseLabelReadme from './noCloseLabel.md'
+import usageReadme from './usage.md'
+
+export default {
+  component: DropdownMenu,
+  title: 'DropdownMenu',
+  parameters: {
+    readme: {
+      sidebar: usageReadme,
+    },
+  },
+}
+
+const withState = (Component) => () => {
+  const [isOpen, setState] = React.useState(false)
+  const clickAction = action('click')
+  return (
+    <Component
+      open={isOpen}
+      onClick={(nextState) => {
+        clickAction(nextState)
+        setState(nextState)
+      }}
+    />
+  )
+}
+
+const DefaultComponent = (props) => (
+  <DropdownMenu label="View Options" closedLabel="Hide Options" {...props}>
+    <DropdownButton buttonColour={GREY_3} buttonTextColour={BLACK}>
+      Add to or remove from list
+    </DropdownButton>
+    <DropdownButton buttonColour={GREY_3} buttonTextColour={BLACK}>
+      Add to pipeline
+    </DropdownButton>
+  </DropdownMenu>
+)
+
+export const Default = withState(DefaultComponent)
+
+Default.story = {
+  parameters: {
+    readme: {
+      content: defaultReadme,
+    },
+  },
+}
+
+const NoClosedLabelComponent = (props) => (
+  <DropdownMenu label="View Options" {...props}>
+    <DropdownButton buttonColour={GREY_3} buttonTextColour={BLACK}>
+      Add to or remove from list
+    </DropdownButton>
+    <DropdownButton buttonColour={GREY_3} buttonTextColour={BLACK}>
+      Add to pipeline
+    </DropdownButton>
+  </DropdownMenu>
+)
+
+export const NoClosedLabel = withState(NoClosedLabelComponent)
+
+NoClosedLabel.story = {
+  parameters: {
+    readme: {
+      content: noCloseLabelReadme,
+    },
+  },
+}

--- a/src/client/components/DropdownMenu/__stories__/default.md
+++ b/src/client/components/DropdownMenu/__stories__/default.md
@@ -1,0 +1,16 @@
+### Input
+
+```jsx
+import DropdownMenu, { DropdownButton } from '../DropdownMenu'
+
+<DropdownMenu label="View Options" closedLabel="Hide Options" isOpen={false} onClick={(nextState: Boolean) => toggleState(nextState)}>
+    <DropdownButton buttonColour="#dee0e2" buttonTextColour={BLACK}>
+      Add to or remove from list
+    </DropdownButton>
+    <DropdownButton buttonColour="#dee0e2" buttonTextColour={BLACK}>
+      Add to pipeline
+    </DropdownButton>
+</DropdownMenu>
+```
+
+### Output

--- a/src/client/components/DropdownMenu/__stories__/noCloseLabel.md
+++ b/src/client/components/DropdownMenu/__stories__/noCloseLabel.md
@@ -1,0 +1,15 @@
+### Input
+```jsx
+import DropdownMenu, { DropdownButton } from '../DropdownMenu'
+
+<DropdownMenu label="View Options" open={false} onClick={(nextState: Boolean) => toggleState(nextState)}>
+    <DropdownButton buttonColour="#dee0e2" buttonTextColour="#000">
+      Add to or remove from list
+    </DropdownButton>
+    <DropdownButton buttonColour="#dee0e2" buttonTextColour="#000">
+      Add to pipeline
+    </DropdownButton>
+</DropdownMenu>
+```
+
+### Output

--- a/src/client/components/DropdownMenu/__stories__/usage.md
+++ b/src/client/components/DropdownMenu/__stories__/usage.md
@@ -1,0 +1,34 @@
+ButtonDropdown
+=========
+
+### Description
+
+DropdownMenu displays contextual overlays for menus.
+
+In Desktop view the menu will "float" over the content in mobile view the menu is in flow and will push the content down.
+
+### DropdownButton
+Dropdown button is extending styles of Button for usage please visit the button docs [here](https://govuk-react.github.io/govuk-react/?path=/story/form-buttons--component-default).
+### Usage
+
+```jsx
+  <DropdownMenu label="View Options" closedLabel="Hide Options" {...props}>
+    <DropdownButton buttonColour={GREY_3} buttonTextColour={BLACK}>
+      Add to or remove from list
+    </DropdownButton>
+    <DropdownButton buttonColour={GREY_3} buttonTextColour={BLACK}>
+      Add to pipeline
+    </DropdownButton>
+  </DropdownMenu>
+```
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `label` | true | `````` | string | Text for button
+ `children` | false | null | node | Buttons for dropdown group
+ `closedLabel` | false | `````` | string | Close text for button
+ `active` | false | `````` | boolean | Set the open and close state of the dropdown
+ `onClick` | true | `````` | function | Signature: function(nextOpenState: boolean) => void
+
+

--- a/src/client/components/DropdownMenu/index.js
+++ b/src/client/components/DropdownMenu/index.js
@@ -1,0 +1,1 @@
+export { default as ButtonGroup, ButtonGroupItem } from './DropdownMenu'


### PR DESCRIPTION
## Description of change

This PR introduces the dropdown contextual menu for our upcoming Pipeline feature. At the moment the component is built in isolation due to the parent container not ready for integration.  The integration and test of this component will be followed up in a later PR.

## Usage
```jsx
import DropdownMenu, { DropdownButton } from '../DropdownMenu'
<DropdownMenu 
  label="View Options"
  closedLabel="Hide Options"
  isOpen={false}
  onClick={(nextState: Boolean) => toggleState(nextState)}
>
    <DropdownButton buttonColour="#dee0e2" buttonTextColour={BLACK}>
      Add to or remove from list
    </DropdownButton>
    <DropdownButton buttonColour="#dee0e2" buttonTextColour={BLACK}>
      Add to pipeline
    </DropdownButton>
</DropdownMenu>
```
As you can see there is also another component `<DropdownButton />` this is extending the styles gov-uk/react button to reduce the margin.

## Test instructions

Open storybook, `yarn storybook`, and you will see an example on the Dropdown menu.

## Screenshots

![image](https://user-images.githubusercontent.com/5575331/80960815-8672bf80-8e01-11ea-9e11-cf71f3c05dd8.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
