### PR TITLE
Prevent API calls when there are no edit company form changes

### DIFF
--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -27,10 +27,12 @@ function EditCompanyForm({
 }) {
   async function onSubmit(values, isPristine) {
     if (isPristine) {
-      return
+      // The user has not made any changes so redirect
+      // back to the Business Details page.
+      return urls.companies.businessDetails(company.id)
     }
 
-    // There are changes so make an API call
+    // The user has made some changes so make an API call
     await axios.post(urls.companies.edit(company.id), values, {
       params: { _csrf: csrfToken },
     })

--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -25,7 +25,12 @@ function EditCompanyForm({
   oneListEmail,
   isOnOneList,
 }) {
-  async function onSubmit(values) {
+  async function onSubmit(values, isPrestine) {
+    if (isPrestine) {
+      return
+    }
+
+    // There are changes so make an API call
     await axios.post(urls.companies.edit(company.id), values, {
       params: { _csrf: csrfToken },
     })

--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -25,8 +25,8 @@ function EditCompanyForm({
   oneListEmail,
   isOnOneList,
 }) {
-  async function onSubmit(values, isPrestine) {
-    if (isPrestine) {
+  async function onSubmit(values, isPristine) {
+    if (isPristine) {
       return
     }
 

--- a/src/apps/companies/apps/edit-company/transformers.js
+++ b/src/apps/companies/apps/edit-company/transformers.js
@@ -74,6 +74,8 @@ const transformFormToApi = (company, formValues) => {
     ? MATCHED_COMPANY_EDITABLE_FIELDS
     : UNMATCHED_COMPANY_EDITABLE_FIELDS
 
+  const originalFormValues = transformCompanyToForm(company)
+
   return omitBy(
     {
       ...formValues,
@@ -90,7 +92,9 @@ const transformFormToApi = (company, formValues) => {
       },
     },
     (fieldValue, fieldName) =>
-      isUndefined(fieldValue) || !whitelistedFields.includes(fieldName)
+      isUndefined(fieldValue) ||
+      !whitelistedFields.includes(fieldName) ||
+      originalFormValues[fieldName] === formValues[fieldName]
   )
 }
 

--- a/src/client/components/Form/hooks/useForm.js
+++ b/src/client/components/Form/hooks/useForm.js
@@ -42,10 +42,9 @@ function useForm({
   const [submissionError, setSubmissionError] = useState(null)
   const isDirty =
     !isEmpty(touched) || (!isEmpty(values) && !isEqual(values, initialValues))
-  const isPrestine = isEqual(values, initialValues)
+  const isPristine = isEqual(values, initialValues)
 
   const [redirectUrl, setRedirectUrl] = useState(null)
-
   const formState = {
     values,
     touched,
@@ -56,7 +55,7 @@ function useForm({
     isLoading,
     isSubmitted,
     isDirty,
-    isPrestine,
+    isPristine,
     submissionError,
   }
 
@@ -199,7 +198,7 @@ function useForm({
       setIsLoading(true)
 
       if (typeof onSubmit === 'function') {
-        newRedirectUrl = await onSubmit(values, isPrestine)
+        newRedirectUrl = await onSubmit(values, isPristine)
       }
 
       if (newRedirectUrl) {

--- a/src/client/components/Form/hooks/useForm.js
+++ b/src/client/components/Form/hooks/useForm.js
@@ -42,6 +42,7 @@ function useForm({
   const [submissionError, setSubmissionError] = useState(null)
   const isDirty =
     !isEmpty(touched) || (!isEmpty(values) && !isEqual(values, initialValues))
+  const isPrestine = isEqual(values, initialValues)
 
   const [redirectUrl, setRedirectUrl] = useState(null)
 
@@ -55,6 +56,7 @@ function useForm({
     isLoading,
     isSubmitted,
     isDirty,
+    isPrestine,
     submissionError,
   }
 
@@ -197,7 +199,7 @@ function useForm({
       setIsLoading(true)
 
       if (typeof onSubmit === 'function') {
-        newRedirectUrl = await onSubmit(values)
+        newRedirectUrl = await onSubmit(values, isPrestine)
       }
 
       if (newRedirectUrl) {

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -10,6 +10,10 @@ describe('Company', () => {
   })
 
   it('should display name of the person who made company record changes', () => {
+    cy.get(selectors.companyEdit.website)
+      .clear()
+      .type('www.example.com')
+
     cy.get(selectors.companyEdit.saveButton).click()
     cy.get(selectors.message.successful).should('be.visible')
 
@@ -18,11 +22,6 @@ describe('Company', () => {
     cy.get(selectors.editHistory.change(1).updated)
       .should('contain', todaysDate)
       .and('contain', 'DIT Staff')
-
-    cy.get(selectors.editHistory.change(1).noChanges).should(
-      'have.text',
-      'No changes were made to business details in this update'
-    )
   })
 })
 

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -407,9 +407,12 @@ describe('Company edit', () => {
       cy.visit(urls.companies.edit(company.id))
     })
 
-    it('should not redirect', () => {
+    it('should redirect back to the Business Details page', () => {
       cy.contains('Submit').click()
-      cy.location('pathname').should('eq', urls.companies.edit(company.id))
+      cy.location('pathname').should(
+        'eq',
+        urls.companies.businessDetails(company.id)
+      )
     })
   })
 })

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -398,4 +398,18 @@ describe('Company edit', () => {
       cy.contains('Company record updated')
     })
   })
+
+  context('when the form is submitted and there are no changes', () => {
+    const company = fixtures.company.dnbLtd
+
+    before(() => {
+      cy.server()
+      cy.visit(urls.companies.edit(company.id))
+    })
+
+    it('should not redirect', () => {
+      cy.contains('Submit').click()
+      cy.location('pathname').should('eq', urls.companies.edit(company.id))
+    })
+  })
 })


### PR DESCRIPTION
## Description of change

Prevent users from submitting the Edit Company Form when they haven't made a change.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
