### PR TITLE
Move <FieldInput> element into FE and add filter style...

### DIFF
--- a/src/client/components/Form/elements/FieldInput/__stories__/FieldInput.stories.jsx
+++ b/src/client/components/Form/elements/FieldInput/__stories__/FieldInput.stories.jsx
@@ -63,7 +63,6 @@ storiesOf('Forms/Input', module)
             hint="Some hint"
             name="testField"
             required="Enter text"
-            legend={() => <>mooo</>}
             type="text"
             reduced={true}
           />

--- a/src/client/components/Form/elements/FieldInput/__stories__/FieldInput.stories.jsx
+++ b/src/client/components/Form/elements/FieldInput/__stories__/FieldInput.stories.jsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { addDecorator, storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions/dist'
+import { withKnobs } from '@storybook/addon-knobs'
+import Button from '@govuk-react/button'
+
+import FieldInput from '../../FieldInput'
+import FormStateful from '../../FormStateful'
+
+import exampleReadme from '../example.md'
+import usageReadme from '../usage.md'
+
+addDecorator(withKnobs)
+
+storiesOf('Forms/Input', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('FieldInput - Text', () => (
+    <FormStateful onSubmit={action('onSubmit')}>
+      {(state) => (
+        <>
+          <FieldInput
+            label="Text"
+            hint="Some hint"
+            name="testField"
+            required="Enter text"
+            type="text"
+          />
+          <Button>Submit</Button>
+          <pre>{JSON.stringify(state, null, 2)}</pre>
+        </>
+      )}
+    </FormStateful>
+  ))
+  .add('FieldInput - Number', () => (
+    <FormStateful onSubmit={action('onSubmit')}>
+      {(state) => (
+        <>
+          <FieldInput
+            label="Number"
+            hint="Some hint"
+            name="testField"
+            required="Enter number"
+            type="number"
+          />
+          <Button>Submit</Button>
+          <pre>{JSON.stringify(state, null, 2)}</pre>
+        </>
+      )}
+    </FormStateful>
+  ))
+  .add('FieldInput (reduced)', () => (
+    <FormStateful onSubmit={action('onSubmit')}>
+      {() => (
+        <>
+          <FieldInput
+            label="Text"
+            hint="Some hint"
+            name="testField"
+            required="Enter text"
+            legend={() => <>mooo</>}
+            type="text"
+            reduced={true}
+          />
+        </>
+      )}
+    </FormStateful>
+  ))

--- a/src/client/components/Form/elements/FieldInput/example.md
+++ b/src/client/components/Form/elements/FieldInput/example.md
@@ -1,0 +1,6 @@
+### Import
+```js
+import FieldInput from 'FieldInput'
+```
+
+### Output

--- a/src/client/components/Form/elements/FieldInput/index.jsx
+++ b/src/client/components/Form/elements/FieldInput/index.jsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import Input from '@govuk-react/input'
+import ErrorText from '@govuk-react/error-text'
+import {
+  BORDER_WIDTH_FORM_ELEMENT_ERROR,
+  SPACING,
+} from '@govuk-react/constants'
+import { ERROR_COLOUR } from 'govuk-colours'
+
+import useField from '../../hooks/useField'
+import FieldWrapper from '../FieldWrapper'
+
+const StyledInputWrapper = styled('div')`
+  ${(props) =>
+    props.error &&
+    `
+    border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    margin-right: ${SPACING.SCALE_3};
+    padding-left: ${SPACING.SCALE_2};
+  `}
+`
+
+const FieldInput = ({
+  name,
+  type,
+  validate,
+  required,
+  label,
+  legend,
+  hint,
+  initialValue,
+  reduced,
+  ...rest
+}) => {
+  const { value, error, touched, onChange, onBlur } = useField({
+    name,
+    validate,
+    required,
+    initialValue,
+  })
+  return (
+    <FieldWrapper {...{ name, label, legend, hint, error, reduced }}>
+      <StyledInputWrapper error={error}>
+        {touched && error && <ErrorText>{error}</ErrorText>}
+        <Input
+          key={name}
+          error={touched && error}
+          id={name}
+          type={type}
+          name={name}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          {...rest}
+        />
+      </StyledInputWrapper>
+    </FieldWrapper>
+  )
+}
+
+FieldInput.propTypes = {
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
+  required: PropTypes.string,
+  label: PropTypes.node,
+  legend: PropTypes.node,
+  hint: PropTypes.node,
+  initialValue: PropTypes.string,
+  reduced: PropTypes.bool,
+}
+
+FieldInput.defaultProps = {
+  validate: null,
+  required: null,
+  label: null,
+  legend: null,
+  hint: null,
+  initialValue: '',
+  reduced: false,
+}
+
+export default FieldInput

--- a/src/client/components/Form/elements/FieldInput/usage.md
+++ b/src/client/components/Form/elements/FieldInput/usage.md
@@ -1,0 +1,40 @@
+FieldInput
+=========
+
+### Description
+
+A basic input field for numbers and text. 
+
+**Note: The `<FieldInput>` has to be wrapped with either the `<Form>` or `<FormStateful>`.**
+
+### Usage
+
+```jsx
+<FormStateful onSubmit={action('onSubmit')}>
+  {(state) => (
+    <>
+      <FieldInput
+        label="Text"
+        hint="Some hint"
+        name="testField"
+        required="Enter text"
+        type="text"
+        reduced
+      />
+    </>
+  )}
+</FormStateful>
+```
+
+### Properties
+Prop | Required | Default | Type | Description
+:--- | :------- | :------ | :--- | :----------
+ `name` | true | `````` | string | Text for name attribute value
+ `label` | false | null | string | Text for the label element
+ `legend` | false | null | node | Node for legend element
+ `hint` | false | null | node | Node for hint element
+ `type` | true | `````` | string | Text for type attribute value
+ `validate` | false | null | function or array of functions | Validate functions for input
+ `required` | false | `````` | Boolean | Text 'required' sets wether the input is required or not
+ `initialValue` | false | `````` | Text | Sets initial value of the input
+ `reduced` | false | false | Boolean | Toggles wether the element is a filter or not

--- a/src/client/components/Form/elements/FieldWrapper.jsx
+++ b/src/client/components/Form/elements/FieldWrapper.jsx
@@ -1,0 +1,173 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import FormGroup from '@govuk-react/form-group'
+import Label from '@govuk-react/label'
+import styled from 'styled-components'
+import HintText from '@govuk-react/hint-text'
+import { ERROR_COLOUR, GREY_2, GREY_3 } from 'govuk-colours'
+import {
+  BORDER_WIDTH_FORM_ELEMENT_ERROR,
+  FONT_WEIGHTS,
+  SPACING,
+  BODY_SIZES,
+} from '@govuk-react/constants'
+import Paragraph from '@govuk-react/paragraph'
+
+const StyledFormGroup = styled(FormGroup)`
+  ${(props) => {
+    const isReduced = props.reduced
+    const hasHint = !!props.hint
+    return (
+      isReduced &&
+      `
+    background-color: ${GREY_3};
+    padding: 8px;
+    label {
+      ${
+        hasHint
+          ? `padding-bottom: ${SPACING.SCALE_1}`
+          : `padding-bottom: ${SPACING.SCALE_2}`
+      };
+    }
+    label, span {
+      font-size: ${BODY_SIZES.S}px;
+    }
+    input {
+      border-width: 1px;
+    }
+  `
+    )
+  }}
+`
+
+const StyledFieldset = styled('fieldset')`
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  ${(props) =>
+    props.showBorder &&
+    `
+    border: 1px solid ${GREY_2};
+    padding: ${SPACING.SCALE_3};
+  `}
+`
+
+const StyledLegend = styled('legend')`
+  box-sizing: border-box;
+  display: table;
+  white-space: normal;
+  padding: 0;
+  margin: 0;
+  padding-bottom: ${SPACING.SCALE_1};
+  * {
+    margin-bottom: ${SPACING.SCALE_1} !important;
+  }
+  ${(props) =>
+    props.error &&
+    `
+    border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    margin-right: ${SPACING.SCALE_3};
+    padding-left: ${SPACING.SCALE_2};
+  `}
+  ${(props) =>
+    props.showBorder &&
+    `
+    padding: ${SPACING.SCALE_2};
+    margin-left: -${SPACING.SCALE_2};
+  `}
+`
+
+const StyledLabel = styled(Label)`
+  padding-bottom: ${SPACING.SCALE_1};
+  font-weight: ${FONT_WEIGHTS.bold};
+`
+
+const StyledHint = styled(HintText)`
+  padding: 0;
+  margin: 0;
+  padding-bottom: ${SPACING.SCALE_2};
+  ${(props) =>
+    props.error &&
+    `
+    border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    margin-right: ${SPACING.SCALE_3};
+    padding-left: ${SPACING.SCALE_2};
+    padding-bottom: ${SPACING.SCALE_1};
+  `}
+`
+
+const FieldInner = ({ legend, error, showBorder, children }) =>
+  legend ? (
+    <StyledFieldset showBorder={showBorder}>
+      <StyledLegend error={error} showBorder={showBorder}>
+        {legend}
+      </StyledLegend>
+      {children}
+    </StyledFieldset>
+  ) : (
+    children
+  )
+
+const FieldWrapper = ({
+  name,
+  label,
+  legend,
+  hint,
+  error,
+  showBorder,
+  children,
+  reduced,
+}) => (
+  <StyledFormGroup id={`field-${name}`} reduced={reduced} hint={hint}>
+    <FieldInner legend={legend} error={error} showBorder={showBorder}>
+      {label && (
+        <StyledLabel error={error} htmlFor={name}>
+          {label}
+        </StyledLabel>
+      )}
+      {hint &&
+        (showBorder ? (
+          <Paragraph>{hint}</Paragraph>
+        ) : (
+          <StyledHint error={error}>{hint}</StyledHint>
+        ))}
+      {children}
+    </FieldInner>
+  </StyledFormGroup>
+)
+
+FieldInner.propTypes = {
+  legend: PropTypes.node,
+  error: PropTypes.string,
+  showBorder: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+FieldInner.defaultProps = {
+  legend: null,
+  error: null,
+  showBorder: false,
+  children: null,
+}
+
+FieldWrapper.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  legend: PropTypes.node,
+  hint: PropTypes.node,
+  error: PropTypes.string,
+  showBorder: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+FieldWrapper.defaultProps = {
+  label: null,
+  legend: null,
+  hint: null,
+  error: null,
+  showBorder: false,
+  children: null,
+}
+
+export default FieldWrapper

--- a/src/client/components/Form/elements/Form.jsx
+++ b/src/client/components/Form/elements/Form.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import useFormContext from '../hooks/useFormContext'
+
+function Form({ formAttributes, children, ...contextProps }) {
+  return (
+    <useFormContext.Provider {...contextProps}>
+      <form
+        {...formAttributes}
+        noValidate={true}
+        onSubmit={(e) => {
+          e.preventDefault()
+          contextProps.goForward()
+        }}
+      >
+        {children}
+      </form>
+    </useFormContext.Provider>
+  )
+}
+
+Form.propTypes = {
+  values: PropTypes.object,
+  touched: PropTypes.object,
+  errors: PropTypes.object,
+  fields: PropTypes.objectOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      initialValue: PropTypes.any,
+      validate: PropTypes.arrayOf(PropTypes.func),
+    })
+  ),
+  steps: PropTypes.arrayOf(PropTypes.string),
+  currentStep: PropTypes.number,
+  isDirty: PropTypes.bool,
+  registerField: PropTypes.func.isRequired,
+  deregisterField: PropTypes.func.isRequired,
+  setFieldValue: PropTypes.func.isRequired,
+  setFieldTouched: PropTypes.func.isRequired,
+  setFieldError: PropTypes.func.isRequired,
+  validateForm: PropTypes.func.isRequired,
+  registerStep: PropTypes.func.isRequired,
+  deregisterStep: PropTypes.func.isRequired,
+  setCurrentStep: PropTypes.func.isRequired,
+  goForward: PropTypes.func.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goToStepByName: PropTypes.func.isRequired,
+  getStepIndex: PropTypes.func.isRequired,
+  isLastStep: PropTypes.func.isRequired,
+  isFirstStep: PropTypes.func.isRequired,
+  getFieldState: PropTypes.func.isRequired,
+  formAttributes: PropTypes.object,
+  children: PropTypes.node,
+}
+
+Form.defaultProps = {
+  values: {},
+  touched: {},
+  errors: {},
+  fields: {},
+  steps: [],
+  currentStep: 0,
+  isDirty: false,
+  formAttributes: {},
+  children: null,
+}
+
+export default Form

