### PR TITLE
Replace pipeline feature headers with React

### DIFF
--- a/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
@@ -25,6 +25,9 @@ import {
 } from './constants'
 import { getPipelineUrl } from './utils'
 
+import { Main } from '../../../client/components/'
+import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
+
 function isOnPipeline(pipelineStatus, companyId) {
   if (pipelineStatus?.companyId === companyId) {
     return !!pipelineStatus.count
@@ -84,6 +87,7 @@ function PipelineCheck({
 }
 
 function AddPipelineItemForm({
+  companyName,
   companyId,
   pipelineStatus,
   savedPipelineItem,
@@ -101,49 +105,64 @@ function AddPipelineItemForm({
   }, [savedPipelineItem])
 
   return (
-    <Task>
-      {(getTask) => {
-        const getPipelineByCompany = getTask(
-          TASK_GET_PIPELINE_BY_COMPANY,
-          STATE_ID
-        )
-        const addCompanyToPipeline = getTask(
-          TASK_ADD_COMPANY_TO_PIPELINE,
-          STATE_ID
-        )
-        return (
-          <>
-            <PipelineCheck
-              getPipelineByCompany={getPipelineByCompany}
-              pipelineStatus={pipelineStatus}
-              companyId={companyId}
-            >
-              <LoadingBox
-                loading={addCompanyToPipeline.progress || savedPipelineItem}
-              >
-                <PipelineForm
-                  cancelLink={urls.companies.detail(companyId)}
+    <>
+      <LocalHeader
+        heading={`Add ${companyName} to your pipeline`}
+        breadcrumbs={[
+          { link: urls.dashboard(), text: 'Home' },
+          { link: urls.companies.index(), text: 'Companies' },
+          { link: urls.companies.detail(companyId), text: companyName },
+          { link: urls.pipeline.index(), text: 'Add to your pipeline' },
+        ]}
+      />
+      <Main>
+        <Task>
+          {(getTask) => {
+            const getPipelineByCompany = getTask(
+              TASK_GET_PIPELINE_BY_COMPANY,
+              STATE_ID
+            )
+            const addCompanyToPipeline = getTask(
+              TASK_ADD_COMPANY_TO_PIPELINE,
+              STATE_ID
+            )
+            return (
+              <>
+                <PipelineCheck
+                  getPipelineByCompany={getPipelineByCompany}
                   pipelineStatus={pipelineStatus}
-                  sectors={sectors}
-                  contacts={contacts}
-                  onSubmit={(values) => {
-                    addCompanyToPipeline.start({
-                      payload: { values, companyId },
-                      onSuccessDispatch: PIPELINE__ADD_ITEM,
-                    })
-                  }}
-                  submissionError={addCompanyToPipeline.errorMessage}
-                />
-              </LoadingBox>
-            </PipelineCheck>
-          </>
-        )
-      }}
-    </Task>
+                  companyId={companyId}
+                >
+                  <LoadingBox
+                    loading={addCompanyToPipeline.progress || savedPipelineItem}
+                  >
+                    <PipelineForm
+                      companyName={companyName}
+                      cancelLink={urls.companies.detail(companyId)}
+                      pipelineStatus={pipelineStatus}
+                      sectors={sectors}
+                      contacts={contacts}
+                      onSubmit={(values) => {
+                        addCompanyToPipeline.start({
+                          payload: { values, companyId },
+                          onSuccessDispatch: PIPELINE__ADD_ITEM,
+                        })
+                      }}
+                      submissionError={addCompanyToPipeline.errorMessage}
+                    />
+                  </LoadingBox>
+                </PipelineCheck>
+              </>
+            )
+          }}
+        </Task>
+      </Main>
+    </>
   )
 }
 
 AddPipelineItemForm.propTypes = {
+  companyName: PropTypes.string,
   companyId: PropTypes.string,
   pipelineStatus: PipelineItemsPropType,
   savedId: PipelineItemPropType,

--- a/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
@@ -112,7 +112,7 @@ function AddPipelineItemForm({
           { link: urls.dashboard(), text: 'Home' },
           { link: urls.companies.index(), text: 'Companies' },
           { link: urls.companies.detail(companyId), text: companyName },
-          { link: urls.pipeline.index(), text: 'Add to your pipeline' },
+          { link: null, text: 'Add to your pipeline' },
         ]}
       />
       <Main>

--- a/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
@@ -84,7 +84,11 @@ function ArchivePipelineItemForm({
                       id={STATE_ID}
                       onSubmit={(values) => {
                         archivePipelineItem.start({
-                          payload: { values, pipelineItemId },
+                          payload: {
+                            values,
+                            pipelineItemId,
+                            projectName: currentPipelineItem.name,
+                          },
                           onSuccessDispatch: PIPELINE__ARCHIVE_ITEM,
                         })
                       }}

--- a/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
@@ -8,9 +8,13 @@ import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import { SPACING } from '@govuk-react/constants'
 
+import urls from '../../../lib/urls'
 import Task from '../../../client/components/Task'
 import Form from '../../../client/components/Form'
 import { PIPELINE__ARCHIVE_ITEM } from '../../../client/actions'
+
+import { Main } from '../../../client/components/'
+import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 
 import {
   ID as STATE_ID,
@@ -42,64 +46,74 @@ function ArchivePipelineItemForm({
   }, [savedPipelineItem])
 
   return (
-    <Task>
-      {(getTask) => {
-        const archivePipelineItem = getTask(
-          TASK_ARCHIVE_PIPELINE_ITEM,
-          STATE_ID
-        )
+    <>
+      <LocalHeader
+        heading="Archive project"
+        breadcrumbs={[
+          { link: urls.dashboard(), text: 'Home' },
+          { link: urls.pipeline.index(), text: 'My Pipeline' },
+          { link: null, text: 'Archive project' },
+        ]}
+      />
+      <Main>
+        <Task>
+          {(getTask) => {
+            const archivePipelineItem = getTask(
+              TASK_ARCHIVE_PIPELINE_ITEM,
+              STATE_ID
+            )
 
-        return (
-          <GetPipelineData
-            getTask={getTask}
-            pipelineItemId={pipelineItemId}
-            currentPipelineItem={currentPipelineItem}
-          >
-            {() => (
-              <LoadingBox loading={archivePipelineItem.progress}>
-                <StyledP>
-                  Archive this project if it’s no longer required or active.
-                  <br />
-                  You can unarchive or delete an archived project from your
-                  pipeline dashboard.
-                </StyledP>
-                <PipelineDetails item={currentPipelineItem}></PipelineDetails>
-                <Form
-                  id={STATE_ID}
-                  onSubmit={(values) => {
-                    archivePipelineItem.start({
-                      payload: {
-                        values,
-                        pipelineItemId,
-                        projectName: currentPipelineItem.name,
-                      },
-                      onSuccessDispatch: PIPELINE__ARCHIVE_ITEM,
-                    })
-                  }}
-                  showErrorSummary={false}
-                >
-                  <br />
-                  <FieldTextarea
-                    label="Reason for archive"
-                    hint="Details on why you are archiving this project"
-                    name="reason"
-                    type="text"
-                    required="Enter the reason why you are archiving this project"
-                    className="govuk-!-width-two-thirds"
-                  />
-                  <FormActions>
-                    <Button>Archive project</Button>
-                    <Link href={getPipelineUrl(currentPipelineItem)}>
-                      Cancel
-                    </Link>
-                  </FormActions>
-                </Form>
-              </LoadingBox>
-            )}
-          </GetPipelineData>
-        )
-      }}
-    </Task>
+            return (
+              <GetPipelineData
+                getTask={getTask}
+                pipelineItemId={pipelineItemId}
+                currentPipelineItem={currentPipelineItem}
+              >
+                {() => (
+                  <LoadingBox loading={archivePipelineItem.progress}>
+                    <StyledP>
+                      Archive this project if it’s no longer required or active.
+                      <br />
+                      You can unarchive or delete an archived project from your
+                      pipeline dashboard.
+                    </StyledP>
+                    <PipelineDetails
+                      item={currentPipelineItem}
+                    ></PipelineDetails>
+                    <Form
+                      id={STATE_ID}
+                      onSubmit={(values) => {
+                        archivePipelineItem.start({
+                          payload: { values, pipelineItemId },
+                          onSuccessDispatch: PIPELINE__ARCHIVE_ITEM,
+                        })
+                      }}
+                      showErrorSummary={false}
+                    >
+                      <br />
+                      <FieldTextarea
+                        label="Reason for archive"
+                        hint="Details on why you are archiving this project"
+                        name="reason"
+                        type="text"
+                        required="Enter the reason why you are archiving this project"
+                        className="govuk-!-width-two-thirds"
+                      />
+                      <FormActions>
+                        <Button>Archive project</Button>
+                        <Link href={getPipelineUrl(currentPipelineItem)}>
+                          Cancel
+                        </Link>
+                      </FormActions>
+                    </Form>
+                  </LoadingBox>
+                )}
+              </GetPipelineData>
+            )
+          }}
+        </Task>
+      </Main>
+    </>
   )
 }
 

--- a/src/apps/my-pipeline/client/DeletePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/DeletePipelineItemForm.jsx
@@ -10,9 +10,13 @@ import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import { SPACING } from '@govuk-react/constants'
 
+import urls from '../../../lib/urls'
 import Task from '../../../client/components/Task'
 import Form from '../../../client/components/Form'
 import { PIPELINE__DELETE_ITEM } from '../../../client/actions'
+
+import { Main } from '../../../client/components/'
+import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 
 import { ID as STATE_ID, TASK_DELETE_PIPELINE_ITEM, state2props } from './state'
 import { PipelineItemPropType } from './constants'
@@ -40,49 +44,66 @@ function DeletePipelineItemForm({
   }, [itemDeleted])
 
   return (
-    <Task>
-      {(getTask) => {
-        const deletePipelineItem = getTask(TASK_DELETE_PIPELINE_ITEM, STATE_ID)
+    <>
+      <LocalHeader
+        heading="Delete project"
+        breadcrumbs={[
+          { link: urls.dashboard(), text: 'Home' },
+          { link: urls.pipeline.index(), text: 'My Pipeline' },
+          { link: null, text: 'Delete project' },
+        ]}
+      />
+      <Main>
+        <Task>
+          {(getTask) => {
+            const deletePipelineItem = getTask(
+              TASK_DELETE_PIPELINE_ITEM,
+              STATE_ID
+            )
 
-        return (
-          <GetPipelineData
-            getTask={getTask}
-            pipelineItemId={pipelineItemId}
-            currentPipelineItem={currentPipelineItem}
-          >
-            {() => (
-              <LoadingBox loading={deletePipelineItem.progress}>
-                <StyledWarningText>
-                  Deleting this project will remove all project details from
-                  your pipeline.
-                </StyledWarningText>
-                <PipelineDetails item={currentPipelineItem}></PipelineDetails>
-                <Form
-                  id={STATE_ID}
-                  onSubmit={() => {
-                    deletePipelineItem.start({
-                      payload: {
-                        projectName: currentPipelineItem.name,
-                        pipelineItemId,
-                      },
-                      onSuccessDispatch: PIPELINE__DELETE_ITEM,
-                    })
-                  }}
-                  submissionError={deletePipelineItem.errorMessage}
-                >
-                  <FormActions>
-                    <Button buttonColour={RED}>Delete project</Button>
-                    <Link href={getPipelineUrl(currentPipelineItem)}>
-                      Cancel
-                    </Link>
-                  </FormActions>
-                </Form>
-              </LoadingBox>
-            )}
-          </GetPipelineData>
-        )
-      }}
-    </Task>
+            return (
+              <GetPipelineData
+                getTask={getTask}
+                pipelineItemId={pipelineItemId}
+                currentPipelineItem={currentPipelineItem}
+              >
+                {() => (
+                  <LoadingBox loading={deletePipelineItem.progress}>
+                    <StyledWarningText>
+                      Deleting this project will remove all project details from
+                      your pipeline.
+                    </StyledWarningText>
+                    <PipelineDetails
+                      item={currentPipelineItem}
+                    ></PipelineDetails>
+                    <Form
+                      id={STATE_ID}
+                      onSubmit={() => {
+                        deletePipelineItem.start({
+                          payload: {
+                            pipelineName: currentPipelineItem.name,
+                            pipelineItemId,
+                          },
+                          onSuccessDispatch: PIPELINE__DELETE_ITEM,
+                        })
+                      }}
+                      submissionError={deletePipelineItem.errorMessage}
+                    >
+                      <FormActions>
+                        <Button buttonColour={RED}>Delete project</Button>
+                        <Link href={getPipelineUrl(currentPipelineItem)}>
+                          Cancel
+                        </Link>
+                      </FormActions>
+                    </Form>
+                  </LoadingBox>
+                )}
+              </GetPipelineData>
+            )
+          }}
+        </Task>
+      </Main>
+    </>
   )
 }
 

--- a/src/apps/my-pipeline/client/DeletePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/DeletePipelineItemForm.jsx
@@ -81,7 +81,7 @@ function DeletePipelineItemForm({
                       onSubmit={() => {
                         deletePipelineItem.start({
                           payload: {
-                            pipelineName: currentPipelineItem.name,
+                            projectName: currentPipelineItem.name,
                             pipelineItemId,
                           },
                           onSuccessDispatch: PIPELINE__DELETE_ITEM,

--- a/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
@@ -8,16 +8,22 @@ import {
   PIPELINE__EDIT_ITEM,
   PIPELINE__GET_COMPANY_CONTACTS,
 } from '../../../client/actions'
+
 import {
   ID as STATE_ID,
   TASK_GET_PIPELINE_COMPANY_CONTACTS,
   TASK_EDIT_PIPELINE_ITEM,
 } from './state'
+
+import urls from '../../../lib/urls'
 import PipelineForm from './PipelineForm'
 import GetPipelineData from './GetPipelineData'
 import { PipelineItemPropType } from './constants'
 import { getPipelineUrl } from './utils'
 import moment from 'moment'
+
+import { Main } from '../../../client/components/'
+import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 
 function formatInitialValues(values) {
   const { sector, contacts } = values
@@ -70,59 +76,74 @@ function EditPipelineItemForm({
   }, [savedPipelineItem])
 
   return (
-    <Task>
-      {(getTask) => {
-        const editPipelineItem = getTask(TASK_EDIT_PIPELINE_ITEM, STATE_ID)
+    <>
+      <LocalHeader
+        heading="Edit project"
+        breadcrumbs={[
+          { link: urls.dashboard(), text: 'Home' },
+          { link: urls.pipeline.index(), text: 'My Pipeline' },
+          {
+            text: 'Edit project',
+          },
+        ]}
+      />
+      <Main>
+        <Task>
+          {(getTask) => {
+            const editPipelineItem = getTask(TASK_EDIT_PIPELINE_ITEM, STATE_ID)
 
-        const getCompanyContacts = getTask(
-          TASK_GET_PIPELINE_COMPANY_CONTACTS,
-          STATE_ID
-        )
-        return (
-          <>
-            <GetPipelineData
-              getTask={getTask}
-              pipelineItemId={pipelineItemId}
-              currentPipelineItem={currentPipelineItem}
-            >
-              {() => (
-                <GetCompanyContacts
-                  task={getCompanyContacts}
-                  companyId={currentPipelineItem.company.id}
+            const getCompanyContacts = getTask(
+              TASK_GET_PIPELINE_COMPANY_CONTACTS,
+              STATE_ID
+            )
+            return (
+              <>
+                <GetPipelineData
+                  getTask={getTask}
+                  pipelineItemId={pipelineItemId}
+                  currentPipelineItem={currentPipelineItem}
                 >
-                  <LoadingBox
-                    loading={
-                      getCompanyContacts.progress || editPipelineItem.progress
-                    }
-                  >
-                    <PipelineForm
-                      submissionError={editPipelineItem.errorMessage}
-                      onSubmit={(values) => {
-                        editPipelineItem.start({
-                          payload: {
-                            values,
-                            pipelineItemId,
-                            currentPipelineItem,
-                          },
-                          onSuccessDispatch: PIPELINE__EDIT_ITEM,
-                        })
-                      }}
-                      cancelLink={getPipelineUrl(currentPipelineItem)}
-                      initialValue={
-                        currentPipelineItem &&
-                        formatInitialValues(currentPipelineItem)
-                      }
-                      sectors={sectors}
-                      contacts={contacts}
-                    />
-                  </LoadingBox>
-                </GetCompanyContacts>
-              )}
-            </GetPipelineData>
-          </>
-        )
-      }}
-    </Task>
+                  {() => (
+                    <GetCompanyContacts
+                      task={getCompanyContacts}
+                      companyId={currentPipelineItem.company.id}
+                    >
+                      <LoadingBox
+                        loading={
+                          getCompanyContacts.progress ||
+                          editPipelineItem.progress
+                        }
+                      >
+                        <PipelineForm
+                          submissionError={editPipelineItem.errorMessage}
+                          onSubmit={(values) => {
+                            editPipelineItem.start({
+                              payload: {
+                                values,
+                                pipelineItemId,
+                                currentPipelineItem,
+                              },
+                              onSuccessDispatch: PIPELINE__EDIT_ITEM,
+                            })
+                          }}
+                          cancelLink={getPipelineUrl(currentPipelineItem)}
+                          initialValue={
+                            currentPipelineItem &&
+                            formatInitialValues(currentPipelineItem)
+                          }
+                          sectors={sectors}
+                          contacts={contacts}
+                        />
+                      </LoadingBox>
+                    </GetCompanyContacts>
+                  )}
+                </GetPipelineData>
+              </>
+            )
+          }}
+        </Task>
+      </Main>
+    </>
   )
 }
 

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
+
 import {
   FieldRadios,
   FormActions,
@@ -9,6 +10,7 @@ import {
   FieldTypeahead,
   FieldDate,
 } from 'data-hub-components'
+
 import Form from '../../../client/components/Form'
 import { ID as STATE_ID } from './state'
 import { STATUS_VALUES, LIKELIHOOD_VALUES } from './constants'

--- a/src/apps/my-pipeline/client/UnarchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/UnarchivePipelineItemForm.jsx
@@ -8,9 +8,13 @@ import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 import { SPACING } from '@govuk-react/constants'
 
+import urls from '../../../lib/urls'
 import Task from '../../../client/components/Task'
 import Form from '../../../client/components/Form'
 import { PIPELINE__UNARCHIVE_ITEM } from '../../../client/actions'
+
+import { Main } from '../../../client/components/'
+import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 
 import {
   ID as STATE_ID,
@@ -42,52 +46,66 @@ function UnarchivePipelineItemForm({
   }, [savedPipelineItem])
 
   return (
-    <Task>
-      {(getTask) => {
-        const unarchivePipelineItem = getTask(
-          TASK_UNARCHIVE_PIPELINE_ITEM,
-          STATE_ID
-        )
+    <>
+      <LocalHeader
+        heading="Unarchive project"
+        breadcrumbs={[
+          { link: urls.dashboard(), text: 'Home' },
+          { link: urls.pipeline.index(), text: 'My Pipeline' },
+          { link: null, text: 'Unarchive project' },
+        ]}
+      />
+      <Main>
+        <Task>
+          {(getTask) => {
+            const unarchivePipelineItem = getTask(
+              TASK_UNARCHIVE_PIPELINE_ITEM,
+              STATE_ID
+            )
 
-        return (
-          <GetPipelineData
-            getTask={getTask}
-            pipelineItemId={pipelineItemId}
-            currentPipelineItem={currentPipelineItem}
-          >
-            {() => (
-              <LoadingBox loading={unarchivePipelineItem.progress}>
-                <StyledP>
-                  Unarchiving this project will restore these project details in
-                  your pipeline.
-                </StyledP>
-                <PipelineDetails item={currentPipelineItem}></PipelineDetails>
-                <Form
-                  id={STATE_ID}
-                  onSubmit={() => {
-                    unarchivePipelineItem.start({
-                      payload: {
-                        projectName: currentPipelineItem.name,
-                        pipelineItemId,
-                      },
-                      onSuccessDispatch: PIPELINE__UNARCHIVE_ITEM,
-                    })
-                  }}
-                  submissionError={unarchivePipelineItem.errorMessage}
-                >
-                  <FormActions>
-                    <Button>Unarchive project</Button>
-                    <Link href={getPipelineUrl(currentPipelineItem)}>
-                      Cancel
-                    </Link>
-                  </FormActions>
-                </Form>
-              </LoadingBox>
-            )}
-          </GetPipelineData>
-        )
-      }}
-    </Task>
+            return (
+              <GetPipelineData
+                getTask={getTask}
+                pipelineItemId={pipelineItemId}
+                currentPipelineItem={currentPipelineItem}
+              >
+                {() => (
+                  <LoadingBox loading={unarchivePipelineItem.progress}>
+                    <StyledP>
+                      Unarchiving this project will restore these project
+                      details in your pipeline.
+                    </StyledP>
+                    <PipelineDetails
+                      item={currentPipelineItem}
+                    ></PipelineDetails>
+                    <Form
+                      id={STATE_ID}
+                      onSubmit={() => {
+                        unarchivePipelineItem.start({
+                          payload: {
+                            pipelineName: currentPipelineItem.name,
+                            pipelineItemId,
+                          },
+                          onSuccessDispatch: PIPELINE__UNARCHIVE_ITEM,
+                        })
+                      }}
+                      submissionError={unarchivePipelineItem.errorMessage}
+                    >
+                      <FormActions>
+                        <Button>Unarchive project</Button>
+                        <Link href={getPipelineUrl(currentPipelineItem)}>
+                          Cancel
+                        </Link>
+                      </FormActions>
+                    </Form>
+                  </LoadingBox>
+                )}
+              </GetPipelineData>
+            )
+          }}
+        </Task>
+      </Main>
+    </>
   )
 }
 

--- a/src/apps/my-pipeline/client/UnarchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/UnarchivePipelineItemForm.jsx
@@ -83,7 +83,7 @@ function UnarchivePipelineItemForm({
                       onSubmit={() => {
                         unarchivePipelineItem.start({
                           payload: {
-                            pipelineName: currentPipelineItem.name,
+                            projectName: currentPipelineItem.name,
                             pipelineItemId,
                           },
                           onSuccessDispatch: PIPELINE__UNARCHIVE_ITEM,

--- a/src/apps/my-pipeline/controllers/add.js
+++ b/src/apps/my-pipeline/controllers/add.js
@@ -1,22 +1,18 @@
-const urls = require('../../../lib/urls')
 const { getOptions } = require('../../../lib/options')
 
 async function renderAddToPipeline(req, res, next) {
   try {
     const { company } = res.locals
     const { token } = req.session
-    res
-      .breadcrumb(company.name, urls.companies.detail(company.id))
-      .breadcrumb('Add to your pipeline')
-      .render('my-pipeline/views/pipeline-form', {
-        heading: `Add ${company.name} to your pipeline`,
-        props: {
-          companyId: company.id,
-          companyName: company.name,
-          sectors: await getOptions(token, 'sector'),
-          contacts: company.contacts,
-        },
-      })
+
+    res.render('my-pipeline/views/pipeline-form', {
+      props: {
+        companyId: company.id,
+        companyName: company.name,
+        sectors: await getOptions(token, 'sector'),
+        contacts: company.contacts,
+      },
+    })
   } catch (e) {
     next(e)
   }

--- a/src/apps/my-pipeline/controllers/archive.js
+++ b/src/apps/my-pipeline/controllers/archive.js
@@ -2,8 +2,7 @@ async function renderArchivePipelineItem(req, res, next) {
   try {
     const { pipelineItemId } = req.params
 
-    res.breadcrumb('Archive project').render('my-pipeline/views/archive', {
-      heading: `Archive project`,
+    res.render('my-pipeline/views/archive', {
       props: {
         pipelineItemId,
       },

--- a/src/apps/my-pipeline/controllers/delete.js
+++ b/src/apps/my-pipeline/controllers/delete.js
@@ -1,8 +1,7 @@
 async function renderDeletePipelineItem(req, res) {
   const { pipelineItemId } = req.params
 
-  res.breadcrumb('Delete project').render('my-pipeline/views/delete', {
-    heading: `Delete project`,
+  res.render('my-pipeline/views/delete', {
     props: {
       pipelineItemId,
     },

--- a/src/apps/my-pipeline/controllers/edit.js
+++ b/src/apps/my-pipeline/controllers/edit.js
@@ -5,15 +5,12 @@ async function renderEditPipeline(req, res, next) {
     const { pipelineItemId } = req.params
     const { token } = req.session
 
-    res
-      .breadcrumb('Edit your pipeline')
-      .render('my-pipeline/views/pipeline-form', {
-        heading: `Edit your pipeline`,
-        props: {
-          pipelineItemId,
-          sectors: await getOptions(token, 'sector'),
-        },
-      })
+    res.render('my-pipeline/views/pipeline-form', {
+      props: {
+        pipelineItemId,
+        sectors: await getOptions(token, 'sector'),
+      },
+    })
   } catch (e) {
     next(e)
   }

--- a/src/apps/my-pipeline/controllers/unarchive.js
+++ b/src/apps/my-pipeline/controllers/unarchive.js
@@ -1,8 +1,7 @@
 async function renderUnarchivePipelineItem(req, res) {
   const { pipelineItemId } = req.params
 
-  res.breadcrumb('Unarchive project').render('my-pipeline/views/unarchive', {
-    heading: `Unarchive project`,
+  res.render('my-pipeline/views/unarchive', {
     props: {
       pipelineItemId,
     },

--- a/src/apps/my-pipeline/views/archive.njk
+++ b/src/apps/my-pipeline/views/archive.njk
@@ -1,6 +1,6 @@
-{% extends "_layouts/template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block body_main_content %}
+{% block body %}
 
   {% component 'react-slot', {
     id: 'archive-pipeline-item-form',

--- a/src/apps/my-pipeline/views/delete.njk
+++ b/src/apps/my-pipeline/views/delete.njk
@@ -1,6 +1,6 @@
-{% extends "_layouts/template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block body_main_content %}
+{% block body %}
 
   {% component 'react-slot', {
     id: 'delete-pipeline-item-form',

--- a/src/apps/my-pipeline/views/pipeline-form.njk
+++ b/src/apps/my-pipeline/views/pipeline-form.njk
@@ -1,6 +1,6 @@
-{% extends "_layouts/template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block body_main_content %}
+{% block body %}
 
   {% component 'react-slot', {
     id: 'pipeline-form',

--- a/src/apps/my-pipeline/views/unarchive.njk
+++ b/src/apps/my-pipeline/views/unarchive.njk
@@ -1,6 +1,6 @@
-{% extends "_layouts/template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block body_main_content %}
+{% block body %}
 
   {% component 'react-slot', {
     id: 'unarchive-pipeline-item-form',

--- a/src/client/components/Main/index.jsx
+++ b/src/client/components/Main/index.jsx
@@ -24,7 +24,12 @@ const InnerContainer = styled('div')({
 })
 
 const Main = ({ children, ...props }) => (
-  <OuterContainer {...props} role="main" id="main-content">
+  <OuterContainer
+    {...props}
+    role="main"
+    id="main-content"
+    data-auto-id="bodyMainContent"
+  >
     <InnerContainer>{children}</InnerContainer>
   </OuterContainer>
 )

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -29,7 +29,7 @@ describe('Company add to pipeline form', () => {
     })
 
     it('should render the heading', () => {
-      cy.get(selectors.localHeader().heading).should(
+      cy.get('[data-auto-id="localHeader"] h1').should(
         'have.text',
         `Add ${minimallyMinimal.name} to your pipeline`
       )
@@ -120,7 +120,7 @@ describe('Company add to pipeline form', () => {
     })
 
     it('should render the heading', () => {
-      cy.get(selectors.localHeader().heading).should(
+      cy.get('[data-auto-id="localHeader"] h1').should(
         'have.text',
         `Add ${lambdaPlc.name} to your pipeline`
       )

--- a/test/functional/cypress/specs/pipeline/my-pipeline-archive-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-archive-spec.js
@@ -23,9 +23,9 @@ function assertHeader() {
   })
 
   it('should render the heading', () => {
-    cy.get(selectors.localHeader().heading).should(
+    cy.get('[data-auto-id="localHeader"] h1').should(
       'have.text',
-      `Archive project`
+      'Archive project'
     )
   })
 }

--- a/test/functional/cypress/specs/pipeline/my-pipeline-delete-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-delete-spec.js
@@ -14,9 +14,9 @@ function assertHeader() {
   })
 
   it('should render the heading', () => {
-    cy.get(selectors.localHeader().heading).should(
+    cy.get('[data-auto-id="localHeader"] h1').should(
       'have.text',
-      `Delete project`
+      'Delete project'
     )
   })
 }

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
@@ -23,14 +23,14 @@ describe('Pipeline edit form', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
         'My Pipeline': urls.pipeline.index(),
-        'Edit your pipeline': null,
+        'Edit project': null,
       })
     })
 
     it('should render the heading', () => {
-      cy.get(selectors.localHeader().heading).should(
+      cy.get('[data-auto-id="localHeader"] h1').should(
         'have.text',
-        `Edit your pipeline`
+        'Edit project'
       )
     })
 
@@ -50,14 +50,14 @@ describe('Pipeline edit form', () => {
         assertBreadcrumbs({
           Home: urls.dashboard(),
           'My Pipeline': urls.pipeline.index(),
-          'Edit your pipeline': null,
+          'Edit project': null,
         })
       })
 
       it('should render the heading', () => {
-        cy.get(selectors.localHeader().heading).should(
+        cy.get('[data-auto-id="localHeader"] h1').should(
           'have.text',
-          `Edit your pipeline`
+          `Edit project`
         )
       })
 
@@ -137,14 +137,14 @@ describe('Pipeline edit form', () => {
         assertBreadcrumbs({
           Home: urls.dashboard(),
           'My Pipeline': urls.pipeline.index(),
-          'Edit your pipeline': null,
+          'Edit project': null,
         })
       })
 
       it('should render the heading', () => {
-        cy.get(selectors.localHeader().heading).should(
+        cy.get('[data-auto-id="localHeader"] h1').should(
           'have.text',
-          `Edit your pipeline`
+          'Edit project'
         )
       })
 

--- a/test/functional/cypress/specs/pipeline/my-pipeline-unarchive-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-unarchive-spec.js
@@ -14,9 +14,9 @@ function assertHeader() {
   })
 
   it('should render the heading', () => {
-    cy.get(selectors.localHeader().heading).should(
+    cy.get('[data-auto-id="localHeader"] h1').should(
       'have.text',
-      `Unarchive project`
+      'Unarchive project'
     )
   })
 }


### PR DESCRIPTION
## Description of change
The pipeline feature uses the old nunjucks header so we need to change it to React. Also there is a small content change do, When editing a project the breadcrumb and title should say "Edit project" not "Edit pipeline".

## Test instructions

Adding a project to a pipeline happens on the company page, you can then access your pipeline projects on the home page

1. Add a project to a pipeline- should work as before
2. Edit a project in a pipeline - you should see the content changes as above in description.
3. Delete a project in a pipeline- should work as before
4. Archive a project in a pipeline- should work as before
5. Unarchive a project in a pipeline- should work as before

## Screenshots

![Screenshot 2020-07-10 at 09 17 00](https://user-images.githubusercontent.com/10154302/87132679-22032f00-c28e-11ea-8453-14e06d0a255e.png)

![Screenshot 2020-07-10 at 09 12 10](https://user-images.githubusercontent.com/10154302/87132700-26c7e300-c28e-11ea-819e-d7cece6dc092.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
