### PR TITLE
Fix flash message margin, background and font weight

### DIFF
--- a/src/client/components/LocalHeader/FlashMessages.jsx
+++ b/src/client/components/LocalHeader/FlashMessages.jsx
@@ -30,6 +30,7 @@ const StyledHeading = styled('h2')`
 const StyledMessage = styled('p')`
   margin: 0;
   font-size: ${FONT_SIZE.SIZE_20};
+  font-weight: ${FONT_WEIGHTS.bold};
 `
 
 const StyledStatusMessage = styled(StatusMessage)`

--- a/src/client/components/LocalHeader/FlashMessages.jsx
+++ b/src/client/components/LocalHeader/FlashMessages.jsx
@@ -2,9 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { ERROR_COLOUR, BLUE, BUTTON_COLOUR, ORANGE, BLACK } from 'govuk-colours'
+import {
+  ERROR_COLOUR,
+  BLUE,
+  BUTTON_COLOUR,
+  ORANGE,
+  BLACK,
+  WHITE,
+} from 'govuk-colours'
 import { FONT_WEIGHTS } from '@govuk-react/constants/lib/typography'
-import { FONT_SIZE } from '@govuk-react/constants'
+import { FONT_SIZE, SPACING } from '@govuk-react/constants'
 import UnorderedList from '@govuk-react/unordered-list'
 import { StatusMessage } from 'data-hub-components'
 import flashUtils from '../../utils/flash-messages'
@@ -23,6 +30,11 @@ const StyledHeading = styled('h2')`
 const StyledMessage = styled('p')`
   margin: 0;
   font-size: ${FONT_SIZE.SIZE_20};
+`
+
+const StyledStatusMessage = styled(StatusMessage)`
+  margin-top: ${SPACING.SCALE_3};
+  background-color: ${WHITE};
 `
 
 const messageColours = {
@@ -46,21 +58,21 @@ const FlashMessages = ({ flashMessages }) => {
             return parts.length > 1
               ? message.map((message) => (
                   <li key={message.body}>
-                    <StatusMessage colour={messageColours[parts[0]]}>
+                    <StyledStatusMessage colour={messageColours[parts[0]]}>
                       <StyledHeading>{message.heading}</StyledHeading>
                       <StyledBody
                         dangerouslySetInnerHTML={{ __html: message.body }}
                       />
-                    </StatusMessage>
+                    </StyledStatusMessage>
                   </li>
                 ))
               : message.map((message) => (
                   <li key={message}>
-                    <StatusMessage colour={messageColours[type]}>
+                    <StyledStatusMessage colour={messageColours[type]}>
                       <StyledMessage
                         dangerouslySetInnerHTML={{ __html: message }}
                       />
-                    </StatusMessage>
+                    </StyledStatusMessage>
                   </li>
                 ))
           }


### PR DESCRIPTION
## Description of change

This PR fixes the stying of the React FlashMessages component by adding a `margin-top` and white `background-color`. This is needed because when flash messages are displayed on the dashboard page the local header is a darker shade of grey, making the component hard to read, and as there are no breadcrumbs on the dashboard the component needs some top margin to stop it being right up against the nav bar. This top margin is no greater than the bottom margin of the breadcrumbs, so won't come into effect when a breadcrumb is present - https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing

The second commit also adds bold font weighting to the status message which was missing. 

## Test instructions

When editing a pipeline item you should see the flash message on the dashboard with the new stylings. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/42253716/82654231-4f314a80-9c18-11ea-9212-da7daf0a912e.png)

### After

![image](https://user-images.githubusercontent.com/42253716/82654138-2c9f3180-9c18-11ea-984e-be105531ac6a.png)

![image](https://user-images.githubusercontent.com/42253716/82654786-28bfdf00-9c19-11ea-8bb2-5dea67f8c34f.png)

Second commit with bold weighting:
![image](https://user-images.githubusercontent.com/42253716/82655985-e26b7f80-9c1a-11ea-8e0f-86bc072d654c.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
