### PR TITLE
Add mechanism to show account plan link on companies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ aliases:
     HELP_CENTRE_API_FEED: http://localhost:8000/help-centre/announcement
     HELP_CENTRE_FEED_API_TOKEN: apiToken
     ZEN_TICKETS_URL: http://localhost:8000/zendesk/tickets
+    ACCOUNT_PLAN_URLS: '{"000000001": "/some-test-account-plan-url", "123456789": "/some-other-test-account-plan-url"}'
 
   # Data hub base docker container
   - &docker_data_hub_base

--- a/dev-stack.sample.env
+++ b/dev-stack.sample.env
@@ -50,3 +50,4 @@ WEB_CONCURRENCY=2
 ZEN_EMAIL=look@in.vault.com
 ZEN_TICKETS_URL=https://lookInVault.com/
 ZEN_TOKEN=lookInVault
+ACCOUNT_PLAN_URLS={"000000001": "/some-test-account-plan-url","123456789": "/some-other-test-account-plan-urls"}

--- a/src/apps/companies/client/CompanyLocalHeader.jsx
+++ b/src/apps/companies/client/CompanyLocalHeader.jsx
@@ -250,7 +250,13 @@ const CompanyLocalHeader = ({
               company.one_list_group_global_account_manager.contact_email && (
                 <>
                   &nbsp;To do so, contact the Global Account Manager at&nbsp;
-                  <a href={"mailto:" + company.one_list_group_global_account_manager.contact_email}>
+                  <a
+                    href={
+                      'mailto:' +
+                      company.one_list_group_global_account_manager
+                        .contact_email
+                    }
+                  >
                     {
                       company.one_list_group_global_account_manager
                         .contact_email

--- a/src/apps/companies/client/CompanyLocalHeader.jsx
+++ b/src/apps/companies/client/CompanyLocalHeader.jsx
@@ -250,7 +250,7 @@ const CompanyLocalHeader = ({
               company.one_list_group_global_account_manager.contact_email && (
                 <>
                   &nbsp;To do so, contact the Global Account Manager at&nbsp;
-                  <a href="mailto:{company.one_list_group_global_account_manager.contact_email}">
+                  <a href={"mailto:" + company.one_list_group_global_account_manager.contact_email}>
                     {
                       company.one_list_group_global_account_manager
                         .contact_email

--- a/src/apps/companies/client/CompanyLocalHeader.jsx
+++ b/src/apps/companies/client/CompanyLocalHeader.jsx
@@ -5,7 +5,7 @@ import pluralize from 'pluralize'
 import GridCol from '@govuk-react/grid-col'
 import GridRow from '@govuk-react/grid-row'
 import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
-import { GREY_3 } from 'govuk-colours'
+import { GREY_3, PURPLE, BLACK } from 'govuk-colours'
 import Details from '@govuk-react/details'
 import Main from '@govuk-react/main'
 import { Badge, StatusMessage, DateUtils } from 'data-hub-components'
@@ -51,6 +51,14 @@ const StyledDetails = styled(Details)`
   }
 `
 
+const StyledDetailsMuted = styled(Details)`
+  margin: 0;
+  span,
+  div {
+    font-size: ${FONT_SIZE.SIZE_16};
+  }
+`
+
 const StyledDescription = styled('div')`
   padding: ${SPACING.SCALE_2};
   background-color: ${GREY_3};
@@ -77,6 +85,20 @@ const StyledMain = styled(Main)`
   padding-top: ${SPACING.SCALE_1};
   div {
     font-size: ${FONT_SIZE.SIZE_20};
+  }
+`
+
+const StyledMainMuted = styled(Main)`
+  padding-top: ${SPACING.SCALE_1};
+  div {
+    font-size: ${FONT_SIZE.SIZE_16};
+    font-weight: normal;
+    color: ${BLACK};
+  }
+  div > div {
+    border: 3px solid ${PURPLE};
+    margin: 0;
+    padding: ${SPACING.SCALE_3};
   }
 `
 
@@ -214,6 +236,48 @@ const CompanyLocalHeader = ({
             Hub support team.
           </StatusMessage>
         </StyledMain>
+      )}
+
+      {company.account_plan_url && (
+        <StyledMainMuted data-auto-id="accountPlanMessage">
+          <StatusMessage>
+            <a href={company.account_plan_url} target="_blank">
+              Go to Sharepoint to view the account plan
+            </a>{' '}
+            for {company.name} (opens in a new window or tab). You might have to
+            request access to this file.
+            {company.one_list_group_global_account_manager &&
+              company.one_list_group_global_account_manager.contact_email && (
+                <>
+                  &nbsp;To do so, contact the Global Account Manager at&nbsp;
+                  <a href="mailto:{company.one_list_group_global_account_manager.contact_email}">
+                    {
+                      company.one_list_group_global_account_manager
+                        .contact_email
+                    }
+                  </a>
+                  .
+                </>
+              )}
+            <StyledDetailsMuted
+              summary="What is an account plan?"
+              data-auto-id="metaList"
+            >
+              All businesses on the One List are expected to have an account
+              plan, to ensure that the wider virtual team understands the
+              company and its key priorities. The Global Account Manager is
+              responsible for adding and updating the account plan. For further
+              information{' '}
+              <a
+                href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/the-account-management-strategy-team"
+                target="_blank"
+              >
+                view the Account Management Framework
+              </a>{' '}
+              (opens in a new window or tab).
+            </StyledDetailsMuted>
+          </StatusMessage>
+        </StyledMainMuted>
       )}
     </>
   )

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -4,6 +4,7 @@ const {
   getDitCompanyFromList,
   removeDitCompanyFromList,
 } = require('../repos')
+const config = require('../../../config')
 
 const { isItaTierDAccount } = require('../../../lib/is-tier-type-company')
 
@@ -20,6 +21,10 @@ async function getCompany(req, res, next, id) {
       !!company.is_global_ultimate && features['companies-ultimate-hq']
     company.isGlobalHQ =
       company.headquarter_type && company.headquarter_type.name === 'ghq'
+
+    if (config.accountPlanUrls[company.duns_number]) {
+      company.account_plan_url = config.accountPlanUrls[company.duns_number]
+    }
 
     res.locals.company = company
     next()

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -22,6 +22,9 @@ const OAUTH2_URI = Joi.string().uri()
   .when('OAUTH2_BYPASS_SSO', { is: false, then: Joi.required() })
 
 const envSchema = Joi.object({
+  // A mapping of { duns_number: url, .. } for the companies that have account plans
+  ACCOUNT_PLAN_URLS: ExtendedJoi.json().default({}),
+
   // The url for a back end server instance for the service
   API_ROOT: Joi.string().uri().required(),
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -51,6 +51,7 @@ const config = {
   version: envVars.GIT_BRANCH,
   noCache: envVars.CACHE_ASSETS ? false : isDev,
   port: envVars.PORT,
+  accountPlanUrls: envVars.ACCOUNT_PLAN_URLS,
   apiRoot: envVars.API_ROOT,
   api: {
     authUrl: '/token/',

--- a/test/functional/cypress/specs/companies/local-header/account-plan-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/account-plan-spec.js
@@ -1,0 +1,66 @@
+const selectors = require('../../../../../selectors')
+const fixtures = require('../../../fixtures')
+const urls = require('../../../../../../src/lib/urls')
+
+const companyLocalHeader = selectors.companyLocalHeader()
+
+describe('Local header for company with an account plan', () => {
+  context(
+    'when visting a company which has an account plan (no contact email)',
+    () => {
+      before(() => {
+        cy.visit(urls.companies.activity.index(fixtures.company.dnbCorp.id))
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.dnbCorp.name
+        )
+      })
+
+      it('should display the account plan message', () => {
+        cy.get(companyLocalHeader.accountPlanMessage).contains(
+          'Go to Sharepoint to view the account plan for DnB Corp (opens in a new ' +
+            'window or tab). You might have to request access to this file.'
+        )
+      })
+    }
+  )
+  context(
+    'when visting a company which has an account plan (including contact email)',
+    () => {
+      before(() => {
+        cy.visit(urls.companies.activity.index(fixtures.company.oneListCorp.id))
+      })
+
+      it('should display the company name', () => {
+        cy.get(companyLocalHeader.companyName).contains(
+          fixtures.company.oneListCorp.name
+        )
+      })
+
+      it('should display the account plan message', () => {
+        cy.get(companyLocalHeader.accountPlanMessage).contains(
+          'Go to Sharepoint to view the account plan for One List Corp (opens in ' +
+            'a new window or tab). You might have to request access to this file. ' +
+            'To do so, contact the Global Account Manager at travis@example.net'
+        )
+      })
+    }
+  )
+  context('when visting a company which does not have an account plan', () => {
+    before(() => {
+      cy.visit(urls.companies.activity.index(fixtures.company.venusLtd.id))
+    })
+
+    it('should display the company name', () => {
+      cy.get(companyLocalHeader.companyName).contains(
+        fixtures.company.venusLtd.name
+      )
+    })
+
+    it('should not display the account plan message', () => {
+      cy.get(companyLocalHeader.accountPlanMessage).should('not.exist')
+    })
+  })
+})

--- a/test/sandbox/fixtures/v4/company/company-one-list-corp.json
+++ b/test/sandbox/fixtures/v4/company/company-one-list-corp.json
@@ -46,6 +46,7 @@
     "name": "Travis Greene",
     "first_name": "Travis",
     "last_name": "Greene",
+    "contact_email": "travis@example.net",
     "dit_team": {
       "name": "IST - Sector Advisory Services",
       "uk_region": {

--- a/test/selectors/company-local-header.js
+++ b/test/selectors/company-local-header.js
@@ -10,6 +10,7 @@ module.exports = () => {
     },
     archivedMessage: '[data-auto-id="archivedMessage"]',
     investigationMessage: '[data-auto-id="investigationMessage"]',
+    accountPlanMessage: '[data-auto-id="accountPlanMessage"]',
     flashMessageList: '[data-auto-id="flash"]',
   }
 }


### PR DESCRIPTION
## Description of change

This PR adds a simple first iteration for surfacing Account Plans in Data Hub.

Our (Blue team) current thinking is that the *simplest thing* is to put a link to an account plan on company pages.  This has been achieved in the first instance without any backend work; there is a map of duns numbers to account plan URLs in the application configuration.  This can be effected by setting a JSON vault variable `ACCOUNT_PLAN_URLS`.

If it becomes clear that this experiment is a success that we want to further iterate, we can look at adding API support for account plan links.

**Note:** The copy here is not final - I expect to make some extra commits for minor amends, but the overall approach is ready for review.

## Screenshots

![Screenshot from 2020-06-24 15-40-14](https://user-images.githubusercontent.com/3239148/85577478-2b0ac400-b631-11ea-895d-cafbc3112ede.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [X] Has the branch been rebased to master?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
