### PR TITLE
Fix a bug when referrals were ordered ascending

### DIFF
--- a/src/client/components/ReferralList/index.jsx
+++ b/src/client/components/ReferralList/index.jsx
@@ -58,9 +58,10 @@ export default multiInstance({
     >
       {() => {
         if (referrals) {
-          const filteredReferrals = referrals.filter(
-            ({ direction }) => direction === filter
-          )
+          const filteredReferrals = referrals
+            .filter(({ direction }) => direction === filter)
+            .sort((a, b) => new Date(b.date) - new Date(a.date))
+
           return (
             <ContentWithHeading
               heading={pluralize(

--- a/src/client/components/ReferralList/task.js
+++ b/src/client/components/ReferralList/task.js
@@ -17,17 +17,15 @@ export default () =>
   ])
     .catch(handleError)
     .then(([{ data: { results } }, { data: { id } }]) =>
-      results
-        .map((referral) => ({
-          companyId: referral.company.id,
-          id: referral.id,
-          subject: referral.subject,
-          companyName: referral.company.name,
-          date: referral.created_on,
-          dateAccepted: referral.completed_on,
-          sender: convertAdviser(referral.created_by),
-          recipient: convertAdviser(referral.recipient),
-          direction: referral.created_by.id === id ? SENT : RECEIVED,
-        }))
-        .sort((a, b) => new Date(a.date) - new Date(b.date))
+      results.map((referral) => ({
+        companyId: referral.company.id,
+        id: referral.id,
+        subject: referral.subject,
+        companyName: referral.company.name,
+        date: referral.created_on,
+        dateAccepted: referral.completed_on,
+        sender: convertAdviser(referral.created_by),
+        recipient: convertAdviser(referral.recipient),
+        direction: referral.created_by.id === id ? SENT : RECEIVED,
+      }))
     )

--- a/test/functional/cypress/specs/referrals/referral-list-on-dashboard.js
+++ b/test/functional/cypress/specs/referrals/referral-list-on-dashboard.js
@@ -213,18 +213,18 @@ describe('Referall list on dashboard', () => {
       )
 
     assertResultList([
-      EXPECTED_REFERRALS.lou2andy,
-      EXPECTED_REFERRALS.andy2lou,
       EXPECTED_REFERRALS.yeahButNo,
+      EXPECTED_REFERRALS.andy2lou,
+      EXPECTED_REFERRALS.lou2andy,
     ])
   })
 
   it('Only sent referrals shold be visible when sent filter is set', () => {
     selectFilter('Sent referrals')
     assertResultList([
-      EXPECTED_REFERRALS.computerSaysNo,
-      EXPECTED_REFERRALS.zoo,
       EXPECTED_REFERRALS.yeahIKnow,
+      EXPECTED_REFERRALS.zoo,
+      EXPECTED_REFERRALS.computerSaysNo,
     ])
   })
 })


### PR DESCRIPTION
## Description of change

Changes the ordering of _My referrals_ on the _Dashboard_ from ascending to descending.

## Test instructions

1. (optional) Create a couple of referrals if you don't have any
2. Go to the homepage
3. Click on the _My referrals_ tab
4. The referrals should be displayed in the descending order of their creation time i.e. most recent first.

