### PR TITLE
Add sentry logging

### DIFF
--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -115,7 +115,7 @@ async function renderMatchConfirmation(req, res, next) {
   }
 }
 
-async function linkCompanies(req, res) {
+async function linkCompanies(req, res, next) {
   try {
     const { token } = req.session
     const { company } = res.locals
@@ -135,9 +135,7 @@ async function linkCompanies(req, res) {
     )
     res.json(result)
   } catch (error) {
-    const statusCode = get(error, 'response.status', 500)
-    const message = get(error, 'response.data.description')
-    res.status(statusCode).json({ message })
+    next(error)
   }
 }
 


### PR DESCRIPTION
## Description of change
Currently we have a Prod issue where a user is unable to verify/match a Data Hub company against a D&B company. A HTTP 500 is thrown with very little detail as `next(error)` is not being called, therefore, the error is not being passed to Express and subsequently logged in Sentry. Once we have this additional detail we should be in a better place to diagnose the problem.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
