### PR TITLE
Move EntityList into Datahub

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanySearchStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanySearchStep.jsx
@@ -5,12 +5,8 @@ import { Link } from 'govuk-react'
 import PropTypes from 'prop-types'
 import { get } from 'lodash'
 import { H3 } from '@govuk-react/heading'
-import {
-  EntityListItem,
-  FieldDnbCompany,
-  Step,
-  useFormContext,
-} from 'data-hub-components'
+import { EntityListItem } from '../../../../../client/components/'
+import { FieldDnbCompany, Step, useFormContext } from 'data-hub-components'
 
 function DnbCompanyRenderer(props) {
   const { setFieldValue, goForward } = useFormContext()

--- a/src/apps/companies/apps/match-company/client/FindCompany.jsx
+++ b/src/apps/companies/apps/match-company/client/FindCompany.jsx
@@ -4,12 +4,8 @@ import { H4 } from '@govuk-react/heading'
 import InsetText from '@govuk-react/inset-text'
 
 import urls from '../../../../../lib/urls'
-import {
-  EntityListItem,
-  FieldDnbCompany,
-  FormStateful,
-  SummaryList,
-} from 'data-hub-components'
+import { EntityListItem } from '../../../../../client/components/'
+import { FieldDnbCompany, FormStateful, SummaryList } from 'data-hub-components'
 
 function FindCompany({ company, csrfToken }) {
   return (

--- a/src/client/components/EntityList/EntityListItem.jsx
+++ b/src/client/components/EntityList/EntityListItem.jsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { isEmpty } from 'lodash'
+import styled from 'styled-components'
+import {
+  FOCUSABLE,
+  FONT_SIZE,
+  MEDIA_QUERIES,
+  SPACING,
+} from '@govuk-react/constants'
+import { GREY_2, GREY_4, LINK_COLOUR, LINK_HOVER_COLOUR } from 'govuk-colours'
+import { H3 } from '@govuk-react/heading'
+import InsetText from '@govuk-react/inset-text'
+
+import { Metadata } from 'data-hub-components'
+
+const KEY_ENTER = 13
+
+const StyledEntity = styled('div')`
+  margin-bottom: ${SPACING.SCALE_2};
+  padding: ${SPACING.SCALE_2};
+  border: 1px solid ${GREY_2};
+  ${FOCUSABLE};
+
+  ${({ isClickable }) =>
+    isClickable &&
+    `
+    cursor: pointer;
+
+    h3 {
+      color: ${LINK_COLOUR};
+    }
+
+    &:hover {
+      border: 1px solid ${LINK_HOVER_COLOUR};
+      background-color: ${GREY_4};
+
+      & > h3 {
+        color: ${LINK_HOVER_COLOUR};
+      }
+    }
+  `}
+`
+
+const StyledHeading = styled(H3)`
+  font-size: ${FONT_SIZE.SIZE_16};
+  margin: 0 0 ${SPACING.SCALE_2};
+  ${MEDIA_QUERIES.TABLET} {
+    font-size: ${FONT_SIZE.SIZE_19};
+  }
+`
+
+const StyledInsetText = styled(InsetText)`
+  & {
+    margin-top: ${SPACING.SCALE_2};
+  }
+`
+
+const EntityListItem = ({ id, onEntityClick, data, text, heading, meta }) => {
+  return (
+    <StyledEntity
+      key={`entity_${id}`}
+      tabIndex={onEntityClick ? 0 : undefined}
+      onClick={() => onEntityClick && onEntityClick(data)}
+      onKeyDown={(e) =>
+        onEntityClick && e.keyCode === KEY_ENTER && onEntityClick(data)
+      }
+      isClickable={onEntityClick}
+    >
+      {heading && <StyledHeading>{heading}</StyledHeading>}
+
+      {!isEmpty(meta) && <Metadata rows={meta} />}
+
+      {text && <StyledInsetText>{text}</StyledInsetText>}
+    </StyledEntity>
+  )
+}
+
+EntityListItem.propTypes = {
+  id: PropTypes.string.isRequired,
+  onEntityClick: PropTypes.func,
+  data: PropTypes.shape({}),
+  text: PropTypes.node,
+  heading: PropTypes.string,
+  meta: PropTypes.array,
+}
+
+EntityListItem.defaultProps = {
+  text: null,
+  onEntityClick: null,
+  data: {},
+  heading: null,
+  meta: [],
+}
+
+export default EntityListItem

--- a/src/client/components/EntityList/__fixtures__/company-search-no-results.json
+++ b/src/client/components/EntityList/__fixtures__/company-search-no-results.json
@@ -1,0 +1,7 @@
+{
+  "total_matches": 0,
+  "total_returned": 0,
+  "page_size": 0,
+  "page_number": 1,
+  "results": []
+}

--- a/src/client/components/EntityList/__fixtures__/company-search-postcode-BN1-4SE.json
+++ b/src/client/components/EntityList/__fixtures__/company-search-postcode-BN1-4SE.json
@@ -1,0 +1,60 @@
+{
+  "total_matches": 271,
+  "total_returned": 2,
+  "page_size": 2,
+  "page_number": 1,
+  "results": [
+    {
+      "dnb_company": {
+        "duns_number": "12345678",
+        "primary_name": "Some company name",
+        "trading_names": [
+          "Some trading name"
+        ],
+        "registration_numbers": [
+          {
+            "registration_type": "uk_companies_house_number",
+            "registration_number": "1234567"
+          }
+        ],
+        "global_ultimate_duns_number": "123456789",
+        "global_ultimate_primary_name": "Some parent company name",
+        "domain": "example.co.uk",
+        "is_out_of_business": false,
+        "address_line_1": "123 Fake Street",
+        "address_line_2": "",
+        "address_town": "Brighton",
+        "address_county": "",
+        "address_postcode": "BN1 4SE",
+        "address_country": "GB",
+        "registered_address_line_1": "",
+        "registered_address_line_2": "",
+        "registered_address_town": "Brighton",
+        "registered_address_county": "",
+        "registered_address_postcode": "BN1 4SE",
+        "registered_address_country": "GB",
+        "annual_sales": 1860000000,
+        "annual_sales_currency": "USD",
+        "is_annual_sales_estimated": null,
+        "employee_number": 2000,
+        "is_employees_number_estimated": true,
+        "industry_codes": [
+          {
+            "usSicV4": "1623",
+            "usSicV4Description": "Water/sewer/utility construction"
+          }
+        ],
+        "legal_status": "corporation"
+      },
+      "datahub_company": {
+        "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+        "latest_interaction": {
+          "id": "ec4a46ef-6e50-4a5c-bba0-e311f0471312",
+          "created_on": "2019-08-01T18:10:00",
+          "date": "2019-08-01",
+          "subject": "Meeting between DIT and Joe Bloggs"
+        }
+      }
+    }
+  ]
+}

--- a/src/client/components/EntityList/__fixtures__/company-search-some-other-company.json
+++ b/src/client/components/EntityList/__fixtures__/company-search-some-other-company.json
@@ -1,0 +1,50 @@
+{
+  "total_matches": 271,
+  "total_returned": 2,
+  "page_size": 2,
+  "page_number": 1,
+  "results": [
+    {
+      "dnb_company": {
+        "duns_number": "219999999",
+        "primary_name": "Some other company",
+        "trading_names": [],
+        "registration_numbers": [
+          {
+            "registration_type": "uk_companies_house_number",
+            "registration_number": "00016033"
+          }
+        ],
+        "global_ultimate_duns_number": "319999999",
+        "global_ultimate_primary_name": "Some other company parent",
+        "domain": "example.co.uk",
+        "is_out_of_business": false,
+        "address_line_1": "123 ABC Road",
+        "address_line_2": "",
+        "address_town": "Brighton",
+        "address_county": "",
+        "address_postcode": "BN2 9QB",
+        "address_country": "GB",
+        "registered_address_line_1": "",
+        "registered_address_line_2": "",
+        "registered_address_town": "Brighton",
+        "registered_address_county": "",
+        "registered_address_postcode": "BN2 9QB",
+        "registered_address_country": "GB",
+        "annual_sales": 1999999999,
+        "annual_sales_currency": "USD",
+        "is_annual_sales_estimated": null,
+        "employee_number": 300,
+        "is_employees_number_estimated": true,
+        "industry_codes": [
+          {
+            "usSicV4": "3799",
+            "usSicV4Description": "Mfg transportation equipment"
+          }
+        ],
+        "legal_status": "corporation"
+      },
+      "datahub_company": null
+    }
+  ]
+}

--- a/src/client/components/EntityList/__fixtures__/company-search.json
+++ b/src/client/components/EntityList/__fixtures__/company-search.json
@@ -1,0 +1,132 @@
+{
+  "total_matches": 271,
+  "total_returned": 2,
+  "page_size": 2,
+  "page_number": 1,
+  "results": [
+    {
+      "dnb_company": {
+        "duns_number": "12345678",
+        "primary_name": "Some company name",
+        "trading_names": [
+          "Some trading name"
+        ],
+        "registration_numbers": [
+          {
+            "registration_type": "uk_companies_house_number",
+            "registration_number": "1234567"
+          }
+        ],
+        "global_ultimate_duns_number": "123456789",
+        "global_ultimate_primary_name": "Some parent company name",
+        "domain": "example.co.uk",
+        "is_out_of_business": false,
+        "address_line_1": "123 Fake Street",
+        "address_line_2": "",
+        "address_town": "Brighton",
+        "address_county": "",
+        "address_postcode": "BN1 4SE",
+        "address_country": "GB",
+        "registered_address_line_1": "",
+        "registered_address_line_2": "",
+        "registered_address_town": "Brighton",
+        "registered_address_county": "",
+        "registered_address_postcode": "BN1 4SE",
+        "registered_address_country": "GB",
+        "annual_sales": 1860000000,
+        "annual_sales_currency": "USD",
+        "is_annual_sales_estimated": null,
+        "employee_number": 2000,
+        "is_employees_number_estimated": true,
+        "industry_codes": [
+          {
+            "usSicV4": "1623",
+            "usSicV4Description": "Water/sewer/utility construction"
+          }
+        ],
+        "legal_status": "corporation"
+      },
+      "datahub_company": {
+        "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+        "latest_interaction": {
+          "id": "ec4a46ef-6e50-4a5c-bba0-e311f0471312",
+          "created_on": "2019-08-01T18:10:00",
+          "date": "2019-08-01",
+          "subject": "Meeting between DIT and Joe Bloggs"
+        }
+      }
+    },
+    {
+      "dnb_company": {
+        "duns_number": "219999999",
+        "primary_name": "Some other company",
+        "trading_names": [],
+        "registration_numbers": [
+          {
+            "registration_type": "uk_companies_house_number",
+            "registration_number": "00016033"
+          }
+        ],
+        "global_ultimate_duns_number": "319999999",
+        "global_ultimate_primary_name": "Some other company parent",
+        "domain": "example.co.uk",
+        "is_out_of_business": false,
+        "address_line_1": "123 ABC Road",
+        "address_line_2": "",
+        "address_town": "Brighton",
+        "address_county": "",
+        "address_postcode": "BN2 9QB",
+        "address_country": "GB",
+        "registered_address_line_1": "",
+        "registered_address_line_2": "",
+        "registered_address_town": "Brighton",
+        "registered_address_county": "",
+        "registered_address_postcode": "BN2 9QB",
+        "registered_address_country": "GB",
+        "annual_sales": 1999999999,
+        "annual_sales_currency": "USD",
+        "is_annual_sales_estimated": null,
+        "employee_number": 300,
+        "is_employees_number_estimated": true,
+        "industry_codes": [
+          {
+            "usSicV4": "3799",
+            "usSicV4Description": "Mfg transportation equipment"
+          }
+        ],
+        "legal_status": "corporation"
+      },
+      "datahub_company": null
+    },
+    {
+      "dnb_company": {
+        "duns_number": "219999996",
+        "primary_name": "Dissolvex",
+        "trading_names": [],
+        "global_ultimate_duns_number": "319999999",
+        "global_ultimate_primary_name": "Dissolvex Global",
+        "domain": "example.co.uk",
+        "is_out_of_business": true,
+        "address_line_1": "20 New Fake Road",
+        "address_line_2": "",
+        "address_town": "Bristol",
+        "address_county": "",
+        "address_postcode": "B11 9QC",
+        "address_country": "GB",
+        "registered_address_line_1": "",
+        "registered_address_line_2": "",
+        "registered_address_town": "Bristol",
+        "registered_address_county": "",
+        "registered_address_postcode": "B11 9QC",
+        "registered_address_country": "GB",
+        "annual_sales": 2222222,
+        "annual_sales_currency": "USD",
+        "is_annual_sales_estimated": null,
+        "employee_number": 100,
+        "is_employees_number_estimated": true,
+        "legal_status": "corporation"
+      },
+      "datahub_company": null
+    }
+  ]
+}

--- a/src/client/components/EntityList/__fixtures__/index.js
+++ b/src/client/components/EntityList/__fixtures__/index.js
@@ -1,0 +1,11 @@
+import companySearch from './company-search.json'
+import companySearchNoResults from './company-search-no-results.json'
+import companySearchFilteredByPostcode from './company-search-postcode-BN1-4SE.json'
+import companySearchFilteredByCompanyName from './company-search-some-other-company.json'
+
+export default {
+  companySearch,
+  companySearchNoResults,
+  companySearchFilteredByPostcode,
+  companySearchFilteredByCompanyName,
+}

--- a/src/client/components/EntityList/__mocks__/company-search.js
+++ b/src/client/components/EntityList/__mocks__/company-search.js
@@ -1,0 +1,34 @@
+import MockAdapter from 'axios-mock-adapter'
+import axios from 'axios'
+
+import fixtures from '../__fixtures__'
+
+export function setupSuccessMocks(
+  apiEndpoint,
+  adapterOptions = {},
+  queryParams = {}
+) {
+  const mock = new MockAdapter(axios, adapterOptions)
+  mock.onPost(apiEndpoint, queryParams).reply(200, fixtures.companySearch)
+  mock
+    .onPost(apiEndpoint, { search_term: 'some other company', ...queryParams })
+    .reply(200, fixtures.companySearchFilteredByCompanyName)
+  mock
+    .onPost(apiEndpoint, { postal_code: 'BN1 4SE', ...queryParams })
+    .reply(200, fixtures.companySearchFilteredByPostcode)
+
+  mock.onAny(apiEndpoint).reply(200, fixtures.companySearch)
+  return mock
+}
+
+export function setupErrorMocks(apiEndpoint, adapterOptions = {}) {
+  const mock = new MockAdapter(axios, adapterOptions)
+  mock.onPost(apiEndpoint).reply(500)
+  return mock
+}
+
+export function setupNoResultsMocks(apiEndpoint, adapterOptions = {}) {
+  const mock = new MockAdapter(axios, adapterOptions)
+  mock.onPost(apiEndpoint).reply(200, fixtures.companySearchNoResults)
+  return mock
+}

--- a/src/client/components/EntityList/__stories__/EntityList.stories.jsx
+++ b/src/client/components/EntityList/__stories__/EntityList.stories.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+import useDnbSearch from '../useDnbSearch'
+import companySearchFixture from '../__fixtures__/company-search.json'
+import EntityList from 'EntityList'
+
+storiesOf('EntitySearch', module).add('EntityList - DnB', () => {
+  const { transformCompanyRecord } = useDnbSearch()
+  const fixtures = companySearchFixture.results.map(transformCompanyRecord)
+  return (
+    <EntityList
+      onEntityClick={action('EntitySearch.onEntityClick')}
+      entities={fixtures}
+    />
+  )
+})

--- a/src/client/components/EntityList/index.jsx
+++ b/src/client/components/EntityList/index.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
+
+import EntityListItem from './EntityListItem'
+
+const StyledEntityList = styled('ol')`
+  margin-bottom: ${SPACING.SCALE_4};
+  padding-left: 0;
+`
+
+const StyledEntityListItem = styled('li')`
+  list-style-type: none;
+`
+
+const EntityList = ({ entities, entityRenderer: EntityRenderer }) => (
+  <StyledEntityList>
+    {entities.map((entity) => (
+      <StyledEntityListItem key={`entity-list-item_${entity.id}`}>
+        <EntityRenderer {...entity} />
+      </StyledEntityListItem>
+    ))}
+  </StyledEntityList>
+)
+
+EntityList.propTypes = {
+  entities: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      heading: PropTypes.string.isRequired,
+      meta: PropTypes.array.isRequired,
+      data: PropTypes.object.isRequired,
+    })
+  ).isRequired,
+  entityRenderer: PropTypes.func,
+}
+
+EntityList.defaultProps = {
+  entityRenderer: EntityListItem,
+}
+
+export default EntityList

