### PR TITLE
Back out postcode and website validation as the API has a bug

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -10,21 +10,19 @@ import { ISO_CODE, WEBSITE_REGEX } from './constants'
 import InformationList from './InformationList'
 
 // TODO: Move this validation to the component library
-const requiredWebsiteAndOrPhoneValidator = (
+const requiredWebsiteOrPhoneValidator = (
   value,
   name,
   { values: { website, telephone_number } }
 ) => {
-  if (!telephone_number && !website) {
-    return 'Enter a website or phone number'
-  }
-
-  if (telephone_number && !website) {
-    return null
-  }
-
-  return !WEBSITE_REGEX.test(website) ? 'Enter a valid website URL' : null
+  return !website && !telephone_number
+    ? 'Enter a website or phone number'
+    : null
 }
+
+// TODO: Move this validation to the component library
+const websiteValidator = (value) =>
+  !WEBSITE_REGEX.test(value) ? 'Enter a valid website URL' : null
 
 function CompanyNotFoundStep({ organisationTypes, regions, sectors, country }) {
   return (
@@ -54,14 +52,14 @@ function CompanyNotFoundStep({ organisationTypes, regions, sectors, country }) {
         label="Company's website"
         name="website"
         type="url"
-        validate={[requiredWebsiteAndOrPhoneValidator]}
+        validate={[requiredWebsiteOrPhoneValidator, websiteValidator]}
       />
 
       <FieldInput
         label="Company's telephone number"
         name="telephone_number"
         type="tel"
-        validate={requiredWebsiteAndOrPhoneValidator}
+        validate={requiredWebsiteOrPhoneValidator}
       />
 
       <FieldAddress


### PR DESCRIPTION
## Description of change

Temporarily backing this out as the API has a bug that needs fixing. If we don't back it out the user will validate the form only to be given a 400 when saving - they won't know what's gone wrong or how to fix it.

<img width="1176" alt="err" src="https://user-images.githubusercontent.com/964268/82561341-21da9300-9b6b-11ea-9bf8-34ef02e6f5c1.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
