### PR TITLE
Move Metadata to Datahub

### DIFF
--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -7,8 +7,7 @@ import Link from '@govuk-react/link'
 import { HEADING_SIZES, SPACING } from '@govuk-react/constants'
 import { GREY_2 } from 'govuk-colours'
 import Details from '@govuk-react/details'
-
-const { Badge, Metadata } = require('data-hub-components')
+import { Badge, Metadata } from '../../components/'
 
 const ItemWrapper = styled('div')`
   border-bottom: 1px solid ${GREY_2};

--- a/src/client/components/Metadata/MetadataItem.jsx
+++ b/src/client/components/Metadata/MetadataItem.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { BLACK, GREY_1 } from 'govuk-colours'
+
+const StyledMetaWrapper = styled('div')`
+  color: ${BLACK};
+`
+
+const StyledItemLabel = styled('span')`
+  color: ${GREY_1};
+`
+
+function MetadataItem({ label, children }) {
+  return (
+    <StyledMetaWrapper>
+      {label && <StyledItemLabel>{label}</StyledItemLabel>} {children}
+    </StyledMetaWrapper>
+  )
+}
+
+MetadataItem.propTypes = {
+  label: PropTypes.string,
+  children: PropTypes.node.isRequired,
+}
+
+MetadataItem.defaultProps = {
+  label: null,
+}
+
+export default MetadataItem

--- a/src/client/components/Metadata/__stories__/Metadata.stories.jsx
+++ b/src/client/components/Metadata/__stories__/Metadata.stories.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import Link from '@govuk-react/link'
+
+import Metadata from 'Metadata'
+
+const stories = storiesOf('Metadata', module)
+
+const metadata = [
+  { label: 'Updated on', value: '5 September 2019' },
+  { label: 'Sector', value: 'Environment' },
+  {
+    label: 'Parent company',
+    value: <Link href="http://example.com">E-corp LTD</Link>,
+  },
+]
+
+stories.add('Default', () => <Metadata rows={metadata} />)

--- a/src/client/components/Metadata/index.jsx
+++ b/src/client/components/Metadata/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { FONT_SIZE, SPACING } from '@govuk-react/constants'
+
+import MetadataItem from './MetadataItem'
+
+const StyledMetadataWrapper = styled('div')`
+  font-size: ${FONT_SIZE.SIZE_16};
+  line-height: ${FONT_SIZE.SIZE_27};
+  display: grid;
+
+  & > * {
+    margin-bottom: ${SPACING.SCALE_1};
+  }
+`
+
+const Metadata = ({ rows }) =>
+  rows && (
+    <StyledMetadataWrapper>
+      {rows.map(({ label, value }) => (
+        <MetadataItem key={label} label={label}>
+          {value}
+        </MetadataItem>
+      ))}
+    </StyledMetadataWrapper>
+  )
+
+Metadata.propTypes = {
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.node,
+      value: PropTypes.node,
+    })
+  ),
+}
+
+Metadata.defaultProps = {
+  rows: null,
+}
+
+export default Metadata

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -16,3 +16,5 @@ export { default as MyCompaniesTile } from './Dashboard/my-companies/MyCompanies
 export { default as useMyCompaniesContext } from './Dashboard/my-companies/useMyCompaniesContext'
 export { default as EntityList } from './EntityList'
 export { default as EntityListItem } from './EntityList/EntityListItem'
+export { default as Metadata } from './Metadata'
+export { default as MetadataItem } from './Metadata/MetadataItem'


### PR DESCRIPTION
(9) This is a small PR that moves the Metadata files from Storybook over to DataHub. Tests have not been carried over yet (hence the poor codecov score), as we need to implement Jest into DH - however this is pending on another ticket. 

Just as a heads up, in this PR, we've started exporting sibling/child components - I'll have to make a cleanup PR to go back and import the first 5 PR's children/siblings. 

## Test instructions

Thanks to Dave, you can now run `npm run storybook` which should successfully bring up Storybook on your browser. navigate to the Metadata component, and you should see everything working as expected. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
