### PR TITLE
Change pipeline status terms

### DIFF
--- a/src/apps/my-pipeline/client/constants.js
+++ b/src/apps/my-pipeline/client/constants.js
@@ -34,17 +34,17 @@ export const PipelineItemsPropType = PropTypes.exact({
 export const STATUSES = {
   LEADS: {
     value: 'leads',
-    label: 'Prospect',
+    label: 'To do',
     url: urls.pipeline.index,
   },
   IN_PROGRESS: {
     value: 'in_progress',
-    label: 'Active',
+    label: 'In progress',
     url: urls.pipeline.active,
   },
   WIN: {
     value: 'win',
-    label: 'Won',
+    label: 'Done',
     url: urls.pipeline.won,
   },
 }

--- a/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
@@ -33,15 +33,15 @@ describe('My Pipeline tab on the dashboard', () => {
       const tabs = [
         {
           url: urls.pipeline.index(),
-          status: 'prospect',
+          status: 'to do',
         },
         {
           url: urls.pipeline.active(),
-          status: 'active',
+          status: 'in progress',
         },
         {
           url: urls.pipeline.won(),
-          status: 'won',
+          status: 'done',
         },
       ]
 

--- a/test/functional/cypress/specs/pipeline/my-pipeline-delete.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-delete.js
@@ -96,7 +96,7 @@ describe('Delete pipeline item form', () => {
   )
 
   context('When cancelling it should link to the pipeline category', () => {
-    it('should redirect to the prospect tab in my pipeline', () => {
+    it('should redirect to the to do tab in my pipeline', () => {
       cy.visit(urls.pipeline.delete('LEADS'))
       cy.contains('a', 'Cancel').should(
         'have.attr',
@@ -107,7 +107,7 @@ describe('Delete pipeline item form', () => {
       cy.url().should('include', urls.pipeline.index())
     })
 
-    it('should redirect to the active tab in my pipeline', () => {
+    it('should redirect to the in progress tab in my pipeline', () => {
       cy.visit(urls.pipeline.delete('IN_PROGRESS'))
       cy.contains('a', 'Cancel').should(
         'have.attr',
@@ -118,7 +118,7 @@ describe('Delete pipeline item form', () => {
       cy.url().should('include', urls.pipeline.active())
     })
 
-    it('should redirect to the won tab in my pipeline', () => {
+    it('should redirect to the done tab in my pipeline', () => {
       cy.visit(urls.pipeline.delete('WIN'))
       cy.contains('a', 'Cancel').should(
         'have.attr',

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
@@ -77,7 +77,7 @@ describe('Pipeline edit form', () => {
             element,
             label: 'Choose a status',
             optionsCount: 3,
-            value: 'Active',
+            value: 'In progress',
           })
         })
       })
@@ -164,7 +164,7 @@ describe('Pipeline edit form', () => {
             element,
             label: 'Choose a status',
             optionsCount: 3,
-            value: 'Prospect',
+            value: 'To do',
           })
         })
       })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -143,30 +143,30 @@ function assertPipelineItem(
 }
 
 function assertAcrossTabs(callback) {
-  cy.contains('Prospect').click()
-  cy.contains('Prospect').should('have.attr', 'aria-selected', 'true')
-  callback('Prospect')
+  cy.contains('To do').click()
+  cy.contains('To do').should('have.attr', 'aria-selected', 'true')
+  callback('To do')
 
-  cy.contains('Active').click()
-  cy.contains('Active').should('have.attr', 'aria-selected', 'true')
-  callback('Active')
+  cy.contains('In progress').click()
+  cy.contains('In progress').should('have.attr', 'aria-selected', 'true')
+  callback('In progress')
 
-  cy.contains('Won').click()
-  cy.contains('Won').should('have.attr', 'aria-selected', 'true')
-  callback('Won')
+  cy.contains('Done').click()
+  cy.contains('Done').should('have.attr', 'aria-selected', 'true')
+  callback('Done')
 }
 
 describe('My pipeline app', () => {
-  context('When viewing the prospect status', () => {
+  context('When viewing the to do status', () => {
     before(() => {
       cy.visit(urls.pipeline.index())
     })
 
     it('should render the sub tab nav', () => {
       cy.get('[data-auto-id="pipelineSubTabNav"]').within(() => {
-        cy.contains('Prospect').should('have.attr', 'aria-selected', 'true')
-        cy.contains('Active')
-        cy.contains('Won')
+        cy.contains('To do').should('have.attr', 'aria-selected', 'true')
+        cy.contains('In progress')
+        cy.contains('Done')
       })
     })
 
@@ -189,16 +189,16 @@ describe('My pipeline app', () => {
     })
   })
 
-  context('When viewing the active status', () => {
+  context('When viewing the in progress status', () => {
     before(() => {
       cy.visit(urls.pipeline.active())
     })
 
     it('should render the sub tab nav', () => {
       cy.get('[data-auto-id="pipelineSubTabNav"]').within(() => {
-        cy.contains('Prospect')
-        cy.contains('Active').should('have.attr', 'aria-selected', 'true')
-        cy.contains('Won')
+        cy.contains('To do')
+        cy.contains('In progress').should('have.attr', 'aria-selected', 'true')
+        cy.contains('Done')
       })
     })
 
@@ -221,16 +221,16 @@ describe('My pipeline app', () => {
     })
   })
 
-  context('When viewing the won status', () => {
+  context('When viewing the done status', () => {
     before(() => {
       cy.visit(urls.pipeline.won())
     })
 
     it('should render the sub tab nav', () => {
       cy.get('[data-auto-id="pipelineSubTabNav"]').within(() => {
-        cy.contains('Prospect')
-        cy.contains('Active')
-        cy.contains('Won').should('have.attr', 'aria-selected', 'true')
+        cy.contains('To do')
+        cy.contains('In progress')
+        cy.contains('Done').should('have.attr', 'aria-selected', 'true')
       })
     })
 


### PR DESCRIPTION
## Description of change

Change the pipeline status terms from 'Lead', 'Active' and 'Won' to 'To do', 'In progress' and 'Done'. 

## Test instructions

When viewing 'My pipelines' or the associated create or edit forms you should see the new terms. 

## Screenshots
### Before

My pipeline
![image](https://user-images.githubusercontent.com/42253716/86820578-28708b80-c081-11ea-916a-f64ec4e7c7e2.png)

Edit form
![image](https://user-images.githubusercontent.com/42253716/86820630-39210180-c081-11ea-9fc2-0546b1ff1ac0.png)

### After

My pipeline
![image](https://user-images.githubusercontent.com/42253716/86820494-0d9e1700-c081-11ea-8014-234e9eec5b7f.png)

Edit form
![image](https://user-images.githubusercontent.com/42253716/86820663-463df080-c081-11ea-9384-0fcec5e2ccef.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
