### PR TITLE
Move and update the SummaryList component from DH Components

### DIFF
--- a/src/client/components/SummaryList/__stories__/SummaryList.stories.jsx
+++ b/src/client/components/SummaryList/__stories__/SummaryList.stories.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import SummaryList from 'SummaryList'
+import exampleReadme from '../example.md'
+import usageReadme from '../usage.md'
+
+const rows = [
+  { label: 'Registered company name', value: 'Example Ltd' },
+  { label: 'Trading name(s)', value: 'Examples & Tests' },
+  {
+    label: 'Located at',
+    value:
+      '99 Loooooooooooooooooooooooooong name Street, London, SE1 456, United Kingdom',
+  },
+  {
+    label: 'Registered address',
+    value: '123 Fake Road, London, SE1 123, United Kingdom',
+  },
+]
+
+storiesOf('SummaryList', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => <SummaryList rows={rows} />)

--- a/src/client/components/SummaryList/example.md
+++ b/src/client/components/SummaryList/example.md
@@ -1,0 +1,6 @@
+### Import
+```js
+import SummaryList from 'SummaryList'
+```
+
+### Output

--- a/src/client/components/SummaryList/index.jsx
+++ b/src/client/components/SummaryList/index.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { isEmpty } from 'lodash'
+import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+const StyledInnerRow = styled('div')`
+  padding: ${SPACING.SCALE_2} 0;
+
+  ${MEDIA_QUERIES.TABLET} {
+    display: inline-flex;
+  }
+`
+
+const StyledDL = styled('dl')`
+  ${MEDIA_QUERIES.TABLET} {
+    display: flex;
+    flex-direction: column;
+  }
+`
+
+const StyledDT = styled('dt')`
+  padding-right: ${SPACING.SCALE_4};
+  width: 30%;
+  font-weight: bold;
+`
+
+const StyledDD = styled('dd')`
+  width: 70%;
+`
+
+const SummaryList = ({ rows, ...rest }) =>
+  rows ? (
+    <StyledDL {...rest}>
+      {rows
+        .filter((r) => !isEmpty(r) && !isEmpty(r.value))
+        .map(({ label, value }) => (
+          <StyledInnerRow key={label}>
+            <StyledDT>{label}</StyledDT>
+            <StyledDD>
+              {Array.isArray(value) ? value.join(', ') : value}
+            </StyledDD>
+          </StyledInnerRow>
+        ))}
+    </StyledDL>
+  ) : null
+
+SummaryList.propTypes = {
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.node,
+      value: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.arrayOf(PropTypes.node),
+      ]),
+    })
+  ),
+}
+
+SummaryList.defaultProps = {
+  rows: null,
+}
+
+export default SummaryList

--- a/src/client/components/SummaryList/usage.md
+++ b/src/client/components/SummaryList/usage.md
@@ -1,0 +1,22 @@
+SummaryList
+=========
+
+### Description
+
+A styled version of a description list, with terms and descriptions.
+
+### Usage
+
+```jsx
+  <SummaryList rows={[
+  { label: 'Company name', value: 'Example Ltd' },
+  { label: 'Trading name', value: 'Examples & Tests' },
+]}>
+```
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `rows` | false | null | array | Items to display in the list
+
+

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -1,2 +1,3 @@
 export { default as Panel } from './Panel'
 export { default as Main } from './Main'
+export { default as SummaryList } from './SummaryList'


### PR DESCRIPTION
## Description of change
As I need to style the `SummaryList` component for the PR #2830 we decided to port the component over to the FE as we are slowly porting all components over to the FE.

## Test instructions
1. Run Storybook and you should see the `SummaryList` component in the left navigation

There are two changes to the component.

1. I now forward the `...rest` props, so if we need to extend the styles we can now use Styled components as before we were limiting it to deconstruct only "rows" which means styles could not get forwarded. 

2. I have added the remaining width to the `dd` tags as if we had a long data in that tag the alignment was off (see attached).

## Screenshots
### Before
![Screenshot 2020-07-20 at 14 30 18](https://user-images.githubusercontent.com/10154302/87944133-e68b1080-ca96-11ea-863f-1ef44c0b4258.png)

### After
![Screenshot 2020-07-20 at 14 30 30](https://user-images.githubusercontent.com/10154302/87944153-edb21e80-ca96-11ea-847b-ab35945f14f3.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
