### PR TITLE
Add validation for potential export value

### DIFF
--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -81,7 +81,7 @@ function PipelineForm({
         label="Potential export value (optional)"
         hint="Amount in GBP"
         name="export_value"
-        type="number"
+        type="text"
         initialValue={initialValue.export_value}
         pattern="[0-9]*"
         inputmode="numeric"

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -19,6 +19,8 @@ const statusOptions = STATUS_VALUES.map(({ value, label }) => ({
 }))
 
 const likelihoodOptions = Object.values(LIKELIHOOD_VALUES)
+
+const IS_NUMBER = /^[0-9]*$/
 function PipelineForm({
   onSubmit,
   submissionError,
@@ -85,6 +87,11 @@ function PipelineForm({
         inputmode="numeric"
         spellcheck="false"
         className="govuk-input--width-10"
+        validate={(value) =>
+          !value || IS_NUMBER.test(value)
+            ? null
+            : 'Potential export value must be a number'
+        }
       />
       <FieldDate
         format="short"

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -65,10 +65,9 @@ describe('Edit One List', () => {
     })
 
     it('should submit updated data', () => {
-      cy.get(selectors.companyEditOneList.globalAccountManagerField)
-        .click()
-        .type('shawn{enter}')
-        .contains('Shawn Cohen')
+      cy.get(
+        selectors.companyEditOneList.globalAccountManagerField
+      ).selectTypeaheadOption('shawn')
 
       cy.contains('Holly Collins')
         .next()
@@ -79,11 +78,9 @@ describe('Edit One List', () => {
         'Holly Collins'
       )
 
-      cy.get(selectors.companyEditOneList.coreTeamField)
-        .click()
-        .type('leroy{enter}')
-        .contains('Leroy Powers')
-        .click({ force: true })
+      cy.get(selectors.companyEditOneList.coreTeamField).selectTypeaheadOption(
+        'leroy'
+      )
 
       cy.contains('Submit').click()
 
@@ -124,8 +121,7 @@ describe('Edit One List', () => {
 
       it('should submit updated data', () => {
         cy.get(selectors.companyEditOneList.globalAccountManagerField)
-          .click()
-          .type('shawn{enter}')
+          .selectTypeaheadOption('shawn')
           .contains('Shawn Cohen')
 
         cy.contains('Submit').click()

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -205,4 +205,43 @@ describe('Company add to pipeline form', () => {
       cy.contains('Choose a status')
     })
   })
+
+  context('Potential export value validation', () => {
+    beforeEach(() => {
+      cy.visit(urls.companies.pipelineAdd(minimallyMinimal.id))
+      cy.contains('Potential export value')
+    })
+
+    function checkError(value, assertion = 'contain') {
+      cy.window().then((win) => {
+        win.document.querySelector('#export_value').type = 'text'
+      })
+      cy.get(formSelectors.value).type(value)
+      cy.contains('button', 'Add').click()
+      cy.get('#form-errors').should(
+        assertion,
+        'Potential export value must be a number'
+      )
+    }
+
+    context('With only numbers', () => {
+      it('Should not show an error', () => {
+        checkError('123456', 'not.contain')
+      })
+    })
+
+    context('When the form is submitted with a non numeric value', () => {
+      context('With characters', () => {
+        it('Should show an error', () => {
+          checkError('ABC')
+        })
+      })
+
+      context('With a £ sign and commas in the number', () => {
+        it('Should show an error', () => {
+          checkError('£1,000')
+        })
+      })
+    })
+  })
 })

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -213,9 +213,6 @@ describe('Company add to pipeline form', () => {
     })
 
     function checkError(value, assertion = 'contain') {
-      cy.window().then((win) => {
-        win.document.querySelector('#export_value').type = 'text'
-      })
       cy.get(formSelectors.value).type(value)
       cy.contains('button', 'Add').click()
       cy.get('#form-errors').should(


### PR DESCRIPTION
## Description of change

To stop an invalid value being sent to the API.

To enable the testing of this I have had to alter the HTML using JavaScript from Cypress. This is necessary as Chrome will not allow any non numeric values to be typed into a `<input type="number` field.

## Test instructions

1) Go to add a company to your pipeline
2) If using Chrome, Inspect the element and change the type to "text" - Chrome will not allow non numeric values in `type="number"` 
3) Try entering anything other than numbers for the value

You should get a validation error when submitting the form.

## Screenshots
### After

<img width="985" alt="Screenshot 2020-06-22 at 16 12 10" src="https://user-images.githubusercontent.com/1481883/85304179-5c558980-b4a3-11ea-8740-5d10d88ab6df.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
