### PR TITLE
Move AddressSearch into Datahub

### DIFF
--- a/src/client/components/AddressSearch/__fixtures__/address-search-SW1H 9AJ.json
+++ b/src/client/components/AddressSearch/__fixtures__/address-search-SW1H 9AJ.json
@@ -1,0 +1,58 @@
+[
+  {
+    "county": "Greater London",
+    "city": "London",
+    "address1": "D S D Ltd -  102 Petty France",
+    "address2": "Westminster",
+    "postcode": "SW1H 9AJ",
+    "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  {
+    "county": "Greater London",
+    "city": "London",
+    "address1": "DESIGN102 -  102 Petty France",
+    "address2": "Westminster",
+    "postcode": "SW1H 9AJ",
+    "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  {
+    "county": "Greater London",
+    "city": "London",
+    "address1": "Her Majesty’s Courts and Tribunals Service -  102 Petty France",
+    "address2": "Westminster",
+    "postcode": "SW1H 9AJ",
+    "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  {
+    "county": "Greater London",
+    "city": "London",
+    "address1": "Judicial Appointments Commission -  102 Petty France",
+    "address2": "Westminster",
+    "postcode": "SW1H 9AJ",
+    "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  {
+    "county": "Greater London",
+    "city": " London",
+    "address1": "Legal Aid Agency (London) -  102 Petty France",
+    "address2": "Westminster",
+    "postcode": "SW1H 9AJ",
+    "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  {
+    "county": " ",
+    "city": "London",
+    "address1": "Ministry of Justice",
+    "address2": "102 Petty France",
+    "postcode": "SW1H 9AJ",
+    "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  {
+    "county": "Greater London",
+    "city": "London",
+    "address1": "National Probation Service -  102 Petty France",
+    "address2": "Westminster",
+    "postcode": "SW1H 9AJ",
+    "country": "80756b9a-5d95-e211-a939-e4115bead28a"
+  }
+]

--- a/src/client/components/AddressSearch/__mocks__/postcode-lookup.js
+++ b/src/client/components/AddressSearch/__mocks__/postcode-lookup.js
@@ -1,0 +1,25 @@
+import MockAdapter from 'axios-mock-adapter'
+import axios from 'axios'
+
+import addressSearch from '../__fixtures__/address-search-SW1H 9AJ.json'
+
+export function setupPostcodeMock200(apiEndpoint, adapterOptions = {}) {
+  const mock = new MockAdapter(axios, adapterOptions)
+  mock.onGet(apiEndpoint).reply(200, addressSearch)
+
+  return mock
+}
+
+export function setupPostcodeMock400(apiEndpoint, adapterOptions = {}) {
+  const mock = new MockAdapter(axios, adapterOptions)
+  mock.onGet(apiEndpoint).reply(400)
+
+  return mock
+}
+
+export function setupPostcodeMock404(apiEndpoint, adapterOptions = {}) {
+  const mock = new MockAdapter(axios, adapterOptions)
+  mock.onGet(apiEndpoint).reply(404)
+
+  return mock
+}

--- a/src/client/components/AddressSearch/useAddressSearch.js
+++ b/src/client/components/AddressSearch/useAddressSearch.js
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+function useAddressSearch(addressSearchCallback) {
+  const [addressList, setAddressList] = useState(null)
+  const [error, setError] = useState(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function onAddressSearch(postcode) {
+    try {
+      setIsSubmitting(true)
+      setError(null)
+      setAddressList(await addressSearchCallback(postcode))
+    } catch (ex) {
+      setAddressList(null)
+      setError('Error occurred while searching for an address.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return {
+    error,
+    addressList,
+    isSubmitting,
+    onAddressSearch,
+  }
+}
+
+export default useAddressSearch

--- a/src/client/components/AddressSearch/usePostcodeLookup.js
+++ b/src/client/components/AddressSearch/usePostcodeLookup.js
@@ -1,0 +1,20 @@
+import axios from 'axios'
+import pluralize from 'pluralize'
+
+function usePostcodeLookup(apiEndpoint) {
+  function createAddressCount(addresses) {
+    const addressCount = pluralize('address', addresses.length, true)
+    return {
+      address1: `${addressCount} found`,
+    }
+  }
+
+  return async function findAddress(postcode) {
+    const { data } = await axios.get(`${apiEndpoint}/${postcode}`)
+    const addressCount = createAddressCount(data)
+
+    return [addressCount, ...data]
+  }
+}
+
+export default usePostcodeLookup


### PR DESCRIPTION
## Description of change

(3) This is a small PR that moves the AddressSearch files from Storybook over to DataHub. Tests have not been carried over yet (hence the poor codecov score), as we need to implement Jest into DH - however this is pending on another ticket. 

## Test instructions

Thanks to Dave, you can now run `npm run storybook` which should successfully bring up Storybook on your browser.  You should see everything working as expected. 


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
