### PR TITLE
Restyle pipeline archive page

### DIFF
--- a/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
@@ -72,7 +72,7 @@ function ArchivePipelineItemForm({
                       onSuccessDispatch: PIPELINE__ARCHIVE_ITEM,
                     })
                   }}
-                  submissionError={archivePipelineItem.errorMessage}
+                  showErrorSummary={false}
                 >
                   <br />
                   <FieldTextarea

--- a/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
@@ -6,9 +6,7 @@ import styled from 'styled-components'
 import LoadingBox from '@govuk-react/loading-box'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
-import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
-
-import { H2 } from '@govuk-react/heading'
+import { SPACING } from '@govuk-react/constants'
 
 import Task from '../../../client/components/Task'
 import Form from '../../../client/components/Form'
@@ -23,16 +21,6 @@ import { PipelineItemPropType } from './constants'
 import PipelineDetails from './PipelineDetails'
 import GetPipelineData from './GetPipelineData'
 import { getPipelineUrl } from './utils'
-
-const StyledH2 = styled(H2)`
-  margin-top: ${SPACING.SCALE_6};
-  margin-bottom: ${SPACING.SCALE_3};
-  font-size: ${FONT_SIZE.SIZE_16};
-
-  ${MEDIA_QUERIES.DESKTOP} {
-    font-size: ${FONT_SIZE.SIZE_19};
-  }
-`
 
 const StyledP = styled.p`
   margin: ${SPACING.SCALE_2} 0 ${SPACING.SCALE_5} 0;
@@ -86,9 +74,10 @@ function ArchivePipelineItemForm({
                   }}
                   submissionError={archivePipelineItem.errorMessage}
                 >
-                  <StyledH2>Reason for archive</StyledH2>
+                  <br />
                   <FieldTextarea
-                    label="Details on why the project is being archived"
+                    label="Reason for archive"
+                    hint="Details on why the project is being archived"
                     name="reason"
                     type="text"
                     required="Enter why the project is being archived"

--- a/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
@@ -80,7 +80,7 @@ function ArchivePipelineItemForm({
                     hint="Details on why the project is being archived"
                     name="reason"
                     type="text"
-                    required="Enter why the project is being archived"
+                    required="Enter the reason why you are archiving this project"
                     className="govuk-!-width-two-thirds"
                   />
                   <FormActions>

--- a/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
@@ -77,7 +77,7 @@ function ArchivePipelineItemForm({
                   <br />
                   <FieldTextarea
                     label="Reason for archive"
-                    hint="Details on why the project is being archived"
+                    hint="Details on why you are archiving this project"
                     name="reason"
                     type="text"
                     required="Enter the reason why you are archiving this project"

--- a/src/apps/my-pipeline/client/PipelineDetails.jsx
+++ b/src/apps/my-pipeline/client/PipelineDetails.jsx
@@ -55,7 +55,7 @@ export default function PipelineDetails({ item }) {
       'Expected date for win',
       moment(item.expected_win_date).format('MMM Y'),
     ],
-    ['Created on', DateUtils.format(item.created_on)],
+    ['Created', DateUtils.format(item.created_on)],
     item.archived && ['Reason for archive', item.archived_reason],
     item.archived && ['Archived on', DateUtils.format(item.archived_on)],
   ]

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -52,6 +52,7 @@ const Form = ({
   values = {},
   touched = {},
   steps = [],
+  showErrorSummary = true,
   ...props
 }) => {
   useEffect(() => {
@@ -101,7 +102,7 @@ const Form = ({
           }
         }}
       >
-        {(!isEmpty(errors) || submissionError) && (
+        {(!isEmpty(errors) || submissionError) && showErrorSummary && (
           <ErrorSummary
             id="form-errors"
             heading="There is a problem"

--- a/test/functional/cypress/specs/pipeline/my-pipeline-archive.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-archive.js
@@ -31,14 +31,12 @@ function assertHeader() {
 }
 
 function assertForm() {
-  it('Should have a heading', () => {
-    cy.contains('h2', 'Reason for archive')
-  })
   it('Should render the reason for achive textarea', () => {
     cy.get(formSelectors.reason).then((element) => {
       assertFieldTextarea({
         element,
-        label: 'Details on why the project is being archived',
+        label: 'Reason for archive',
+        hint: 'Details on why you are archiving this project',
       })
     })
   })
@@ -73,7 +71,7 @@ describe('Archive pipeline item form', () => {
 
     it('Should show a validation error', () => {
       cy.contains('button', 'Archive project').click()
-      cy.contains('There is a problemEnter why the project is being archived')
+      cy.contains('Enter the reason why you are archiving this project')
     })
   })
 

--- a/test/functional/cypress/support/pipeline-assertions.js
+++ b/test/functional/cypress/support/pipeline-assertions.js
@@ -65,7 +65,7 @@ module.exports = {
         ).format('MMM Y')
       }
 
-      content['Created on'] = DateUtils.format(item.created_on)
+      content.Created = DateUtils.format(item.created_on)
 
       if (item.archived) {
         content['Reason for archive'] = item.archived_reason


### PR DESCRIPTION
## Description of change

This PR:

- removes the word "on" from the "Created on" field label.
- removes the Error summary (it isn't necessary on a React page where you are not return to the top of the screen after submit)
- increases the height of the red vertical line so that it also indents the heading of textarea **Reason for archive**
- changes the error message from "Enter why the project is being archived" to "Enter the reason why you are archiving this project"
- changes the hint message from "Details on why the project is being archived" to "Details on why you are archiving this project"

## Test instructions

Click 'Archive this project' on any pipeline item and you will see the new design. If you try and submit the form without giving a reason for the archive, you will see the new error styling. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/42253716/86929939-54961600-c12e-11ea-8ae6-dc7b616a8d7d.png)

### After

![image](https://user-images.githubusercontent.com/42253716/86929990-611a6e80-c12e-11ea-8915-2ba63408df83.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
