### PR TITLE
Remove the API call to Zendesk when editing a company

### DIFF
--- a/src/apps/companies/apps/edit-company/transformers.js
+++ b/src/apps/companies/apps/edit-company/transformers.js
@@ -80,7 +80,7 @@ const transformFormToApi = (company, formValues) => {
   )
 }
 
-const transformFormToZendesk = (company, formValues) => {
+const transformFormToChangeRequest = (company, formValues) => {
   const originalFormValues = transformCompanyToForm(company)
   return omitBy(
     formValues,
@@ -93,7 +93,7 @@ const transformFormToZendesk = (company, formValues) => {
 }
 
 const transformFormToDnbChangeRequest = (company, formValues) => {
-  const obj = transformFormToZendesk(company, formValues)
+  const obj = transformFormToChangeRequest(company, formValues)
   const address = omitBy(
     {
       line_1: obj.address1,
@@ -135,6 +135,5 @@ const transformFormToDnbChangeRequest = (company, formValues) => {
 module.exports = {
   transformCompanyToForm,
   transformFormToApi,
-  transformFormToZendesk,
   transformFormToDnbChangeRequest,
 }

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -318,13 +318,7 @@ describe('Company edit', () => {
       cy.visit(urls.companies.edit(company.id))
     })
 
-    it('should create ZenDesk ticket and redirect to the business details', () => {
-      cy.contains('Company name')
-        .next()
-        .find('input')
-        .clear()
-        .type('Test company name')
-
+    it('should redirect to the business details page', () => {
       cy.contains('Trading name')
         .next()
         .find('input')
@@ -334,17 +328,8 @@ describe('Company edit', () => {
       cy.contains('Submit').click()
 
       cy.wait('@editCompanyResponse').then((xhr) => {
-        expect(xhr.responseBody.changeRequests.length).to.equal(1)
-
-        const companyUrl =
-          Cypress.config().baseUrl + urls.companies.detail(company.id)
-        expect(xhr.responseBody.changeRequests[0]).to.equal(
-          `User DIT Staff requested company details change of ${company.name} (${companyUrl})\n\n` +
-            `Company DUNS number: ${company.duns_number}\n\n` +
-            'Current name: DnB Ltd\n' +
-            'Requested name: Test company name\n\n' +
-            'Current trading_names: DnB\n' +
-            'Requested trading_names: Test company trading name'
+        expect(xhr.request.body.trading_names).to.equal(
+          'Test company trading name'
         )
       })
 

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -319,18 +319,32 @@ describe('Company edit', () => {
     })
 
     it('should redirect to the business details page', () => {
+      cy.contains('Company name')
+        .next()
+        .find('input')
+        .clear()
+        .type('Test company name')
+
       cy.contains('Trading name')
         .next()
         .find('input')
         .clear()
         .type('Test company trading name')
 
+      cy.contains('Website (optional)')
+        .next()
+        .find('input')
+        .clear()
+        .type('example.com')
+
       cy.contains('Submit').click()
 
       cy.wait('@editCompanyResponse').then((xhr) => {
+        expect(xhr.request.body.name).to.equal('Test company name')
         expect(xhr.request.body.trading_names).to.equal(
           'Test company trading name'
         )
+        expect(xhr.request.body.website).to.equal('example.com')
       })
 
       cy.location('pathname').should(


### PR DESCRIPTION
## Description of change
When a user edits and saves a D&B company we send a Zendesk ticket (containing a company change request) for the Support Team to pick up. Now that we have [automated](https://github.com/uktrade/data-hub-frontend/pull/2583) the process we can safely remove the API call to Zendesk.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
