### PR TITLE
Pipeline item spacing fix

### DIFF
--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -45,6 +45,10 @@ const StyledListItem = styled('li')`
   ${MEDIA_QUERIES.TABLET} {
     display: block;
   }
+  margin-bottom: ${SPACING.SCALE_2};
+  &:last-child {
+    margin-bottom: 0;
+  }
 `
 
 const StyledLabel = styled('span')`
@@ -98,12 +102,6 @@ const StyledTagSpacing = styled('span')`
   }
 `
 
-const StyledUnorderedList = styled('ul')`
-  li + li {
-    margin-bottom: ${SPACING.SCALE_2};
-  }
-`
-
 const StyledLink = styled(Link)`
   text-decoration-line: none;
 `
@@ -153,6 +151,7 @@ function buildMetaList({
       label: 'Created',
       value: moment(created_on).format('DD MMM Y'),
       subtle: true,
+      showArchived: true,
     },
     archived &&
       archived_reason && {
@@ -175,7 +174,15 @@ function buildMetaList({
   return list.filter(Boolean)
 }
 
-const PipelineItemMeta = ({ label, value, href, subtle, id, archived }) => {
+const PipelineItemMeta = ({
+  label,
+  value,
+  href,
+  subtle,
+  id,
+  archived,
+  showArchived,
+}) => {
   const Wrapper = subtle ? StyledValueSubtle : StyledValue
 
   return (
@@ -183,7 +190,7 @@ const PipelineItemMeta = ({ label, value, href, subtle, id, archived }) => {
       <StyledLabel>{label}</StyledLabel>
       <Wrapper>
         {href ? <StyledLink href={href}>{value}</StyledLink> : value}
-        {!archived && (
+        {!archived && showArchived && (
           <StyledUnderlinedLink href={urls.pipeline.archive(id)}>
             Archive this project
           </StyledUnderlinedLink>
@@ -216,19 +223,22 @@ const PipelineItem = ({
       <StyledH3 archived={archived}>{name}</StyledH3>
       <StyledGridRow>
         <GridCol>
-          <StyledUnorderedList>
-            {metaListItems.map(({ label, value, href, subtle }) => (
-              <PipelineItemMeta
-                key={label}
-                label={label}
-                value={value}
-                href={href}
-                subtle={subtle}
-                id={id}
-                archived={archived}
-              />
-            ))}
-          </StyledUnorderedList>
+          <ul>
+            {metaListItems.map(
+              ({ label, value, href, subtle, showArchived }) => (
+                <PipelineItemMeta
+                  key={label}
+                  label={label}
+                  value={value}
+                  href={href}
+                  subtle={subtle}
+                  id={id}
+                  archived={archived}
+                  showArchived={showArchived}
+                />
+              )
+            )}
+          </ul>
         </GridCol>
         <StyledGridCol>
           {archived ? (


### PR DESCRIPTION
## Description of change

This is a small fix on the styling for pipeline and the archived button fix.

## Test instructions

Style update that matches the screenshot

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5575331/86117057-4b6dcf00-bac6-11ea-969a-b90b0a8a2723.png)


### After

![image](https://user-images.githubusercontent.com/5575331/86119424-56c2f980-baca-11ea-8ba6-91b68596a166.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
