### PR TITLE
Add Elastic APM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5375,6 +5375,11 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
+    "after-all-results": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
+      "integrity": "sha1-asL8ICtQD4jaj09VMM+hAPTGotA="
+    },
     "agent-base": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
@@ -5941,6 +5946,30 @@
         "lodash": "^4.17.14"
       }
     },
+    "async-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
+      "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
+      "requires": {
+        "lru-cache": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -5963,6 +5992,19 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
+    },
+    "async-value": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/async-value/-/async-value-1.2.2.tgz",
+      "integrity": "sha1-hFF6Hny2saW14YH6Mb4QQ3t/sSU="
+    },
+    "async-value-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/async-value-promise/-/async-value-promise-1.1.1.tgz",
+      "integrity": "sha512-c2RFDKjJle1rHa0YxN9Ysu97/QBu3Wa+NOejJxsX+1qVDJrkD3JL/GN1B3gaILAEXJXbu/4Z1lcoCHFESe/APA==",
+      "requires": {
+        "async-value": "^1.2.2"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5999,6 +6041,11 @@
           "integrity": "sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ=="
         }
       }
+    },
+    "await-event": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/await-event/-/await-event-2.1.0.tgz",
+      "integrity": "sha1-eOn5JoS65AIvn6C18xShFVD5qnY="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -6923,6 +6970,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -7146,6 +7198,14 @@
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
+      }
+    },
+    "breadth-filter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/breadth-filter/-/breadth-filter-2.0.0.tgz",
+      "integrity": "sha512-thQShDXnFWSk2oVBixRCyrWsFoV5tfOpWKHmxwafHQDNxCfDBk539utpvytNjmlFrTMqz41poLwJvA1MW3z0MQ==",
+      "requires": {
+        "object.entries": "^1.0.4"
       }
     },
     "brorand": {
@@ -9170,6 +9230,11 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
+    "console-log-level": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/console-log-level/-/console-log-level-1.4.1.tgz",
+      "integrity": "sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ=="
+    },
     "console-stream": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
@@ -9193,6 +9258,11 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/constate/-/constate-1.3.2.tgz",
       "integrity": "sha512-aaILV4vXwGTUZaQZHS5F1xBV8wRCR0Ow1505fdkS5/BPg6hbQrhNqdHL4wgxWgaDeEj43mu/Fb+LhqOKTMcrgQ=="
+    },
+    "container-info": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/container-info/-/container-info-1.0.1.tgz",
+      "integrity": "sha512-wk/+uJvPHOFG+JSwQS+fw6H6yw3Oyc8Kw9L4O2MN817uA90OqJ59nlZbbLPqDudsjJ7Tetee3pwExdKpd2ahjQ=="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -11189,6 +11259,78 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
+    "elastic-apm-http-client": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-9.4.0.tgz",
+      "integrity": "sha512-/jOZDyfzLNwHrNkPAI+AspLg0TXYXODWT+I1eoAWRCB7gP1vKvzUQAsP5iChodVqCbAj1eUNXB0KrvM6b07Thw==",
+      "requires": {
+        "breadth-filter": "^2.0.0",
+        "container-info": "^1.0.1",
+        "end-of-stream": "^1.4.4",
+        "fast-safe-stringify": "^2.0.7",
+        "fast-stream-to-buffer": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.4.0",
+        "stream-chopper": "^3.0.1",
+        "unicode-byte-truncate": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "elastic-apm-node": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.6.1.tgz",
+      "integrity": "sha512-4BdcLtlGm1oJtyKO0EVudVp8zyyf+ueIamdIaYYPJoImMrHGi5MhA/xrYrDwxHc3O02xdtII6YPR5XOblkU+Ng==",
+      "requires": {
+        "after-all-results": "^2.0.0",
+        "async-value-promise": "^1.1.1",
+        "basic-auth": "^2.0.1",
+        "console-log-level": "^1.4.1",
+        "cookie": "^0.4.0",
+        "core-util-is": "^1.0.2",
+        "elastic-apm-http-client": "^9.4.0",
+        "end-of-stream": "^1.4.4",
+        "error-stack-parser": "^2.0.6",
+        "fast-safe-stringify": "^2.0.7",
+        "http-headers": "^3.0.2",
+        "http-request-to-url": "^1.0.0",
+        "is-native": "^1.0.1",
+        "measured-reporting": "^1.51.1",
+        "monitor-event-loop-delay": "^1.0.0",
+        "object-filter-sequence": "^1.0.0",
+        "object-identity-map": "^1.0.2",
+        "original-url": "^1.2.3",
+        "read-pkg-up": "^7.0.1",
+        "redact-secrets": "^1.0.0",
+        "relative-microtime": "^2.0.0",
+        "require-ancestors": "^1.0.0",
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^6.3.0",
+        "set-cookie-serde": "^1.0.0",
+        "shallow-clone-shim": "^2.0.0",
+        "sql-summary": "^1.0.1",
+        "stackman": "^4.0.1",
+        "traceparent": "^1.0.0",
+        "unicode-byte-truncate": "^1.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.483",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.483.tgz",
@@ -11413,6 +11555,11 @@
       "requires": {
         "prr": "~1.0.1"
       }
+    },
+    "error-callsites": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/error-callsites/-/error-callsites-2.0.3.tgz",
+      "integrity": "sha512-v036z4IEffZFE5kBkV5/F2MzhLnG0vuDyN+VXpzCf4yWXvX/1WJCI0A+TGTr8HWzBfCw5k8gr9rwAo09V+obTA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -12941,13 +13088,20 @@
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fast-stream-to-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stream-to-buffer/-/fast-stream-to-buffer-1.0.0.tgz",
+      "integrity": "sha512-bI/544WUQlD2iXBibQbOMSmG07Hay7YrpXlKaeGTPT7H7pC0eitt3usak5vUwEvCGK/O7rUAM3iyQValGU22TQ==",
+      "requires": {
+        "end-of-stream": "^1.4.1"
+      }
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -13624,6 +13778,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "forwarded-parse": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.0.tgz",
+      "integrity": "sha512-as9a7Xelt0CvdUy7/qxrY73dZq2vMx49F556fwjjFrUyzq5uHHfeLgD2cCq/6P4ZvusGZzjD6aL2NdgGdS5Cew=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -15002,6 +15161,14 @@
         }
       }
     },
