### PR TITLE
Fix filtering of services on the interaction form

### DIFF
--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -124,11 +124,16 @@ const getInitialFormValues = (req, res) => {
   const { company, investment, interaction, referral } = res.locals
   const { theme, kind } = req.params
   const date = interaction ? moment(interaction.date) : moment()
+  const investmentId = get(
+    investment,
+    'id',
+    get(interaction, 'investment_project')
+  )
   return {
     theme,
     kind,
     company: company.id,
-    investment_project: investment && investment.id,
+    investment_project: investmentId,
     date: {
       day: date.format('DD'),
       month: date.format('MM'),

--- a/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
@@ -767,3 +767,116 @@ describe('Editing an interaction from an interactions list', () => {
     cy.contains('button', 'Save interaction')
   })
 })
+
+describe('Filtering services based on theme & kind', () => {
+  const openFormForNewInteraction = (theme, kind) =>
+    cy.visit(
+      urls.companies.interactions.createType(
+        fixtures.company.dnbCorp,
+        theme,
+        kind
+      )
+    )
+
+  it('should show filtered services for Export => Interaction', () => {
+    openFormForNewInteraction(THEMES.EXPORT, KINDS.INTERACTION)
+
+    cy.get('#field-service').should(
+      'have.text',
+      [
+        '-- Select service --',
+        'A Specific DIT Export Service or Funding',
+        'Enquiry or Referral Received',
+        'Export Relationship Management',
+        'Global Growth Service',
+        'Making Export Introductions',
+        'Providing Export Advice & Information',
+        'Referral to UKEFRelationship Management',
+        'Trade - EnquiryTrade - Services',
+      ].join('')
+    )
+  })
+
+  it('should show filtered services for Export => Service delivery', () => {
+    openFormForNewInteraction(THEMES.EXPORT, KINDS.SERVICE_DELIVERY)
+
+    cy.get('#field-service').should(
+      'have.text',
+      [
+        '-- Select service --',
+        'A Specific DIT Export Service or Funding',
+        'Enquiry or Referral Received',
+        'Events - Overseas',
+        'Events',
+        'Export Relationship Management',
+        'Global Growth Service',
+        'Relationship Management',
+      ].join('')
+    )
+  })
+
+  it('should show filtered services for Investment', () => {
+    openFormForNewInteraction(THEMES.INVESTMENT, KINDS.INTERACTION)
+
+    cy.get('#field-service').should(
+      'have.text',
+      [
+        '-- Select service --',
+        'Enquiry received',
+        'IST Specific Service',
+        'Investment - Aftercare Company Visit',
+        'Investment - Business Proposition',
+        'Investment - Company Visit',
+        'Investment - Services',
+        'Making Investment Introductions',
+        'Providing Investment Advice & Information',
+        'Relationship Management',
+      ].join('')
+    )
+  })
+
+  it('should show filtered services for Other => Interaction', () => {
+    openFormForNewInteraction(THEMES.OTHER, KINDS.INTERACTION)
+
+    cy.get('#field-service').should(
+      'have.text',
+      [
+        '-- Select service --',
+        'A Specific DIT Export Service or Funding',
+        'A Specific DIT Service',
+        'A Specific Service',
+        'Enquiry or Referral Received',
+        'Global Growth Pilot (2017)',
+        'Global Growth Pilot (2017) – Diagnostic Output Report completed',
+        'Global Growth Pilot (2017) – Diagnostic completed',
+        'Global Growth Pilot (2017) – Export Growth Plan agreed with customer',
+        'Global Growth Pilot (2017) – GGP process complete',
+        'Investment - Aftercare Company Visit',
+        'Investment - Business Proposition',
+        'Investment - Company Visit',
+        'Investment - Services',
+        'Onward Referral',
+        'Relationship Management',
+        'Trade - EnquiryTrade - Services',
+      ].join('')
+    )
+  })
+
+  it('should show filtered services for Other => Service delivery', () => {
+    openFormForNewInteraction(THEMES.OTHER, KINDS.SERVICE_DELIVERY)
+
+    cy.get('#field-service').should(
+      'have.text',
+      [
+        '-- Select service --',
+        'A Specific DIT Service',
+        'A Specific Service',
+        'Enquiry or Referral Received',
+        'Events - Overseas',
+        'Events',
+        'Global Growth Pilot (2017) – Eligible GGP customer',
+        'Relationship Management',
+      ].join('')
+    )
+  })
+})


### PR DESCRIPTION
## Description of change

Fix a bug with filtering of services when editing interaction.

E.g. 
Editing existing interaction doesn't populate the service:
https://www.datahub.trade.gov.uk/interactions/c1d79f11-8bb4-42e0-b11c-3ecd335fb9d0/edit

## Test instructions

1. Go to an existing investment interactions (from the interactions nav link)
2. Edit the interaction
3. Verify if the service is prepopulated.
