### PR TITLE
Style the tabs for mobile screen sizes

### DIFF
--- a/src/client/components/Pipeline/index.jsx
+++ b/src/client/components/Pipeline/index.jsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
 import { BLUE, WHITE } from 'govuk-colours'
-import { FONT_SIZE } from '@govuk-react/constants'
+import {
+  FONT_SIZE,
+  MEDIA_QUERIES,
+  SPACING_POINTS,
+} from '@govuk-react/constants'
 
 import TabNav from '../TabNav'
 import PipelineList from './PipelineList'
@@ -11,29 +15,41 @@ const SubTabs = styled(TabNav)`
   margin-top: -15px; /* Because we are in a tabpanel of an existing TabNav, it has a 30px margin at the top but we don't want that much */
 
   [role='tablist'] {
-    padding: 0;
-    margin: 0 0 2px 0;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center; /* Backwards compatible */
-    justify-content: space-between;
-    color: ${BLUE};
-    background-color: ${WHITE};
+    ${MEDIA_QUERIES.TABLET} {
+      padding: 0;
+      margin: 0 0 2px 0;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: center; /* Backwards compatible */
+      justify-content: space-between;
+      color: ${BLUE};
+      background-color: ${WHITE};
+    }
+    span {
+      &::before {
+        margin-left: ${SPACING_POINTS[5]}px;
+      }
+    }
   }
 
   [role='tab'] {
-    background: none;
     border: none;
-    color: ${BLUE};
-    font-size: ${FONT_SIZE.SIZE_24};
-    line-height: 1.3;
-    padding: 0 0 6px 0;
+    ${MEDIA_QUERIES.TABLET} {
+      background: none;
+      border: none;
+      color: ${BLUE};
+      font-size: ${FONT_SIZE.SIZE_24};
+      line-height: 1.3;
+      padding: 0 0 6px 0;
+    }
 
     &[aria-selected='true'] {
-      border-bottom: 8px solid ${BLUE};
-      color: ${BLUE};
-      padding: 0;
+      ${MEDIA_QUERIES.TABLET} {
+        border-bottom: 8px solid ${BLUE};
+        color: ${BLUE};
+        padding: 0;
+      }
     }
   }
 `

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -94,6 +94,9 @@ const StyledTablist = styled.div({
   borderBottom: 'none',
   [MEDIA_QUERIES.TABLET]: {
     borderBottom: `1px solid ${BORDER_COLOUR}`,
+    '& > *:not(:last-child)': {
+      marginRight: 5,
+    },
   },
 })
 

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -2,7 +2,15 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Route } from 'react-router-dom'
 import styled from 'styled-components'
-import { GREY_4, TEXT_COLOUR, BORDER_COLOUR, FOCUS_COLOUR } from 'govuk-colours'
+import {
+  GREY_4,
+  WHITE,
+  LINK_COLOUR,
+  TEXT_COLOUR,
+  BORDER_COLOUR,
+  FOCUS_COLOUR,
+} from 'govuk-colours'
+import { MEDIA_QUERIES, SPACING_POINTS } from '@govuk-react/constants'
 
 import multiInstance from '../../utils/multiinstance'
 import focusable from '../../utils/focusable'
@@ -14,50 +22,86 @@ const RIGHT_ARROW_KEY = 39
 
 const FocusableButton = focusable('button')
 
