### PR TITLE
Feature/intergrate dropdownmenu company page

### DIFF
--- a/src/apps/companies/client/CompanyLocalHeader.jsx
+++ b/src/apps/companies/client/CompanyLocalHeader.jsx
@@ -117,7 +117,7 @@ const CompanyLocalHeader = ({
               <DropdownButton
                 href={`/companies/${company.id}/lists/add-remove?returnUrl=${queryString}`}
               >
-                Add to or remove from list
+                Add to or remove from lists
               </DropdownButton>
               <DropdownButton href={urls.companies.pipelineAdd(company.id)}>
                 Add to pipeline

--- a/src/apps/companies/client/CompanyLocalHeader.jsx
+++ b/src/apps/companies/client/CompanyLocalHeader.jsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import pluralize from 'pluralize'
 import GridCol from '@govuk-react/grid-col'
 import GridRow from '@govuk-react/grid-row'
-import Link from '@govuk-react/link'
 import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
 import { GREY_3 } from 'govuk-colours'
 import Details from '@govuk-react/details'
@@ -13,9 +12,12 @@ import { Badge, StatusMessage, DateUtils } from 'data-hub-components'
 
 import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 import LocalHeaderHeading from '../../../client/components/LocalHeader/LocalHeaderHeading'
-import SecondaryButton from '../../../client/components/SecondaryButton.jsx'
 import formatAddress from '../../../client/utils/formatAddress'
-import { companies } from '../../../lib/urls'
+import urls from '../../../lib/urls'
+import {
+  ConnectedDropdownMenu,
+  DropdownButton,
+} from '../../../client/components/DropdownMenu'
 
 const StyledAddress = styled('p')`
   margin-top: ${SPACING.SCALE_2};
@@ -107,12 +109,20 @@ const CompanyLocalHeader = ({
             </StyledAddress>
           </GridCol>
           <GridCol setWith="one-third">
-            <SecondaryButton
-              as={Link}
-              href={`/companies/${company.id}/lists/add-remove?returnUrl=${queryString}`}
+            <ConnectedDropdownMenu
+              label="View Options"
+              closedLabel="Hide Options"
+              id="local_header"
             >
-              Add to or remove from lists
-            </SecondaryButton>
+              <DropdownButton
+                href={`/companies/${company.id}/lists/add-remove?returnUrl=${queryString}`}
+              >
+                Add to or remove from list
+              </DropdownButton>
+              <DropdownButton href={urls.companies.pipelineAdd(company.id)}>
+                Add to pipeline
+              </DropdownButton>
+            </ConnectedDropdownMenu>
           </GridCol>
         </GridRow>
         {(company.isUltimate || company.isGlobalHQ) && (
@@ -140,7 +150,7 @@ const CompanyLocalHeader = ({
             {dnbRelatedCompaniesCount > 0 && (
               <p>
                 Data Hub contains{' '}
-                <a href={companies.dnbHierarchy.index(company.id)}>
+                <a href={urls.companies.dnbHierarchy.index(company.id)}>
                   {dnbRelatedCompaniesCount} other company{' '}
                   {pluralize('record', dnbRelatedCompaniesCount)}
                 </a>{' '}
@@ -158,7 +168,7 @@ const CompanyLocalHeader = ({
                     ? 'Lead ITA'
                     : 'Global Account Manager'}
                   : {company.one_list_group_global_account_manager.name}{' '}
-                  <a href={companies.advisers.index(company.id)}>
+                  <a href={urls.companies.advisers.index(company.id)}>
                     {company.isItaTierDAccount
                       ? 'View Lead adviser'
                       : 'View core team'}
@@ -169,7 +179,7 @@ const CompanyLocalHeader = ({
           </StyledDescription>
         )}
         <p>
-          <a href={companies.businessDetails(company.id)}>
+          <a href={urls.companies.businessDetails(company.id)}>
             View full business details
           </a>
         </p>
@@ -191,7 +201,7 @@ const CompanyLocalHeader = ({
             <strong>Reason:</strong> {company.archived_reason}
             <br />
             <br />
-            <a href={companies.unarchive(company.id)}>Unarchive</a>
+            <a href={urls.companies.unarchive(company.id)}>Unarchive</a>
           </StatusMessage>
         </StyledMain>
       )}

--- a/src/apps/companies/client/__stories__/CompanyLocalHeader.stories.jsx
+++ b/src/apps/companies/client/__stories__/CompanyLocalHeader.stories.jsx
@@ -1,11 +1,17 @@
 import React from 'react'
+import { createStore, combineReducers } from 'redux'
+import { BrowserRouter as Router } from 'react-router-dom'
+import { Provider } from 'react-redux'
 import { storiesOf } from '@storybook/react'
 
 import dnBGlobalUltimate from '../../../../../test/sandbox/fixtures/v4/company/company-dnb-global-ultimate.json'
 import { companies, dashboard } from '../../../../lib/urls'
 import CompanyLocalHeader from '../CompanyLocalHeader'
+import ConnectedDropdownMenu from '../../../../client/components/DropdownMenu/ConnectedDropdownMenu'
 import exampleReadme from './example.md'
 import usageReadme from './usage.md'
+
+const store = createStore(combineReducers(ConnectedDropdownMenu.reducerSpread))
 
 storiesOf('Company Local Header', module)
   .addParameters({
@@ -16,37 +22,41 @@ storiesOf('Company Local Header', module)
     },
   })
   .add('Default', () => (
-    <CompanyLocalHeader
-      breadcrumbs={[
-        { link: dashboard(), text: 'Home' },
-        { link: companies.index(), text: 'Companies' },
-        {
-          link: companies.detail(dnBGlobalUltimate.id),
-          text: dnBGlobalUltimate.name,
-        },
-        { text: 'Activity Feed' },
-      ]}
-      flashMessages={{
-        'success:with-body': [
-          {
-            heading: 'Business details verified.',
-            body:
-              'Thanks for helping to improve the quality of records on Data Hub!',
-            id: 'message-company-matched',
-          },
-        ],
-      }}
-      company={{
-        ...dnBGlobalUltimate,
-        ...{
-          hasManagedAccountDetails: true,
-          archived: true,
-          pending_dnb_investigation: true,
-          isUltimate: true,
-          archived_on: '2019-06-12T14:19:05.473413Z',
-          archived_reason: 'Client cancelled',
-        },
-      }}
-      dnbRelatedCompaniesCount={3}
-    />
+    <Provider store={store}>
+      <Router>
+        <CompanyLocalHeader
+          breadcrumbs={[
+            { link: dashboard(), text: 'Home' },
+            { link: companies.index(), text: 'Companies' },
+            {
+              link: companies.detail(dnBGlobalUltimate.id),
+              text: dnBGlobalUltimate.name,
+            },
+            { text: 'Activity Feed' },
+          ]}
+          flashMessages={{
+            'success:with-body': [
+              {
+                heading: 'Business details verified.',
+                body:
+                  'Thanks for helping to improve the quality of records on Data Hub!',
+                id: 'message-company-matched',
+              },
+            ],
+          }}
+          company={{
+            ...dnBGlobalUltimate,
+            ...{
+              hasManagedAccountDetails: true,
+              archived: true,
+              pending_dnb_investigation: true,
+              isUltimate: true,
+              archived_on: '2019-06-12T14:19:05.473413Z',
+              archived_reason: 'Client cancelled',
+            },
+          }}
+          dnbRelatedCompaniesCount={3}
+        />
+      </Router>
+    </Provider>
   ))

--- a/src/client/components/DropdownMenu/ConnectedDropdownMenu.jsx
+++ b/src/client/components/DropdownMenu/ConnectedDropdownMenu.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import multiInstance from '../../../client/utils/multiinstance'
+import DropdownMenu from './DropdownMenu'
+
+const DROP_DOWN_MENU_TOGGLE = 'DROP_DOWN_MENU_TOGGLE'
+const DROP_DOWN_MENU_OPEN = 'DROP_DOWN_MENU_OPEN'
+const DROP_DOWN_MENU_CLOSED = 'DROP_DOWN_MENU_CLOSED'
+const DROP_DOWN_MENU_UPDATE_INDEX = 'DROP_DOWN_MENU_UPDATE_INDEX'
+
+const toggle = {
+  type: DROP_DOWN_MENU_TOGGLE,
+}
+
+const open = {
+  type: DROP_DOWN_MENU_OPEN,
+}
+
+const close = {
+  type: DROP_DOWN_MENU_CLOSED,
+}
+
+const updateIndex = (activeIndex) => ({
+  type: DROP_DOWN_MENU_UPDATE_INDEX,
+  activeIndex,
+})
+
+function reducer(state = {}, { type, ...rest }) {
+  switch (type) {
+    case DROP_DOWN_MENU_OPEN:
+      return { open: true }
+    case DROP_DOWN_MENU_CLOSED:
+      return { open: false }
+    case DROP_DOWN_MENU_TOGGLE:
+      return { open: !state.open }
+    case DROP_DOWN_MENU_UPDATE_INDEX:
+      return { ...state, activeIndex: rest.activeIndex }
+  }
+  return state
+}
+
+const dispatchToProps = (dispatch) => ({
+  openMenu: dispatch.bind(void 0, open),
+  closeMenu: dispatch.bind(void 0, close),
+  toggleMenu: dispatch.bind(void 0, toggle),
+  onUpdateIndex: (activeIndex) => dispatch(updateIndex(activeIndex)),
+})
+
+export default multiInstance({
+  name: 'DropdownMenu',
+  actionPattern: 'DROP_DOWN_MENU',
+  component: (props) => (
+    <DropdownMenu {...props} onClick={() => props.toggleMenu()} />
+  ),
+  reducer,
+  dispatchToProps,
+})

--- a/src/client/components/DropdownMenu/DropdownMenu.jsx
+++ b/src/client/components/DropdownMenu/DropdownMenu.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Button from '@govuk-react/button'
-import { GREY_3, BLACK, GREY_2 } from 'govuk-colours'
+import { GREY_2 } from 'govuk-colours'
 import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 import { spacing } from '@govuk-react/lib'
 import styled from 'styled-components'
-
+import Link from '@govuk-react/link'
+import SecondaryButton from '../../components/SecondaryButton'
 import trianglePng from '../../../../assets/images/icon-triangle.svg'
 
 const DropdownMenuContainer = styled.div`
@@ -23,6 +23,7 @@ const DropdownMenuGroup = styled.div`
   })}
   ${MEDIA_QUERIES.TABLET} {
     position: absolute;
+    z-index: 1;
   }
 `
 
@@ -33,11 +34,15 @@ const Icon = styled.img`
   transform-origin: center;
 `
 
-const DropdownToggleButton = styled(Button)`
+const DropdownToggleButton = styled(SecondaryButton)`
   font-weight: Bold;
 `
 
-export const DropdownButton = styled(Button)`
+export const DropdownButton = styled(SecondaryButton).attrs(() => ({
+  tabIndex: '-1',
+  role: 'option',
+  forwardedAs: Link,
+}))`
   ${spacing.responsive({
     size: 3,
     property: 'margin-bottom',
@@ -46,14 +51,69 @@ export const DropdownButton = styled(Button)`
     margin-bottom: 0;
   }
 `
+const KEY_ARROW_UP = 38
+const KEY_ARROW_DOWN = 40
+const KEY_TAB = 9
+const KEY_ESC = 27
+const KEY_HOME = 36
+const KEY_END = 35
 
-const DropdownMenu = ({ label, children, closedLabel, onClick, open }) => {
+const DropdownMenu = ({
+  label,
+  children,
+  closedLabel,
+  onClick,
+  open,
+  activeIndex,
+  onUpdateIndex,
+  closeMenu,
+}) => {
+  const childrenGroupRef = React.useRef(null)
+  const onKeyUp = ({ keyCode }) => {
+    switch (keyCode) {
+      case KEY_ARROW_UP:
+        onUpdateIndex(Math.max(0, (activeIndex ?? 0) - 1))
+        break
+      case KEY_ARROW_DOWN:
+        onUpdateIndex(Math.min((activeIndex ?? -1) + 1, children.length - 1))
+        break
+      case KEY_HOME:
+        onUpdateIndex(0)
+        break
+      case KEY_END:
+        onUpdateIndex(children.length - 1)
+        break
+    }
+  }
+
+  const onKeyDown = (event) => {
+    switch (event.keyCode) {
+      case KEY_TAB:
+      case KEY_ESC:
+        closeMenu()
+        break
+      case KEY_HOME:
+      case KEY_END:
+      case KEY_ARROW_UP:
+      case KEY_ARROW_DOWN:
+        if (open) {
+          // Prevent page scrolling if open
+          event.preventDefault()
+        }
+        break
+    }
+  }
+
+  React.useEffect(() => {
+    if (!isNaN(activeIndex) && childrenGroupRef.current) {
+      childrenGroupRef.current.children[activeIndex].focus()
+    }
+  }, [activeIndex])
+
   return (
-    <DropdownMenuContainer>
+    <DropdownMenuContainer onKeyUp={onKeyUp} onKeyDown={onKeyDown}>
       <DropdownToggleButton
         buttonShadowColour="transparent"
-        buttonColour={GREY_3}
-        buttonTextColour={BLACK}
         onClick={() => onClick(!open)}
         icon={<Icon src={trianglePng} active={open} />}
         aria-haspopup={true}
@@ -61,12 +121,17 @@ const DropdownMenu = ({ label, children, closedLabel, onClick, open }) => {
       >
         {(open ? closedLabel : label) || label}
       </DropdownToggleButton>
-      {open && <DropdownMenuGroup>{children}</DropdownMenuGroup>}
+      {open && (
+        <DropdownMenuGroup ref={childrenGroupRef}>{children}</DropdownMenuGroup>
+      )}
     </DropdownMenuContainer>
   )
 }
 
 DropdownMenu.propTypes = {
+  onUpdateIndex: PropTypes.func.isRequired,
+  closeMenu: PropTypes.func.isRequired,
+  activeIndex: PropTypes.number,
   label: PropTypes.string.isRequired,
   closedLabel: PropTypes.string,
   children: PropTypes.node,

--- a/src/client/components/DropdownMenu/DropdownMenu.jsx
+++ b/src/client/components/DropdownMenu/DropdownMenu.jsx
@@ -68,6 +68,7 @@ const DropdownMenu = ({
   onUpdateIndex,
   closeMenu,
 }) => {
+  const buttonRef = React.useRef(null)
   const childrenGroupRef = React.useRef(null)
   const onKeyUp = ({ keyCode }) => {
     switch (keyCode) {
@@ -91,6 +92,8 @@ const DropdownMenu = ({
       case KEY_TAB:
       case KEY_ESC:
         closeMenu()
+      case KEY_ESC:
+        buttonRef.current && buttonRef.current.focus()
         break
       case KEY_HOME:
       case KEY_END:
@@ -113,6 +116,7 @@ const DropdownMenu = ({
   return (
     <DropdownMenuContainer onKeyUp={onKeyUp} onKeyDown={onKeyDown}>
       <DropdownToggleButton
+        ref={buttonRef}
         buttonShadowColour="transparent"
         onClick={() => onClick(!open)}
         icon={<Icon src={trianglePng} active={open} />}

--- a/src/client/components/DropdownMenu/__stories__/DropdownMenu.stories.jsx
+++ b/src/client/components/DropdownMenu/__stories__/DropdownMenu.stories.jsx
@@ -19,9 +19,13 @@ export default {
 
 const withState = (Component) => () => {
   const [isOpen, setState] = React.useState(false)
+  const [activeIndex, onUpdateIndex] = React.useState(void 0)
   const clickAction = action('click')
   return (
     <Component
+      closeMenu={() => setState(false)}
+      activeIndex={activeIndex}
+      onUpdateIndex={onUpdateIndex}
       open={isOpen}
       onClick={(nextState) => {
         clickAction(nextState)

--- a/src/client/components/DropdownMenu/index.js
+++ b/src/client/components/DropdownMenu/index.js
@@ -1,1 +1,2 @@
-export { default as ButtonGroup, ButtonGroupItem } from './DropdownMenu'
+export { default, DropdownButton, DropdownLink } from './DropdownMenu'
+export { default as ConnectedDropdownMenu } from './ConnectedDropdownMenu'

--- a/src/client/components/SecondaryButton.jsx
+++ b/src/client/components/SecondaryButton.jsx
@@ -3,8 +3,13 @@ import Button from '@govuk-react/button'
 import React from 'react'
 
 // TODO: Move to data-hub-components
-const SecondaryButton = (props) => (
-  <Button buttonColour={GREY_3} buttonTextColour={TEXT_COLOUR} {...props} />
-)
+const SecondaryButton = React.forwardRef((props, ref) => (
+  <Button
+    ref={ref}
+    buttonColour={GREY_3}
+    buttonTextColour={TEXT_COLOUR}
+    {...props}
+  />
+))
 
 export default SecondaryButton

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -42,7 +42,7 @@ import PipelineForm from '../apps/my-pipeline/client'
 import CompanyLocalHeader from '../apps/companies/client/CompanyLocalHeader.jsx'
 import InvestmentProjectAdmin from '../apps/investments/views/admin/client/InvestmentProjectAdmin.jsx'
 import FlashMessages from './components/LocalHeader/FlashMessages.jsx'
-
+import { ConnectedDropdownMenu } from './components/DropdownMenu'
 import tasksSaga from './components/Task/saga'
 import tasks from './components/Task/reducer'
 
@@ -138,6 +138,7 @@ const store = createStore(
     ...TabNav.reducerSpread,
     ...ReferralList.reducerSpread,
     ...Form.reducerSpread,
+    ...ConnectedDropdownMenu.reducerSpread,
     // A reducer is required to be able to set a preloadedState parameter
     referrerUrl: (state = {}) => state,
     [INVESTEMENT_PROJECT_ADMIN_ID]: investmentProjectAdminReducer,

--- a/src/client/utils/multiinstance.js
+++ b/src/client/utils/multiinstance.js
@@ -154,7 +154,7 @@ export const connect = (componentState2props, dispatch2props, ...rest) =>
  * const store = createStore(combineReducers({
  *   // So we can use it like this and we can be sure that both the reducer
  *   // and the component are connected to the same part of the state
- *   ...Counter.redcerSpread,
+ *   ...Counter.reducerSpread,
  * }))
  *
  * const App = () =>

--- a/test/functional/cypress/specs/companies/local-header/archived-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/archived-spec.js
@@ -31,6 +31,7 @@ describe('Local header for archived company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -104,6 +105,7 @@ describe('Local header for archived company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -177,6 +179,7 @@ describe('Local header for archived company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -256,6 +259,7 @@ describe('Local header for archived company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -336,6 +340,7 @@ describe('Local header for archived company', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -411,6 +416,7 @@ describe('Local header for archived company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -489,6 +495,7 @@ describe('Local header for archived company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -564,6 +571,7 @@ describe('Local header for archived company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -36,6 +36,7 @@ describe('Local header for global ultimate company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -119,6 +120,7 @@ describe('Local header for global ultimate company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -204,6 +206,7 @@ describe('Local header for global ultimate company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -293,6 +296,7 @@ describe('Local header for global ultimate company', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -383,6 +387,7 @@ describe('Local header for global ultimate company', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -469,6 +474,7 @@ describe('Local header for global ultimate company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -559,6 +565,7 @@ describe('Local header for global ultimate company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -642,6 +649,7 @@ describe('Local header for global ultimate company', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -39,6 +39,7 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -108,6 +109,7 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -179,6 +181,7 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -250,6 +253,7 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -321,6 +325,7 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -388,6 +393,7 @@ describe('Local header for company under dnb investigation', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',
@@ -459,6 +465,7 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       it('should display the correct buttons', () => {
+        cy.contains('View Options').click()
         cy.contains('Add to or remove from lists').should(
           'have.attr',
           'href',
@@ -524,6 +531,7 @@ describe('Local header for company under dnb investigation', () => {
     })
 
     it('should display the correct buttons', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists').should(
         'have.attr',
         'href',

--- a/test/functional/cypress/specs/companies/tab-history.spec.js
+++ b/test/functional/cypress/specs/companies/tab-history.spec.js
@@ -10,6 +10,7 @@ const testTab = (tabText) => {
     cy.get(tabbedLocalNav().tabs)
       .contains(tabText)
       .click()
+    cy.contains('View Options').click()
     cy.contains('Add to or remove from lists').click()
     cy.get(cancelLink).click()
     cy.get(tabbedLocalNav().tabs)

--- a/test/functional/cypress/specs/company-lists/add-remove.spec.js
+++ b/test/functional/cypress/specs/company-lists/add-remove.spec.js
@@ -10,6 +10,7 @@ describe('Adding and removing a company to a list', () => {
       cy.visit(`/companies/${fixtures.company.lambdaPlc.id}/activity`)
     })
     it('displays a button to add or remove from a list', () => {
+      cy.contains('View Options').click()
       cy.contains('Add to or remove from lists')
     })
   })


### PR DESCRIPTION
## Description of change

This PR integrates the dropdown menu into the company local header for support more options which is Add company to pipeline.
The dropdown menu is integrated with redux to hold its open and close state and current index for keyboard support. 
The dropdown menu conform to aria practice for dropdown menus. https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html 

| Key        | Function                                                                                                                                                                                                                           |
|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Enter      | If the focus is on the button, expands the listbox and places focus on the currently selected option in the list\.If focus is in the listbox , collapses the listbox and keeps the currently selected option as the button label\. |
| Escape     | If the listbox is displayed, collapses the listbox and moves focus to the button\.                                                                                                                                                 |
| Down Arrow | Moves focus to and selects the next option\.If the listbox is collapsed, also expands the list\.                                                                                                                                   |
| Up Arrow   | Moves focus to and selects the previous option\.If the listbox is collapsed, also expands the list\.                                                                                                                               |
| Home       | If the listbox is displayed, moves focus to and selects the first option\.                                                                                                                                                         |
| End        | If the listbox is displayed, moves focus to and selects the last option\.                                                                                                                                                          |


## Test instructions

On the deployment site go to the company page and you should be able to click on it or tab and navigate with the arrow keys.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/82895744-98510980-9f4c-11ea-83ab-02ecf03e714f.png)

### After
![image](https://user-images.githubusercontent.com/5575331/82897844-2c70a000-9f50-11ea-85fd-45f4e3fd4d30.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
