### PR TITLE
Change back to --inspect so the server starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "develop": "NODE_ENV=development run-p watch:js:*",
     "watch:test": "yarn test:unit -- -w",
     "watch:js:client": "webpack --watch --progress",
-    "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect-brk=0.0.0.0 --ignore 'src/**/__test__/**/*'",
+    "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect --ignore 'src/**/__test__/**/*'",
     "lint": "run-p lint:*",
     "lint:js": "eslint --ext .jsx,.js ./test ./src ./assets ./.circleci",
     "lint:sass": "sass-lint -v -q -c .sass-lint.yml assets/stylesheets/**/*.scss",


### PR DESCRIPTION
## Description of change

Without a debugger listening the Node server will not start, so this changes it back to start without a debugger

## Test instructions

Run `yarn develop` without a debugger and the server should start

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
