### PR TITLE
Feature/split add company unhappy path form

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -19,6 +19,7 @@ import CompanyFoundStep from './CompanyFoundStep'
 import CompanyNotFoundStep from './CompanyNotFoundStep'
 import CompanySearchStep from './CompanySearchStep'
 import CompanyRegionAndSector from './CompanyRegionAndSector'
+import InformationList from './InformationList'
 import { ISO_CODE } from './constants'
 
 function AddCompanyForm({
@@ -83,6 +84,7 @@ function AddCompanyForm({
         const countryName = get(country, 'label')
         const countryIsoCode = get(country, 'value')
         const postcode = get(values.dnbCompany, 'address_postcode')
+        const manualPostcode = values.postcode
 
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
@@ -123,10 +125,34 @@ function AddCompanyForm({
             {values.cannotFind && (
               <CompanyNotFoundStep
                 organisationTypes={organisationTypes}
-                regions={regions}
-                sectors={sectors}
                 country={country}
               />
+            )}
+            {values.cannotFind && (
+              <CompanyRegionAndSector
+                regions={regions}
+                sectors={sectors}
+                isUK={country.value === ISO_CODE.UK}
+                postcode={manualPostcode}
+              >
+                <InformationList
+                  heading="What happens next"
+                  description="You are requesting that a new company be added to Data Hub. Once you select the ‘Add company’ button below:"
+                >
+                  <InformationList.Item>
+                    you can continue to record interactions with the company
+                  </InformationList.Item>
+                  <InformationList.Item>
+                    Data Hub’s external data provider will confirm with the
+                    company that the information on this page is correct
+                  </InformationList.Item>
+                  <InformationList.Item>
+                    within 3 weeks the Data Hub support team will send you an
+                    email to tell you whether the information on this page has
+                    been confirmed
+                  </InformationList.Item>
+                </InformationList>
+              </CompanyRegionAndSector>
             )}
           </>
         )

--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -3,11 +3,10 @@
 import React from 'react'
 import { Details } from 'govuk-react'
 import PropTypes from 'prop-types'
-import { FieldInput, FieldRadios, FieldSelect, Step } from 'data-hub-components'
+import { FieldInput, FieldRadios, Step } from 'data-hub-components'
 import FieldAddress from 'data-hub-components/dist/forms/elements/FieldAddress'
 
-import { ISO_CODE, WEBSITE_REGEX } from './constants'
-import InformationList from './InformationList'
+import { WEBSITE_REGEX } from './constants'
 
 const requiredWebsiteAndOrPhoneValidator = (
   value,
@@ -26,9 +25,9 @@ const requiredWebsiteAndOrPhoneValidator = (
   return !WEBSITE_REGEX.test(website) ? 'Enter a valid website URL' : null
 }
 
-function CompanyNotFoundStep({ organisationTypes, regions, sectors, country }) {
+function CompanyNotFoundStep({ organisationTypes, country }) {
   return (
-    <Step name="unhappy" forwardButton="Add company">
+    <Step name="unhappy">
       <Details summary="Why am I seeing this?">
         The company you want to add to Data Hub cannot be found in the external
         databases Data Hub checks. You will need to provide information about
@@ -71,41 +70,6 @@ function CompanyNotFoundStep({ organisationTypes, regions, sectors, country }) {
         }}
         apiEndpoint="/api/postcodelookup"
       />
-
-      {country.value === ISO_CODE.UK && (
-        <FieldSelect
-          name="uk_region"
-          label="DIT region"
-          emptyOption="-- Select DIT region --"
-          options={regions}
-          required="Select DIT region"
-        />
-      )}
-
-      <FieldSelect
-        name="sector"
-        label="DIT sector"
-        emptyOption="-- Select DIT sector --"
-        options={sectors}
-        required="Select DIT sector"
-      />
-
-      <InformationList
-        heading="What happens next"
-        description="You are requesting that a new company be added to Data Hub. Once you select the ‘Add company’ button below:"
-      >
-        <InformationList.Item>
-          you can continue to record interactions with the company
-        </InformationList.Item>
-        <InformationList.Item>
-          Data Hub’s external data provider will confirm with the company that
-          the information on this page is correct
-        </InformationList.Item>
-        <InformationList.Item>
-          within 3 weeks the Data Hub support team will send you an email to
-          tell you whether the information on this page has been confirmed
-        </InformationList.Item>
-      </InformationList>
     </Step>
   )
 }

--- a/src/apps/companies/apps/add-company/client/CompanyRegionAndSector.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyRegionAndSector.jsx
@@ -23,6 +23,7 @@ function CompanyRegionAndSector({ regions, region, sectors, isUK, postcode }) {
         >
           {() => (
             <FieldSelect
+              key={region?.value}
               name="uk_region"
               label="DIT region"
               initialValue={region?.value}

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -365,24 +365,17 @@ describe('Add company form', () => {
         cy.get(
           selectors.companyAdd.newCompanyRecordForm.address.postcode
         ).should('be.visible')
-        cy.get(selectors.companyAdd.form).contains('United Kingdom')
-        cy.get(selectors.companyAdd.newCompanyRecordForm.sector).should(
-          'be.visible'
-        )
-      })
-      it('should display the UK-related fields', () => {
         cy.get(
           selectors.companyAdd.newCompanyRecordForm.address.findUkAddress
         ).should('be.visible')
-        cy.get(selectors.companyAdd.newCompanyRecordForm.region).should(
-          'be.visible'
-        )
+        cy.get(selectors.companyAdd.form).contains('United Kingdom')
       })
+
       context(
         'when the form is submitted without filling the required fields',
         () => {
           before(() => {
-            cy.get(selectors.companyAdd.submitButton).click()
+            cy.get(selectors.companyAdd.continueButton).click()
           })
           it('should display errors', () => {
             cy.get(selectors.companyAdd.form).contains(
@@ -395,8 +388,6 @@ describe('Add company form', () => {
             )
             cy.get(selectors.companyAdd.form).contains('Enter address line 1')
             cy.get(selectors.companyAdd.form).contains('Enter town or city')
-            cy.get(selectors.companyAdd.form).contains('Select DIT region')
-            cy.get(selectors.companyAdd.form).contains('Select DIT sector')
           })
         }
       )
@@ -405,7 +396,7 @@ describe('Add company form', () => {
           cy.get(selectors.companyAdd.newCompanyRecordForm.website).type(
             'www.example.com'
           )
-          cy.get(selectors.companyAdd.submitButton).click()
+          cy.get(selectors.companyAdd.continueButton).click()
         })
         it('should not display "Enter a website or phone number"', () => {
           cy.get(selectors.companyAdd.form).should(
@@ -422,7 +413,7 @@ describe('Add company form', () => {
           cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).type(
             '0123456789'
           )
-          cy.get(selectors.companyAdd.submitButton).click()
+          cy.get(selectors.companyAdd.continueButton).click()
         })
         it('should not display "Enter a website or phone number"', () => {
           cy.get(selectors.companyAdd.form).should(
@@ -439,7 +430,7 @@ describe('Add company form', () => {
           cy.get(selectors.companyAdd.newCompanyRecordForm.website).type(
             'hello'
           )
-          cy.get(selectors.companyAdd.submitButton).click()
+          cy.get(selectors.companyAdd.continueButton).click()
         })
         it('should display invalid website URL error', () => {
           cy.get(selectors.companyAdd.form).contains(
@@ -448,7 +439,7 @@ describe('Add company form', () => {
         })
       })
       context(
-        'when the form is submitted after filling the required fields',
+        'when the form is submitted after filling the required fields, but the region and sector fields are not filled in',
         () => {
           before(() => {
             cy.get(
@@ -473,6 +464,29 @@ describe('Add company form', () => {
             cy.get(
               selectors.companyAdd.newCompanyRecordForm.address.options
             ).select('Ministry of Justice')
+            cy.get(selectors.companyAdd.continueButton).click()
+          })
+          it('should render the region and sector fields', () => {
+            cy.get(selectors.companyAdd.form).contains('London')
+            cy.get(selectors.companyAdd.form).contains('Select DIT sector')
+          })
+          it('should shown errors if neither field are selected', () => {
+            cy.get(selectors.companyAdd.newCompanyRecordForm.region).select(
+              '-- Select DIT region --'
+            )
+            cy.get(selectors.companyAdd.submitButton)
+              .click()
+              .get(selectors.companyAdd.form)
+              .contains('Select DIT region')
+              .get(selectors.companyAdd.form)
+              .contains('Select DIT sector')
+          })
+        }
+      )
+      context(
+        'when the form and section region section is submitted after filling the required fields',
+        () => {
+          before(() => {
             cy.get(selectors.companyAdd.newCompanyRecordForm.region).select(
               'London'
             )
@@ -559,9 +573,6 @@ describe('Add company form', () => {
         cy.get(
           selectors.companyAdd.newCompanyRecordForm.address.postcode
         ).should('be.visible')
-        cy.get(selectors.companyAdd.newCompanyRecordForm.sector).should(
-          'be.visible'
-        )
         cy.get(selectors.companyAdd.form).contains('India')
       })
 
@@ -569,9 +580,6 @@ describe('Add company form', () => {
         cy.get(
           selectors.companyAdd.newCompanyRecordForm.address.findUkAddress
         ).should('not.be.visible')
-        cy.get(selectors.companyAdd.newCompanyRecordForm.region).should(
-          'not.be.visible'
-        )
       })
     }
   )


### PR DESCRIPTION
## Description of change

This PR splits the add company unhappy path form allowing the DIT region to be preselected based on the postcode entered by the user in the previous step. 

There is a limitation with this. Do to the construction of the `FieldSelect` form it doesn't re-render even when a key based on the changing region value is provided. As this component is so tightly linked to the `useFormContext` setup it was too difficult to unpick in this instance. Therefore, if the user goes back and changes the postcode and clicks 'continue', the previously selected region is still there and they would have to manually update this. Hopefully though, this proves to be a lightly followed user journey.

The bigger solution here is to stop using `FormStateful` and rewrite this whole form flow using redux state. However, that is a very large job and outside of the scope of the work here just to update the region automatically.  

## Test instructions

Follow the unhappy path for adding a UK based company by clicking 'I still can't find what I'm looking for', fill in the form including the postcode, click continue and you should be presented with a preselected DIT region based on the postcode you provided. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/42253716/88307813-433f3300-cd04-11ea-9e91-aaf7ab8df08c.png)

### After

![image](https://user-images.githubusercontent.com/42253716/88307951-6833a600-cd04-11ea-9c09-5a71aae7c9b5.png)
![image](https://user-images.githubusercontent.com/42253716/88308018-78e41c00-cd04-11ea-91ba-d801108c0665.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
