### PR TITLE
Filter out inactive advisers for interaction form

### DIFF
--- a/src/client/components/AdviserTypeAhead/index.jsx
+++ b/src/client/components/AdviserTypeAhead/index.jsx
@@ -6,7 +6,13 @@ import { FieldTypeahead } from '../../../client/components'
 
 import { parseAdviserData } from '../../utils/formatAdviser'
 
-const AdviserTypeAhead = ({ name, label, required, isMulti }) => {
+const AdviserTypeAhead = ({
+  name,
+  label,
+  required,
+  isMulti,
+  onlyShowActiveAdvisers = true,
+}) => {
   return (
     <FieldTypeahead
       name={name}
@@ -20,6 +26,7 @@ const AdviserTypeAhead = ({ name, label, required, isMulti }) => {
             .get('/api-proxy/adviser/', {
               params: {
                 autocomplete: searchString,
+                is_active: onlyShowActiveAdvisers,
               },
             })
             .then(({ data: { results } }) => parseAdviserData(results)),


### PR DESCRIPTION
## Description of change
Before the React version of the interaction form was built, we used to filter out inactive advisers by default. I have now added a configurable property to the adviser typeahead so by default it filters out the inactive advisers but you still have the option to override this. 

## Test instructions
1. Go to Django and find an adviser.
2. Make that adviser inactive.
3. Try to search for that adviser in the interaction form, they should not be returned in the results.
4. Make them active.
5. Search for that adviser again and you should see them returned in the results.

## Screenshots
![Screenshot 2020-08-27 at 10 35 39](https://user-images.githubusercontent.com/10154302/91423936-1628f780-e851-11ea-870a-79ea9349b00b.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
