### PR TITLE
Move 'Skip to main content' link inside of a landmark

### DIFF
--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -97,6 +97,12 @@
       <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>
     </p>
   </div>
+  <nav role="navigation"> 
+    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  </nav>
+{% endblock %}
+
+{% block skipLink %}
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
## Description of change

As part of the accessibility work for the top 25 pages in DataHub, testing with Axe has highlighted that the 'Skip to main content' link needs to be inside a landmark. Beforehand this link was just floating about in the govuk frontend nunjucks template, so we've moved it inside of a nav in order to satisfy the tests. 

Is this the right thing to do? I'm not an expert by any stretch but I can't find a guideline in the WCAG specifying that it has to be in a landmark, only Axe says this. After researching online, it seems to be that it's a nice to have but not a necessity? This seems to appease Axe though. 

## Test instructions

Nothing visually should have changed. If you go to the homepage and click tab till you see the skip to main content link show on focus, it should all still look the same as Staging or prod etc. When you look in the dev tools however, you should see that before the header, you have a nav which holds the 'skip to main content' link. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
