### PR TITLE
Add expected win date to pipeline form

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "5.6.1",
+    "data-hub-components": "5.7.0",
     "date-fns": "^1.29.0",
     "del-cli": "^3.0.0",
     "details-element-polyfill": "^2.4.0",

--- a/src/apps/my-pipeline/client/EditPipelineForm.jsx
+++ b/src/apps/my-pipeline/client/EditPipelineForm.jsx
@@ -18,9 +18,11 @@ import ProgressIndicator from '../../../client/components/ProgressIndicator'
 import PipelineForm from './PipelineForm'
 import { PipelineItemPropType } from './constants'
 import { getPipelineUrl } from './utils'
+import moment from 'moment'
 
 function formatInitialValues(values) {
   const { sector, contact } = values
+  const expectedWinDate = moment(values.expected_win_date, 'YYYY-MM-DD', true)
   return {
     name: values.name,
     category: values.status,
@@ -28,6 +30,15 @@ function formatInitialValues(values) {
     sector: sector ? { value: sector.id, label: sector.segment } : null,
     contact: contact ? { value: contact.id, label: contact.name } : null,
     export_value: values.potential_value,
+    expected_win_date: expectedWinDate.isValid()
+      ? {
+          month: expectedWinDate.format('MM'),
+          year: expectedWinDate.format('YYYY'),
+        }
+      : {
+          month: '',
+          year: '',
+        },
   }
 }
 

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -88,7 +88,7 @@ function PipelineForm({
       />
       <FieldDate
         format="short"
-        label="Expected date for win (Optional)"
+        label="Expected date for win (optional)"
         hint="For example 11 2020"
         name="expected_win_date"
         initialValue={initialValue.expected_win_date}

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -7,6 +7,7 @@ import {
   FormActions,
   FieldInput,
   FieldTypeahead,
+  FieldDate,
 } from 'data-hub-components'
 import Form from '../../../client/components/Form'
 import { ID as STATE_ID } from './state'
@@ -84,6 +85,13 @@ function PipelineForm({
         inputmode="numeric"
         spellcheck="false"
         className="govuk-input--width-10"
+      />
+      <FieldDate
+        format="short"
+        label="Expected date for win (Optional)"
+        hint="For example 11 2020"
+        name="expected_win_date"
+        initialValue={initialValue.expected_win_date}
       />
       <FormActions>
         <Button>{Object.keys(initialValue).length ? 'Update' : 'Add'}</Button>

--- a/src/apps/my-pipeline/client/tasks.js
+++ b/src/apps/my-pipeline/client/tasks.js
@@ -1,6 +1,7 @@
 import pipelineApi from './api'
 import { addSuccessMessage } from '../../../client/utils/flash-messages'
 import axios from 'axios'
+import moment from 'moment'
 
 function transformValuesForApi(values, oldValues = {}) {
   const data = {
@@ -21,6 +22,13 @@ function transformValuesForApi(values, oldValues = {}) {
   addValue('contact', values.contact?.value)
   addValue('potential_value', values.export_value)
 
+  const { month, year } = values.expected_win_date
+  const expectedWinDate = moment(`${year}-${month}`, 'YYYY-MM', true)
+  if (expectedWinDate.isValid()) {
+    addValue('expected_win_date', expectedWinDate.format('YYYY-MM-DD'))
+  } else {
+    addValue('expected_win_date')
+  }
   return data
 }
 

--- a/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
@@ -128,6 +128,12 @@ describe('My Pipeline tab on the dashboard', () => {
           cy.get(formSelectors.fields.sector).selectTypeaheadOption('Aero')
           cy.get(formSelectors.fields.contact).selectTypeaheadOption('Dean')
           cy.get(formSelectors.value).type('1000')
+          cy.get(formSelectors.fields.expectedWinDate)
+            .find('input')
+            .then((element) => {
+              cy.wrap(element[0]).type('06')
+              cy.wrap(element[1]).type('2025')
+            })
 
           cy.contains('button', 'Update').click()
 
@@ -138,6 +144,7 @@ describe('My Pipeline tab on the dashboard', () => {
               'Project sectorAerospace',
               'Company contactDean Cox',
               'Potential export value£1,000',
+              'Expected date for winJun 2025',
             ],
           })
         })
@@ -154,6 +161,9 @@ describe('My Pipeline tab on the dashboard', () => {
           cy.get(formSelectors.fields.sector).removeAllTypeaheadValues()
           cy.get(formSelectors.fields.contact).removeAllTypeaheadValues()
           cy.get(formSelectors.value).clear()
+          cy.get(formSelectors.fields.expectedWinDate)
+            .find('input')
+            .clear()
 
           cy.contains('button', 'Update').click()
 
@@ -164,6 +174,7 @@ describe('My Pipeline tab on the dashboard', () => {
               'Project sector',
               'Company contact',
               'Potential export value',
+              'Expected date for win',
             ],
           })
         })

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -7,6 +7,7 @@ const {
   assertFormButtons,
   assertFieldInput,
   assertFieldTypeahead,
+  assertFieldDateShort,
 } = require('../../support/assertions')
 const selectors = require('../../../../selectors')
 
@@ -81,6 +82,16 @@ describe('Company add to pipeline form', () => {
           element,
           label: 'Potential export value (optional)',
           hint: 'Amount in GBP',
+        })
+      })
+    })
+
+    it('Should render the expected date for win input', () => {
+      cy.get(formSelectors.fields.expectedWinDate).then((element) => {
+        assertFieldDateShort({
+          element,
+          label: 'Expected date for win (optional)',
+          hint: 'For example 11 2020',
         })
       })
     })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
@@ -5,6 +5,7 @@ const {
   assertBreadcrumbs,
   assertFieldInput,
   assertFieldTypeahead,
+  assertFieldDateShort,
 } = require('../../support/assertions')
 
 const selectors = require('../../../../selectors')
@@ -112,6 +113,16 @@ describe('Pipeline edit form', () => {
           })
         })
       })
