### PR TITLE
Move CollectionList into Datahub

### DIFF
--- a/src/apps/companies/apps/dnb-hierarchy/client/DnbHierarchy.jsx
+++ b/src/apps/companies/apps/dnb-hierarchy/client/DnbHierarchy.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useSearchParam } from 'react-use'
-import { CollectionList } from 'data-hub-components'
+import { CollectionList } from '../../../../../client/components/'
 import axios from 'axios'
 import { Details, LoadingBox } from 'govuk-react'
 

--- a/src/apps/companies/apps/exports/client/ExportWins/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportWins/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { SPACING } from '@govuk-react/constants'
-import { CollectionList } from 'data-hub-components'
+import { CollectionList } from '../../../../../../client/components/'
 
 import { connect } from 'react-redux'
 import Task from '../../../../../../client/components/Task/index.jsx'

--- a/src/apps/companies/apps/exports/client/ExportsHistory/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsHistory/index.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { H2 } from '@govuk-react/heading'
 import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
 import InsetText from '@govuk-react/inset-text'
-import { CollectionList } from 'data-hub-components'
+import { CollectionList } from '../../../../../../client/components/'
 import { connect } from 'react-redux'
 
 import Task from '../../../../../../client/components/Task/index.jsx'

--- a/src/apps/investments/client/LargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/LargeCapitalProfileCollection.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import { useSearchParam } from 'react-use'
-import { CollectionList } from 'data-hub-components'
+import { CollectionList } from '../../../client/components/'
 import LoadingBox from '@govuk-react/loading-box'
 import ErrorSummary from '@govuk-react/error-summary'
 import { investments } from '../../../lib/urls'

--- a/src/client/components/CollectionList/CollectionDownload.jsx
+++ b/src/client/components/CollectionList/CollectionDownload.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import pluralize from 'pluralize'
+import { MEDIA_QUERIES } from '@govuk-react/constants'
+import Button from '@govuk-react/button'
+import CollectionHeaderRow from './CollectionHeaderRow'
+import MAX_ITEMS_TO_DOWNLOAD from './constants'
+
+const StyledInnerText = styled('div')`
+  width: 100%;
+  line-height: 36px;
+  ${MEDIA_QUERIES.TABLET} {
+    width: 0;
+    flex-grow: 1;
+  }
+`
+
+const StyledButton = styled(Button)`
+  margin-bottom: 0;
+`
+
+function getInnerText(totalItems, itemName) {
+  const itemPlural = pluralize.plural(itemName)
+  const itemPluralWithCount = pluralize(itemName, totalItems, true)
+
+  if (totalItems === 0) {
+    return `There are no ${itemPlural} to download`
+  } else if (totalItems <= MAX_ITEMS_TO_DOWNLOAD) {
+    return `You can now download ${itemPluralWithCount}`
+  } else {
+    return `Filter to fewer than ${MAX_ITEMS_TO_DOWNLOAD} ${itemPlural} to download`
+  }
+}
+
+function CollectionDownload({ totalItems, itemName, downloadUrl }) {
+  if (!downloadUrl) {
+    return null
+  }
+
+  const canDownload = totalItems > 0 && totalItems <= MAX_ITEMS_TO_DOWNLOAD
+  const innerText = getInnerText(totalItems, itemName)
+  const actions = canDownload && (
+    <StyledButton href={downloadUrl}>Download</StyledButton>
+  )
+
+  return (
+    <CollectionHeaderRow actions={actions}>
+      <StyledInnerText>{innerText}</StyledInnerText>
+    </CollectionHeaderRow>
+  )
+}
+
+CollectionDownload.propTypes = {
+  totalItems: PropTypes.number.isRequired,
+  itemName: PropTypes.string.isRequired,
+  downloadUrl: PropTypes.string,
+}
+
+CollectionDownload.defaultProps = {
+  downloadUrl: null,
+}
+
+export default CollectionDownload

