### PR TITLE
Temporarily disable IE visuals

### DIFF
--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -56,6 +56,7 @@ var v4pipelineItem = require('./routes/v4/pipeline-item/index.js')
 
 // Data store service (github.com/uktrade/data-store-service)
 app.get('/api/v1/get-postcode-data/', postcodeToRegion.lookup)
+app.get('/api/v1/get-postcode-data/:postCode', postcodeToRegion.lookup)
 
 // Referral details
 app.get('/v4/company-referral/:id', v4Company.referralDetails)

--- a/test/visual/wdio.conf.js
+++ b/test/visual/wdio.conf.js
@@ -37,13 +37,6 @@ exports.config = {
       'browser_version': '83.0 beta',
       'resolution': '1280x1024'
     },
-    {
-      'os': 'Windows',
-      'os_version': '10',
-      'browserName': 'IE',
-      'browser_version': '11.0',
-      'resolution': '1280x1024'
-    },
   ],
   featureFlags: {
     specFiltering: true


### PR DESCRIPTION
## Description of change

Given browserstack intermittently hides the scroll bar in the edges of IE11, our visuals turn out to be very flaky, hence will be disabling until a fix is provided. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
