### PR TITLE
#2 React company local header - add more tests

### DIFF
--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -107,7 +107,7 @@ router.get(
 )
 
 router.use(urls.companies.create.route, addCompanyFormRouter)
-router.use(urls.companies.lists.route, companyListsRouter)
+router.use(urls.companies.lists.index.route, companyListsRouter)
 router.use(urls.companies.edit.route, editCompanyFormRouter)
 router.use(urls.companies.editHistory.index.route, editHistoryRouter)
 router.use(urls.companies.pipeline.route, pipelineRouter)

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -299,6 +299,9 @@ function App() {
         <Mount selector="#company-local-header">
           {(props) => <CompanyLocalHeader {...props} />}
         </Mount>
+        <Mount selector="#company-local-header">
+          {(props) => <CompanyLocalHeader {...props} />}
+        </Mount>
       </ConnectedRouter>
     </Provider>
   )

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -218,6 +218,14 @@ describe('urls', () => {
         urls.companies.referrals.interactions.index(companyId, referralId)
       ).to.equal(`/companies/${companyId}/referrals/${referralId}/interactions`)
 
+      expect(urls.companies.lists.index(companyId)).to.equal(
+        `/companies/${companyId}/lists`
+      )
+
+      expect(urls.companies.lists.addRemove(companyId)).to.equal(
+        `/companies/${companyId}/lists/add-remove`
+      )
+
       expect(urls.companies.pipeline(companyId)).to.equal(
         `/companies/${companyId}/pipeline`
       )

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -87,7 +87,10 @@ module.exports = {
     detail: url('/companies', '/:companyId'),
     edit: url('/companies', '/:companyId/edit'),
     audit: url('/companies', '/:companyId/audit'),
-    lists: url('/companies', '/:companyId/lists'),
+    lists: {
+      index: url('/companies', '/:companyId/lists'),
+      addRemove: url('/companies', '/:companyId/lists/add-remove'),
+    },
     pipeline: url('/companies', '/:companyId/pipeline'),
     orders: url('/companies', '/:companyId/orders'),
     details: url('/companies', '/:companyId/details'),

--- a/src/templates/_layouts/template-no-local-header.njk
+++ b/src/templates/_layouts/template-no-local-header.njk
@@ -1,6 +1,6 @@
 {% extends "./template.njk" %}
 
-{% block local_header %}{% endblock %}
+{% block local_nav %}{% endblock %}
 
 {% block main %}
       {% block body %}{% endblock %}

--- a/test/functional/cypress/specs/companies/local-header/archived-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/archived-spec.js
@@ -1,0 +1,617 @@
+const selectors = require('../../../../../selectors')
+const { testBreadcrumbs } = require('../../../support/assertions')
+const fixtures = require('../../../fixtures')
+const urls = require('../../../../../../src/lib/urls')
+
+const companyLocalHeader = selectors.companyLocalHeader()
+
+const address = '16 Getabergsvagen, Geta, 22340, Malta'
+
+describe('Local header for archived company', () => {
+  context('when visting an archived company activity page', () => {
+    before(() => {
+      cy.visit(urls.companies.activity.index(fixtures.company.archivedLtd.id))
+    })
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.archivedLtd.name]: urls.companies.detail(
+        fixtures.company.archivedLtd.id
+      ),
+      'Activity Feed': null,
+    })
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.archivedLtd.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.archivedLtd.id
+        )}?returnUrl=${urls.companies.detail(fixtures.company.archivedLtd.id)}`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Global HQ')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+
+      cy.get(companyLocalHeader.description.paragraph(2))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    it('should display the archived message', () => {
+      cy.get(companyLocalHeader.archivedMessage)
+        .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+        .contains('Reason: Company is dissolved')
+        .contains('Unarchive')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.unarchive(fixtures.company.archivedLtd.id)
+        )
+    })
+  })
+  context('when visting an archived company contacts page', () => {
+    before(() => {
+      cy.visit(urls.companies.contacts(fixtures.company.archivedLtd.id))
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.archivedLtd.name]: urls.companies.detail(
+        fixtures.company.archivedLtd.id
+      ),
+      Contacts: null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.archivedLtd.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.archivedLtd.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.archivedLtd.id
+        )}/contacts?sortby=modified_on%3Adesc&archived=false`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Global HQ')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+
+      cy.get(companyLocalHeader.description.paragraph(2))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    it('should display the archived message', () => {
+      cy.get(companyLocalHeader.archivedMessage)
+        .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+        .contains('Reason: Company is dissolved')
+        .contains('Unarchive')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.unarchive(fixtures.company.archivedLtd.id)
+        )
+    })
+  })
+  context('when visting an archived company core team page', () => {
+    before(() => {
+      cy.visit(urls.companies.advisers.index(fixtures.company.archivedLtd.id))
+    })
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.archivedLtd.name]: urls.companies.detail(
+        fixtures.company.archivedLtd.id
+      ),
+      'Core Team': null,
+    })
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.archivedLtd.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.archivedLtd.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.archivedLtd.id
+        )}/advisers`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Global HQ')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+
+      cy.get(companyLocalHeader.description.paragraph(2))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    it('should display the archived message', () => {
+      cy.get(companyLocalHeader.archivedMessage)
+        .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+        .contains('Reason: Company is dissolved')
+        .contains('Unarchive')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.unarchive(fixtures.company.archivedLtd.id)
+        )
+    })
+  })
+  context('when visting an archived company investment projects page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.investments.companyInvestment(
+          fixtures.company.archivedLtd.id
+        )
+      )
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.archivedLtd.name]: urls.companies.detail(
+        fixtures.company.archivedLtd.id
+      ),
+      Investment: null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.archivedLtd.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.archivedLtd.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.archivedLtd.id
+        )}/investments/projects`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Global HQ')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+      cy.get(companyLocalHeader.description.paragraph(2))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    it('should display the archived message', () => {
+      cy.get(companyLocalHeader.archivedMessage)
+        .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+        .contains('Reason: Company is dissolved')
+        .contains('Unarchive')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.unarchive(fixtures.company.archivedLtd.id)
+        )
+    })
+  })
+  context(
+    'when visting an archived company investment large capital page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.investments.largeCapitalProfile(
+            fixtures.company.archivedLtd.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.archivedLtd.name]: urls.companies.detail(
+          fixtures.company.archivedLtd.id
+        ),
+        Investment: null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.archivedLtd.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.archivedLtd.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.archivedLtd.id
+          )}/investments/large-capital-profile`
+        )
+      })
+
+      it('should display an "Ultimate HQ" badge', () => {
+        cy.get(companyLocalHeader.badge).contains('Global HQ')
+      })
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1)).contains(
+          'This is an account managed company (One List Tier A - Strategic Account)'
+        )
+
+        cy.get(companyLocalHeader.description.paragraph(2))
+          .contains('Global Account Manager: Travis Greene View core team')
+          .contains('View core team')
+          .should(
+            'have.attr',
+            'href',
+            urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+          )
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+        )
+      })
+
+      it('should display the archived message', () => {
+        cy.get(companyLocalHeader.archivedMessage)
+          .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+          .contains('Reason: Company is dissolved')
+          .contains('Unarchive')
+          .should(
+            'have.attr',
+            'href',
+            urls.companies.unarchive(fixtures.company.archivedLtd.id)
+          )
+      })
+    }
+  )
+  context('when visting an archived company export page', () => {
+    before(() => {
+      cy.visit(urls.companies.exports.index(fixtures.company.archivedLtd.id))
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.archivedLtd.name]: urls.companies.detail(
+        fixtures.company.archivedLtd.id
+      ),
+      Exports: null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.archivedLtd.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.archivedLtd.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.archivedLtd.id
+        )}/exports`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Global HQ')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+
+      cy.get(companyLocalHeader.description.paragraph(2))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    it('should display the archived message', () => {
+      cy.get(companyLocalHeader.archivedMessage)
+        .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+        .contains('Reason: Company is dissolved')
+        .contains('Unarchive')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.unarchive(fixtures.company.archivedLtd.id)
+        )
+    })
+  })
+  context('when visting an archived company export history page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.exports.history.index(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.archivedLtd.name]: urls.companies.detail(
+        fixtures.company.archivedLtd.id
+      ),
+      Exports: urls.companies.exports.index(fixtures.company.archivedLtd.id),
+      'Export countries history': null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.archivedLtd.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.archivedLtd.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.archivedLtd.id
+        )}/exports/history`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Global HQ')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+
+      cy.get(companyLocalHeader.description.paragraph(2))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    it('should display the archived message', () => {
+      cy.get(companyLocalHeader.archivedMessage)
+        .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+        .contains('Reason: Company is dissolved')
+        .contains('Unarchive')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.unarchive(fixtures.company.archivedLtd.id)
+        )
+    })
+  })
+  context('when visting an archived company orders page', () => {
+    before(() => {
+      cy.visit(urls.companies.orders(fixtures.company.archivedLtd.id))
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.archivedLtd.name]: urls.companies.detail(
+        fixtures.company.archivedLtd.id
+      ),
+      'Orders (OMIS)': null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.archivedLtd.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.archivedLtd.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.archivedLtd.id
+        )}/orders`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Global HQ')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+
+      cy.get(companyLocalHeader.description.paragraph(2))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.archivedLtd.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.archivedLtd.id)
+      )
+    })
+
+    it('should display the archived message', () => {
+      cy.get(companyLocalHeader.archivedMessage)
+        .contains('This company was archived on 06 Jul 2018 by John Rogers.')
+        .contains('Reason: Company is dissolved')
+        .contains('Unarchive')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.unarchive(fixtures.company.archivedLtd.id)
+        )
+    })
+  })
+})

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -1,0 +1,703 @@
+const selectors = require('../../../../../selectors')
+const { testBreadcrumbs } = require('../../../support/assertions')
+const fixtures = require('../../../fixtures')
+const urls = require('../../../../../../src/lib/urls')
+
+const companyLocalHeader = selectors.companyLocalHeader()
+
+const address =
+  '1700 Amphitheatre Way, Mountain Range, 95543-1771, United States'
+
+describe('Local header for global ultimate company', () => {
+  context('when visting a global ultimate company activity page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.activity.index(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+        fixtures.company.dnbGlobalUltimate.id
+      ),
+      'Activity Feed': null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.dnbGlobalUltimate.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.dnbGlobalUltimate.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        )}`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+    })
+
+    it('should display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList)
+        .should('contain', 'What does this mean?')
+        .should(
+          'contain',
+          'This HQ is in control of all related company records for DnB Global Ultimate'
+        )
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1))
+        .contains(
+          'Data Hub contains 2 other company records related to this company'
+        )
+        .contains('2 other company records')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.dnbHierarchy.index(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      cy.get(companyLocalHeader.description.paragraph(2)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+      cy.get(companyLocalHeader.description.paragraph(3))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+  })
+  context('when visting a global ultimate company contacts page', () => {
+    before(() => {
+      cy.visit(urls.companies.contacts(fixtures.company.dnbGlobalUltimate.id))
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+        fixtures.company.dnbGlobalUltimate.id
+      ),
+      Contacts: null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.dnbGlobalUltimate.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.dnbGlobalUltimate.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        )}/contacts?sortby=modified_on%3Adesc&archived=false`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+    })
+
+    it('should display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList)
+        .should('contain', 'What does this mean?')
+        .should(
+          'contain',
+          'This HQ is in control of all related company records for DnB Global Ultimate'
+        )
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1))
+        .contains(
+          'Data Hub contains 2 other company records related to this company'
+        )
+        .contains('2 other company records')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.dnbHierarchy.index(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      cy.get(companyLocalHeader.description.paragraph(2)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+      cy.get(companyLocalHeader.description.paragraph(3))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+  })
+  context('when visting a global ultimate company core team page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+        fixtures.company.dnbGlobalUltimate.id
+      ),
+      'Core Team': null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.dnbGlobalUltimate.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.dnbGlobalUltimate.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        )}/advisers`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+    })
+
+    it('should display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList)
+        .should('contain', 'What does this mean?')
+        .should(
+          'contain',
+          'This HQ is in control of all related company records for DnB Global Ultimate'
+        )
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1))
+        .contains(
+          'Data Hub contains 2 other company records related to this company'
+        )
+        .contains('2 other company records')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.dnbHierarchy.index(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      cy.get(companyLocalHeader.description.paragraph(2)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+      cy.get(companyLocalHeader.description.paragraph(3))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+  })
+  context(
+    'when visting a global ultimate company investment projects page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.investments.companyInvestment(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        ),
+        Investment: null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.dnbGlobalUltimate.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.dnbGlobalUltimate.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.dnbGlobalUltimate.id
+          )}/investments/projects`
+        )
+      })
+
+      it('should display an "Ultimate HQ" badge', () => {
+        cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+      })
+
+      it('should display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList)
+          .should('contain', 'What does this mean?')
+          .should(
+            'contain',
+            'This HQ is in control of all related company records for DnB Global Ultimate'
+          )
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1))
+          .contains(
+            'Data Hub contains 2 other company records related to this company'
+          )
+          .contains('2 other company records')
+          .should(
+            'have.attr',
+            'href',
+            urls.companies.dnbHierarchy.index(
+              fixtures.company.dnbGlobalUltimate.id
+            )
+          )
+        cy.get(companyLocalHeader.description.paragraph(2)).contains(
+          'This is an account managed company (One List Tier A - Strategic Account)'
+        )
+        cy.get(companyLocalHeader.description.paragraph(3))
+          .contains('Global Account Manager: Travis Greene View core team')
+          .contains('View core team')
+          .should(
+            'have.attr',
+            'href',
+            urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+          )
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+        )
+      })
+    }
+  )
+  context(
+    'when visting a global ultimate company investment large capital page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.investments.largeCapitalProfile(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        ),
+        Investment: null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.dnbGlobalUltimate.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.dnbGlobalUltimate.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.dnbGlobalUltimate.id
+          )}/investments/large-capital-profile`
+        )
+      })
+
+      it('should display an "Ultimate HQ" badge', () => {
+        cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+      })
+
+      it('should display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList)
+          .should('contain', 'What does this mean?')
+          .should(
+            'contain',
+            'This HQ is in control of all related company records for DnB Global Ultimate'
+          )
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1))
+          .contains(
+            'Data Hub contains 2 other company records related to this company'
+          )
+          .contains('2 other company records')
+          .should(
+            'have.attr',
+            'href',
+            urls.companies.dnbHierarchy.index(
+              fixtures.company.dnbGlobalUltimate.id
+            )
+          )
+        cy.get(companyLocalHeader.description.paragraph(2)).contains(
+          'This is an account managed company (One List Tier A - Strategic Account)'
+        )
+        cy.get(companyLocalHeader.description.paragraph(3))
+          .contains('Global Account Manager: Travis Greene View core team')
+          .contains('View core team')
+          .should(
+            'have.attr',
+            'href',
+            urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+          )
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+        )
+      })
+    }
+  )
+  context('when visting a global ultimate company export page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.exports.index(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+        fixtures.company.dnbGlobalUltimate.id
+      ),
+      Exports: null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.dnbGlobalUltimate.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.dnbGlobalUltimate.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        )}/exports`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+    })
+
+    it('should display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList)
+        .should('contain', 'What does this mean?')
+        .should(
+          'contain',
+          'This HQ is in control of all related company records for DnB Global Ultimate'
+        )
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1))
+        .contains(
+          'Data Hub contains 2 other company records related to this company'
+        )
+        .contains('2 other company records')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.dnbHierarchy.index(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      cy.get(companyLocalHeader.description.paragraph(2)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+      cy.get(companyLocalHeader.description.paragraph(3))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+  })
+  context('when visting a global ultimate company export history page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.exports.history.index(
+          fixtures.company.dnbGlobalUltimate.id
+        )
+      )
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+        fixtures.company.dnbGlobalUltimate.id
+      ),
+      Exports: urls.companies.exports.index(
+        fixtures.company.dnbGlobalUltimate.id
+      ),
+      'Export countries history': null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.dnbGlobalUltimate.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.dnbGlobalUltimate.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        )}/exports/history`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+    })
+
+    it('should display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList)
+        .should('contain', 'What does this mean?')
+        .should(
+          'contain',
+          'This HQ is in control of all related company records for DnB Global Ultimate'
+        )
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1))
+        .contains(
+          'Data Hub contains 2 other company records related to this company'
+        )
+        .contains('2 other company records')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.dnbHierarchy.index(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      cy.get(companyLocalHeader.description.paragraph(2)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+      cy.get(companyLocalHeader.description.paragraph(3))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+  })
+  context('when visting a global ultimate company orders page', () => {
+    before(() => {
+      cy.visit(urls.companies.orders(fixtures.company.dnbGlobalUltimate.id))
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.dnbGlobalUltimate.name]: urls.companies.detail(
+        fixtures.company.dnbGlobalUltimate.id
+      ),
+      'Orders (OMIS)': null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.dnbGlobalUltimate.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.dnbGlobalUltimate.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.dnbGlobalUltimate.id
+        )}/orders`
+      )
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      cy.get(companyLocalHeader.badge).contains('Ultimate HQ')
+    })
+
+    it('should display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList)
+        .should('contain', 'What does this mean?')
+        .should(
+          'contain',
+          'This HQ is in control of all related company records for DnB Global Ultimate'
+        )
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1))
+        .contains(
+          'Data Hub contains 2 other company records related to this company'
+        )
+        .contains('2 other company records')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.dnbHierarchy.index(
+            fixtures.company.dnbGlobalUltimate.id
+          )
+        )
+      cy.get(companyLocalHeader.description.paragraph(2)).contains(
+        'This is an account managed company (One List Tier A - Strategic Account)'
+      )
+      cy.get(companyLocalHeader.description.paragraph(3))
+        .contains('Global Account Manager: Travis Greene View core team')
+        .contains('View core team')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.advisers.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.dnbGlobalUltimate.id)
+      )
+    })
+  })
+})

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -1,0 +1,564 @@
+const selectors = require('../../../../../selectors')
+const { testBreadcrumbs } = require('../../../support/assertions')
+const fixtures = require('../../../fixtures')
+const urls = require('../../../../../../src/lib/urls')
+
+const companyLocalHeader = selectors.companyLocalHeader()
+
+const address = 'Unit 10, Ockham Drive, GREENFORD, UB6 0F2, United Kingdom'
+
+describe('Local header for company under dnb investigation', () => {
+  context(
+    'when visting a company under dnb investigation activity page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.activity.index(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.investigationLimited.name]: urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        ),
+        'Activity Feed': null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.investigationLimited.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.investigationLimited.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.investigationLimited.id
+          )}`
+        )
+      })
+
+      it('should not display a badge', () => {
+        cy.get(companyLocalHeader.badge).should('not.exist')
+      })
+
+      it('should not display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList).should('not.exist')
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      it('should display the investigation message', () => {
+        cy.get(companyLocalHeader.investigationMessage).contains(
+          'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+        )
+      })
+    }
+  )
+  context(
+    'when visting a company under dnb investigation contacts page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.contacts(fixtures.company.investigationLimited.id)
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.investigationLimited.name]: urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        ),
+        Contacts: null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.investigationLimited.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.investigationLimited.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.investigationLimited.id
+          )}/contacts?sortby=modified_on%3Adesc&archived=false`
+        )
+      })
+
+      it('should not display a badge', () => {
+        cy.get(companyLocalHeader.badge).should('not.exist')
+      })
+
+      it('should not display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList).should('not.exist')
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      it('should display the investigation message', () => {
+        cy.get(companyLocalHeader.investigationMessage).contains(
+          'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+        )
+      })
+    }
+  )
+  context(
+    'when visting a company under dnb investigation lead adviser page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.advisers.index(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.investigationLimited.name]: urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        ),
+        'Lead adviser': null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.investigationLimited.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.investigationLimited.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.investigationLimited.id
+          )}/advisers`
+        )
+      })
+
+      it('should not display a badge', () => {
+        cy.get(companyLocalHeader.badge).should('not.exist')
+      })
+
+      it('should not display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList).should('not.exist')
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      it('should display the investigation message', () => {
+        cy.get(companyLocalHeader.investigationMessage).contains(
+          'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+        )
+      })
+    }
+  )
+  context(
+    'when visting a company under dnb investigation investment projects page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.investments.companyInvestment(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.investigationLimited.name]: urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        ),
+        Investment: null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.investigationLimited.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.investigationLimited.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.investigationLimited.id
+          )}/investments/projects`
+        )
+      })
+
+      it('should not display a badge', () => {
+        cy.get(companyLocalHeader.badge).should('not.exist')
+      })
+
+      it('should not display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList).should('not.exist')
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      it('should display the investigation message', () => {
+        cy.get(companyLocalHeader.investigationMessage).contains(
+          'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+        )
+      })
+    }
+  )
+  context(
+    'when visting a company under dnb investigation investment large capital page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.investments.largeCapitalProfile(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.investigationLimited.name]: urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        ),
+        Investment: null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.investigationLimited.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.investigationLimited.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.investigationLimited.id
+          )}/investments/large-capital-profile`
+        )
+      })
+
+      it('should not display a badge', () => {
+        cy.get(companyLocalHeader.badge).should('not.exist')
+      })
+
+      it('should not display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList).should('not.exist')
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      it('should display the investigation message', () => {
+        cy.get(companyLocalHeader.investigationMessage).contains(
+          'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+        )
+      })
+    }
+  )
+  context('when visting a company under dnb investigation export page', () => {
+    before(() => {
+      cy.visit(
+        urls.companies.exports.index(fixtures.company.investigationLimited.id)
+      )
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.investigationLimited.name]: urls.companies.detail(
+        fixtures.company.investigationLimited.id
+      ),
+      Exports: null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.investigationLimited.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.investigationLimited.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        )}/exports`
+      )
+    })
+
+    it('should not display a badge', () => {
+      cy.get(companyLocalHeader.badge).should('not.exist')
+    })
+
+    it('should not display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList).should('not.exist')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.investigationLimited.id)
+      )
+    })
+
+    it('should display the investigation message', () => {
+      cy.get(companyLocalHeader.investigationMessage).contains(
+        'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+      )
+    })
+  })
+  context(
+    'when visting a company under dnb investigation export history page',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.exports.history.index(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      testBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [fixtures.company.investigationLimited.name]: urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        ),
+        Exports: urls.companies.exports.index(
+          fixtures.company.investigationLimited.id
+        ),
+        'Export countries history': null,
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.investigationLimited.name
+        )
+      })
+
+      it('should display the company address', () => {
+        cy.get(companyLocalHeader.address).contains(address)
+      })
+
+      it('should display the correct buttons', () => {
+        cy.contains('Add to or remove from lists').should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.investigationLimited.id
+          )}?returnUrl=${urls.companies.detail(
+            fixtures.company.investigationLimited.id
+          )}/exports/history`
+        )
+      })
+
+      it('should not display a badge', () => {
+        cy.get(companyLocalHeader.badge).should('not.exist')
+      })
+
+      it('should not display "What does this mean?" details', () => {
+        cy.get(companyLocalHeader.metaList).should('not.exist')
+      })
+
+      it('should display the correct description', () => {
+        cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+      })
+
+      it('should display the link to the full business details', () => {
+        cy.contains('View full business details').should(
+          'have.attr',
+          'href',
+          urls.companies.businessDetails(
+            fixtures.company.investigationLimited.id
+          )
+        )
+      })
+
+      it('should display the investigation message', () => {
+        cy.get(companyLocalHeader.investigationMessage).contains(
+          'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+        )
+      })
+    }
+  )
+  context('when visting a company under dnb investigation orders page', () => {
+    before(() => {
+      cy.visit(urls.companies.orders(fixtures.company.investigationLimited.id))
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [fixtures.company.investigationLimited.name]: urls.companies.detail(
+        fixtures.company.investigationLimited.id
+      ),
+      'Orders (OMIS)': null,
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.investigationLimited.name
+      )
+    })
+
+    it('should display the company address', () => {
+      cy.get(companyLocalHeader.address).contains(address)
+    })
+
+    it('should display the correct buttons', () => {
+      cy.contains('Add to or remove from lists').should(
+        'have.attr',
+        'href',
+        `${urls.companies.lists.addRemove(
+          fixtures.company.investigationLimited.id
+        )}?returnUrl=${urls.companies.detail(
+          fixtures.company.investigationLimited.id
+        )}/orders`
+      )
+    })
+
+    it('should not display a badge', () => {
+      cy.get(companyLocalHeader.badge).should('not.exist')
+    })
+
+    it('should not display "What does this mean?" details', () => {
+      cy.get(companyLocalHeader.metaList).should('not.exist')
+    })
+
+    it('should display the correct description', () => {
+      cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
+    })
+
+    it('should display the link to the full business details', () => {
+      cy.contains('View full business details').should(
+        'have.attr',
+        'href',
+        urls.companies.businessDetails(fixtures.company.investigationLimited.id)
+      )
+    })
+
+    it('should display the investigation message', () => {
+      cy.get(companyLocalHeader.investigationMessage).contains(
+        'This company record is based on information that has not yet been validated. This information is currently being checked by the Data Hub support team.'
+      )
+    })
+  })
+})

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -451,6 +451,11 @@ Sandbox.define(
   'PATCH',
   v4Company.exportDetail
 )
+Sandbox.define(
+  '/v4/company/{companyId}/one-list-group-core-team',
+  'GET',
+  v4Company.getOneListGroupCoreTeam
+)
 
 // V4 DnB
 Sandbox.define('/v4/dnb/company-create', 'POST', v4Dnb.companyCreate)

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -37,6 +37,8 @@ var largeCapitalProfileList20 = require('../../../fixtures/v4/investment/large-c
 var referralDetails = require('../../../fixtures/v4/referrals/referral-details.json')
 var referralDetailsNoContact = require('../../../fixtures/v4/referrals/referral-details-no-contact.json')
 
+var oneListGroupCoreTeam = require('../../../fixtures/v4/company/one-list-group-core-team.json')
+
 var ReferralIds = require('../../../constants/referrals')
 
 state.investor_description = state.investor_description || ''
@@ -215,4 +217,8 @@ exports.exportDetail = function(req, res) {
   } else {
     res.send('')
   }
+}
+
+exports.getOneListGroupCoreTeam = function(req, res) {
+  res.json(oneListGroupCoreTeam)
 }


### PR DESCRIPTION
## Description of change

This PR implements add more thorough tests to the React company local header which was brought in with two previous PRs - https://github.com/uktrade/data-hub-frontend/pull/2647 & https://github.com/uktrade/data-hub-frontend/pull/2653 - and then implemented in https://github.com/uktrade/data-hub-frontend/pull/2657

Because of the significant changes in architecture and the lack of functional testing around this part of the site I have split the work into two sister PRs. This one and https://github.com/uktrade/data-hub-frontend/pull/2657

This PR contains more tests to extensively test the company local header. This part of the site wasn't tested well with functional tests previously and when it was tested it was spread sporadically across many different areas. This PR concentrates the tests in three specs for three different types of company - global ultimate, archived and under DnB investigation.

For context - I've undertaken this work to be able to add a new button to the company local header. So to avoid adding to the legacy nunjucks template I have ported this part of the site into React. 

## Test instructions

Navigate to any company page to see the header in action. 

## Screenshots

No visual changes. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
