### PR TITLE
Set flash message in session storage

### DIFF
--- a/src/apps/investments/views/admin/client/InvestmentProjectAdmin.jsx
+++ b/src/apps/investments/views/admin/client/InvestmentProjectAdmin.jsx
@@ -11,6 +11,7 @@ import Task from '../../../../../client/components/Task'
 import { ID as STATE_ID, TASK_UPDATE_STAGE, state2props } from './state'
 import { INVESTMENT_PROJECT_ADMIN__UPDATE_STAGE } from '../../../../../client/actions'
 import urls from '../../../../../lib/urls'
+import flashUtils from '../../../../../client/utils/flash-messages'
 
 const StyledP = styled('p')`
   margin-bottom: ${SPACING.SCALE_2};
@@ -24,8 +25,10 @@ const InvestmentProjectAdmin = ({
   stageUpdated,
 }) => {
   useEffect(() => {
-    stageUpdated &&
-      (window.location.href = urls.investments.projects.project(projectId))
+    if (stageUpdated) {
+      flashUtils.addSuccessMessage('Project stage saved')
+      window.location.href = urls.investments.projects.project(projectId)
+    }
   }, [stageUpdated])
   const newStageOptions = stages.filter(
     (stage) => stage.value != projectStage.id

--- a/src/client/components/LocalHeader/FlashMessages.jsx
+++ b/src/client/components/LocalHeader/FlashMessages.jsx
@@ -7,6 +7,7 @@ import { FONT_WEIGHTS } from '@govuk-react/constants/lib/typography'
 import { FONT_SIZE } from '@govuk-react/constants'
 import UnorderedList from '@govuk-react/unordered-list'
 import { StatusMessage } from 'data-hub-components'
+import flashUtils from '../../utils/flash-messages'
 
 const StyledBody = styled('p')`
   margin-bottom: 0;
@@ -32,31 +33,43 @@ const messageColours = {
   muted: BLACK,
 }
 
-const FlashMessages = ({ flashMessages }) => (
-  <UnorderedList listStyleType="none" data-auto-id="flash">
-    {Object.entries(flashMessages).map(([type, message]) => {
-      const parts = String(type).split(':')
-      return parts.length > 1
-        ? message.map((message) => (
-            <li key={message.body}>
-              <StatusMessage colour={messageColours[parts[0]]}>
-                <StyledHeading>{message.heading}</StyledHeading>
-                <StyledBody
-                  dangerouslySetInnerHTML={{ __html: message.body }}
-                />
-              </StatusMessage>
-            </li>
-          ))
-        : message.map((message) => (
-            <li key={message}>
-              <StatusMessage colour={messageColours[type]}>
-                <StyledMessage dangerouslySetInnerHTML={{ __html: message }} />
-              </StatusMessage>
-            </li>
-          ))
-    })}
-  </UnorderedList>
-)
+const FlashMessages = ({ flashMessages }) => {
+  const flashMessagesFromStorage = flashUtils.getMessages()
+  flashUtils.clearMessages()
+
+  if (flashMessages || flashMessagesFromStorage) {
+    return (
+      <UnorderedList listStyleType="none" data-auto-id="flash">
+        {Object.entries(flashMessages || flashMessagesFromStorage).map(
+          ([type, message]) => {
+            const parts = String(type).split(':')
+            return parts.length > 1
+              ? message.map((message) => (
+                  <li key={message.body}>
+                    <StatusMessage colour={messageColours[parts[0]]}>
+                      <StyledHeading>{message.heading}</StyledHeading>
+                      <StyledBody
+                        dangerouslySetInnerHTML={{ __html: message.body }}
+                      />
+                    </StatusMessage>
+                  </li>
+                ))
+              : message.map((message) => (
+                  <li key={message}>
+                    <StatusMessage colour={messageColours[type]}>
+                      <StyledMessage
+                        dangerouslySetInnerHTML={{ __html: message }}
+                      />
+                    </StatusMessage>
+                  </li>
+                ))
+          }
+        )}
+      </UnorderedList>
+    )
+  }
+  return null
+}
 
 FlashMessages.propTypes = {
   flashMessages: PropTypes.shape({
@@ -70,7 +83,7 @@ FlashMessages.propTypes = {
       ),
       PropTypes.arrayOf(PropTypes.string).isRequired,
     ]),
-  }).isRequired,
+  }),
 }
 
 export default FlashMessages

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -41,6 +41,7 @@ import InteractionReferralDetails from '../apps/companies/apps/referrals/details
 import AddToPipelineForm from '../apps/pipeline/client/AddToPipelineForm'
 import CompanyLocalHeader from '../apps/companies/client/CompanyLocalHeader.jsx'
 import InvestmentProjectAdmin from '../apps/investments/views/admin/client/InvestmentProjectAdmin.jsx'
