### PR TITLE
Content changes to my pipelines

### DIFF
--- a/src/apps/companies/client/CompanyLocalHeader.jsx
+++ b/src/apps/companies/client/CompanyLocalHeader.jsx
@@ -142,7 +142,7 @@ const CompanyLocalHeader = ({
                 Add to or remove from lists
               </DropdownButton>
               <DropdownButton href={urls.companies.pipelineAdd(company.id)}>
-                Add to pipeline
+                Add to my pipeline
               </DropdownButton>
             </ConnectedDropdownMenu>
           </GridCol>

--- a/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
+import pluralize from 'pluralize'
+
 import ErrorSummary from '@govuk-react/error-summary'
 import { StatusMessage } from 'data-hub-components'
 import Task from '../../../client/components/Task'
@@ -16,7 +18,11 @@ import {
 } from './state'
 import urls from '../../../lib/urls'
 import PipelineForm from './PipelineForm'
-import { PipelineItemPropType, PipelineItemsPropType } from './constants'
+import {
+  PipelineItemPropType,
+  PipelineItemsPropType,
+  STATUS_VALUES,
+} from './constants'
 import { getPipelineUrl } from './utils'
 
 function isOnPipeline(pipelineStatus, companyId) {
@@ -56,9 +62,20 @@ function PipelineCheck({
     <>
       {onPipeline && (
         <StatusMessage>
-          This company is already in your pipeline.
+          You've already added this company to the following{' '}
+          {pluralize('projects', pipelineStatus.count, true)}:
           <br />
-          You can add it again under another project name.
+          <br />
+          <ul>
+            {pipelineStatus.results.map((project) => (
+              <li key={project.id}>
+                {project.name} -{' '}
+                {STATUS_VALUES.filter(
+                  (status) => status.value === project.status
+                ).map((status) => status.label)}
+              </li>
+            ))}
+          </ul>
         </StatusMessage>
       )}
       {children}

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -128,7 +128,7 @@ describe('Company add to pipeline form', () => {
 
     it('should render a message', () => {
       cy.contains(
-        'This company is already in your pipeline.You can add it again under another project name.'
+        "You've already added this company to the following 1 project:TEST - In progressTEST - all fields - To do"
       )
     })
 


### PR DESCRIPTION
## Description of change

This PR updates the 'View options' button dropdown content and, when adding a company to your pipeline that is already listed against another project, gives the user more information about which projects the company already exists on.

## Test instructions

Click on the 'View options' button on the company page to see the new content there. 

Add a company that is already on your pipeline to another project to see the status message with the enhanced information. 

## Screenshots
### Before

'More options' button
![image](https://user-images.githubusercontent.com/42253716/87283737-84a63600-c4ed-11ea-904b-e191223a5347.png)

Company already on pipeline status message
![image](https://user-images.githubusercontent.com/42253716/87283804-9ab3f680-c4ed-11ea-8490-d3c6466d4efa.png)

### After

'More options' button
![image](https://user-images.githubusercontent.com/42253716/87285989-2595f080-c4f0-11ea-8deb-2d487168438e.png)


Company already on pipeline status message
![image](https://user-images.githubusercontent.com/42253716/87284116-ec5c8100-c4ed-11ea-9eae-bb88d2f20b83.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
