### PR TITLE
Add consistent error messaging for pipelines

### DIFF
--- a/src/apps/my-pipeline/client/AddToPipelineForm.jsx
+++ b/src/apps/my-pipeline/client/AddToPipelineForm.jsx
@@ -28,7 +28,6 @@ function isOnPipeline(pipelineStatus, companyId) {
 
 function PipelineCheck({
   pipelineStatus,
-  companyName,
   companyId,
   getPipelineByCompany,
   children,
@@ -45,8 +44,8 @@ function PipelineCheck({
     return (
       <ErrorSummary
         heading="There is a problem"
-        description={`There was an error checking the status of ${companyName}`}
-        errors={[getPipelineByCompany.errorMessage]}
+        description={`Error: ${getPipelineByCompany.errorMessage}`}
+        errors={[]}
       />
     )
   }
@@ -67,12 +66,7 @@ function PipelineCheck({
   )
 }
 
-function AddToPipelineForm({
-  companyId,
-  companyName,
-  pipelineStatus,
-  savedPipelineItem,
-}) {
+function AddToPipelineForm({ companyId, pipelineStatus, savedPipelineItem }) {
   useEffect(() => {
     if (savedPipelineItem) {
       /**
@@ -100,7 +94,6 @@ function AddToPipelineForm({
               getPipelineByCompany={getPipelineByCompany}
               pipelineStatus={pipelineStatus}
               companyId={companyId}
-              companyName={companyName}
             >
               <LoadingBox
                 loading={addCompanyToPipeline.progress || savedPipelineItem}
@@ -127,7 +120,6 @@ function AddToPipelineForm({
 
 AddToPipelineForm.propTypes = {
   companyId: PropTypes.string,
-  companyName: PropTypes.string,
   pipelineStatus: PipelineItemsPropType,
   savedId: PipelineItemPropType,
 }

--- a/src/apps/my-pipeline/client/EditPipelineForm.jsx
+++ b/src/apps/my-pipeline/client/EditPipelineForm.jsx
@@ -43,7 +43,7 @@ function PipelineCheck({
     return (
       <ErrorSummary
         heading="There is a problem"
-        description={getCompanyByPipeline.errorMessage}
+        description={`Error: ${getCompanyByPipeline.errorMessage}`}
         errors={[]}
       />
     )

--- a/src/apps/my-pipeline/client/api.js
+++ b/src/apps/my-pipeline/client/api.js
@@ -2,20 +2,38 @@ import axios from 'axios'
 
 const endpoint = '/api-proxy/v4/pipeline-item'
 
+function handleSuccess(result) {
+  return result
+}
+
+function handleError(error) {
+  const message = error?.response?.data?.detail || error.message
+  return Promise.reject({
+    message,
+    ...error,
+  })
+}
+
 function getPipelineItems(filter) {
-  return axios.get(`${endpoint}`, { params: filter })
+  return axios
+    .get(`${endpoint}`, { params: filter })
+    .then(handleSuccess, handleError)
 }
 
 function getPipelineItem(pipelineItemId) {
-  return axios.get(`${endpoint}/${pipelineItemId}`)
+  return axios
+    .get(`${endpoint}/${pipelineItemId}`)
+    .then(handleSuccess, handleError)
 }
 
 function createPipelineItem(values) {
-  return axios.post(`${endpoint}`, values)
+  return axios.post(`${endpoint}`, values).then(handleSuccess, handleError)
 }
 
 function updatePipelineItem(pipelineItemId, values) {
-  return axios.patch(`${endpoint}/${pipelineItemId}`, values)
+  return axios
+    .patch(`${endpoint}/${pipelineItemId}`, values)
+    .then(handleSuccess, handleError)
 }
 
 const pipelineApi = {

--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -20,8 +20,9 @@ const PipelineList = ({ status, items }) => {
   return (
     <Task.Status
       name={TASK_GET_PIPELINE_LIST}
-      id={STATE_ID}
+      id={`${STATE_ID}_${status}`}
       progressMessage="loading pipelines items"
+      noun="my pipelines"
       startOnRender={{
         payload: { status },
         onSuccessDispatch: PIPELINE__LIST_LOADED,

--- a/src/client/components/Pipeline/tasks.js
+++ b/src/client/components/Pipeline/tasks.js
@@ -1,17 +1,5 @@
-import axios from 'axios'
-
-function handleError(e) {
-  const message = e?.response?.data?.detail || 'An unknown error occured'
-  return Promise.reject(new Error(message))
-}
+import pipelineApi from '../../../apps/my-pipeline/client/api'
 
 export function getPipelineList({ status }) {
-  return axios
-    .get('/api-proxy/v4/pipeline-item', {
-      params: {
-        status,
-      },
-    })
-    .catch(handleError)
-    .then(({ data }) => data.results)
+  return pipelineApi.list({ status }).then(({ data }) => data.results)
 }


### PR DESCRIPTION
## Description of change
This PR improves the consistently of error messages for pipeline on the dashboard and the add/edit form. The error messages is now using the error provided by the backend. Similar to what the datahub site is currently doing. 

## Test instructions

on the heroku deployment side go to [/my-pipeline](https://data-hub-fro-bugfix-pip-6dws1s.herokuapp.com/my-pipeline) and you should see and error. 
Same with [companies/{companyId}/my-pipeline](https://data-hub-fro-bugfix-pip-6dws1s.herokuapp.com/companies/5bb239e4-b227-4a84-bc2e-3420fc129447/my-pipeline)


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/82659502-b7842a00-9c20-11ea-825e-4dfdfd789e22.png)



![image](https://user-images.githubusercontent.com/5575331/82659671-f74b1180-9c20-11ea-8129-220a5f8e010c.png)


### After
![image](https://user-images.githubusercontent.com/5575331/82659534-c10d9200-9c20-11ea-9a8b-5fadae84fdcf.png)

![image](https://user-images.githubusercontent.com/5575331/82659560-ca96fa00-9c20-11ea-9593-690293216ac7.png)

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
