### PR TITLE
Revert email marketing opt-in changes

### DIFF
--- a/src/apps/contacts/services/__test__/form.test.js
+++ b/src/apps/contacts/services/__test__/form.test.js
@@ -203,7 +203,7 @@ describe('contact form service', () => {
         telephone_number: '652423467167',
         telephone_countrycode: '+1',
         email: 'zboasdaan@opasdasdov.com',
-        accepts_dit_email_marketing: false,
+        accepts_dit_email_marketing: true,
         address_same_as_company: false,
         address_1: '99 N Shore Road',
         address_2: 'Suite 20',
@@ -246,7 +246,7 @@ describe('contact form service', () => {
     context('when the contact accepts DIT email marketing', () => {
       it('it should send accepts DIT email marketing as true', async () => {
         this.formData = assign({}, formData, {
-          accepts_dit_email_marketing: true,
+          rejects_dit_email_marketing: false,
         })
 
         await contactFormService.saveContactForm('1234', this.formData)

--- a/src/apps/contacts/services/form.js
+++ b/src/apps/contacts/services/form.js
@@ -73,7 +73,8 @@ function saveContactForm(token, contactForm) {
         ['title', 'company', 'address_country']
       )
       const contactFormForApiRequest = merge({}, transformedContactForm, {
-        accepts_dit_email_marketing: !!contactForm.accepts_dit_email_marketing,
+        // database is positive on accepts, negative on rejects; UI is reverse, so flip that here
+        accepts_dit_email_marketing: !contactForm.rejects_dit_email_marketing,
       })
       const savedContact = await contactsRepository.saveContact(
         token,

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -85,7 +85,7 @@
       error: errors.messages.email
     }) }}
 
-    <fieldset id="group-field-accepts_dit_email_marketing" class="c-form-group">
+    <fieldset id="group-field-rejects_dit_email_marketing" class="c-form-group">
         <legend class="c-form-group__label u-visually-hidden">
             <span class="c-form-group__label-text">
                 Marketing preferences
@@ -93,17 +93,11 @@
         </legend>
         <div class="c-form-group__inner">
             <div class="c-multiple-choice">
-                <input class="c-multiple-choice__input" type="checkbox" name="accepts_dit_email_marketing" value="true" id="field-accepts_dit_email_marketing-1" {% if formData.accepts_dit_email_marketing %} checked {% endif %}>
-                      <label class="c-multiple-choice__label" for="field-accepts_dit_email_marketing-1">
+                <input class="c-multiple-choice__input" type="checkbox" name="rejects_dit_email_marketing" value="rejects_dit_email_marketing" id="field-rejects_dit_email_marketing-1" {% if formData.rejects_dit_email_marketing %} checked {% endif %}>
+                      <label class="c-multiple-choice__label" for="field-rejects_dit_email_marketing-1">
                           <span class="c-multiple-choice__label-text">
-                              The company contact does accept email marketing
+                              Does not accept email marketing
                           </span>
-
-                          {# TODO when form rewritten in React: conditionally render on checked #}
-                          <span class="c-form-group__hint" id="hint-group-field-accepts_dit_email_marketing">
-                            By checking this box, you confirm that the contact has opted in to email marketing.
-                          </span>
-
                       </label>
             </div>
         </div>

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -56,7 +56,7 @@ describe('Contacts', () => {
       'Phone number': '(44) 0778877778800',
       Address: "12 St George's Road, Paris, 75001, France",
       Email: 'company.contact@dit.com',
-      'Email marketing': 'Cannot be marketed to',
+      'Email marketing': 'Can be marketed to',
     })
   })
 


### PR DESCRIPTION
## Description of change

Reverts https://github.com/uktrade/data-hub-frontend/pull/2793 after request to check text from legal department. Unfortunately, that PR contained visual test updates, so I couldn't just press the 'revert' button.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