+
+      it('Should render the expected date for win input', () => {
+        cy.get(formSelectors.fields.expectedWinDate).then((element) => {
+          assertFieldDateShort({
+            element,
+            label: 'Expected date for win (optional)',
+            hint: 'For example 11 2020',
+          })
+        })
+      })
     })
 
     context('With values for all fields', () => {
@@ -209,12 +220,16 @@ describe('Pipeline edit form', () => {
           cy.get(formSelectors.fields.sector).removeAllTypeaheadValues()
           cy.get(formSelectors.fields.contact).removeAllTypeaheadValues()
           cy.get(formSelectors.value).clear()
-          cy.contains('button', 'Update').click()
+          cy.get(formSelectors.fields.expectedWinDate)
+            .find('input')
+            .clear()
 
+          cy.contains('button', 'Update').click()
           cy.wait('@updatePipelineItem').then((xhr) => {
             expect(xhr.request.body.sector).to.equal(null)
             expect(xhr.request.body.contact).to.equal(null)
             expect(xhr.request.body.potential_value).to.equal(null)
+            expect(xhr.request.body.expected_win_date).to.equal(null)
           })
         })
       })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -272,6 +272,19 @@ const assertFieldDate = ({ element, label, value = {} }) => {
   value.year && expect(inputs[2]).to.have.value(value.year)
 }
 
+const assertFieldDateShort = ({ element, label, value = {} }) => {
+  const labels = element.find('label')
+  const inputs = element.find('input')
+
+  label && expect(labels[0]).to.have.text(label)
+
+  expect(labels[1]).to.have.text('Month')
+  expect(labels[2]).to.have.text('Year')
+
+  value.month && expect(inputs[0]).to.have.value(value.month)
+  value.year && expect(inputs[1]).to.have.value(value.year)
+}
+
 const assertFormActions = ({ element, buttons }) =>
   cy
     .wrap(element)
@@ -351,6 +364,7 @@ module.exports = {
   assertFieldUneditable,
   assertFormActions,
   assertFieldDate,
+  assertFieldDateShort,
   assertFormFields,
   assertDetails,
   assertLocalHeader,

--- a/test/sandbox/fixtures/v4/pipeline-item/pipeline-item-lambda-plc.json
+++ b/test/sandbox/fixtures/v4/pipeline-item/pipeline-item-lambda-plc.json
@@ -13,7 +13,8 @@
             },
             "name": "TEST",
             "status": "in_progress",
-            "created_on": "2020-05-05T18:30:07.869217Z"
+            "created_on": "2020-05-05T18:30:07.869217Z",
+            "expected_win_date": null
         },{
           "id": "0fb3379c-341c-4da4-b825-bf8d47b26bab",
           "company": {
@@ -34,7 +35,8 @@
             "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9",
             "name": "Dean Cox"
           },
-          "potential_value": 111
+          "potential_value": 111,
+          "expected_win_date": "2021-11-01"
       }
     ]
 }

--- a/test/selectors/pipeline-form.js
+++ b/test/selectors/pipeline-form.js
@@ -16,5 +16,6 @@ module.exports = {
     sector: '#field-sector',
     contact: '#field-contact',
     value: '#field-export_value',
+    expectedWinDate: '#field-expected_win_date',
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7167,10 +7167,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.6.1.tgz#956ae382bec4f8753235e348b5a73a5812ab1387"
-  integrity sha512-HU5ANvrJp6uV/pfDZxOkUSwErd4i8kV/2hZTrhQAhjjap59ac0jEWlHpmdeuhU4NiM5F06WsUBiyTHFCCb7E/A==
+data-hub-components@5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.7.0.tgz#2c6909df66794df3464ce9220e42863eafbed860"
+  integrity sha512-D3y8PIJLxY0UYVXVt9eb/OnX5z24oPbtAhASJyDC4pKT7omZW2zYaZBY1A4vRFrcEGKCmF62URYCx/ba2kLP0w==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change

The PR introduces a new date field component for only Month and Year from data-hub-components.
The Date is send to the server as the 1st of the month e.g If the user enters 05-2020 the date will be transformed and sent to the server as 2020-05-01.

## Test instructions
You should be able to enter and edit the values in the data field. You can check if the value has been updated by checking it against the expected win date  filed in the my-pipeline dash


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/83854406-94707480-a70e-11ea-879f-7d753e38b9b8.png)
### After
![image](https://user-images.githubusercontent.com/5575331/83860690-81ae6d80-a717-11ea-8c5a-f5da4836f055.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
