### PR TITLE
Refactor flash messages to check session storage and set messages with body

### DIFF
--- a/src/apps/investments/views/admin/client/InvestmentProjectAdmin.jsx
+++ b/src/apps/investments/views/admin/client/InvestmentProjectAdmin.jsx
@@ -12,7 +12,7 @@ import { Main } from '../../../../../client/components/'
 import { ID as STATE_ID, TASK_UPDATE_STAGE, state2props } from './state'
 import { INVESTMENT_PROJECT_ADMIN__UPDATE_STAGE } from '../../../../../client/actions'
 import urls from '../../../../../lib/urls'
-import flashUtils from '../../../../../client/utils/flash-messages'
+import { addMessage } from '../../../../../client/utils/flash-messages'
 
 const StyledP = styled('p')`
   margin-bottom: ${SPACING.SCALE_2};
@@ -27,7 +27,7 @@ const InvestmentProjectAdmin = ({
 }) => {
   useEffect(() => {
     if (stageUpdated) {
-      flashUtils.addSuccessMessage('Project stage saved')
+      addMessage('success', 'Project stage saved')
       window.location.href = urls.investments.projects.project(projectId)
     }
   }, [stageUpdated])

--- a/src/apps/my-pipeline/client/tasks.js
+++ b/src/apps/my-pipeline/client/tasks.js
@@ -1,5 +1,5 @@
 import pipelineApi from './api'
-import { addSuccessMessage } from '../../../client/utils/flash-messages'
+import { addMessage } from '../../../client/utils/flash-messages'
 import axios from 'axios'
 import moment from 'moment'
 
@@ -47,7 +47,7 @@ export async function addCompanyToPipeline({ values, companyId }) {
     company: companyId,
     ...transformValuesForApi(values),
   })
-  addSuccessMessage('Pipeline changes for this company have been saved')
+  addMessage('success', 'Pipeline changes for this company have been saved')
   return data
 }
 
@@ -69,6 +69,6 @@ export async function editPipelineItem({
     pipelineItemId,
     transformValuesForApi(values, currentPipelineItem)
   )
-  addSuccessMessage('Pipeline changes for this company have been saved')
+  addMessage('success', 'Pipeline changes for this company have been saved')
   return data
 }

--- a/src/client/components/LocalHeader/FlashMessages.jsx
+++ b/src/client/components/LocalHeader/FlashMessages.jsx
@@ -55,9 +55,11 @@ const FlashMessages = ({ flashMessages }) => {
       {Object.entries(
         !isEmpty(flashMessages) ? flashMessages : flashMessagesFromStorage
       ).map(([type, messages]) => {
-        // Example "success:with-body" -  If the string you pass in the first argument "type"
-        // has a colon then the message argument accepts two props in an object, one for the heading
-        // and one for the body. The first part of the string is used to indicate colour, success - green, info - blue
+        /*
+        Example "success:with-body" -  If the string you pass in the first argument "type"
+        has a colon then the message argument accepts two props in an object, one for the heading
+        and one for the body. The first part of the string is used to indicate colour, success - green, info - blue
+        */
         const parts = String(type).split(':')
         return parts.length > 1
           ? messages.map(({ body, heading }) => (

--- a/src/client/components/LocalHeader/FlashMessages.jsx
+++ b/src/client/components/LocalHeader/FlashMessages.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { isEmpty } from 'lodash'
 
 import {
   ERROR_COLOUR,
@@ -14,7 +15,7 @@ import { FONT_WEIGHTS } from '@govuk-react/constants/lib/typography'
 import { FONT_SIZE, SPACING } from '@govuk-react/constants'
 import UnorderedList from '@govuk-react/unordered-list'
 import { StatusMessage } from 'data-hub-components'
-import flashUtils from '../../utils/flash-messages'
+import { getMessages, clearMessages } from '../../utils/flash-messages'
 
 const StyledBody = styled('p')`
   margin-bottom: 0;
