### PR TITLE
Upgrade to node 12.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ aliases:
   - &mi_postgres_version postgres:9.6
   - &elasticsearch_version docker.elastic.co/elasticsearch/elasticsearch:6.8.2
   - &api_image quay.io/uktrade/data-hub-api:master
-  - &frontend_testing_image ukti/data-hub-frontend-test:3.5.0
+  - &frontend_testing_image ukti/data-hub-frontend-test:3.6.0
   - &oauth2_dit_staff_token ditStaffToken
   - &oauth2_da_staff_token daStaffToken
   - &oauth2_lep_staff_token lepStaffToken

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ aliases:
   - &docker_es_apm
     image: *es_apm
     name: es-apm
-    command: apm-server -e -E output.elasticsearch.hosts=["localhost:9200"]
+    command: apm-server -e -E output.elasticsearch.hosts=["es:9200"]
 
   # Data hub backend
   - &docker_data_hub_backend_base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1
+FROM node:12.17.0
 
 WORKDIR /usr/src/app
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - buildpacks:
-    - https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.13
+    - https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.20
     health-check-type: http
     health-check-http-endpoint: /healthcheck
     memory: 2G

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   },
   "license": "MIT",
   "engines": {
-    "yarn": "1.22.0",
-    "node": "12.16.1"
+    "yarn": "1.22.4",
+    "node": "12.17.0"
   },
   "dependencies": {
     "@babel/core": "^7.10.2",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,10 +1,10 @@
 # This docker image is used ONLY with CircleCI to run tests.
 # For local development image see Dockerfile in the root directory of this project.
 
-FROM node:12.16.1
+FROM node:12.17.0
 
 ENV DOCKERIZE_VERSION      v0.3.0
-ENV YARN_VERSION           1.22.0
+ENV YARN_VERSION           1.22.4
 ENV NPM_CONFIG_LOGLEVEL    warn
 ENV NPM_CONFIG_UNSAFE_PERM true
 ENV TZ                     Europe/London

--- a/test/sandbox/Dockerfile
+++ b/test/sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1
+FROM node:12.17.0
 
 WORKDIR /usr/src/app
 

--- a/test/visual/Dockerfile
+++ b/test/visual/Dockerfile
@@ -1,7 +1,7 @@
 # E2E docker image used to run tests locally
-FROM node:12.16.1
+FROM node:12.17.0
 
-ENV YARN_VERSION 1.22.0
+ENV YARN_VERSION 1.22.4
 
 # Install visual test dependencies
 RUN apt-get update


### PR DESCRIPTION
## Description of change

This PR Bumps the version of node to 12.17.0
https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.7.20

## Test instructions
All test passing and build compiling
