### PR TITLE
Add the DataHubProvider component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -6,6 +6,10 @@ import { createGlobalStyle } from 'styled-components'
 
 const req = require.context('../src', true, /.*\.stories\.(js|jsx)$/)
 
+import DataHubProvider from '../src/client/provider'
+import referralsTask from '../src/client/components/ReferralList/tasks/dummy/spread'
+import companyListsTasks from '../src/client/components/CompanyLists/tasks/dummy/spread'
+
 const GlobalStyle = createGlobalStyle`
   body {
     font: ${FONT_SIZE.SIZE_16} ${FONT_STACK};
@@ -23,6 +27,16 @@ addParameters({
 })
 
 addDecorator(addReadme)
-addDecorator(s => <><GlobalStyle />{s()}</>)
+addDecorator(s =>
+  <>
+    <GlobalStyle />
+    <DataHubProvider tasks={{
+      ...referralsTask(),
+      ...companyListsTasks(),
+    }}>
+      {s()}
+    </DataHubProvider>
+  </>
+)
 
 configure(req, module);

--- a/src/client/components/CompanyLists/__stories__/CompanyLists.stories.jsx
+++ b/src/client/components/CompanyLists/__stories__/CompanyLists.stories.jsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
+import CompanyLists from '..'
 import CreateListForm from '../CreateListForm'
 import AddRemoveFromListForm from '../../../components/CompanyLists/AddRemoveFromListForm'
 import listsWithCompany from '../__fixtures__/lists-with-company.json'
 
 storiesOf('Company lists', module)
+  .add('Default', () => <CompanyLists id="example" />)
   .add('Create a new list', () => {
     return (
       <CreateListForm

--- a/src/client/components/CompanyLists/tasks/dummy/index.js
+++ b/src/client/components/CompanyLists/tasks/dummy/index.js
@@ -1,0 +1,33 @@
+import faker from 'faker'
+
+const randomLists = ({ length, max = 10 }) =>
+  Array(length || faker.random.number(max))
+    .fill(null)
+    .reduce((a) => ({ ...a, [faker.random.uuid()]: faker.random.words(3) }), {})
+
+const randomList = ({ length, max = 10, id }) =>
+  Array(length || faker.random.number(max))
+    .fill()
+    .map(() => ({
+      id: id || faker.random.uuid(),
+      name: faker.random.words(3),
+      interactionId: faker.random.uuid(),
+      date: faker.date.past(),
+      subject: faker.random.words(3),
+      ditParticipants: Array(faker.random.number(2))
+        .fill()
+        .map(() => ({
+          name: faker.name.findName(),
+          team: faker.random.words(3),
+        })),
+    }))
+
+export const listsTaskFactory = ({ delay, lists, length }) => () =>
+  new Promise((resolve) =>
+    setTimeout(resolve, delay, lists || randomLists(length))
+  )
+
+export const listTaskFactory = ({ delay, ...rest } = {}) => (id) =>
+  new Promise((resolve) =>
+    setTimeout(resolve, delay, randomList({ id, ...rest }))
+  )

--- a/src/client/components/CompanyLists/tasks/dummy/spread.js
+++ b/src/client/components/CompanyLists/tasks/dummy/spread.js
@@ -1,0 +1,11 @@
+import { listTaskFactory, listsTaskFactory } from '.'
+
+export default ({
+  listsLength = 5,
+  listsDelay = 1000,
+  listLength = 5,
+  listDelay = 1000,
+} = {}) => ({
+  'Company lists': listsTaskFactory({ delay: listsDelay, length: listsLength }),
+  'Company list': listTaskFactory({ delay: listDelay, length: listLength }),
+})

--- a/src/client/components/CompanyLists/tasks/index.js
+++ b/src/client/components/CompanyLists/tasks/index.js
@@ -1,5 +1,5 @@
 import { get, pick } from 'lodash'
-import { apiProxyAxios } from '../Task/utils'
+import { apiProxyAxios } from '../../Task/utils'
 
 export const fetchCompanyLists = () =>
   apiProxyAxios.get('v4/company-list').then((res) =>

--- a/src/client/components/ReferralList/__stories__/ReferralList.stories.jsx
+++ b/src/client/components/ReferralList/__stories__/ReferralList.stories.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import ReferralList from '..'
+
+storiesOf('ReferralList', module).add('Default', () => (
+  <ReferralList id="example" />
+))

--- a/src/client/components/ReferralList/tasks/dummy/index.js
+++ b/src/client/components/ReferralList/tasks/dummy/index.js
@@ -1,0 +1,23 @@
+import faker from 'faker'
+
+const randomAdviser = () => ({
+  ...faker.helpers.createCard(),
+  team: faker.random.words(3),
+})
+
+const randomReferral = () => ({
+  companyId: faker.random.uuid(),
+  id: faker.random.uuid(),
+  subject: faker.lorem.sentence(),
+  companyName: faker.company.companyName(),
+  date: faker.date.past(1),
+  dateAccepted: faker.date.recent(),
+  sender: randomAdviser(),
+  recipient: randomAdviser(),
+  direction: Math.random() > 0.5 ? 'sent' : 'received',
+})
+
+const randomReferrals = (length) => Array(length).fill(null).map(randomReferral)
+
+export default (delay = 1000, length = 10) => () =>
+  new Promise((resolve) => setTimeout(resolve, delay, randomReferrals(length)))

--- a/src/client/components/ReferralList/tasks/dummy/spread.js
+++ b/src/client/components/ReferralList/tasks/dummy/spread.js
@@ -1,0 +1,5 @@
+import referralTask from '.'
+
+export default (...args) => ({
+  Referrals: referralTask(...args),
+})

--- a/src/client/components/ReferralList/tasks/index.js
+++ b/src/client/components/ReferralList/tasks/index.js
@@ -1,5 +1,5 @@
-import { apiProxyAxios } from '../../components/Task/utils'
-import { SENT, RECEIVED } from './constants'
+import { apiProxyAxios } from '../../Task/utils'
+import { SENT, RECEIVED } from '../constants'
 
 const convertAdviser = ({ name, contact_email, dit_team }) => ({
   name,

--- a/src/client/components/TabNav/__stories__/TabNav.stories.jsx
+++ b/src/client/components/TabNav/__stories__/TabNav.stories.jsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import TabNav from '..'
+import usageReadme from './usage.md'
+
+storiesOf('TabNav', module)
+  .addParameters({
+    readme: {
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <TabNav
+      id="example"
+      label="Example"
+      selectedIndex="bar"
+      tabs={{
+        foo: {
+          label: 'Foo',
+          content: <h1>Foo</h1>,
+        },
+        bar: {
+          label: 'Bar',
+          content: (
+            <TabNav
+              id="nested"
+              label="Nested"
+              selectedIndex="bbb"
+              tabs={{
+                aaa: {
+                  label: 'A',
+                  content: 'aaaaa',
+                },
+                bbb: {
+                  label: 'B',
+                  content: 'bbbbb',
+                },
+                ccc: {
+                  label: 'C',
+                  content: 'ccccc',
+                },
+              }}
+            />
+          ),
+        },
+        baz: {
+          label: 'Baz',
+          content: <h3>Baz</h3>,
+        },
+      }}
+    />
+  ))
+  .add('Routed', () => (
+    <TabNav
+      id="routed-example"
+      label="RoutedExample"
+      selectedIndex="bar"
+      routed={true}
+      tabs={{
+        foo: {
+          label: 'Foo',
+          content: <h1>Foo</h1>,
+        },
+        bar: {
+          label: 'Bar',
+          content: <h2>Bar</h2>,
+        },
+        baz: {
+          label: 'Baz',
+          content: <h3>Baz</h3>,
+        },
+      }}
+    />
+  ))

--- a/src/client/components/TabNav/__stories__/usage.md
+++ b/src/client/components/TabNav/__stories__/usage.md
@@ -1,0 +1,42 @@
+# TabNav
+
+### Description
+
+Accessible, optionally routed tab navigation.
+
+### Usage
+
+```jsx
+<TabNav
+  id="tab-nav"
+  label="Tab navigation"
+  selectedIndex={1}
+  tabs={[
+    { label: 'Foo', content: <h1>Foo</h1> },
+    { label: 'Bar', content: <h2>Bar</h2> },
+    { label: 'Baz', content: <h3>Baz</h3> },
+  ]}
+/>
+
+<TabNav
+  id="routed-tab-nav"
+  label="Routed tab navigation"
+  routed
+  selectedIndex="bar"
+  tabs={{
+    foo: { label: 'Foo', content: <h1>Foo</h1> },
+    bar: { label: 'Bar', content: <h2>Bar</h2> },
+    baz: { label: 'Baz', content: <h3>Baz</h3> },
+  }}
+/>
+```
+
+### Properties
+
+#### Label
+
+| Prop            | Required | Default                                   | Type | Description |
+| :-------------- | :------- | :---------------------------------------- | :--- | :---------- |
+| `label`| Yes | `undefined`| `String`  | A label required for accessibility |
+| `routed`| No | `false` | `Boolean` | If `true` the component will set the current path of the route to the value of the selected index and vice versa |
+| `tabs`| Yes | `undefined` | An object or array of `{label: string, content: ReactNode}` objects | If `true` the component will set the current path of the route to the value of the selected index |

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -1,18 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { createBrowserHistory } from 'history'
-import {
-  connectRouter,
-  routerMiddleware,
-  ConnectedRouter,
-} from 'connected-react-router'
-import { Provider } from 'react-redux'
-import { createStore, combineReducers, applyMiddleware } from 'redux'
-import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly'
-import createSagaMiddleware from 'redux-saga'
-
 import * as Sentry from '@sentry/browser'
 
+import Provider from './provider'
 import AddCompanyForm from '../apps/companies/apps/add-company/client/AddCompanyForm'
 import InteractionDetailsForm from '../apps/interactions/apps/details-form/client/InteractionDetailsForm'
 import CompanyActivityFeed from '../apps/companies/apps/activity-feed/client/CompanyActivityFeed'
@@ -46,136 +36,55 @@ import FlashMessages from './components/LocalHeader/FlashMessages.jsx'
 import ArchivePipelineItemForm from '../apps/my-pipeline/client/ArchivePipelineItemForm.jsx'
 import UnarchivePipelineItemForm from '../apps/my-pipeline/client/UnarchivePipelineItemForm.jsx'
 import DeletePipelineItemForm from '../apps/my-pipeline/client/DeletePipelineItemForm.jsx'
-
-import ConnectedDropdownMenu from './components/DropdownMenu/ConnectedDropdownMenu'
-import tasks from './components/Task/reducer'
-import rootSaga from './root-saga'
-
-import { ID as COMPANY_LISTS_STATE_ID } from './components/CompanyLists/state'
-import companyListsReducer from './components/CompanyLists/reducer'
-
-import { ID as REFERRALS_DETAILS_STATE_ID } from '../apps/companies/apps/referrals/details/client/state'
-import referralsReducer from '../apps/companies/apps/referrals/details/client/reducer'
-
-import { ID as REFERRALS_SEND_ID } from '../apps/companies/apps/referrals/send-referral/client/state'
-import referralsSendReducer from '../apps/companies/apps/referrals/send-referral/client/reducer'
-import * as referralsSendTasks from '../apps/companies/apps/referrals/send-referral/client/tasks'
-
-import { ID as EXPORTS_HISTORY_ID } from '../apps/companies/apps/exports/client/ExportsHistory/state'
-import exportsHistoryReducer from '../apps/companies/apps/exports/client/ExportsHistory/reducer'
-
-import TabNav from './components/TabNav'
-
-import ReferralList from './components/ReferralList'
 import Dashboard from './components/Dashboard'
 import CompanyLocalHeader from './components/CompanyLocalHeader'
 
-import { ID as EXPORTS_WINS_ID } from '../apps/companies/apps/exports/client/ExportWins/state'
-import exportWinsReducer from '../apps/companies/apps/exports/client/ExportWins/reducer'
-
-import { MultiInstanceForm } from './components'
-
-import { ID as EXPORT_COUNTRIES_EDIT_ID } from '../apps/companies/apps/exports/client/ExportCountriesEdit/state'
-import exportCountriesEditReducer from '../apps/companies/apps/exports/client/ExportCountriesEdit/reducer'
-
-import * as addInteractionFormState from '../apps/interactions/apps/details-form/client/state'
+import * as companyListsTasks from './components/CompanyLists/tasks'
+import * as referralTasks from '../apps/companies/apps/referrals/details/client/tasks'
+import * as exportsHistoryTasks from '../apps/companies/apps/exports/client/ExportsHistory/tasks'
+import referralListTask from './components/ReferralList/tasks'
+import {
+  TASK_OPEN_REFERRALS_CONTACT_FORM,
+  TASK_SAVE_REFERRAL,
+} from '../apps/companies/apps/referrals/send-referral/client/state'
+import * as referralsSendTasks from '../apps/companies/apps/referrals/send-referral/client/tasks'
+import * as exportWinsTasks from '../apps/companies/apps/exports/client/ExportWins/tasks'
+import { TASK_NAME as EXPORT_COUNTRIES_EDIT_NAME } from '../apps/companies/apps/exports/client/ExportCountriesEdit/state'
+import * as exportCountriesEditTasks from '../apps/companies/apps/exports/client/ExportCountriesEdit/tasks'
+import addCompanyPostcodeToRegionTask from '../apps/companies/apps/add-company/client/tasks'
+import { TASK_SAVE_ONE_LIST_DETAILS } from '../apps/companies/apps/edit-one-list/client/state'
+import * as editOneListTasks from '../apps/companies/apps/edit-one-list/client/tasks'
+import {
+  TASK_GET_PIPELINE_BY_COMPANY,
+  TASK_ADD_COMPANY_TO_PIPELINE,
+  TASK_GET_PIPELINE_ITEM,
+  TASK_EDIT_PIPELINE_ITEM,
+  TASK_ARCHIVE_PIPELINE_ITEM,
+  TASK_UNARCHIVE_PIPELINE_ITEM,
+  TASK_DELETE_PIPELINE_ITEM,
+  TASK_GET_PIPELINE_COMPANY_CONTACTS,
+} from '../apps/my-pipeline/client/state'
+import * as pipelineTasks from '../apps/my-pipeline/client/tasks'
+import { TASK_GET_PIPELINE_LIST } from './components/Pipeline/state'
+import * as pipelineListTasks from './components/Pipeline/tasks'
+import { TASK_UPDATE_STAGE } from '../apps/investments/views/admin/client/state'
+import * as investmentAdminTasks from '../apps/investments/views/admin/client/tasks'
+import { TASK_POSTCODE_TO_REGION } from '../apps/companies/apps/add-company/client/state'
+import {
+  TASK_GET_ACTIVE_EVENTS,
+  TASK_SAVE_INTERACTION,
+  TASK_OPEN_CONTACT_FORM,
+} from '../apps/interactions/apps/details-form/client/state'
 import * as addInteractionFormTasks from '../apps/interactions/apps/details-form/client/tasks'
-import addInteractionFormReducer from '../apps/interactions/apps/details-form/client/reducer'
 
-import * as addCompanyState from '../apps/companies/apps/add-company/client/state'
-import addCompanyPostcodeToRegionReducer from '../apps/companies/apps/add-company/client/reducer'
+import { TASK_UPDATE_ADVISER } from '../apps/companies/apps/advisers/client/state'
+import * as manageAdviser from '../apps/companies/apps/advisers/client/tasks'
 
-import { ID as ONE_LIST_DETAILS_ID } from '../apps/companies/apps/edit-one-list/client/state'
-import editOneListReducer from '../apps/companies/apps/edit-one-list/client/reducer'
+import { DNB__CHECK_PENDING_REQUEST } from '../apps/companies/apps/business-details/client/state'
+import * as dnbCheck from '../apps/companies/apps/business-details/client/tasks'
 
-import { ID as ADD_TO_PIPELINE_ID } from '../apps/my-pipeline/client/state'
-import addToPipelineReducer from '../apps/my-pipeline/client/reducer'
-
-import { ID as PIPELINE_LIST_ID } from './components/Pipeline/state'
-import pipelineListReducer from './components/Pipeline/reducer'
-
-import { ID as INVESTEMENT_PROJECT_ADMIN_ID } from '../apps/investments/views/admin/client/state'
-
-import investmentProjectAdminReducer from '../apps/investments/views/admin/client/reducer'
-
-import { ID as MANAGE_ADVISER_ID } from '../apps/companies/apps/advisers/client/state'
-import manageAdviserReducer from '../apps/companies/apps/advisers/client/reducer'
-
-import { ID as DNB_CHECK_ID } from '../apps/companies/apps/business-details/client/state'
-import dnbCheckReducer from '../apps/companies/apps/business-details/client/reducer'
-
-import { ID as INVESTMENT_PROFILES_ID } from '../apps/investments/client/state'
-import investmentProfileReducer from '../apps/investments/client/reducer'
-
-const sagaMiddleware = createSagaMiddleware()
-const history = createBrowserHistory({
-  // The baseURI is set to the <base/> tag by the spaFallbackSpread
-  // middleware, which should be applied to each Express route where
-  // react-router is expected to be used.
-  basename: new URL(
-    document.baseURI ||
-      // IE doesn't support baseURI so we need to access base.href manually
-      document.querySelector('base')?.href ||
-      document.location.href
-  ).pathname,
-})
-
-const store = createStore(
-  combineReducers({
-    router: connectRouter(history),
-    tasks,
-    [COMPANY_LISTS_STATE_ID]: companyListsReducer,
-    [EXPORTS_HISTORY_ID]: exportsHistoryReducer,
-    [REFERRALS_DETAILS_STATE_ID]: referralsReducer,
-    [REFERRALS_SEND_ID]: referralsSendReducer,
-    [EXPORTS_WINS_ID]: exportWinsReducer,
-    [EXPORT_COUNTRIES_EDIT_ID]: exportCountriesEditReducer,
-    [addInteractionFormState.ID]: addInteractionFormReducer,
-    [ONE_LIST_DETAILS_ID]: editOneListReducer,
-    [addCompanyState.ID]: addCompanyPostcodeToRegionReducer,
-    [ADD_TO_PIPELINE_ID]: addToPipelineReducer,
-    [PIPELINE_LIST_ID]: pipelineListReducer,
-    ...TabNav.reducerSpread,
-    ...ReferralList.reducerSpread,
-    ...MultiInstanceForm.reducerSpread,
-    ...ConnectedDropdownMenu.reducerSpread,
-
-    // A reducer is required to be able to set a preloadedState parameter
-    referrerUrl: (state = {}) => state,
-    [INVESTEMENT_PROJECT_ADMIN_ID]: investmentProjectAdminReducer,
-    [MANAGE_ADVISER_ID]: manageAdviserReducer,
-    [DNB_CHECK_ID]: dnbCheckReducer,
-    [INVESTMENT_PROFILES_ID]: investmentProfileReducer,
-  }),
-  {
-    referrerUrl: window.document.referrer,
-    Form: {
-      [addInteractionFormState.ID]: {
-        values: {},
-        touched: {},
-        errors: {},
-        fields: {},
-        steps: [],
-        currentStep: 0,
-        ...addInteractionFormTasks.restoreState(),
-      },
-      [REFERRALS_SEND_ID]: {
-        values: {},
-        touched: {},
-        errors: {},
-        fields: {},
-        steps: [],
-        currentStep: 0,
-        ...referralsSendTasks.restoreState(),
-      },
-    },
-  },
-  composeWithDevTools(
-    applyMiddleware(sagaMiddleware, routerMiddleware(history))
-  )
-)
-
-sagaMiddleware.run(rootSaga)
+import { TASK_GET_PROFILES_LIST } from '../apps/investments/client/state'
+import * as investmentProfilesTasks from '../apps/investments/client/tasks'
 
 function parseProps(domNode) {
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}
@@ -203,151 +112,175 @@ if (globalProps.sentryDsn) {
 
 function App() {
   return (
-    <Provider store={store}>
-      <ConnectedRouter history={history}>
-        <Mount selector="#add-company-form">
-          {(props) => (
-            <AddCompanyForm csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#interaction-details-form">
-          {(props) => (
-            <InteractionDetailsForm
-              csrfToken={globalProps.csrfToken}
-              {...props}
-            />
-          )}
-        </Mount>
-        <Mount selector="#edit-company-form">
-          {(props) => (
-            <EditCompanyForm csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#company-edit-history">
-          {(props) => (
-            <CompanyEditHistory csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#investment-edit-history">
-          {(props) => (
-            <InvestmentEditHistory
-              csrfToken={globalProps.csrfToken}
-              {...props}
-            />
-          )}
-        </Mount>
-        <Mount selector="#match-confirmation">
-          {(props) => (
-            <MatchConfirmation csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#cannot-find-match">
-          {(props) => (
-            <CannotFindMatch csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#find-company">
-          {(props) => (
-            <FindCompany csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#activity-feed-app">
-          {(props) => <CompanyActivityFeed {...props} />}
-        </Mount>
-        <Mount selector="#company-lists">
-          <Dashboard id="homepage" />
-        </Mount>
-        <Mount selector="#delete-company-list">
-          {(props) => (
-            <DeleteCompanyList csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#edit-company-list">
-          {(props) => (
-            <EditCompanyList csrfToken={globalProps.csrfToken} {...props} />
-          )}
-        </Mount>
-        <Mount selector="#create-company-list-form">
-          {(props) => (
-            <CreateListFormSection
-              csrfToken={globalProps.csrfToken}
-              {...props}
-            />
-          )}
-        </Mount>
-        <Mount selector="#add-remove-list-form">
-          {(props) => <AddRemoveFromListSection {...props} />}
-        </Mount>
-        <Mount selector="#lead-advisers">
-          {(props) => <LeadAdvisers {...props} />}
-        </Mount>
-        <Mount selector="#dnb-hierarchy">
-          {(props) => <DnbHierarchy {...props} />}
-        </Mount>
-        <Mount selector="#company-business-details">
-          {(props) => <CompanyBusinessDetails {...props} />}
-        </Mount>
-        <Mount selector="#company-edit-one-list">
-          {(props) => (
-            <EditOneListForm {...props} csrfToken={globalProps.csrfToken} />
-          )}
-        </Mount>
-        <Mount selector="#large-capital-profile-collection">
-          {(props) => <LargeCapitalProfileCollection {...props} />}
-        </Mount>
-        <Mount selector="#manage-adviser">
-          {(props) => (
-            <ManageAdviser {...props} csrfToken={globalProps.csrfToken} />
-          )}
-        </Mount>
-        <Mount selector="#company-export-index-page">
-          {(props) => <ExportsIndex {...props} />}
-        </Mount>
-        <Mount selector="#send-referral-form">
-          {(props) => (
-            <SendReferralForm {...props} csrfToken={globalProps.csrfToken} />
-          )}
-        </Mount>
-        <Mount selector="#company-export-full-history">
-          {(props) => <ExportsHistory {...props} />}
-        </Mount>
-        <Mount selector="#referral-details">
-          {(props) => <ReferralDetails {...props} />}
-        </Mount>
-        <Mount selector="#referral-help">
-          {(props) => <ReferralHelp {...props} />}
-        </Mount>
-        <Mount selector="#company-export-exports-edit">
-          {(props) => <ExportsEdit {...props} />}
-        </Mount>
-        <Mount selector="#interaction-referral-details">
-          {(props) => <InteractionReferralDetails {...props} />}
-        </Mount>
-        <Mount selector="#company-export-countries-edit">
-          {(props) => <ExportCountriesEdit {...props} />}
-        </Mount>
-        <Mount selector="#pipeline-form">
-          {(props) => <PipelineForm {...props} />}
-        </Mount>
-        <Mount selector="#company-local-header">
-          {(props) => <CompanyLocalHeader {...props} />}
-        </Mount>
-        <Mount selector="#investment-project-admin">
-          {(props) => <InvestmentProjectAdmin {...props} />}
-        </Mount>
-        <Mount selector="#flash-messages">
-          {(props) => <FlashMessages {...props} />}
-        </Mount>
-        <Mount selector="#archive-pipeline-item-form">
-          {(props) => <ArchivePipelineItemForm {...props} />}
-        </Mount>
-        <Mount selector="#unarchive-pipeline-item-form">
-          {(props) => <UnarchivePipelineItemForm {...props} />}
-        </Mount>
-        <Mount selector="#delete-pipeline-item-form">
-          {(props) => <DeletePipelineItemForm {...props} />}
-        </Mount>
-      </ConnectedRouter>
+    <Provider
+      tasks={{
+        'Company lists': companyListsTasks.fetchCompanyLists,
+        'Company list': companyListsTasks.fetchCompanyList,
+        'Exports history': exportsHistoryTasks.fetchExportsHistory,
+        'Referral details': referralTasks.fetchReferralDetails,
+        Referrals: referralListTask,
+        'Export wins': exportWinsTasks.fetchExportWins,
+        [TASK_OPEN_REFERRALS_CONTACT_FORM]: referralsSendTasks.openContactForm,
+        [TASK_SAVE_REFERRAL]: referralsSendTasks.saveReferral,
+        [TASK_SAVE_ONE_LIST_DETAILS]: editOneListTasks.saveOneListDetails,
+        [EXPORT_COUNTRIES_EDIT_NAME]:
+          exportCountriesEditTasks.saveExportCountries,
+        [TASK_GET_PIPELINE_BY_COMPANY]: pipelineTasks.getPipelineByCompany,
+        [TASK_ADD_COMPANY_TO_PIPELINE]: pipelineTasks.addCompanyToPipeline,
+        [TASK_GET_PIPELINE_LIST]: pipelineListTasks.getPipelineList,
+        [TASK_GET_PIPELINE_ITEM]: pipelineTasks.getPipelineItem,
+        [TASK_EDIT_PIPELINE_ITEM]: pipelineTasks.editPipelineItem,
+        [TASK_ARCHIVE_PIPELINE_ITEM]: pipelineTasks.archivePipelineItem,
+        [TASK_UNARCHIVE_PIPELINE_ITEM]: pipelineTasks.unarchivePipelineItem,
+        [TASK_DELETE_PIPELINE_ITEM]: pipelineTasks.deletePipelineItem,
+        [TASK_GET_PIPELINE_COMPANY_CONTACTS]: pipelineTasks.getCompanyContacts,
+        [TASK_POSTCODE_TO_REGION]: addCompanyPostcodeToRegionTask,
+        [TASK_GET_ACTIVE_EVENTS]: addInteractionFormTasks.fetchActiveEvents,
+        [TASK_SAVE_INTERACTION]: addInteractionFormTasks.saveInteraction,
+        [TASK_OPEN_CONTACT_FORM]: addInteractionFormTasks.openContactForm,
+        [TASK_UPDATE_STAGE]: investmentAdminTasks.updateProjectStage,
+        [TASK_UPDATE_ADVISER]: manageAdviser.updateAdviser,
+        [DNB__CHECK_PENDING_REQUEST]: dnbCheck.checkIfPendingRequest,
+        [TASK_GET_PROFILES_LIST]:
+          investmentProfilesTasks.getLargeCapitalProfiles,
+      }}
+    >
+      <Mount selector="#add-company-form">
+        {(props) => (
+          <AddCompanyForm csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#interaction-details-form">
+        {(props) => (
+          <InteractionDetailsForm
+            csrfToken={globalProps.csrfToken}
+            {...props}
+          />
+        )}
+      </Mount>
+      <Mount selector="#edit-company-form">
+        {(props) => (
+          <EditCompanyForm csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#company-edit-history">
+        {(props) => (
+          <CompanyEditHistory csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#investment-edit-history">
+        {(props) => (
+          <InvestmentEditHistory csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#match-confirmation">
+        {(props) => (
+          <MatchConfirmation csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#cannot-find-match">
+        {(props) => (
+          <CannotFindMatch csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#find-company">
+        {(props) => (
+          <FindCompany csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#activity-feed-app">
+        {(props) => <CompanyActivityFeed {...props} />}
+      </Mount>
+      <Mount selector="#company-lists">
+        <Dashboard id="homepage" />
+      </Mount>
+      <Mount selector="#delete-company-list">
+        {(props) => (
+          <DeleteCompanyList csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#edit-company-list">
+        {(props) => (
+          <EditCompanyList csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#create-company-list-form">
+        {(props) => (
+          <CreateListFormSection csrfToken={globalProps.csrfToken} {...props} />
+        )}
+      </Mount>
+      <Mount selector="#add-remove-list-form">
+        {(props) => <AddRemoveFromListSection {...props} />}
+      </Mount>
+      <Mount selector="#lead-advisers">
+        {(props) => <LeadAdvisers {...props} />}
+      </Mount>
+      <Mount selector="#dnb-hierarchy">
+        {(props) => <DnbHierarchy {...props} />}
+      </Mount>
+      <Mount selector="#company-business-details">
+        {(props) => <CompanyBusinessDetails {...props} />}
+      </Mount>
+      <Mount selector="#company-edit-one-list">
+        {(props) => (
+          <EditOneListForm {...props} csrfToken={globalProps.csrfToken} />
+        )}
+      </Mount>
+      <Mount selector="#large-capital-profile-collection">
+        {(props) => <LargeCapitalProfileCollection {...props} />}
+      </Mount>
+      <Mount selector="#manage-adviser">
+        {(props) => (
+          <ManageAdviser {...props} csrfToken={globalProps.csrfToken} />
+        )}
+      </Mount>
+      <Mount selector="#company-export-index-page">
+        {(props) => <ExportsIndex {...props} />}
+      </Mount>
+      <Mount selector="#send-referral-form">
+        {(props) => (
+          <SendReferralForm {...props} csrfToken={globalProps.csrfToken} />
+        )}
+      </Mount>
+      <Mount selector="#company-export-full-history">
+        {(props) => <ExportsHistory {...props} />}
+      </Mount>
+      <Mount selector="#referral-details">
+        {(props) => <ReferralDetails {...props} />}
+      </Mount>
+      <Mount selector="#referral-help">
+        {(props) => <ReferralHelp {...props} />}
+      </Mount>
+      <Mount selector="#company-export-exports-edit">
+        {(props) => <ExportsEdit {...props} />}
+      </Mount>
+      <Mount selector="#interaction-referral-details">
+        {(props) => <InteractionReferralDetails {...props} />}
+      </Mount>
+      <Mount selector="#company-export-countries-edit">
+        {(props) => <ExportCountriesEdit {...props} />}
+      </Mount>
+      <Mount selector="#pipeline-form">
+        {(props) => <PipelineForm {...props} />}
+      </Mount>
+      <Mount selector="#company-local-header">
+        {(props) => <CompanyLocalHeader {...props} />}
+      </Mount>
+      <Mount selector="#investment-project-admin">
+        {(props) => <InvestmentProjectAdmin {...props} />}
+      </Mount>
+      <Mount selector="#flash-messages">
+        {(props) => <FlashMessages {...props} />}
+      </Mount>
+      <Mount selector="#archive-pipeline-item-form">
+        {(props) => <ArchivePipelineItemForm {...props} />}
+      </Mount>
+      <Mount selector="#unarchive-pipeline-item-form">
+        {(props) => <UnarchivePipelineItemForm {...props} />}
+      </Mount>
+      <Mount selector="#delete-pipeline-item-form">
+        {(props) => <DeletePipelineItemForm {...props} />}
+      </Mount>
     </Provider>
   )
 }

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -1,0 +1,171 @@
+import _ from 'lodash'
+import React from 'react'
+import { createBrowserHistory } from 'history'
+import {
+  connectRouter,
+  routerMiddleware,
+  ConnectedRouter,
+} from 'connected-react-router'
+import { Provider } from 'react-redux'
+import { createStore, combineReducers, applyMiddleware } from 'redux'
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly'
+import createSagaMiddleware from 'redux-saga'
+
+import { MultiInstanceForm } from './components'
+import DropdownMenu from './components/DropdownMenu/ConnectedDropdownMenu'
+import tasks from './components/Task/reducer'
+import rootSaga from './root-saga'
+
+import { ID as COMPANY_LISTS_STATE_ID } from './components/CompanyLists/state'
+import companyListsReducer from './components/CompanyLists/reducer'
+
+import { ID as REFERRALS_DETAILS_STATE_ID } from '../apps/companies/apps/referrals/details/client/state'
+import referralsReducer from '../apps/companies/apps/referrals/details/client/reducer'
+
+import { ID as REFERRALS_SEND_ID } from '../apps/companies/apps/referrals/send-referral/client/state'
+import referralsSendReducer from '../apps/companies/apps/referrals/send-referral/client/reducer'
+import * as referralsSendTasks from '../apps/companies/apps/referrals/send-referral/client/tasks'
+
+import { ID as EXPORTS_HISTORY_ID } from '../apps/companies/apps/exports/client/ExportsHistory/state'
+import exportsHistoryReducer from '../apps/companies/apps/exports/client/ExportsHistory/reducer'
+
+import TabNav from './components/TabNav'
+
+import ReferralList from './components/ReferralList'
+
+import { ID as EXPORTS_WINS_ID } from '../apps/companies/apps/exports/client/ExportWins/state'
+import exportWinsReducer from '../apps/companies/apps/exports/client/ExportWins/reducer'
+
+import { ID as EXPORT_COUNTRIES_EDIT_ID } from '../apps/companies/apps/exports/client/ExportCountriesEdit/state'
+import exportCountriesEditReducer from '../apps/companies/apps/exports/client/ExportCountriesEdit/reducer'
+
+import * as addInteractionFormState from '../apps/interactions/apps/details-form/client/state'
+import * as addInteractionFormTasks from '../apps/interactions/apps/details-form/client/tasks'
+import addInteractionFormReducer from '../apps/interactions/apps/details-form/client/reducer'
+
+import * as addCompanyState from '../apps/companies/apps/add-company/client/state'
+import addCompanyPostcodeToRegionReducer from '../apps/companies/apps/add-company/client/reducer'
+
+import { ID as ONE_LIST_DETAILS_ID } from '../apps/companies/apps/edit-one-list/client/state'
+import editOneListReducer from '../apps/companies/apps/edit-one-list/client/reducer'
+
+import { ID as ADD_TO_PIPELINE_ID } from '../apps/my-pipeline/client/state'
+import addToPipelineReducer from '../apps/my-pipeline/client/reducer'
+
+import { ID as PIPELINE_LIST_ID } from './components/Pipeline/state'
+import pipelineListReducer from './components/Pipeline/reducer'
+
+import { ID as INVESTEMENT_PROJECT_ADMIN_ID } from '../apps/investments/views/admin/client/state'
+
+import investmentProjectAdminReducer from '../apps/investments/views/admin/client/reducer'
+
+import { ID as MANAGE_ADVISER_ID } from '../apps/companies/apps/advisers/client/state'
+import manageAdviserReducer from '../apps/companies/apps/advisers/client/reducer'
+
+import { ID as DNB_CHECK_ID } from '../apps/companies/apps/business-details/client/state'
+import dnbCheckReducer from '../apps/companies/apps/business-details/client/reducer'
+
+import { ID as INVESTMENT_PROFILES_ID } from '../apps/investments/client/state'
+import investmentProfileReducer from '../apps/investments/client/reducer'
+
+const sagaMiddleware = createSagaMiddleware()
+const history = createBrowserHistory({
+  // The baseURI is set to the <base/> tag by the spaFallbackSpread
+  // middleware, which should be applied to each Express route where
+  // react-router is expected to be used.
+  basename: new URL(
+    document.baseURI ||
+      // IE doesn't support baseURI so we need to access base.href manually
+      document.querySelector('base')?.href ||
+      document.location.href
+  ).pathname,
+})
+
+const store = createStore(
+  combineReducers({
+    router: connectRouter(history),
+    tasks,
+    [COMPANY_LISTS_STATE_ID]: companyListsReducer,
+    [EXPORTS_HISTORY_ID]: exportsHistoryReducer,
+    [REFERRALS_DETAILS_STATE_ID]: referralsReducer,
+    [REFERRALS_SEND_ID]: referralsSendReducer,
+    [EXPORTS_WINS_ID]: exportWinsReducer,
+    [EXPORT_COUNTRIES_EDIT_ID]: exportCountriesEditReducer,
+    [addInteractionFormState.ID]: addInteractionFormReducer,
+    [ONE_LIST_DETAILS_ID]: editOneListReducer,
+    [addCompanyState.ID]: addCompanyPostcodeToRegionReducer,
+    [ADD_TO_PIPELINE_ID]: addToPipelineReducer,
+    [PIPELINE_LIST_ID]: pipelineListReducer,
+    ...TabNav.reducerSpread,
+    ...ReferralList.reducerSpread,
+    ...MultiInstanceForm.reducerSpread,
+    ...DropdownMenu.reducerSpread,
+    // A reducer is required to be able to set a preloadedState parameter
+    referrerUrl: (state = {}) => state,
+    [INVESTEMENT_PROJECT_ADMIN_ID]: investmentProjectAdminReducer,
+    [MANAGE_ADVISER_ID]: manageAdviserReducer,
+    [DNB_CHECK_ID]: dnbCheckReducer,
+    [INVESTMENT_PROFILES_ID]: investmentProfileReducer,
+  }),
+  {
+    referrerUrl: window.document.referrer,
+    Form: {
+      [addInteractionFormState.ID]: {
+        values: {},
+        touched: {},
+        errors: {},
+        fields: {},
+        steps: [],
+        currentStep: 0,
+        ...addInteractionFormTasks.restoreState(),
+      },
+      [REFERRALS_SEND_ID]: {
+        values: {},
+        touched: {},
+        errors: {},
+        fields: {},
+        steps: [],
+        currentStep: 0,
+        ...referralsSendTasks.restoreState(),
+      },
+    },
+  },
+  composeWithDevTools(
+    applyMiddleware(sagaMiddleware, routerMiddleware(history))
+  )
+)
+
+const runMiddlewareOnce = _.once((tasks) => sagaMiddleware.run(rootSaga(tasks)))
+
+/**
+ * Provides state management and routing infrastructure required by the
+ * stateful/routed components.
+ * @param {Object} props
+ * @param {Object} props.tasks - A map of _task_ names to _tasks_, if required
+ * by the wrapped components.
+ * @example
+ * import ReferralList from 'components/ReferralList'
+ * import dummyReferralListTask from 'components/ReferralList/task/dummy'
+ *
+ * // ReferralList is a stateful component,
+ * // which also requires the Referrals task.
+ * <DataHubProvider task={{ Referrals: dummyReferralListTask() }}>
+ *    <ReferralList id="foo"/>
+ * </DataHubProvider>
+ */
+export default class DataHubProvider extends React.Component {
+  constructor(...args) {
+    super(...args)
+    // We only ever want to start the sagas once
+    runMiddlewareOnce(this.props.tasks || {})
+  }
+  render() {
+    return (
+      <Provider store={store}>
+        <ConnectedRouter history={history}>
+          {this.props.children}
+        </ConnectedRouter>
+      </Provider>
+    )
+  }
+}

--- a/src/client/root-saga.js
+++ b/src/client/root-saga.js
@@ -3,85 +3,9 @@ import { fork } from 'redux-saga/effects'
 import tasksSaga from './components/Task/saga'
 import analyticsSaga from './components/Analytics/saga'
 
-import * as companyListsTasks from './components/CompanyLists/tasks'
-import * as referralTasks from '../apps/companies/apps/referrals/details/client/tasks'
-import * as exportsHistoryTasks from '../apps/companies/apps/exports/client/ExportsHistory/tasks'
-import referralListTask from './components/ReferralList/task'
-import {
-  TASK_OPEN_REFERRALS_CONTACT_FORM,
-  TASK_SAVE_REFERRAL,
-} from '../apps/companies/apps/referrals/send-referral/client/state'
-import * as referralsSendTasks from '../apps/companies/apps/referrals/send-referral/client/tasks'
-import * as exportWinsTasks from '../apps/companies/apps/exports/client/ExportWins/tasks'
-import { TASK_NAME as EXPORT_COUNTRIES_EDIT_NAME } from '../apps/companies/apps/exports/client/ExportCountriesEdit/state'
-import * as exportCountriesEditTasks from '../apps/companies/apps/exports/client/ExportCountriesEdit/tasks'
-import addCompanyPostcodeToRegionTask from '../apps/companies/apps/add-company/client/tasks'
-import { TASK_SAVE_ONE_LIST_DETAILS } from '../apps/companies/apps/edit-one-list/client/state'
-import * as editOneListTasks from '../apps/companies/apps/edit-one-list/client/tasks'
-import {
-  TASK_GET_PIPELINE_BY_COMPANY,
-  TASK_ADD_COMPANY_TO_PIPELINE,
-  TASK_GET_PIPELINE_ITEM,
-  TASK_EDIT_PIPELINE_ITEM,
-  TASK_ARCHIVE_PIPELINE_ITEM,
-  TASK_UNARCHIVE_PIPELINE_ITEM,
-  TASK_DELETE_PIPELINE_ITEM,
-  TASK_GET_PIPELINE_COMPANY_CONTACTS,
-} from '../apps/my-pipeline/client/state'
-import * as pipelineTasks from '../apps/my-pipeline/client/tasks'
-import { TASK_GET_PIPELINE_LIST } from './components/Pipeline/state'
-import * as pipelineListTasks from './components/Pipeline/tasks'
-import { TASK_UPDATE_STAGE } from '../apps/investments/views/admin/client/state'
-import * as investmentAdminTasks from '../apps/investments/views/admin/client/tasks'
-import { TASK_POSTCODE_TO_REGION } from '../apps/companies/apps/add-company/client/state'
-import {
-  TASK_GET_ACTIVE_EVENTS,
-  TASK_SAVE_INTERACTION,
-  TASK_OPEN_CONTACT_FORM,
-} from '../apps/interactions/apps/details-form/client/state'
-import * as addInteractionFormTasks from '../apps/interactions/apps/details-form/client/tasks'
-
-import { TASK_UPDATE_ADVISER } from '../apps/companies/apps/advisers/client/state'
-import * as manageAdviser from '../apps/companies/apps/advisers/client/tasks'
-
-import { DNB__CHECK_PENDING_REQUEST } from '../apps/companies/apps/business-details/client/state'
-import * as dnbCheck from '../apps/companies/apps/business-details/client/tasks'
-
-import { TASK_GET_PROFILES_LIST } from '../apps/investments/client/state'
-import * as investmentProfilesTasks from '../apps/investments/client/tasks'
-
-export default function* rootSaga() {
-  yield fork(
-    tasksSaga({
-      'Company lists': companyListsTasks.fetchCompanyLists,
-      'Company list': companyListsTasks.fetchCompanyList,
-      'Exports history': exportsHistoryTasks.fetchExportsHistory,
-      'Referral details': referralTasks.fetchReferralDetails,
-      Referrals: referralListTask,
-      'Export wins': exportWinsTasks.fetchExportWins,
-      [TASK_OPEN_REFERRALS_CONTACT_FORM]: referralsSendTasks.openContactForm,
-      [TASK_SAVE_REFERRAL]: referralsSendTasks.saveReferral,
-      [TASK_SAVE_ONE_LIST_DETAILS]: editOneListTasks.saveOneListDetails,
-      [EXPORT_COUNTRIES_EDIT_NAME]:
-        exportCountriesEditTasks.saveExportCountries,
-      [TASK_GET_PIPELINE_BY_COMPANY]: pipelineTasks.getPipelineByCompany,
-      [TASK_ADD_COMPANY_TO_PIPELINE]: pipelineTasks.addCompanyToPipeline,
-      [TASK_GET_PIPELINE_LIST]: pipelineListTasks.getPipelineList,
-      [TASK_GET_PIPELINE_ITEM]: pipelineTasks.getPipelineItem,
-      [TASK_EDIT_PIPELINE_ITEM]: pipelineTasks.editPipelineItem,
-      [TASK_ARCHIVE_PIPELINE_ITEM]: pipelineTasks.archivePipelineItem,
-      [TASK_UNARCHIVE_PIPELINE_ITEM]: pipelineTasks.unarchivePipelineItem,
-      [TASK_DELETE_PIPELINE_ITEM]: pipelineTasks.deletePipelineItem,
-      [TASK_GET_PIPELINE_COMPANY_CONTACTS]: pipelineTasks.getCompanyContacts,
-      [TASK_POSTCODE_TO_REGION]: addCompanyPostcodeToRegionTask,
-      [TASK_GET_ACTIVE_EVENTS]: addInteractionFormTasks.fetchActiveEvents,
-      [TASK_SAVE_INTERACTION]: addInteractionFormTasks.saveInteraction,
-      [TASK_OPEN_CONTACT_FORM]: addInteractionFormTasks.openContactForm,
-      [TASK_UPDATE_STAGE]: investmentAdminTasks.updateProjectStage,
-      [TASK_UPDATE_ADVISER]: manageAdviser.updateAdviser,
-      [DNB__CHECK_PENDING_REQUEST]: dnbCheck.checkIfPendingRequest,
-      [TASK_GET_PROFILES_LIST]: investmentProfilesTasks.getLargeCapitalProfiles,
-    })
-  )
-  yield fork(analyticsSaga)
+export default (tasks) => {
+  return function* rootSaga() {
+    yield fork(tasksSaga(tasks))
+    yield fork(analyticsSaga)
+  }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
 require('dotenv').config()
 
-require('elastic-apm-node').start()
+// require('elastic-apm-node').start()
 
 const path = require('path')
 const bodyParser = require('body-parser')


### PR DESCRIPTION
## Description of change

Refactored all the redux and redux-saga configuration from `src/client/index.jsx` into `src/client/provider.jsx` which exports the `DataHubProvider`. The provider enables to have stateful and routed components in Storybook and also to use them outside of DataHub.

### Usage

If you want to use a stateful/routed component outside of DataHub (for now only in Storybook), you only need to wrap it in the `DataHubProvider` and satisfy it's `Task` requirements if the component uses any tasks:

```jsx
import DataHubProvider from 'client/provider'
import CompanyLists from 'client/components/CompanyLists'
import ReferralList from 'client/components/ReferralList'
import dummyCompanyListsTasks from 'client/components/CompanyLists/tasks/dummy'
import dummyReferralTaskFactory from 'client/components/ReferralList/tasks/dummy'

<DataHubProvider tasks={{
  // A task required by the ReferalList
  'Referrals': dummyReferralTaskFactory(),
  // Tasks required by CompanyLists
  'Company List':  dummyCompanyListsTasks.listTaskFactory(),
  'Company Lists':  dummyCompanyListsTasks.listsTaskFactory(),
}}>
  <CompanyLists id="example" />
  <ReferralList id="example" />
  <TabNav id="example" tabs={{
    foo: {label: 'Foo', content: 'Fooooo'},
    bar: {label: 'Bar', content: 'Baaaaar'}
  }}/>
</DataHubProvider>
```

## Test instructions

* The application should work as before
* The `TabNav`, `ReferralList` and `CompaniesLists` components should now have their stories in Storybook
