### PR TITLE
Add Main component for full page layouts

### DIFF
--- a/src/client/components/Main/__stories__/Main.stories.jsx
+++ b/src/client/components/Main/__stories__/Main.stories.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import Main from 'Main'
+import exampleReadme from '../example.md'
+import usageReadme from '../usage.md'
+
+storiesOf('layout/Main', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <Main>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor
+        sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        ut labore et dolore magna aliqua.
+      </p>
+    </Main>
+  ))

--- a/src/client/components/Main/example.md
+++ b/src/client/components/Main/example.md
@@ -1,0 +1,6 @@
+### Import
+```js
+import Main from 'Main'
+```
+
+### Output

--- a/src/client/components/Main/index.jsx
+++ b/src/client/components/Main/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { MEDIA_QUERIES, SPACING, SITE_WIDTH } from '@govuk-react/constants'
+
+const OuterContainer = styled('main')({
+  paddingTop: SPACING.SCALE_5,
+  textAlign: 'center',
+})
+
+const InnerContainer = styled('div')({
+  maxWidth: SITE_WIDTH,
+  marginLeft: SPACING.SCALE_3,
+  marginRight: SPACING.SCALE_3,
+  textAlign: 'left',
+  [MEDIA_QUERIES.LARGESCREEN]: {
+    marginLeft: SPACING.SCALE_5,
+    marginRight: SPACING.SCALE_5,
+  },
+  // no 1020px breakpoint in constants yet
+  '@media only screen and (min-width:1020px)': {
+    margin: '0 auto',
+  },
+})
+
+const Main = ({ children, ...props }) => (
+  <OuterContainer {...props} role="main" id="main-content">
+    <InnerContainer>{children}</InnerContainer>
+  </OuterContainer>
+)
+
+Main.propTypes = {
+  children: PropTypes.node,
+}
+
+Main.defaultProps = {
+  children: undefined,
+}
+
+export default Main

--- a/src/client/components/Main/usage.md
+++ b/src/client/components/Main/usage.md
@@ -1,0 +1,27 @@
+Main
+=========
+
+### Description
+
+ The`<Main>`is a layout component which wraps content inside the`<main>`HTML tag, this component also contains a grid container which will center the content in the page with the appropriate gutters and responsive behaviour we expect from [our grid](https://design-system.service.gov.uk/styles/layout/). Its important that we include this in all pages as the`<main>`represents the dominant content of the`<body>`of the document, this also acts as a landmark which can help assistive technologies.
+
+
+### Usage
+
+```jsx
+  <Main role="main" id="main-content">
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit
+      amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+      labore et dolore magna aliqua.
+    </p>
+  </Main>
+```
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `children` | false | undefined | node | Text for main
+
+

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -1,1 +1,2 @@
 export { default as Panel } from './Panel'
+export { default as Main } from './Main'


### PR DESCRIPTION
## Description of change
Currently we are using a `<Main>` component from govuk-react, the problem with this layout component is that it does not render the HTML `<main>`. Also, although not ideal, some styles currently hang off of this tag. More importantly we need the HTML `<main>` to mark the dominant content area whilst also creating a landmark which helps with assistive technologies.

## Test instructions
Please run Storybook `yarn storybook`

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
