### PR TITLE
Fix setting a default theme when editing interactions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ aliases:
   - &start_api_sandbox
     run:
       name: Start API sandbox
-      command: java -jar /usr/local/sandbox.jar --port=8001 --watch=false --base=./test/sandbox run
+      command: sandbox --port=8001 --watch=false --base=./test/sandbox run
       background: true
 
   - &wait_for_api_sandbox
@@ -105,7 +105,7 @@ aliases:
 
   # Data hub base docker container
   - &docker_data_hub_base
-    image: ukti/data-hub-frontend-test:3.4.0
+    image: ukti/data-hub-frontend-test:3.5.0
     environment: *data_hub_base_envs
 
   # Data hub redis container

--- a/docs/Running tests.md
+++ b/docs/Running tests.md
@@ -3,7 +3,7 @@
 ## Creating Docker container for CircleCI
 
 ```bash
-export VERSION=3.4.0 # Increment this version each time when you edit Dockerfile.
+export VERSION=3.5.0 # Increment this version each time when you edit Dockerfile.
 
 docker login # Ask webops for Docker Hub access to the ukti group.
 docker build -f test/Dockerfile -t data-hub-frontend-test .
@@ -60,9 +60,10 @@ Sandbox is as a light replacement for API backend and it's used only by function
 1. Install sandbox, for more info see [instructions](https://github.com/getsandbox/sandbox)
 
 ```bash
