### PR TITLE
Multiple contacts for a pipeline item

### DIFF
--- a/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
@@ -20,14 +20,14 @@ import { getPipelineUrl } from './utils'
 import moment from 'moment'
 
 function formatInitialValues(values) {
-  const { sector, contact } = values
+  const { sector, contacts } = values
   const expectedWinDate = moment(values.expected_win_date, 'YYYY-MM-DD', true)
   return {
     name: values.name,
     category: values.status,
     likelihood: String(values.likelihood_to_win),
     sector: sector ? { value: sector.id, label: sector.segment } : null,
-    contact: contact ? { value: contact.id, label: contact.name } : null,
+    contacts: contacts?.map(({ id, name }) => ({ value: id, label: name })),
     export_value: values.potential_value,
     expected_win_date: expectedWinDate.isValid()
       ? {

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -65,7 +65,7 @@ function PipelineForm({
         className="govuk-!-width-two-thirds"
       />
       <FieldTypeahead
-        label="Company contact (optional)"
+        label="Company contacts (optional)"
         name="contacts"
         options={contacts.map(({ id, name, job_title }) => ({
           value: id,

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -66,16 +66,17 @@ function PipelineForm({
       />
       <FieldTypeahead
         label="Company contact (optional)"
-        name="contact"
-        options={contacts.map(({ id, name }) => ({
+        name="contacts"
+        options={contacts.map(({ id, name, job_title }) => ({
           value: id,
-          label: name,
+          label: name + (job_title ? ', ' + job_title : ''),
         }))}
-        initialValue={initialValue.contact}
+        initialValue={initialValue.contacts}
         noOptionsMessage={() => 'This company has no contacts'}
         placeholder="Select a contact..."
         isClearable={true}
         className="govuk-!-width-two-thirds"
+        isMulti="true"
       />
       <FieldInput
         label="Potential export value (optional)"

--- a/src/apps/my-pipeline/client/tasks.js
+++ b/src/apps/my-pipeline/client/tasks.js
@@ -1,6 +1,6 @@
+import axios from 'axios'
 import pipelineApi from './api'
 import { addMessage } from '../../../client/utils/flash-messages'
-import axios from 'axios'
 import { transformValueForApi } from '../../../common/date'
 
 function transformValuesForApi(values, oldValues = {}) {
@@ -10,16 +10,22 @@ function transformValuesForApi(values, oldValues = {}) {
   }
 
   function addValue(key, value) {
-    const hasExistingValue = !!oldValues[key]
+    const existingValue = oldValues[key]
+    const hasExistingValue = Array.isArray(existingValue)
+      ? !!existingValue.length
+      : !!existingValue
 
-    if (hasExistingValue || value) {
+    if (hasExistingValue || (Array.isArray(value) ? value.length : value)) {
       data[key] = value || null
     }
   }
 
   addValue('likelihood_to_win', parseInt(values.likelihood, 10))
   addValue('sector', values.sector?.value)
-  addValue('contact', values.contact?.value)
+  addValue(
+    'contacts',
+    values.contacts ? values.contacts.map(({ value }) => value) : []
+  )
   addValue('potential_value', values.export_value)
   addValue('expected_win_date', transformValueForApi(values.expected_win_date))
 

--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -121,6 +121,7 @@ function buildMetaList({
   potential_value,
   sector,
   contact,
+  contacts,
   expected_win_date,
   created_on,
   archived,
@@ -134,10 +135,20 @@ function buildMetaList({
       href: urls.companies.detail(company.id),
     },
     sector && { label: 'Export sector', value: sector.segment },
-    contact && {
-      label: 'Company contact',
-      value: contact.name,
-      href: urls.contacts.contact(contact.id),
+    !contacts?.length &&
+      contact && {
+        label: 'Company contact',
+        value: contact.name,
+        href: urls.contacts.contact(contact.id),
+      },
+    contacts?.length && {
+      label: 'Company contact' + (contacts.length > 1 ? 's' : ''),
+      value: contacts.map(({ id, name }, index) => (
+        <>
+          <StyledLink href={urls.contacts.details(id)}>{name}</StyledLink>
+          {index === contacts.length - 1 ? '' : ', '}
+        </>
+      )),
     },
     potential_value && {
       label: 'Potential export value',

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -158,6 +158,10 @@ Cypress.Commands.add(
   }
 )
 
+Cypress.Commands.add('getTypeaheadValues', { prevSubject: 'element'}, ( subject) => {
+  return cy.wrap(subject).find('div > div > div > div[class*="-multiValue"]')
+})
+
 Cypress.Commands.add('setFeatureFlag', (name, isActive) => {
   const body = {
     code: name,

--- a/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
@@ -126,7 +126,7 @@ describe('My Pipeline tab on the dashboard', () => {
 
           cy.get(formSelectors.likelihood.low).click()
           cy.get(formSelectors.fields.sector).selectTypeaheadOption('Aero')
-          cy.get(formSelectors.fields.contact).selectTypeaheadOption('Dean')
+          cy.get(formSelectors.fields.contacts).selectTypeaheadOption('Dean')
           cy.get(formSelectors.value).type('1000')
           cy.get(formSelectors.fields.expectedWinDate)
             .find('input')
@@ -159,7 +159,7 @@ describe('My Pipeline tab on the dashboard', () => {
             .click()
 
           cy.get(formSelectors.fields.sector).removeAllTypeaheadValues()
-          cy.get(formSelectors.fields.contact).removeAllTypeaheadValues()
+          cy.get(formSelectors.fields.contacts).removeAllTypeaheadValues()
           cy.get(formSelectors.value).clear()
           cy.get(formSelectors.fields.expectedWinDate)
             .find('input')

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -1,5 +1,5 @@
 const minimallyMinimal = require('../../../../sandbox/fixtures/v4/company/company-minimally-minimal.json')
-const lambdaPlc = require('../../../../sandbox/fixtures/v4/company/company-lambda-plc')
+const lambdaPlc = require('../../../../sandbox/fixtures/v4/company/company-lambda-plc.json')
 const urls = require('../../../../../src/lib/urls')
 const {
   assertFieldRadios,
@@ -70,9 +70,9 @@ describe('Company add to pipeline form', () => {
       })
     })
 
-    it('Should render the company contact typeahead', () => {
-      cy.get(formSelectors.fields.contact).then((element) => {
-        assertFieldTypeahead({ element, label: 'Company contact (optional)' })
+    it('Should render the company contacts typeahead', () => {
+      cy.get(formSelectors.fields.contacts).then((element) => {
+        assertFieldTypeahead({ element, label: 'Company contacts (optional)' })
       })
     })
 
@@ -239,6 +239,21 @@ describe('Company add to pipeline form', () => {
           checkError('£1,000')
         })
       })
+    })
+  })
+
+  context('Company contacts', () => {
+    before(() => {
+      cy.visit(urls.companies.pipelineAdd(lambdaPlc.id))
+    })
+
+    it('Should allow more than one contact to be selected', () => {
+      cy.get(formSelectors.fields.contacts)
+        .selectTypeaheadOption('Dean')
+        .selectTypeaheadOption('Georg')
+        .getTypeaheadValues()
+        .should('contain', 'Georgina Clark')
+        .should('contain', 'Dean Cox')
     })
   })
 })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
@@ -98,9 +98,12 @@ describe('Pipeline edit form', () => {
         })
       })
 
-      it('Should render the company contact typeahead', () => {
-        cy.get(formSelectors.fields.contact).then((element) => {
-          assertFieldTypeahead({ element, label: 'Company contact (optional)' })
+      it('Should render the company contacts typeahead', () => {
+        cy.get(formSelectors.fields.contacts).then((element) => {
+          assertFieldTypeahead({
+            element,
+            label: 'Company contacts (optional)',
+          })
         })
       })
 
@@ -187,11 +190,11 @@ describe('Pipeline edit form', () => {
         })
       })
 
-      it('Should render the company contact typeahead', () => {
-        cy.get(formSelectors.fields.contact).then((element) => {
+      it('Should render the company contacts typeahead', () => {
+        cy.get(formSelectors.fields.contacts).then((element) => {
           assertFieldTypeahead({
             element,
-            label: 'Company contact (optional)',
+            label: 'Company contacts (optional)',
             value: 'Dean Cox',
           })
         })
@@ -218,7 +221,7 @@ describe('Pipeline edit form', () => {
 
         it('should call the api with a null value for each field', () => {
           cy.get(formSelectors.fields.sector).removeAllTypeaheadValues()
-          cy.get(formSelectors.fields.contact).removeAllTypeaheadValues()
+          cy.get(formSelectors.fields.contacts).removeAllTypeaheadValues()
           cy.get(formSelectors.value).clear()
           cy.get(formSelectors.fields.expectedWinDate)
             .find('input')
@@ -227,7 +230,7 @@ describe('Pipeline edit form', () => {
           cy.contains('button', 'Update').click()
           cy.wait('@updatePipelineItem').then((xhr) => {
             expect(xhr.request.body.sector).to.equal(null)
-            expect(xhr.request.body.contact).to.equal(null)
+            expect(xhr.request.body.contacts).to.deep.equal([])
             expect(xhr.request.body.potential_value).to.equal(null)
             expect(xhr.request.body.expected_win_date).to.equal(null)
           })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -208,15 +208,15 @@ describe('My pipeline app', () => {
 
     context('should render the pipeline list', () => {
       it('should render the first item', () => {
-        assertPipelineItem(0, { expectedDate: '12 May 2020' }, inProgress)
+        assertPipelineItem(0, { expectedDate: '13 May 2020' }, inProgress)
       })
 
       it('should render the second item with one contact', () => {
         assertPipelineItem(1, { expectedDate: '12 May 2020' }, inProgress)
       })
 
-      it('should render the thirs item with two contacts', () => {
-        assertPipelineItem(2, { expectedDate: '12 May 2020' }, inProgress)
+      it('should render the third item with two contacts', () => {
+        assertPipelineItem(2, { expectedDate: '11 May 2020' }, inProgress)
       })
     })
   })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -121,7 +121,12 @@ function assertPipelineItem(
         cy.contains('Potential export value').should('not.exist')
       }
 
-      if (result.contact) {
+      if (result.contacts && result.contacts.length) {
+        cy.contains(
+          result.contacts.length > 1 ? 'Company contacts' : 'Company contact'
+        )
+        cy.contains(result.contacts.map(({ name }) => name).join(', '))
+      } else if (result.contact) {
         cy.contains('Company contact')
         cy.contains(result.contact.name)
       } else {
@@ -152,7 +157,7 @@ function assertAcrossTabs(callback) {
 }
 
 describe('My pipeline app', () => {
-  context('When viewing the propspect status', () => {
+  context('When viewing the prospect status', () => {
     before(() => {
       cy.visit(urls.pipeline.index())
     })
@@ -198,12 +203,20 @@ describe('My pipeline app', () => {
     })
 
     it('should render the item counter', () => {
-      cy.contains('1 item')
+      cy.contains('3 items')
     })
 
     context('should render the pipeline list', () => {
       it('should render the first item', () => {
         assertPipelineItem(0, { expectedDate: '12 May 2020' }, inProgress)
+      })
+
+      it('should render the second item with one contact', () => {
+        assertPipelineItem(1, { expectedDate: '12 May 2020' }, inProgress)
+      })
+
+      it('should render the thirs item with two contacts', () => {
+        assertPipelineItem(2, { expectedDate: '12 May 2020' }, inProgress)
       })
     })
   })

--- a/test/sandbox/fixtures/v4/pipeline-item/in-progress.json
+++ b/test/sandbox/fixtures/v4/pipeline-item/in-progress.json
@@ -13,7 +13,7 @@
           },
           "name": "Socks to Finland",
           "status": "in_progress",
-          "created_on": "2020-05-12T16:02:47.569367Z",
+          "created_on": "2020-05-13T16:02:47.569367Z",
           "archived": false,
           "archived_on": null,
           "archived_reason": null
@@ -49,7 +49,7 @@
           },
           "name": "Socks to the north pole - 2 contacts",
           "status": "in_progress",
-          "created_on": "2020-05-12T16:04:47.569367Z",
+          "created_on": "2020-05-11T16:04:47.569367Z",
           "archived": false,
           "archived_on": null,
           "archived_reason": null,

--- a/test/sandbox/fixtures/v4/pipeline-item/in-progress.json
+++ b/test/sandbox/fixtures/v4/pipeline-item/in-progress.json
@@ -3,20 +3,70 @@
   "next": null,
   "previous": null,
   "results": [
-    {
-      "id": "5567c549-bc44-4c3a-a825-2bb79c460fa6",
-      "company": {
-        "name": "Venus Ltd",
-        "turnover": null,
-        "export_potential": null,
-        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      {
+          "id": "5567c549-bc44-4c3a-a825-2bb79c460fa6",
+          "company": {
+              "name": "Venus Ltd",
+              "turnover": null,
+              "export_potential": null,
+              "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          },
+          "name": "Socks to Finland",
+          "status": "in_progress",
+          "created_on": "2020-05-12T16:02:47.569367Z",
+          "archived": false,
+          "archived_on": null,
+          "archived_reason": null
       },
-      "name": "Socks to Finland",
-      "status": "in_progress",
-      "created_on": "2020-05-12T16:02:47.569367Z",
-      "archived": false,
-      "archived_on": null,
-      "archived_reason": null
-    }
+      {
+          "id": "50780c53-b81f-4b53-a00f-9b8496297ba2",
+          "company": {
+              "name": "Venus Ltd",
+              "turnover": null,
+              "export_potential": null,
+              "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          },
+          "name": "Socks to the north pole - 1 contact",
+          "status": "in_progress",
+          "created_on": "2020-05-12T16:03:47.569367Z",
+          "archived": false,
+          "archived_on": null,
+          "archived_reason": null,
+          "contacts": [
+              {
+                  "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef",
+                  "name": "Johnny Cakeman"
+              }
+          ]
+      },
+      {
+          "id": "98b3f79f-fe45-4998-8e18-f0d3b34b559e",
+          "company": {
+              "name": "Venus Ltd",
+              "turnover": null,
+              "export_potential": null,
+              "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          },
+          "name": "Socks to the north pole - 2 contacts",
+          "status": "in_progress",
+          "created_on": "2020-05-12T16:04:47.569367Z",
+          "archived": false,
+          "archived_on": null,
+          "archived_reason": null,
+          "contact": {
+              "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef",
+              "name": "Johnny Cakeman"
+          },
+          "contacts": [
+              {
+                  "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef",
+                  "name": "Johnny Cakeman"
+              },
+              {
+                  "id": "86f21272-b4f4-44d0-882b-21136656f270",
+                  "name": "Kameron Durgan"
+              }
+          ]
+      }
   ]
 }

--- a/test/sandbox/fixtures/v4/pipeline-item/pipeline-item-lambda-plc.json
+++ b/test/sandbox/fixtures/v4/pipeline-item/pipeline-item-lambda-plc.json
@@ -37,10 +37,10 @@
             "id": "af959812-6095-e211-a939-e4115bead28a",
             "segment": "Advanced Engineering"
           },
-          "contact": {
+          "contacts": [{
             "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9",
             "name": "Dean Cox"
-          },
+          }],
           "potential_value": 111,
           "expected_win_date": "2021-11-01"
       }

--- a/test/selectors/pipeline-form.js
+++ b/test/selectors/pipeline-form.js
@@ -14,7 +14,7 @@ module.exports = {
     status: '#field-category',
     likelihood: '#field-likelihood',
     sector: '#field-sector',
-    contact: '#field-contact',
+    contacts: '#field-contacts',
     value: '#field-export_value',
     expectedWinDate: '#field-expected_win_date',
   },


### PR DESCRIPTION
## Description of change

We want to allow more than one contact to be associated with a pipeline item, so this changes the add/edit form to allow more than one contact to be selected and saved and also updates the pipeline list on the dashboard to show more than one contact.

## Test instructions

Add a company with more than one contact to your pipeline, on the add form you should be able to select more than one contact. When saving and viewing on the dashboard each contact should be listed and linked to the contact detail page. If you edit the pipeline item you should be able to remove all the contacts and then add more than one back again.

## Screenshots
### Before

<img width="653" alt="Screenshot 2020-06-29 at 19 46 16" src="https://user-images.githubusercontent.com/1481883/86044290-d062d500-ba41-11ea-8ea7-1b6620c283c6.png">

<img width="978" alt="Screenshot 2020-06-29 at 19 47 09" src="https://user-images.githubusercontent.com/1481883/86044304-d658b600-ba41-11ea-911c-4c63cc540e8f.png">


### After

<img width="660" alt="Screenshot 2020-06-29 at 19 45 46" src="https://user-images.githubusercontent.com/1481883/86044318-dce72d80-ba41-11ea-8e65-a3395814408d.png">

<img width="979" alt="Screenshot 2020-06-29 at 19 43 52" src="https://user-images.githubusercontent.com/1481883/86044325-dfe21e00-ba41-11ea-955e-83a390df2d0d.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
