### PR TITLE
Do not remove the Form fieldName when it's an empty String

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "5.5.1",
+    "data-hub-components": "5.5.2",
     "date-fns": "^1.29.0",
     "del-cli": "^3.0.0",
     "dotenv": "^8.2.0",

--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -60,12 +60,6 @@ export default (
         fields: omit(state.fields, action.fieldName),
       }
     case FORM__FIELD_SET_VALUE:
-      if (action.fieldValue === '') {
-        return {
-          ...state,
-          values: omit(state.values, action.fieldName),
-        }
-      }
       return {
         ...state,
         values: {


### PR DESCRIPTION
## Description of change
This PR removes code that prevents an empty string field value from being added to the form state. This code would cause a bug where if an optional field had a value entered into it and saved, then later the user edited that field again and cleared the value, this input would not be updated. 

Similar changes have been made [in the components library](https://github.com/uktrade/data-hub-components/pull/299). Due to the components library being updated too, this PR also includes a version bump of the data-hub-components dependency. 

A visual example of what I'm on about: 

Before
```javascript
// Form values
const values: { a: '', b: 'foo' }
// Strip out any object key when the value is an empty string.
const values: { b: 'foo' }
```
After
```javascript
// Form values
const values: { a: '', b: 'foo' } 
// Keep all keys where the corresponding value is an empty string
const values: { a: '', b: 'foo' }

``` 

## Test instructions
On master - navigate to the interactions tab, then click on an interaction and edit it. Fill out all the fields including the notes text area. Click save, and you'll notice all is fine. Edit that same interaction again and clear out the notes text area. Click save, and you'll see it does not update. 

On this branch - do the same as above, however you should notice that once you clear the notes text area and save, the notes do not appear in the table row (as there's nothing to show cause it's updated your empty value).

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
