### PR TITLE
Make the website field on company editable

### DIFF
--- a/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
+++ b/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
@@ -54,7 +54,8 @@ const CompanyMatched = ({
 
     <Paragraph>
       Changes will be reviewed by our third-party data supplier and updated.
-      Business description, region and sector are not updated by third parties.
+      Business description, website, region and sector are not updated by third
+      parties.
     </Paragraph>
   </>
 )

--- a/src/apps/companies/apps/edit-company/transformers.js
+++ b/src/apps/companies/apps/edit-company/transformers.js
@@ -15,7 +15,12 @@ const UNMATCHED_COMPANY_EDITABLE_FIELDS = [
   'address',
 ]
 
-const MATCHED_COMPANY_EDITABLE_FIELDS = ['description', 'uk_region', 'sector']
+const MATCHED_COMPANY_EDITABLE_FIELDS = [
+  'description',
+  'uk_region',
+  'sector',
+  'website',
+]
 
 const MATCHED_COMPANY_VERIFIABLE_FIELDS = [
   'name',
@@ -23,7 +28,6 @@ const MATCHED_COMPANY_VERIFIABLE_FIELDS = [
   'turnover',
   'trading_names',
   'vat_number',
-  'website',
   'address1',
   'address2',
   'city',

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -299,7 +299,7 @@ describe('Company edit', () => {
               .should(
                 'have.text',
                 'Changes will be reviewed by our third-party data' +
-                  ' supplier and updated. Business description, region and' +
+                  ' supplier and updated. Business description, website, region and' +
                   ' sector are not updated by third parties.'
               ),
         },


### PR DESCRIPTION
## Description of change

Make the website field editable on the frontend so instead of sending Zendesk ticket the field will be updated via API.

Depends on https://github.com/uktrade/data-hub-api/pull/2850

## Test instructions

1. Go to D&B company business details
2. Change the website
3. Changes should appear immediately

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
