### PR TITLE
Change the content around asking for policy feedback

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -9,6 +9,10 @@ import axios from 'axios'
 import { GREY_1 } from 'govuk-colours'
 import styled from 'styled-components'
 
+import PropTypes from 'prop-types'
+import { throttle } from 'lodash'
+import axios from 'axios'
+
 import {
   FieldCheckboxes,
   FieldDate,
@@ -255,7 +259,7 @@ const StepInteractionDetails = ({
       <FieldRadios
         inline={true}
         name="was_policy_feedback_provided"
-        label="Did the contact give any feedback on government policy?"
+        label="Did the contact provide feedback on government policy or business intelligence?"
         options={OPTIONS_YES_NO}
         required="Answer if the contact gave any feedback on government policy"
       />

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -9,10 +9,6 @@ import axios from 'axios'
 import { GREY_1 } from 'govuk-colours'
 import styled from 'styled-components'
 
-import PropTypes from 'prop-types'
-import { throttle } from 'lodash'
-import axios from 'axios'
-
 import {
   FieldCheckboxes,
   FieldDate,

--- a/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
@@ -94,7 +94,8 @@ const ELEMENT_NOTES = {
   assert: assertFieldTextarea,
 }
 const ELEMENT_FEEDBACK_POLICY = {
-  label: 'Did the contact give any feedback on government policy?',
+  label:
+    'Did the contact provide feedback on government policy or business intelligence?',
   assert: assertFieldRadios,
   optionsCount: 2,
 }


### PR DESCRIPTION
## Description of change

This is a content change to the question around policy feedback.

## Test instructions

Go to add an interaction, scroll down to the option to add policy feedback and you should see the new content (refer to screenshots below)

## Screenshots
### Before
![Screenshot 2020-05-13 at 09 29 24](https://user-images.githubusercontent.com/10154302/81789997-ab032180-94fc-11ea-8b8d-4b93ce100d26.png)

### After
![Screenshot 2020-05-18 at 10 48 32](https://user-images.githubusercontent.com/10154302/82213928-dc208f00-990c-11ea-9935-e074d296a509.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