+import FlashMessages from './components/LocalHeader/FlashMessages.jsx'
 
 import tasksSaga from './components/Task/saga'
 import tasks from './components/Task/reducer'
@@ -317,6 +318,9 @@ function App() {
         </Mount>
         <Mount selector="#investment-project-admin">
           {(props) => <InvestmentProjectAdmin {...props} />}
+        </Mount>
+        <Mount selector="#flash-messages">
+          {(props) => <FlashMessages {...props} />}
         </Mount>
       </ConnectedRouter>
     </Provider>

--- a/src/client/utils/flash-messages.js
+++ b/src/client/utils/flash-messages.js
@@ -1,0 +1,41 @@
+const KEY = 'flash-messages'
+
+function getMessages() {
+  const items = window.sessionStorage.getItem(KEY)
+  if (items) {
+    try {
+      return JSON.parse(items)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log(e) // TODO: replace with more robust error logging when implemented
+    }
+  }
+  return {}
+}
+
+function addMessage(messageType, message) {
+  const messages = getMessages()
+  messages[messageType] = messages[messageType] || []
+  messages[messageType].push(message)
+  try {
+    window.sessionStorage.setItem(KEY, JSON.stringify(messages))
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e) // TODO: replace with more robust error logging when implemented
+  }
+}
+
+function addSuccessMessage(message) {
+  addMessage('success', message)
+}
+
+function clearMessages() {
+  window.sessionStorage.removeItem(KEY)
+}
+
+module.exports = {
+  getMessages,
+  addMessage,
+  addSuccessMessage,
+  clearMessages,
+}

--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -29,6 +29,10 @@
           }) }}
         {% endif %}
 
+        <div id="flash-messages" class="react-slot">
+          <noscript>Please enable JavaScript in your browser to see the content.</noscript>
+        </div>
+
         {% if messages|length %}
           {{ MessageList({ items: messages }) }}
         {% endif %}

--- a/test/functional/cypress/specs/investment-project/admin-page-spec.js
+++ b/test/functional/cypress/specs/investment-project/admin-page-spec.js
@@ -118,6 +118,11 @@ describe('Update the project stage', () => {
           'contain',
           urls.investments.projects.details(fixtures.investment.newHotelFdi.id)
         )
+        cy.contains('div', 'Project stage saved')
+      })
+      it('should no longer show the flash message when the page is refreshed', () => {
+        cy.reload()
+        cy.contains('div', 'Project stage saved').should('not.be.visible')
       })
     }
   )


### PR DESCRIPTION
## Description of change

This PR proposes a solution for setting flash messages client-side when redirecting from a react page to a nunjucks page.

**Logic**

- I have added a slot for the flashMessages react component to the nunjucks local-header template. 
- I have also created a set of flash message util functions, which set, retrieve or clear flash messages in `window.sessionStorage`
- The FlashMessages component has been updated to either receive flashMessages as a prop, or get the flashMessages object from sessionStorage.
- The object from sessionStorage is saved as a const and then removed from localStorage to avoid the flash message persisting after refresh/change of url.
- If no flash message is coming from props or sessionStorage, the component returns null, avoiding there being an error in the local-header template when no flash message is present. 

**Implementation in the investment admin page**

- When the update stage task is successful, a flash message object is added to sessionStorage from the InvestmentAdminPage component and the user is redirected to the project details page. 
- The FlashMessages component gets this object from sessionStorage and it is rendered as part of the local-header nunjucks template. 

When the flash message is set through sessionStorage it's not possible to type check it as it's not passed as a prop to the FlashMessages component, which is a drawback of this solution. For now the error will be logged in the console.

This PR is linked to #2674 and will be merged into that branch when approved.

## Test instructions

- Ensure you have the `investment.change_to_any_stage_investmentproject` permission
- Go to an investment project and click on the 'Admin' tab
- Select a new stage and click save
- Check that the flash message appears on the project details page
- Refresh the page or go to another page to check that the flash message is removed

## Screenshots

### After
![Screenshot 2020-05-14 at 14 50 47](https://user-images.githubusercontent.com/22460823/81942663-4f1ac480-95f2-11ea-8073-7feca7aec7c6.png)

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
