### PR TITLE
Refactor pipelines to use contants for statuses

### DIFF
--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -5,6 +5,12 @@ import Link from '@govuk-react/link'
 import { FieldRadios, FormActions, FieldInput } from 'data-hub-components'
 import Form from '../../../client/components/Form'
 import { ID as STATE_ID } from './state'
+import { STATUS_VALUES } from './constants'
+
+const options = STATUS_VALUES.map(({ value, label }) => ({
+  value,
+  label,
+}))
 
 function PipelineForm({
   onSubmit,
@@ -25,11 +31,7 @@ function PipelineForm({
         name="category"
         label="Choose a status"
         required="Choose a status"
-        options={[
-          { value: 'leads', label: 'Lead' },
-          { value: 'in_progress', label: 'In progress' },
-          { value: 'win', label: 'Win' },
-        ]}
+        options={options}
         initialValue={initialValue.category}
       />
       <FormActions>

--- a/src/apps/my-pipeline/client/constants.js
+++ b/src/apps/my-pipeline/client/constants.js
@@ -1,10 +1,5 @@
 import PropTypes from 'prop-types'
-
-export const URL_MAP = {
-  leads: 'index',
-  in_progress: 'active',
-  win: 'won',
-}
+import urls from '../../../lib/urls'
 
 export const PipelineItemPropType = PropTypes.exact({
   company: PropTypes.exact({
@@ -24,3 +19,23 @@ export const PipelineItemsPropType = PropTypes.exact({
   count: PropTypes.number,
   results: PropTypes.arrayOf(PipelineItemPropType),
 })
+
+export const STATUSES = {
+  LEADS: {
+    value: 'leads',
+    label: 'Prospect',
+    url: urls.pipeline.index,
+  },
+  IN_PROGRESS: {
+    value: 'in_progress',
+    label: 'Active',
+    url: urls.pipeline.active,
+  },
+  WIN: {
+    value: 'win',
+    label: 'Won',
+    url: urls.pipeline.won,
+  },
+}
+
+export const STATUS_VALUES = Object.values(STATUSES)

--- a/src/apps/my-pipeline/client/utils.js
+++ b/src/apps/my-pipeline/client/utils.js
@@ -1,6 +1,11 @@
 import urls from '../../../lib/urls'
-import { URL_MAP } from './constants'
+import { STATUS_VALUES } from './constants'
+
+const URL_MAP = STATUS_VALUES.reduce((acc, { value, url }) => {
+  acc[value] = url
+  return acc
+}, {})
 
 export function getPipelineUrl({ status } = {}) {
-  return urls.pipeline[URL_MAP[status] || 'index']()
+  return (URL_MAP[status] || urls.pipeline.index)()
 }

--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -10,13 +10,7 @@ import { state2props, ID as STATE_ID, TASK_GET_PIPELINE_LIST } from './state'
 import { PIPELINE__LIST_LOADED } from '../../actions'
 import PipelineItem from './PipelineItem'
 
-const statusConstants = {
-  leads: 'prospect',
-  in_progress: 'active',
-  win: 'won',
-}
-
-const PipelineList = ({ status, items }) => {
+const PipelineList = ({ status, statusText, items }) => {
   return (
     <Task.Status
       name={TASK_GET_PIPELINE_LIST}
@@ -44,9 +38,9 @@ const PipelineList = ({ status, items }) => {
             ))
           ) : (
             <InsetText>
-              There are no companies in the {statusConstants[status]} section of
-              your pipeline. You can add companies to your pipeline from the
-              company page.
+              There are no companies in the {statusText} section of your
+              pipeline. You can add companies to your pipeline from the company
+              page.
             </InsetText>
           )}
         </StyledOrderedList>

--- a/src/client/components/Pipeline/index.jsx
+++ b/src/client/components/Pipeline/index.jsx
@@ -3,9 +3,9 @@ import styled from 'styled-components'
 import { BLUE, WHITE } from 'govuk-colours'
 import { FONT_SIZE } from '@govuk-react/constants'
 
-import urls from '../../../lib/urls'
 import TabNav from '../TabNav'
 import PipelineList from './PipelineList'
+import { STATUS_VALUES } from '../../../apps/my-pipeline/client/constants'
 
 const SubTabs = styled(TabNav)`
   margin-top: -15px; /* Because we are in a tabpanel of an existing TabNav, it has a 30px margin at the top but we don't want that much */
@@ -45,20 +45,18 @@ export default function Pipeline() {
       label="Pipeline statuses"
       routed={true}
       data-auto-id="pipelineSubTabNav"
-      tabs={{
-        [urls.pipeline.index()]: {
-          label: 'Prospect',
-          content: <PipelineList status="leads" />,
-        },
-        [urls.pipeline.active()]: {
-          label: 'Active',
-          content: <PipelineList status="in_progress" />,
-        },
-        [urls.pipeline.won()]: {
-          label: 'Won',
-          content: <PipelineList status="win" />,
-        },
-      }}
+      tabs={STATUS_VALUES.reduce((acc, status) => {
+        acc[status.url()] = {
+          label: status.label,
+          content: (
+            <PipelineList
+              status={status.value}
+              statusText={status.label.toLocaleLowerCase()}
+            />
+          ),
+        }
+        return acc
+      }, {})}
     />
   )
 }

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
@@ -73,7 +73,7 @@ describe('Pipeline edit form', () => {
           element,
           label: 'Choose a status',
           optionsCount: 3,
-          value: 'In progress',
+          value: 'Active',
         })
       })
     })


### PR DESCRIPTION
## Description of change

Ensure consistent labels are used across the pipelines feature

## Test instructions

The labels should now match between:
1) The add to pipeline form
2) The my pipeline sub tabs on the dashboard
3) The edit pipeline item form

## Screenshots
### Before

<img width="979" alt="Screenshot 2020-05-27 at 08 05 06" src="https://user-images.githubusercontent.com/1481883/82988274-cdaf3300-9ff0-11ea-9e9f-45dd2efa65d4.png">


### After

<img width="988" alt="Screenshot 2020-05-27 at 08 04 14" src="https://user-images.githubusercontent.com/1481883/82988284-d142ba00-9ff0-11ea-93f0-33f4b040ef86.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
