### PR TITLE
Add mock server for BE third party services for E2E suites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,16 @@ aliases:
       command: node ./test/sandbox/server.js
       background: true
 
+  - &start_api_sandbox_e2e
+    run:
+      name: Start API sandbox
+      command: | 
+        echo 'export SANDBOX_PORT=8888' >> $BASH_ENV
+        source $BASH_ENV
+        node ./test/sandbox/server.js
+      background: true
+
+
   - &start_frontend
     run:
       name: Start data hub frontend
@@ -165,14 +175,14 @@ aliases:
     ADMIN_OAUTH2_ENABLED: 'False'
     ES_APM_ENABLED: 'False'
     COLUMNS: 80 # Workaround for Docker/CircleCI compatibility problem with Python 3.8
-    CONSENT_SERVICE_BASE_URL: $DH_CONSENT_SERVICE_BASE_URL
-    CONSENT_SERVICE_HAWK_ID: $DH_CONSENT_SERVICE_HAWK_ID
-    CONSENT_SERVICE_HAWK_KEY: $DH_CONSENT_SERVICE_HAWK_KEY
-    DNB_SERVICE_BASE_URL: $DH_DNB_SERVICE_BASE_URL
-    DNB_SERVICE_TOKEN: $DH_DNB_SERVICE_TOKEN
-    COMPANY_MATCHING_SERVICE_BASE_URL: $DH_COMPANY_MATCHING_SERVICE_BASE_URL
-    COMPANY_MATCHING_HAWK_ID: $DH_COMPANY_MATCHING_HAWK_ID
-    COMPANY_MATCHING_HAWK_KEY: $DH_COMPANY_MATCHING_HAWK_KEY
+    CONSENT_SERVICE_BASE_URL: http://localhost:8888
+    CONSENT_SERVICE_HAWK_ID: dummyId
+    CONSENT_SERVICE_HAWK_KEY: dummyKey
+    DNB_SERVICE_BASE_URL: http://localhost:8888
+    DNB_SERVICE_TOKEN: dummyToken
+    COMPANY_MATCHING_SERVICE_BASE_URL: http://localhost:8888
+    COMPANY_MATCHING_HAWK_ID: dummyId
+    COMPANY_MATCHING_HAWK_KEY: dummyKey
 
   # Data hub backend
   - &docker_data_hub_backend_base
@@ -352,6 +362,7 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run build
+      - *start_api_sandbox_e2e
       - *wait_for_backend
       - *wait_for_mock_sso
       - *start_frontend
@@ -385,6 +396,7 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run build
+      - *start_api_sandbox_e2e
       - *wait_for_backend
       - *wait_for_mock_sso
       - *start_frontend
@@ -418,6 +430,7 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run build
+      - *start_api_sandbox_e2e
       - *wait_for_backend
       - *wait_for_mock_sso
       - *start_frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,42 +133,52 @@ aliases:
       - MOCK_SSO_SCOPE: 'data-hub:internal-front-end'
       - MOCK_SSO_TOKEN: 123
 
+  - &docker_data_hub_backend_env
+    AWS_DEFAULT_REGION: eu-west-2
+    AWS_ACCESS_KEY_ID: foo
+    AWS_SECRET_ACCESS_KEY: bar
+    DATABASE_URL: postgresql://postgres:datahub@postgres/datahub
+    MI_DATABASE_URL: postgresql://postgres:datahub@mi-postgres/mi
+    DEBUG: 'False'
+    DEFAULT_BUCKET: baz
+    DJANGO_SECRET_KEY: topSecret
+    DJANGO_SETTINGS_MODULE: config.settings.local
+    ENABLE_CELERY_ES_SYNC_OBJECT: 'True'
+    ES_INDEX_PREFIX: test_index
+    ES5_URL: http://es:9200
+    POSTGRES_URL: tcp://postgres:5432
+    MI_POSTGRES_URL: tcp://mi-postgres:5432
+    REDIS_BASE_URL: redis://redis:6379
+    REDIS_CACHE_DB: 5
+    REDIS_CELERY_DB: 6
+    SSO_ENABLED: 'True'
+    RESOURCE_SERVER_INTROSPECTION_URL: http://localhost:8080/o/introspect # required but not used as user with token has been created in backend setup script
+    RESOURCE_SERVER_AUTH_TOKEN: sso-token
+    STAFF_SSO_BASE_URL: http://localhost:8080/
+    STAFF_SSO_AUTH_TOKEN: sso-token
+    WEB_CONCURRENCY: 2
+    ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
+    ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
+    DISABLE_PAAS_IP_CHECK: 'True'
+    DATA_HUB_FRONTEND_ACCESS_KEY_ID: frontend-key-id
+    DATA_HUB_FRONTEND_SECRET_ACCESS_KEY: frontend-key
+    ADMIN_OAUTH2_ENABLED: 'False'
+    ES_APM_ENABLED: 'False'
+    COLUMNS: 80 # Workaround for Docker/CircleCI compatibility problem with Python 3.8
+    CONSENT_SERVICE_BASE_URL: $DH_CONSENT_SERVICE_BASE_URL
+    CONSENT_SERVICE_HAWK_ID: $DH_CONSENT_SERVICE_HAWK_ID
+    CONSENT_SERVICE_HAWK_KEY: $DH_CONSENT_SERVICE_HAWK_KEY
+    DNB_SERVICE_BASE_URL: $DH_DNB_SERVICE_BASE_URL
+    DNB_SERVICE_TOKEN: $DH_DNB_SERVICE_TOKEN
+    COMPANY_MATCHING_SERVICE_BASE_URL: $DH_COMPANY_MATCHING_SERVICE_BASE_URL
+    COMPANY_MATCHING_HAWK_ID: $DH_COMPANY_MATCHING_HAWK_ID
+    COMPANY_MATCHING_HAWK_KEY: $DH_COMPANY_MATCHING_HAWK_KEY
+
   # Data hub backend
   - &docker_data_hub_backend_base
     image: *api_image
