### PR TITLE
Add missing ES_APM_ENABLED to BE image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ aliases:
       DATA_HUB_FRONTEND_ACCESS_KEY_ID: frontend-key-id
       DATA_HUB_FRONTEND_SECRET_ACCESS_KEY: frontend-key
       ADMIN_OAUTH2_ENABLED: 'False'
+      ES_APM_ENABLED: 'False'
       # Workaround for Docker/CircleCI compatibility problem with Python 3.8
       COLUMNS: 80
 


### PR DESCRIPTION
## Description of change
The Circle CI is breaking due to a new ES_APM_ENABLED env var introduce from this PR.
https://github.com/uktrade/data-hub-api/pull/2930

## Test instructions

All test pass

