### PR TITLE
Pin chrome version and remove no cache build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,6 @@ jobs:
     steps:
       - checkout
       - run_make:
-          label: Clean base compose
-          target: clean-base
-      - run_make:
           label: Run functional tests
           target: start-mock functional-tests
       - store_cypress_artifacts
@@ -103,9 +100,6 @@ jobs:
         type: string
     steps:
       - checkout
-      - run_make:
-          label: Clean base compose
-          target: clean-base
       - run_make:
           label: Run e2e tests
           target: start-e2e-<< parameters.staff >> e2e-tests-<< parameters.staff >>

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV TZ                     Europe/London
 ENV TERM                   xterm
 ENV LANG                   C.UTF-8
 ENV NODE_ENV               development
+ENV CHROME_VERSION         85.0.4183.83-1
 
 RUN apt-get update
 
@@ -46,11 +47,12 @@ RUN apt-get install -y \
 # Install visual test dependencies
 RUN apt-get install -y imagemagick
 
-# Install Chrome (Latest)
+# Install Chrome (Version 85)
+# See all available versions for download on: https://www.ubuntuupdates.org/package_logs?type=ppas&vals=8
 RUN apt-get install -y xvfb xdg-utils libgtk-3-0 lsb-release libappindicator3-1 fonts-liberation libasound2 libnspr4 libnss3 \
-  && curl https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -O \
-  && dpkg -i google-chrome-stable_current_amd64.deb \
-  && rm google-chrome-stable_current_amd64.deb \
+  && curl https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb -O \
+  && dpkg -i google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+  && rm google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   && google-chrome --version
 
 WORKDIR /usr/src/app

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,6 @@ e2e-tests-dit:
 	@echo "*** Requires the e2e stack with the DIT role, it can be started with 'make start-e2e-dit' ***"
 	$(docker-e2e) exec frontend bash -c '$(wait-for-frontend) && npm run test:e2e:dit $(cypress-args)'
 
-clean-base:
-	docker-compose -f docker-compose.base.yml rm -f
-	$(docker-base) build --no-cache
-
 clean:
 	make stop-base
 	make stop-mock


### PR DESCRIPTION
## Description of change

We are currently building the FE with no cache to ensure the chrome version of all VMs in circleci are using the same chrome version. Instead to speed up the builds we will pin the chrome version and rely on due diligence to update chrome versions whenever there is a major release.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
