### PR TITLE
Bugfix: move key to parent element

### DIFF
--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -175,9 +175,8 @@ const TabNav = ({
                   const Button = selected ? StyledSelectedButton : StyledButton
                   const tabId = createId(id, key)
                   return (
-                    <StyledSpan>
+                    <StyledSpan key={tabId}>
                       <Button
-                        key={tabId}
                         role="tab"
                         focused={index === focusIndex}
                         aria-selected={selected}


### PR DESCRIPTION
## Description of change

This PR moves the `TabNav` key to the parent element to avoid the React unique key error in the console. 

## Test instructions

You should no longer see a unique key error in the console. 

## Screenshots

No visual changes. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