-wget https://s3.amazonaws.com/sandbox-binaries/runtime-binary.tar \
-  && tar -C /usr/local/bin -xzvf runtime-binary.tar \
-  && rm runtime-binary.tar
+wget https://github.com/getsandbox/sandbox/releases/download/1.1.0/sandbox-runtime.tar \
+  && tar -C /usr/local/bin -xzvf sandbox-runtime.tar \
+  && mv /usr/local/bin/sandbox-runtime /usr/local/bin/sandbox \
+  && rm sandbox-runtime.tar
 ```
 
 2. Start sandbox on port `8001`:

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -83,17 +83,17 @@ const transformInteractionToValues = (interaction) => {
     return {}
   }
 
-  const service = interaction.service
-  const [parentServiceLabel, childServiceLabel] = service.name.split(' : ')
+  const serviceId = get(interaction, 'service.id')
+  const serviceName = get(interaction, 'service.name', '')
+  const [parentServiceLabel, childServiceLabel] = serviceName.split(' : ')
 
   return {
-    theme: THEMES.OTHER,
-    service: childServiceLabel ? parentServiceLabel : service.id,
-    service_2nd_level: childServiceLabel ? service.id : undefined,
+    theme: interaction.theme || THEMES.OTHER,
+    service: childServiceLabel ? parentServiceLabel : serviceId,
+    service_2nd_level: childServiceLabel ? serviceId : undefined,
     ...pick(interaction, [
       'id',
       'kind',
-      'theme',
       'subject',
       'notes',
       'grant_amount_offered',

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -62,7 +62,10 @@ RUN apt-get install -y xvfb xdg-utils libgtk-3-0 lsb-release libappindicator3-1 
 RUN apt-get install -y openjdk-8-jre
 
 # Install sandbox
-RUN wget -O /usr/local/sandbox.jar https://dl.bintray.com/getsandbox/public/com/sandbox/sandbox/1.0.235/sandbox-1.0.235-all.jar
+RUN wget https://github.com/getsandbox/sandbox/releases/download/1.1.0/sandbox-runtime.tar \
+  && tar -C /usr/local/bin -xvf sandbox-runtime.tar \
+  && mv /usr/local/bin/sandbox-runtime /usr/local/bin/sandbox \
+  && rm sandbox-runtime.tar
 
 # Versions of local tools
 RUN node -v

--- a/test/functional/cypress/specs/interaction/complete-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/complete-interaction-spec.js
@@ -380,6 +380,7 @@ describe('Complete interaction', () => {
       })
 
       it('should redirect to the interaction create form', () => {
+        cy.contains('h1', 'Edit interaction for Venus Ltd')
         cy.location('pathname').should(
           'eq',
           `/companies/${params.companyId}/interactions/${[

--- a/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
@@ -9,6 +9,7 @@ import {
 
 const urls = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
+const interactionWithoutTheme = require('../../../../sandbox/fixtures/v3/interaction/interaction-without-theme')
 const {
   assertFieldTextarea,
   assertFieldDate,
@@ -878,5 +879,21 @@ describe('Filtering services based on theme & kind', () => {
         'Relationship Management',
       ].join('')
     )
+  })
+})
+
+describe('Editing an interaction without a theme', () => {
+  it('should set a default theme (Other)', () => {
+    cy.visit(urls.interactions.edit(interactionWithoutTheme.id))
+
+    cy.get('#field-subject').then((element) =>
+      assertFieldInput({
+        element,
+        label: 'Subject',
+        value: interactionWithoutTheme.subject,
+      })
+    )
+
+    cy.contains('button', 'Save interaction')
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -177,7 +177,8 @@ const assertFieldInput = ({ element, label, hint, value }) =>
     )
     .find('input')
     .then(
-      ($el) => value ?? cy.wrap($el).should('have.attr', 'value', value || '')
+      ($el) =>
+        value && cy.wrap($el).should('have.attr', 'value', String(value) || '')
     )
 
 const assertFieldTextarea = ({ element, label, hint, value }) =>

--- a/test/sandbox/Dockerfile
+++ b/test/sandbox/Dockerfile
@@ -1,11 +1,19 @@
 FROM openjdk:8u171-jre-slim
 
-ADD https://dl.bintray.com/getsandbox/public/com/sandbox/sandbox/1.0.235/sandbox-1.0.235-all.jar /sandbox.jar
 ENV LANG C.UTF-8
+
+RUN apt-get update
+
+RUN apt-get install -y wget
+
+RUN wget https://github.com/getsandbox/sandbox/releases/download/1.1.0/sandbox-runtime.tar \
+  && tar -C /usr/local/bin -xvf sandbox-runtime.tar \
+  && mv /usr/local/bin/sandbox-runtime /usr/local/bin/sandbox \
+  && rm sandbox-runtime.tar
 
 WORKDIR /usr/src/app
 COPY . .
 
 EXPOSE 8001
 
-CMD java -XX:+UseG1GC -XX:+UseStringDeduplication ${JAVA_OPTS:--Xmx128m -Xmx128m} -jar /sandbox.jar --port=${PORT:-8001} --watch=true $JAVA_PARAMS run
+CMD sandbox --port=${PORT:-8001} --watch=true run

--- a/test/sandbox/fixtures/v3/interaction/interaction-without-theme.js
+++ b/test/sandbox/fixtures/v3/interaction/interaction-without-theme.js
@@ -1,0 +1,7 @@
+var interactionFixture = require('./interaction.json')
+
+module.exports = Object.assign({}, interactionFixture, {
+  id: '65e984ad-1ad5-4d89-9b12-71cdff5f412c',
+  subject: 'Interaction without theme',
+  theme: null,
+})

--- a/test/sandbox/main.js
+++ b/test/sandbox/main.js
@@ -1,3 +1,5 @@
+require('./polyfills')
+
 var adviser = require('./routes/adviser.js')
 var dashboard = require('./routes/dashboard.js')
 var healthcheck = require('./routes/ping.js')

--- a/test/sandbox/polyfills.js
+++ b/test/sandbox/polyfills.js
@@ -1,0 +1,8 @@
+if (!Object.assign) {
+  Object.defineProperty(Object, 'assign', {
+    enumerable: false,
+    configurable: true,
+    writable: true,
+    value: _.assign,
+  })
+}

--- a/test/sandbox/routes/v3/interaction/interaction.js
+++ b/test/sandbox/routes/v3/interaction/interaction.js
@@ -11,6 +11,7 @@ var interactionDraftFutureMeeting = require('../../../fixtures/v3/interaction/in
 var interactionDraftPastMeeting = require('../../../fixtures/v3/interaction/interaction-draft-past-meeting.json')
 var interactionValidationError = require('../../../fixtures/v3/interaction/interaction-validation-error.json')
 var interactionWithReferral = require('../../../fixtures/v3/interaction/interaction-with-referral.json')
+var interactionWithoutTheme = require('../../../fixtures/v3/interaction/interaction-without-theme')
 
 var getInteractions = function(req, res) {
   if (req.query.contact_id) {
@@ -38,6 +39,7 @@ var getInteractionById = function(req, res) {
     '999c12ee-91db-4964-908e-0f18ce823096': interactionDraftFutureMeeting,
     '888c12ee-91db-4964-908e-0f18ce823096': interactionDraftPastMeeting,
     '65e984ad-1ad5-4d89-9b12-71cdff5f412d': interactionWithReferral,
+    '65e984ad-1ad5-4d89-9b12-71cdff5f412c': interactionWithoutTheme,
   }
 
   var interactionResponse =


### PR DESCRIPTION
## Description of change

In some cases the `theme` field for interactions is not filled, if this happens we should use the `Other` theme by default.

## Test instructions

1. Edit interaction that doesn't have `theme` field filled.
2. The form should not display the `theme` and `kind` step.