--- a/src/client/components/EntityList/useDnbSearch.jsx
+++ b/src/client/components/EntityList/useDnbSearch.jsx
@@ -1,0 +1,52 @@
+/* eslint-disable camelcase */
+
+import axios from 'axios'
+import { compact, isEmpty } from 'lodash'
+
+function getTradingNames(dnb_company) {
+  return isEmpty(dnb_company.trading_names)
+    ? null
+    : {
+        label: 'Trading name(s)',
+        value: dnb_company.trading_names.join(', '),
+      }
+}
+
+function getAddress(dnb_company) {
+  return {
+    label: 'Location at',
+    value: compact([
+      dnb_company.address_line_1,
+      dnb_company.address_line_2,
+      dnb_company.address_town,
+      dnb_company.address_county,
+      dnb_company.address_postcode,
+    ]).join(', '),
+  }
+}
+
+function useDnbSearch(apiEndpoint) {
+  function transformCompanyRecord(record) {
+    const { dnb_company } = record
+
+    return {
+      id: dnb_company.duns_number,
+      heading: dnb_company.primary_name,
+      meta: compact([getTradingNames(dnb_company), getAddress(dnb_company)]),
+      data: record,
+    }
+  }
+
+  async function findCompany(filters) {
+    const { data } = await axios.post(apiEndpoint, filters)
+
+    return data.results.map(transformCompanyRecord)
+  }
+
+  return {
+    findCompany,
+    transformCompanyRecord,
+  }
+}
+
+export default useDnbSearch

