### PR TITLE
Add OR boolean logic validation to both website and phone number.

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -9,20 +9,22 @@ import FieldAddress from 'data-hub-components/dist/forms/elements/FieldAddress'
 import { ISO_CODE, WEBSITE_REGEX } from './constants'
 import InformationList from './InformationList'
 
-// TODO: Move this validation to the component library
-const requiredWebsiteOrPhoneValidator = (
+const requiredWebsiteAndOrPhoneValidator = (
   value,
   name,
   { values: { website, telephone_number } }
 ) => {
-  return !website && !telephone_number
-    ? 'Enter a website or phone number'
-    : null
-}
+  if (!telephone_number && !website) {
+    return 'Enter a website or phone number'
+  }
 
-// TODO: Move this validation to the component library
-const websiteValidator = (value) =>
-  !WEBSITE_REGEX.test(value) ? 'Enter a valid website URL' : null
+  if (telephone_number && !website) {
+    return null
+  }
+
+  // TODO: Move this validation to the component library
+  return !WEBSITE_REGEX.test(website) ? 'Enter a valid website URL' : null
+}
 
 function CompanyNotFoundStep({ organisationTypes, regions, sectors, country }) {
   return (
@@ -52,14 +54,14 @@ function CompanyNotFoundStep({ organisationTypes, regions, sectors, country }) {
         label="Company's website"
         name="website"
         type="url"
-        validate={[requiredWebsiteOrPhoneValidator, websiteValidator]}
+        validate={requiredWebsiteAndOrPhoneValidator}
       />
 
       <FieldInput
         label="Company's telephone number"
         name="telephone_number"
         type="tel"
-        validate={requiredWebsiteOrPhoneValidator}
+        validate={requiredWebsiteAndOrPhoneValidator}
       />
 
       <FieldAddress

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -400,6 +400,40 @@ describe('Add company form', () => {
           })
         }
       )
+      context('when only the website is submitted', () => {
+        before(() => {
+          cy.get(selectors.companyAdd.newCompanyRecordForm.website).type(
+            'www.example.com'
+          )
+          cy.get(selectors.companyAdd.submitButton).click()
+        })
+        it('should not display "Enter a website or phone number"', () => {
+          cy.get(selectors.companyAdd.form).should(
+            'not.contain',
+            'Enter a website or phone number'
+          )
+        })
+        after(() => {
+          cy.get(selectors.companyAdd.newCompanyRecordForm.website).clear()
+        })
+      })
+      context('when only the phone number is submitted', () => {
+        before(() => {
+          cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).type(
+            '0123456789'
+          )
+          cy.get(selectors.companyAdd.submitButton).click()
+        })
+        it('should not display "Enter a website or phone number"', () => {
+          cy.get(selectors.companyAdd.form).should(
+            'not.contain',
+            'Enter a website or phone number'
+          )
+        })
+        after(() => {
+          cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).clear()
+        })
+      })
       context('when an invalid website URL is filled', () => {
         before(() => {
           cy.get(selectors.companyAdd.newCompanyRecordForm.website).type(


### PR DESCRIPTION
## Description of change
This change applies to the unhappy path of `Add company`. 

Apply OR Boolean Logic to `website` and `phone number` form validation.

1. Go to /companies
2. Click `Add company`
3. Select `United Kingdom` and `Continue`
4. Add `An unknown company` to the `Company name` search field
5. Click `Find company`
6. Click `I can't find what I'm looking for`
7. Click `I still can't find what I'm looking for`

At this stage complete the entire form bar website, phone number and DIT region (not completing the DIT region allows you to test the validation around website and phone number without creating a record on Data Hub) and then play with the website and phone number to ensure it's consistent with OR boolean logic.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
