### PR TITLE
fix: show more than one participant in interaction details form

### DIFF
--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -130,6 +130,12 @@ const getInitialFormValues = (req, res) => {
     'id',
     get(interaction, 'investment_project')
   )
+  const advisers =
+    interaction &&
+    interaction.dit_participants &&
+    interaction.dit_participants
+      .filter((participant) => participant.adviser.name)
+      .map((participant) => participant.adviser)
   return {
     theme,
     kind,
@@ -145,9 +151,9 @@ const getInitialFormValues = (req, res) => {
         ? [transformObjectToOption(referral.contact)]
         : [],
     dit_participants: [
-      transformObjectToOption(
-        get(interaction, 'dit_participants[0].adviser') || user
-      ),
+      (advisers &&
+        advisers.map((adviser) => transformObjectToOption(adviser))) ||
+        transformObjectToOption(user),
     ],
     ...transformInteractionToValues(interaction),
   }


### PR DESCRIPTION
## Description of change

This PR fixes a bug where upon editing an interaction with more than one adviser, only the first adviser is rendered to the form - so when you click save only one adviser is saved and the rest are lost. This was because the initial form values were only ever grabbing the first adviser. Now it provides an array of advisers. 

## Test instructions

When editing an interaction with more than one adviser you should see all the adviser rendered in the form.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