--- a/src/client/components/Form/elements/FormStateful.jsx
+++ b/src/client/components/Form/elements/FormStateful.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import LoadingBox from '@govuk-react/loading-box'
+
+import useForm from '../hooks/useForm'
+import Form from './Form'
+
+const FormStateful = ({ children, formAttributes, ...contextProps }) => {
+  const state = useForm(contextProps)
+
+  const renderChildren = () => {
+    if (typeof children === 'function') {
+      return children(state)
+    }
+    return children
+  }
+
+  return (
+    <Form {...formAttributes} {...state}>
+      <LoadingBox loading={state.isLoading}>{renderChildren()}</LoadingBox>
+    </Form>
+  )
+}
+
+FormStateful.propTypes = {
+  initialValues: PropTypes.object,
+  initialStep: PropTypes.number,
+  onSubmit: PropTypes.func,
+  scrollToTop: PropTypes.bool,
+  onExit: PropTypes.func,
+  formAttributes: PropTypes.object,
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
+}
+
+FormStateful.defaultProps = {
+  initialValues: {},
+  initialStep: 0,
+  onSubmit: undefined,
+  scrollToTop: true,
+  onExit: undefined,
+  formAttributes: {},
+}
+
+export default FormStateful

--- a/src/client/components/Form/hooks/useField.js
+++ b/src/client/components/Form/hooks/useField.js
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+import { isEmpty, castArray } from 'lodash'
+
+import useFormContext from './useFormContext'
+
+function useField({
+  name,
+  initialValue = '',
+  validate = null,
+  required = null,
+}) {
+  const {
+    registerField,
+    deregisterField,
+    setFieldTouched,
+    setFieldValue,
+    getFieldState,
+  } = useFormContext()
+
+  function prepareValidators() {
+    const validators = castArray(validate).filter((v) => v)
+
+    if (required) {
+      validators.unshift((value) => (isEmpty(value) ? required : null))
+    }
+
+    return validators
+  }
+
+  useEffect(() => {
+    registerField({ name, initialValue, validate: prepareValidators() })
+
+    return () => {
+      deregisterField(name)
+    }
+  }, [name])
+
+  const fieldState = getFieldState(name, initialValue)
+
+  return {
+    name,
+    value: fieldState.value,
+    error: fieldState.error,
+    touched: fieldState.touched,
+    onChange: (e) => setFieldValue(name, e.target.value),
+    onBlur: () => setFieldTouched(name, true),
+  }
+}
+
+export default useField

