### PR TITLE
Additional fields for pipeline items

### DIFF
--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -1,70 +1,143 @@
 import React from 'react'
+import moment from 'moment'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
+import { PipeLineItemPropType } from './types'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
-import { BLUE } from 'govuk-colours'
-import Card from 'data-hub-components/dist/activity-feed/activities/card/Card'
-import CardHeader from 'data-hub-components/dist/activity-feed/activities/card/CardHeader'
+import { BLUE, GREEN } from 'govuk-colours'
+import {
+  Card,
+  CardDetailsList,
+  CardHeader,
+} from 'data-hub-components/dist/activity-feed/activities/card'
+import { Badge, NumberUtils } from 'data-hub-components'
 
 import urls from '../../../lib/urls'
 
-const StyledButtonWrapper = styled(GridCol)`
-  align-items: flex-start;
+const StyledGridCol = styled(GridCol)`
   display: flex;
-  justify-content: flex-start;
-  min-width: 100%;
-
-  ${MEDIA_QUERIES.TABLET} {
-    justify-content: flex-end;
-    min-width: unset;
-  }
-
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: space-between;
   a {
-    margin-bottom: 0;
+    margin: ${SPACING.SCALE_3} 0 0 0;
+  }
+  ${MEDIA_QUERIES.TABLET} {
+    align-items: flex-end;
+  }
+`
+const StyledGridValue = styled(GridCol)`
+  flex: 1;
+  margin-top: ${SPACING.SCALE_1};
+  ${MEDIA_QUERIES.TABLET} {
+    margin-top: 0;
+  }
+`
+const StyledGridLabel = styled(StyledGridValue)`
+  font-weight: bold;
+  margin-top: ${SPACING.SCALE_2};
+  ${MEDIA_QUERIES.TABLET} {
+    flex: 0 0 200px;
+    margin-top: 0;
   }
 `
 
 const StyledGridRow = styled(GridRow)`
-  align-items: baseline;
+  padding-top: ${SPACING.SCALE_3};
 