-    environment:
-      AWS_DEFAULT_REGION: eu-west-2
-      AWS_ACCESS_KEY_ID: foo
-      AWS_SECRET_ACCESS_KEY: bar
-      DATABASE_URL: postgresql://postgres:datahub@postgres/datahub
-      MI_DATABASE_URL: postgresql://postgres:datahub@mi-postgres/mi
-      DEBUG: 'False'
-      DEFAULT_BUCKET: baz
-      DJANGO_SECRET_KEY: topSecret
-      DJANGO_SETTINGS_MODULE: config.settings.local
-      ENABLE_CELERY_ES_SYNC_OBJECT: 'True'
-      ES_INDEX_PREFIX: test_index
-      ES5_URL: http://es:9200
-      POSTGRES_URL: tcp://postgres:5432
-      MI_POSTGRES_URL: tcp://mi-postgres:5432
-      REDIS_BASE_URL: redis://redis:6379
-      REDIS_CACHE_DB: 5
-      REDIS_CELERY_DB: 6
-      SSO_ENABLED: 'True'
-      RESOURCE_SERVER_INTROSPECTION_URL: http://localhost:8080/o/introspect # required but not used as user with token has been created in backend setup script
-      RESOURCE_SERVER_AUTH_TOKEN: sso-token
-      STAFF_SSO_BASE_URL: http://localhost:8080/
-      STAFF_SSO_AUTH_TOKEN: sso-token
-      WEB_CONCURRENCY: 2
-      ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
-      ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
-      DISABLE_PAAS_IP_CHECK: 'True'
-      DATA_HUB_FRONTEND_ACCESS_KEY_ID: frontend-key-id
-      DATA_HUB_FRONTEND_SECRET_ACCESS_KEY: frontend-key
-      ADMIN_OAUTH2_ENABLED: 'False'
-      ES_APM_ENABLED: 'False'
-      # Workaround for Docker/CircleCI compatibility problem with Python 3.8
-      COLUMNS: 80
+    environment: *docker_data_hub_backend_env
+      
 
   - &docker_data_hub_backend_api
     <<: *docker_data_hub_backend_base

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -56,7 +56,7 @@ describe('Contacts', () => {
       'Phone number': '(44) 0778877778800',
       Address: "12 St George's Road, Paris, 75001, France",
       Email: 'company.contact@dit.com',
-      'Email marketing': 'Can be marketed to',
+      'Email marketing': 'Cannot be marketed to',
     })
   })
 

--- a/test/sandbox/routes/api/consentService.js
+++ b/test/sandbox/routes/api/consentService.js
@@ -1,0 +1,7 @@
+exports.person = function(req, res) {
+  res.json({})
+}
+
+exports.bulkPerson = function(req, res) {
+  res.json({ count: 0, next: null, previous: null, results: [] })
+}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -459,7 +459,6 @@ app.delete(
 
 app.post('/api/v1/person', consentService.person)
 app.get('/api/v1/person/bulk_lookup', consentService.bulkPerson)
-app.post('/api/v1/person/bulk_lookup', consentService.bulkPerson)
 
 app.use((req, res) =>
   res.status(404).json({ message: 'Route' + req.url + ' Not found.' })

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -3,7 +3,7 @@ const bodyParser = require('body-parser')
 const _ = require('lodash')
 
 const config = {
-  PORT: process.env.PORT || 8000,
+  PORT: process.env.SANDBOX_PORT || 8000,
 }
 
 const app = express()
@@ -53,6 +53,9 @@ var v4SearchLargeInvestorProfiles = require('./routes/v4/search/large-investor-p
 var v4SearchExports = require('./routes/v4/search/export')
 var v4referralList = require('./routes/v4/referrals/list.js')
 var v4pipelineItem = require('./routes/v4/pipeline-item/index.js')
+
+// Datahub API 3rd party dependencies
+var consentService = require('./routes/api/consentService.js')
 
 // Data store service (github.com/uktrade/data-store-service)
 app.get('/api/v1/get-postcode-data/', postcode.toRegion)
@@ -453,6 +456,11 @@ app.delete(
   '/v4/pipeline-item/:pipelineItemId',
   v4pipelineItem.deletePipelineItem
 )
+
+app.post('/api/v1/person', consentService.person)
+app.get('/api/v1/person/bulk_lookup', consentService.bulkPerson)
+app.post('/api/v1/person/bulk_lookup', consentService.bulkPerson)
+
 app.use((req, res) =>
   res.status(404).json({ message: 'Route' + req.url + ' Not found.' })
 )


### PR DESCRIPTION
## Description of change

After the BE removed the feature flag we now need to ensure that the BE has an endpoint to hit for 3rd party services around consent service, company matching and dnb.

The intent of this PR is to introduce a mock server for the E2E test suite so that we don't rely on the 3rd party services being up.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
