### PR TITLE
Remove duplicate header

### DIFF
--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -9,7 +9,9 @@ import Breadcrumbs from '@govuk-react/breadcrumbs'
 import LocalHeaderHeading from './LocalHeaderHeading'
 import FlashMessages from './FlashMessages'
 
-const StyledHeader = styled('header')`
+// Using <div> as there is already a <header> on the page
+// role="region" gives the element significance as a landmark
+const StyledHeader = styled('div')`
   padding-bottom: ${SPACING.SCALE_5};
   background-color: ${GREY_4};
   padding-top: ${SPACING.SCALE_3};
@@ -24,7 +26,11 @@ const BreadcrumbsWrapper = styled(Breadcrumbs)`
   margin-top: 0;
 `
 const LocalHeader = ({ breadcrumbs, flashMessages, heading, children }) => (
-  <StyledHeader aria-label="local header" data-auto-id="localHeader">
+  <StyledHeader
+    aria-label="local header"
+    data-auto-id="localHeader"
+    role="region"
+  >
     <StyledMain>
       <BreadcrumbsWrapper>
         {breadcrumbs?.map((breadcrumb) =>

--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -18,7 +18,8 @@
   {% set modifier = props.modifier | concat('') | reverse | join(' c-local-header--') if props.modifier %}
 
   {% if props %}
-    <header class="c-local-header {{ modifier }}{{ ' c-local-header--relative' if props.fullWidthContent }}" aria-label="local header" data-auto-id="localHeader">
+  {# Using <div> as there is already a <header> on the page - role="region" gives the element significance as a landmark #}
+    <div class="c-local-header {{ modifier }}{{ ' c-local-header--relative' if props.fullWidthContent }}" aria-label="local header" data-auto-id="localHeader" role="region">
       <div class="govuk-width-container c-local-header__container">
         {% if breadcrumbs|length > 1 %}
           {{ govukBreadcrumbs({
@@ -60,6 +61,6 @@
         </div>
 
       </div>
-    </header>
+    </div>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Description of change
Changes the `<header>` tag of the local header to a `<div>`.

During the Accessibility audit we were receiving notifications of there being too many 'banner' landmarks. Even though only one of the two `<header>` tags was assigned `role="banner"`, both were being interpreted as a banner component. 

Ideally, the second, local header would be split, with the breadcrumbs being absorbed into the `<nav>` and the title being absorbed into `<main id="main-content">`. After some discussion, we decided that this would be too significant a change for this problem at this time. 

Instead, the second `<header>` is changed to a `<div>`, and given `<role="region">` to make sure it is easily accessible to users skimming through the site with a screen reader. 

## Test instructions

View any pages with the [axe accessibility tool](https://www.deque.com/axe/). The local header should **not** cause these errors:
* All page content must be contained by landmarks
* Document must not have more than one banner landmark


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