-  div {
-    margin-top: ${SPACING.SCALE_3};
-
-    ${MEDIA_QUERIES.TABLET} {
-      margin-top: 0;
-    }
+  ${MEDIA_QUERIES.TABLET} {
+    padding-top: 0;
   }
 `
 
-const PipelineItem = ({ id, companyId, companyName, projectName, date }) => (
+const StyledBadgeSpacing = styled.span`
+  margin: ${SPACING.SCALE_3} 0 0 0;
+  ${MEDIA_QUERIES.TABLET} {
+    margin: 0;
+  }
+  & > span {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+  }
+`
+
+const LIKELIHOOD_TO_WIN = {
+  1: 'Low',
+  2: 'Medium',
+  3: 'High',
+}
+
+function buildMetaList({
+  potential_value,
+  sector,
+  contact,
+  expected_win_date,
+}) {
+  const list = [
+    sector && { id: 0, label: 'Project sector', value: sector.segment },
+    contact && { id: 1, label: 'Company contact', value: contact.name },
+    potential_value && {
+      id: 2,
+      label: 'Potential export value',
+      value: NumberUtils.currencyGBP(potential_value),
+    },
+    expected_win_date && {
+      id: 3,
+      label: 'Expected date for win',
+      value: moment(expected_win_date).format('MMM Y'),
+    },
+  ]
+  // remove falsy values
+  return list.filter(Boolean)
+}
+
+const PipelineItemMeta = ({ label, value }) => (
+  <GridRow>
+    <StyledGridLabel>{label}</StyledGridLabel>
+    <StyledGridValue>{value}</StyledGridValue>
+  </GridRow>
+)
+const PipelineItem = ({
+  item: { id, name, company, created_on, likelihood_to_win, ...meta },
+}) => (
   <Card>
     <CardHeader
-      company={{ name: projectName }}
+      company={{ name }}
       heading={
-        <Link href={urls.companies.detail(companyId)}>{companyName}</Link>
+        <Link href={urls.companies.detail(company.id)}>{company.name}</Link>
       }
-      startTime={date}
+      startTime={created_on}
     />
     <StyledGridRow>
-      <StyledButtonWrapper>
+      <GridCol>
+        <CardDetailsList
+          itemRenderer={(metaItem) => <PipelineItemMeta {...metaItem} />}
+          items={buildMetaList(meta)}
+        />
+      </GridCol>
+      <StyledGridCol>
+        {LIKELIHOOD_TO_WIN[likelihood_to_win] && (
+          <StyledBadgeSpacing>
+            <Badge
+              borderColour={GREEN}
+            >{`Likelihood to succeed - ${LIKELIHOOD_TO_WIN[likelihood_to_win]}`}</Badge>
+          </StyledBadgeSpacing>
+        )}
+
         <Button as={Link} href={urls.pipeline.edit(id)} buttonColour={BLUE}>
           Edit
         </Button>
-      </StyledButtonWrapper>
+      </StyledGridCol>
     </StyledGridRow>
   </Card>
 )
 
 PipelineItem.propTypes = {
-  id: PropTypes.string.isRequired,
-  companyId: PropTypes.string.isRequired,
-  companyName: PropTypes.string.isRequired,
-  projectName: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
+  item: PipeLineItemPropType,
 }
 
 export default PipelineItem

--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -27,13 +27,7 @@ const PipelineList = ({ status, statusText, items }) => {
           {items && items.length ? (
             items.map((item) => (
               <ListItem key={item.id}>
-                <PipelineItem
-                  id={item.id}
-                  companyId={item.company.id}
-                  companyName={item.company.name}
-                  projectName={item.name}
-                  date={item.created_on}
-                />
+                <PipelineItem item={item} />
               </ListItem>
             ))
           ) : (

--- a/src/client/components/Pipeline/types.js
+++ b/src/client/components/Pipeline/types.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types'
+
+export const PipeLineItemPropType = PropTypes.shape({
+  company: PropTypes.shape({
+    export_potential: PropTypes.any,
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    turnover: PropTypes.any,
+  }).isRequired,
+  contact: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }),
+  created_on: PropTypes.string.isRequired,
+  expected_win_date: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  likelihood_to_win: PropTypes.number,
+  name: PropTypes.string.isRequired,
+  potential_value: PropTypes.string,
+  sector: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    segment: PropTypes.string.isRequired,
+  }),
+  status: PropTypes.string.isRequired,
+}).isRequired

--- a/test/sandbox/fixtures/v4/pipeline-item/leads.json
+++ b/test/sandbox/fixtures/v4/pipeline-item/leads.json
@@ -13,7 +13,11 @@
       },
       "name": "Socks to Norway",
       "status": "leads",
-      "created_on": "2020-05-15T14:13:01.053350Z"
+      "created_on": "2020-05-15T14:13:01.053350Z",
+      "contact": {
+        "id": "048f2edc-e7ed-4881-b1cc-29142a80238a",
+        "name": "John Smith"
+      }
     },
     {
       "id": "1211a313-1ab9-4330-9b9d-b971c434e9f0",
@@ -35,9 +39,60 @@
         "export_potential": null,
         "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
       },
-      "name": "Socks to Japan",
+      "name": "Socks to France",
       "status": "leads",
-      "created_on": "2020-05-13T14:12:46.838377Z"
+      "created_on": "2020-05-13T14:12:46.838377Z",
+      "contact": {
+        "id": "048f2edc-e7ed-4881-b1cc-29142a80238a",
+        "name": "John Smith"
+      },
+      "sector": {
+        "id": "9738cecc-5f95-e211-a939-e4115bead28a",
+        "segment": "Textiles"
+      },
+      "potential_value": 14453420,
+      "likelihood_to_win": 1,
+      "expected_win_date": "2021-05-01"
+    },
+    {
+      "id": "96631105-6b08-44b3-a939-93ccb1adcc3e",
+      "company": {
+        "name": "Venus Ltd",
+        "turnover": null,
+        "export_potential": null,
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "name": "Socks to Germany",
+      "status": "leads",
+      "created_on": "2020-05-12T14:12:46.838377Z",
+      "contact": {
+        "id": "048f2edc-e7ed-4881-b1cc-29142a80238a",
+        "name": "John Smith"
+      },
+      "sector": {
+        "id": "9738cecc-5f95-e211-a939-e4115bead28a",
+        "segment": "Textiles"
+      },
+      "potential_value": 14453420,
+      "likelihood_to_win": 2,
+      "expected_win_date": "2021-05-01"
+    },
+    {
+      "id": "96631105-6b08-44b3-a939-93ccb1adcc3e",
+      "company": {
+        "name": "Venus Ltd",
+        "turnover": null,
+        "export_potential": null,
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499645"
+      },
+      "name": "Socks to Thailand",
+      "status": "leads",
+      "created_on": "2020-05-11T14:12:46.838377Z",
+      "contact": null,
+      "sector": null,
+      "potential_value": null,
+      "likelihood_to_win": 3,
+      "expected_win_date": null
     }
   ]
 }


### PR DESCRIPTION
## Description of change

This PR surfaces the following information in the pipeline lists.
- Project sector
- Company contact
- Potential export value
- Expected date for win

The meta fields will be hidden if the backend returns null for the fields. This is becuse the fields are optional.
## Test instructions
As the form is not ready to insert the additional fields the first test should be to see if the list will render correctly without the data. This can be down on the Heroku deployment env. To test the data would will need to use the sandbox environment. 


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/83287065-eed27800-a1d8-11ea-8d26-1f94b0dbf9ee.png)



### After
![image](https://user-images.githubusercontent.com/5575331/83418602-cedec680-a41b-11ea-9d46-5162b9c09038.png)


_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
