### PR TITLE
Mark tasks as finished

### DIFF
--- a/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
@@ -63,89 +63,84 @@ export default connect(({ referrerUrl, ...state }) => ({
           onSuccessDispatch: REFERRAL_DETAILS,
         }}
       >
-        {() =>
-          company && (
-            <>
-              <SummaryTable caption={subject}>
-                <SummaryTable.Row heading="Company">
-                  <Link href={urls.companies.detail(company.id)}>
-                    {company.name}
+        {() => (
+          <>
+            <SummaryTable caption={subject}>
+              <SummaryTable.Row heading="Company">
+                <Link href={urls.companies.detail(company.id)}>
+                  {company.name}
+                </Link>
+              </SummaryTable.Row>
+              {contact && (
+                <SummaryTable.Row heading="Contact">
+                  <Link href={urls.contacts.contact(contact.id)}>
+                    {contact.name}
                   </Link>
                 </SummaryTable.Row>
-                {contact && (
-                  <SummaryTable.Row heading="Contact">
-                    <Link href={urls.contacts.contact(contact.id)}>
-                      {contact.name}
-                    </Link>
-                  </SummaryTable.Row>
-                )}
-                <SummaryTable.Row heading="Sending adviser">
-                  {sendingAdviser && <AdviserDetails {...sendingAdviser} />}
-                </SummaryTable.Row>
-                <SummaryTable.Row heading="Receiving adviser">
-                  {receivingAdviser && <AdviserDetails {...receivingAdviser} />}
-                </SummaryTable.Row>
-                <SummaryTable.Row heading="Date of referral">
-                  {DateUtils.format(date)}
-                </SummaryTable.Row>
-                <SummaryTable.Row heading="Notes">{notes}</SummaryTable.Row>
-              </SummaryTable>
-              {completed ? (
-                <SummaryTable caption="Referral accepted">
-                  <SummaryTable.Row heading="Date">
-                    {DateUtils.format(completed.on)}
-                  </SummaryTable.Row>
-                  <SummaryTable.Row heading="By">
-                    <AdviserDetails {...completed.by} />
-                  </SummaryTable.Row>
-                  <SummaryTable.Row heading="With interaction">
-                    <Link href={urls.interactions.detail(interaction.id)}>
-                      {interaction.subject}
-                    </Link>
-                  </SummaryTable.Row>
-                </SummaryTable>
-              ) : (
-                <>
-                  <Details summary="Why can I not edit the referral?">
-                    <p>
-                      For now, you can't edit the referral once it's been sent.
-                    </p>
-                    <p>Contact the recipient if something's changed.</p>
-                  </Details>
-                  <FormActions>
-                    <Button
-                      as={Link}
-                      href={urls.companies.referrals.interactions.create(
-                        company.id,
-                        referralId
-                      )}
-                    >
-                      Accept referral
-                    </Button>
-                    <SecondaryButton
-                      as={Link}
-                      href={urls.companies.referrals.help(
-                        company.id,
-                        referralId
-                      )}
-                    >
-                      I cannot accept the referral
-                    </SecondaryButton>
-                    <Link
-                      href={
-                        cameFromHomePage
-                          ? urls.companies.referrals.list()
-                          : urls.companies.detail(company.id)
-                      }
-                    >
-                      Back
-                    </Link>
-                  </FormActions>
-                </>
               )}
-            </>
-          )
-        }
+              <SummaryTable.Row heading="Sending adviser">
+                {sendingAdviser && <AdviserDetails {...sendingAdviser} />}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Receiving adviser">
+                {receivingAdviser && <AdviserDetails {...receivingAdviser} />}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Date of referral">
+                {DateUtils.format(date)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Notes">{notes}</SummaryTable.Row>
+            </SummaryTable>
+            {completed ? (
+              <SummaryTable caption="Referral accepted">
+                <SummaryTable.Row heading="Date">
+                  {DateUtils.format(completed.on)}
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="By">
+                  <AdviserDetails {...completed.by} />
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="With interaction">
+                  <Link href={urls.interactions.detail(interaction.id)}>
+                    {interaction.subject}
+                  </Link>
+                </SummaryTable.Row>
+              </SummaryTable>
+            ) : (
+              <>
+                <Details summary="Why can I not edit the referral?">
+                  <p>
+                    For now, you can't edit the referral once it's been sent.
+                  </p>
+                  <p>Contact the recipient if something's changed.</p>
+                </Details>
+                <FormActions>
+                  <Button
+                    as={Link}
+                    href={urls.companies.referrals.interactions.create(
+                      company.id,
+                      referralId
+                    )}
+                  >
+                    Accept referral
+                  </Button>
+                  <SecondaryButton
+                    as={Link}
+                    href={urls.companies.referrals.help(company.id, referralId)}
+                  >
+                    I cannot accept the referral
+                  </SecondaryButton>
+                  <Link
+                    href={
+                      cameFromHomePage
+                        ? urls.companies.referrals.list()
+                        : urls.companies.detail(company.id)
+                    }
+                  >
+                    Back
+                  </Link>
+                </FormActions>
+              </>
+            )}
+          </>
+        )}
       </Task.Status>
     )
   }

--- a/src/client/components/Task/index.jsx
+++ b/src/client/components/Task/index.jsx
@@ -220,7 +220,7 @@ Task.Status = ({
               errorMessage,
               retry: () => start({ payload, onSuccessDispatch }),
             })}
-          {!status && children()}
+          {status === 'finished' && children()}
         </>
       )
     }}

