### PR TITLE
Remove post to endpoint that doesn't get used anymore

### DIFF
--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -128,12 +128,11 @@ async function submit(req, res, next) {
   const {
     company: { id },
   } = res.locals
-  const action = req.url === '/remove' ? 'remove' : 'self-assign'
 
   try {
     await authorisedRequest(req.session.token, {
       method: 'POST',
-      url: `${config.apiRoot}/v4/company/${id}/${action}-account-manager`,
+      url: `${config.apiRoot}/v4/company/${id}/remove-account-manager`,
     })
 
     req.flash('success', 'Lead adviser information updated')


### PR DESCRIPTION
## Description of change
We don't need to have the POST to `/assign-account-manager` end point in node/express anymore as this task has changed and is done in the client side using a Redux Saga task.

## Test instructions

Nothing should change

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
