### PR TITLE
Feature/opt in market email checkbox

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@ $toolkit-font-stack: $govuk-font-family;
 @import "trumps";
 
 @import "../../src/apps/companies/apps/investments/styles";
+@import "../../src/apps/contacts/styles";
 
 //// application specific (deprecated)
 @import "_deprecated/dashboard";

--- a/src/apps/contacts/__test__/transformers.test.js
+++ b/src/apps/contacts/__test__/transformers.test.js
@@ -207,7 +207,7 @@ describe('Contact transformers', () => {
         beforeEach(() => {
           this.view = transformContactToView(
             assign({}, contact, {
-              rejects_dit_email_marketing: true,
+              accepts_dit_email_marketing: true,
             }),
             company
           )
@@ -228,7 +228,7 @@ describe('Contact transformers', () => {
         beforeEach(() => {
           this.view = transformContactToView(
             assign({}, contact, {
-              rejects_dit_email_marketing: false,
+              accepts_dit_email_marketing: false,
             }),
             company
           )

--- a/src/apps/contacts/__test__/transformers.test.js
+++ b/src/apps/contacts/__test__/transformers.test.js
@@ -207,7 +207,7 @@ describe('Contact transformers', () => {
         beforeEach(() => {
           this.view = transformContactToView(
             assign({}, contact, {
-              accepts_dit_email_marketing: true,
+              accepts_dit_email_marketing: false,
             }),
             company
           )
@@ -228,7 +228,7 @@ describe('Contact transformers', () => {
         beforeEach(() => {
           this.view = transformContactToView(
             assign({}, contact, {
-              accepts_dit_email_marketing: false,
+              accepts_dit_email_marketing: true,
             }),
             company
           )

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -38,9 +38,6 @@ async function getCommon(req, res, next) {
 
 function getDetails(req, res, next) {
   try {
-    // database is positive on accepts, negative on rejects; UI is reverse, so flip that here
-    res.locals.contact.rejects_dit_email_marketing = !res.locals.contact
-      .accepts_dit_email_marketing
     res.render('contacts/views/details', {
       contactDetails: transformContactToView(
         res.locals.contact,

--- a/src/apps/contacts/services/__test__/form.test.js
+++ b/src/apps/contacts/services/__test__/form.test.js
@@ -87,7 +87,7 @@ describe('contact form service', () => {
         telephone_number: '652423467167',
         telephone_countrycode: '+1',
         email: 'zboasdaan@opasdasdov.com',
-        rejects_dit_email_marketing: false,
+        accepts_dit_email_marketing: false,
         accepts_dit_email_marketing: true,
         address_same_as_company: 'no',
         address_1: '99 N Shore Road',
@@ -141,7 +141,7 @@ describe('contact form service', () => {
         email_alternative: 'fred@me.com',
         notes: 'Some notes',
         accepts_dit_email_marketing: true,
-        rejects_dit_email_marketing: false,
+        accepts_dit_email_marketing: false,
       }
 
       const actual = contactFormService.getContactAsFormData(contact)
@@ -156,7 +156,7 @@ describe('contact form service', () => {
     context('when the contact accepts DIT email marketing', () => {
       it('should set the marketing preferences to accepts_dit_email_marketing', () => {
         const contact = assign({}, contactData, {
-          rejects_dit_email_marketing: false,
+          accepts_dit_email_marketing: false,
         })
         const actual = contactFormService.getContactAsFormData(contact)
         expect(actual.accepts_dit_email_marketing).to.be.true
@@ -246,7 +246,7 @@ describe('contact form service', () => {
     context('when the contact accepts DIT email marketing', () => {
       it('it should send accepts DIT email marketing as true', async () => {
         this.formData = assign({}, formData, {
-          rejects_dit_email_marketing: false,
+          accepts_dit_email_marketing: false,
         })
 
         await contactFormService.saveContactForm('1234', this.formData)

--- a/src/apps/contacts/services/__test__/form.test.js
+++ b/src/apps/contacts/services/__test__/form.test.js
@@ -87,7 +87,6 @@ describe('contact form service', () => {
         telephone_number: '652423467167',
         telephone_countrycode: '+1',
         email: 'zboasdaan@opasdasdov.com',
-        accepts_dit_email_marketing: false,
         accepts_dit_email_marketing: true,
         address_same_as_company: 'no',
         address_1: '99 N Shore Road',
@@ -141,7 +140,6 @@ describe('contact form service', () => {
         email_alternative: 'fred@me.com',
         notes: 'Some notes',
         accepts_dit_email_marketing: true,
-        accepts_dit_email_marketing: false,
       }
 
       const actual = contactFormService.getContactAsFormData(contact)
@@ -156,7 +154,7 @@ describe('contact form service', () => {
     context('when the contact accepts DIT email marketing', () => {
       it('should set the marketing preferences to accepts_dit_email_marketing', () => {
         const contact = assign({}, contactData, {
-          accepts_dit_email_marketing: false,
+          accepts_dit_email_marketing: true,
         })
         const actual = contactFormService.getContactAsFormData(contact)
         expect(actual.accepts_dit_email_marketing).to.be.true
@@ -203,7 +201,7 @@ describe('contact form service', () => {
         telephone_number: '652423467167',
         telephone_countrycode: '+1',
         email: 'zboasdaan@opasdasdov.com',
-        accepts_dit_email_marketing: true,
+        accepts_dit_email_marketing: false,
         address_same_as_company: false,
         address_1: '99 N Shore Road',
         address_2: 'Suite 20',
@@ -246,7 +244,7 @@ describe('contact form service', () => {
     context('when the contact accepts DIT email marketing', () => {
       it('it should send accepts DIT email marketing as true', async () => {
         this.formData = assign({}, formData, {
-          accepts_dit_email_marketing: false,
+          accepts_dit_email_marketing: true,
         })
 
         await contactFormService.saveContactForm('1234', this.formData)

--- a/src/apps/contacts/services/form.js
+++ b/src/apps/contacts/services/form.js
@@ -36,7 +36,6 @@ function getContactAsFormData(contact) {
     telephone_countrycode: contact.telephone_countrycode,
     email: contact.email,
     accepts_dit_email_marketing: contact.accepts_dit_email_marketing,
-    rejects_dit_email_marketing: !contact.accepts_dit_email_marketing,
     address_same_as_company: contact.address_same_as_company ? 'yes' : 'no',
     address_1: contact.address_1,
     address_2: contact.address_2,
@@ -72,9 +71,9 @@ function saveContactForm(token, contactForm) {
         contactFormWithEmptyAsNull,
         ['title', 'company', 'address_country']
       )
+
       const contactFormForApiRequest = merge({}, transformedContactForm, {
-        // database is positive on accepts, negative on rejects; UI is reverse, so flip that here
-        accepts_dit_email_marketing: !contactForm.rejects_dit_email_marketing,
+        accepts_dit_email_marketing: !!contactForm.accepts_dit_email_marketing,
       })
       const savedContact = await contactsRepository.saveContact(
         token,

--- a/src/apps/contacts/styles.scss
+++ b/src/apps/contacts/styles.scss
@@ -1,0 +1,9 @@
+#hint-group-field-accepts_dit_email_marketing {
+    display: none;
+}
+input:checked[name="accepts_dit_email_marketing"] {
+    + label #hint-group-field-accepts_dit_email_marketing {
+        display: block;
+        margin-top: 4px;
+    }
+}

--- a/src/apps/contacts/transformers.js
+++ b/src/apps/contacts/transformers.js
@@ -107,7 +107,7 @@ function transformContactToView(
     telephone_number,
     job_title,
     email,
-    rejects_dit_email_marketing,
+    accepts_dit_email_marketing,
     address_1,
     address_2,
     address_town,
@@ -131,9 +131,9 @@ function transformContactToView(
       telephone_countrycode,
       telephone_number
     ),
-    email_marketing: rejects_dit_email_marketing
-      ? 'Cannot be marketed to'
-      : 'Can be marketed to',
+    email_marketing: accepts_dit_email_marketing
+      ? 'Can be marketed to'
+      : 'Cannot be marketed to',
     address: {
       type: 'address',
       address: getContactAddress(

--- a/src/apps/contacts/views/edit.njk
+++ b/src/apps/contacts/views/edit.njk
@@ -85,20 +85,25 @@
       error: errors.messages.email
     }) }}
 
-    <fieldset id="group-field-rejects_dit_email_marketing" class="c-form-group">
+    <fieldset id="group-field-accepts_dit_email_marketing" class="c-form-group">
         <legend class="c-form-group__label u-visually-hidden">
             <span class="c-form-group__label-text">
                 Marketing preferences
             </span>
         </legend>
+
         <div class="c-form-group__inner">
             <div class="c-multiple-choice">
-                <input class="c-multiple-choice__input" type="checkbox" name="rejects_dit_email_marketing" value="rejects_dit_email_marketing" id="field-rejects_dit_email_marketing-1" {% if formData.rejects_dit_email_marketing %} checked {% endif %}>
-                      <label class="c-multiple-choice__label" for="field-rejects_dit_email_marketing-1">
-                          <span class="c-multiple-choice__label-text">
-                              Does not accept email marketing
-                          </span>
-                      </label>
+                <input class="c-multiple-choice__input" type="checkbox" name="accepts_dit_email_marketing" value="accepts_dit_email_marketing" id="field-accepts_dit_email_marketing-1" {% if formData.accepts_dit_email_marketing %} checked {% endif %} />
+                  <label class="c-multiple-choice__label" for="field-accepts_dit_email_marketing-1">
+                        <span class="c-multiple-choice__label-text">
+                              The company contact does accept email marketing
+                        </span>
+                        {# TODO: When moving this to react remove file src/apps/contacts/styles.scss and port to css-js #}
+                        <span class="c-form-group__hint" id="hint-group-field-accepts_dit_email_marketing">
+                          By checking this box, you confirm that the contact has opted in to email marketing.
+                        </span>
+                  </label> 
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
## Description of change

This PR changes the accepts market checkbox to opt-in rather than opt-out. I've had to add some scss to make the message dynamic but places a message to port the css over when it is time to make it into a React page.

## Test instructions
Go to https://data-hub-fro-feature-op-heaazz.herokuapp.com/contacts/da132e67-dfcb-452e-8a03-fcb27c2f9c14/edit
When you opt-in you should see a message appear telling saying "By checking this box, you confirm that the contact has opted in to email marketing."

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/5575331/91062309-71c26d80-e624-11ea-9fd4-98f33e034e9b.png)


### After
 
![image](https://user-images.githubusercontent.com/5575331/91062132-3e7fde80-e624-11ea-9e28-f577fee23c60.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