+    "http-headers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-headers/-/http-headers-3.0.2.tgz",
+      "integrity": "sha512-87E1I+2Wg4dxxz4rcxElo3dxO/w1ZtgL1yA0Sb6vH3qU16vRKq1NjWQv9SCY3ly2OQROcoxHZOUpmelS+k6wOw==",
+      "requires": {
+        "next-line": "^1.1.0"
+      }
+    },
     "http-parser-js": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
@@ -15071,6 +15238,15 @@
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
         "micromatch": "^4.0.2"
+      }
+    },
+    "http-request-to-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-request-to-url/-/http-request-to-url-1.0.0.tgz",
+      "integrity": "sha512-YYx0lKXG9+T1fT2q3ZgXLczMI3jW09g9BvIA6L3BG0tFqGm83Ka/+RUZGANRG7Ut/yueD7LPcZQ/+pA5ndNajw==",
+      "requires": {
+        "await-event": "^2.1.0",
+        "socket-location": "^1.0.0"
       }
     },
     "http-signature": {
@@ -15468,6 +15644,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
+    "in-publish": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
+    },
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -15861,8 +16042,7 @@
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "optional": true
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -15923,6 +16103,14 @@
         "is-path-inside": "^3.0.1"
       }
     },
+    "is-integer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
     "is-jpg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-2.0.0.tgz",
@@ -15953,11 +16141,25 @@
         "xtend": "^4.0.0"
       }
     },
+    "is-native": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-native/-/is-native-1.0.1.tgz",
+      "integrity": "sha1-zRjMFi6EUNaDtbq+eayZwUVElnU=",
+      "requires": {
+        "is-nil": "^1.0.0",
+        "to-source-code": "^1.0.0"
+      }
+    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
       "optional": true
+    },
+    "is-nil": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-nil/-/is-nil-1.0.1.tgz",
+      "integrity": "sha1-LauingtYUGOHXntTnQcfWxWTeWk="
     },
     "is-npm": {
       "version": "4.0.0",
@@ -16086,6 +16288,11 @@
       "resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
       "integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA=",
       "dev": true
+    },
+    "is-secret": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-secret/-/is-secret-1.2.1.tgz",
+      "integrity": "sha512-VtBantcgKL2a64fDeCmD1JlkHToh3v0bVOhyJZ5aGTjxtCgrdNcjaC9GaaRFXi19gA4/pYFpnuyoscIgQCFSMQ=="
     },
     "is-set": {
       "version": "2.0.1",
@@ -17899,6 +18106,16 @@
         }
       }
     },
