### PR TITLE
Change empty pipeline message and 'items' to 'projects' in count

### DIFF
--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -25,7 +25,6 @@ const StyledItemsCounter = styled('p')`
 
 const PipelineList = ({
   status,
-  statusText,
   lists,
   updateArchiveFilter,
   updateSort,
@@ -42,7 +41,7 @@ const PipelineList = ({
         {({ items, progress }) => (
           <>
             <StyledItemsCounter>
-              {pluralize('item', items.length, true)}
+              {pluralize('project', items.length, true)}
             </StyledItemsCounter>
             <StyledOrderedList data-auto-id="pipelineList">
               {items.length ? (
@@ -54,14 +53,16 @@ const PipelineList = ({
               ) : (
                 <LoadingBox loading={progress} timeIn={0} timeOut={400}>
                   <InsetText>
-                    There are no companies in the {statusText} section of your
-                    pipeline. You can add companies to your pipeline from the
-                    company page. To find out more{' '}
+                    My pipeline allows you to track the progress of your
+                    projects.
+                    <br />
+                    <br />
+                    For more information please see the{' '}
                     <Link href={urls.external.helpCentre.pipeline()}>
                       {' '}
-                      visit the help centre article on how to use My Pipeline
-                    </Link>
-                    .
+                      help centre article
+                    </Link>{' '}
+                    on how to use this feature.
                   </InsetText>
                 </LoadingBox>
               )}

--- a/src/client/components/Pipeline/index.jsx
+++ b/src/client/components/Pipeline/index.jsx
@@ -64,12 +64,7 @@ export default function Pipeline() {
       tabs={STATUS_VALUES.reduce((acc, status) => {
         acc[status.url()] = {
           label: status.label,
-          content: (
-            <PipelineList
-              status={status.value}
-              statusText={status.label.toLocaleLowerCase()}
-            />
-          ),
+          content: <PipelineList status={status.value} />,
         }
         return acc
       }, {})}

--- a/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/my-pipeline-spec.js
@@ -33,29 +33,21 @@ describe('My Pipeline tab on the dashboard', () => {
       const tabs = [
         {
           url: urls.pipeline.index(),
-          status: 'to do',
         },
         {
           url: urls.pipeline.active(),
-          status: 'in progress',
         },
         {
           url: urls.pipeline.won(),
-          status: 'done',
         },
       ]
 
       tabs.forEach((tab) => {
         cy.visit(tab.url)
-        cy.get(tabPanelSelector)
-          .should(
-            'contain',
-            `There are no companies in the ${tab.status} section of your pipeline`
-          )
-          .contains(
-            'a',
-            'visit the help centre article on how to use My Pipeline'
-          )
+        cy.contains(
+          'My pipeline allows you to track the progress of your projects.'
+        )
+          .contains('a', 'help centre article')
           .should('have.attr', 'href', urls.external.helpCentre.pipeline())
       })
     })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -171,7 +171,7 @@ describe('My pipeline app', () => {
     })
 
     it('should render the item counter', () => {
-      cy.contains('4 items')
+      cy.contains('4 projects')
     })
 
     context('should render the pipeline list', () => {
@@ -203,7 +203,7 @@ describe('My pipeline app', () => {
     })
 
     it('should render the item counter', () => {
-      cy.contains('3 items')
+      cy.contains('3 projects')
     })
 
     context('should render the pipeline list', () => {
@@ -235,7 +235,7 @@ describe('My pipeline app', () => {
     })
 
     it('should render the item counter', () => {
-      cy.contains('1 item')
+      cy.contains('1 project')
     })
 
     context('should render the pipeline list', () => {
@@ -302,7 +302,7 @@ describe('My pipeline app', () => {
     })
 
     it('should render the item counter with only non-archived items', () => {
-      cy.contains('4 items')
+      cy.contains('4 projects')
     })
 
     it('should render archived items', () => {
@@ -322,7 +322,7 @@ describe('My pipeline app', () => {
           return cy.wait('@pipelineGet')
         })
         .then(() => {
-          cy.contains('5 items')
+          cy.contains('5 projects')
         })
         .then(() => {
           expectedOutcomeList.forEach((expectedData, index) => {


### PR DESCRIPTION
## Description of change

Change empty pipeline message and 'items' to 'projects' in count

## Test instructions

Go to My pipeline and find a status with no projects in it. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/42253716/87672975-af9dbd80-c76b-11ea-92c8-1a8ec2649dd2.png)

### After

![image](https://user-images.githubusercontent.com/42253716/87672833-7a916b00-c76b-11ea-8358-5d2c25c74c8f.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
