### PR TITLE
Allow users with right permission to add lead ITA

### DIFF
--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -66,24 +66,30 @@ const RenderHasNoAccountManager = ({
 }) => (
   <div>
     <H2 size={LEVEL_SIZE[3]}>Lead ITA for {companyName}</H2>
-    <p>This company has no Lead ITA.</p>
     {featureFlagOn ? (
       <>
+        <p>
+          This company record has no lead International Trade Adviser (ITA).
+        </p>
+        {hasPermissionToAddIta && (
+          <>
+            <p>
+              You can add a lead ITA. This will be visible to all Data Hub
+              users.
+            </p>
+            <Button as={Link} href={addUrl}>
+              Add a lead ITA
+            </Button>
+          </>
+        )}
+      </>
+    ) : (
+      <>
+        <p>This company has no Lead ITA.</p>
         <p>
           An ITA (International Trade Adviser) can add themselves as the Lead
           ITA, which will be visible to all Data Hub users on the company page
           and any of its subsidiaries.
-        </p>
-        <Button as={Link} href={addUrl}>
-          Add a lead ITA
-        </Button>
-      </>
-    ) : (
-      <>
-        <p>
-          You can add an ITA (International Trade Adviser) as the Lead ITA,
-          which will be visible to all Data Hub users on the company page and
-          any of its subsidiaries.
         </p>
         {hasPermissionToAddIta && (
           <Button as={Link} href={addUrl}>

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -22,10 +22,11 @@ describe('Lead advisers', () => {
       )
     })
     it('should display help text for adding a lead adviser', () => {
-      cy.contains('This company has no Lead ITA.')
       cy.contains(
-        'An ITA (International Trade Adviser) can add themselves as the Lead ITA,' +
-          ' which will be visible to all Data Hub users on the company page and any of its subsidiaries.'
+        'This company record has no lead International Trade Adviser (ITA).'
+      )
+      cy.contains(
+        'You can add a lead ITA. This will be visible to all Data Hub users.'
       )
     })
     it('should display a button to add a lead adviser', () => {


### PR DESCRIPTION
## Description of change

Previously it was the purple team's intention that any adviser could add a Lead ITA to a company. It has now been decided that only those with the `company.can_add_regional_account_manager` permission can do this. 

This PR adds a condition so that only users with this permission can view the 'Add a lead ITA' button. It also updates the content which appears in the Lead Adviser tab to reflect these changes.

## Test instructions

- Go to the lead adviser tab of a non-One list tier company
- Check that the content is updated
- Check you can view the button if you have the correct permission in the API you're pointing to

## Screenshots
### Before
![Screenshot 2020-06-08 at 12 19 01](https://user-images.githubusercontent.com/22460823/84024693-3f3c9900-a982-11ea-9c5f-07b0dfe0b603.png)

### After
![image](https://user-images.githubusercontent.com/22460823/84050847-3067dd80-a9a6-11ea-838e-1a8162174e18.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