-const buttonStyle = {
-  color: TEXT_COLOUR,
-  fontSize: 19,
-  fontFamily: 'Arial, sans-serif',
-}
-
 const focusStyle = {
   '&:focus': {
     outline: `3px solid ${FOCUS_COLOUR}`,
+    background: FOCUS_COLOUR,
+    [MEDIA_QUERIES.TABLET]: {
+      background: WHITE,
+    },
   },
+}
+
+const StyledSpan = styled('span')({
+  display: 'block',
+  '::before': {
+    color: '#0b0c0c',
+    content: '"\u2014 "',
+    paddingRight: `${SPACING_POINTS[1]}px`,
+  },
+  [MEDIA_QUERIES.TABLET]: {
+    display: `inline-block`,
+    '::before': {
+      display: 'none',
+    },
+  },
+})
+
+const buttonStyle = {
+  padding: 0,
+  margin: `0 0 ${SPACING_POINTS[2]}px 0`,
+  color: LINK_COLOUR,
+  fontSize: 16,
+  fontFamily: 'Arial, sans-serif',
+  textDecoration: 'underline',
+  border: 'none',
+  background: 'transparent',
 }
 
 const StyledButton = styled(FocusableButton)({
   ...buttonStyle,
-  padding: '10px 20px',
-  margin: '5px 0 5px',
-  background: GREY_4,
-  border: 'none',
-  cursor: 'pointer',
   ...focusStyle,
+  [MEDIA_QUERIES.TABLET]: {
+    color: TEXT_COLOUR,
+    fontSize: 19,
+    textDecoration: 'none',
+    padding: `${SPACING_POINTS[2]}px ${SPACING_POINTS[4]}px`,
+    margin: `${SPACING_POINTS[1]}px 0 ${SPACING_POINTS[1]}px`,
+    background: GREY_4,
+    border: 'none',
+    cursor: 'pointer',
+  },
 })
 
 const StyledSelectedButton = styled(FocusableButton)({
   ...buttonStyle,
-  border: `1px solid ${BORDER_COLOUR}`,
-  borderBottom: 'none',
-  // The negative margin is here so that it overcasts tabpane's top border
-  marginBottom: -1,
-  // The 19px include compensation for the 1px negative margin above
-  padding: '14px 19px 16px',
-  background: 'white',
   ...focusStyle,
+  [MEDIA_QUERIES.TABLET]: {
+    color: TEXT_COLOUR,
+    fontSize: 19,
+    textDecoration: 'none',
+    border: `1px solid ${BORDER_COLOUR}`,
+    borderBottom: 'none',
+    // The negative margin is here so that it overcasts tabpane's top border
+    marginBottom: -1,
+    // The 19px include compensation for the 1px negative margin above
+    padding: '14px 19px 16px',
+    background: WHITE,
+  },
 })
 
 const StyledTablist = styled.div({
-  borderBottom: `1px solid ${BORDER_COLOUR}`,
-  '& > *:not(:last-child)': {
-    marginRight: 5,
+  borderBottom: 'none',
+  [MEDIA_QUERIES.TABLET]: {
+    borderBottom: `1px solid ${BORDER_COLOUR}`,
   },
 })
 
 const StyledTabpanel = styled.div({
-  ...focusStyle,
-  marginTop: 30,
+  marginTop: 15,
+  [MEDIA_QUERIES.TABLET]: {
+    marginTop: 30,
+  },
 })
 
 const createId = (id, key) => `${id}.tab.${key.replace('/', '_')}`
@@ -128,30 +172,32 @@ const TabNav = ({
                   const Button = selected ? StyledSelectedButton : StyledButton
                   const tabId = createId(id, key)
                   return (
-                    <Button
-                      key={tabId}
-                      role="tab"
-                      focused={index === focusIndex}
-                      aria-selected={selected}
-                      id={tabId}
-                      tabIndex={
-                        // If no tab is selected...
-                        selectedIndex === undefined && !index
-                          ? // ...only the first tab participates in the tabindex
-                            0
-                          : // Otherwise, only the selected tab participates in tabindex
-                          selected
-                          ? 0
-                          : -1
-                      }
-                      onClick={() =>
-                        selected || routed
-                          ? (history.push(key), onFocusChange(index))
-                          : onChange(key, index)
-                      }
-                    >
-                      {label}
-                    </Button>
+                    <StyledSpan>
+                      <Button
+                        key={tabId}
+                        role="tab"
+                        focused={index === focusIndex}
+                        aria-selected={selected}
+                        id={tabId}
+                        tabIndex={
+                          // If no tab is selected...
+                          selectedIndex === undefined && !index
+                            ? // ...only the first tab participates in the tabindex
+                              0
+                            : // Otherwise, only the selected tab participates in tabindex
+                            selected
+                            ? 0
+                            : -1
+                        }
+                        onClick={() =>
+                          selected || routed
+                            ? (history.push(key), onFocusChange(index))
+                            : onChange(key, index)
+                        }
+                      >
+                        {label}
+                      </Button>
+                    </StyledSpan>
                   )
                 })}
               </StyledTablist>

--- a/test/selectors/tabbed-nav.js
+++ b/test/selectors/tabbed-nav.js
@@ -2,7 +2,7 @@ module.exports = () => {
   const tabbedNavSelector = `[role="tablist"]`
   return {
     container: tabbedNavSelector,
-    item: (number) => `${tabbedNavSelector} button:nth-child(${number})`,
+    item: (number) => `${tabbedNavSelector} span:nth-child(${number}) button`,
     selected: `${tabbedNavSelector} button[aria-selected="true"]`,
     buttons: `${tabbedNavSelector} button`,
   }


### PR DESCRIPTION
## Description of change
Currently we do not have any mobile styles for the new tabs that feature on the home page. These tab styles should respond in the same way as other tabs for consistency throughout Data Hub.

## Test instructions
Visit the homepage and look at how the tabs render in a small screen. Use Chrome dev tools to re-create the small screen `< 641px` in width.  The tabs should behave in the same way as they do in the likes of the tabs that feature in the company pages.

## Screenshots
### Before
![Screenshot 2020-05-20 at 15 23 45](https://user-images.githubusercontent.com/10154302/82458636-d2cf2800-9aae-11ea-8a67-a1f7b2f4e5a7.png)

### After
![Screenshot 2020-05-20 at 15 23 55](https://user-images.githubusercontent.com/10154302/82458697-eda19c80-9aae-11ea-8ad2-8cf865eeb383.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
