### PR TITLE
Split flat services field into hierarchical select on the interaction form

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "5.5.2",
+    "data-hub-components": "5.6.0",
     "date-fns": "^1.29.0",
     "del-cli": "^3.0.0",
     "dotenv": "^8.2.0",

--- a/src/apps/companies/controllers/__test__/interactions.test.js
+++ b/src/apps/companies/controllers/__test__/interactions.test.js
@@ -10,7 +10,7 @@ describe('Companies interactions middleware', () => {
       it('should set the return URL', () => {
         expect(
           middlewareParameters.resMock.locals.interactions.returnLink
-        ).to.equal(`/companies/${expectedCompanyId}/interactions/`)
+        ).to.equal(`/companies/${expectedCompanyId}/interactions`)
       })
 
       it('should set the entity name', () => {

--- a/src/apps/companies/middleware/__test__/interactions.test.js
+++ b/src/apps/companies/middleware/__test__/interactions.test.js
@@ -53,7 +53,7 @@ describe('Interactions middleware', () => {
       it('should set the return link', () => {
         expect(
           this.middlewareParameters.resMock.locals.interactions.returnLink
-        ).to.equal(`/companies/${companyMock.id}/interactions/`)
+        ).to.equal(`/companies/${companyMock.id}/interactions`)
       })
 
       it('should set the entity name', () => {

--- a/src/apps/companies/middleware/interactions.js
+++ b/src/apps/companies/middleware/interactions.js
@@ -1,3 +1,5 @@
+const urls = require('../../../lib/urls')
+
 function setInteractionsDetails(req, res, next) {
   const { company } = res.locals
 
@@ -7,7 +9,7 @@ function setInteractionsDetails(req, res, next) {
 
   res.locals.interactions = {
     view: 'companies/views/interactions',
-    returnLink: `/companies/${company.id}/interactions/`,
+    returnLink: urls.companies.interactions.index(company.id),
     entityName: company.name,
     query: { company_id: company.id },
     canAdd: !company.archived,
@@ -15,11 +17,11 @@ function setInteractionsDetails(req, res, next) {
     breadcrumbs: [
       {
         text: company.name,
-        href: `/companies/${company.id}`,
+        href: urls.companies.detail(company.id),
       },
       {
         text: 'Interactions',
-        href: `/companies/${company.id}/interactions`,
+        href: urls.companies.interactions.index(company.id),
       },
     ],
   }

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -70,7 +70,7 @@ const transformServiceAnswers = (serviceAnswers) => {
   return Object.keys(serviceAnswers).reduce(
     (acc, questionId) => ({
       ...acc,
-      [`service_answers[${questionId}]`]: Object.keys(
+      [`service_answers.${questionId}`]: Object.keys(
         serviceAnswers[questionId]
       )[0],
     }),
@@ -83,8 +83,13 @@ const transformInteractionToValues = (interaction) => {
     return {}
   }
 
+  const service = interaction.service
+  const [parentServiceLabel, childServiceLabel] = service.name.split(' : ')
+
   return {
     theme: THEMES.OTHER,
+    service: childServiceLabel ? parentServiceLabel : service.id,
+    service_2nd_level: childServiceLabel ? service.id : undefined,
     ...pick(interaction, [
       'id',
       'kind',
@@ -105,7 +110,6 @@ const transformInteractionToValues = (interaction) => {
       'policy_issue_types',
     ]),
     ...transformValues(interaction, transformToTypeahead, [
-      'service',
       'contacts',
       'event',
       'communication_channel',

--- a/src/apps/interactions/controllers/__test__/list.test.js
+++ b/src/apps/interactions/controllers/__test__/list.test.js
@@ -162,7 +162,7 @@ describe('interaction list', () => {
             locals: {
               interactions: {
                 view: 'entity/interactions',
-                returnLink: 'entity/interactions/',
+                returnLink: 'entity/interactions',
                 createKind: 'interaction',
                 theme: 'export',
                 canAdd: true,

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const qs = require('querystring')
 const { get, set } = require('lodash')
 const { collectionFilterFields } = require('../macros')
@@ -159,9 +160,11 @@ function renderInteractionsForEntity(req, res, next) {
       ? [
           {
             label: 'Add interaction',
-            url: `${returnLink}create${
+            url: path.join(
+              returnLink,
+              '/create',
               createKind ? `/${theme}/${createKind}` : ''
-            }`,
+            ),
           },
         ]
       : undefined

--- a/src/apps/interactions/transformers/__test__/interaction-list-item-to-have-url.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-list-item-to-have-url.test.js
@@ -7,7 +7,7 @@ describe('#transformInteractionListItemToHaveUrlPrefix', () => {
       const actualInteraction = transformInteractionListItemToHaveUrlPrefix(
         '/url'
       )(mockInteraction)
-      const expectedInteraction = { ...mockInteraction, urlPrefix: 'url' }
+      const expectedInteraction = { ...mockInteraction, urlPrefix: 'url/' }
 
       expect(actualInteraction).to.deep.equal(expectedInteraction)
     })
@@ -18,7 +18,7 @@ describe('#transformInteractionListItemToHaveUrlPrefix', () => {
       const actualInteraction = transformInteractionListItemToHaveUrlPrefix(
         'url'
       )(mockInteraction)
-      const expectedInteraction = { ...mockInteraction, urlPrefix: 'url' }
+      const expectedInteraction = { ...mockInteraction, urlPrefix: 'url/' }
 
       expect(actualInteraction).to.deep.equal(expectedInteraction)
     })

--- a/src/apps/interactions/transformers/interaction-list-item-to-have-url.js
+++ b/src/apps/interactions/transformers/interaction-list-item-to-have-url.js
@@ -5,7 +5,8 @@ function transformInteractionListItemToHaveUrlPrefix(urlPrefix) {
     if (!urlPrefix) return item
     return assign({}, item, {
       urlPrefix:
-        urlPrefix.charAt(0) === '/' ? urlPrefix.substring(1) : urlPrefix,
+        (urlPrefix.charAt(0) === '/' ? urlPrefix.substring(1) : urlPrefix) +
+        '/',
     })
   }
 }

--- a/src/apps/investments/middleware/__test__/interactions.test.js
+++ b/src/apps/investments/middleware/__test__/interactions.test.js
@@ -38,7 +38,7 @@ describe('Investment projects interactions middleware', () => {
 
     it('should set the return URL', () => {
       expect(this.res.locals.interactions.returnLink).to.equal(
-        '/investments/projects/1/interactions/'
+        '/investments/projects/1/interactions'
       )
     })
 

--- a/src/apps/investments/middleware/interactions.js
+++ b/src/apps/investments/middleware/interactions.js
@@ -1,10 +1,11 @@
+const urls = require('../../../lib/urls')
+
 function setInteractionsDetails(req, res, next) {
-  const { projects } = res.locals.paths
   const { name } = res.locals.investment
   const { investmentId } = req.params
 
   res.locals.interactions = {
-    returnLink: `${projects}/${investmentId}/interactions/`,
+    returnLink: urls.investments.projects.interactions.index(investmentId),
     entityName: name,
     query: { investment_project_id: investmentId },
     view: 'investments/views/interactions',

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -21,7 +21,7 @@ describe('Interaction', () => {
       const subject = 'Some interesting interaction'
       const formSelectors = selectors.interactionForm
 
-      cy.get(formSelectors.service).selectTypeaheadOption('Export Win')
+      cy.get(formSelectors.service).select('Export Win')
       cy.get(formSelectors.contact).selectTypeaheadOption('Johnny Cakeman')
       cy.get(formSelectors.communicationChannel).selectTypeaheadOption(
         'Email/Website'
@@ -56,7 +56,7 @@ describe('Interaction', () => {
         const subject = 'Some interesting interaction about countries'
         const formSelectors = selectors.interactionForm
 
-        cy.get(formSelectors.service).selectTypeaheadOption('Export Win')
+        cy.get(formSelectors.service).select('Export Win')
         cy.get(formSelectors.contact).selectTypeaheadOption('Johnny Cakeman')
         cy.get(formSelectors.communicationChannel).selectTypeaheadOption(
           'Email/Website'
@@ -93,7 +93,7 @@ describe('Interaction', () => {
         const subject = 'Some interesting interaction about countries'
         const formSelectors = selectors.interactionForm
 
-        cy.get(formSelectors.service).selectTypeaheadOption('Export Win')
+        cy.get(formSelectors.service).select('Export Win')
         cy.get(formSelectors.contact).selectTypeaheadOption('Johnny Cakeman')
         cy.get(formSelectors.communicationChannel).selectTypeaheadOption(
           'Email/Website'
@@ -119,7 +119,7 @@ describe('Interaction', () => {
         const subject = 'Some interesting interaction about countries'
         const formSelectors = selectors.interactionForm
 
-        cy.get(formSelectors.service).selectTypeaheadOption('Export Win')
+        cy.get(formSelectors.service).select('Export Win')
         cy.get(formSelectors.contact).selectTypeaheadOption('Johnny Cakeman')
         cy.get(formSelectors.communicationChannel).selectTypeaheadOption(
           'Email/Website'
@@ -154,7 +154,7 @@ describe('Service delivery', () => {
 
     const formSelectors = selectors.interactionForm
 
-    cy.get(formSelectors.service).selectTypeaheadOption('Export Win')
+    cy.get(formSelectors.service).select('Export Win')
     cy.get(formSelectors.contact).selectTypeaheadOption('Johnny Cakeman')
     cy.get(formSelectors.eventNo).click()
     cy.get(formSelectors.subject).type(subject)

--- a/test/end-to-end/cypress/specs/DIT/referrals-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/referrals-spec.js
@@ -78,7 +78,7 @@ describe('Referrals', () => {
       cy.get(selectors.createInteractionContext.export.interaction).click()
       cy.get(selectors.createInteractionContext.button).click()
 
-      cy.get(formSelectors.service).selectTypeaheadOption('Export Win')
+      cy.get(formSelectors.service).select('Export Win')
       cy.get(formSelectors.contact).selectTypeaheadOption('Dean Cox')
       cy.get(formSelectors.communicationChannel).selectTypeaheadOption(
         'Email/Website'

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -59,7 +59,7 @@ describe('Company Export tab - Edit exports', () => {
           assertFieldSelect({
             element,
             label: 'Export win category (optional)',
-            value: '-- Select Category --',
+            value: '-- Select category --',
             optionsCount: 7,
           })
         })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -90,23 +90,44 @@ const assertFieldUneditable = ({ element, label, value = null }) =>
     .parent()
     .then(($el) => value && cy.wrap($el).should('contain', value))
 
-const assertFieldSelect = ({ element, label, value, optionsCount = 0 }) =>
+const assertFieldSelect = ({
+  element,
+  label,
+  emptyOption,
+  value,
+  optionsCount = 0,
+}) =>
   cy
     .wrap(element)
     .as('fieldSelect')
-    .find('label')
-    .first()
-    .should('have.text', label)
+    .then(
+      () =>
+        label &&
+        cy
+          .get('@fieldSelect')
+          .find('label')
+          .first()
+          .should('have.text', label)
+    )
+    .then(
+      () =>
+        emptyOption &&
+        cy
+          .get('@fieldSelect')
+          .find('option')
+          .first()
+          .should('have.text', emptyOption)
+    )
     .next()
     .find('option')
     .should('have.length', optionsCount)
     .then(
       () =>
-        value ??
+        value &&
         cy
           .get('@fieldSelect')
           .find('option[selected]')
-          .should('have.text', value || '')
+          .should('have.text', value)
     )
 
 const assertFieldRadios = ({ element, label, value, optionsCount }) =>

--- a/test/selectors/interaction-form.js
+++ b/test/selectors/interaction-form.js
@@ -10,7 +10,7 @@ module.exports = {
   dateOfInteractionDay: '#field-date_day',
   contact: '#field-contacts',
   add: '#interaction-details-form button[name=forward]',
-  service: '#field-service',
+  service: '#field-service select',
   serviceDeliveryStatus: '#field-service_delivery_status',
   subService: '.is-active > .c-form-group__inner > #field-subService',
   grantOffered: '#field-grant_amount_offered',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7086,10 +7086,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.5.1.tgz#a016dc9063374630f9f30fade6d74c0fab03da3b"
-  integrity sha512-GdhIGKkXiFh0Uyf33wWgTEOCq+n0NLn1s4Gcg/6Ec2Zig6ObjeuUNJg6AbN3K2ssboV/xz1wKQpQq4+z1k7BZA==
+data-hub-components@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.6.0.tgz#20e9eb43ad92d2574a5f10f7afc183f0bb746e76"
+  integrity sha512-GakWymZdY0WV8ApABqNEwFUvQMvLJyI3j+DVjZ5006GIW25enP1uqJkI6qz5SON6GjPEcnHyhHSDNbQptp9YtA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change

Replace the typeahead component for selection of service with two select elements to improve the UX aligning with the old interaction form.

## Screenshots

![image](https://user-images.githubusercontent.com/4199239/82245275-8a8ef900-993a-11ea-8651-fa861ce39bf5.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
