### PR TITLE
Add content to guide users around leaving policy feedback notes

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -1,9 +1,14 @@
 import React from 'react'
 import { H3 } from '@govuk-react/heading'
 import Link from '@govuk-react/link'
+import UnorderedList from '@govuk-react/unordered-list'
+import ListItem from '@govuk-react/list-item'
 import PropTypes from 'prop-types'
 import { throttle } from 'lodash'
 import axios from 'axios'
+import { GREY_1 } from 'govuk-colours'
+import styled from 'styled-components'
+
 import {
   FieldCheckboxes,
   FieldDate,
@@ -13,6 +18,7 @@ import {
   FieldTextarea,
   FieldTypeahead,
   useFormContext,
+  NewWindowLink,
 } from 'data-hub-components'
 
 import {
@@ -30,6 +36,10 @@ import {
 } from '../../../../constants'
 
 import urls from '../../../../../lib/urls'
+
+const StyledListItem = styled(ListItem)`
+  color: ${GREY_1};
+`
 
 const getServiceContext = (theme, kind, investmentProject) => {
   if (investmentProject) {
@@ -270,7 +280,25 @@ const StepInteractionDetails = ({
             name="policy_feedback_notes"
             label="Policy feedback notes"
             required="Enter policy feedback notes"
-            hint="These notes will be visible to other Data Hub users and may be shared within the department"
+            hint={
+              <>
+                <p>
+                  These notes will be visible to other Data Hub users and may be
+                  shared within the department. Please:
+                </p>
+                <UnorderedList listStyleType="bullet">
+                  <StyledListItem>
+                    summarise relevant information - don’t copy and paste
+                  </StyledListItem>
+                  <StyledListItem>
+                    use relevant keywords and accurate tags
+                  </StyledListItem>
+                </UnorderedList>
+                <NewWindowLink href="https://data-services-help.trade.gov.uk/data-hub/updates/announcements/what-makes-good-policy-feedback/">
+                  Read more guidance here
+                </NewWindowLink>
+              </>
+            }
           />
         </>
       )}

--- a/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
@@ -188,7 +188,25 @@ function fillCommonFields({ service, contact = 'Johnny Cakeman' }) {
     .selectTypeaheadOption('State Aid')
 
   cy.contains(ELEMENT_POLICY_FEEDBACK_NOTES.label)
-    .parent()
+    .next()
+    .contains(
+      'These notes will be visible to other Data Hub users and may be shared within the department. Please:'
+    )
+    .next()
+    .find('li')
+    .contains('summarise relevant information - don’t copy and paste')
+    .next()
+    .contains('use relevant keywords and accurate tags')
+    .parent('ul')
+    .next()
+    .contains('Read more guidance here')
+    .and(
+      'have.attr',
+      'href',
+      'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/what-makes-good-policy-feedback/'
+    )
+    .parent('span')
+    .next()
     .find('textarea')
     .type('Some policy feedback notes')
 }


### PR DESCRIPTION
## Description of change

This is around adding content to help guide the user on providing policy feedback notes.

Trello - https://trello.com/c/0FVT9HtG/1250-provide-more-guidance-on-providing-policy-feedback

## Test instructions
## Screenshots
### Before
![Screenshot 2020-05-15 at 16 26 12](https://user-images.githubusercontent.com/10154302/82067580-d470a880-96c8-11ea-9673-dc8bfa2931e4.png)

### After
![Screenshot 2020-05-15 at 16 33 34](https://user-images.githubusercontent.com/10154302/82068399-d7b86400-96c9-11ea-9279-4e2560f8415a.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
