### PR TITLE
Fix storybook config

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
-const webpackConfig = require('../webpack.config').resolve
+const { resolve } = require('../webpack.config')()
 
 module.exports = {
   stories: ['../src/**/*.stories.(js|jsx)$/'],
@@ -6,7 +6,7 @@ module.exports = {
     return {
       ...config,
       resolve: {
-        ...webpackConfig,
+        ...resolve,
       },
     }
   },

--- a/src/client/components/Form/elements/__stories__/FieldCheckboxes.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldCheckboxes.stories.jsx
@@ -5,7 +5,7 @@ import Button from '@govuk-react/button'
 import { H1 } from '@govuk-react/heading'
 
 import FieldCheckboxes from '../FieldCheckboxes'
-import FormStateful from '../FormStateful'
+import FormStateful from '../../FormStateful'
 
 import exampleReadme from '../FieldCheckboxes/example.md'
 import usageReadme from '../FieldCheckboxes/usage.md'

--- a/src/client/components/Form/elements/__stories__/FieldDate.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldDate.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import Button from '@govuk-react/button'
 
 import FieldDate from '../FieldDate'
-import FormStateful from '../FormStateful'
+import FormStateful from '../../FormStateful'
 
 import exampleReadme from '../FieldDate/example.md'
 import usageReadme from '../FieldDate/usage.md'

--- a/src/client/components/Form/elements/__stories__/FieldInput.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldInput.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import Button from '@govuk-react/button'
 
 import FieldInput from '../FieldInput'
-import FormStateful from '../FormStateful'
+import FormStateful from '../../FormStateful'
 
 import exampleReadme from '../FieldInput/example.md'
 import usageReadme from '../FieldInput/usage.md'

--- a/src/client/components/Form/elements/__stories__/FieldSelect.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldSelect.stories.jsx
@@ -6,7 +6,7 @@ import Button from '@govuk-react/button'
 
 import FieldSelect from '../FieldSelect'
 import FieldInput from '../FieldInput'
-import FormStateful from '../FormStateful'
+import FormStateful from '../../FormStateful'
 
 addDecorator(withKnobs)
 


### PR DESCRIPTION
## Description of change
When Webpack had been updated we forgot to update the Storybook config as part of the Webpack config that Storybook uses wasn't being included so none of the components could be resolved. Also some paths to the component `<FormStateful>` needed updating.

## Test instructions
1. Run `npm run storybook`
2. You should be able to view Storybook


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
