### PR TITLE
Add status and required field

### DIFF
--- a/src/apps/pipeline/client/AddToPipelineForm.jsx
+++ b/src/apps/pipeline/client/AddToPipelineForm.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import ErrorSummary from '@govuk-react/error-summary'
+import { StatusMessage } from 'data-hub-components'
 import {
   FormStateful,
   FieldRadios,
@@ -59,7 +60,13 @@ function PipelineCheck({
   }
   return (
     <>
-      {onPipeline && <p>{companyName} is already in your pipeline</p>}
+      {onPipeline && (
+        <StatusMessage>
+          This company is already in your pipeline.
+          <br />
+          You can add it again under another project name.
+        </StatusMessage>
+      )}
       {children}
     </>
   )
@@ -120,8 +127,9 @@ function AddToPipelineForm({
                 >
                   <FieldInput
                     name="name"
-                    label="Project name (Optional)"
+                    label="Project name"
                     type="text"
+                    required="Enter a Project name"
                   />
                   <FieldRadios
                     name="category"

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -35,7 +35,7 @@ describe('Company add to pipeline form', () => {
       cy.get('#field-name').then((element) => {
         assertFieldInput({
           element,
-          label: 'Project name (Optional)',
+          label: 'Project name',
           optionsCount: 3,
         })
       })
@@ -82,14 +82,16 @@ describe('Company add to pipeline form', () => {
     })
 
     it('should render a message', () => {
-      cy.contains(`${lambdaPlc.name} is already in your pipeline`)
+      cy.contains(
+        'This company is already in your pipeline.You can add it again under another project name.'
+      )
     })
 
     it('should render the project name text input', () => {
       cy.get('#field-name').then((element) => {
         assertFieldInput({
           element,
-          label: 'Project name (Optional)',
+          label: 'Project name',
           optionsCount: 3,
         })
       })
@@ -124,13 +126,16 @@ describe('Company add to pipeline form', () => {
       cy.get('#field-name').then((element) => {
         assertFieldInput({
           element,
-          label: 'Project name (Optional)',
+          label: 'Project name',
           optionsCount: 3,
         })
       })
     })
 
     it('should redirect to dashboard with a flash message', () => {
+      cy.get('#field-name')
+        .find('input')
+        .type('Test Project')
       cy.get('input[value=win').click()
       cy.contains('button', 'Add').click()
       cy.url().should('include', urls.dashboard())
@@ -138,6 +143,18 @@ describe('Company add to pipeline form', () => {
         'contain',
         'Pipeline changes for this company have been saved'
       )
+    })
+  })
+
+  context('when form is submitted without any input', () => {
+    beforeEach(() => {
+      cy.visit(urls.companies.pipeline(minimallyMinimal.id))
+    })
+
+    it('should display error messages', () => {
+      cy.contains('button', 'Add').click()
+      cy.contains('Enter a Project name')
+      cy.contains('Choose a status')
     })
   })
 })


### PR DESCRIPTION
## Description of change

This PR adds the ` <StatusMessage>` component if a company is already in the pipeline previously it was text in a `<p>` element.
It also set the project name field to required. I've added a cypress test case to test form validation.

## Test instructions
When you navigate to /companies/Company:ID/pipeline. You will see a form asking which pipeline you wish to add the company to. Once added you'll be redirected back to the dashboard with a success flash message. Navigate back to /companies/Company:ID/pipeline and you should see the form and a messaging saying COMPANY_NAME is already in your pipeline. Also you should be required to enter all the fields on the page.

_What should I see?_

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/82045030-4d123d80-96a6-11ea-8979-271eae3a3245.png)

### After
![image](https://user-images.githubusercontent.com/5575331/82044968-31a73280-96a6-11ea-8547-43ebac53dd38.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
