### PR TITLE
Update lead adviser tab content

### DIFF
--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -62,19 +62,35 @@ const RenderHasNoAccountManager = ({
   hasPermissionToAddIta,
   addUrl,
   companyName,
+  featureFlagOn,
 }) => (
   <div>
     <H2 size={LEVEL_SIZE[3]}>Lead ITA for {companyName}</H2>
-    <p>This company has no Lead ITA</p>
-    <p>
-      An ITA (International Trade Adviser) can add themselves as the Lead ITA,
-      which will be visible to all Data Hub users on the company page and any of
-      its subsidiaries.
-    </p>
-    {hasPermissionToAddIta && (
-      <Button as={Link} href={addUrl}>
-        Add myself as Lead ITA
-      </Button>
+    <p>This company has no Lead ITA.</p>
+    {featureFlagOn ? (
+      <>
+        <p>
+          An ITA (International Trade Adviser) can add themselves as the Lead
+          ITA, which will be visible to all Data Hub users on the company page
+          and any of its subsidiaries.
+        </p>
+        <Button as={Link} href={addUrl}>
+          Add a lead ITA
+        </Button>
+      </>
+    ) : (
+      <>
+        <p>
+          You can add an ITA (International Trade Adviser) as the Lead ITA,
+          which will be visible to all Data Hub users on the company page and
+          any of its subsidiaries.
+        </p>
+        {hasPermissionToAddIta && (
+          <Button as={Link} href={addUrl}>
+            Add myself as Lead ITA
+          </Button>
+        )}
+      </>
     )}
   </div>
 )
@@ -89,6 +105,7 @@ const LeadAdvisers = ({
   addUrl,
   removeUrl,
   hasPermissionToAddIta,
+  featureFlagOn,
 }) => {
   return hasAccountManager ? (
     <RenderHasAccountManager
@@ -107,14 +124,15 @@ const LeadAdvisers = ({
       hasPermissionToAddIta={hasPermissionToAddIta}
       addUrl={addUrl}
       removeUrl={removeUrl}
+      featureFlagOn={featureFlagOn}
     />
   )
 }
 
 LeadAdvisers.propTypes = {
   hasAccountManager: PropTypes.bool.isRequired,
-  name: PropTypes.string.isRequired,
-  team: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  team: PropTypes.string,
   email: PropTypes.string,
   companyName: PropTypes.string.isRequired,
   companyId: PropTypes.string.isRequired,

--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -20,6 +20,7 @@ function renderLeadAdvisers(req, res) {
     user: { permissions },
     returnUrl,
     dnbRelatedCompaniesCount,
+    features,
   } = res.locals
   const { name, team, email } = companyToLeadITA(company) || {}
 
@@ -46,6 +47,7 @@ function renderLeadAdvisers(req, res) {
       returnUrl,
       dnbRelatedCompaniesCount,
       flashMessages: res.locals.getMessages(),
+      featureFlagOn: features['manage-lead-adviser'],
     },
   })
 }

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -21,8 +21,15 @@ describe('Lead advisers', () => {
         'Lead ITA for Mars Exports Ltd'
       )
     })
-    it('should display a button to add myself as lead adviser', () => {
-      cy.contains('Add myself as Lead ITA')
+    it('should display help text for adding a lead adviser', () => {
+      cy.contains('This company has no Lead ITA.')
+      cy.contains(
+        'An ITA (International Trade Adviser) can add themselves as the Lead ITA,' +
+          ' which will be visible to all Data Hub users on the company page and any of its subsidiaries.'
+      )
+    })
+    it('should display a button to add a lead adviser', () => {
+      cy.contains('Add a lead ITA')
         .invoke('attr', 'href')
         .should(
           'eq',

--- a/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+++ b/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
@@ -46,5 +46,9 @@
   {
     "code": "companies-matching",
     "is_active": true
+  },
+  {
+    "code": "manage-lead-adviser",
+    "is_active": true
   }
 ]


### PR DESCRIPTION
## Description of change

Currently an ITA can only add themselves as lead adviser on a company record. This PR is part of a new feature in which any user can add an ITA as lead adviser to a company.

When the `manage-lead-adviser` feature flag is turned on, the button text and content in the Lead Adviser tab will be updated to reflect this new ability. 

It's not currently possible to test the Lead Adviser tab with the feature flag both turned on and off, so I have turned the feature flag on for Sandbox and have updated the company-page-spec to reflect the new content.

## Test instructions

- Go to the Lead Adviser tab on a company page
- The button and paragraph text should be updated to reflect being able to add someone else as lead adviser

## Screenshots
### Before
![Screenshot 2020-06-02 at 11 24 45](https://user-images.githubusercontent.com/22460823/83509648-aca08380-a4c3-11ea-9808-3c116e797735.png)

_Add a screenshot_

### After
![Screenshot 2020-06-02 at 11 25 14](https://user-images.githubusercontent.com/22460823/83509700-bde99000-a4c3-11ea-89c7-120831c0ce20.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
