### PR TITLE
Allow Date to be entered without the 0 padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "5.7.0",
+    "data-hub-components": "5.8.1",
     "date-fns": "^1.29.0",
     "del-cli": "^3.0.0",
     "details-element-polyfill": "^2.4.0",

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -6,6 +6,7 @@ import getContactFromQuery from '../../../../../client/utils/getContactFromQuery
 import { INTERACTION_STATUS } from '../../../constants'
 import { EXPORT_INTEREST_STATUS_VALUES, OPTION_NO } from '../../../../constants'
 import { ID as STORE_ID } from './state'
+import { transformValueForApi } from '../../../../../common/date'
 
 const FIELDS_TO_OMIT = [
   'currently_exporting',
@@ -110,7 +111,7 @@ export function saveInteraction({ values, companyId, referralId }) {
     dit_participants: values.dit_participants.map((a) => ({
       adviser: a.value,
     })),
-    date: `${values.date.year}-${values.date.month}-${values.date.day}`,
+    date: transformValueForApi(values.date),
     policy_areas: transformArrayOfOptions(values.policy_areas),
     communication_channel: transformOption(values.communication_channel),
     event: transformOption(values.event),

--- a/src/apps/my-pipeline/client/tasks.js
+++ b/src/apps/my-pipeline/client/tasks.js
@@ -1,7 +1,7 @@
 import pipelineApi from './api'
 import { addMessage } from '../../../client/utils/flash-messages'
 import axios from 'axios'
-import moment from 'moment'
+import { transformValueForApi } from '../../../common/date'
 
 function transformValuesForApi(values, oldValues = {}) {
   const data = {
@@ -21,14 +21,8 @@ function transformValuesForApi(values, oldValues = {}) {
   addValue('sector', values.sector?.value)
   addValue('contact', values.contact?.value)
   addValue('potential_value', values.export_value)
+  addValue('expected_win_date', transformValueForApi(values.expected_win_date))
 
-  const { month, year } = values.expected_win_date
-  const expectedWinDate = moment(`${year}-${month}`, 'YYYY-MM', true)
-  if (expectedWinDate.isValid()) {
-    addValue('expected_win_date', expectedWinDate.format('YYYY-MM-DD'))
-  } else {
-    addValue('expected_win_date')
-  }
   return data
 }
 

--- a/src/common/date.js
+++ b/src/common/date.js
@@ -30,8 +30,27 @@ function parseDateString(dateString) {
   return null
 }
 
+function padZero(value) {
+  const parsedValue = parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    return value
+  }
+  return parsedValue < 10 ? `0${parsedValue}` : parsedValue.toString()
+}
+
+function transformValueForApi({ year, month, day = 1 }) {
+  if (year && month && day) {
+    const y = padZero(year)
+    const m = padZero(month)
+    const yearAndMonth = `${y}-${m}`
+    return day ? `${yearAndMonth}-${padZero(day)}` : yearAndMonth
+  }
+  return null
+}
+
 module.exports = {
   formatLongDate,
   formatMediumDate,
   parseDateString,
+  transformValueForApi,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7196,10 +7196,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-hub-components@5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.7.0.tgz#2c6909df66794df3464ce9220e42863eafbed860"
-  integrity sha512-D3y8PIJLxY0UYVXVt9eb/OnX5z24oPbtAhASJyDC4pKT7omZW2zYaZBY1A4vRFrcEGKCmF62URYCx/ba2kLP0w==
+data-hub-components@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/data-hub-components/-/data-hub-components-5.8.1.tgz#425b9e4fde0cfbb0fd7d3b6c0abab1b68a1fe609"
+  integrity sha512-IvhoEeZQbXpm720Ap5SK1LKe136e6cZnPWjkQySAIJSn2h3RbaNYCRCAS3xu9vVpQ5SYZnMC4xLTmBikheX22g==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@govuk-react/button" "^0.7.1"


### PR DESCRIPTION
## Description of change

This PR allows date to be entered as 6-6-2020 and 06-06-2020 with and without the leading zero.

## Test instructions

Interactions  should allow the date to be entered as 'YYYY-MM-DD', 'YYYY-MM-D', 'YYYY-M-D', 'YYYY-M-DD'

and pipelines should allow 'YYYY-MM', 'YYYY-M'

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/84684185-39215c00-af30-11ea-94d6-5e6dd35a10c0.png)


_Add a screenshot_

### After
![image](https://user-images.githubusercontent.com/5575331/84684205-41799700-af30-11ea-9bac-81a9938fa4b5.png)



## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
