### PR TITLE
Update collection tests to handle more than one page

### DIFF
--- a/test/end-to-end/cypress/support/assertions.js
+++ b/test/end-to-end/cypress/support/assertions.js
@@ -1,6 +1,8 @@
+const { keys, forEach } = require('lodash')
+
 const selectors = require('../../../selectors')
 
-const { keys, forEach } = require('lodash')
+const PAGE_SIZE = 10
 
 const assertError = (message) => {
   cy.get('body').should('contain', message)
@@ -10,9 +12,22 @@ const assertCollection = (headerCountSelector, collectionItemsSelector) => {
   cy.get(headerCountSelector)
     .invoke('text')
     .then((headerCount) => {
+      const hasMoreThanOnePage = headerCount > PAGE_SIZE
+
       cy.get(collectionItemsSelector).should((collectionItems) => {
-        expect(headerCount).to.eq(collectionItems.length.toString())
+        expect(collectionItems.length).to.eq(
+          hasMoreThanOnePage ? PAGE_SIZE : Number(headerCount)
+        )
       })
+
+      if (hasMoreThanOnePage) {
+        const totalPages = Math.ceil(headerCount / PAGE_SIZE)
+        cy.get('.c-collection__pagination-summary').contains(
+          `Page 1 of ${totalPages}`
+        )
+
+        cy.get('.c-pagination__label--next').should('be.visible')
+      }
     })
 }
 


### PR DESCRIPTION
## Description of change

Additional fixtures that we use for e2e tests have been added to the API. This meant that the contact interactions collection page now had more than one page to display. This fix checks the total amount of results and alters the subsequent test to expect the correct amount items in the list based on the standard page size. Also adds an assertion that the pagination is shown.

## Test instructions

All e2e tests should now pass

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