@@ -47,41 +48,36 @@ const messageColours = {
 }
 
 const FlashMessages = ({ flashMessages }) => {
-  const flashMessagesFromStorage = flashUtils.getMessages()
-  flashUtils.clearMessages()
-
-  if (flashMessages || flashMessagesFromStorage) {
-    return (
-      <UnorderedList listStyleType="none" data-auto-id="flash">
-        {Object.entries(flashMessages || flashMessagesFromStorage).map(
-          ([type, message]) => {
-            const parts = String(type).split(':')
-            return parts.length > 1
-              ? message.map((message) => (
-                  <li key={message.body}>
-                    <StyledStatusMessage colour={messageColours[parts[0]]}>
-                      <StyledHeading>{message.heading}</StyledHeading>
-                      <StyledBody
-                        dangerouslySetInnerHTML={{ __html: message.body }}
-                      />
-                    </StyledStatusMessage>
-                  </li>
-                ))
-              : message.map((message) => (
-                  <li key={message}>
-                    <StyledStatusMessage colour={messageColours[type]}>
-                      <StyledMessage
-                        dangerouslySetInnerHTML={{ __html: message }}
-                      />
-                    </StyledStatusMessage>
-                  </li>
-                ))
-          }
-        )}
-      </UnorderedList>
-    )
-  }
-  return null
+  const flashMessagesFromStorage = getMessages()
+  clearMessages()
+  return !isEmpty(flashMessages) || flashMessagesFromStorage ? (
+    <UnorderedList listStyleType="none" data-auto-id="flash">
+      {Object.entries(
+        !isEmpty(flashMessages) ? flashMessages : flashMessagesFromStorage
+      ).map(([type, messages]) => {
+        // Example "success:with-body" -  If the string you pass in the first argument "type"
+        // has a colon then the message argument accepts two props in an object, one for the heading
+        // and one for the body. The first part of the string is used to indicate colour, success - green, info - blue
+        const parts = String(type).split(':')
+        return parts.length > 1
+          ? messages.map(({ body, heading }) => (
+              <li key={body}>
+                <StyledStatusMessage colour={messageColours[parts[0]]}>
+                  <StyledHeading>{heading}</StyledHeading>
+                  <StyledBody dangerouslySetInnerHTML={{ __html: body }} />
+                </StyledStatusMessage>
+              </li>
+            ))
+          : messages.map((body, i) => (
+              <li key={i}>
+                <StyledStatusMessage colour={messageColours[type]}>
+                  <StyledMessage dangerouslySetInnerHTML={{ __html: body }} />
+                </StyledStatusMessage>
+              </li>
+            ))
+      })}
+    </UnorderedList>
+  ) : null
 }
 
 FlashMessages.propTypes = {

--- a/src/client/components/LocalHeader/__stories__/FlashMessages.stories.jsx
+++ b/src/client/components/LocalHeader/__stories__/FlashMessages.stories.jsx
@@ -16,12 +16,14 @@ storiesOf('Flash Messages', module)
   .add('Default', () => (
     <FlashMessages
       flashMessages={{
+        success: ['Success message'],
         'success:with-body': [
           {
             heading: 'Success message heading',
             body: 'Success message body',
           },
         ],
+        info: ['Info message'],
         'info:with-body': [
           {
             heading: 'Info message heading',

--- a/src/client/components/LocalHeader/__stories__/usage.md
+++ b/src/client/components/LocalHeader/__stories__/usage.md
@@ -2,26 +2,30 @@
 
 ### Description
 
-Flash messages for users in different colours depending on the message
+Flash messages for users in different colours depending on the message. 
+
+Note: If the props "flashMessages" are not passed down to the component then flash messages will be taken from session storage, if none exist in session storage then `null` is returned.
 
 ### Usage
 
 ```jsx
 <FlashMessages
   flashMessages={{
+    success: ['Success message'],
     'success:with-body': [
       {
         heading: 'Success message heading',
         body: 'Success message body',
       },
     ],
+    info: ['Info message'],
     'info:with-body': [
       {
         heading: 'Info message heading',
         body: 'Info message body',
       },
     ],
-    error: ['Error test message'],
+    error: ['Error test message', 'Another error message'],
     warning: ['Warning test message'],
     muted: ['Muted test message'],
   }}
@@ -32,4 +36,4 @@ Flash messages for users in different colours depending on the message
 
 | Prop            | Required | Default                                   | Type | Description |
 | :-------------- | :------- | :---------------------------------------- | :--- | :---------- |
-| `flashMessages` | true     | `` | Object | Contains the flash messages |
+| `flashMessages` | false    | `` | Object | Contains the flash messages |

--- a/src/client/utils/flash-messages.js
+++ b/src/client/utils/flash-messages.js
@@ -1,19 +1,19 @@
 const KEY = 'flash-messages'
 
-function getMessages() {
+const getMessages = () => {
   const items = window.sessionStorage.getItem(KEY)
   if (items) {
     try {
       return JSON.parse(items)
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.log(e) // TODO: replace with more robust error logging when implemented
+      console.error('Cannot get messages from session storage', e)
     }
   }
   return {}
 }
 
-function addMessage(messageType, message) {
+const addMessage = (messageType, message) => {
   const messages = getMessages()
   messages[messageType] = messages[messageType] || []
   messages[messageType].push(message)
@@ -21,21 +21,14 @@ function addMessage(messageType, message) {
     window.sessionStorage.setItem(KEY, JSON.stringify(messages))
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.log(e) // TODO: replace with more robust error logging when implemented
+    console.error('Cannot set messages to session storage', e)
   }
 }
 
-function addSuccessMessage(message) {
-  addMessage('success', message)
-}
-
-function clearMessages() {
-  window.sessionStorage.removeItem(KEY)
-}
+const clearMessages = () => window.sessionStorage.removeItem(KEY)
 
 module.exports = {
   getMessages,
   addMessage,
-  addSuccessMessage,
   clearMessages,
 }

--- a/src/client/utils/flash-messages.js
+++ b/src/client/utils/flash-messages.js
@@ -25,10 +25,15 @@ const addMessage = (messageType, message) => {
   }
 }
 
+const addMessageWithBody = (type, heading, body) => {
+  addMessage(`${type}:with-body`, { heading, body })
+}
+
 const clearMessages = () => window.sessionStorage.removeItem(KEY)
 
 module.exports = {
-  getMessages,
   addMessage,
+  getMessages,
+  addMessageWithBody,
   clearMessages,
 }


### PR DESCRIPTION
## Description of change
There are two ways you can set flash messages, one is through the node layer and the other is via session storage. The later is done when we are using the likes of a saga tasks in React and submitting forms client side. Currently we are not checking session storage if the flash messages object is empty, this PR fixes this and simplifies the utility function used to set messages in React components.

## Test instructions
Nothing should change as we are not currently using these new methods but see Storybook for an example of what this looks like.


## Screenshots
![Screenshot 2020-06-08 at 15 36 47](https://user-images.githubusercontent.com/10154302/84043190-e7139000-a99d-11ea-8acb-b1e2d341cc4f.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
