### PR TITLE
Remove archived contacts from interaction form typeahead

### DIFF
--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -156,7 +156,7 @@ async function renderInteractionDetailsForm(req, res, next) {
   try {
     const { token } = req.session
     const { company, interaction, referral, investment, contact } = res.locals
-
+    const contacts = company.contacts.filter((contact) => !contact.archived)
     const [
       services,
       serviceDeliveryStatuses,
@@ -190,7 +190,7 @@ async function renderInteractionDetailsForm(req, res, next) {
           investmentId: get(investment, 'id'),
           referralId: get(referral, 'id'),
           contactId: get(contact, 'id'),
-          contacts: company.contacts.map(transformContactToOption),
+          contacts: contacts.map(transformContactToOption),
           activeEvents: activeEvents.map(transformObjectToOption),
           services,
           serviceDeliveryStatuses,

--- a/src/templates/_components/archive-form.njk
+++ b/src/templates/_components/archive-form.njk
@@ -47,6 +47,6 @@
   }) }}
 
   <div class="c-form-actions">
-    <button class="govuk--button" type="submit">Archive</button>
+    <button class="govuk-button" type="submit">Archive</button>
   </div>
 </form>

--- a/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
@@ -357,6 +357,15 @@ describe('Interaction theme', () => {
       ])
     })
 
+    it('should only show non-archived contacts in the contacts field', () => {
+      cy.contains(ELEMENT_CONTACT.label)
+        .next()
+        .next()
+        .click()
+        .find('> div > div > div')
+        .should('have.text', '-- Select contact --Johnny Cakeman')
+    })
+
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
       cy.contains('h2', 'There is a problem')

--- a/test/sandbox/fixtures/v4/company/company-with-investment-1.json
+++ b/test/sandbox/fixtures/v4/company/company-with-investment-1.json
@@ -66,6 +66,44 @@
       "archived_by": null,
       "created_on": "2017-02-28T15:00:00Z",
       "modified_on": "2017-06-05T00:00:00Z"
+    },
+    {
+      "id": "8a1138ab-ec7b-497f-b8c3-27fed21694ef",
+      "title": null,
+      "first_name": "Archived",
+      "last_name": "Contact",
+      "name": "Archived Contact",
+      "job_title": null,
+      "company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "adviser": null,
+      "primary": false,
+      "telephone_countrycode": "44",
+      "telephone_number": "67890123432",
+      "email": "archived@cakeman.com",
+      "address_same_as_company": false,
+      "address_1": "82 Ramsgate Rd",
+      "address_2": null,
+      "address_town": "Willington",
+      "address_county": null,
+      "address_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "address_postcode": "NE28 5JB",
+      "telephone_alternative": null,
+      "email_alternative": null,
+      "notes": "This is a dummy contact for testing",
+      "accepts_dit_email_marketing": false,
+      "archived": true,
+      "archived_documents_url_path": "/documents/123",
+      "archived_on": "2018-02-28T15:00:00Z",
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-02-28T15:00:00Z",
+      "modified_on": "2017-06-05T00:00:00Z"
     }
   ],
   "employee_range": null,


### PR DESCRIPTION
## Description of change

Feedback has come through Zendesk that archived contacts are appearing in the Contacts typeahead options when adding an interaction. 

This PR adds a filter in the interactions controller to remove archived contacts before passing the prop to the form.

Whilst testing, i noticed that the 'Archive' button on the contacts page was using the class `govuk--button` rather than `govuk-button` meaning that it wasn't rendering the correct styling, so I have updated this as well. 

## Test instructions

- Go to a company
- Find a contact
- Archive that contact
- Check that the correct styling appears on the Archive button
- Go to the add interaction form
- Check that the archived contact does not appear in the Contacts typeahead

## Screenshots
### Before
**Archive button**
![Screenshot 2020-06-04 at 12 43 50](https://user-images.githubusercontent.com/22460823/83754277-9df0d280-a663-11ea-915f-44aa326fd0b6.png)


### After
**Archive button**
![Screenshot 2020-06-04 at 12 54 46](https://user-images.githubusercontent.com/22460823/83754432-da243300-a663-11ea-864b-acd8ce29bc81.png)



## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