+    "load-source-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-source-map/-/load-source-map-1.0.0.tgz",
+      "integrity": "sha1-MY9JkFzopwnft8w/FvPv47zx3QU=",
+      "requires": {
+        "in-publish": "^2.0.0",
+        "semver": "^5.3.0",
+        "source-map": "^0.5.6"
+      }
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -18774,6 +18991,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "mapcap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mapcap/-/mapcap-1.0.0.tgz",
+      "integrity": "sha512-KcNlZSlFPx+r1jYZmxEbTVymG+dIctf10WmWkuhrhrblM+KMoF77HelwihL5cxYlORye79KoR4IlOOk99lUJ0g=="
+    },
     "markdown-escapes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
@@ -18871,6 +19093,26 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
+    "measured-core": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/measured-core/-/measured-core-1.51.1.tgz",
+      "integrity": "sha512-DZQP9SEwdqqYRvT2slMK81D/7xwdxXosZZBtLVfPSo6y5P672FBTbzHVdN4IQyUkUpcVOR9pIvtUy5Ryl7NKyg==",
+      "requires": {
+        "binary-search": "^1.3.3",
+        "optional-js": "^2.0.0"
+      }
+    },
+    "measured-reporting": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/measured-reporting/-/measured-reporting-1.51.1.tgz",
+      "integrity": "sha512-JCt+2u6XT1I5lG3SuYqywE0e62DJuAzBcfMzWGUhIYtPQV2Vm4HiYt/durqmzsAbZV181CEs+o/jMKWJKkYIWw==",
+      "requires": {
+        "console-log-level": "^1.4.1",
+        "mapcap": "^1.0.0",
+        "measured-core": "^1.51.1",
+        "optional-js": "^2.0.0"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -19971,6 +20213,11 @@
         "xtend": "^4.0.0"
       }
     },
+    "module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
+    },
     "module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
@@ -19986,6 +20233,11 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
       "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
+    },
+    "monitor-event-loop-delay": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/monitor-event-loop-delay/-/monitor-event-loop-delay-1.0.0.tgz",
+      "integrity": "sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -20111,6 +20363,11 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
+    },
+    "next-line": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-line/-/next-line-1.1.0.tgz",
+      "integrity": "sha1-/K5XhTBStqm66CCOQN19PC0wRgM="
     },
     "next-tick": {
       "version": "1.0.0",
@@ -20817,6 +21074,19 @@
         }
       }
     },
+    "object-filter-sequence": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object-filter-sequence/-/object-filter-sequence-1.0.0.tgz",
+      "integrity": "sha512-CsubGNxhIEChNY4cXYuA6KXafztzHqzLLZ/y3Kasf3A+sa3lL9thq3z+7o0pZqzEinjXT6lXDPAfVWI59dUyzQ=="
+    },
+    "object-identity-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-identity-map/-/object-identity-map-1.0.2.tgz",
+      "integrity": "sha512-a2XZDGyYTngvGS67kWnqVdpoaJWsY7C1GhPJvejWAFCsUioTAaiTu8oBad7c6cI4McZxr4CmvnZeycK05iav5A==",
+      "requires": {
+        "object.entries": "^1.1.0"
+      }
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -21005,6 +21275,11 @@
         }
       }
     },
+    "optional-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/optional-js/-/optional-js-2.3.0.tgz",
+      "integrity": "sha512-B0LLi+Vg+eko++0z/b8zIv57kp7HKEzaPJo7LowJXMUKYdf+3XJGu/cw03h/JhIOsLnP+cG5QnTHAuicjA5fMw=="
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -21036,6 +21311,14 @@
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "requires": {
         "url-parse": "^1.4.3"
+      }
+    },
+    "original-url": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/original-url/-/original-url-1.2.3.tgz",
+      "integrity": "sha512-BYm+pKYLtS4mVe/mgT3YKGtWV5HzN/XKiaIu1aK4rsxyjuHeTW9N+xVBEpJcY1onB3nccfH0RbzUEoimMqFUHQ==",
+      "requires": {
+        "forwarded-parse": "^2.1.0"
       }
     },
     "os-browserify": {
@@ -22850,6 +23133,11 @@
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
+    "random-poly-fill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/random-poly-fill/-/random-poly-fill-1.0.1.tgz",
+      "integrity": "sha512-bMOL0hLfrNs52+EHtIPIXxn2PxYwXb0qjnKruTjXiM/sKfYqj506aB2plFwWW1HN+ri724bAVVGparh4AtlJKw=="
+    },
     "random-string": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/random-string/-/random-string-0.2.0.tgz",