--- a/src/client/components/Task/reducer.js
+++ b/src/client/components/Task/reducer.js
@@ -1,4 +1,3 @@
-import { omit } from 'lodash'
 import { TASK__PROGRESS, TASK__ERROR, TASK__CLEAR } from '../../actions'
 
 const setTaskState = (state, { name, id, ...action }, status) => {
@@ -24,13 +23,7 @@ export default (state = {}, { type, ...action }) => {
     case TASK__ERROR:
       return setTaskState(state, action, 'error')
     case TASK__CLEAR:
-      return omit(
-        state,
-        Object.entries(state[action.name]).length > 1
-          ? `${action.name}.${action.id}`
-          : // Remove the whole task group if removing its last task
-            action.name
-      )
+      return setTaskState(state, action, 'finished')
     default:
       return state
   }


### PR DESCRIPTION
## Description of change

Currently the child components of `Task.Status` will flash on the screen with no data before the task is started. Then when it is finished the child components re-render with data. This isn't ideal behaviour and so other developers have introduced checks against the state to see whether the task has finished or not. However, this doesn't work when you would still like to render a child component even if there are no results after the task has finished (unless you add another piece of state like `isFinished` that is updated in the reducer), and this has to be implemented each time a new component is built. This is easily missed and there are areas of the site that do flash before the Task start - this isn't great (but hands up, most of these are components I wrote...). 

Currently there is a `status` for the task. After it is started the `status` is set to `progress`. If it errors the `status` is set to `error`. However, when it finishes the task, and its `status`, is simply removed from the state entirely. 

This PR, rather than removing the task from state upon completion, leaves the task in state but marks its `status` as `finished`. This allows the `Task.Status` to check whether the status is `finished` before rendering the components. Currently it just checks to see if `status` is undefined. I think the problem we're seeing is that `status` is undefined momentarily before the Task begins. So checking to instead see whether it is `finished` should be more robust. 

This could lead to the state becomes clogged with all of the Tasks that a user has dispatched. However, currently in our express/React hybrid app, the state refreshes on every page change (barring the React routed dashboard sub tabs). So the state is wiped clean anyway as the user navigates around the site. Also, it probably isn't a big problem that they hang around in state anyway, there will never be enough to cause any performance problems. 

In summary, this change means that child components of `Task.Status` don't flash before the `Task` has finished. And you don't have to put a solution together to prevent this each time. 

## Test instructions

Navigate to referrals, make sure there are some in the database, and you will see there is no flash of the component before loading - even though I have removed the condition check that was there previously. You can also see that export history no longer flashes before loading. 

You may want to throttle your network speed to slow 3G to more easily see this in action. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
