### PR TITLE
Add empty pipeline message

### DIFF
--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -2,12 +2,19 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import ListItem from '@govuk-react/list-item'
+import InsetText from '@govuk-react/inset-text'
 
 import StyledOrderedList from '../StyledOrderedList'
 import Task from '../Task'
 import { state2props, ID as STATE_ID, TASK_GET_PIPELINE_LIST } from './state'
 import { PIPELINE__LIST_LOADED } from '../../actions'
 import PipelineItem from './PipelineItem'
+
+const statusConstants = {
+  leads: 'prospect',
+  in_progress: 'active',
+  win: 'won',
+}
 
 const PipelineList = ({ status, items }) => {
   return (
@@ -22,17 +29,25 @@ const PipelineList = ({ status, items }) => {
     >
       {() => (
         <StyledOrderedList data-auto-id="pipelineList">
-          {items?.map((item) => (
-            <ListItem key={item.id}>
-              <PipelineItem
-                id={item.id}
-                companyId={item.company.id}
-                companyName={item.company.name}
-                projectName={item.name}
-                date={item.created_on}
-              />
-            </ListItem>
-          ))}
+          {items && items.length ? (
+            items.map((item) => (
+              <ListItem key={item.id}>
+                <PipelineItem
+                  id={item.id}
+                  companyId={item.company.id}
+                  companyName={item.company.name}
+                  projectName={item.name}
+                  date={item.created_on}
+                />
+              </ListItem>
+            ))
+          ) : (
+            <InsetText>
+              There are no companies in the {statusConstants[status]} section of
+              your pipeline. You can add companies to your pipeline from the
+              company page.
+            </InsetText>
+          )}
         </StyledOrderedList>
       )}
     </Task.Status>


### PR DESCRIPTION
## Description of change

This PR simply adds a message to an empty pipeline list. This work is branched off of https://github.com/uktrade/data-hub-frontend/pull/2689 which in turn is branched off the feature branch https://github.com/uktrade/data-hub-frontend/pull/2677

Due to the routing of the sandbox API I can't add a functional test for this as I need to thoroughly test the happy path of having items in each category. However, add the end of adding this functionality we will add an end-to-end test that will start from the point of having an empty pipeline and this will be checked. Due to the lack of jest on the frontend I also can't add a unit test. 

## Test instructions

Go to an empty section of `my-pipeline` and you will see the message. 

## Screenshots
(the gif is missing the full stop at the end, but it is there in the code)
![no companies text](https://user-images.githubusercontent.com/42253716/82468683-03b55a00-9abb-11ea-923c-ae9cb9553d6b.gif)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