--- a/src/client/components/CollectionList/CollectionHeader.jsx
+++ b/src/client/components/CollectionList/CollectionHeader.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Button from '@govuk-react/button'
+import styled from 'styled-components'
+import pluralize from 'pluralize'
+import { H2 } from '@govuk-react/heading'
+import { BLACK, GREY_3 } from 'govuk-colours'
+import { HEADING_SIZES } from '@govuk-react/constants'
+import CollectionHeaderRow from './CollectionHeaderRow'
+
+const { NumberUtils } = require('data-hub-components')
+
+const StyledHeaderText = styled(H2)`
+  margin-top: 0;
+  font-weight: normal;
+  font-size: ${HEADING_SIZES.MEDIUM}px;
+  margin-bottom: 0;
+`
+
+const StyledLink = styled.a`
+  margin-bottom: 0;
+`
+
+const StyledResultCount = styled('span')`
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 1;
+`
+
+function CollectionHeader({ totalItems, itemName, addItemUrl }) {
+  const formattedTotal = NumberUtils.decimal(totalItems)
+  const counterSuffix = pluralize(itemName, totalItems)
+
+  const actions = addItemUrl && (
+    <Button
+      as={StyledLink}
+      href={addItemUrl}
+      buttonColour={GREY_3}
+      buttonTextColour={BLACK}
+    >
+      Add {itemName}
+    </Button>
+  )
+
+  return (
+    <CollectionHeaderRow primary={true} actions={actions}>
+      <StyledHeaderText>
+        <StyledResultCount>{formattedTotal}</StyledResultCount>
+        {` ${counterSuffix}`}
+      </StyledHeaderText>
+    </CollectionHeaderRow>
+  )
+}
+
+CollectionHeader.propTypes = {
+  totalItems: PropTypes.number.isRequired,
+  itemName: PropTypes.string.isRequired,
+  addItemUrl: PropTypes.string,
+}
+
+CollectionHeader.defaultProps = {
+  addItemUrl: null,
+}
+
+export default CollectionHeader

--- a/src/client/components/CollectionList/CollectionHeaderRow.jsx
+++ b/src/client/components/CollectionList/CollectionHeaderRow.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { BLACK, GREY_2 } from 'govuk-colours'
+import { FONT_SIZE, MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
+
+const StyledRowWrapper = styled('div')`
+  display: flex;
+  flex-flow: row wrap;
+  font-size: ${FONT_SIZE.SIZE_16};
+  padding: ${SPACING.SCALE_2} 0;
+  border-bottom: ${({ primary }) =>
+    primary ? `${SPACING.SCALE_1} solid ${BLACK}` : `1px solid ${GREY_2}`};
+`
+
+const StyledActions = styled('div')`
+  text-align: right;
+  width: 100%;
+  ${MEDIA_QUERIES.TABLET} {
+    width: 0;
+    flex-grow: 1;
+  }
+`
+
+function CollectionHeaderRow({ primary, actions, children }) {
+  return (
+    <StyledRowWrapper primary={primary}>
+      {children}
+
+      {actions && <StyledActions>{actions}</StyledActions>}
+    </StyledRowWrapper>
+  )
+}
+
+CollectionHeaderRow.propTypes = {
+  primary: PropTypes.bool,
+  actions: PropTypes.node,
+  children: PropTypes.node.isRequired,
+}
+
+CollectionHeaderRow.defaultProps = {
+  primary: false,
+  actions: null,
+}
+
+export default CollectionHeaderRow

--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import styled from 'styled-components'
+import { H3 } from '@govuk-react/heading'
+import Link from '@govuk-react/link'
+import { HEADING_SIZES, SPACING } from '@govuk-react/constants'
+import { GREY_2 } from 'govuk-colours'
+import Details from '@govuk-react/details'
+
+const { Badge, Metadata } = require('data-hub-components')
+
+const ItemWrapper = styled('div')`
+  border-bottom: 1px solid ${GREY_2};
+  padding: ${SPACING.SCALE_3} 0;
+`
+
+const StyledBadgesWrapper = styled('div')`
+  float: right;
+  & > * {
+    margin-right: ${SPACING.SCALE_1};
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+`
+
+const StyledHeader = styled(H3)`
+  font-size: ${HEADING_SIZES.SMALL}px;
+`
+
+const StyledLinkHeader = styled(StyledHeader)`
+  & > a:link,
+  a:visited,
+  a:hover,
+  a:active {
+    text-decoration: none;
+  }
+`
+
+const StyledSubheading = styled('h4')`
+  font-size: 14px;
+  line-height: 20px;
+  color: #6f777b;
+  font-weight: normal;
+  margin: -${SPACING.SCALE_3} 0 ${SPACING.SCALE_2} 0;
+`
+
+const StyledDetails = styled(Details)`
+  margin: ${SPACING.SCALE_3} 0 0 0;
+`
+
+function CollectionItem({
+  headingUrl,
+  headingText,
+  subheading,
+  badges,
+  metadata,
+  type,
+}) {
+  const summaryMessage = type ? `View ${type} details` : 'View details'
+
+  return (
+    <ItemWrapper>
+      {badges && (
+        <StyledBadgesWrapper>
+          {badges.map((badge) => (
+            <Badge key={badge.text} borderColour={badge.borderColour}>
+              {badge.text}
+            </Badge>
+          ))}
+        </StyledBadgesWrapper>
+      )}
+
+      {headingUrl ? (
+        <StyledLinkHeader>
+          <Link href={headingUrl}>{headingText}</Link>
+        </StyledLinkHeader>
+      ) : (
+        <StyledHeader>{headingText}</StyledHeader>
+      )}
+
+      <StyledSubheading>{subheading}</StyledSubheading>
+
+      {metadata && metadata.length > 4 ? (
+        <>
+          <StyledDetails summary={summaryMessage}>
+            <Metadata rows={metadata} />
+          </StyledDetails>
+        </>
+      ) : (
+        <Metadata rows={metadata} />
+      )}
+    </ItemWrapper>
+  )
+}
+
+CollectionItem.propTypes = {
+  headingUrl: PropTypes.string,
+  headingText: PropTypes.string.isRequired,
+  subheading: PropTypes.string,
+  badges: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      borderColour: PropTypes.string,
+    })
+  ),
+  metadata: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.node.isRequired,
+    })
+  ),
+  type: PropTypes.string,
+}
+
+CollectionItem.defaultProps = {
+  badges: null,
+  subheading: null,
+  metadata: null,
+  headingUrl: null,
+  type: null,
+}
+
+export default CollectionItem

