### PR TITLE
Add project name input to form

### DIFF
--- a/src/apps/pipeline/client/AddToPipelineForm.jsx
+++ b/src/apps/pipeline/client/AddToPipelineForm.jsx
@@ -26,7 +26,7 @@ import urls from '../../../lib/urls'
 
 function isOnPipeline(pipelineStatus, companyId) {
   if (pipelineStatus?.companyId === companyId) {
-    return Boolean(pipelineStatus.count)
+    return !!pipelineStatus.count
   }
   return null
 }
@@ -48,13 +48,13 @@ function PipelineCheck({
   if (getPipelineByCompany.error) {
     return (
       <ErrorSummary
-        heading={`There was an error checking the status of ${companyName}`}
-        description={getPipelineByCompany.errorMessage}
-        errors={[]}
+        heading="There is a problem"
+        description={`There was an error checking the status of ${companyName}`}
+        errors={[getPipelineByCompany.errorMessage]}
       />
     )
   }
-  if (onPipeline == null) {
+  if (onPipeline === null) {
     return <ProgressIndicator message="checking pipeline..." />
   }
   return (
@@ -97,9 +97,9 @@ function AddToPipelineForm({
           <>
             {addCompanyToPipeline.error && (
               <ErrorSummary
-                heading={`There was an error adding ${companyName} to a pipeline`}
-                description={addCompanyToPipeline.errorMessage}
-                errors={[]}
+                heading="There is a problem"
+                description={`There was an error adding ${companyName} to a pipeline`}
+                errors={[addCompanyToPipeline.errorMessage]}
               />
             )}
             <PipelineCheck
@@ -120,7 +120,7 @@ function AddToPipelineForm({
                 >
                   <FieldInput
                     name="name"
-                    label="Give a project name (Optional)"
+                    label="Project name (Optional)"
                     type="text"
                   />
                   <FieldRadios

--- a/src/apps/pipeline/client/AddToPipelineForm.jsx
+++ b/src/apps/pipeline/client/AddToPipelineForm.jsx
@@ -2,7 +2,12 @@ import React, { useEffect } from 'react'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import ErrorSummary from '@govuk-react/error-summary'
-import { FormStateful, FieldRadios, FormActions } from 'data-hub-components'
+import {
+  FormStateful,
+  FieldRadios,
+  FormActions,
+  FieldInput,
+} from 'data-hub-components'
 import { connect } from 'react-redux'
 import Task from '../../../client/components/Task'
 import LoadingBox from '@govuk-react/loading-box'
@@ -113,6 +118,11 @@ function AddToPipelineForm({
                   }}
                   submissionError={addCompanyToPipeline.errorMessage}
                 >
+                  <FieldInput
+                    name="name"
+                    label="Give a project name (Optional)"
+                    type="text"
+                  />
                   <FieldRadios
                     name="category"
                     label="Choose a status"

--- a/src/apps/pipeline/client/tasks.js
+++ b/src/apps/pipeline/client/tasks.js
@@ -2,13 +2,13 @@ import axios from 'axios'
 import urls from '../../../lib/urls'
 
 export async function getPipelineByCompany({ companyId }) {
-  const pipelineItemRes = await axios.get(
+  const { data } = await axios.get(
     `/api-proxy/v4/pipeline-item?company_id=${companyId}`
   )
   return {
     companyId,
-    count: pipelineItemRes.data.count,
-    results: pipelineItemRes.data.results,
+    count: data.count,
+    results: data.results,
   }
 }
 
@@ -16,6 +16,7 @@ export async function addCompanyToPipeline({ values, companyId, csrfToken }) {
   await axios.post(
     `${urls.companies.pipeline(companyId, { _csrf: csrfToken })}`,
     {
+      company: companyId,
       name: values.name,
       status: values.category,
     }

--- a/src/apps/pipeline/client/tasks.js
+++ b/src/apps/pipeline/client/tasks.js
@@ -16,7 +16,7 @@ export async function addCompanyToPipeline({ values, companyId, csrfToken }) {
   await axios.post(
     `${urls.companies.pipeline(companyId, { _csrf: csrfToken })}`,
     {
-      name: null,
+      name: values.name,
       status: values.category,
     }
   )

--- a/src/apps/pipeline/controllers/add.js
+++ b/src/apps/pipeline/controllers/add.js
@@ -17,15 +17,11 @@ function renderAddToPipeline(req, res) {
 }
 
 async function addCompanyToPipeline(req, res) {
-  const { company } = res.locals
   try {
     const response = await authorisedRequest(req.session.token, {
       url: `${config.apiRoot}/v4/pipeline-item`,
       method: 'POST',
-      body: {
-        company: company.id,
-        ...req.body,
-      },
+      body: req.body,
     })
     req.flash('success', 'Pipeline changes for this company have been saved')
     return res.send(response)

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -35,7 +35,7 @@ describe('Company add to pipeline form', () => {
       cy.get('#field-name').then((element) => {
         assertFieldInput({
           element,
-          label: 'Give a project name (Optional)',
+          label: 'Project name (Optional)',
           optionsCount: 3,
         })
       })
@@ -89,7 +89,7 @@ describe('Company add to pipeline form', () => {
       cy.get('#field-name').then((element) => {
         assertFieldInput({
           element,
-          label: 'Give a project name (Optional)',
+          label: 'Project name (Optional)',
           optionsCount: 3,
         })
       })
@@ -124,7 +124,7 @@ describe('Company add to pipeline form', () => {
       cy.get('#field-name').then((element) => {
         assertFieldInput({
           element,
-          label: 'Give a project name (Optional)',
+          label: 'Project name (Optional)',
           optionsCount: 3,
         })
       })

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -5,6 +5,7 @@ const {
   assertFieldRadios,
   assertBreadcrumbs,
   assertFormButtons,
+  assertFieldInput,
 } = require('../../support/assertions')
 const selectors = require('../../../../selectors')
 
@@ -28,6 +29,16 @@ describe('Company add to pipeline form', () => {
         'have.text',
         `Add ${minimallyMinimal.name} to your pipeline`
       )
+    })
+
+    it('should render the project name text input', () => {
+      cy.get('#field-name').then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Give a project name (Optional)',
+          optionsCount: 3,
+        })
+      })
     })
 
     it('should render the status radio buttons', () => {
@@ -74,6 +85,16 @@ describe('Company add to pipeline form', () => {
       cy.contains(`${lambdaPlc.name} is already in your pipeline`)
     })
 
+    it('should render the project name text input', () => {
+      cy.get('#field-name').then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Give a project name (Optional)',
+          optionsCount: 3,
+        })
+      })
+    })
+
     it('should render the status radio buttons', () => {
       cy.get('#field-category').then((element) => {
         assertFieldRadios({
@@ -88,6 +109,7 @@ describe('Company add to pipeline form', () => {
     beforeEach(() => {
       cy.visit(urls.companies.pipeline(minimallyMinimal.id))
     })
+
     it('should render the status radio buttons', () => {
       cy.get('#field-category').then((element) => {
         assertFieldRadios({
@@ -97,6 +119,17 @@ describe('Company add to pipeline form', () => {
         })
       })
     })
+
+    it('should render the project name text input', () => {
+      cy.get('#field-name').then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Give a project name (Optional)',
+          optionsCount: 3,
+        })
+      })
+    })
+
     it('should redirect to dashboard with a flash message', () => {
       cy.get('input[value=win').click()
       cy.contains('button', 'Add').click()


### PR DESCRIPTION
## Description of change

This PR adds project name field to the Pipeline form. The PR is also dependant on https://github.com/uktrade/data-hub-frontend/pull/2661 and can only be merged after.

This is part of yellow team's mission work for this quarter to build functionality that allows users to add companies to three defined statuses - lead, in progress and win - in a single pipeline. This will work in a similar way to the existing company list feature.

The url for this page is not linked anywhere on the site.

## Test instructions

When you navigate to /companies/Company:ID/pipeline. You will see a form with a project name text put added to it.
## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/81583805-c873a680-93a9-11ea-9bee-09503979abd0.png)




### After
![image](https://user-images.githubusercontent.com/5575331/81583876-e3461b00-93a9-11ea-8958-cc8feefa3696.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
