### PR TITLE
Refactor/send business details

### DIFF
--- a/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
+++ b/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
@@ -8,21 +8,16 @@ import InsetText from '@govuk-react/inset-text'
 import ErrorSummary from '@govuk-react/error-summary'
 import Paragraph from '@govuk-react/paragraph'
 
+import LocalHeader from '../../../../../client/components/LocalHeader/LocalHeader.jsx'
+import { Main, SummaryList } from '../../../../../client/components/'
 import urls from '../../../../../lib/urls'
 import { WEBSITE_REGEX } from '../../add-company/client/constants'
 
-import {
-  FormStateful,
-  SummaryList,
-  FormActions,
-  FieldInput,
-} from 'data-hub-components'
+import { FormStateful, FormActions, FieldInput } from 'data-hub-components'
 
-const requiredWebsiteOrPhoneValidator = (
-  value,
-  name,
-  { values: { website, telephoneNumber } }
-) => {
+const requiredWebsiteOrPhoneValidator = ({
+  values: { website, telephoneNumber },
+}) => {
   return !website && !telephoneNumber ? 'Enter a website or phone number' : null
 }
 
@@ -42,70 +37,83 @@ async function onFormSubmit(values, csrfToken) {
 
 function CannotFindMatch({ company, csrfToken }) {
   return (
-    <FormStateful
-      initialValues={{
-        companyId: company.id,
-        address: company.address.join(', '),
-      }}
-      onSubmit={(values) => onFormSubmit(values, csrfToken)}
-    >
-      {({ submissionError }) => (
-        <>
-          {submissionError && (
-            <ErrorSummary
-              heading="There was an error submitting these details"
-              description={submissionError.message}
-              errors={[]}
-            />
+    <>
+      <LocalHeader
+        heading="I still can’t find what I’m looking for"
+        breadcrumbs={[
+          { link: urls.dashboard(), text: 'Home' },
+          { link: urls.companies.index(), text: 'Companies' },
+          { link: urls.companies.detail(company.id), text: company.name },
+          {
+            text: 'Send business details',
+          },
+        ]}
+      >
+        <Paragraph>
+          Add the company contact details below. It will be sent to our third
+          party data supplier for verification.
+        </Paragraph>
+      </LocalHeader>
+      <Main>
+        <FormStateful
+          initialValues={{
+            companyId: company.id,
+            address: company.address.join(', '),
+          }}
+          onSubmit={(values) => onFormSubmit(values, csrfToken)}
+        >
+          {({ submissionError }) => (
+            <>
+              {submissionError && (
+                <ErrorSummary
+                  heading="There was an error submitting these details"
+                  description={submissionError.message}
+                  errors={[]}
+                />
+              )}
+              <H4 as="h2">Data Hub business details (un-verified)</H4>
+              <InsetText>
+                <SummaryList
+                  rows={[
+                    { label: 'Company name', value: company.name },
+                    { label: 'Located at', value: company.address.join(', ') },
+                  ]}
+                />
+              </InsetText>
+              <H4 as="h2">Company contact information</H4>
+              <FieldInput
+                label="Website address"
+                name="website"
+                type="url"
+                validate={[requiredWebsiteOrPhoneValidator, websiteValidator]}
+              />
+              <FieldInput
+                label="Phone number"
+                hint="If the name or address on the company website is different to what there is in Data Hub, please provide the phone number, so the company can be contacted."
+                name="telephoneNumber"
+                type="tel"
+                validate={requiredWebsiteOrPhoneValidator}
+              />
+              <H4 as="h2">What happens next</H4>
+              <Paragraph>You don’t need to do anything else.</Paragraph>
+              <Paragraph>
+                Our third-party supplier will verify the company’s business
+                details directly, so make sure the details are correct and you
+                have consent to share them.
+              </Paragraph>
+              <Paragraph>
+                It will NOT change any recorded activity (interactions, OMIS
+                orders or Investment projects).
+              </Paragraph>
+              <FormActions>
+                <Button>Send</Button>
+                <Link href={urls.companies.match.index(company.id)}>Back</Link>
+              </FormActions>
+            </>
           )}
-          <H4 as="h2">Data Hub business details (un-verified)</H4>
-          <InsetText>
-            <SummaryList
-              rows={[
-                { label: 'Company name', value: company.name },
-                { label: 'Located at', value: company.address.join(', ') },
-              ]}
-            />
-          </InsetText>
-          <H4 as="h2">Contact details of the business for verification</H4>
-          <FieldInput
-            label="Company's website"
-            name="website"
-            type="url"
-            validate={[requiredWebsiteOrPhoneValidator, websiteValidator]}
-          />
-          <FieldInput
-            label="Company's telephone number"
-            hint="If the website of the business does not show the name and address
-              of the business as you want it to appear in Data Hub, it is important
-              to provide a valid phone number, so the company can be contacted when
-              verifying the business details."
-            name="telephoneNumber"
-            type="tel"
-            validate={requiredWebsiteOrPhoneValidator}
-          />
-          <H4 as="h2">What happens next</H4>
-          <Paragraph>
-            These business details will be sent to our third party data
-            suppliers, so it is important you have consent from the business to
-            share these details.
-          </Paragraph>
-          <Paragraph>
-            Our data suppliers might need to contact the company to verify the
-            details, so it is important that the website and phone number are
-            valid.
-          </Paragraph>
-          <Paragraph>
-            It will NOT change any recorded activity (interactions, OMIS orders
-            or Investment projects).
-          </Paragraph>
-          <FormActions>
-            <Button>Send</Button>
-            <Link href={urls.companies.match.index(company.id)}>Back</Link>
-          </FormActions>
-        </>
-      )}
-    </FormStateful>
+        </FormStateful>
+      </Main>
+    </>
   )
 }
 

--- a/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
+++ b/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
@@ -15,9 +15,11 @@ import { WEBSITE_REGEX } from '../../add-company/client/constants'
 
 import { FormStateful, FormActions, FieldInput } from 'data-hub-components'
 
-const requiredWebsiteOrPhoneValidator = ({
-  values: { website, telephoneNumber },
-}) => {
+const requiredWebsiteOrPhoneValidator = (
+  value,
+  name,
+  { values: { website, telephoneNumber } }
+) => {
   return !website && !telephoneNumber ? 'Enter a website or phone number' : null
 }
 

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -182,17 +182,15 @@ async function renderCannotFindMatch(req, res, next) {
     const { token } = req.session
     const countries = await getCountries(token)
 
-    res
-      .breadcrumb(company.name, urls.companies.detail(company.id))
-      .breadcrumb('Send business details')
-      .render('companies/apps/match-company/views/cannot-find-match', {
-        props: {
-          company: {
-            ...pick(company, ['id', 'name']),
-            address: parseAddress(company.address, countries),
-          },
+    res.locals.title = `Send business details - ${company.name}`
+    res.render('companies/apps/match-company/views/cannot-find-match', {
+      props: {
+        company: {
+          ...pick(company, ['id', 'name']),
+          address: parseAddress(company.address, countries),
         },
-      })
+      },
+    })
   } catch (error) {
     next(error)
   }

--- a/src/apps/companies/apps/match-company/views/cannot-find-match.njk
+++ b/src/apps/companies/apps/match-company/views/cannot-find-match.njk
@@ -1,15 +1,6 @@
-{% extends "_layouts/template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block local_header %}
-  {{
-    LocalHeader({
-      heading: "Send these business details to our third party data supplier for verification",
-      modifier: 'light-banner'
-    })
-  }}
-{% endblock %}
-
-{% block body_main_content %}
+{% block body %}
   {% component 'react-slot', {
     id: 'cannot-find-match',
     props: props

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -239,7 +239,7 @@ describe('Match a company', () => {
     () => {
       before(() => {
         cy.visit(urls.companies.match.cannotFind(fixtures.company.venusLtd.id))
-        cy.contains('button', 'Send').click()
+        cy.get('main button').click()
       })
 
       it('should display two error message', () => {

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -148,8 +148,9 @@ describe('Match a company', () => {
     })
 
     it('should render the header', () => {
-      assertLocalHeader(
-        'Send these business details to our third party data supplier for verification'
+      assertLocalHeader('I still can’t find what I’m looking for')
+      cy.get(selectors.localHeader().headingAfter).contains(
+        'Add the company contact details below. It will be sent to our third party data supplier for verification.'
       )
     })
 
@@ -178,13 +179,13 @@ describe('Match a company', () => {
     })
 
     it('should render the rest of the page', () => {
-      cy.contains('Contact details of the business for verification')
+      cy.contains('Company contact information')
         .and('match', 'h2')
         .next()
         .children()
         .should('have.length', 2)
         .first()
-        .should('have.text', "Company's website")
+        .should('have.text', 'Website address')
         .next()
         .find('input')
         .should('have.attr', 'type', 'url')
@@ -194,14 +195,11 @@ describe('Match a company', () => {
         .children()
         .should('have.length', 3)
         .first()
-        .should('have.text', "Company's telephone number")
+        .should('have.text', 'Phone number')
         .next()
         .should(
           'have.text',
-          'If the website of the business does not show the name and address of' +
-            ' the business as you want it to appear in Data Hub, it is important' +
-            ' to provide a valid phone number, so the company can be contacted' +
-            ' when verifying the business details.'
+          'If the name or address on the company website is different to what there is in Data Hub, please provide the phone number, so the company can be contacted.'
         )
         .next()
         .find('input')
@@ -212,24 +210,16 @@ describe('Match a company', () => {
         .should('have.text', 'What happens next')
         .and('match', 'h2')
         .next()
+        .should('have.text', 'You don’t need to do anything else.')
+        .next()
         .should(
           'have.text',
-          'These business details will be sent to our third party data' +
-            ' suppliers, so it is important you have consent from the' +
-            ' business to share these details.'
+          'Our third-party supplier will verify the company’s business details directly, so make sure the details are correct and you have consent to share them.'
         )
         .next()
         .should(
           'have.text',
-          'Our data suppliers might need to contact the company to verify the' +
-            ' details, so it is important that the website and phone number' +
-            ' are valid.'
-        )
-        .next()
-        .should(
-          'have.text',
-          'It will NOT change any recorded activity (interactions, OMIS orders' +
-            ' or Investment projects).'
+          'It will NOT change any recorded activity (interactions, OMIS orders or Investment projects).'
         )
         .next()
         .contains('Send')
@@ -253,13 +243,13 @@ describe('Match a company', () => {
       })
 
       it('should display two error message', () => {
-        cy.contains("Company's website")
+        cy.contains('Website address')
           .next()
           .children()
           .first()
           .should('have.text', 'Enter a website or phone number')
 
-        cy.contains("Company's telephone number")
+        cy.contains('Phone number')
           .next()
           .next()
           .children()
@@ -282,12 +272,12 @@ describe('Match a company', () => {
       })
 
       it('should submit both fields', () => {
-        cy.contains("Company's website")
+        cy.contains('Website address')
           .next()
           .find('input')
           .type('01185673456')
 
-        cy.contains("Company's telephone number")
+        cy.contains('Phone number')
           .next()
           .next()
           .find('input')

--- a/test/selectors/local-header.js
+++ b/test/selectors/local-header.js
@@ -2,8 +2,8 @@ module.exports = () => {
   const localHeaderSelector = '[data-auto-id="localHeader"]'
   return {
     metaList: `${localHeaderSelector} .c-meta-list`,
-    heading: `${localHeaderSelector} h1.c-local-header__heading`,
-    headingAfter: `${localHeaderSelector} p.c-local-header__heading-after`,
+    heading: `${localHeaderSelector} h1`,
+    headingAfter: `${localHeaderSelector} p`,
     badge: (number) =>
       `${localHeaderSelector} span.c-badge:nth-child(${number})`,
     description: {


### PR DESCRIPTION
## Description of change

This is just some content changes around the unhappy path when try to send business details.

## Test instructions

1. Go to a company page and replace the url '/activity' to '/match/cannot-find'
2. Compare the form with the one that displays in dev or just refer to the screenshots below.

## Screenshots
![Screenshot 2020-07-17 at 13 01 05](https://user-images.githubusercontent.com/10154302/87784648-9b6ec480-c82e-11ea-9786-3a929cc5e3b3.png)

### After
![Screenshot 2020-07-17 at 13 00 24](https://user-images.githubusercontent.com/10154302/87784673-a590c300-c82e-11ea-9a1d-4fe93899bd0d.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
