### PR TITLE
Forward Zipkin headers for correlation tracing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "develop": "NODE_ENV=development run-p watch:js:*",
     "watch:test": "yarn test:unit -- -w",
     "watch:js:client": "webpack --watch --progress",
-    "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect --ignore 'src/**/__test__/**/*'",
+    "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect-brk=0.0.0.0 --ignore 'src/**/__test__/**/*'",
     "lint": "run-p lint:*",
     "lint:js": "eslint --ext .jsx,.js ./test ./src ./assets ./.circleci",
     "lint:sass": "sass-lint -v -q -c .sass-lint.yml assets/stylesheets/**/*.scss",

--- a/src/lib/get-zipkin-headers.js
+++ b/src/lib/get-zipkin-headers.js
@@ -1,0 +1,9 @@
+const { pickBy } = require('lodash')
+
+const ZIPKIN_HEADERS = ['x-b3-traceid', 'x-b3-spanid']
+
+function getZipkinHeaders(req) {
+  return pickBy(req.headers, (header) => header.toLowerCase() in ZIPKIN_HEADERS)
+}
+
+module.exports = getZipkinHeaders

--- a/src/middleware/__test__/api-proxy.test.js
+++ b/src/middleware/__test__/api-proxy.test.js
@@ -1,0 +1,34 @@
+const express = require('express')
+const request = require('supertest')
+
+const config = require('../../config')
+const apiProxy = require('../../middleware/api-proxy')
+
+describe('API proxy middleware', () => {
+  it('should forward requests to the backend', async () => {
+    const scope = nock(config.apiRoot)
+      .get('/whoami')
+      .reply(200, {})
+
+    const app = express()
+    app.use((req, res, next) => {
+      req.session = { token: '123' }
+      next()
+    })
+    apiProxy(app)
+
+    await request(app)
+      .get('/api-proxy/whoami')
+      .set({
+        'X-B3-TraceId': 'fake-trace-id',
+        'X-B3-SpanId': 'fake-span-id',
+      })
+      .expect(200)
+
+    expect(scope.interceptors[0].req.headers).to.contains({
+      authorization: 'Bearer 123',
+      'x-b3-spanid': 'fake-span-id',
+      'x-b3-traceid': 'fake-trace-id',
+    })
+  })
+})

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -1,6 +1,7 @@
 const { createProxyMiddleware } = require('http-proxy-middleware')
 
-const config = require('../config/')
+const config = require('../config')
+const getZipkinHeaders = require('../lib/get-zipkin-headers')
 
 const API_PROXY_PATH = '/api-proxy'
 const WHITELIST = [
@@ -33,6 +34,12 @@ module.exports = (app) => {
         ['^' + API_PROXY_PATH]: '',
       },
       onProxyReq: (proxyReq, req) => {
+        Object.entries(getZipkinHeaders(req)).forEach(
+          ([header, headerValue]) => {
+            proxyReq.setHeader(header, headerValue)
+          }
+        )
+
         proxyReq.setHeader('authorization', `Bearer ${req.session.token}`)
         // this is required to be able to handle POST requests and avoid a conflict with bodyParser
         // issue here -> https://github.com/chimurai/http-proxy-middleware/issues/320


### PR DESCRIPTION
## Description of change

Preserve Zipkin headers added by Cloud Foundry to allow for correlation tracing.

https://docs.cloudfoundry.org/concepts/http-routing.html#zipkin-headers