### PR TITLE
New tag component

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "5.8.1",
+    "data-hub-components": "5.7.0",
     "date-fns": "^1.29.0",
     "del-cli": "^3.0.0",
     "details-element-polyfill": "^2.4.0",

--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -7,15 +7,17 @@ import Link from '@govuk-react/link'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
-import { BLUE, GREEN } from 'govuk-colours'
+import { BLUE } from 'govuk-colours'
 import {
   Card,
   CardDetailsList,
   CardHeader,
 } from 'data-hub-components/dist/activity-feed/activities/card'
-import { Badge, NumberUtils } from 'data-hub-components'
+import { NumberUtils } from 'data-hub-components'
 
 import urls from '../../../lib/urls'
+import Tag from '../Tag'
+import LIKELIHOOD_TO_SUCCEED from './constants'
 
 const StyledGridCol = styled(GridCol)`
   display: flex;
@@ -53,7 +55,7 @@ const StyledGridRow = styled(GridRow)`
   }
 `
 
-const StyledBadgeSpacing = styled.span`
+const StyledTagSpacing = styled.span`
   margin: ${SPACING.SCALE_3} 0 0 0;
   ${MEDIA_QUERIES.TABLET} {
     margin: 0;
@@ -64,12 +66,6 @@ const StyledBadgeSpacing = styled.span`
     box-sizing: border-box;
   }
 `
-
-const LIKELIHOOD_TO_WIN = {
-  1: 'Low',
-  2: 'Medium',
-  3: 'High',
-}
 
 function buildMetaList({
   potential_value,
@@ -120,14 +116,13 @@ const PipelineItem = ({
         />
       </GridCol>
       <StyledGridCol>
-        {LIKELIHOOD_TO_WIN[likelihood_to_win] && (
-          <StyledBadgeSpacing>
-            <Badge
-              borderColour={GREEN}
-            >{`Likelihood to succeed - ${LIKELIHOOD_TO_WIN[likelihood_to_win]}`}</Badge>
-          </StyledBadgeSpacing>
+        {LIKELIHOOD_TO_SUCCEED[likelihood_to_win] && (
+          <StyledTagSpacing aria-label="Likelihood to succeed">
+            <Tag
+              colour={LIKELIHOOD_TO_SUCCEED[likelihood_to_win].colour}
+            >{`${LIKELIHOOD_TO_SUCCEED[likelihood_to_win].text}`}</Tag>
+          </StyledTagSpacing>
         )}
-
         <Button as={Link} href={urls.pipeline.edit(id)} buttonColour={BLUE}>
           Edit
         </Button>

--- a/src/client/components/Pipeline/constants.js
+++ b/src/client/components/Pipeline/constants.js
@@ -1,0 +1,16 @@
+const LIKELIHOOD_TO_SUCCEED = {
+  1: {
+    text: 'LOW',
+    colour: 'red',
+  },
+  2: {
+    text: 'MEDIUM',
+    colour: 'yellow',
+  },
+  3: {
+    text: 'HIGH',
+    colour: 'green',
+  },
+}
+
+export default LIKELIHOOD_TO_SUCCEED

--- a/src/client/components/Tag/__stories__/Tag.stories.jsx
+++ b/src/client/components/Tag/__stories__/Tag.stories.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import styled from 'styled-components'
+import { storiesOf } from '@storybook/react'
+import { SPACING } from '@govuk-react/constants'
+
+import Tag from '../index'
+import defaultReadme from './default.md'
+import usageReadme from './usage.md'
+
+const List = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  strong {
+    margin-bottom: ${SPACING.SCALE_3};
+  }
+`
+
+storiesOf('Tag', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: defaultReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <List>
+      <Tag>BETA</Tag>
+      <Tag colour="grey">INACTIVE</Tag>
+      <Tag colour="green">NEW</Tag>
+      <Tag colour="turquoise">ACTIVE</Tag>
+      <Tag colour="blue">PENDING</Tag>
+      <Tag colour="purple">RECEIVED</Tag>
+      <Tag colour="pink">SENT</Tag>
+      <Tag colour="red">REJECTED</Tag>
+      <Tag colour="orange">DECLINED</Tag>
+      <Tag colour="yellow">DELAYED</Tag>
+    </List>
+  ))

--- a/src/client/components/Tag/__stories__/default.md
+++ b/src/client/components/Tag/__stories__/default.md
@@ -1,0 +1,18 @@
+### Input
+
+```jsx
+import Tag from '../Tag'
+
+<Tag>BETA</Tag>
+<Tag colour="grey">INACTIVE</Tag>
+<Tag colour="green">NEW</Tag>
+<Tag colour="turquoise">ACTIVE</Tag>
+<Tag colour="blue">PENDING</Tag>
+<Tag colour="purple">RECEIVED</Tag>
+<Tag colour="pink">SENT</Tag>
+<Tag colour="red">REJECTED</Tag>
+<Tag colour="orange">DECLINED</Tag>
+<Tag colour="yellow">DELAYED</Tag>
+```
+
+### Output

