### PR TITLE
Add guidance content for sending a referral

### DIFF
--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -19,6 +19,7 @@ import {
   InputField,
 } from 'govuk-react'
 import { MEDIA_QUERIES } from '@govuk-react/constants'
+import { WHITE, LIGHT_BLUE_50 } from 'govuk-colours'
 
 import {
   SEND_REFERRAL_FORM__CONTINUE,
@@ -31,6 +32,7 @@ import {
 } from '../../../../../../client/actions'
 import SendReferralConfirmation from './SendReferralConfirmation'
 import LocalHeader from '../../../../../../client/components/LocalHeader/LocalHeader'
+import { Panel } from '../../../../../../client/components/'
 import { companies, dashboard } from '../../../../../../lib/urls'
 
 const StyledTextArea = styled(TextArea)({
@@ -40,6 +42,16 @@ const StyledTextArea = styled(TextArea)({
     },
   },
 })
+
+const StyledPanel = styled(Panel)`
+  a:link,
+  a:visited {
+    color: ${WHITE};
+  }
+  a:hover {
+    color: ${LIGHT_BLUE_50};
+  }
+`
 
 const SendReferralForm = ({
   companyContacts,
@@ -74,6 +86,14 @@ const SendReferralForm = ({
       />
 
       <Main>
+        <StyledPanel title="When to send a referral">
+          Referrals are for when you want to ask another DIT advisor to help out
+          an account you are working on.
+          <br />
+          <NewWindowLink href="https://data-services-help.trade.gov.uk/data-hub/updates/announcements/improving-collaboration-internal-referrals/">
+            Read more guidance here
+          </NewWindowLink>
+        </StyledPanel>
         <form
           onSubmit={(event) => {
             event.preventDefault()

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -41,6 +41,22 @@ describe('Send a referral form', () => {
         assertLocalHeader('Send a referral')
       })
 
+      it('should display guidance on sending a referral', () => {
+        cy.get('h2')
+          .contains('When to send a referral')
+          .next()
+          .should(
+            'have.text',
+            'Referrals are for when you want to ask another DIT advisor to help out an account you are working on.Read more guidance here (opens in a new window or tab)'
+          )
+          .find('a')
+          .should(
+            'have.attr',
+            'href',
+            'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/improving-collaboration-internal-referrals/'
+          )
+      })
+
       it('should display the headings and four fields', () => {
         cy.contains('Who do you want to refer this company to?').should(
           'be.visible'


### PR DESCRIPTION
## Description of change
This is a piece of content to help guide the user towards the sending of a referral.

## Test instructions
Go to send a referral and at the top you should see a panel with the new content inside. The link should open in a new window.

## Screenshots
![Screenshot 2020-05-19 at 11 36 16](https://user-images.githubusercontent.com/10154302/82318093-2ebe8180-99c7-11ea-996c-654c08848fcf.png)
### After
![Screenshot 2020-05-19 at 11 35 50](https://user-images.githubusercontent.com/10154302/82318117-3a11ad00-99c7-11ea-8f7f-638d98c12bfd.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
