### PR TITLE
Update data-hub-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10200,9 +10200,9 @@
       }
     },
     "data-hub-components": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/data-hub-components/-/data-hub-components-5.10.0.tgz",
-      "integrity": "sha512-+R9psPjrY1Qm9gkniTnc1wiHcktMj/N040BGoLuxKyW/rx3GgsNqPXxVrmdR5wqocVahXbhWxz5QpDfrSF6ERg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/data-hub-components/-/data-hub-components-5.10.1.tgz",
+      "integrity": "sha512-8t9WqXlkEEzyzpcZXDQ7tUp9mb9fhk/6zzqGeQ0NKgqbZBZzbmnSWgcug1T/TZlTJ+IhxQEvrAP23Q98MpCFQQ==",
       "requires": {
         "@babel/runtime": "^7.4.5",
         "@govuk-react/button": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "csurf": "^1.9.0",
-    "data-hub-components": "5.10.0",
+    "data-hub-components": "5.10.1",
     "date-fns": "^1.29.0",
     "del-cli": "^3.0.0",
     "details-element-polyfill": "^2.4.0",


### PR DESCRIPTION
## Description of change

Update `data-hub-components` from `5.10.0` to `5.10.1`.  

This updates dependencies and also emboldens the React form labels. This is so these forms are visually consistent with the older nunjucks-based forms.

## Test instructions

Navigate to any React form, e.g. my pipeline edit, and you will see the form labels are now in bold. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/42253716/86926792-67a6e700-c12a-11ea-941d-28731e705032.png)

### After

![image](https://user-images.githubusercontent.com/42253716/86926910-91600e00-c12a-11ea-9bc4-c6695c86ef78.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