--- a/src/client/components/Tag/__stories__/usage.md
+++ b/src/client/components/Tag/__stories__/usage.md
@@ -1,0 +1,22 @@
+# Tag
+
+### Description
+
+The is a implementation of the [Tag](https://design-system.service.gov.uk/components/tag/) component from the GovUK Design System.
+
+Use the tag component when it’s possible for something to have more than one status and it’s useful for the user to know about that status. For example, you can use a tag to show whether an item in a [task list](https://design-system.service.gov.uk/patterns/task-list-pages) has been ‘completed’.
+
+### Usage
+
+If no colour is specified the tag will default to a blue background and white text.
+
+```jsx
+<Tag colour="green">NEW</Tag>
+```
+
+### Properties
+
+| Prop       | Required | Default                                                   | Type | Description |
+| :--------- | :------- | :-------------------------------------------------------- | :--- | :---------- |
+| `children` | true     | 'default'                                                 | node | Text of tag |
+| `colour`   | false    | `` | string | Dictates the `background-color` and `color` |

--- a/src/client/components/Tag/index.jsx
+++ b/src/client/components/Tag/index.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import GovUkTag from '@govuk-react/tag'
+import { BLUE, WHITE } from 'govuk-colours'
+
+// Most of these colours aren't included as part of the govuk-colours package so we need to define them here. Currrently we only need them here, but we can lift them out into their own file if we start to use them elsewhere.
+const TAG_COLOURS = {
+  default: {
+    color: WHITE,
+    background: BLUE,
+  },
+  grey: {
+    color: '#454a4d',
+    background: '#eff0f1',
+  },
+  green: {
+    color: '#005a30',
+    background: '#cce2d8',
+  },
+  turquoise: {
+    color: '#10403c',
+    background: '#bfe3e0',
+  },
+  blue: {
+    color: '#144e81',
+    background: '#d2e2f1',
+  },
+  purple: {
+    color: '#3d2375',
+    background: '#dbd5e9',
+  },
+  pink: {
+    color: '#80224d',
+    background: '#f7d7e6',
+  },
+  red: {
+    color: '#942514',
+    background: '#f6d7d2',
+  },
+  orange: {
+    color: '#6e3619',
+    background: '#fcd6c3',
+  },
+  yellow: {
+    color: '#594d00',
+    background: '#fff7bf',
+  },
+}
+
+const StyledTag = styled(GovUkTag)`
+  background-color: ${(props) => TAG_COLOURS[props.colour].background};
+  color: ${(props) => TAG_COLOURS[props.colour].color};
+`
+
+const Tag = ({ colour, children }) => (
+  <StyledTag colour={colour}>{children}</StyledTag>
+)
+
+Tag.propTypes = {
+  colour: PropTypes.oneOf(Object.keys(TAG_COLOURS)),
+  children: PropTypes.node.isRequired,
+}
+
+Tag.defaultProps = {
+  colour: 'default',
+}
+
+export default Tag

--- a/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
@@ -169,7 +169,7 @@ describe('My Pipeline tab on the dashboard', () => {
 
           cy.url().should('include', urls.pipeline.won())
           assertTabListItem({
-            contain: [projectName + ' edited', 'Likelihood to succeed - Low'],
+            contain: [projectName + ' edited', 'LOW'],
             notContain: [
               'Project sector',
               'Company contact',

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -1,8 +1,10 @@
+const { NumberUtils } = require('data-hub-components')
+
 const urls = require('../../../../../src/lib/urls')
 const leads = require('../../../../sandbox/fixtures/v4/pipeline-item/leads.json')
 const inProgress = require('../../../../sandbox/fixtures/v4/pipeline-item/in-progress.json')
 const win = require('../../../../sandbox/fixtures/v4/pipeline-item/win.json')
-const { NumberUtils } = require('data-hub-components')
+const LIKELIHOOD_TO_SUCCEED = require('../../../../../src/client/components/Pipeline/constants')
 
 function assertPipelineItem(
   index,
@@ -29,14 +31,15 @@ function assertPipelineItem(
         urls.pipeline.edit(result.id)
       )
       if (result.likelihood_to_win) {
-        const likelihoodToWinText = {
-          1: 'Likelihood to succeed - Low',
-          2: 'Likelihood to succeed - Medium',
-          3: 'Likelihood to succeed - High',
-        }
-        cy.contains(likelihoodToWinText[result.likelihood_to_win])
+        cy.get('span[aria-label="Likelihood to succeed"]').should('exist')
+        cy.contains(LIKELIHOOD_TO_SUCCEED[result.likelihood_to_win].text)
       } else {
-        cy.contains('Likelihood to succeed').should('not.exist')
+        const values = Object.values(LIKELIHOOD_TO_SUCCEED).map(
+          (item) => item.text
+        )
+        const regex = new RegExp(`${values.join('|')}`, 'g')
+        cy.get('span[aria-label="Likelihood to succeed"]').should('not.exist')
+        cy.contains(regex).should('not.exist')
       }
 
       if (result.expected_win_date) {


### PR DESCRIPTION
## Description of change

Introduce new `Tag` component based on the [Tag component](https://design-system.service.gov.uk/components/tag/) from the GOV.UK Design system. This implementation extends the `Tag` component found in the govuk-react library. 

Implement the new `Tag` component in the `pipeline` app with new colour coding and moving the label 'Likelihood to win' to an aria-label. 

## Test instructions

When you go to `My pipleline` on the dashboard you will now see the new tag instead of the old badge.

You can also see documentation and examples of the new component by firing up storybook. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/42253716/85150850-f79ff200-b24a-11ea-9dc7-c52c897c5c20.png)

### After

![new tags](https://user-images.githubusercontent.com/42253716/85150873-ff5f9680-b24a-11ea-96a7-ad0c9e7a75aa.gif)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
