### PR TITLE
Add new SubTabNav component

### DIFF
--- a/src/client/components/SubTabNav/__stories__/SubTabNav.stories.jsx
+++ b/src/client/components/SubTabNav/__stories__/SubTabNav.stories.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import SubTabNav from 'SubTabNav'
+import exampleReadme from '../example.md'
+import usageReadme from '../usage.md'
+
+storiesOf('SubTabNav', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <SubTabNav
+      id="test-sub-tabs"
+      label="Tabs for scenario 1"
+      tabs={{
+        prospect: {
+          label: 'Prospect',
+          href: '#',
+          content: 'Content for prospect tab here',
+        },
+        active: {
+          label: 'Active',
+          href: '#',
+          content: 'Content for active tab here',
+        },
+        won: { label: 'Won', href: '#', content: 'Content for won tab here' },
+      }}
+    />
+  ))
+  .add('Second tab selected', () => (
+    <SubTabNav
+      id="test-sub-tabs-2"
+      label="Tabs for scenario 2"
+      selected="1"
+      tabs={[
+        {
+          label: 'Prospect',
+          href: '#',
+          content: 'Content for prospect tab here',
+        },
+        {
+          label: 'Active',
+          href: '#',
+          content: 'Content for active tab here',
+        },
+        { label: 'Won', href: '#', content: 'Content for won tab here' },
+      ]}
+    />
+  ))

--- a/src/client/components/SubTabNav/example.md
+++ b/src/client/components/SubTabNav/example.md
@@ -1,0 +1,6 @@
+### Import
+```js
+import SubTabNav from 'SubTabNav'
+```
+
+### Output

--- a/src/client/components/SubTabNav/index.jsx
+++ b/src/client/components/SubTabNav/index.jsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { WHITE, BLUE, GREY_2 } from 'govuk-colours'
+import { SPACING, FONT_SIZE } from '@govuk-react/constants'
+import Link from '@govuk-react/link'
+
+const StyledTabList = styled.ol`
+  padding: 0;
+  margin: 0 0 2px 0;
+  color: ${BLUE};
+  background-color: ${WHITE};
+  display: flex;
+  flex-direction: row;
+  flext-wrap: wrap;
+  justify-content: center;
+  justify-content: space-between;
+`
+const StyledTabItem = styled.li`
+  list-style: none;
+  font-size: ${FONT_SIZE.SIZE_24};
+  font-weight: normal;
+  display: inline-block;
+  line-height: 2;
+`
+
+const StyledTabPanel = styled.div`
+  margin: 0;
+  padding ${SPACING.SCALE_4} 0 0 0;
+  border-top: 1px solid ${GREY_2};
+`
+
+const StyledSpan = styled.span`
+  border-bottom: 8px solid ${BLUE};
+  padding-bottom: ${SPACING.SCALE_1};
+`
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+`
+
+function createId(id, key) {
+  return `sub-nav.${id}.${key}`
+}
+
+function SubTabNav({ id, label, selected, tabs, ...rest }) {
+  const tabList = Object.entries(tabs)
+  const selectedKey = selected || tabList[0][0]
+  const panelId = createId(id, selectedKey)
+  return (
+    <>
+      <StyledTabList {...rest} role="tablist" aria-label={label}>
+        {tabList.map(([key, { label, href }]) => {
+          const isSelected = selectedKey === key
+          const tabId = createId(id, key) + '.tab'
+          return (
+            <StyledTabItem
+              role="tab"
+              aria-selected={isSelected ? 'true' : 'false'}
+              id={tabId}
+              key={tabId}
+            >
+              {isSelected ? (
+                <StyledSpan>{label}</StyledSpan>
+              ) : (
+                <StyledLink href={href}>{label}</StyledLink>
+              )}
+            </StyledTabItem>
+          )
+        })}
+      </StyledTabList>
+      <StyledTabPanel
+        role="tabpanel"
+        tabIndex={0}
+        aria-labelledby={`tab.${panelId}`}
+        id={panelId}
+        key={panelId}
+      >
+        {tabs[selectedKey]?.content}
+      </StyledTabPanel>
+    </>
+  )
+}
+
+const tabPropType = PropTypes.shape({
+  label: PropTypes.node.isRequired,
+  href: PropTypes.string,
+  content: PropTypes.node,
+})
+
+SubTabNav.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired, //for the aria-label
+  selected: PropTypes.string,
+  tabs: PropTypes.oneOfType([
+    PropTypes.arrayOf(tabPropType),
+    PropTypes.objectOf(tabPropType),
+  ]).isRequired,
+}
+
+export default SubTabNav

--- a/src/client/components/SubTabNav/usage.md
+++ b/src/client/components/SubTabNav/usage.md
@@ -1,0 +1,43 @@
+SubTabNav
+=========
+
+### Description
+
+Used as a child of a `TabNav` component to have sub tabs to further split the content
+
+### Usage
+
+#### Object for tabs
+```jsx
+  <SubTabNav
+    id="test-sub-tabs"
+    label="My tabs"
+    tabs={{
+      tab1: { label: 'Tab 1', href: '#', content: 'Tab 1 content' },
+      tab2: { label: 'Tab 2', href: '#', content: 'Tab 2 content' },
+      tab3: { label: 'Tab 3', href: '#', content: 'Tab 3 content' },
+    }}
+  />
+```
+#### Array for tabs
+```jsx
+  <SubTabNav
+    id="test-array-sub-tabs"
+    label="My tabs using an array"
+    tabs={[
+      { label: 'Tab 1', href: '#', content: 'Tab 1 content' },
+      { label: 'Tab 2', href: '#', content: 'Tab 2 content' },
+      { label: 'Tab 3', href: '#', content: 'Tab 3 content' },
+    ]}
+  />
+```
+
+### Properties
+Prop        | Required | Default   | Type   | Description
+:---------- | :------- | :-------- | :----- | :----------
+ `id`       | true     |           | string | Used to generate ids for the sub components in the DOM
+ `label`    | true     |           | string | A human description of the tabs used in the `aria-label`
+ `tabs`     | true     |           | string | A object or array of tabs to show
+ `selected` | false    | first tab | string | The key of the selected tab (if using an object for the tabs). Index of the array item (if using an array for the tabs)
+
+


### PR DESCRIPTION
## Description of change

As part of the upcoming pipeline to the dashboard, this component is needed to provide sub tabs for the main `TabNav` tab. This is currently a simple component and will be fleshed out when used as part of the `TavNav` tab in an upcoming PR - along with functional tests.

## Test instructions

Run story book with `yarn storybook`

## Screenshots
<img width="742" alt="Screenshot 2020-05-05 at 15 43 15" src="https://user-images.githubusercontent.com/1481883/81079464-7df4b480-8ee7-11ea-8d56-bc864384264a.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
