### PR TITLE
skip broken collection test

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/collection-spec.js
@@ -12,7 +12,7 @@ const checkCollection = () => {
   assertCollection(selectors.collection.headerCount, selectors.collection.items)
 }
 
-describe('Collection', () => {
+describe.skip('Collection', () => {
   describe('contact', () => {
     before(() => {
       cy.visit(companies.orders(fixtures.company.lambdaPlc.id))


### PR DESCRIPTION
## Description of change

These is a PR to unblock developers due to a bug in the e2e code.
```js
assertCollection(selectors.collection.headerCount, selectors.collection.items)
```
This code fails because the header count is the total count for the interaction query and the assertCollection is counting the items that are being rendered on screen. 

If we are going to go ahead and continue to assert the count I would suggest a refactor that parse the header count number. 

```js
const count =  cy.get('.c-collection__result-count').text()
if(parseInt(count, 10) > 10) {
    cy.get(selectors.collection.items).should('have.length', 10)
} else {
    cy.get(selectors.collection.items).should('have.length', count)
}

```
  
Backend PR that updated the fixture
https://github.com/uktrade/data-hub-api/commit/c64bd74cca95d1c1e8d2677eb71391bcb91ca51f#diff-45e01b144926eddaca68b5cf7c1a81ad

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