--- a/src/client/components/CollectionList/__fixtures__/capitalProfileItem.json
+++ b/src/client/components/CollectionList/__fixtures__/capitalProfileItem.json
@@ -1,0 +1,18 @@
+{
+  "headingText": "Mars Exports Ltd",
+  "headingUrl": "https://example.com/profile/1",
+  "subheading": "Updated on 1 Nov 2019",
+  "metadata": [
+    {
+      "label": "Sector",
+      "value": "Finance"
+    },
+    {
+      "label": "Address",
+      "value": "123 Random Street, Lucky City"
+    }
+  ],
+  "badges": [
+    {"text": "United States"}
+  ]
+}

--- a/src/client/components/CollectionList/__fixtures__/capitalProfiles.json
+++ b/src/client/components/CollectionList/__fixtures__/capitalProfiles.json
@@ -1,0 +1,248 @@
+[
+  {
+    "headingText": "Mars Exports Ltd",
+    "headingUrl": "https://example.com/item/1",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      },
+      {
+        "text": "Global HQ"
+      }
+    ]
+  },
+  {
+    "headingText": "Stage One Boutique",
+    "headingUrl": "https://example.com/item/2",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "999 Old Fake Road, New York, NY 123"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United States"
+      }
+    ]
+  },
+  {
+    "headingText": "Onet Technologies",
+    "headingUrl": "https://example.com/item/3",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "13 Unlucky Street, Miami, MI 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United States"
+      }
+    ]
+  },
+  {
+    "headingText": "Lambda plc",
+    "headingUrl": "https://example.com/item/4",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  },
+  {
+    "headingText": "One List Corp",
+    "headingUrl": "https://example.com/item/5",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      },
+      {
+        "text": "Global HQ"
+      }
+    ]
+  },
+  {
+    "headingText": "Angel syndicate",
+    "headingUrl": "https://example.com/item/6",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  },
+  {
+    "headingText": "Venus Ltd",
+    "headingUrl": "https://example.com/item/7",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  },
+  {
+    "headingText": "A1 BMW LTD",
+    "headingUrl": "https://example.com/item/8",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  },
+  {
+    "headingText": "Bargainworld",
+    "headingUrl": "https://example.com/item/9",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  },
+  {
+    "headingText": "JOHN LEWIS PLC",
+    "headingUrl": "https://example.com/item/10",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  },
+  {
+    "headingText": "JOHN LEWIS LTD",
+    "headingUrl": "https://example.com/item/10",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  },
+  {
+    "headingText": "M&S",
+    "headingUrl": "https://example.com/item/10",
+    "subheading": "Updated on 5 September 2019",
+    "metadata": [
+      {
+        "label": "Sector",
+        "value": "Environment"
+      },
+      {
+        "label": "Address",
+        "value": "20 New Fake Road, Bristol, B11 9QC"
+      }
+    ],
+    "badges": [
+      {
+        "text": "United Kingdom"
+      }
+    ]
+  }
+]