@@ -23713,6 +24001,15 @@
         "minimatch": "3.0.4"
       }
     },
+    "redact-secrets": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redact-secrets/-/redact-secrets-1.0.0.tgz",
+      "integrity": "sha1-YPHbVpJP6QogO6jMs5KDzbsNkHw=",
+      "requires": {
+        "is-secret": "^1.0.0",
+        "traverse": "^0.6.6"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -23904,6 +24201,11 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
+    "relative-microtime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/relative-microtime/-/relative-microtime-2.0.0.tgz",
+      "integrity": "sha512-l18ha6HEZc+No/uK4GyAnNxgKW7nvEe35IaeN54sShMojtqik2a6GbTyuiezkjpPaqP874Z3lW5ysBo5irz4NA=="
+    },
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -24093,10 +24395,25 @@
         "tough-cookie": "^2.3.3"
       }
     },
+    "require-ancestors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/require-ancestors/-/require-ancestors-1.0.0.tgz",
+      "integrity": "sha512-Nqeo9Gfp0KvnxTixnxLGEbThMAi+YYgnwRoigtOs1Oo3eGBYfqCd3dagq1vBCVVuc1EnIt3Eu1eGemwOOEZozw=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-in-the-middle": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.0.3.tgz",
+      "integrity": "sha512-p/ICV8uMlqC4tjOYabLMxAWCIKa0YUQgZZ6KDM0xgXJNgdGQ1WmL2A07TwmrZw+wi6ITUFKzH5v3n+ENEyXVkA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.12.0"
+      }
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -25337,6 +25654,11 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "set-cookie-serde": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-serde/-/set-cookie-serde-1.0.0.tgz",
+      "integrity": "sha512-Vq8e5GsupfJ7okHIvEPcfs5neCo7MZ1ZuWrO3sllYi3DOWt6bSSCpADzqXjz3k0fXehnoFIrmmhty9IN6U6BXQ=="
+    },
     "set-harmonic-interval": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
@@ -25420,6 +25742,11 @@
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
         }
       }
+    },
+    "shallow-clone-shim": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shallow-clone-shim/-/shallow-clone-shim-2.0.0.tgz",
+      "integrity": "sha512-YRNymdiL3KGOoS67d73TEmk4tdPTO9GSMCoiphQsTcC9EtC+AOmMPjkyBkRoCJfW9ASsaZw1craaiw1dPN2D3Q=="
     },
     "shallow-equal": {
       "version": "1.2.1",
@@ -25820,6 +26147,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sniffr/-/sniffr-1.2.0.tgz",
       "integrity": "sha512-k7C0ZcHBU330LcSkKyc2cOOB0uHosME8b2t9qFJqdqB1cKwGmZWd7BVwBz5mWOMJ5dggK1dy2qv+DSwteKLBzQ=="
+    },
+    "socket-location": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/socket-location/-/socket-location-1.0.0.tgz",
+      "integrity": "sha512-TwxpRM0pPE/3b24XQGLx8zq2J8kOwTy40FtiNC1KrWvl/Tsf7RYXruE9icecMhQwicXMo/HUJlGap8DNt2cgYw==",
+      "requires": {
+        "await-event": "^2.1.0"
+      }
     },
     "socket.io": {
       "version": "2.1.1",
@@ -26262,6 +26597,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sql-summary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sql-summary/-/sql-summary-1.0.1.tgz",
+      "integrity": "sha512-IpCr2tpnNkP3Jera4ncexsZUp0enJBLr+pHCyTweMUBrbJsTgQeLWx1FXLhoBj/MvcnUQpkgOn2EY8FKOkUzww=="
+    },
     "squeak": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
@@ -26370,6 +26710,18 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
+    "stackman": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/stackman/-/stackman-4.0.1.tgz",
+      "integrity": "sha512-lntIge3BFEElgvpZT2ld5f4U+mF84fRtJ8vA3ymUVx1euVx43ZMkd09+5RWW4FmvYDFhZwPh1gvtdsdnJyF4Fg==",
+      "requires": {
+        "after-all-results": "^2.0.0",
+        "async-cache": "^1.1.0",
+        "debug": "^4.1.1",
+        "error-callsites": "^2.0.3",
+        "load-source-map": "^1.0.0"
+      }
+    },
     "stacktrace-gps": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
