### PR TITLE
Allow users to view quotes and payment receipts for cancelled orders

### DIFF
--- a/src/apps/omis/apps/view/__test__/controllers.test.js
+++ b/src/apps/omis/apps/view/__test__/controllers.test.js
@@ -2,6 +2,7 @@ const proxyquire = require('proxyquire')
 
 const subscriberData = require('../../../../../../test/unit/data/omis/subscribers.json')
 const assigneeData = require('../../../../../../test/unit/data/omis/assignees.json')
+const paymentData = require('../../../../../../test/unit/data/omis/payments.json')
 const contactData = require('../../../../../../test/unit/data/contacts/contact.json')
 
 const orderMock = {
@@ -127,9 +128,9 @@ describe('OMIS View controllers', () => {
       })
     })
 
-    context('when an order is in paid state', () => {
+    context('when an order has been paid', () => {
       beforeEach(() => {
-        this.resMock.locals.order.status = 'paid'
+        this.resMock.locals.payments = paymentData
       })
 
       it('should set a breadcrumb option', () => {

--- a/src/apps/omis/apps/view/controllers.js
+++ b/src/apps/omis/apps/view/controllers.js
@@ -29,9 +29,10 @@ function renderQuote(req, res) {
 }
 
 function renderPaymentReceipt(req, res) {
-  const { id, status } = get(res.locals, 'order')
+  const { id } = get(res.locals, 'order')
+  const { payments } = res.locals
 
-  if (!['paid', 'complete'].includes(status)) {
+  if (!payments || payments.length === 0) {
     return res.redirect(`/omis/${id}`)
   }
 

--- a/src/apps/omis/apps/view/router.js
+++ b/src/apps/omis/apps/view/router.js
@@ -40,6 +40,7 @@ router.get(
   setContact,
   setAssignees,
   setSubscribers,
+  setPayments,
   renderWorkOrder
 )
 router.get('/payment-receipt', setInvoice, setPayments, renderPaymentReceipt)

--- a/src/apps/omis/apps/view/views/_layouts/view.njk
+++ b/src/apps/omis/apps/view/views/_layouts/view.njk
@@ -7,7 +7,7 @@
     </p>
   {% endif %}
 
-  {% if order.status in ['paid', 'complete'] %}
+  {% if payments and payments.length %}
     <p class="c-local-header__action">
       <a href="payment-receipt">View payment receipt</a>
     </p>
@@ -23,7 +23,7 @@
     <p class="c-local-header__action">
       {% if order.status == 'draft' %}
         <a href="quote" class="govuk-button">Preview quote</a>
-      {% elif order.status not in ['cancelled']  %}
+      {% else %}
         <a href="quote">View quote</a>
       {% endif %}
     </p>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -242,6 +242,9 @@ module.exports = {
   omis: {
     index: url('/omis'),
     create: url('/omis/create?company=', ':companyId'),
+    order: url('/omis', '/:orderId'),
+    paymentReceipt: url('/omis', '/:orderId/payment-receipt'),
+    quote: url('/omis', '/:orderId/quote'),
   },
   support: url('/support'),
   pipeline: {

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -45,6 +45,11 @@ module.exports = {
   export: {
     historyWithInteractions: require('../../../sandbox/fixtures/v4/export/history-with-interactions.json'),
   },
+  omis: {
+    cancelledOrder: require('../../../sandbox/fixtures/v3/omis/cancelled-order.json'),
+    draftOrder: require('../../../sandbox/fixtures/v3/omis/draft-order.json'),
+    paidOrder: require('../../../sandbox/fixtures/v3/omis/paid-order.json'),
+  },
   referrals: {
     referalDetails: require('../../../sandbox/fixtures/v4/referrals/referral-details.json'),
   },

--- a/test/functional/cypress/specs/omis/view-order-spec.js
+++ b/test/functional/cypress/specs/omis/view-order-spec.js
@@ -1,0 +1,69 @@
+const fixtures = require('../../fixtures/index')
+const selectors = require('../../../../selectors')
+const urls = require('../../../../../src/lib/urls')
+
+const { cancelledOrder, draftOrder, paidOrder } = fixtures.omis
+const {
+  actionContainer,
+  cancelOrder,
+  completeOrder,
+  previewQuote,
+  viewPayment,
+  viewQuote,
+} = selectors.omisWorkOrder
+
+const assertContainActions = (actions) => {
+  actions.forEach((action) => {
+    cy.get(action.link).should('contain', action.text)
+  })
+}
+
+const assertNotContainActions = (actions) => {
+  actions.forEach((action) => {
+    cy.get(actionContainer).not('contain', action.text)
+  })
+}
+
+describe('View draft order without payment', () => {
+  before(() => {
+    cy.visit(urls.omis.order(draftOrder.id))
+  })
+
+  it('displays expected draft actions', () => {
+    assertContainActions([cancelOrder, previewQuote])
+    assertNotContainActions([completeOrder, viewPayment, viewQuote])
+  })
+})
+
+describe('View paid order', () => {
+  before(() => {
+    cy.visit(urls.omis.order(paidOrder.id))
+  })
+
+  it('displays expected actions for paid order', () => {
+    assertContainActions([completeOrder, viewPayment, viewQuote])
+    assertNotContainActions([cancelOrder, previewQuote])
+  })
+})
+
+describe('View cancelled order with payment', () => {
+  beforeEach(() => {
+    cy.visit(urls.omis.order(cancelledOrder.id))
+  })
+
+  it('does not show unsupported options', () => {
+    assertNotContainActions([cancelOrder, completeOrder, previewQuote])
+  })
+
+  it('allows user to view the payment receipt', () => {
+    cy.get(viewPayment.link).click()
+
+    cy.url().should('contain', urls.omis.paymentReceipt(cancelledOrder.id))
+  })
+
+  it('allows user to view the quote', () => {
+    cy.get(viewQuote.link).click()
+
+    cy.url().should('contain', urls.omis.quote(cancelledOrder.id))
+  })
+})

--- a/test/sandbox/fixtures/v3/omis/assignees.json
+++ b/test/sandbox/fixtures/v3/omis/assignees.json
@@ -1,0 +1,22 @@
+[
+  {
+    "adviser": {
+      "first_name": "Joe",
+      "last_name": "Doe",
+      "name": "Joe Doe",
+      "id": "33736be0-3e6b-4d4e-9fa8-32f23d0ba55e"
+    },
+    "estimated_time": 200,
+    "is_lead": true
+  },
+  {
+    "adviser": {
+      "first_name": "Rebecca",
+      "last_name": "Bah",
+      "name": "Rebecca Bah",
+      "id": "3cfad090-8f7e-4a8b-beb0-14c909d6f052"
+    },
+    "estimated_time": 250,
+    "is_lead": false
+  }
+]

--- a/test/sandbox/fixtures/v3/omis/cancelled-order.json
+++ b/test/sandbox/fixtures/v3/omis/cancelled-order.json
@@ -1,0 +1,70 @@
+{
+  "id": "1d2d26c3-1234-f223-b424-d2334feed28b",
+  "status": "cancelled",
+  "reference": "UST768/45",
+  "paid_on": "2018-09-27T08:59:20.381047",
+  "subtotal_cost": "1234",
+  "vat_cost": "12",
+  "total_cost": "123455",
+  "created_on": "2017-07-26T14:08:36.380979",
+  "created_by": null,
+  "modified_on": "2017-08-16T14:18:28.328729",
+  "modified_by": {
+    "name": "Test CMU 1",
+    "id": "8036f207-ae3e-e611-8d53-e4115bed50dc"
+  },
+  "company": {
+    "name": "Venus Ltd",
+    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+  },
+  "contact": {
+    "name": "Jenny Cakeman",
+    "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+  },
+  "primary_market": {
+    "name": "France",
+    "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "sector": {
+    "name": "Aerospace : Component Manufacturing",
+    "id": "e74171b4-efe9-e511-8ffa-e4115bead28a"
+  },
+  "service_types": [
+    {
+      "name": "Validated contacts",
+      "id": "c7915c75-cf29-42cf-99db-2acb75b96a78"
+    },
+    {
+      "name": "Visit programme",
+      "id": "8b48de3d-0066-4d98-991e-f79594bf55c0"
+    },
+    {
+      "name": "Strategic offer",
+      "id": "622aedd8-8936-4e62-99f2-2b8bb3783166"
+    },
+    {
+      "name": "Subscription",
+      "id": "66b57a5b-ca6e-4d6e-9941-4a6e7f9aa3ae"
+    },
+    {
+      "name": "Retainer",
+      "id": "80beb270-c1ce-40a3-8ad4-20a569a7bca0"
+    }
+  ],
+  "description": "Yeah yeah yeah",
+  "contacts_not_to_approach": "Brian",
+  "contact_email": "",
+  "contact_phone": "",
+  "product_info": "legacy product info",
+  "further_info": "legacy further info",
+  "existing_agents": "legacy existing agents",
+  "permission_to_approach_contacts": "legacy permission to approach contacts",
+  "delivery_date": "",
+  "po_number": "123PO",
+  "vat_status": "eu",
+  "vat_number": "0123456789",
+  "vat_verified": true,
+  "discount_value": 0,
+  "net_cost": 0,
+  "uk_region": "London"
+}

--- a/test/sandbox/fixtures/v3/omis/draft-order.json
+++ b/test/sandbox/fixtures/v3/omis/draft-order.json
@@ -1,0 +1,69 @@
+{
+  "id": "084b934e-9bde-4e2b-88d8-5fbeb17de54d",
+  "reference": "XYT113/17",
+  "status": "draft",
+  "created_on": "2017-07-26T14:08:36.380979",
+  "created_by": null,
+  "modified_on": "2017-08-16T14:18:28.328729",
+  "modified_by": {
+    "name": "Test CMU 1",
+    "id": "8036f207-ae3e-e611-8d53-e4115bed50dc"
+  },
+  "company": {
+    "name": "Venus Ltd",
+    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+  },
+  "contact": {
+    "name": "Jenny Cakeman",
+    "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+  },
+  "primary_market": {
+    "name": "France",
+    "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "sector": {
+    "name": "Aerospace : Component Manufacturing",
+    "id": "e74171b4-efe9-e511-8ffa-e4115bead28a"
+  },
+  "service_types": [
+    {
+      "name": "Validated contacts",
+      "id": "c7915c75-cf29-42cf-99db-2acb75b96a78"
+    },
+    {
+      "name": "Visit programme",
+      "id": "8b48de3d-0066-4d98-991e-f79594bf55c0"
+    },
+    {
+      "name": "Strategic offer",
+      "id": "622aedd8-8936-4e62-99f2-2b8bb3783166"
+    },
+    {
+      "name": "Subscription",
+      "id": "66b57a5b-ca6e-4d6e-9941-4a6e7f9aa3ae"
+    },
+    {
+      "name": "Retainer",
+      "id": "80beb270-c1ce-40a3-8ad4-20a569a7bca0"
+    }
+  ],
+  "description": "Yeah yeah yeah",
+  "contacts_not_to_approach": "Brian",
+  "contact_email": "",
+  "contact_phone": "",
+  "product_info": "legacy product info",
+  "further_info": "legacy further info",
+  "existing_agents": "legacy existing agents",
+  "permission_to_approach_contacts": "legacy permission to approach contacts",
+  "delivery_date": "",
+  "po_number": "123PO",
+  "vat_status": "eu",
+  "vat_number": "0123456789",
+  "vat_verified": true,
+  "discount_value": 0,
+  "net_cost": 0,
+  "subtotal_cost": 0,
+  "vat_cost": 0,
+  "total_cost": 0,
+  "uk_region": "London"
+}

--- a/test/sandbox/fixtures/v3/omis/invoice.json
+++ b/test/sandbox/fixtures/v3/omis/invoice.json
@@ -1,0 +1,26 @@
+{
+  "created_on": "2017-09-27T08:59:20.381047",
+  "invoice_number": "201709270001",
+  "invoice_company_name": "Department for International Trade",
+  "invoice_address_1": "3 Whitehall Place",
+  "invoice_address_2": "",
+  "invoice_address_town": "London",
+  "invoice_address_county": "",
+  "invoice_address_postcode": "SW1A 2AW",
+  "invoice_address_country": {
+    "name": "United Kingdom",
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "invoice_vat_number": "888 850455",
+  "billing_contact_name": "Jeff Fisher",
+  "billing_address_1": "Apt 0.",
+  "billing_address_2": "0 Foo st.",
+  "billing_address_county": "Eos et quibusdam dignissimos molestias saepe sit exercitationem pariatur. Velit fugit delectus tempore cumque ipsa. Temporibus quaerat deserunt illo perferendis beatae incidunt.",
+  "billing_address_postcode": "SW1A1AA",
+  "billing_address_town": "London",
+  "billing_address_country": {
+    "name": "United Kingdom",
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "po_number": "At ipsam dolorum inventore."
+}

--- a/test/sandbox/fixtures/v3/omis/paid-order.json
+++ b/test/sandbox/fixtures/v3/omis/paid-order.json
@@ -1,0 +1,70 @@
+{
+  "id": "7d3d26c7-9698-f211-b939-d4115adde28a",
+  "reference": "SDE234/91",
+  "status": "paid",
+  "paid_on": "2018-09-27T08:59:20.381047",
+  "subtotal_cost": "1234",
+  "vat_cost": "12",
+  "total_cost": "123455",
+  "created_on": "2017-07-26T14:08:36.380979",
+  "created_by": null,
+  "modified_on": "2017-08-16T14:18:28.328729",
+  "modified_by": {
+    "name": "Test CMU 1",
+    "id": "8036f207-ae3e-e611-8d53-e4115bed50dc"
+  },
+  "company": {
+    "name": "Venus Ltd",
+    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+  },
+  "contact": {
+    "name": "Jenny Cakeman",
+    "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+  },
+  "primary_market": {
+    "name": "France",
+    "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "sector": {
+    "name": "Aerospace : Component Manufacturing",
+    "id": "e74171b4-efe9-e511-8ffa-e4115bead28a"
+  },
+  "service_types": [
+    {
+      "name": "Validated contacts",
+      "id": "c7915c75-cf29-42cf-99db-2acb75b96a78"
+    },
+    {
+      "name": "Visit programme",
+      "id": "8b48de3d-0066-4d98-991e-f79594bf55c0"
+    },
+    {
+      "name": "Strategic offer",
+      "id": "622aedd8-8936-4e62-99f2-2b8bb3783166"
+    },
+    {
+      "name": "Subscription",
+      "id": "66b57a5b-ca6e-4d6e-9941-4a6e7f9aa3ae"
+    },
+    {
+      "name": "Retainer",
+      "id": "80beb270-c1ce-40a3-8ad4-20a569a7bca0"
+    }
+  ],
+  "description": "Yeah yeah yeah",
+  "contacts_not_to_approach": "Brian",
+  "contact_email": "",
+  "contact_phone": "",
+  "product_info": "legacy product info",
+  "further_info": "legacy further info",
+  "existing_agents": "legacy existing agents",
+  "permission_to_approach_contacts": "legacy permission to approach contacts",
+  "delivery_date": "",
+  "po_number": "123PO",
+  "vat_status": "eu",
+  "vat_number": "0123456789",
+  "vat_verified": true,
+  "discount_value": 0,
+  "net_cost": 0,
+  "uk_region": "London"
+}

--- a/test/sandbox/fixtures/v3/omis/payments.json
+++ b/test/sandbox/fixtures/v3/omis/payments.json
@@ -1,0 +1,20 @@
+[
+  {
+    "created_on": "2017-10-17T10:07:41.838058",
+    "reference": "201710170001",
+    "transaction_reference": "some ref 1",
+    "additional_reference": "",
+    "amount": 5343,
+    "method": "bacs",
+    "received_on": "2017-04-20T13:00:00"
+  },
+  {
+    "created_on": "2017-10-17T10:07:41.931472",
+    "reference": "201710170002",
+    "transaction_reference": "some ref 2",
+    "additional_reference": "",
+    "amount": 100,
+    "method": "bacs",
+    "received_on": "2017-04-21T13:00:00"
+  }
+]

--- a/test/sandbox/fixtures/v3/omis/subscribers.json
+++ b/test/sandbox/fixtures/v3/omis/subscribers.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "name": "Puck Head",
+    "dit_team": {
+      "name": "CBBC North EAST",
+      "id": "602b971d-5df6-e511-888e-e4115bead28a"
+    }
+  },
+  {
+    "id": "25628b23-c75b-4aef-b120-dac2d64c0696",
+    "first_name": "",
+    "last_name": "",
+    "name": "",
+    "dit_team": null
+  }
+]

--- a/test/sandbox/routes/v3/omis/omis.js
+++ b/test/sandbox/routes/v3/omis/omis.js
@@ -1,0 +1,33 @@
+var cancelledOrder = require('../../../fixtures/v3/omis/cancelled-order.json')
+var draftOrder = require('../../../fixtures/v3/omis/draft-order.json')
+var paidOrder = require('../../../fixtures/v3/omis/paid-order.json')
+var assignees = require('../../../fixtures/v3/omis/assignees.json')
+var invoice = require('../../../fixtures/v3/omis/invoice.json')
+var payments = require('../../../fixtures/v3/omis/payments.json')
+var subscribers = require('../../../fixtures/v3/omis/subscribers.json')
+
+exports.assignees = function(req, res) {
+  res.json(assignees)
+}
+
+exports.invoice = function(req, res) {
+  res.json(invoice)
+}
+
+exports.getOrderById = function(req, res) {
+  var orders = {
+    [cancelledOrder.id]: cancelledOrder,
+    [paidOrder.id]: paidOrder,
+    [draftOrder.id]: draftOrder,
+  }
+
+  res.json(orders[req.params.id] || paidOrder)
+}
+
+exports.payments = function(req, res) {
+  res.json(req.params.id === draftOrder.id ? [] : payments)
+}
+
+exports.subscriberList = function(req, res) {
+  res.json(subscribers)
+}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -28,6 +28,7 @@ var postcodeToRegion = require('./routes/postcodeToRegion.js')
 // V3
 var v3Contact = require('./routes/v3/contact/contact.js')
 var v3Event = require('./routes/v3/event/event.js')
+var v3OMIS = require('./routes/v3/omis/omis.js')
 var v3FeatureFlag = require('./routes/v3/feature-flag/feature-flag.js')
 var v3Interaction = require('./routes/v3/interaction/interaction.js')
 var v3Investment = require('./routes/v3/investment/investment-projects.js')
@@ -322,6 +323,13 @@ app.get(
   v3Investment.investmentProjectAudit
 )
 app.post('/v3/investment/:id/update-stage', v3Investment.investmentProjectById)
+
+// V3 Omis
+app.get('/v3/omis/order/:id', v3OMIS.getOrderById)
+app.get('/v3/omis/order/:id/assignee', v3OMIS.assignees)
+app.get('/v3/omis/order/:id/invoice', v3OMIS.invoice)
+app.get('/v3/omis/order/:id/subscriber-list', v3OMIS.subscriberList)
+app.get('/v3/omis/order/:id/payment', v3OMIS.payments)
 
 // V3 Search
 app.post('/v3/search/company', v3SearchCompany.companies)

--- a/test/selectors/index.js
+++ b/test/selectors/index.js
@@ -37,6 +37,7 @@ exports.eventCreate = require('./event/create')
 
 exports.omisCreate = require('./omis/create')
 exports.omisSummary = require('./omis/summary')
+exports.omisWorkOrder = require('./omis/work-order')
 
 exports.breadcrumbs = require('./breadcrumbs')
 exports.detailsContainer = require('./details-container')

--- a/test/selectors/omis/work-order.js
+++ b/test/selectors/omis/work-order.js
@@ -1,0 +1,14 @@
+module.exports = {
+  actionContainer: '.c-local-header__actions',
+  previewQuote: { link: 'a[href="quote"]', text: 'Preview quote' },
+  cancelOrder: { link: 'a[href="edit/cancel-order"]', text: 'Cancel order' },
+  completeOrder: {
+    link: 'a[href="edit/complete-order"]',
+    text: 'Complete order',
+  },
+  viewPayment: {
+    link: 'a[href="payment-receipt"]',
+    text: 'View payment receipt',
+  },
+  viewQuote: { link: 'a[href="quote"]', text: 'View quote' },
+}


### PR DESCRIPTION
## Description of change

Allows Data Hub users to view payment information and quote details for orders that had been cancelled. This was requested by the Live Services team in order to make it easier for them to process refunds.

## Test instructions
You will need an example of a cancelled order with a payment attached. I have created one in the sandbox mock data, so to view the changes:
* Make sure your local front end is using the sandbox API
* Visit `[your local root]omis/1d2d26c3-1234-f223-b424-d2334feed28b/` to view the cancelled (but paid) order
* Click on `View Payment Receipt` and see the receipt

## Screenshots
### Before
<img width="572" alt="Screenshot 2020-06-26 at 13 12 12" src="https://user-images.githubusercontent.com/23265724/85855916-ec027d00-b7ae-11ea-8f55-64dc909de80b.png">

(view cropped to hide live data)

### After
<img width="1027" alt="Screenshot 2020-06-26 at 14 39 58" src="https://user-images.githubusercontent.com/23265724/85863474-1e19dc00-b7bb-11ea-8eac-385da9aef8ff.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
