### PR TITLE
hotfix: show advisers in interaction form

### DIFF
--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -150,10 +150,9 @@ const getInitialFormValues = (req, res) => {
       referral && referral.contact
         ? [transformObjectToOption(referral.contact)]
         : [],
-    dit_participants: [
-      (advisers &&
-        advisers.map((adviser) => transformObjectToOption(adviser))) ||
-        transformObjectToOption(user),
+    dit_participants: (advisers &&
+      advisers.map((adviser) => transformObjectToOption(adviser))) || [
+      transformObjectToOption(user),
     ],
     ...transformInteractionToValues(interaction),
   }


### PR DESCRIPTION
When getting the initial values the user also needs to be in an array for the interaction to save. Hotfix for #2862 

Testing instructions:

- create an interaction with just yourself as adviser, does it save?
- create an interaction with you and some other people as advisers, does it save?
- when clicking back into either of the interaction above do you see the correct advisers in the edit form or are any missing?