### PR TITLE
Add e2e test to cover missing UK Region

### DIFF
--- a/test/end-to-end/cypress/fixtures/company/empty-uk-region-ltd.json
+++ b/test/end-to-end/cypress/fixtures/company/empty-uk-region-ltd.json
@@ -1,0 +1,4 @@
+{
+  "name": "Empty UK Region Ltd",
+  "id": "3cb006bb-c8bd-4062-bc8c-c086273b84e1"
+}

--- a/test/end-to-end/cypress/fixtures/index.js
+++ b/test/end-to-end/cypress/fixtures/index.js
@@ -5,6 +5,7 @@ module.exports = {
     oneListCorp: require('./company/one-list-corp'),
     archivedLtd: require('./company/archived-ltd'),
     teddyBearExpo: require('./company/teddy-bear-expo'),
+    emptyUkRegionLtd: require('./company/empty-uk-region-ltd.json'),
   },
   contact: {
     johnnyCakeman: require('./contact/johnny-cakeman'),

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -6,7 +6,7 @@ const { companies, contacts } = require('../../../../../src/lib/urls')
 
 const { assertKeyValueTable } = require('../../support/assertions')
 
-const { oneListCorp, lambdaPlc } = fixtures.company
+const { oneListCorp, lambdaPlc, emptyUkRegionLtd } = fixtures.company
 
 describe('Advisors', () => {
   const globalManagerTable = 2
@@ -84,42 +84,56 @@ describe('Export', () => {
   }
 
   describe('Edit exports', () => {
-    context('Selecting a value', () => {
-      it('Should update the export win category', () => {
-        cy.visit(companies.exports.edit(lambdaPlc.id))
+    function runEditTests() {
+      context('Selecting a value', () => {
+        it('Should update the export win category', () => {
+          cy.get(selectors.companyExport.winCategory).select('Export growth')
+          cy.contains('Save and return').click()
 
-        cy.get(selectors.companyExport.winCategory).select('Export growth')
-        cy.contains('Save and return').click()
-
-        assertTable([
-          'Export growth',
-          'No profile',
-          'No score given',
-          'None',
-          'None',
-          'None',
-        ])
+          assertTable([
+            'Export growth',
+            'No profile',
+            'No score given',
+            'None',
+            'None',
+            'None',
+          ])
+        })
       })
+
+      context('Selecting no value', () => {
+        it('Should remove the export win category', () => {
+          cy.get(selectors.companyExport.winCategory).select(
+            '-- Select category --'
+          )
+          cy.contains('Save and return').click()
+
+          assertTable([
+            'None',
+            'No profile',
+            'No score given',
+            'None',
+            'None',
+            'None',
+          ])
+        })
+      })
+    }
+
+    context('With lambdaPlc (which has a UK Region set)', () => {
+      beforeEach(() => {
+        cy.visit(companies.exports.edit(lambdaPlc.id))
+      })
+
+      runEditTests()
     })
 
-    context('Selecting no value', () => {
-      it('Should remove the export win category', () => {
-        cy.visit(companies.exports.edit(lambdaPlc.id))
-
-        cy.get(selectors.companyExport.winCategory).select(
-          '-- Select category --'
-        )
-        cy.contains('Save and return').click()
-
-        assertTable([
-          'None',
-          'No profile',
-          'No score given',
-          'None',
-          'None',
-          'None',
-        ])
+    context('With emptyUkRegionLtd (which does not have UK Region set)', () => {
+      beforeEach(() => {
+        cy.visit(companies.exports.edit(emptyUkRegionLtd.id))
       })
+
+      runEditTests()
     })
   })
 


### PR DESCRIPTION
## Description of change

When working on the Export tab we noticed a scenario where a company can have the `uk_region` set to `null` and when trying to send a `PATCH` to `/v4/company/<company_id>` it would return an error. We stopped the error from happening and this PR adds a test to cover that scenario so that we do not regress.

## Test instructions

All e2e tests should pass

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
