### PR TITLE
Pipeline item counter

### DIFF
--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { connect } from 'react-redux'
-
+import styled from 'styled-components'
+import pluralize from 'pluralize'
 import ListItem from '@govuk-react/list-item'
 import InsetText from '@govuk-react/inset-text'
 import Link from '@govuk-react/link'
-import { LoadingBox } from 'govuk-react'
+import LoadingBox from '@govuk-react/loading-box'
+import { SPACING } from '@govuk-react/constants'
+import { FONT_WEIGHTS } from '@govuk-react/constants/lib/typography'
 
 import urls from '../../../lib/urls'
 import StyledOrderedList from '../StyledOrderedList'
@@ -14,6 +17,11 @@ import { state2props, dispatchToProps } from './state'
 import PipelineItem from './PipelineItem'
 import PipelineFilterSort from './PipelineFilterSort'
 import GetPipeLineData from './GetPipelineData'
+
+const StyledItemsCounter = styled('p')`
+  font-weight: ${FONT_WEIGHTS.bold};
+  margin: ${SPACING.SCALE_4} 0 -${SPACING.SCALE_2} 0;
+`
 
 const PipelineList = ({
   status,
@@ -30,30 +38,33 @@ const PipelineList = ({
       />
       <GetPipeLineData lists={lists} status={status} filter={filter}>
         {({ items, progress }) => (
-          <StyledOrderedList data-auto-id="pipelineList">
-            {items.length ? (
-              <>
-                {items.map((item) => (
+          <>
+            <StyledItemsCounter>
+              {pluralize('item', items.length, true)}
+            </StyledItemsCounter>
+            <StyledOrderedList data-auto-id="pipelineList">
+              {items.length ? (
+                items.map((item) => (
                   <ListItem key={item.id}>
                     <PipelineItem item={item} />
                   </ListItem>
-                ))}
-              </>
-            ) : (
-              <LoadingBox loading={progress} timeIn={0} timeOut={400}>
-                <InsetText>
-                  There are no companies in the {statusText} section of your
-                  pipeline. You can add companies to your pipeline from the
-                  company page. To find out more{' '}
-                  <Link href={urls.external.helpCentre.pipeline()}>
-                    {' '}
-                    visit the help centre article on how to use My Pipeline
-                  </Link>
-                  .
-                </InsetText>
-              </LoadingBox>
-            )}
-          </StyledOrderedList>
+                ))
+              ) : (
+                <LoadingBox loading={progress} timeIn={0} timeOut={400}>
+                  <InsetText>
+                    There are no companies in the {statusText} section of your
+                    pipeline. You can add companies to your pipeline from the
+                    company page. To find out more{' '}
+                    <Link href={urls.external.helpCentre.pipeline()}>
+                      {' '}
+                      visit the help centre article on how to use My Pipeline
+                    </Link>
+                    .
+                  </InsetText>
+                </LoadingBox>
+              )}
+            </StyledOrderedList>
+          </>
         )}
       </GetPipeLineData>
     </>

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -150,6 +150,10 @@ describe('My pipeline app', () => {
       })
     })
 
+    it('should render the item counter', () => {
+      cy.contains('4 items')
+    })
+
     context('should render the pipeline list', () => {
       const expectedOutcomeList = [
         { expectedDate: '15 May 2020' },
@@ -178,6 +182,10 @@ describe('My pipeline app', () => {
       })
     })
 
+    it('should render the item counter', () => {
+      cy.contains('1 item')
+    })
+
     context('should render the pipeline list', () => {
       it('should render the first item', () => {
         assertPipelineItem(0, { expectedDate: '12 May 2020' }, inProgress)
@@ -196,6 +204,10 @@ describe('My pipeline app', () => {
         cy.contains('Active')
         cy.contains('Won').should('have.attr', 'aria-selected', 'true')
       })
+    })
+
+    it('should render the item counter', () => {
+      cy.contains('1 item')
     })
 
     context('should render the pipeline list', () => {
@@ -275,6 +287,10 @@ describe('My pipeline app', () => {
         })
     })
 
+    it('should render the item counter with only non-archived items', () => {
+      cy.contains('4 items')
+    })
+
     it('should render archived items', () => {
       const expectedOutcomeList = [
         { expectedDate: '15 May 2020' },
@@ -290,6 +306,9 @@ describe('My pipeline app', () => {
           cy.wrap(element).check()
           cy.wrap(element).should('be.checked')
           return cy.wait('@pipelineGet')
+        })
+        .then(() => {
+          cy.contains('5 items')
         })
         .then(() => {
           expectedOutcomeList.forEach((expectedData, index) => {


### PR DESCRIPTION
## Description of change

This PR adds an item counter to the top of the Pipeline List. 

## Test instructions

Navigate to the My pipeline app and you should see the counter. It should update when you move between statuses and when you check and uncheck the `Show archived items` filter. It should show `item` when there is 1 item and `items` all other times. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/42253716/85881335-5c23f980-b7d5-11ea-92d0-9795b8e60efd.png)

### After

![image](https://user-images.githubusercontent.com/42253716/85881245-35fe5980-b7d5-11ea-97de-0b5efaa524f4.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
