### PR TITLE
Hotfix: remove yarn from engines section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "license": "MIT",
   "engines": {
-    "yarn": "YARN NO LONGER USED - use npm instead.",
     "node": "12.18.0"
   },
   "dependencies": {


### PR DESCRIPTION
Hotfix

Remove any mention of yarn from the engines section of the package.json. Currently the Cloud Foundry build is failing as it can't determine the version of yarn from my deprecation message. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