--- a/src/client/components/CollectionList/__fixtures__/interactionItem.json
+++ b/src/client/components/CollectionList/__fixtures__/interactionItem.json
@@ -1,0 +1,32 @@
+{
+  "headingText": "Leadership Academy",
+  "headingUrl": "https://example.com/interaction/1",
+  "metadata": [
+    {
+      "label": "Date",
+      "value": "1 February 2022"
+    },
+    {
+      "label": "Contact(s)",
+      "value": "Ned Neddington"
+    },
+    {
+      "label": "Company",
+      "value": "Ministry of Funny Walks"
+    },
+    {
+      "label": "Adviser(s)",
+      "value": "Bob Bobbington, British Embassy Cairo Egypt"
+    },
+    {
+      "label": "Service",
+      "value": "Making Export Introductions : Business Partners (e.g. distributors or manufacturers"
+    }
+  ],
+  "badges": [
+    {
+      "text": "Interaction",
+      "borderColour": "rgb(0, 100, 53)"
+    }
+  ]
+}

--- a/src/client/components/CollectionList/__stories__/CollectionDownload.stories.jsx
+++ b/src/client/components/CollectionList/__stories__/CollectionDownload.stories.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import CollectionDownload from '../CollectionDownload'
+
+const collectionStories = storiesOf('Collection', module)
+
+collectionStories.add('Collection Download - no items', () => (
+  <CollectionDownload totalItems={0} itemName="profile" downloadUrl="#" />
+))
+
+collectionStories.add('Collection Download - 1 item', () => (
+  <CollectionDownload totalItems={1} itemName="profile" downloadUrl="#" />
+))
+
+collectionStories.add('Collection Download - 101 items', () => (
+  <CollectionDownload totalItems={101} itemName="profile" downloadUrl="#" />
+))
+
+collectionStories.add('Collection Download - need to filter', () => (
+  <CollectionDownload totalItems={5001} itemName="profile" downloadUrl="#" />
+))

--- a/src/client/components/CollectionList/__stories__/CollectionHeader.stories.jsx
+++ b/src/client/components/CollectionList/__stories__/CollectionHeader.stories.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import CollectionHeader from '../CollectionHeader'
+
+const collectionStories = storiesOf('Collection', module)
+
+collectionStories.add('Collection Header', () => (
+  <CollectionHeader
+    totalItems={1}
+    itemName="profile"
+    addItemText="#"
+    addItemUrl="#"
+  />
+))
+
+collectionStories.add('Collection Header', () => (
+  <CollectionHeader totalItems={1} itemName="profile" addItemUrl="#" />
+))

--- a/src/client/components/CollectionList/__stories__/CollectionItem.stories.jsx
+++ b/src/client/components/CollectionList/__stories__/CollectionItem.stories.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import CollectionItem from '../CollectionItem'
+
+import capitalProfileItem from '../__fixtures__/capitalProfileItem.json'
+import interactionItem from '../__fixtures__/interactionItem.json'
+
+const collectionStories = storiesOf('Collection', module)
+
+collectionStories.add('Capital Profile item', () => (
+  <CollectionItem {...capitalProfileItem} />
+))
+
+collectionStories.add('Interaction item', () => (
+  <CollectionItem {...interactionItem} type="interaction" />
+))
+
+collectionStories.add('Item without link', () => (
+  <CollectionItem
+    headingText={capitalProfileItem.headingText}
+    subheading={capitalProfileItem.subheading}
+    badges={capitalProfileItem.badges}
+    metadata={capitalProfileItem.metadata}
+  />
+))

