### PR TITLE
Add sandbox endpoint for feature flag

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -11,7 +11,6 @@
   "env": {
     "codeCoverage": {
       "url": "http://localhost:3000/__coverage__"
-    },
-    "sandbox_url": "http://localhost:8000"
+    }
   }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -11,6 +11,7 @@
   "env": {
     "codeCoverage": {
       "url": "http://localhost:3000/__coverage__"
-    }
+    },
+    "sandbox_url": "http://localhost:8000"
   }
 }

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -1,6 +1,9 @@
 /* eslint-disable */
+require('dotenv').config()
+
 module.exports = (on, config) => {
   on('task', require('@cypress/code-coverage/task'))
   on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'))
+  config.env.sandbox_url = process.env.API_ROOT || config.env.sandbox_url
+  return config
 }
-

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -4,6 +4,6 @@ require('dotenv').config()
 module.exports = (on, config) => {
   on('task', require('@cypress/code-coverage/task'))
   on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'))
-  config.env.sandbox_url = process.env.API_ROOT || config.env.sandbox_url
+  config.env.sandbox_url = process.env.API_ROOT
   return config
 }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -158,3 +158,16 @@ Cypress.Commands.add(
     return cy.wrap(subject)
   }
 )
+
+Cypress.Commands.add(
+  'setFeatureFlag',
+  (name, isActive) => {
+    const body = {
+      code: name,
+      is_active: isActive,
+    }
+    backend_url = Cypress.env('sandbox_url')
+    uri = '/sandbox/feature-flag'
+    return cy.request('PUT', `${backend_url}${uri}`, body)
+  }
+)

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -171,3 +171,12 @@ Cypress.Commands.add(
     return cy.request('PUT', `${backend_url}${uri}`, body)
   }
 )
+
+Cypress.Commands.add(
+  'resetFeatureFlags',
+  () => {
+    backend_url = Cypress.env('sandbox_url')
+    uri = '/sandbox/reset-feature-flag'
+    return cy.request('POST', `${backend_url}${uri}`)
+  }
+)

--- a/test/sandbox/routes/v3/feature-flag/feature-flag.js
+++ b/test/sandbox/routes/v3/feature-flag/feature-flag.js
@@ -1,5 +1,17 @@
 var featureFlag = require('../../../fixtures/v3/feature-flag/feature-flag.json')
 
+let updatedFeatureFlag = null
+
 exports.featureFlag = function(req, res) {
+  if (updatedFeatureFlag) {
+    return res.json(updatedFeatureFlag)
+  }
   res.json(featureFlag)
+}
+
+exports.updateFeatureFlag = (req, res) => {
+  updatedFeatureFlag = featureFlag.map((flag) =>
+    flag.code === req.body.code ? { ...req.body } : flag
+  )
+  res.json(updatedFeatureFlag)
 }

--- a/test/sandbox/routes/v3/feature-flag/feature-flag.js
+++ b/test/sandbox/routes/v3/feature-flag/feature-flag.js
@@ -1,17 +1,17 @@
-var featureFlag = require('../../../fixtures/v3/feature-flag/feature-flag.json')
+var defaultFeatureFlags = require('../../../fixtures/v3/feature-flag/feature-flag.json')
 
-let updatedFeatureFlag = null
+let featureFlags = { ...defaultFeatureFlags }
 
 exports.featureFlag = function(req, res) {
-  if (updatedFeatureFlag) {
-    return res.json(updatedFeatureFlag)
-  }
-  res.json(featureFlag)
+  return res.json(defaultFeatureFlags)
 }
 
-exports.setSandboxFlag = (req, res) => {
-  updatedFeatureFlag = featureFlag.map((flag) =>
-    flag.code === req.body.code ? { ...req.body } : flag
-  )
-  res.json(updatedFeatureFlag)
+exports.setSandboxFlag = function(req, res) {
+  featureFlags[req.body.code] = req.body
+  res.json(featureFlags)
+}
+
+exports.resetSandboxFlags = function(req, res) {
+  featureFlags = { ...defaultFeatureFlags }
+  res.json(featureFlags)
 }

--- a/test/sandbox/routes/v3/feature-flag/feature-flag.js
+++ b/test/sandbox/routes/v3/feature-flag/feature-flag.js
@@ -9,7 +9,7 @@ exports.featureFlag = function(req, res) {
   res.json(featureFlag)
 }
 
-exports.updateFeatureFlag = (req, res) => {
+exports.setSandboxFlag = (req, res) => {
   updatedFeatureFlag = featureFlag.map((flag) =>
     flag.code === req.body.code ? { ...req.body } : flag
   )

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -301,7 +301,7 @@ app.get('/v3/event/:eventId', v3Event.eventById)
 
 // V3 Feature Flag
 app.get('/v3/feature-flag', v3FeatureFlag.featureFlag)
-app.put('/v3/feature-flag', v3FeatureFlag.updateFeatureFlag)
+app.put('/sandbox/feature-flag', v3FeatureFlag.setSandboxFlag)
 
 // V3 Interaction
 app.get('/v3/interaction', v3Interaction.getInteractions)

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -302,6 +302,7 @@ app.get('/v3/event/:eventId', v3Event.eventById)
 // V3 Feature Flag
 app.get('/v3/feature-flag', v3FeatureFlag.featureFlag)
 app.put('/sandbox/feature-flag', v3FeatureFlag.setSandboxFlag)
+app.post('/sandbox/reset-feature-flag', v3FeatureFlag.resetSandboxFlags)
 
 // V3 Interaction
 app.get('/v3/interaction', v3Interaction.getInteractions)

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -9,6 +9,7 @@ const config = {
 const app = express()
 
 app.use(bodyParser.urlencoded({ extended: true }))
+app.use(bodyParser.json())
 
 // TODO: Remove these legacy Sandbox vars after all the mocks are refactored
 global.state = {}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -8,7 +8,7 @@ const config = {
 
 const app = express()
 
-app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({ extended: true }))
 
 // TODO: Remove these legacy Sandbox vars after all the mocks are refactored
 global.state = {}
@@ -300,6 +300,7 @@ app.get('/v3/event/:eventId', v3Event.eventById)
 
 // V3 Feature Flag
 app.get('/v3/feature-flag', v3FeatureFlag.featureFlag)
+app.put('/v3/feature-flag', v3FeatureFlag.updateFeatureFlag)
 
 // V3 Interaction
 app.get('/v3/interaction', v3Interaction.getInteractions)


### PR DESCRIPTION
## Description of change

The intent of this PR is add the capability to update feature flags during the tests, so we can have coverage for both conditions, when the flag is on or off.

## Test instructions

Within any test, you should be able to invoke the command setFeatureFlag, I.E:

`cy.setFeatureFlag('manage-lead-adviser', false)`

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
