### PR TITLE
style: change pipeline button labels

### DIFF
--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -102,7 +102,9 @@ function PipelineForm({
         initialValue={initialValue.expected_win_date}
       />
       <FormActions>
-        <Button>{Object.keys(initialValue).length ? 'Update' : 'Add'}</Button>
+        <Button>
+          {Object.keys(initialValue).length ? 'Save' : 'Create project'}
+        </Button>
         <Link href={cancelLink}>Cancel</Link>
       </FormActions>
     </Form>

--- a/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
@@ -69,7 +69,7 @@ describe('My Pipeline tab on the dashboard', () => {
 
       cy.get(formSelectors.name).type(projectName)
       cy.get(formSelectors.status.prospect).click()
-      cy.contains('button', 'Add').click()
+      cy.contains('button', 'Create project').click()
 
       cy.url().should('include', urls.pipeline.index())
       assertTabListItem({ contain: [projectName] })
@@ -85,7 +85,7 @@ describe('My Pipeline tab on the dashboard', () => {
             .click()
 
           cy.get(formSelectors.status.active).click()
-          cy.contains('button', 'Update').click()
+          cy.contains('button', 'Save').click()
 
           cy.url().should('include', urls.pipeline.active())
           assertTabListItem({ contain: [projectName] })
@@ -108,7 +108,7 @@ describe('My Pipeline tab on the dashboard', () => {
               .clear()
               .type(newProjectName)
             cy.get(formSelectors.status.won).click()
-            cy.contains('button', 'Update').click()
+            cy.contains('button', 'Save').click()
 
             cy.url().should('include', urls.pipeline.won())
             assertTabListItem({ contain: [newProjectName] })
@@ -135,7 +135,7 @@ describe('My Pipeline tab on the dashboard', () => {
               cy.wrap(element[1]).type('2025')
             })
 
-          cy.contains('button', 'Update').click()
+          cy.contains('button', 'Save').click()
 
           cy.url().should('include', urls.pipeline.won())
           assertTabListItem({
@@ -165,7 +165,7 @@ describe('My Pipeline tab on the dashboard', () => {
             .find('input')
             .clear()
 
-          cy.contains('button', 'Update').click()
+          cy.contains('button', 'Save').click()
 
           cy.url().should('include', urls.pipeline.won())
           assertTabListItem({

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -98,7 +98,7 @@ describe('Company add to pipeline form', () => {
 
     it('should render the form buttons', () => {
       assertFormButtons({
-        submitText: 'Add',
+        submitText: 'Create project',
         cancelText: 'Cancel',
         cancelLink: urls.companies.detail(minimallyMinimal.id),
       })
@@ -162,7 +162,7 @@ describe('Company add to pipeline form', () => {
       it('should redirect to the prospect tab in my pipeline', () => {
         cy.get(formSelectors.name).type('Test Project')
         cy.get(formSelectors.status.prospect).click()
-        cy.contains('button', 'Add').click()
+        cy.contains('button', 'Create project').click()
         cy.url().should('include', urls.pipeline.index())
         cy.get(selectors.companyLocalHeader().flashMessageList).should(
           'contain',
@@ -173,7 +173,7 @@ describe('Company add to pipeline form', () => {
       it('should redirect to the active tab in my pipeline', () => {
         cy.get(formSelectors.name).type('Test Project')
         cy.get(formSelectors.status.active).click()
-        cy.contains('button', 'Add').click()
+        cy.contains('button', 'Create project').click()
         cy.url().should('include', urls.pipeline.active())
         cy.get(selectors.companyLocalHeader().flashMessageList).should(
           'contain',
@@ -184,7 +184,7 @@ describe('Company add to pipeline form', () => {
       it('should redirect to the won tab in my pipeline', () => {
         cy.get(formSelectors.name).type('Test Project')
         cy.get(formSelectors.status.won).click()
-        cy.contains('button', 'Add').click()
+        cy.contains('button', 'Create project').click()
         cy.url().should('include', urls.pipeline.won())
         cy.get(selectors.companyLocalHeader().flashMessageList).should(
           'contain',
@@ -200,7 +200,7 @@ describe('Company add to pipeline form', () => {
     })
 
     it('should display error messages', () => {
-      cy.contains('button', 'Add').click()
+      cy.contains('button', 'Create project').click()
       cy.contains('Enter a Project name')
       cy.contains('Choose a status')
     })
@@ -214,7 +214,7 @@ describe('Company add to pipeline form', () => {
 
     function checkError(value, assertion = 'contain') {
       cy.get(formSelectors.value).type(value)
-      cy.contains('button', 'Add').click()
+      cy.contains('button', 'Create project').click()
       cy.get('#form-errors').should(
         assertion,
         'Potential export value must be a number'

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit.js
@@ -227,7 +227,7 @@ describe('Pipeline edit form', () => {
             .find('input')
             .clear()
 
-          cy.contains('button', 'Update').click()
+          cy.contains('button', 'Save').click()
           cy.wait('@updatePipelineItem').then((xhr) => {
             expect(xhr.request.body.sector).to.equal(null)
             expect(xhr.request.body.contacts).to.deep.equal([])
@@ -248,7 +248,7 @@ describe('Pipeline edit form', () => {
 
       it('should redirect to the prospect tab in my pipeline', () => {
         cy.get('input[value=leads').click()
-        cy.contains('button', 'Update').click()
+        cy.contains('button', 'Save').click()
         cy.url().should('include', urls.pipeline.index())
         cy.get(selectors.companyLocalHeader().flashMessageList).should(
           'contain',
@@ -258,7 +258,7 @@ describe('Pipeline edit form', () => {
 
       it('should redirect to the active tab in my pipeline', () => {
         cy.get('input[value=in_progress').click()
-        cy.contains('button', 'Update').click()
+        cy.contains('button', 'Save').click()
         cy.url().should('include', urls.pipeline.active())
         cy.get(selectors.companyLocalHeader().flashMessageList).should(
           'contain',
@@ -268,7 +268,7 @@ describe('Pipeline edit form', () => {
 
       it('should redirect to the won tab in my pipeline', () => {
         cy.get('input[value=win').click()
-        cy.contains('button', 'Update').click()
+        cy.contains('button', 'Save').click()
         cy.url().should('include', urls.pipeline.won())
         cy.get(selectors.companyLocalHeader().flashMessageList).should(
           'contain',


### PR DESCRIPTION
## Description of change

This PR updates the text on the following two primary buttons:

1. **Update > Save**
On the **Edit project page** change the primary button, which is currently entitled **Update** to **Save**

2. **Add > Create project**
On the **Add project page/Add [company name] to your pipeline** change the primary button, which is currently entitled **Add** to **Create project**

## Test instructions

On both the create and edit pipeline page the text should have changed. 

## Screenshots

Create form
![image](https://user-images.githubusercontent.com/42253716/87022391-56171b00-c1ce-11ea-9f79-f8ddfb975955.png)

Edit form
![image](https://user-images.githubusercontent.com/42253716/87022366-4ac3ef80-c1ce-11ea-9a68-a0c2a051bdca.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