--- a/src/client/components/EntityList/useEntitySearch.js
+++ b/src/client/components/EntityList/useEntitySearch.js
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+
+function useEntitySearch(searchEntitiesCallback) {
+  const [entities, setEntities] = useState([])
+  const [error, setError] = useState(null)
+  const [searching, setSearching] = useState(false)
+  const [searched, setSearched] = useState(false)
+
+  async function onEntitySearch(filters = {}) {
+    try {
+      setSearching(true)
+      setError(null)
+      const newEntities = await searchEntitiesCallback(filters)
+      setEntities(newEntities)
+    } catch (ex) {
+      setEntities([])
+      setError('Error occurred while searching entities.')
+    } finally {
+      setSearching(false)
+      setSearched(true)
+    }
+  }
+
+  return {
+    onEntitySearch,
+    entities,
+    error,
+    searching,
+    searched,
+  }
+}
+
+export default useEntitySearch

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -14,3 +14,5 @@ export { default as MyCompaniesFilters } from './Dashboard/my-companies/MyCompan
 export { default as MyCompaniesTable } from './Dashboard/my-companies/MyCompaniesTable'
 export { default as MyCompaniesTile } from './Dashboard/my-companies/MyCompaniesTile'
 export { default as useMyCompaniesContext } from './Dashboard/my-companies/useMyCompaniesContext'
+export { default as EntityList } from './EntityList'
+export { default as EntityListItem } from './EntityList/EntityListItem'


### PR DESCRIPTION
(8) This is a small PR that moves the EntitySearch files from Storybook over to DataHub. Tests have not been carried over yet (hence the poor codecov score), as we need to implement Jest into DH - however this is pending on another ticket. 

Just as a heads up, in this PR, we've started exporting sibling/child components - I'll have to make a cleanup PR to go back and import the first 5 PR's children/siblings. 

After talking it through with Ian, we've decided to rename the folder from EntitySearch to EntityList - It just made more sense considering the main component was EntityList. We were also getting an error about using a react hook outside of a function, so the Stories file for this component had to be refactored in order to get around this.  

## Test instructions

Thanks to Dave, you can now run `npm run storybook` which should successfully bring up Storybook on your browser. navigate to the EntitySearch component, and you should see everything working as expected. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
