### PR TITLE
fix: update flash message

### DIFF
--- a/src/apps/companies/apps/edit-company/controllers.js
+++ b/src/apps/companies/apps/edit-company/controllers.js
@@ -74,7 +74,7 @@ async function postEditCompany(req, res, next) {
 
       req.flashWithBody(
         'success',
-        'Update sent for third party review.',
+        'Change requested.',
         'Thanks for keeping Data Hub running smoothly.',
         'message-company-change-request'
       )

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -359,9 +359,9 @@ describe('Company edit', () => {
       )
     })
 
-    it('displays the "Update sent for third party review" flash message and the ID used in GA', () => {
+    it('displays the "Change requested. Thanks for keeping Data Hub running smoothly" flash message and the ID used in GA', () => {
       cy.contains(
-        'Update sent for third party review.Thanks for keeping Data Hub running smoothly.'
+        'Change requested.Thanks for keeping Data Hub running smoothly.'
       ).should('have.attr', 'id', 'message-company-change-request')
     })
   })


### PR DESCRIPTION
## Description of change

This PR fixes the content for the flash message meant to be included in a previous PR - #2792 

## Test instructions

Make a change to a DNB company and you will see the green flash message with the new content as per the screenshot below.

## Screenshots

![image (2)](https://user-images.githubusercontent.com/42253716/89801490-28542780-db28-11ea-9cb9-833c07bcaabb.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