--- a/src/client/components/CollectionList/__stories__/CollectionList.stories.jsx
+++ b/src/client/components/CollectionList/__stories__/CollectionList.stories.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import CollectionList from 'CollectionList'
+
+import profilesFixture from '../__fixtures__/capitalProfiles.json'
+
+const collectionStories = storiesOf('Collection', module)
+
+const CollectionWithState = () => {
+  const [activePage, setActivePage] = useState(1)
+
+  const index = activePage - 1
+  const offset = index * 10
+  const limit = (index + 1) * 10
+
+  const items = profilesFixture.slice(offset, limit)
+
+  return (
+    <CollectionList
+      items={items}
+      onPageClick={(page, event) => {
+        setActivePage(page)
+        event.preventDefault()
+      }}
+      activePage={activePage}
+      totalItems={profilesFixture.length}
+      itemName="profile"
+      addItemUrl="http://example.com"
+      downloadUrl="http://example.com"
+    />
+  )
+}
+
+collectionStories.add('Collection List', () => <CollectionWithState />)
+
+collectionStories.add('Collection List with 0 items', () => (
+  <CollectionList totalItems={0} itemName="results" />
+))

--- a/src/client/components/CollectionList/constants.js
+++ b/src/client/components/CollectionList/constants.js
@@ -1,0 +1,3 @@
+const MAX_ITEMS_TO_DOWNLOAD = 5000
+
+export default MAX_ITEMS_TO_DOWNLOAD

--- a/src/client/components/CollectionList/index.jsx
+++ b/src/client/components/CollectionList/index.jsx
@@ -1,0 +1,91 @@
+/* eslint-disable react/no-array-index-key */
+// this is because there isn't necessarily a unique id to use as the key
+
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import CollectionHeader from './CollectionHeader'
+import CollectionDownload from './CollectionDownload'
+import CollectionItem from './CollectionItem'
+
+const { Pagination } = require('data-hub-components')
+
+function CollectionList({
+  totalItems,
+  itemName,
+  addItemUrl,
+  downloadUrl,
+  items,
+  onPageClick,
+  getPageUrl,
+  activePage,
+  itemsPerPage,
+}) {
+  const totalPages = Math.ceil(totalItems / itemsPerPage)
+
+  return (
+    <>
+      <CollectionHeader
+        totalItems={totalItems}
+        itemName={itemName}
+        addItemUrl={addItemUrl}
+      />
+
+      <CollectionDownload
+        totalItems={totalItems}
+        itemName={itemName}
+        downloadUrl={downloadUrl}
+      />
+
+      {items.map(
+        (
+          { headingText, headingUrl, subheading, badges, metadata, type },
+          index
+        ) => (
+          <CollectionItem
+            key={[totalItems, activePage, index].join('-')}
+            headingUrl={headingUrl}
+            headingText={headingText}
+            subheading={subheading}
+            badges={badges}
+            metadata={metadata}
+            type={type}
+          />
+        )
+      )}
+
+      <Pagination
+        totalPages={totalPages}
+        activePage={activePage}
+        onPageClick={onPageClick}
+        getPageUrl={getPageUrl}
+      />
+    </>
+  )
+}
+
+CollectionList.propTypes = {
+  totalItems: PropTypes.number,
+  itemName: PropTypes.string,
+  addItemUrl: PropTypes.string,
+  downloadUrl: PropTypes.string,
+  items: PropTypes.array,
+  onPageClick: PropTypes.func,
+  getPageUrl: PropTypes.func,
+  activePage: PropTypes.number,
+  itemsPerPage: PropTypes.number,
+}
+
+CollectionList.defaultProps = {
+  totalItems: 0,
+  itemName: 'result',
+  addItemUrl: null,
+  downloadUrl: null,
+  items: [],
+  onPageClick: null,
+  getPageUrl: (page) => `#page-${page}`,
+  activePage: 1,
+  itemsPerPage: 10,
+}
+
+export default CollectionList

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -1,3 +1,4 @@
 export { default as Panel } from './Panel'
 export { default as Main } from './Main'
 export { default as SummaryList } from './SummaryList'
+export { default as CollectionList } from './CollectionList'


### PR DESCRIPTION
## Description of change
 
(1) This is a small PR that moves the CollectionList files from Storybook over to DataHub. Tests have not been carried over yet (hence the poor codecov score), as we need to implement Jest into DH - however this is pending on another ticket. 

## Test instructions

Thanks to Dave, you can now run `npm run storybook` which should successfully bring up Storybook on your browser. navigate to the CollectionList component, and you should see everything working as expected. 


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
