### PR TITLE
Add link to pipeline help centre article

### DIFF
--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -3,7 +3,9 @@ import { connect } from 'react-redux'
 
 import ListItem from '@govuk-react/list-item'
 import InsetText from '@govuk-react/inset-text'
+import Link from '@govuk-react/link'
 
+import urls from '../../../lib/urls'
 import StyledOrderedList from '../StyledOrderedList'
 import Task from '../Task'
 import { state2props, ID as STATE_ID, TASK_GET_PIPELINE_LIST } from './state'
@@ -34,7 +36,12 @@ const PipelineList = ({ status, statusText, items }) => {
             <InsetText>
               There are no companies in the {statusText} section of your
               pipeline. You can add companies to your pipeline from the company
-              page.
+              page. To find out more{' '}
+              <Link href={urls.external.helpCentre.pipeline()}>
+                {' '}
+                visit the help centre article on how to use My Pipeline
+              </Link>
+              .
             </InsetText>
           )}
         </StyledOrderedList>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -78,6 +78,10 @@ module.exports = {
       teams:
         'https://people.trade.gov.uk/teams/department-for-international-trade',
     },
+    helpCentre: {
+      pipeline: () =>
+        'https://data-services-help.trade.gov.uk/data-hub/how-articles/account-management/my-pipeline/',
+    },
   },
   dashboard: url('/'),
   companies: {

--- a/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
@@ -47,9 +47,16 @@ describe('My Pipeline tab on the dashboard', () => {
 
       tabs.forEach((tab) => {
         cy.visit(tab.url)
-        cy.get(tabPanelSelector).contains(
-          `There are no companies in the ${tab.status} section of your pipeline`
-        )
+        cy.get(tabPanelSelector)
+          .should(
+            'contain',
+            `There are no companies in the ${tab.status} section of your pipeline`
+          )
+          .contains(
+            'a',
+            'visit the help centre article on how to use My Pipeline'
+          )
+          .should('have.attr', 'href', urls.external.helpCentre.pipeline())
       })
     })
   })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -68,6 +68,7 @@ function assertPipelineItem(
       }
     })
 }
+
 describe('My pipeline app', () => {
   context('When viewing the propspect status', () => {
     before(() => {


### PR DESCRIPTION
## Description of change

Update empty pipeline text to include a link to the help centre article

## Test instructions

Click on the pipeline tab on the dashboard, without any items there is some default text. This has now bee updated to include some more content with a link to the help centre.

## Screenshots
### Before

<img width="893" alt="Screenshot 2020-06-08 at 10 44 11" src="https://user-images.githubusercontent.com/1481883/84016363-18c43100-a975-11ea-97d4-5eaa05a2dd31.png">


### After

<img width="895" alt="Screenshot 2020-06-08 at 10 44 49" src="https://user-images.githubusercontent.com/1481883/84016371-1bbf2180-a975-11ea-8a49-39249b9f7068.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
