### PR TITLE
Add details element polyfill IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "data-hub-components": "5.6.1",
     "date-fns": "^1.29.0",
     "del-cli": "^3.0.0",
+    "details-element-polyfill": "^2.4.0",
     "dotenv": "^8.2.0",
     "element-closest": "^2.0.2",
     "express": "^4.16.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ const common = {
     'react-app': [
       'react-app-polyfill/ie9',
       'react-app-polyfill/stable',
+      'details-element-polyfill',
       './src/client/index.jsx',
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7538,6 +7538,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+details-element-polyfill@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz#e0622adef7902662faf27b4ab8acba5dc4e3a6e6"
+  integrity sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g==
+
 detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"


### PR DESCRIPTION
## Description of change

The detail component from govuk react is using a Detail Element https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
It is not currently supported by IE so this PR introduce a lightweight polyfill to bring the functionality to IE.

https://caniuse.com/#feat=details
https://govuk-react.github.io/govuk-react/?path=/story/typography-details--component-default

## Test instructions
On your local machine go to http://localhost:3000/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa/exports in IE and you should see the detail component working. 

## Screenshots
### Before

_Add a screenshot_
![image](https://user-images.githubusercontent.com/5575331/83427720-1455c080-a429-11ea-99c2-3bb4c75fa96f.png)


### After

_Add a screenshot_
![image](https://user-images.githubusercontent.com/5575331/83427760-23d50980-a429-11ea-872e-5a245e108222.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