--- a/src/client/components/Form/hooks/useForm.js
+++ b/src/client/components/Form/hooks/useForm.js
@@ -1,0 +1,263 @@
+import { useEffect, useState } from 'react'
+import { isEmpty, isEqual } from 'lodash'
+import { useDeepCompareEffect } from 'react-use'
+
+// Based on react-use/useBeforeUnload but can handle custom handlers (for tests).
+function useBeforeUnload(enabled, onExit) {
+  useEffect(() => {
+    const handler = (event) => {
+      event.preventDefault()
+      const callbackReturnValue =
+        typeof onExit === 'function' ? onExit() : false
+      if (callbackReturnValue) {
+        // eslint-disable-next-line no-param-reassign
+        event.returnValue = callbackReturnValue
+      }
+      return callbackReturnValue
+    }
+
+    if (enabled) {
+      window.addEventListener('beforeunload', handler)
+    }
+
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [enabled, onExit])
+}
+
+function useForm({
+  initialValues = {},
+  initialStep = 0,
+  onSubmit,
+  scrollToTop = true,
+  onExit,
+} = {}) {
+  const [values, setValues] = useState(initialValues)
+  const [touched, setTouched] = useState({})
+  const [errors, setErrors] = useState({})
+  const [fields, setFields] = useState({})
+  const [steps, setSteps] = useState([])
+  const [currentStep, setCurrentStep] = useState(initialStep)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [submissionError, setSubmissionError] = useState(null)
+  const isDirty =
+    !isEmpty(touched) || (!isEmpty(values) && !isEqual(values, initialValues))
+
+  const [redirectUrl, setRedirectUrl] = useState(null)
+
+  const formState = {
+    values,
+    touched,
+    errors,
+    fields,
+    steps,
+    currentStep,
+    isLoading,
+    isSubmitted,
+    isDirty,
+    submissionError,
+  }
+
+  useBeforeUnload(
+    isDirty && !isSubmitted && !submissionError && !redirectUrl,
+    onExit
+  )
+
+  useEffect(() => {
+    if (redirectUrl) {
+      window.location.assign(redirectUrl)
+    }
+  }, [redirectUrl])
+
+  useDeepCompareEffect(() => {
+    if (scrollToTop) {
+      window.scrollTo(0, 0)
+    }
+  }, [currentStep, errors])
+
+  const getFieldState = (name, initialState) => {
+    return {
+      value: values[name] ?? initialState,
+      touched: touched[name] || false,
+      error: errors[name] || null,
+    }
+  }
+
+  const validateField = (name) => {
+    const field = fields[name]
+    const value = values[name]
+
+    if (!field) {
+      throw new Error(`Field ${name} does not exist`)
+    }
+
+    if (field && 'validate' in field) {
+      if (typeof field.validate === 'function') {
+        return field.validate(value, name, formState)
+      }
+
+      if (Array.isArray(field.validate)) {
+        const validationErrors = field.validate
+          .map((validator) => validator(value, field, formState))
+          .filter((e) => e)
+        return validationErrors.length > 0 ? validationErrors[0] : null
+      }
+    }
+
+    return null
+  }
+
+  const validateForm = (fieldNames = []) => {
+    const fieldsToValidate =
+      fieldNames.length > 0 ? fieldNames : Object.keys(fields)
+    const newErrors = {}
+    const newTouched = {}
+
+    fieldsToValidate.forEach((name) => {
+      const error = validateField(name)
+      if (error) {
+        newErrors[name] = error
+      }
+      newTouched[name] = true
+    })
+
+    setErrors(newErrors)
+    setTouched(newTouched)
+
+    return newErrors
+  }
+
+  const setFieldValue = (name, fieldValue) =>
+    setValues((prevValues) => {
+      return { ...prevValues, [name]: fieldValue }
+    })
+  const setFieldTouched = (name, fieldTouched) => {
+    setTouched((prevTouched) => ({ ...prevTouched, [name]: fieldTouched }))
+  }
+  const setFieldError = (name, error) =>
+    setErrors((prevErrors) => ({ ...prevErrors, [name]: error }))
+
+  const registerField = (field) =>
+    setFields((prevFields) => {
+      const { name, initialValue } = field
+
+      if (initialValue && values[name] === undefined) {
+        setFieldValue(name, initialValue)
+      }
+
+      setFieldTouched(name, false)
+
+      if (!(name in prevFields)) {
+        return {
+          ...prevFields,
+          [name]: field,
+        }
+      }
+      return prevFields
+    })
+
+  const deregisterField = (name) => {
+    setFields((prevFields) => {
+      const newFields = { ...prevFields }
+      delete newFields[name]
+      return newFields
+    })
+    setErrors((prevErrors) => {
+      const newErrors = { ...prevErrors }
+      delete newErrors[name]
+      return newErrors
+    })
+    setTouched((prevTouched) => {
+      const newTouched = { ...prevTouched }
+      delete newTouched[name]
+      return newTouched
+    })
+  }
+
+  const registerStep = (name) => {
+    setSteps((prevSteps) => {
+      if (!prevSteps.includes(name)) {
+        const newSteps = [...prevSteps]
+        newSteps.push(name)
+        return newSteps
+      }
+      return prevSteps
+    })
+  }
+  const deregisterStep = (name) =>
+    setSteps((prevSteps) => prevSteps.filter((s) => s !== name))
+
+  const isFirstStep = () => currentStep === 0
+  const isLastStep = () =>
+    currentStep === steps.length - 1 || steps.length === 0
+
+  const submitForm = async () => {
+    try {
+      let newRedirectUrl
+      setIsLoading(true)
+
+      if (typeof onSubmit === 'function') {
+        newRedirectUrl = await onSubmit(values)
+      }
+
+      if (newRedirectUrl) {
+        setRedirectUrl(newRedirectUrl)
+      } else {
+        setIsLoading(false)
+        setIsSubmitted(true)
+      }
+    } catch (e) {
+      setSubmissionError(e)
+      setIsLoading(false)
+    }
+  }
+
+  const getStepIndex = (stepName) => {
+    const index = steps.indexOf(stepName)
+    return index !== -1 ? index : null
+  }
+
+  const goForward = async () => {
+    const validationErrors = validateForm()
+
+    if (!isEmpty(validationErrors)) {
+      return
+    }
+
+    if (!isLastStep()) {
+      setCurrentStep(currentStep + 1)
+      return
+    }
+
+    await submitForm()
+  }
+
+  const goBack = () => setCurrentStep(currentStep - 1)
+
+  const goToStepByName = (stepName) => setCurrentStep(steps.indexOf(stepName))
+
+  return {
+    ...formState,
+    registerField,
+    deregisterField,
+    setFieldValue,
+    setFieldTouched,
+    setFieldError,
+    getFieldState,
+    validateForm,
+    validateField,
+    registerStep,
+    deregisterStep,
+    setCurrentStep,
+    setIsLoading,
+    setIsSubmitted,
+    goForward,
+    goBack,
+    goToStepByName,
+    getStepIndex,
+    isLastStep,
+    isFirstStep,
+  }
+}
+
+export default useForm

--- a/src/client/components/Form/hooks/useFormContext.js
+++ b/src/client/components/Form/hooks/useFormContext.js
@@ -1,0 +1,5 @@
+import createUseContext from 'constate'
+
+const useFormContext = createUseContext((state) => state)
+
+export default useFormContext

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -4,3 +4,5 @@ export { default as SummaryList } from './SummaryList'
 export { default as CollectionList } from './CollectionList'
 export { default as Badge } from './Badge'
 export { default as ButtonLink } from './ButtonLink'
+
+export { default as FieldInput } from './Form/elements/FieldInput'


### PR DESCRIPTION
## Description of change

This is work around moving all components from DH Components to DH FE. As I have moving this I am also adding a new prop that can be passed to the component which will toggle styles for when using the form element as a filter in the left aside of the collection list pages.

## Test instructions
Run storybook and you should now see a form section and in there you see the input field examples with a new (reduced) version .

![Screenshot 2020-07-29 at 09 28 12](https://user-images.githubusercontent.com/10154302/88776570-0a78e100-d17e-11ea-9559-6a115b3e31e1.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
