### PR TITLE
remove apm from ci testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &postgres_version postgres:10
   - &mi_postgres_version postgres:9.6
   - &elasticsearch_version docker.elastic.co/elasticsearch/elasticsearch:6.8.2
-  - &api_image quay.io/uktrade/data-hub-api:feature_no-es-apm-uat
+  - &api_image quay.io/uktrade/data-hub-api:master
   - &frontend_testing_image ukti/data-hub-frontend-test:3.7.0
   - &oauth2_dit_staff_token ditStaffToken
   - &oauth2_da_staff_token daStaffToken

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,11 @@ aliases:
   - &postgres_version postgres:10
   - &mi_postgres_version postgres:9.6
   - &elasticsearch_version docker.elastic.co/elasticsearch/elasticsearch:6.8.2
-  - &api_image quay.io/uktrade/data-hub-api:master
+  - &api_image quay.io/uktrade/data-hub-api:feature_no-es-apm-uat
   - &frontend_testing_image ukti/data-hub-frontend-test:3.7.0
   - &oauth2_dit_staff_token ditStaffToken
   - &oauth2_da_staff_token daStaffToken
   - &oauth2_lep_staff_token lepStaffToken
-  - &es_apm docker.elastic.co/apm/apm-server:7.7.1
 
   - &wait_for_backend
     run:
@@ -134,11 +133,6 @@ aliases:
       - MOCK_SSO_SCOPE: 'data-hub:internal-front-end'
       - MOCK_SSO_TOKEN: 123
 
-  # Data hub backend Elasticsearch APM
-  - &docker_es_apm
-    image: *es_apm
-    name: es-apm
-    command: apm-server -e -E output.elasticsearch.hosts=["es:9200"]
 
   # Data hub backend
   - &docker_data_hub_backend_base
@@ -340,7 +334,6 @@ jobs:
           OAUTH2_DEV_TOKEN: *oauth2_dit_staff_token
       - *docker_redis
       - *docker_elasticsearch
-      - *docker_es_apm
       - *docker_postgres
       - *docker_mi_postgres
       - *docker_mock_sso
@@ -374,7 +367,6 @@ jobs:
           OAUTH2_DEV_TOKEN: *oauth2_lep_staff_token
       - *docker_redis
       - *docker_elasticsearch
-      - *docker_es_apm
       - *docker_postgres
       - *docker_mi_postgres
       - *docker_mock_sso
@@ -408,7 +400,6 @@ jobs:
           OAUTH2_DEV_TOKEN: *oauth2_da_staff_token
       - *docker_redis
       - *docker_elasticsearch
-      - *docker_es_apm
       - *docker_postgres
       - *docker_mi_postgres
       - *docker_mock_sso


### PR DESCRIPTION
## Description of change

Remove es-apm container for CI-test. This PR is dependant on the backend PR.
https://github.com/uktrade/data-hub-api/pull/3026

## Test instructions

All tests pass