@@ -26469,6 +26821,26 @@
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
       "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
       "dev": true
+    },
+    "stream-chopper": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stream-chopper/-/stream-chopper-3.0.1.tgz",
+      "integrity": "sha512-f7h+ly8baAE26iIjcp3VbnBkbIRGtrvV0X0xxFM/d7fwLTYnLzDPTXRKNxa2HZzohOrc96NTrR+FaV3mzOelNA==",
+      "requires": {
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "stream-combiner": {
       "version": "0.0.4",
@@ -27468,6 +27840,14 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "to-source-code": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-source-code/-/to-source-code-1.0.2.tgz",
+      "integrity": "sha1-3RNr2x4dvYC76s8IiZJnjpBwv+o=",
+      "requires": {
+        "is-nil": "^1.0.0"
+      }
+    },
     "toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
@@ -27521,6 +27901,19 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "traceparent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/traceparent/-/traceparent-1.0.0.tgz",
+      "integrity": "sha512-b/hAbgx57pANQ6cg2eBguY3oxD6FGVLI1CC2qoi01RmHR7AYpQHPXTig9FkzbWohEsVuHENZHP09aXuw3/LM+w==",
+      "requires": {
+        "random-poly-fill": "^1.0.1"
+      }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "traverse-chain": {
       "version": "0.1.0",
@@ -27839,6 +28232,15 @@
         "xtend": "^4.0.0"
       }
     },
+    "unicode-byte-truncate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-byte-truncate/-/unicode-byte-truncate-1.0.0.tgz",
+      "integrity": "sha1-qm8PNHUZP+IMMgrJIT425i6HZKc=",
+      "requires": {
+        "is-integer": "^1.0.6",
+        "unicode-substring": "^0.1.0"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -27862,6 +28264,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+    },
+    "unicode-substring": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-substring/-/unicode-substring-0.1.0.tgz",
+      "integrity": "sha1-YSDOPDkDhdvND2DDK5BlxBgdSzY="
     },
     "unified": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "del-cli": "^3.0.0",
     "details-element-polyfill": "^2.4.0",
     "dotenv": "^8.2.0",
+    "elastic-apm-node": "^3.6.1",
     "element-closest": "^3.0.2",
     "express": "^4.16.2",
     "express-minify-html": "^0.12.0",

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -178,7 +178,7 @@ const envSchema = Joi.object({
   // Elastic APM secret token used to authenticate the service
   ELASTIC_APM_SECRET_TOKEN: Joi.string(),
   // Elastic APM server timeout used to timeout if no response is found after 20 secs
-  ELASTIC_APM_SERVER_TIMEOUT: Joi.integer().default(20)
+  ELASTIC_APM_SERVER_TIMEOUT: Joi.number().integer().default(20)
 })
 /* eslint-enable prettier/prettier */
 

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -170,6 +170,15 @@ const envSchema = Joi.object({
   ZEN_TICKETS_URL: Joi.string().uri().required(),
   // Zendesk token used for API queries
   ZEN_TOKEN: Joi.string().required(),
+
+  // Elastic APM service name used to label the service you want to monitor
+  ELASTIC_APM_SERVICE_NAME: Joi.string().default('datahub-fe'),
+  // Elastic APM server url is where you host the monitoring of transactions
+  ELASTIC_APM_SERVER_URL: Joi.string().uri(),
+  // Elastic APM secret token used to authenticate the service
+  ELASTIC_APM_SECRET_TOKEN: Joi.string(),
+  // Elastic APM server timeout used to timeout if no response is found after 20 secs
+  ELASTIC_APM_SERVER_TIMEOUT: Joi.integer().default(20)
 })
 /* eslint-enable prettier/prettier */
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,7 @@
 require('dotenv').config()
 
+require('elastic-apm-node').start()
+
 const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')


### PR DESCRIPTION
## Description of change
This adds Elastic APM (Application Performance Monitoring) to the node layer so we can monitor transactions from the FE - https://www.elastic.co/guide/en/apm/agent/nodejs/3.x/configuring-the-agent.html

## Test instructions
This shouldn't effect anything on the FE, the only way you can see this take effect is by logging into our Kibana account and you will need access.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
