### PR TITLE
Update authorisedRequest() to forward Zipkin headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ stop-dev:
 
 lint:
 	$(docker-base) build frontend
-	$(docker-base) run --no-deps --rm frontend bash -c 'mkdir -p reports && npm run lint'
+	$(docker-base) run --no-deps --rm frontend bash -c 'mkdir -p reports && npm run lint:sass && npm run lint:js -- --format junit --output-file reports/eslint.xml'
 
 unit-tests:
 	$(docker-base) build frontend

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -28,7 +28,7 @@ services:
       MOCK_SSO_EMAIL_USER_ID: test@gov.uk
 
   api:
-    image: quay.io/uktrade/data-hub-api:master
+    image: quay.io/uktrade/data-hub-api:develop
     env_file: .env
     environment:
       DEBUG: 'False'
@@ -51,7 +51,7 @@ services:
     command: /app/setup-uat.sh || echo "all ood"
 
   celery:
-    image: quay.io/uktrade/data-hub-api:master
+    image: quay.io/uktrade/data-hub-api:develop
     env_file: .env
     depends_on:
       - postgres

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "watch:js:client": "webpack --watch --progress",
     "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect --ignore 'src/**/__test__/**/*'",
     "lint": "run-p lint:*",
-    "lint:js": "npx eslint --ext .jsx,.js --format junit --output-file reports/eslint.xml ./test ./src ./assets",
+    "lint:js": "npx eslint --ext .jsx,.js ./test ./src ./assets",
     "lint:sass": "npx sass-lint -v -q -c .sass-lint.yml 'assets/stylesheets/**/*.scss'",
     "test": "run-s test:*",
     "test:unit": "NODE_ENV=test API_ROOT=http://test LOG_LEVEL=silent MOCHA_FILE=junit/test-results.xml npx mocha ./src/**/*.test.js --opts ./test/unit/mocha.opts",

--- a/src/apps/__test__/builders.test.js
+++ b/src/apps/__test__/builders.test.js
@@ -4,6 +4,8 @@ const builders = require('../builders')
 const config = require('../../config')
 
 describe('Global builders', () => {
+  const stubRequest = { session: { token: '1234' } }
+
   describe('#getDeepObjectValuesForKey', () => {
     it('should return an empty array when no valid args are given', () => {
       expect(builders.getDeepObjectValuesForKey({}))
@@ -501,7 +503,7 @@ describe('Global builders', () => {
         }
 
         this.result = await builders.buildFieldsWithSelectedEntities(
-          '1234',
+          stubRequest,
           this.fields,
           query
         )
@@ -532,7 +534,7 @@ describe('Global builders', () => {
         }
 
         this.result = await builders.buildFieldsWithSelectedEntities(
-          '1234',
+          stubRequest,
           this.fields,
           query
         )
@@ -557,7 +559,7 @@ describe('Global builders', () => {
         const query = {}
 
         this.result = await builders.buildFieldsWithSelectedEntities(
-          '1234',
+          stubRequest,
           this.fields,
           query
         )

--- a/src/apps/adviser/__test__/repos.test.js
+++ b/src/apps/adviser/__test__/repos.test.js
@@ -10,7 +10,7 @@ describe('Adviser repository', () => {
         nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, badAdviserData)
-        this.advisers = await repos.getAdvisers(123)
+        this.advisers = await repos.getAdvisers({ session: { token: 123 } })
       })
 
       it('will be filtered out', async () => {
@@ -33,7 +33,7 @@ describe('Adviser repository', () => {
         nock(config.apiRoot)
           .get(`/adviser/?limit=100000&offset=0`)
           .reply(200, adviserData)
-        this.advisers = await repos.getAdvisers(123)
+        this.advisers = await repos.getAdvisers({ session: { token: 123 } })
       })
 
       it('will not filter out any advisers', () => {
@@ -58,10 +58,13 @@ describe('Adviser repository', () => {
             results: [this.bertSmith],
           })
 
-        this.advisers = await repos.fetchAdviserSearchResults('1234', {
-          term: 'be',
-          is_active: true,
-        })
+        this.advisers = await repos.fetchAdviserSearchResults(
+          { session: { token: '1234' } },
+          {
+            term: 'be',
+            is_active: true,
+          }
+        )
       })
 
       it('should return the results', () => {

--- a/src/apps/adviser/repos.js
+++ b/src/apps/adviser/repos.js
@@ -11,7 +11,7 @@ if (!config.isTest) {
   redisAsyncGet = redisClient.asyncGet()
 }
 
-async function getAdvisers(token) {
+async function getAdvisers(req) {
   let results
   const url = `${config.apiRoot}/adviser/?limit=100000&offset=0`
   const advisers = config.isTest ? null : await redisAsyncGet('advisers')
@@ -19,7 +19,7 @@ async function getAdvisers(token) {
   if (advisers) {
     results = JSON.parse(advisers)
   } else {
-    const response = await authorisedRequest(token, url)
+    const response = await authorisedRequest(req, url)
 
     results = response.results.filter(
       (adviser) => get(adviser, 'name', '').trim().length
@@ -40,14 +40,14 @@ async function getAdvisers(token) {
   }
 }
 
-function getAdviser(token, id) {
-  return authorisedRequest(token, `${config.apiRoot}/adviser/${id}/`)
+function getAdviser(req, id) {
+  return authorisedRequest(req, `${config.apiRoot}/adviser/${id}/`)
 }
 
-async function fetchAdviserSearchResults(token, params) {
+async function fetchAdviserSearchResults(req, params) {
   const isActive = params.is_active ? '&is_active=true' : ''
   const url = `${config.apiRoot}/adviser/?autocomplete=${params.term}${isActive}`
-  const adviserResults = await authorisedRequest(token, { url })
+  const adviserResults = await authorisedRequest(req, { url })
   return adviserResults.results
 }
 

--- a/src/apps/api/controllers/__test__/options.test.js
+++ b/src/apps/api/controllers/__test__/options.test.js
@@ -99,21 +99,21 @@ describe('options API controller', () => {
   })
 
   context('given that defined target is search_autocomplete', () => {
-    beforeEach(async () => {
-      const reqMock = {
-        query: {
-          target: 'search_autocomplete',
-          is_active: true,
-          autocomplete: 'France',
-        },
-        session: {
-          token: '1234',
-        },
-        params: {
-          entity: 'company',
-        },
-      }
+    const reqMock = {
+      query: {
+        target: 'search_autocomplete',
+        is_active: true,
+        autocomplete: 'France',
+      },
+      session: {
+        token: '1234',
+      },
+      params: {
+        entity: 'company',
+      },
+    }
 
+    beforeEach(async () => {
       this.searchAutocomplete = sinon.stub().resolves({})
 
       const controller = proxyquire('../options', {
@@ -129,7 +129,7 @@ describe('options API controller', () => {
       expect(this.searchAutocomplete).to.be.calledWith({
         searchEntity: 'company',
         searchTerm: 'France',
-        token: '1234',
+        req: reqMock,
       })
     })
   })
@@ -137,23 +137,23 @@ describe('options API controller', () => {
   context(
     'given target is search_autocomplete and list of options depends on another selection',
     () => {
-      beforeEach(async () => {
-        const reqMock = {
-          query: {
-            chained_param: 'chainedParam',
-            chained_value: 'chainedValue',
-            target: 'search_autocomplete',
-            is_active: true,
-            autocomplete: 'France',
-          },
-          session: {
-            token: '1234',
-          },
-          params: {
-            entity: 'company',
-          },
-        }
+      const reqMock = {
+        query: {
+          chained_param: 'chainedParam',
+          chained_value: 'chainedValue',
+          target: 'search_autocomplete',
+          is_active: true,
+          autocomplete: 'France',
+        },
+        session: {
+          token: '1234',
+        },
+        params: {
+          entity: 'company',
+        },
+      }
 
+      beforeEach(async () => {
         this.searchAutocomplete = sinon.stub().resolves({})
 
         const controller = proxyquire('../options', {
@@ -169,7 +169,7 @@ describe('options API controller', () => {
         expect(this.searchAutocomplete).to.be.calledWith({
           searchEntity: 'company',
           searchTerm: 'France&chainedParam=chainedValue',
-          token: '1234',
+          req: reqMock,
         })
       })
     }

--- a/src/apps/api/controllers/advisers.js
+++ b/src/apps/api/controllers/advisers.js
@@ -3,12 +3,11 @@ const { transformAdviserToOption } = require('../../adviser/transformers')
 
 async function getAdviserOptionsHandler(req, res, next) {
   try {
-    const token = req.session.token
     const params = {
       term: req.query.autocomplete,
       is_active: req.query.is_active,
     }
-    const advisers = await fetchAdviserSearchResults(token, params)
+    const advisers = await fetchAdviserSearchResults(req, params)
 
     res.json(advisers.map(transformAdviserToOption))
   } catch (error) {

--- a/src/apps/api/controllers/options.js
+++ b/src/apps/api/controllers/options.js
@@ -3,7 +3,6 @@ const { searchAutocomplete } = require('./../../../modules/search/services')
 const { transformObjectToOption } = require('../../../apps/transformers')
 
 async function getOptionsHandler(req, res, next) {
-  const token = req.session.token
   const key = req.params.entity
 
   if (key === 'adviser') {
@@ -20,14 +19,14 @@ async function getOptionsHandler(req, res, next) {
       }
 
       const options = await searchAutocomplete({
-        token: token,
+        req,
         searchEntity: key,
         searchTerm: searchTerm,
       })
 
       res.json(options.results.map(transformObjectToOption))
     } else {
-      const options = await getOptions(token, key, {
+      const options = await getOptions(req, key, {
         includeDisabled: true,
         term: req.query.autocomplete,
         is_active: req.query.is_active,

--- a/src/apps/api/controllers/postcode-to-region-lookup.js
+++ b/src/apps/api/controllers/postcode-to-region-lookup.js
@@ -2,7 +2,6 @@ const { getDITRegionFromUKPostcode } = require('../services')
 const { getOptions } = require('../../../lib/options')
 
 async function postcodeToRegionLookupHandler(req, res) {
-  const { token } = req.session
   const { postcode } = req.params
 
   try {
@@ -14,7 +13,7 @@ async function postcodeToRegionLookupHandler(req, res) {
     }
 
     const regionName = results[0].regionName
-    const regions = await getOptions(token, 'uk-region')
+    const regions = await getOptions(req, 'uk-region')
     const region = regions.find((region) => region.label === regionName)
     res.json(region)
   } catch (error) {

--- a/src/apps/builders.js
+++ b/src/apps/builders.js
@@ -172,7 +172,7 @@ function getFieldWithSelectedOptions(field) {
   }
 }
 
-async function buildFieldsWithSelectedEntities(token, fields = [], query = {}) {
+async function buildFieldsWithSelectedEntities(req, fields = [], query = {}) {
   const fieldsArray = castArray(fields)
   const processedFields = []
 
@@ -182,7 +182,7 @@ async function buildFieldsWithSelectedEntities(token, fields = [], query = {}) {
 
     if (child.entity && has(query, child.name)) {
       const id = castArray(get(query, child.name))
-      newChild.selectedOptions = await getOptions(token, child.entity, { id })
+      newChild.selectedOptions = await getOptions(req, child.entity, { id })
     }
 
     processedFields.push(newChild)

--- a/src/apps/companies/__test__/repos.test.js
+++ b/src/apps/companies/__test__/repos.test.js
@@ -24,6 +24,8 @@ function makeRepositoryWithAuthRequest(authorisedRequestStub) {
 }
 
 describe('Company repository', () => {
+  const stubRequest = { session: { token: 'TEST_TOKEN' } }
+
   describe('Save company', () => {
     describe('Make correct call to API', () => {
       let authorisedRequestStub
@@ -38,11 +40,11 @@ describe('Company repository', () => {
       })
 
       it('should call the API with a PATCH if an ID is provided.', async () => {
-        await repo.saveCompany('TEST_TOKEN', {
+        await repo.saveCompany(stubRequest, {
           id: 'TEST_TOKEN',
           name: 'fred',
         })
-        expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+        expect(authorisedRequestStub).calledOnceWithExactly(stubRequest, {
           body: { id: 'TEST_TOKEN', name: 'fred' },
           method: 'PATCH',
           url: `${config.apiRoot}/v4/company/TEST_TOKEN`,
@@ -50,8 +52,8 @@ describe('Company repository', () => {
       })
 
       it('should call the API with a POST if no ID is provided.', async () => {
-        await repo.saveCompany('TEST_TOKEN', { name: 'fred' })
-        expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+        await repo.saveCompany(stubRequest, { name: 'fred' })
+        expect(authorisedRequestStub).calledOnceWithExactly(stubRequest, {
           body: { name: 'fred' },
           method: 'POST',
           url: `${config.apiRoot}/v4/company`,
@@ -65,11 +67,11 @@ describe('Company repository', () => {
       const authorisedRequestStub = sinon.stub().resolves(companyData)
       const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
 
-      await repo.updateCompany('TEST_TOKEN', '999', {
+      await repo.updateCompany(stubRequest, '999', {
         global_headquarters: '1',
       })
 
-      expect(authorisedRequestStub).to.be.calledOnceWithExactly('TEST_TOKEN', {
+      expect(authorisedRequestStub).to.be.calledOnceWithExactly(stubRequest, {
         url: `${config.apiRoot}/v4/company/999`,
         method: 'PATCH',
         body: {
@@ -85,7 +87,7 @@ describe('Company repository', () => {
         .get(`/v4/company/${companyV4Data.id}`)
         .reply(200, companyV4Data)
 
-      const company = await getDitCompany('TEST_TOKEN', companyV4Data.id)
+      const company = await getDitCompany(stubRequest, companyV4Data.id)
 
       expect(company).to.deep.equal(companyV4Data)
     })
@@ -96,9 +98,9 @@ describe('Company repository', () => {
       const authorisedRequestStub = sinon.stub()
       const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
 
-      await repo.getDitCompanyFromList('TEST_TOKEN', myCompanyListData.id)
+      await repo.getDitCompanyFromList(stubRequest, myCompanyListData.id)
 
-      expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+      expect(authorisedRequestStub).calledOnceWithExactly(stubRequest, {
         method: 'GET',
         url: `${config.apiRoot}/v4/user/company-list/${myCompanyListData.id}`,
       })
@@ -110,9 +112,9 @@ describe('Company repository', () => {
       const authorisedRequestStub = sinon.stub()
       const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
 
-      await repo.addDitCompanyToList('TEST_TOKEN', myCompanyListData.id)
+      await repo.addDitCompanyToList(stubRequest, myCompanyListData.id)
 
-      expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+      expect(authorisedRequestStub).calledOnceWithExactly(stubRequest, {
         method: 'PUT',
         url: `${config.apiRoot}/v4/user/company-list/${myCompanyListData.id}`,
       })
@@ -124,9 +126,9 @@ describe('Company repository', () => {
       const authorisedRequestStub = sinon.stub()
       const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
 
-      await repo.removeDitCompanyFromList('TEST_TOKEN', myCompanyListData.id)
+      await repo.removeDitCompanyFromList(stubRequest, myCompanyListData.id)
 
-      expect(authorisedRequestStub).calledOnceWithExactly('TEST_TOKEN', {
+      expect(authorisedRequestStub).calledOnceWithExactly(stubRequest, {
         method: 'DELETE',
         url: `${config.apiRoot}/v4/user/company-list/${myCompanyListData.id}`,
       })
@@ -143,7 +145,7 @@ describe('Company repository', () => {
           hello: true,
         })
 
-      const actual = await saveDnbCompany('1234', '123')
+      const actual = await saveDnbCompany(stubRequest, '123')
 
       expect(actual).to.deep.equal({ hello: true })
     })
@@ -163,7 +165,11 @@ describe('Company repository', () => {
           countries: true,
         })
 
-      const actual = await saveCompanyExportDetails('1234', companyId, details)
+      const actual = await saveCompanyExportDetails(
+        stubRequest,
+        companyId,
+        details
+      )
 
       expect(actual).to.deep.equal({ countries: true })
     })

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -29,40 +29,41 @@ describe('Activity feed controllers', () => {
     })
 
     const commonTests = (types, attributedTo) => {
-      expect(fetchActivityFeedStub).to.be.calledWith({
-        token: '1234',
-        body: {
-          from: 0,
-          size: 20,
-          sort: [
-            {
-              'object.startTime': {
-                order: 'desc',
-              },
+      const expectedEsQuery = {
+        from: 0,
+        size: 20,
+        sort: [
+          {
+            'object.startTime': {
+              order: 'desc',
             },
-          ],
-          query: {
-            bool: {
-              filter: {
-                bool: {
-                  must: [
-                    {
-                      terms: {
-                        'object.type': types,
-                      },
+          },
+        ],
+        query: {
+          bool: {
+            filter: {
+              bool: {
+                must: [
+                  {
+                    terms: {
+                      'object.type': types,
                     },
-                    {
-                      term: {
-                        'object.attributedTo.id': attributedTo,
-                      },
+                  },
+                  {
+                    term: {
+                      'object.attributedTo.id': attributedTo,
                     },
-                  ],
-                },
+                  },
+                ],
               },
             },
           },
         },
-      })
+      }
+      expect(fetchActivityFeedStub).to.be.calledWith(
+        middlewareParameters.reqMock,
+        expectedEsQuery
+      )
 
       expect(middlewareParameters.resMock.json).to.be.calledOnceWithExactly(
         activityFeedEsFixtures
@@ -139,46 +140,47 @@ describe('Activity feed controllers', () => {
 
       it('should call fetchActivityFeed with a user id', async () => {
         const { dataHubActivity } = ES_KEYS_GROUPED
-        expect(fetchActivityFeedStub).to.be.calledWith({
-          token: '1234',
-          body: {
-            from: 0,
-            size: 20,
-            sort: [
-              {
-                'object.startTime': {
-                  order: 'desc',
-                },
+        const expectedEsQuery = {
+          from: 0,
+          size: 20,
+          sort: [
+            {
+              'object.startTime': {
+                order: 'desc',
               },
-            ],
-            query: {
-              bool: {
-                filter: {
-                  bool: {
-                    must: [
-                      {
-                        terms: {
-                          'object.type': dataHubActivity,
-                        },
+            },
+          ],
+          query: {
+            bool: {
+              filter: {
+                bool: {
+                  must: [
+                    {
+                      terms: {
+                        'object.type': dataHubActivity,
                       },
-                      {
-                        term: {
-                          'object.attributedTo.id': 'dit:DataHubAdviser:123',
-                        },
+                    },
+                    {
+                      term: {
+                        'object.attributedTo.id': 'dit:DataHubAdviser:123',
                       },
-                      {
-                        term: {
-                          'object.attributedTo.id':
-                            'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
-                        },
+                    },
+                    {
+                      term: {
+                        'object.attributedTo.id':
+                          'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
                       },
-                    ],
-                  },
+                    },
+                  ],
                 },
               },
             },
           },
-        })
+        }
+        expect(fetchActivityFeedStub).to.be.calledWith(
+          middlewareParameters.reqMock,
+          expectedEsQuery
+        )
       })
     })
 
@@ -261,44 +263,45 @@ describe('Activity feed controllers', () => {
 
         it('should call fetchActivityFeed with the right params', async () => {
           const { dataHubActivity } = ES_KEYS_GROUPED
-          expect(fetchActivityFeedStub).to.be.calledWith({
-            token: '1234',
-            body: {
-              from: 0,
-              size: 20,
-              sort: [
-                {
-                  'object.startTime': {
-                    order: 'desc',
-                  },
+          const expectedEsQuery = {
+            from: 0,
+            size: 20,
+            sort: [
+              {
+                'object.startTime': {
+                  order: 'desc',
                 },
-              ],
-              query: {
-                bool: {
-                  filter: {
-                    bool: {
-                      must: [
-                        {
-                          terms: {
-                            'object.type': dataHubActivity,
-                          },
+              },
+            ],
+            query: {
+              bool: {
+                filter: {
+                  bool: {
+                    must: [
+                      {
+                        terms: {
+                          'object.type': dataHubActivity,
                         },
-                        {
-                          terms: {
-                            'object.attributedTo.id': [
-                              'dit:DataHubCompany:123',
-                              'dit:DataHubCompany:456',
-                              'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
-                            ],
-                          },
+                      },
+                      {
+                        terms: {
+                          'object.attributedTo.id': [
+                            'dit:DataHubCompany:123',
+                            'dit:DataHubCompany:456',
+                            'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
+                          ],
                         },
-                      ],
-                    },
+                      },
+                    ],
                   },
                 },
               },
             },
-          })
+          }
+          expect(fetchActivityFeedStub).to.be.calledWith(
+            middlewareParameters.reqMock,
+            expectedEsQuery
+          )
         })
       }
     )
@@ -349,43 +352,43 @@ describe('Activity feed controllers', () => {
 
       it('should call next with an error', async () => {
         const { dataHubActivity } = ES_KEYS_GROUPED
-        const expectedParams = {
-          token: '1234',
-          body: {
-            from: 0,
-            size: 20,
-            sort: [
-              {
-                'object.startTime': {
-                  order: 'desc',
-                },
+        const expectedEsQuery = {
+          from: 0,
+          size: 20,
+          sort: [
+            {
+              'object.startTime': {
+                order: 'desc',
               },
-            ],
-            query: {
-              bool: {
-                filter: {
-                  bool: {
-                    must: [
-                      {
-                        terms: {
-                          'object.type': dataHubActivity,
-                        },
+            },
+          ],
+          query: {
+            bool: {
+              filter: {
+                bool: {
+                  must: [
+                    {
+                      terms: {
+                        'object.type': dataHubActivity,
                       },
-                      {
-                        term: {
-                          'object.attributedTo.id':
-                            'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
-                        },
+                    },
+                    {
+                      term: {
+                        'object.attributedTo.id':
+                          'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
                       },
-                    ],
-                  },
+                    },
+                  ],
                 },
               },
             },
           },
         }
 
-        expect(fetchActivityFeedStub).to.be.calledWith(expectedParams)
+        expect(fetchActivityFeedStub).to.be.calledWith(
+          middlewareParameters.reqMock,
+          expectedEsQuery
+        )
         expect(middlewareParameters.resMock.json).to.not.have.been.called
         expect(middlewareParameters.nextSpy).to.have.been.calledWith(error)
       })

--- a/src/apps/companies/apps/activity-feed/__test__/repos.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/repos.test.js
@@ -3,6 +3,8 @@ const activityFeedRawFixture = require('../../../../../../test/unit/data/activit
 const { ES_KEYS_GROUPED } = require('../constants')
 
 describe('Activity feed repos', () => {
+  const stubRequest = { session: { token: 'abcd' } }
+
   describe('#fetchActivityFeed', () => {
     const authorisedRequestStub = sinon.stub().resolves(activityFeedRawFixture)
     const repos = proxyquire(
@@ -17,7 +19,6 @@ describe('Activity feed repos', () => {
     context('when called with filters', () => {
       const { dataHubActivity } = ES_KEYS_GROUPED
       let body, results
-      const token = 'abcd'
 
       before(async () => {
         body = {
@@ -52,14 +53,11 @@ describe('Activity feed repos', () => {
           },
         }
 
-        results = await repos.fetchActivityFeed({
-          token,
-          body,
-        })
+        results = await repos.fetchActivityFeed(stubRequest, body)
       })
 
       it('should make a request including the filters', () => {
-        expect(authorisedRequestStub).to.be.calledOnceWith(token, {
+        expect(authorisedRequestStub).to.be.calledOnceWith(stubRequest, {
           body,
           url: `${config.apiRoot}/v4/activity-feed`,
         })

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -58,7 +58,6 @@ async function renderActivityFeed(req, res, next) {
 
 async function fetchActivityFeedHandler(req, res, next) {
   try {
-    const { token } = req.session
     const { company, user } = res.locals
     const {
       from = 0,
@@ -70,7 +69,7 @@ async function fetchActivityFeedHandler(req, res, next) {
     let dnbHierarchyIds = []
     if (company.is_global_ultimate && showDnbHierarchy) {
       const { results } = await getGlobalUltimateHierarchy(
-        token,
+        req,
         company.global_ultimate_duns_number
       )
       dnbHierarchyIds = results
@@ -78,17 +77,17 @@ async function fetchActivityFeedHandler(req, res, next) {
         .map((company) => company.id)
     }
 
-    const results = await fetchActivityFeed({
-      token: req.session.token,
-      body: createESFilters(
+    const results = await fetchActivityFeed(
+      req,
+      createESFilters(
         activityTypeFilter,
         dnbHierarchyIds,
         company,
         user,
         from,
         size
-      ),
-    })
+      )
+    )
 
     res.json(results)
   } catch (error) {

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -1,8 +1,8 @@
 const config = require('../../../../config')
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 
-function fetchActivityFeed({ token, body }) {
-  return authorisedRequest(token, {
+function fetchActivityFeed(req, body) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/activity-feed`,
     body,
   })

--- a/src/apps/companies/apps/add-company/__test__/repos.test.js
+++ b/src/apps/companies/apps/add-company/__test__/repos.test.js
@@ -2,7 +2,7 @@ const config = require('../../../../../config')
 const { fetchOrganisationTypes } = require('../repos')
 const businessTypeFixture = require('../../../../../../test/unit/data/metadata/business-type')
 
-const token = 'abcd'
+const stubRequest = { session: { token: 'abcd' } }
 
 describe('Add company form repos', () => {
   describe('#fetchOrganisationTypes', () => {
@@ -13,7 +13,7 @@ describe('Add company form repos', () => {
         .get('/v4/metadata/business-type')
         .reply(200, businessTypeFixture)
 
-      actual = await fetchOrganisationTypes(token)
+      actual = await fetchOrganisationTypes(stubRequest)
     })
 
     it('should return the organisation types', () => {

--- a/src/apps/companies/apps/add-company/repos.js
+++ b/src/apps/companies/apps/add-company/repos.js
@@ -13,8 +13,8 @@ const BUSINESS_TYPE_WHITELIST = {
   soleTrader: '99d14e94-5d95-e211-a939-e4115bead28a',
 }
 
-async function fetchOrganisationTypes(token) {
-  const businessTypeOptions = await getOptions(token, 'business-type')
+async function fetchOrganisationTypes(req) {
+  const businessTypeOptions = await getOptions(req, 'business-type')
   const filteredBusinessTypeOptions = filter(
     businessTypeOptions,
     ({ value }) => {

--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -53,7 +53,6 @@ function renderLeadAdvisers(req, res) {
 async function renderCoreTeamAdvisers(req, res, next) {
   try {
     const { company, returnUrl, dnbRelatedCompaniesCount } = res.locals
-    const token = req.session.token
     const {
       global_account_manager: globalAccountManager,
       adviser_on_core_team: adviserOnCoreTeam,
@@ -72,7 +71,7 @@ async function renderCoreTeamAdvisers(req, res, next) {
         name: adviserOnCoreTeam,
       },
     }
-    const coreTeam = await getOneListGroupCoreTeam(token, company.id).then(
+    const coreTeam = await getOneListGroupCoreTeam(req, company.id).then(
       transformCoreTeamToCollection
     )
     res.render('companies/views/advisers', {
@@ -130,7 +129,7 @@ async function submit(req, res, next) {
   } = res.locals
 
   try {
-    await authorisedRequest(req.session.token, {
+    await authorisedRequest(req, {
       method: 'POST',
       url: `${config.apiRoot}/v4/company/${id}/remove-account-manager`,
     })

--- a/src/apps/companies/apps/business-details/controllers.js
+++ b/src/apps/companies/apps/business-details/controllers.js
@@ -18,7 +18,6 @@ function canEditOneList(permissions) {
 }
 
 async function renderBusinessDetails(req, res) {
-  const { token } = req.session
   const {
     company,
     ARCHIVED_DOCUMENT_BASE_URL,
@@ -28,7 +27,7 @@ async function renderBusinessDetails(req, res) {
     dnbRelatedCompaniesCount,
   } = res.locals
   const userPermissions = res.locals.user.permissions
-  const subsidiaries = await getCompanySubsidiaries(token, company.id)
+  const subsidiaries = await getCompanySubsidiaries(req, company.id)
 
   res
     .breadcrumb(company.name, urls.companies.detail(company.id))

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/repos.test.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/repos.test.js
@@ -6,7 +6,7 @@ const dnbHierarchyFixture = {
   count: 2,
   results: [{ id: '1' }, { id: '2' }],
 }
-const TOKEN = 'abcd'
+const stubRequest = { session: { token: 'abcd' } }
 const DUNS_NUMBER = 999999
 
 describe('D&B Subsidiaries repos', () => {
@@ -18,7 +18,7 @@ describe('D&B Subsidiaries repos', () => {
       })
 
       const actual = await getDnbHierarchy(
-        TOKEN,
+        stubRequest,
         DUNS_NUMBER,
         config.paginationDefaultSize,
         1

--- a/src/apps/companies/apps/dnb-hierarchy/controllers.js
+++ b/src/apps/companies/apps/dnb-hierarchy/controllers.js
@@ -50,13 +50,12 @@ function removeCurrentCompany(dunsNumber, { count, results }) {
 async function fetchDnbHierarchyHandler(req, res, next) {
   try {
     const { company } = res.locals
-    const { token } = req.session
     const { page } = req.query
 
     const { count, results } = removeCurrentCompany(
       company.duns_number,
       await getDnbHierarchy(
-        token,
+        req,
         company.global_ultimate_duns_number,
         config.paginationDefaultSize,
         page

--- a/src/apps/companies/apps/dnb-hierarchy/middleware.js
+++ b/src/apps/companies/apps/dnb-hierarchy/middleware.js
@@ -30,9 +30,9 @@ function setCompanyHierarchyLocalNav(req, res, next) {
   }
 }
 
-async function getDnbHierarchyDetails(token, dunsNumber) {
+async function getDnbHierarchyDetails(req, dunsNumber) {
   if (dunsNumber) {
-    const dnbHierarchy = await getDnbHierarchy(token, dunsNumber, 1)
+    const dnbHierarchy = await getDnbHierarchy(req, dunsNumber, 1)
     const dnbHierarchyCount = dnbHierarchy.count
     const globalUltimate = dnbHierarchy.results.find(
       (c) => c.is_global_ultimate
@@ -54,11 +54,10 @@ async function getDnbHierarchyDetails(token, dunsNumber) {
 
 async function setDnbHierarchyDetails(req, res, next) {
   const { company, features } = res.locals
-  const { token } = req.session
 
   if (features['companies-ultimate-hq']) {
     const { globalUltimate, dnbHierarchyCount } = await getDnbHierarchyDetails(
-      token,
+      req,
       company.global_ultimate_duns_number
     )
 

--- a/src/apps/companies/apps/dnb-hierarchy/repos.js
+++ b/src/apps/companies/apps/dnb-hierarchy/repos.js
@@ -1,10 +1,10 @@
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 const config = require('../../../../config')
 
-function getDnbHierarchy(token, globalUltimateDunsNumber, limit, page = 1) {
+function getDnbHierarchy(req, globalUltimateDunsNumber, limit, page = 1) {
   const offset = limit * (page - 1)
 
-  return authorisedRequest(token, {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company`,
     qs: {
       limit,

--- a/src/apps/companies/apps/edit-company/controllers.js
+++ b/src/apps/companies/apps/edit-company/controllers.js
@@ -15,7 +15,6 @@ const { isItaTierDAccount } = require('../../../../lib/is-tier-type-company')
 async function renderEditCompanyForm(req, res, next) {
   try {
     const { company } = res.locals
-    const { token } = req.session
 
     const [
       turnoverRanges,
@@ -24,11 +23,11 @@ async function renderEditCompanyForm(req, res, next) {
       sectors,
       headquarterTypes,
     ] = await Promise.all([
-      getOptions(token, 'turnover', { sorted: false }),
-      getOptions(token, 'employee-range', { sorted: false }),
-      getOptions(token, 'uk-region', { sorted: false }),
-      getOptions(token, 'sector', { sorted: false }),
-      getHeadquarterOptions(token),
+      getOptions(req, 'turnover', { sorted: false }),
+      getOptions(req, 'employee-range', { sorted: false }),
+      getOptions(req, 'uk-region', { sorted: false }),
+      getOptions(req, 'sector', { sorted: false }),
+      getHeadquarterOptions(req),
     ])
 
     res
@@ -60,7 +59,6 @@ async function renderEditCompanyForm(req, res, next) {
 async function postEditCompany(req, res, next) {
   try {
     const { company } = res.locals
-    const { token } = req.session
 
     const dataHubChanges = transformFormToApi(company, req.body)
 
@@ -76,7 +74,7 @@ async function postEditCompany(req, res, next) {
     // Only D&B changes
     if (isEmpty(dataHubChanges) && !isEmpty(dnbChanges)) {
       const dnbChangeRequest = await createDnbChangeRequest(
-        token,
+        req,
         company.duns_number,
         dnbChanges
       )
@@ -94,7 +92,7 @@ async function postEditCompany(req, res, next) {
     // Only Data Hub changes
     if (!isEmpty(dataHubChanges) && isEmpty(dnbChanges)) {
       const updatedCompany = await updateCompany(
-        token,
+        req,
         company.id,
         dataHubChanges
       )
@@ -107,13 +105,13 @@ async function postEditCompany(req, res, next) {
     // Both D&B and Data Hub changes
     if (!isEmpty(dataHubChanges) && !isEmpty(dnbChanges)) {
       const updatedCompany = await updateCompany(
-        token,
+        req,
         company.id,
         dataHubChanges
       )
 
       const dnbChangeRequest = await createDnbChangeRequest(
-        token,
+        req,
         company.duns_number,
         dnbChanges
       )

--- a/src/apps/companies/apps/edit-company/repos.js
+++ b/src/apps/companies/apps/edit-company/repos.js
@@ -7,8 +7,8 @@ const hqLabels = {
   trading_names: 'Trading names',
 }
 
-async function getHeadquarterOptions(token) {
-  const options = await getOptions(token, 'headquarter-type', { sorted: false })
+async function getHeadquarterOptions(req) {
+  const options = await getOptions(req, 'headquarter-type', { sorted: false })
   const headquarterOptions = options.map((option) => ({
     value: option.value,
     label: hqLabels[option.label],

--- a/src/apps/companies/apps/edit-history/controller.js
+++ b/src/apps/companies/apps/edit-history/controller.js
@@ -19,10 +19,9 @@ function renderEditHistory(req, res) {
 async function fetchCompanyAuditLog(req, res, next) {
   try {
     const { company } = res.locals
-    const { token } = req.session
     const { page } = req.query
 
-    const { results, count } = await getCompanyAuditLog(token, company.id, page)
+    const { results, count } = await getCompanyAuditLog(req, company.id, page)
 
     res.json({
       results: transformCompanyAuditLog(results),

--- a/src/apps/companies/apps/edit-one-list/controllers.js
+++ b/src/apps/companies/apps/edit-one-list/controllers.js
@@ -9,12 +9,11 @@ const {
 } = require('./constants')
 
 async function renderEditOneList(req, res) {
-  const { token } = req.session
   const { company } = res.locals
 
   const [oneListTiers, oneListTeam] = await Promise.all([
-    getOptions(token, 'one-list-tier', { sorted: false }),
-    getOneListGroupCoreTeam(token, company.id),
+    getOptions(req, 'one-list-tier', { sorted: false }),
+    getOneListGroupCoreTeam(req, company.id),
   ])
 
   const oneListGroupTier = company.one_list_group_tier

--- a/src/apps/companies/apps/exports/controllers.js
+++ b/src/apps/companies/apps/exports/controllers.js
@@ -202,11 +202,10 @@ function renderExportEditCountries(req, res) {
 }
 
 async function handleEditFormPost(req, res, next) {
-  const { token } = req.session
   const companyId = res.locals.company.id
 
   try {
-    await saveCompanyExportDetails(token, companyId, {
+    await saveCompanyExportDetails(req, companyId, {
       export_countries: getExportCountries(req.body) || [],
     })
 

--- a/src/apps/companies/apps/investments/__test__/projects.test.js
+++ b/src/apps/companies/apps/investments/__test__/projects.test.js
@@ -46,7 +46,7 @@ describe('Company investments project controlle', () => {
 
       it('should call audit log with correct arguments', () => {
         expect(this.getCompanyInvestmentProjectsStub).to.have.been.calledWith(
-          '1234',
+          this.middlewareParameters.reqMock,
           companyMock.id,
           1
         )

--- a/src/apps/companies/apps/investments/large-capital-profile/__test__/update.test.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/__test__/update.test.js
@@ -12,7 +12,7 @@ describe('HTTP PATCH - Large capital profile', () => {
     const commonTests = () => {
       it('should call updateCompanyProfile with the correct arguments', () => {
         expect(this.updateCompanyProfileStub).to.have.been.calledWith(
-          '1234',
+          this.middlewareParameters.reqMock,
           {},
           '123'
         )

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/create.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/create.js
@@ -2,7 +2,7 @@ const { createCompanyProfile } = require('../repos')
 
 const createProfile = async (req, res, next) => {
   try {
-    const profile = await createCompanyProfile(req.session.token, {
+    const profile = await createCompanyProfile(req, {
       investor_company: req.body.id,
     })
     res.redirect(

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -22,23 +22,22 @@ const { getCompanyProfiles } = require('../repos')
 const { get } = require('lodash')
 const urls = require('../../../../../../lib/urls')
 
-const getCompanyProfile = async (token, company, editing) => {
-  const profiles = await getCompanyProfiles(token, company.id)
+const getCompanyProfile = async (req, company, editing) => {
+  const profiles = await getCompanyProfiles(req, company.id)
   const profile = profiles.results && profiles.results[0]
   return profile ? transformProfile(Object.freeze(profile), editing) : profile
 }
 
 const renderProfile = async (req, res, next) => {
-  const { token } = req.session
   const { company, returnUrl, dnbRelatedCompaniesCount } = res.locals
   const { editing } = req.query
 
   try {
-    const profile = await getCompanyProfile(token, company, editing)
+    const profile = await getCompanyProfile(req, company, editing)
     const editType = get(profile, 'editing')
 
     if (editType === INVESTOR_DETAILS) {
-      await Promise.all(getInvestorDetailsOptions(token)).then(
+      await Promise.all(getInvestorDetailsOptions(req)).then(
         ([investorTypeMD, requiredCheckMD, adviserMD]) => {
           profile.investorDetails.investorType.items = transformInvestorTypes(
             investorTypeMD,
@@ -57,7 +56,7 @@ const renderProfile = async (req, res, next) => {
         }
       )
     } else if (editType === INVESTOR_REQUIREMENTS) {
-      await Promise.all(getInvestorRequirementsOptions(token)).then(
+      await Promise.all(getInvestorRequirementsOptions(req)).then(
         ([
           dealTicketSizeMD,
           assetClassesMD,
@@ -135,7 +134,7 @@ const renderProfile = async (req, res, next) => {
         }
       )
     } else if (editType === LOCATION) {
-      await Promise.all(getLocationOptions(token)).then(
+      await Promise.all(getLocationOptions(req)).then(
         ([regions, countries]) => {
           profile.location.uk_region_locations.items = regions
           profile.location.other_countries_being_considered.items = countries

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/update.js
@@ -19,11 +19,10 @@ const transformer = {
 const updateProfile = async (req, res, next) => {
   const { profileId, editing } = req.body
   const { company } = res.locals
-  const { token } = req.session
 
   try {
     const body = transformer[editing](req.body)
-    await updateCompanyProfile(token, body, profileId)
+    await updateCompanyProfile(req, body, profileId)
     res.redirect(`/companies/${company.id}/investments/large-capital-profile`)
   } catch (error) {
     next(error)

--- a/src/apps/companies/apps/investments/large-capital-profile/options.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/options.js
@@ -10,35 +10,35 @@ const OPTIONS = {
   transformer: transformObjectToGovUKOption,
 }
 
-const getInvestorDetailsOptions = (token) => {
+const getInvestorDetailsOptions = (req) => {
   return [
-    getOptions(token, 'capital-investment/investor-type', OPTIONS),
-    getOptions(token, 'capital-investment/required-checks-conducted', OPTIONS),
-    getAdvisers(token),
+    getOptions(req, 'capital-investment/investor-type', OPTIONS),
+    getOptions(req, 'capital-investment/required-checks-conducted', OPTIONS),
+    getAdvisers(req),
   ]
 }
 
-const getInvestorRequirementsOptions = (token) => {
+const getInvestorRequirementsOptions = (req) => {
   return [
-    getOptions(token, 'capital-investment/deal-ticket-size', OPTIONS),
-    getOptions(token, 'capital-investment/asset-class-interest', {
+    getOptions(req, 'capital-investment/deal-ticket-size', OPTIONS),
+    getOptions(req, 'capital-investment/asset-class-interest', {
       transformer: transformAssetClasses,
     }),
-    getOptions(token, 'capital-investment/large-capital-investment-type', {
+    getOptions(req, 'capital-investment/large-capital-investment-type', {
       sortPropertyName: 'text',
       transformer: transformObjectToGovUKOption,
     }),
-    getOptions(token, 'capital-investment/return-rate', OPTIONS),
-    getOptions(token, 'capital-investment/time-horizon', OPTIONS),
-    getOptions(token, 'capital-investment/restriction', OPTIONS),
-    getOptions(token, 'capital-investment/construction-risk', OPTIONS),
-    getOptions(token, 'capital-investment/equity-percentage', OPTIONS),
-    getOptions(token, 'capital-investment/desired-deal-role', OPTIONS),
+    getOptions(req, 'capital-investment/return-rate', OPTIONS),
+    getOptions(req, 'capital-investment/time-horizon', OPTIONS),
+    getOptions(req, 'capital-investment/restriction', OPTIONS),
+    getOptions(req, 'capital-investment/construction-risk', OPTIONS),
+    getOptions(req, 'capital-investment/equity-percentage', OPTIONS),
+    getOptions(req, 'capital-investment/desired-deal-role', OPTIONS),
   ]
 }
 
-const getLocationOptions = (token) => {
-  return [getOptions(token, 'uk-region'), getOptions(token, 'country')]
+const getLocationOptions = (req) => {
+  return [getOptions(req, 'uk-region'), getOptions(req, 'country')]
 }
 
 module.exports = {

--- a/src/apps/companies/apps/investments/large-capital-profile/repos.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/repos.js
@@ -1,21 +1,21 @@
 const { authorisedRequest } = require('../../../../../lib/authorised-request')
 const config = require('../../../../../config')
 
-function getCompanyProfiles(token, companyId) {
+function getCompanyProfiles(req, companyId) {
   const url = `${config.apiRoot}/v4/large-investor-profile?investor_company_id=${companyId}`
-  return authorisedRequest(token, url)
+  return authorisedRequest(req, url)
 }
 
-function createCompanyProfile(token, body) {
-  return authorisedRequest(token, {
+function createCompanyProfile(req, body) {
+  return authorisedRequest(req, {
     body,
     method: 'POST',
     url: `${config.apiRoot}/v4/large-investor-profile`,
   })
 }
 
-function updateCompanyProfile(token, body, profileId) {
-  return authorisedRequest(token, {
+function updateCompanyProfile(req, body, profileId) {
+  return authorisedRequest(req, {
     body,
     method: 'PATCH',
     url: `${config.apiRoot}/v4/large-investor-profile/${profileId}`,

--- a/src/apps/companies/apps/investments/projects/controllers/list.js
+++ b/src/apps/companies/apps/investments/projects/controllers/list.js
@@ -10,7 +10,6 @@ const {
 const urls = require('../../../../../../lib/urls')
 
 async function renderProjects(req, res, next) {
-  const { token } = req.session
   const { company, returnUrl, dnbRelatedCompaniesCount } = res.locals
   const actionButtons = company.archived
     ? undefined
@@ -23,7 +22,7 @@ async function renderProjects(req, res, next) {
 
   try {
     const results = await getCompanyInvestmentProjects(
-      token,
+      req,
       company.id,
       req.query.page
     ).then(

--- a/src/apps/companies/apps/referrals/middleware/interactions.js
+++ b/src/apps/companies/apps/referrals/middleware/interactions.js
@@ -3,10 +3,7 @@ const urls = require('../../../../../lib/urls')
 
 async function setReferralDetails(req, res, next) {
   try {
-    res.locals.referral = await getReferral(
-      req.session.token,
-      req.params.referralId
-    )
+    res.locals.referral = await getReferral(req, req.params.referralId)
     next()
   } catch (error) {
     next(error)

--- a/src/apps/companies/apps/referrals/repos.js
+++ b/src/apps/companies/apps/referrals/repos.js
@@ -1,9 +1,9 @@
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 const config = require('../../../../config/index')
 
-function getReferral(token, referralId) {
+function getReferral(req, referralId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v4/company-referral/${referralId}`
   )
 }

--- a/src/apps/companies/apps/referrals/send-referral/controllers.js
+++ b/src/apps/companies/apps/referrals/send-referral/controllers.js
@@ -33,7 +33,7 @@ function renderSendReferralForm(req, res) {
 
 async function submitSendReferralForm(req, res, next) {
   try {
-    await authorisedRequest(req.session.token, {
+    await authorisedRequest(req, {
       method: 'POST',
       url: `${config.apiRoot}/v4/company-referral`,
       body: omit(req.body, '_csrf'),

--- a/src/apps/companies/controllers/__test__/archive.test.js
+++ b/src/apps/companies/controllers/__test__/archive.test.js
@@ -26,17 +26,15 @@ describe('Company controller, archive', () => {
   const commonTests = ({ stubName, expectedReason, expectedFlash }) => {
     if (stubName) {
       it('should call archive company with correct args', () => {
-        const expectedToken = this.middlewareParameters.reqMock.session.token
-
         if (expectedReason) {
           expect(this.stub[stubName]).to.have.been.calledWith(
-            expectedToken,
+            this.middlewareParameters.reqMock,
             companyMock.id,
             expectedReason
           )
         } else {
           expect(this.stub[stubName]).to.have.been.calledWith(
-            expectedToken,
+            this.middlewareParameters.reqMock,
             companyMock.id
           )
         }

--- a/src/apps/companies/controllers/__test__/orders.test.js
+++ b/src/apps/companies/controllers/__test__/orders.test.js
@@ -42,13 +42,13 @@ describe('Company orders controller', () => {
 
       it('should call search with correct arguments', () => {
         expect(this.searchStub).to.have.been.calledWith({
+          req: this.middlewareParameters.reqMock,
           isAggregation: false,
           page: 1,
           requestBody: {
             company: companyMock.id,
           },
           searchEntity: 'order',
-          token: '1234',
         })
       })
 

--- a/src/apps/companies/controllers/archive.js
+++ b/src/apps/companies/controllers/archive.js
@@ -17,7 +17,7 @@ async function archiveCompany(req, res) {
   }
 
   try {
-    await archive(req.session.token, company.id, reason)
+    await archive(req, company.id, reason)
 
     req.flash('success', 'Company archived')
     res.redirect(detailsUrl)
@@ -34,7 +34,7 @@ async function unarchiveCompany(req, res) {
   const detailsUrl = `/companies/${company.id}/business-details`
 
   try {
-    await unarchive(req.session.token, company.id)
+    await unarchive(req, company.id)
 
     req.flash('success', 'Company unarchived')
     res.redirect(detailsUrl)

--- a/src/apps/companies/controllers/list.js
+++ b/src/apps/companies/controllers/list.js
@@ -22,21 +22,21 @@ const exportOptions = {
 
 async function renderCompanyList(req, res, next) {
   try {
-    const { token, user } = req.session
+    const { user } = req.session
     const queryString = QUERY_STRING
     const sortForm = merge({}, companySortForm, {
       hiddenFields: { ...omit(req.query, 'sortby') },
       children: [{ value: req.query.sortby }],
     })
 
-    const sectorOptions = await getOptions(token, SECTOR, { queryString })
+    const sectorOptions = await getOptions(req, SECTOR, { queryString })
 
     const filtersFields = companyFiltersFields({
       sectorOptions,
     })
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
-      token,
+      req,
       filtersFields,
       req.query
     )

--- a/src/apps/companies/controllers/orders.js
+++ b/src/apps/companies/controllers/orders.js
@@ -6,7 +6,6 @@ const { transformOrderToListItem } = require('../../omis/transformers')
 const urls = require('../../../lib/urls')
 
 async function renderOrders(req, res, next) {
-  const token = req.session.token
   const page = req.query.page || 1
   const { company, returnUrl, dnbRelatedCompaniesCount } = res.locals
   const actionButtons = company.archived
@@ -20,7 +19,7 @@ async function renderOrders(req, res, next) {
 
   try {
     const results = await search({
-      token,
+      req,
       page,
       searchEntity: 'order',
       requestBody: {

--- a/src/apps/companies/controllers/subsidiaries.js
+++ b/src/apps/companies/controllers/subsidiaries.js
@@ -8,7 +8,6 @@ const { ENTITIES } = require('../../search/constants')
 
 async function renderSubsidiaries(req, res, next) {
   try {
-    const token = req.session.token
     const { company } = res.locals
     const actionButtons = company.archived
       ? undefined
@@ -20,7 +19,7 @@ async function renderSubsidiaries(req, res, next) {
         ]
 
     const subsidiaryCollection = await getCompanySubsidiaries(
-      token,
+      req,
       company.id,
       req.query.page
     ).then(

--- a/src/apps/companies/middleware/collection.js
+++ b/src/apps/companies/middleware/collection.js
@@ -6,8 +6,8 @@ const {
 const { transformCompanyToListItem } = require('../transformers')
 const { ENTITIES } = require('../../search/constants')
 
-async function getNonGlobalHQs(token) {
-  const headerquarterTypes = await getOptions(token, 'headquarter-type')
+async function getNonGlobalHQs(req) {
+  const headerquarterTypes = await getOptions(req, 'headquarter-type')
   const filtered = headerquarterTypes.filter(
     (hqType) => !hqType.disabled && hqType.label !== 'ghq'
   )
@@ -20,25 +20,24 @@ async function getNonGlobalHQs(token) {
   ]
 }
 
-async function getGlobalHQ(token) {
-  const headerquarterTypes = await getOptions(token, 'headquarter-type')
+async function getGlobalHQ(req) {
+  const headerquarterTypes = await getOptions(req, 'headquarter-type')
   return headerquarterTypes.find((hqType) => hqType.label === 'ghq')
 }
 
 async function getGlobalHQCompaniesCollection(req, res, next) {
   const searchTerm = (res.locals.searchTerm = req.query.term)
   const { id: companyId } = res.locals.company
-  const { token } = req.session
 
   if (!searchTerm) {
     return next()
   }
 
   try {
-    const globalHQ = await getGlobalHQ(token)
+    const globalHQ = await getGlobalHQ(req)
 
     res.locals.results = await searchCompanies({
-      token: req.session.token,
+      req,
       searchTerm,
       page: req.query.page,
       requestBody: {
@@ -68,17 +67,16 @@ async function getGlobalHQCompaniesCollection(req, res, next) {
 async function getSubsidiaryCompaniesCollection(req, res, next) {
   const searchTerm = (res.locals.searchTerm = req.query.term)
   const { id: companyId } = res.locals.company
-  const { token } = req.session
 
   if (!searchTerm) {
     return next()
   }
 
   try {
-    const nonGlobalHQs = await getNonGlobalHQs(token)
+    const nonGlobalHQs = await getNonGlobalHQs(req)
 
     res.locals.results = await searchCompanies({
-      token: req.session.token,
+      req,
       searchTerm,
       page: req.query.page,
       requestBody: {

--- a/src/apps/companies/middleware/contact-collection.js
+++ b/src/apps/companies/middleware/contact-collection.js
@@ -10,9 +10,9 @@ const removeArray = require('../../../lib/remove-array')
 async function getCompanyContactCollection(req, res, next) {
   try {
     res.locals.contactResults = await search({
+      req,
       searchEntity: 'contact',
       requestBody: req.body,
-      token: req.session.token,
       page: req.query.page,
       isAggregation: false,
     }).then(

--- a/src/apps/companies/middleware/hierarchies.js
+++ b/src/apps/companies/middleware/hierarchies.js
@@ -7,14 +7,13 @@ function transformErrorMessage(error) {
 }
 
 async function setGlobalHQ(req, res, next) {
-  const token = req.session.token
   const companyId = req.params.companyId
   const globalHqId = req.params.globalHqId
   const body = { global_headquarters: globalHqId }
   const detailsUrl = `/companies/${companyId}/business-details`
 
   try {
-    await updateCompany(token, companyId, body)
+    await updateCompany(req, companyId, body)
 
     req.flash('success', 'You’ve linked the Global Headquarters')
     return res.redirect(detailsUrl)
@@ -28,13 +27,12 @@ async function setGlobalHQ(req, res, next) {
 }
 
 async function removeGlobalHQ(req, res, next) {
-  const token = req.session.token
   const companyId = req.params.companyId
   const body = { global_headquarters: null }
   const detailsUrl = `/companies/${companyId}/business-details`
 
   try {
-    await updateCompany(token, companyId, body)
+    await updateCompany(req, companyId, body)
 
     req.flash('success', 'You’ve removed the link to Global Headquarters')
     return res.redirect(detailsUrl)
@@ -48,12 +46,11 @@ async function removeGlobalHQ(req, res, next) {
 }
 
 async function addSubsidiary(req, res, next) {
-  const token = req.session.token
   const { companyId, subsidiaryCompanyId } = req.params
   const body = { global_headquarters: companyId }
 
   try {
-    await updateCompany(token, subsidiaryCompanyId, body)
+    await updateCompany(req, subsidiaryCompanyId, body)
     req.flash('success', 'You’ve linked the subsidiary')
   } catch (error) {
     if (error.statusCode !== 400) {

--- a/src/apps/companies/middleware/params.js
+++ b/src/apps/companies/middleware/params.js
@@ -11,7 +11,7 @@ const { isItaTierDAccount } = require('../../../lib/is-tier-type-company')
 async function getCompany(req, res, next, id) {
   try {
     const { features } = res.locals
-    const company = await getDitCompany(req.session.token, id)
+    const company = await getDitCompany(req, id)
     company.isItaTierDAccount = isItaTierDAccount(company)
     company.hasAllocatedLeadIta =
       company.one_list_group_global_account_manager != null
@@ -36,7 +36,7 @@ async function getCompany(req, res, next, id) {
 async function setIsCompanyAlreadyAdded(req, res, next, id) {
   let isCompanyAlreadyAdded = false
   try {
-    await getDitCompanyFromList(req.session.token, id)
+    await getDitCompanyFromList(req, id)
     isCompanyAlreadyAdded = true
   } catch (error) {
     //  Do nothing
@@ -47,14 +47,14 @@ async function setIsCompanyAlreadyAdded(req, res, next, id) {
 
 const companyListActions = {
   add: async (req, res, next, companyId) => {
-    await addDitCompanyToList(req.session.token, companyId)
+    await addDitCompanyToList(req, companyId)
     req.flash(
       'success',
       'This company has been added to your list of companies. You can find this list on your Data Hub Home page. Only you can see this list.'
     )
   },
   remove: async (req, res, next, companyId) => {
-    await removeDitCompanyFromList(req.session.token, companyId)
+    await removeDitCompanyFromList(req, companyId)
     req.flash('success', 'This company has been removed from your list.')
   },
 }

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -2,82 +2,82 @@
 const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
-function getDitCompany(token, id) {
-  return authorisedRequest(token, `${config.apiRoot}/v4/company/${id}`)
+function getDitCompany(req, id) {
+  return authorisedRequest(req, `${config.apiRoot}/v4/company/${id}`)
 }
 
-function getDitCompanyFromList(token, id) {
-  return authorisedRequest(token, {
+function getDitCompanyFromList(req, id) {
+  return authorisedRequest(req, {
     method: 'GET',
     url: `${config.apiRoot}/v4/user/company-list/${id}`,
   })
 }
 
-function addDitCompanyToList(token, id) {
-  return authorisedRequest(token, {
+function addDitCompanyToList(req, id) {
+  return authorisedRequest(req, {
     method: 'PUT',
     url: `${config.apiRoot}/v4/user/company-list/${id}`,
   })
 }
 
-function removeDitCompanyFromList(token, id) {
-  return authorisedRequest(token, {
+function removeDitCompanyFromList(req, id) {
+  return authorisedRequest(req, {
     method: 'DELETE',
     url: `${config.apiRoot}/v4/user/company-list/${id}`,
   })
 }
 
-function saveCompany(token, company) {
+function saveCompany(req, company) {
   return company.id
-    ? updateCompany(token, company.id, company)
-    : addCompany(token, company)
+    ? updateCompany(req, company.id, company)
+    : addCompany(req, company)
 }
 
-function archiveCompany(token, companyId, reason) {
+function archiveCompany(req, companyId, reason) {
   const options = {
     body: { reason },
     url: `${config.apiRoot}/v4/company/${companyId}/archive`,
     method: 'POST',
   }
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
-function unarchiveCompany(token, companyId) {
-  return authorisedRequest(token, {
+function unarchiveCompany(req, companyId) {
+  return authorisedRequest(req, {
     method: 'POST',
     url: `${config.apiRoot}/v4/company/${companyId}/unarchive`,
   })
 }
 
-function addCompany(token, body) {
-  return authorisedRequest(token, {
+function addCompany(req, body) {
+  return authorisedRequest(req, {
     body,
     url: `${config.apiRoot}/v4/company`,
     method: 'POST',
   })
 }
 
-function updateCompany(token, companyId, body) {
-  return authorisedRequest(token, {
+function updateCompany(req, companyId, body) {
+  return authorisedRequest(req, {
     body,
     url: `${config.apiRoot}/v4/company/${companyId}`,
     method: 'PATCH',
   })
 }
 
-function getCompanyAuditLog(token, companyId, page = 1) {
+function getCompanyAuditLog(req, companyId, page = 1) {
   const limit = 10
   const offset = limit * (page - 1)
-  return authorisedRequest(token, {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company/${companyId}/audit`,
     qs: { limit, offset },
   })
 }
 
-function getCompanySubsidiaries(token, companyId, page = 1) {
+function getCompanySubsidiaries(req, companyId, page = 1) {
   const limit = 10
   const offset = limit * (page - 1)
-  return authorisedRequest(token, {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company`,
     qs: {
       limit,
@@ -88,8 +88,8 @@ function getCompanySubsidiaries(token, companyId, page = 1) {
   })
 }
 
-function getGlobalUltimateHierarchy(token, globalUltimateDunnsNumber) {
-  return authorisedRequest(token, {
+function getGlobalUltimateHierarchy(req, globalUltimateDunnsNumber) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company`,
     qs: {
       limit: 200,
@@ -98,14 +98,14 @@ function getGlobalUltimateHierarchy(token, globalUltimateDunnsNumber) {
   })
 }
 
-function getOneListGroupCoreTeam(token, companyId) {
-  return authorisedRequest(token, {
+function getOneListGroupCoreTeam(req, companyId) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company/${companyId}/one-list-group-core-team`,
   })
 }
 
-function saveDnbCompany(token, dunsNumber) {
-  return authorisedRequest(token, {
+function saveDnbCompany(req, dunsNumber) {
+  return authorisedRequest(req, {
     body: {
       duns_number: dunsNumber,
     },
@@ -114,24 +114,24 @@ function saveDnbCompany(token, dunsNumber) {
   })
 }
 
-function createDnbCompanyInvestigation(token, body) {
-  return authorisedRequest(token, {
+function createDnbCompanyInvestigation(req, body) {
+  return authorisedRequest(req, {
     body,
     url: `${config.apiRoot}/v4/dnb/company-investigation`,
     method: 'POST',
   })
 }
 
-function saveCompanyExportDetails(token, companyId, body) {
-  return authorisedRequest(token, {
+function saveCompanyExportDetails(req, companyId, body) {
+  return authorisedRequest(req, {
     body,
     url: `${config.apiRoot}/v4/company/${companyId}/export-detail`,
     method: 'PATCH',
   })
 }
 
-function linkDataHubCompanyToDnBCompany(token, companyId, dunsNumber) {
-  return authorisedRequest(token, {
+function linkDataHubCompanyToDnBCompany(req, companyId, dunsNumber) {
+  return authorisedRequest(req, {
     body: {
       company_id: companyId,
       duns_number: dunsNumber,
@@ -141,8 +141,8 @@ function linkDataHubCompanyToDnBCompany(token, companyId, dunsNumber) {
   })
 }
 
-function createDnbChangeRequest(token, dunsNumber, changes) {
-  return authorisedRequest(token, {
+function createDnbChangeRequest(req, dunsNumber, changes) {
+  return authorisedRequest(req, {
     body: {
       duns_number: dunsNumber,
       changes,

--- a/src/apps/company-lists/__test__/repos.test.js
+++ b/src/apps/company-lists/__test__/repos.test.js
@@ -17,6 +17,7 @@ const companyList = require('../../../../test/unit/data/company-lists/list-with-
 const companyListFixture = require('../../../../test/unit/data/company-lists/list-with-multiple-items.json')
 
 const listId = companyListFixture.id
+const stubRequest = { session: { token: 'abcd' } }
 
 describe('Company list repository', () => {
   describe('#fetchCompanyList', () => {
@@ -82,7 +83,7 @@ describe('Company list repository', () => {
 
     it('should return company', async () => {
       const companyList = await createUserCompanyList(
-        'TEST_TOKEN',
+        stubRequest,
         '1',
         'listName'
       )
@@ -102,7 +103,7 @@ describe('Company list repository', () => {
     })
 
     it('should return all lists a company is in', async () => {
-      const companyList = await getListsCompanyIsIn('TEST_TOKEN', '1')
+      const companyList = await getListsCompanyIsIn(stubRequest, '1')
       expect(companyList).to.deep.equal(companyListFixture)
     })
   })
@@ -115,7 +116,7 @@ describe('Company list repository', () => {
     })
 
     it('should return all company lists', async () => {
-      const companyList = await getAllCompanyLists('TEST_TOKEN')
+      const companyList = await getAllCompanyLists(stubRequest)
       expect(companyList).to.deep.equal(companyListFixture)
     })
   })
@@ -128,7 +129,7 @@ describe('Company list repository', () => {
     })
 
     it('returns a company list', async () => {
-      const companyList = await getCompanyList('token', listId)
+      const companyList = await getCompanyList(stubRequest, listId)
       expect(companyList).to.deep.equal(companyListFixture)
     })
   })
@@ -139,7 +140,7 @@ describe('Company list repository', () => {
     })
 
     it('deletes a company list', () => {
-      expect(() => deleteCompanyList('token', listId)).to.not.throw()
+      expect(() => deleteCompanyList(stubRequest, listId)).to.not.throw()
     })
   })
 
@@ -149,7 +150,7 @@ describe('Company list repository', () => {
     })
 
     it('should add a company to a list', () => {
-      expect(() => addCompanyToList('TEST_TOKEN', '1', '2')).to.not.throw()
+      expect(() => addCompanyToList(stubRequest, '1', '2')).to.not.throw()
     })
   })
 
@@ -159,7 +160,7 @@ describe('Company list repository', () => {
     })
 
     it('should delete a company from a list', () => {
-      expect(() => removeCompanyFromList('TEST_TOKEN', '1', '2')).to.not.throw()
+      expect(() => removeCompanyFromList(stubRequest, '1', '2')).to.not.throw()
     })
   })
 })

--- a/src/apps/company-lists/controllers/add-remove.js
+++ b/src/apps/company-lists/controllers/add-remove.js
@@ -15,7 +15,7 @@ async function handleAddRemoveCompanyToList(req, res, next) {
     for (const [listId, value] of Object.entries(list)) {
       const addOrRemoveCompany =
         value === 'yes' ? addCompanyToList : removeCompanyFromList
-      listsToUpdate.push(addOrRemoveCompany(req.session.token, listId, id))
+      listsToUpdate.push(addOrRemoveCompany(req, listId, id))
     }
     await Promise.all(listsToUpdate)
     req.flash('success', 'Lists changes for this company have been saved.')
@@ -29,8 +29,8 @@ async function handleAddRemoveCompanyToList(req, res, next) {
 async function fetchListsCompanyIsOn(req, res, next) {
   try {
     const [allLists, allListsCompaniesIn] = await Promise.all([
-      getAllCompanyLists(req.session.token),
-      getListsCompanyIsIn(req.session.token, res.locals.company.id),
+      getAllCompanyLists(req),
+      getListsCompanyIsIn(req, res.locals.company.id),
     ])
     res.locals.listsCompanyIsIn = await transformCompaniesInLists(
       allLists,

--- a/src/apps/company-lists/controllers/create.js
+++ b/src/apps/company-lists/controllers/create.js
@@ -3,7 +3,7 @@ const { createUserCompanyList } = require('../repos')
 async function createCompanyList(req, res, next) {
   const { id, name } = req.body
   try {
-    await createUserCompanyList(req.session.token, id, name)
+    await createUserCompanyList(req, id, name)
     req.flash('success', 'Company list created')
     res.send()
   } catch (error) {

--- a/src/apps/company-lists/controllers/delete.js
+++ b/src/apps/company-lists/controllers/delete.js
@@ -17,7 +17,7 @@ async function renderDeleteCompanyListPage(req, res, next) {
 
 async function handleDeleteCompanyList(req, res, next) {
   try {
-    await deleteCompanyList(req.session.token, req.params.listId)
+    await deleteCompanyList(req, req.params.listId)
     req.flash('success', 'List deleted')
     res.send()
   } catch (error) {

--- a/src/apps/company-lists/controllers/edit.js
+++ b/src/apps/company-lists/controllers/edit.js
@@ -2,10 +2,9 @@ const { renameCompanyList, getCompanyList } = require('../repos')
 const urls = require('../../../lib/urls')
 // istanbul ignore next: Covered by functional tests
 async function handleEditCompanyList(req, res, next) {
-  const { token } = req.session
   const { name, id } = req.body
   try {
-    await renameCompanyList(token, name, id)
+    await renameCompanyList(req, name, id)
     req.flash('success', 'List updated')
     res.send()
   } catch (error) {
@@ -14,10 +13,9 @@ async function handleEditCompanyList(req, res, next) {
 }
 // istanbul ignore next: Covered by functional tests
 async function renderEditCompanyListPage(req, res, next) {
-  const { token } = req.session
   const { listId } = req.params
   try {
-    res.locals.companyList = await getCompanyList(token, listId)
+    res.locals.companyList = await getCompanyList(req, listId)
     const {
       companyList: { id, name },
     } = res.locals

--- a/src/apps/company-lists/repos.js
+++ b/src/apps/company-lists/repos.js
@@ -2,18 +2,17 @@ const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
 async function fetchCompanyList(req, res, next) {
-  const { token } = req.session
   const { listId } = req.params
   try {
-    res.locals.companyList = await getCompanyList(token, listId)
+    res.locals.companyList = await getCompanyList(req, listId)
     next()
   } catch (error) {
     next(error)
   }
 }
 
-function renameCompanyList(token, name, id) {
-  return authorisedRequest(token, {
+function renameCompanyList(req, name, id) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company-list/${id}`,
     method: 'PATCH',
     body: {
@@ -23,8 +22,8 @@ function renameCompanyList(token, name, id) {
   })
 }
 
-function createUserCompanyList(token, id, name) {
-  return authorisedRequest(token, {
+function createUserCompanyList(req, id, name) {
+  return authorisedRequest(req, {
     method: 'POST',
     url: `${config.apiRoot}/v4/company-list`,
     body: {
@@ -34,37 +33,37 @@ function createUserCompanyList(token, id, name) {
   })
 }
 
-function getListsCompanyIsIn(token, id) {
-  return authorisedRequest(token, {
+function getListsCompanyIsIn(req, id) {
+  return authorisedRequest(req, {
     method: 'GET',
     url: `${config.apiRoot}/v4/company-list?items__company_id=${id}`,
   })
 }
 
-function getAllCompanyLists(token) {
-  return authorisedRequest(token, `${config.apiRoot}/v4/company-list`)
+function getAllCompanyLists(req) {
+  return authorisedRequest(req, `${config.apiRoot}/v4/company-list`)
 }
 
-function getCompanyList(token, id) {
-  return authorisedRequest(token, `${config.apiRoot}/v4/company-list/${id}`)
+function getCompanyList(req, id) {
+  return authorisedRequest(req, `${config.apiRoot}/v4/company-list/${id}`)
 }
 
-function deleteCompanyList(token, id) {
-  return authorisedRequest(token, {
+function deleteCompanyList(req, id) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company-list/${id}`,
     method: 'DELETE',
   })
 }
 
-function addCompanyToList(token, listId, companyId) {
-  return authorisedRequest(token, {
+function addCompanyToList(req, listId, companyId) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company-list/${listId}/item/${companyId}`,
     method: 'PUT',
   })
 }
 
-function removeCompanyFromList(token, listId, companyId) {
-  return authorisedRequest(token, {
+function removeCompanyFromList(req, listId, companyId) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v4/company-list/${listId}/item/${companyId}`,
     method: 'DELETE',
   })

--- a/src/apps/components/controllers.js
+++ b/src/apps/components/controllers.js
@@ -32,7 +32,7 @@ function renderCollection(req, res) {
 
 async function renderEntityList(req, res) {
   const investmentProjects = await authorisedRequest(
-    req.session.token,
+    req,
     `${config.apiRoot}/v3/investment?limit=10`
   ).then((result) => {
     return Object.assign(result, {
@@ -73,11 +73,11 @@ async function renderEntityList(req, res) {
     investmentProjects,
     auditLog,
     companiesSearch: await authorisedRequest(
-      req.session.token,
+      req,
       `${config.apiRoot}/v3/search?term=samsung&entity=company&limit=10`
     ),
     contactsSearch: await authorisedRequest(
-      req.session.token,
+      req,
       `${config.apiRoot}/v3/search?term=samsung&entity=contact&limit=10`
     ),
   })

--- a/src/apps/components/form/controllers.js
+++ b/src/apps/components/form/controllers.js
@@ -6,14 +6,14 @@ const {
   buildSearchEntityResultsData,
 } = require('../../../modules/search/services')
 
-async function getAggregationData(token, searchTerm) {
+async function getAggregationData(req, searchTerm) {
   if (!searchTerm) {
     return null
   }
 
   const results = await search({
     searchTerm,
-    token,
+    req,
     searchEntity: 'company',
   })
 
@@ -43,7 +43,7 @@ async function renderFormElements(req, res) {
     buildFormWithStateAndErrors(entitySearchConfig),
     {
       modifier: 'global',
-      aggregations: await getAggregationData(req.session.token, req.query.term),
+      aggregations: await getAggregationData(req, req.query.term),
     }
   )
 

--- a/src/apps/components/middleware.js
+++ b/src/apps/components/middleware.js
@@ -4,7 +4,6 @@ const { getAdviser } = require('../adviser/repos')
 
 async function adviserLookup(req, res, next) {
   try {
-    const token = req.session.token
     const adviserParam = req.query.adviser
     res.locals.advisers = []
 
@@ -12,7 +11,7 @@ async function adviserLookup(req, res, next) {
       const adviserIds = castArray(adviserParam)
 
       for (let index = 0; index < adviserIds.length; index += 1) {
-        const adviser = await getAdviser(token, adviserIds[index])
+        const adviser = await getAdviser(req, adviserIds[index])
         res.locals.advisers.push({
           value: adviser.id,
           label: adviser.name,

--- a/src/apps/contacts/__test__/repos.test.js
+++ b/src/apps/contacts/__test__/repos.test.js
@@ -5,6 +5,7 @@ const { getContactsForCompany } = require('../repos')
 const contactsApiResult = require('../../../../test/unit/data/contacts/contact-api-result.json')
 
 const companyId = '23232323'
+const stubRequest = { session: { token: 'abcd' } }
 
 describe('Investment repository', () => {
   describe('#getContactsForCompany', () => {
@@ -12,7 +13,7 @@ describe('Investment repository', () => {
       nock(config.apiRoot)
         .get(`/v3/contact?company_id=${companyId}&limit=500`)
         .reply(200, contactsApiResult)
-      this.contacts = await getContactsForCompany('token', companyId)
+      this.contacts = await getContactsForCompany(stubRequest, companyId)
     })
 
     it('should return company contacts array', async () => {

--- a/src/apps/contacts/controllers/__test__/archive.test.js
+++ b/src/apps/contacts/controllers/__test__/archive.test.js
@@ -35,7 +35,7 @@ describe('Contact controller, archive', () => {
       locals: {},
       redirect: () => {
         expect(contactRepositoryArchiveContactStub).to.be.calledWith(
-          token,
+          req,
           id,
           req.body.archived_reason
         )
@@ -56,7 +56,7 @@ describe('Contact controller, archive', () => {
       locals: {},
       redirect: () => {
         expect(contactRepositoryArchiveContactStub).to.be.calledWith(
-          token,
+          req,
           id,
           req.body.archived_reason_other
         )
@@ -113,10 +113,7 @@ describe('Contact controller, archive', () => {
     const res = {
       locals: {},
       redirect: () => {
-        expect(contactRepositoryUnArchiveContactStub).to.be.calledWith(
-          token,
-          id
-        )
+        expect(contactRepositoryUnArchiveContactStub).to.be.calledWith(req, id)
         done()
       },
     }

--- a/src/apps/contacts/controllers/__test__/audit.test.js
+++ b/src/apps/contacts/controllers/__test__/audit.test.js
@@ -50,7 +50,7 @@ describe('Contact audit controller', () => {
           breadcrumb: this.breadcrumbStub,
           render: () => {
             expect(this.getContactAuditLogStub).to.be.calledWith(
-              this.req.session.token,
+              this.req,
               this.req.params.contactId,
               1
             )
@@ -74,7 +74,7 @@ describe('Contact audit controller', () => {
           breadcrumb: this.breadcrumbStub,
           render: () => {
             expect(this.getContactAuditLogStub).to.be.calledWith(
-              this.req.session.token,
+              this.req,
               this.req.params.contactId,
               '3'
             )

--- a/src/apps/contacts/controllers/__test__/edit.test.js
+++ b/src/apps/contacts/controllers/__test__/edit.test.js
@@ -135,7 +135,7 @@ describe('Contact controller, edit', () => {
       it('should include an expanded company', function (done) {
         res.render = () => {
           expect(getDitCompanyStub).to.have.been.calledWith(
-            req.session.token,
+            req,
             contact.company.id
           )
           expect(res.locals.company).to.deep.equal(company)
@@ -186,10 +186,7 @@ describe('Contact controller, edit', () => {
       })
       it('should include an expanded company', function (done) {
         res.render = () => {
-          expect(getDitCompanyStub).to.have.been.calledWith(
-            req.session.token,
-            company.id
-          )
+          expect(getDitCompanyStub).to.have.been.calledWith(req, company.id)
           expect(res.locals.company).to.deep.equal(company)
           done()
         }
@@ -242,10 +239,7 @@ describe('Contact controller, edit', () => {
       })
       it('should include an expanded company', function (done) {
         res.render = () => {
-          expect(getDitCompanyStub).to.have.been.calledWith(
-            req.session.token,
-            company.id
-          )
+          expect(getDitCompanyStub).to.have.been.calledWith(req, company.id)
           expect(res.locals.company).to.deep.equal(company)
           done()
         }
@@ -458,7 +452,7 @@ describe('Contact controller, edit', () => {
     })
     it('should save the form data to the back end', function (done) {
       res.redirect = () => {
-        expect(saveContactFormStub).to.be.calledWith(req.session.token, body)
+        expect(saveContactFormStub).to.be.calledWith(req, body)
         done()
       }
 

--- a/src/apps/contacts/controllers/archive.js
+++ b/src/apps/contacts/controllers/archive.js
@@ -8,11 +8,7 @@ async function archiveContact(req, res, next) {
         : req.body.archived_reason_other
 
     if (reason.length > 0) {
-      await contactsRepository.archiveContact(
-        req.session.token,
-        req.params.id,
-        reason
-      )
+      await contactsRepository.archiveContact(req, req.params.id, reason)
       req.flash('success', 'Contact record updated')
     } else {
       req.flash('error', 'Unable to archive contact, no reason given')
@@ -26,7 +22,7 @@ async function archiveContact(req, res, next) {
 
 async function unarchiveContact(req, res, next) {
   try {
-    await contactsRepository.unarchiveContact(req.session.token, req.params.id)
+    await contactsRepository.unarchiveContact(req, req.params.id)
     req.flash('success', 'Contact record updated')
     res.redirect(`/contacts/${req.params.id}`)
   } catch (error) {

--- a/src/apps/contacts/controllers/audit.js
+++ b/src/apps/contacts/controllers/audit.js
@@ -7,11 +7,10 @@ const { contactAuditLabels } = require('../labels')
 
 async function getAudit(req, res, next) {
   try {
-    const token = req.session.token
     const contactId = req.params.contactId
     const page = req.query.page || 1
 
-    const auditLog = await getContactAuditLog(token, contactId, page).then(
+    const auditLog = await getContactAuditLog(req, contactId, page).then(
       transformApiResponseToCollection(
         { entityType: 'audit', query: req.query },
         transformAuditLogToListItem(contactAuditLabels)

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -11,14 +11,13 @@ const reasonForArchiveOptionsPrefix = 'This contact has:'
 
 async function getCommon(req, res, next) {
   try {
-    const token = req.session.token
     const contact = (res.locals.contact = await contactsRepository.getContact(
-      token,
+      req,
       req.params.contactId
     ))
 
     res.locals.company = await companyRepository.getDitCompany(
-      token,
+      req,
       contact.company.id
     )
     res.locals.id = req.params.contactId

--- a/src/apps/contacts/controllers/edit.js
+++ b/src/apps/contacts/controllers/edit.js
@@ -17,7 +17,6 @@ const urls = require('../../../lib/urls')
 // Todo - rewrite to use form generator
 async function editDetails(req, res, next) {
   try {
-    const { token } = req.session
     const { contactId } = req.params
 
     // Work out what to use for the form data
@@ -56,10 +55,7 @@ async function editDetails(req, res, next) {
     }
 
     if (!res.locals.company) {
-      res.locals.company = await companyRepository.getDitCompany(
-        token,
-        companyId
-      )
+      res.locals.company = await companyRepository.getDitCompany(req, companyId)
     }
 
     if (contactId) {
@@ -74,7 +70,7 @@ async function editDetails(req, res, next) {
     }
 
     res.locals.contactLabels = contactLabels
-    res.locals.countryOptions = await getOptions(token, 'country', {
+    res.locals.countryOptions = await getOptions(req, 'country', {
       createdOn: get(res.locals, 'contact.created_on'),
     })
 
@@ -97,10 +93,7 @@ async function postDetails(req, res, next) {
   try {
     const { origin_type: originType, origin_url: originUrl, ...body } = req.body
 
-    const newContact = await contactFormService.saveContactForm(
-      req.session.token,
-      body
-    )
+    const newContact = await contactFormService.saveContactForm(req, body)
 
     if (req.body.id) {
       req.flash('success', 'Contact record updated')

--- a/src/apps/contacts/controllers/list.js
+++ b/src/apps/contacts/controllers/list.js
@@ -24,21 +24,21 @@ const exportOptions = {
 
 async function renderContactList(req, res, next) {
   try {
-    const { token, user } = req.session
+    const { user } = req.session
     const queryString = QUERY_STRING
     const sortForm = merge({}, contactSortForm, {
       hiddenFields: { ...omit(req.query, 'sortby') },
       children: [{ value: req.query.sortby }],
     })
 
-    const sectorOptions = await getOptions(token, SECTOR, { queryString })
+    const sectorOptions = await getOptions(req, SECTOR, { queryString })
 
     const filtersFields = contactFiltersFields({
       sectorOptions,
     })
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
-      token,
+      req,
       filtersFields,
       req.query
     )

--- a/src/apps/contacts/repos.js
+++ b/src/apps/contacts/repos.js
@@ -2,11 +2,11 @@ const { sortBy } = require('lodash')
 const { authorisedRequest } = require('../../lib/authorised-request')
 const config = require('../../config')
 
-function getContact(token, contactId) {
-  return authorisedRequest(token, `${config.apiRoot}/v3/contact/${contactId}`)
+function getContact(req, contactId) {
+  return authorisedRequest(req, `${config.apiRoot}/v3/contact/${contactId}`)
 }
 
-function saveContact(token, contact) {
+function saveContact(req, contact) {
   const options = {
     body: contact,
   }
@@ -20,27 +20,27 @@ function saveContact(token, contact) {
     options.method = 'POST'
   }
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
-function archiveContact(token, contactId, reason) {
+function archiveContact(req, contactId, reason) {
   const options = {
     body: { reason },
     url: `${config.apiRoot}/v3/contact/${contactId}/archive`,
     method: 'POST',
   }
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
-function unarchiveContact(token, contactId) {
-  return authorisedRequest(token, {
+function unarchiveContact(req, contactId) {
+  return authorisedRequest(req, {
     method: 'POST',
     url: `${config.apiRoot}/v3/contact/${contactId}/unarchive`,
   })
 }
 
-async function getContactsForCompany(token, companyId) {
-  const response = await authorisedRequest(token, {
+async function getContactsForCompany(req, companyId) {
+  const response = await authorisedRequest(req, {
     url: `${config.apiRoot}/v3/contact`,
     qs: {
       company_id: companyId,
@@ -50,11 +50,11 @@ async function getContactsForCompany(token, companyId) {
   return sortBy(response.results, [(name) => name.first_name])
 }
 
-function getContactAuditLog(token, contactId, page = 1) {
+function getContactAuditLog(req, contactId, page = 1) {
   const limit = 10
   const offset = limit * (page - 1)
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/contact/${contactId}/audit?limit=${limit}&offset=${offset}`
   )
 }

--- a/src/apps/contacts/services/__test__/form.test.js
+++ b/src/apps/contacts/services/__test__/form.test.js
@@ -13,7 +13,7 @@ describe('contact form service', () => {
     contactFormService = proxyquire('../form', {
       '../repos': {
         savedContactForm: null,
-        saveContact: function (token, contactForm) {
+        saveContact: function (req, contactForm) {
           return new Promise((resolve, reject) => {
             postedData = contactForm
 

--- a/src/apps/contacts/services/form.js
+++ b/src/apps/contacts/services/form.js
@@ -55,12 +55,12 @@ function getContactAsFormData(contact) {
 /**
  * Accepts a contact posted from a form and converts it into the API format before saving it.
  *
- * @param {string} token Session token to use for network calls
+ * @param {string} req Originating request
  * @param {Object} contactForm A flat form format contact
  * @returns {Promise} Returns a promise that resolves to a copy of the saved contact in API
  * format after the server has saved it
  */
-function saveContactForm(token, contactForm) {
+function saveContactForm(req, contactForm) {
   return new Promise(async (resolve, reject) => {
     try {
       const contactFormWithYesNoAsBool = convertYesNoToBoolean(contactForm)
@@ -76,7 +76,7 @@ function saveContactForm(token, contactForm) {
         accepts_dit_email_marketing: !!contactForm.accepts_dit_email_marketing,
       })
       const savedContact = await contactsRepository.saveContact(
-        token,
+        req,
         contactFormForApiRequest
       )
       resolve(savedContact)

--- a/src/apps/documents/middleware/upload.js
+++ b/src/apps/documents/middleware/upload.js
@@ -15,9 +15,9 @@ function parseForm(req, res) {
       return res.status(500).json({ error: err })
     }
 
-    Object.keys(files).forEach(async (key, index, collection) => {
+    Object.keys(files).map(async (key, index, collection) => {
       try {
-        await chainUploadSequence(req.session.token, {
+        await chainUploadSequence(req, {
           fields,
           file: files[key],
           url: res.locals.documents.url,

--- a/src/apps/documents/repos.js
+++ b/src/apps/documents/repos.js
@@ -5,11 +5,11 @@ const fs = require('fs')
 
 const { authorisedRequest } = require('../../lib/authorised-request')
 
-async function chainUploadSequence(token, data) {
-  const documentUploadData = await getDocumentUploadS3Url(token, data)
+async function chainUploadSequence(req, data) {
+  const documentUploadData = await getDocumentUploadS3Url(req, data)
   const s3Url = documentUploadData.signed_upload_url
 
-  uploadDocumentToS3(token, data, s3Url, documentUploadData.id)
+  uploadDocumentToS3(req, data, s3Url, documentUploadData.id)
 }
 
 function buildApiUrl(url, fields) {
@@ -20,7 +20,7 @@ function buildApiUrl(url, fields) {
   return `${config.apiRoot}/v3${app}${subApp}${document}`
 }
 
-function createRequest(token, urls, file) {
+function createRequest(req, urls, file) {
   request(
     {
       url: urls.s3Url,
@@ -29,7 +29,7 @@ function createRequest(token, urls, file) {
     },
     (error, response) => {
       if (!error && response.statusCode === 200) {
-        authorisedRequest(token, {
+        authorisedRequest(req, {
           url: urls.api,
           method: 'POST',
         })
@@ -38,7 +38,7 @@ function createRequest(token, urls, file) {
   )
 }
 
-function getDocumentUploadS3Url(token, { file, url, fields, textFields = {} }) {
+function getDocumentUploadS3Url(req, { file, url, fields, textFields = {} }) {
   const body = {
     ...textFields,
     original_filename: file.name,
@@ -50,14 +50,14 @@ function getDocumentUploadS3Url(token, { file, url, fields, textFields = {} }) {
     method: 'POST',
   }
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
-function uploadDocumentToS3(token, { url, fields, file }, s3Url, documentId) {
+function uploadDocumentToS3(req, { url, fields, file }, s3Url, documentId) {
   const api = `${buildApiUrl(url, fields)}/${documentId}/upload-callback`
   const urls = { s3Url, api }
 
-  createRequest(token, urls, file)
+  createRequest(req, urls, file)
 }
 
 module.exports = {

--- a/src/apps/events/__test__/repos.test.js
+++ b/src/apps/events/__test__/repos.test.js
@@ -3,7 +3,7 @@ const proxyquire = require('proxyquire')
 const config = require('../../../config')
 const { search } = require('../../../modules/search/services')
 
-const token = 'abcd'
+const stubRequest = { session: { token: 'abcd' } }
 
 describe('Event repos', () => {
   beforeEach(() => {
@@ -24,19 +24,19 @@ describe('Event repos', () => {
       const eventMock = { name: 'Convention' }
 
       it('should call with POST method', () => {
-        this.repos.saveEvent(token, eventMock)
+        this.repos.saveEvent(stubRequest, eventMock)
 
         expect(this.authorisedRequestStub).to.be.calledWith(
-          token,
+          stubRequest,
           sinon.match({ method: 'POST' })
         )
       })
 
       it('should contain event form body', () => {
-        this.repos.saveEvent(token, eventMock)
+        this.repos.saveEvent(stubRequest, eventMock)
 
         expect(this.authorisedRequestStub).to.be.calledWith(
-          token,
+          stubRequest,
           sinon.match({ body: eventMock })
         )
       })
@@ -46,29 +46,29 @@ describe('Event repos', () => {
       const eventMock = { id: '123', name: 'Convention' }
 
       it('should call with POST method', () => {
-        this.repos.saveEvent(token, eventMock)
+        this.repos.saveEvent(stubRequest, eventMock)
 
         expect(this.authorisedRequestStub).to.be.calledWith(
-          token,
+          stubRequest,
           sinon.match({ method: 'PATCH' })
         )
       })
 
       it('should set request URL to event URL', () => {
-        this.repos.saveEvent(token, eventMock)
+        this.repos.saveEvent(stubRequest, eventMock)
 
         expect(this.authorisedRequestStub).to.be.calledWith(
-          token,
+          stubRequest,
           sinon.match({ url: `${config.apiRoot}/v3/event/${eventMock.id}` })
         )
       })
 
       it('should contain event form body', () => {
         const event = { name: 'Convention' }
-        this.repos.saveEvent(token, eventMock)
+        this.repos.saveEvent(stubRequest, eventMock)
 
         expect(this.authorisedRequestStub).to.be.calledWith(
-          token,
+          stubRequest,
           sinon.match({ body: event })
         )
       })
@@ -77,9 +77,9 @@ describe('Event repos', () => {
 
   describe('#fetchEvent', () => {
     it('should call with event URL', () => {
-      this.repos.fetchEvent(token, '123')
+      this.repos.fetchEvent(stubRequest, '123')
       expect(this.authorisedRequestStub).to.be.calledWith(
-        token,
+        stubRequest,
         `${config.apiRoot}/v3/event/123`
       )
     })
@@ -113,7 +113,7 @@ describe('Event repos', () => {
 
             this.currentFormattedTime = now.toISOString()
 
-            this.events = await this.repos.getActiveEvents(token)
+            this.events = await this.repos.getActiveEvents(stubRequest)
           })
 
           afterEach(() => {
@@ -122,6 +122,7 @@ describe('Event repos', () => {
 
           it('should call search to get all active events today', () => {
             expect(this.searchSpy).to.be.calledWith({
+              req: stubRequest,
               searchEntity: 'event',
               requestBody: {
                 sortby: 'name:asc',
@@ -130,7 +131,6 @@ describe('Event repos', () => {
                   after: this.currentFormattedTime,
                 },
               },
-              token,
               limit: 100000,
               isAggregation: false,
             })
@@ -144,13 +144,14 @@ describe('Event repos', () => {
               const now = new Date()
               this.createdOn = now.toISOString()
               this.events = await this.repos.getActiveEvents(
-                token,
+                stubRequest,
                 this.createdOn
               )
             })
 
             it('should call search to get all active events on the specified date', () => {
               expect(this.searchSpy).to.be.calledWith({
+                req: stubRequest,
                 searchEntity: 'event',
                 requestBody: {
                   sortby: 'name:asc',
@@ -159,7 +160,6 @@ describe('Event repos', () => {
                     after: this.createdOn,
                   },
                 },
-                token,
                 limit: 100000,
                 isAggregation: false,
               })

--- a/src/apps/events/attendees/controllers/create.js
+++ b/src/apps/events/attendees/controllers/create.js
@@ -6,7 +6,7 @@ const { fetchEventAttendees } = require('../repos')
 
 async function createAttendee(req, res, next) {
   try {
-    const { user: adviser, token } = req.session
+    const { user: adviser } = req.session
     const contactId = req.params.contactId
     const { event } = res.locals
 
@@ -15,7 +15,7 @@ async function createAttendee(req, res, next) {
     }
 
     const attendees = await fetchEventAttendees({
-      token,
+      req,
       contactId,
       eventId: event.id,
     })
@@ -28,7 +28,7 @@ async function createAttendee(req, res, next) {
       return res.redirect(`/events/${event.id}/attendees`)
     }
 
-    const contact = await getContact(token, contactId)
+    const contact = await getContact(req, contactId)
 
     const serviceDelivery = {
       contacts: [contact.id],
@@ -49,7 +49,7 @@ async function createAttendee(req, res, next) {
       were_countries_discussed: false,
     }
 
-    await saveInteraction(token, serviceDelivery)
+    await saveInteraction(req, serviceDelivery)
 
     req.flash(
       'success',

--- a/src/apps/events/attendees/controllers/find.js
+++ b/src/apps/events/attendees/controllers/find.js
@@ -29,7 +29,6 @@ async function renderFindAttendee(req, res, next) {
 async function findAttendee(req, res, next) {
   try {
     const event = res.locals.event
-    const token = req.session.token
 
     if (!event) {
       throw new Error('No event supplied')
@@ -43,12 +42,12 @@ async function findAttendee(req, res, next) {
     }
 
     const transformListItemToAttendeeSearchResult = await createContactItemToAttendeeSearchResult(
-      token,
+      req,
       event
     )
 
     const contactsResponse = await search({
-      token,
+      req,
       searchEntity: 'contact',
       page: query.page,
       requestBody: {

--- a/src/apps/events/attendees/controllers/list.js
+++ b/src/apps/events/attendees/controllers/list.js
@@ -20,12 +20,11 @@ async function renderAttendees(req, res, next) {
     const name = event.name
     const query = req.query
     const page = query.page || 1
-    const token = req.session.token
     const sortby = req.query.sortby || defaultAttendeeSort
     const incompleteEvent = !event.service || !event.lead_team
 
     const attendeesResponse = await fetchEventAttendees({
-      token,
+      req,
       eventId: event.id,
       page,
       sortby,

--- a/src/apps/events/attendees/repos.js
+++ b/src/apps/events/attendees/repos.js
@@ -4,7 +4,7 @@ const config = require('../../../config')
 const { authorisedRequest } = require('../../../lib/authorised-request')
 
 async function fetchEventAttendees({
-  token,
+  req,
   eventId,
   page = 1,
   sortby,
@@ -17,7 +17,7 @@ async function fetchEventAttendees({
 
   const offset = limit * (page - 1)
 
-  const eventAttendees = await authorisedRequest(token, {
+  const eventAttendees = await authorisedRequest(req, {
     url: `${config.apiRoot}/v3/interaction`,
     qs: pickBy(
       {

--- a/src/apps/events/attendees/transformers.js
+++ b/src/apps/events/attendees/transformers.js
@@ -50,9 +50,9 @@ function transformServiceDeliveryToAttendeeListItem({
   return listItem
 }
 
-async function createContactItemToAttendeeSearchResult(token, event) {
+async function createContactItemToAttendeeSearchResult(req, event) {
   const attendees = await fetchEventAttendees({
-    token,
+    req,
     eventId: event.id,
     limit: 9999,
   })

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -30,27 +30,27 @@ const filterServiceNames = (services) => {
   return filteredServiceNames
 }
 
-async function getEditOptions(token, createdOn, currentAdviser) {
-  const advisers = await getAdvisers(token)
+async function getEditOptions(req, createdOn, currentAdviser) {
+  const advisers = await getAdvisers(req)
   const activeAdvisers = filterActiveAdvisers({
     advisers: advisers.results,
     includeAdviser: currentAdviser,
   })
 
-  const unfilteredServiceOptions = await getOptions(token, 'service', {
+  const unfilteredServiceOptions = await getOptions(req, 'service', {
     createdOn,
     context: 'event',
   })
 
   return {
     advisers: activeAdvisers.map(transformObjectToOption),
-    eventTypes: await getOptions(token, 'event-type', { createdOn }),
-    locationTypes: await getOptions(token, 'location-type', { createdOn }),
-    countries: await getOptions(token, 'country', { createdOn }),
-    teams: await getOptions(token, 'team', { createdOn }),
+    eventTypes: await getOptions(req, 'event-type', { createdOn }),
+    locationTypes: await getOptions(req, 'location-type', { createdOn }),
+    countries: await getOptions(req, 'country', { createdOn }),
+    teams: await getOptions(req, 'team', { createdOn }),
     services: filterServiceNames(unfilteredServiceOptions),
-    programmes: await getOptions(token, 'programme', { createdOn }),
-    ukRegions: await getOptions(token, 'uk-region', { createdOn }),
+    programmes: await getOptions(req, 'programme', { createdOn }),
+    ukRegions: await getOptions(req, 'uk-region', { createdOn }),
   }
 }
 
@@ -67,7 +67,7 @@ async function renderEditPage(req, res, next) {
     )
     const currentAdviser = get(eventData, 'organiser')
     const options = await getEditOptions(
-      req.session.token,
+      req,
       mergedData.created_on,
       currentAdviser
     )

--- a/src/apps/events/controllers/list.js
+++ b/src/apps/events/controllers/list.js
@@ -8,14 +8,13 @@ const { getAdvisers } = require('../../adviser/repos')
 
 async function renderEventList(req, res, next) {
   try {
-    const token = req.session.token
-    const advisers = await getAdvisers(req.session.token)
+    const advisers = await getAdvisers(req)
     const filtersFields = eventFiltersFields({
       advisers: advisers.results,
       userAgent: res.locals.userAgent,
     })
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
-      token,
+      req,
       filtersFields,
       req.query
     )

--- a/src/apps/events/middleware/__test__/details.test.js
+++ b/src/apps/events/middleware/__test__/details.test.js
@@ -83,9 +83,7 @@ describe('Event details middleware', () => {
     context('when all fields are valid', () => {
       it('should post to the API', async () => {
         await this.middleware.postDetails(this.req, this.res, this.nextSpy)
-        expect(this.saveEventStub).to.have.been.calledWith(
-          this.req.session.token
-        )
+        expect(this.saveEventStub).to.have.been.calledWith(this.req)
         expect(this.saveEventStub).to.have.been.calledOnce
         expect(this.saveEventStub.firstCall.args[1]).to.deep.equal(expectedBody)
       })
@@ -112,10 +110,7 @@ describe('Event details middleware', () => {
           teams: ['team 1', 'lead_team'],
         })
 
-        expect(this.saveEventStub).to.have.been.calledWith(
-          this.req.session.token,
-          expected
-        )
+        expect(this.saveEventStub).to.have.been.calledWith(req, expected)
         expect(this.saveEventStub).to.have.been.calledOnce
       })
 
@@ -132,10 +127,7 @@ describe('Event details middleware', () => {
           teams: ['team 1', 'lead_team'],
         })
 
-        expect(this.saveEventStub).to.have.been.calledWith(
-          this.req.session.token,
-          expected
-        )
+        expect(this.saveEventStub).to.have.been.calledWith(req, expected)
         expect(this.saveEventStub).to.have.been.calledOnce
       })
     })
@@ -180,10 +172,7 @@ describe('Event details middleware', () => {
           related_programmes: ['programme 1'],
         })
 
-        expect(this.saveEventStub).to.have.been.calledWith(
-          this.req.session.token,
-          expected
-        )
+        expect(this.saveEventStub).to.have.been.calledWith(req, expected)
         expect(this.saveEventStub).to.have.been.calledOnce
       })
 
@@ -200,10 +189,7 @@ describe('Event details middleware', () => {
           related_programmes: ['programme 1'],
         })
 
-        expect(this.saveEventStub).to.have.been.calledWith(
-          this.req.session.token,
-          expected
-        )
+        expect(this.saveEventStub).to.have.been.calledWith(req, expected)
         expect(this.saveEventStub).to.have.been.calledOnce
       })
     })

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -13,7 +13,7 @@ async function postDetails(req, res, next) {
   }
 
   try {
-    const result = await saveEvent(req.session.token, res.locals.requestBody)
+    const result = await saveEvent(req, res.locals.requestBody)
 
     if (!res.locals.event) {
       req.flash('success', 'Event created')
@@ -35,7 +35,7 @@ async function postDetails(req, res, next) {
 
 async function getEventDetails(req, res, next, eventId) {
   try {
-    res.locals.event = await fetchEvent(req.session.token, eventId)
+    res.locals.event = await fetchEvent(req, eventId)
     res.locals.eventViewRecord = transformEventResponseToViewRecord(
       res.locals.event
     )

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -2,7 +2,7 @@ const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 const { search } = require('../../modules/search/services')
 
-function saveEvent(token, event) {
+function saveEvent(req, event) {
   const options = {
     url: `${config.apiRoot}/v3/event`,
     method: 'POST',
@@ -14,26 +14,27 @@ function saveEvent(token, event) {
     options.method = 'PATCH'
   }
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
-function fetchEvent(token, id) {
-  return authorisedRequest(token, `${config.apiRoot}/v3/event/${id}`)
+function fetchEvent(req, id) {
+  return authorisedRequest(req, `${config.apiRoot}/v3/event/${id}`)
 }
 
-function getEvents(token) {
-  return authorisedRequest(token, `${config.apiRoot}/v3/event`)
+function getEvents(req) {
+  return authorisedRequest(req, `${config.apiRoot}/v3/event`)
 }
 
-function getAllEvents(token) {
+function getAllEvents(req) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/event?limit=100000&offset=0`
   )
 }
 
-async function getActiveEvents(token, createdOn) {
+async function getActiveEvents(req, createdOn) {
   const eventsResponse = await search({
+    req,
     searchEntity: 'event',
     requestBody: {
       sortby: 'name:asc',
@@ -42,7 +43,6 @@ async function getActiveEvents(token, createdOn) {
         exists: false,
       },
     },
-    token: token,
     limit: 100000,
     isAggregation: false,
   })

--- a/src/apps/interactions/__test__/repos.test.js
+++ b/src/apps/interactions/__test__/repos.test.js
@@ -1,7 +1,8 @@
 const config = require('../../../config')
 const draftPastMeeting = require('../../../../test/unit/data/interactions/draft-past-meeting.json')
-
 const { archiveInteraction } = require('../repos')
+
+const stubRequest = { session: { token: 'abcd' } }
 
 describe('Interaction repository', () => {
   describe('#archiveInteraction', () => {
@@ -13,7 +14,7 @@ describe('Interaction repository', () => {
         .reply(200, { id: draftPastMeeting.id })
 
       const interaction = await archiveInteraction(
-        'token',
+        stubRequest,
         draftPastMeeting.id,
         'reason'
       )

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -160,7 +160,6 @@ const getInitialFormValues = (req, res) => {
 
 async function renderInteractionDetailsForm(req, res, next) {
   try {
-    const { token } = req.session
     const { company, interaction, referral, investment, contact } = res.locals
 
     const [
@@ -171,14 +170,14 @@ async function renderInteractionDetailsForm(req, res, next) {
       communicationChannels,
       countries,
     ] = await Promise.all([
-      getOptions(token, 'service', {
+      getOptions(req, 'service', {
         transformer: transformServiceToOption,
       }),
-      getOptions(token, 'service-delivery-status', { sorted: false }),
-      getOptions(token, 'policy-area'),
-      getOptions(token, 'policy-issue-type'),
-      getOptions(token, 'communication-channel'),
-      getOptions(token, 'country'),
+      getOptions(req, 'service-delivery-status', { sorted: false }),
+      getOptions(req, 'policy-area'),
+      getOptions(req, 'policy-issue-type'),
+      getOptions(req, 'communication-channel'),
+      getOptions(req, 'country'),
     ])
 
     res
@@ -212,9 +211,8 @@ async function renderInteractionDetailsForm(req, res, next) {
 }
 
 async function fetchActiveEvents(req, res, next) {
-  const { token } = req.session
   try {
-    const activeEvents = await getActiveEvents(token)
+    const activeEvents = await getActiveEvents(req)
     res.json(activeEvents.map(transformObjectToOption))
   } catch (error) {
     next(error)

--- a/src/apps/interactions/controllers/__test__/complete.test.js
+++ b/src/apps/interactions/controllers/__test__/complete.test.js
@@ -148,7 +148,7 @@ describe('Interaction details controller', () => {
 
       it('should archive the interaction', () => {
         expect(archiveInteractionStub).calledOnceWithExactly(
-          '1234',
+          middlewareParameters.reqMock,
           draftPastMeeting.id,
           'reason'
         )
@@ -320,10 +320,13 @@ describe('Interaction details controller', () => {
         })
 
         it('should save the interaction', () => {
-          expect(saveInteractionStub).calledOnceWithExactly('1234', {
-            date: 'date',
-            id: '888c12ee-91db-4964-908e-0f18ce823096',
-          })
+          expect(saveInteractionStub).calledOnceWithExactly(
+            middlewareParameters.reqMock,
+            {
+              date: 'date',
+              id: '888c12ee-91db-4964-908e-0f18ce823096',
+            }
+          )
         })
 
         it('should not archive the interaction', () => {

--- a/src/apps/interactions/controllers/__test__/list.test.js
+++ b/src/apps/interactions/controllers/__test__/list.test.js
@@ -20,6 +20,7 @@ describe('interaction list', () => {
     token = ''
     req = {
       session: {
+        token,
         save: (cb) => cb(null),
         user: {
           id: '1234',
@@ -274,9 +275,7 @@ describe('interaction list', () => {
 
     context('when the request is not XHR', () => {
       it(`should return all interaction options`, async () => {
-        expect(await getInteractionOptions(token, req, res)).to.deep.equal(
-          expected
-        )
+        expect(await getInteractionOptions(req, res)).to.deep.equal(expected)
       })
     })
 
@@ -286,9 +285,7 @@ describe('interaction list', () => {
       })
 
       it(`should return all interaction options`, async () => {
-        expect(await getInteractionOptions(token, req, res)).to.deep.equal(
-          expected
-        )
+        expect(await getInteractionOptions(req, res)).to.deep.equal(expected)
       })
     })
 
@@ -303,7 +300,7 @@ describe('interaction list', () => {
         })
 
         it(`should return interaction options from session key`, async () => {
-          expect(await getInteractionOptions(token, req, res)).to.equal(
+          expect(await getInteractionOptions(req, res)).to.equal(
             req.session.interactions.options
           )
         })

--- a/src/apps/interactions/controllers/complete.js
+++ b/src/apps/interactions/controllers/complete.js
@@ -49,22 +49,17 @@ async function postComplete(req, res, next) {
     return next()
   }
 
-  const { token } = req.session
   const { interaction } = res.locals
 
   if (req.body.meeting_happen === 'false') {
     try {
       if (req.body.archived_reason === ARCHIVED_REASON.RESCHEDULED) {
-        await saveInteraction(token, {
+        await saveInteraction(req, {
           id: interaction.id,
           date: req.body.date,
         })
       } else {
-        await archiveInteraction(
-          token,
-          interaction.id,
-          req.body.archived_reason
-        )
+        await archiveInteraction(req, interaction.id, req.body.archived_reason)
       }
 
       req.flash('success', 'The interaction has been updated')

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -55,25 +55,25 @@ const filterServiceNames = (services) => {
   return filteredServiceNames
 }
 
-async function getInteractionOptions(token, req, res) {
+async function getInteractionOptions(req, res) {
   if (req.xhr && get(req.session, 'interactions.options')) {
     return req.session.interactions.options
   }
-  const sectorOptions = await getOptions(token, SECTOR, {
+  const sectorOptions = await getOptions(req, SECTOR, {
     queryString: QUERY_STRING,
   })
 
-  const unfilteredServiceOptions = await getOptions(token, 'service', {
+  const unfilteredServiceOptions = await getOptions(req, 'service', {
     includeDisabled: true,
   })
 
   const serviceOptions = filterServiceNames(unfilteredServiceOptions)
 
-  const teamOptions = await getOptions(token, 'team', { includeDisabled: true })
-  const types = await getOptions(token, 'policy-issue-type')
+  const teamOptions = await getOptions(req, 'team', { includeDisabled: true })
+  const types = await getOptions(req, 'policy-issue-type')
 
-  const areas = await getOptions(token, 'policy-area')
-  const oneListTierOptions = await getOptions(token, 'one-list-tier')
+  const areas = await getOptions(req, 'policy-area')
+  const oneListTierOptions = await getOptions(req, 'one-list-tier')
 
   const currentAdvisers =
     get(res.locals, 'interaction.dit_participants') &&
@@ -81,7 +81,7 @@ async function getInteractionOptions(token, req, res) {
       (participant) => participant.adviser && participant.adviser.id
     )
 
-  const advisers = await getAdvisers(token)
+  const advisers = await getAdvisers(req)
 
   const activeAdvisers = filterActiveAdvisers({
     advisers: advisers.results,
@@ -108,10 +108,10 @@ async function getInteractionOptions(token, req, res) {
 
 async function renderInteractionList(req, res, next) {
   try {
-    const { token, user } = req.session
+    const { user } = req.session
     const { id: currentAdviserId, permissions } = user
     const { query } = req
-    const options = await getInteractionOptions(token, req, res)
+    const options = await getInteractionOptions(req, res)
 
     const filtersFields = collectionFilterFields({
       currentAdviserId,
@@ -121,7 +121,7 @@ async function renderInteractionList(req, res, next) {
     })
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
-      token,
+      req,
       filtersFields,
       query
     )

--- a/src/apps/interactions/middleware/collection.js
+++ b/src/apps/interactions/middleware/collection.js
@@ -34,7 +34,7 @@ async function getInteractionCollectionForEntity(req, res, next) {
     const { query: entityQuery, showCompany } = res.locals.interactions
     const params = {
       entityQuery,
-      token: req.session.token,
+      req,
       page: req.query.page,
       sortby: req.query.sortby || getDefaultInteractionSort(showCompany),
     }

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -3,13 +3,11 @@ const { getDitCompany } = require('../../companies/repos')
 
 async function getInteractionDetails(req, res, next, interactionId) {
   try {
-    const { token } = req.session
-
-    const interaction = await fetchInteraction(token, interactionId)
+    const interaction = await fetchInteraction(req, interactionId)
     res.locals.interaction = interaction
 
     if (!res.locals.company) {
-      res.locals.company = await getDitCompany(token, interaction.company.id)
+      res.locals.company = await getDitCompany(req, interaction.company.id)
     }
 
     next()

--- a/src/apps/interactions/repos.js
+++ b/src/apps/interactions/repos.js
@@ -1,14 +1,14 @@
 const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
-function fetchInteraction(token, interactionId) {
+function fetchInteraction(req, interactionId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/interaction/${interactionId}`
   )
 }
 
-function saveInteraction(token, interaction, referralId) {
+function saveInteraction(req, interaction, referralId) {
   const options = {
     url:
       referralId && !interaction.id
@@ -23,13 +23,13 @@ function saveInteraction(token, interaction, referralId) {
     options.method = 'PATCH'
   }
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
-function getInteractionsForEntity({ token, entityQuery, page = 1, sortby }) {
+function getInteractionsForEntity({ req, entityQuery, page = 1, sortby }) {
   const limit = 10
   const offset = limit * (page - 1)
-  return authorisedRequest(token, {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v3/interaction`,
     qs: {
       ...entityQuery,
@@ -40,13 +40,13 @@ function getInteractionsForEntity({ token, entityQuery, page = 1, sortby }) {
   })
 }
 
-function archiveInteraction(token, interactionId, reason) {
+function archiveInteraction(req, interactionId, reason) {
   const options = {
     body: { reason },
     url: `${config.apiRoot}/v3/interaction/${interactionId}/archive`,
     method: 'POST',
   }
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
 module.exports = {

--- a/src/apps/investments/__test__/repos.test.js
+++ b/src/apps/investments/__test__/repos.test.js
@@ -13,6 +13,8 @@ const companyData = require('../../../../test/unit/data/company.json')
 const investmentData = require('../../../../test/unit/data/investment/investment-data.json')
 const investmentProjectAuditData = require('../../../../test/unit/data/investment/audit-log.json')
 
+const stubRequest = { session: { token: 'token' } }
+
 describe('Investment repository', () => {
   describe('#getCompanyInvestmentProjects', () => {
     beforeEach(async () => {
@@ -22,7 +24,7 @@ describe('Investment repository', () => {
         )
         .reply(200, companyData)
       this.investmentProjects = await getCompanyInvestmentProjects(
-        'token',
+        stubRequest,
         companyData.id
       )
     })
@@ -37,7 +39,10 @@ describe('Investment repository', () => {
       nock(config.apiRoot)
         .get(`/v3/investment/${investmentData.id}`)
         .reply(200, investmentData)
-      this.investmentProject = await getInvestment('token', investmentData.id)
+      this.investmentProject = await getInvestment(
+        stubRequest,
+        investmentData.id
+      )
     })
 
     it('should return an investment object', () => {
@@ -48,7 +53,7 @@ describe('Investment repository', () => {
   describe('#createInvestmentProject', () => {
     beforeEach(async () => {
       nock(config.apiRoot).post(`/v3/investment`).reply(200, { id: '12345' })
-      this.investmentProject = await createInvestmentProject('token', {
+      this.investmentProject = await createInvestmentProject(stubRequest, {
         foo: 'bar',
       })
     })
@@ -66,7 +71,7 @@ describe('Investment repository', () => {
         .patch(`/v3/investment/${investmentData.id}`)
         .reply(200, investmentData)
       this.investmentProject = await updateInvestment(
-        'token',
+        stubRequest,
         investmentData.id,
         appendedData
       )
@@ -83,7 +88,7 @@ describe('Investment repository', () => {
         .post(`/v3/investment/${investmentData.id}/archive`, { reason: 'test' })
         .reply(200, investmentProjectAuditData)
       this.investmentProjectAuditData = await archiveInvestmentProject(
-        'token',
+        stubRequest,
         investmentData.id,
         'test'
       )
@@ -102,7 +107,7 @@ describe('Investment repository', () => {
         .post(`/v3/investment/${investmentData.id}/unarchive`)
         .reply(200, investmentProjectAuditData)
       this.investmentProjectAuditData = await unarchiveInvestmentProject(
-        'token',
+        stubRequest,
         investmentData.id
       )
     })

--- a/src/apps/investments/apps/evidence/controllers/create.js
+++ b/src/apps/investments/apps/evidence/controllers/create.js
@@ -7,7 +7,7 @@ const { evidenceForm } = require('../macros/index')
 
 async function renderAddEvidence(req, res) {
   const investment = get(res.locals, 'investment.id')
-  const tags = await getOptions(req.session.token, 'evidence-tag')
+  const tags = await getOptions(req, 'evidence-tag')
 
   const addEvidenceForm = buildFormWithStateAndErrors(
     evidenceForm(

--- a/src/apps/investments/apps/evidence/repos.js
+++ b/src/apps/investments/apps/evidence/repos.js
@@ -1,27 +1,27 @@
 const config = require('../../../../config')
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 
-function getEvidenceForInvestment(token, investmentId) {
+function getEvidenceForInvestment(req, investmentId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment/${investmentId}/evidence-document`
   )
 }
 
-function fetchDownloadLink(token, investmentId, evidenceId) {
+function fetchDownloadLink(req, investmentId, evidenceId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment/${investmentId}/evidence-document/${evidenceId}/download`
   )
 }
 
-function requestDeleteEvidence(token, investmentId, evidenceId) {
+function requestDeleteEvidence(req, investmentId, evidenceId) {
   const options = {
     url: `${config.apiRoot}/v3/investment/${investmentId}/evidence-document/${evidenceId}`,
     method: 'DELETE',
   }
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
 module.exports = {

--- a/src/apps/investments/controllers/__test__/archive.test.js
+++ b/src/apps/investments/controllers/__test__/archive.test.js
@@ -27,23 +27,24 @@ describe('Investment archive controller', () => {
   describe('archive', () => {
     it('should call the archive investment project repo method for the id and reason', (done) => {
       const archived_reason = 'test'
+      const stubRequest = {
+        session: this.session,
+        body: {
+          archived_reason,
+        },
+        params: {
+          investmentId: investmentData.id,
+        },
+      }
 
       this.controller.archiveInvestmentProjectHandler(
-        {
-          session: this.session,
-          body: {
-            archived_reason,
-          },
-          params: {
-            investmentId: investmentData.id,
-          },
-        },
+        stubRequest,
         {
           locals: {},
         },
         () => {
           expect(this.archiveInvestmentProject).to.be.calledWith(
-            this.token,
+            stubRequest,
             investmentData.id,
             archived_reason
           )
@@ -54,24 +55,25 @@ describe('Investment archive controller', () => {
     it('should use the other reason in the call to the repo if it is provided', (done) => {
       const archived_reason = 'Other'
       const archived_reason_other = 'Some other reason'
+      const stubRequest = {
+        session: this.session,
+        body: {
+          archived_reason,
+          archived_reason_other,
+        },
+        params: {
+          investmentId: investmentData.id,
+        },
+      }
 
       this.controller.archiveInvestmentProjectHandler(
-        {
-          session: this.session,
-          body: {
-            archived_reason,
-            archived_reason_other,
-          },
-          params: {
-            investmentId: investmentData.id,
-          },
-        },
+        stubRequest,
         {
           locals: {},
         },
         () => {
           expect(this.archiveInvestmentProject).to.be.calledWith(
-            this.token,
+            stubRequest,
             investmentData.id,
             archived_reason_other
           )
@@ -211,20 +213,21 @@ describe('Investment archive controller', () => {
 
   describe('unarchive', () => {
     it('should call unarchive on repository', (done) => {
-      this.controller.unarchiveInvestmentProjectHandler(
-        {
-          session: {
-            token: this.token,
-          },
-          params: {
-            investmentId: investmentData.id,
-          },
-          flash: this.flashStub,
+      const stubRequest = {
+        session: {
+          token: this.token,
         },
+        params: {
+          investmentId: investmentData.id,
+        },
+        flash: this.flashStub,
+      }
+      this.controller.unarchiveInvestmentProjectHandler(
+        stubRequest,
         {
           redirect: () => {
             expect(this.unarchiveInvestmentProject).to.be.calledWith(
-              this.token,
+              stubRequest,
               investmentData.id
             )
             done()

--- a/src/apps/investments/controllers/__test__/associated.test.js
+++ b/src/apps/investments/controllers/__test__/associated.test.js
@@ -88,7 +88,7 @@ describe('investment associated controller', () => {
         })
 
         it('should save the change to the investment project', () => {
-          expect(this.updateInvestmentStub).to.be.calledWith('abcd', '1', {
+          expect(this.updateInvestmentStub).to.be.calledWith(this.req, '1', {
             associated_non_fdi_r_and_d_project: '1234',
           })
         })
@@ -266,7 +266,7 @@ describe('investment associated controller', () => {
       })
 
       it('should update the investment record', () => {
-        expect(this.updateInvestmentStub).to.be.calledWith('abcd', '1', {
+        expect(this.updateInvestmentStub).to.be.calledWith(this.req, '1', {
           associated_non_fdi_r_and_d_project: null,
         })
       })

--- a/src/apps/investments/controllers/__test__/status.test.js
+++ b/src/apps/investments/controllers/__test__/status.test.js
@@ -141,7 +141,7 @@ describe('investment status controller', () => {
 
       it('should save the data to the API', () => {
         expect(this.updateInvestmentStub).to.be.calledWith(
-          this.req.session.token,
+          this.req,
           this.req.params.investmentId,
           { status: 'test' }
         )

--- a/src/apps/investments/controllers/__test__/ukcompany.test.js
+++ b/src/apps/investments/controllers/__test__/ukcompany.test.js
@@ -55,7 +55,7 @@ describe('investment uk company', () => {
         })
 
         it('should save the change to the investment project', () => {
-          expect(this.updateInvestmentStub).to.be.calledWith('abcd', '1', {
+          expect(this.updateInvestmentStub).to.be.calledWith(this.req, '1', {
             uk_company: '1234',
           })
         })
@@ -208,7 +208,7 @@ describe('investment uk company', () => {
       })
 
       it('should update the investment record', () => {
-        expect(this.updateInvestmentStub).to.be.calledWith('abcd', '1', {
+        expect(this.updateInvestmentStub).to.be.calledWith(this.req, '1', {
           uk_company: null,
         })
       })

--- a/src/apps/investments/controllers/admin.js
+++ b/src/apps/investments/controllers/admin.js
@@ -1,7 +1,6 @@
 const { getOptions } = require('../../../lib/options')
 
 async function renderAdminView(req, res) {
-  const { token } = req.session
   const { id, name, stage } = res.locals.investment
   // orderStages puts the stages array in chronological order, rather than alphabetical
   const orderStages = (stages) => {
@@ -10,9 +9,7 @@ async function renderAdminView(req, res) {
     stages[2] = activeStage
     return stages
   }
-  const stages = orderStages(
-    await getOptions(token, 'investment-project-stage')
-  )
+  const stages = orderStages(await getOptions(req, 'investment-project-stage'))
 
   res.locals.title = `Admin - ${name} - Projects - Investments - DIT Data Hub`
   res.render('investments/views/admin/client-container.njk', {

--- a/src/apps/investments/controllers/archive.js
+++ b/src/apps/investments/controllers/archive.js
@@ -10,7 +10,7 @@ async function archiveInvestmentProjectHandler(req, res, next) {
         ? req.body.archived_reason_other
         : req.body.archived_reason
     await investmentRepository.archiveInvestmentProject(
-      req.session.token,
+      req,
       req.params.investmentId,
       reason
     )
@@ -37,7 +37,7 @@ async function archiveInvestmentProjectHandler(req, res, next) {
 async function unarchiveInvestmentProjectHandler(req, res, next) {
   try {
     await investmentRepository.unarchiveInvestmentProject(
-      req.session.token,
+      req,
       req.params.investmentId
     )
     req.flash('success', 'Investment project updated')

--- a/src/apps/investments/controllers/associated.js
+++ b/src/apps/investments/controllers/associated.js
@@ -21,7 +21,7 @@ async function selectAssociatedInvestmentProject(req, res, next) {
     const { projects } = res.locals.paths
     const investmentId = req.params.investmentId
 
-    await updateInvestment(req.session.token, investmentId, {
+    await updateInvestment(req, investmentId, {
       associated_non_fdi_r_and_d_project: req.query.project,
     })
 
@@ -35,7 +35,6 @@ async function selectAssociatedInvestmentProject(req, res, next) {
 async function searchForAssociatedInvestmentProject(req, res, next) {
   const searchTerm = req.query.term
   const page = req.query.page || '1'
-  const token = req.session.token
 
   if (!searchTerm) {
     return next()
@@ -51,7 +50,7 @@ async function searchForAssociatedInvestmentProject(req, res, next) {
     res.locals.searchTerm = searchTerm
 
     res.locals.results = await searchInvestments({
-      token,
+      req,
       searchTerm,
       page,
       filters: {
@@ -81,7 +80,7 @@ function renderAssociatedInvestmentProjectResults(req, res) {
 
 async function removeAssociatedInvestmentProject(req, res, next) {
   try {
-    await updateInvestment(req.session.token, req.params.investmentId, {
+    await updateInvestment(req, req.params.investmentId, {
       associated_non_fdi_r_and_d_project: null,
     })
 

--- a/src/apps/investments/controllers/create/__test__/equity-source.test.js
+++ b/src/apps/investments/controllers/create/__test__/equity-source.test.js
@@ -2,7 +2,7 @@ const proxyquire = require('proxyquire')
 
 const paths = require('../../../paths')
 
-const token = 'abcd'
+const stubRequest = { session: { token: 'abcd' }, query: {} }
 const ukCompany = {
   id: '12345',
   name: 'Test company',
@@ -55,21 +55,12 @@ describe('Investment start controller', () => {
           breadcrumb: this.breadcrumbStub,
         }
 
-        this.controller.getHandler(
-          {
-            session: {
-              token,
-            },
-            query: {},
-          },
-          this.resMock,
-          () => {
-            expect(this.resMock.locals.company).to.be.undefined
-            expect(this.resMock.locals.company).to.be.undefined
-            expect(this.resMock.locals.showSearch).to.equal(false)
-            done()
-          }
-        )
+        this.controller.getHandler(stubRequest, this.resMock, () => {
+          expect(this.resMock.locals.company).to.be.undefined
+          expect(this.resMock.locals.company).to.be.undefined
+          expect(this.resMock.locals.showSearch).to.equal(false)
+          done()
+        })
       })
     })
 
@@ -83,27 +74,18 @@ describe('Investment start controller', () => {
           breadcrumb: this.breadcrumbStub,
         }
 
-        this.controller.getHandler(
-          {
-            session: {
-              token,
-            },
-            query: {},
-          },
-          this.resMock,
-          () => {
-            expect(this.getCompanyInvestmentProjects).to.be.calledWith(
-              token,
-              '12345'
-            )
-            expect(this.resMock.locals.company).to.deep.equal(ukCompany)
-            expect(this.resMock.locals.companyInvestments).to.deep.equal(
-              investmentProjects
-            )
-            expect(this.resMock.locals.showSearch).to.equal(true)
-            done()
-          }
-        )
+        this.controller.getHandler(stubRequest, this.resMock, () => {
+          expect(this.getCompanyInvestmentProjects).to.be.calledWith(
+            stubRequest,
+            '12345'
+          )
+          expect(this.resMock.locals.company).to.deep.equal(ukCompany)
+          expect(this.resMock.locals.companyInvestments).to.deep.equal(
+            investmentProjects
+          )
+          expect(this.resMock.locals.showSearch).to.equal(true)
+          done()
+        })
       })
     })
 
@@ -117,27 +99,18 @@ describe('Investment start controller', () => {
           breadcrumb: this.breadcrumbStub,
         }
 
-        this.controller.getHandler(
-          {
-            session: {
-              token,
-            },
-            query: {},
-          },
-          this.resMock,
-          () => {
-            expect(this.getCompanyInvestmentProjects).to.be.calledWith(
-              token,
-              '12345'
-            )
-            expect(this.resMock.locals.company).to.deep.equal(foreignCompany)
-            expect(this.resMock.locals.companyInvestments).to.deep.equal(
-              investmentProjects
-            )
-            expect(this.resMock.locals.showSearch).to.equal(false)
-            done()
-          }
-        )
+        this.controller.getHandler(stubRequest, this.resMock, () => {
+          expect(this.getCompanyInvestmentProjects).to.be.calledWith(
+            stubRequest,
+            '12345'
+          )
+          expect(this.resMock.locals.company).to.deep.equal(foreignCompany)
+          expect(this.resMock.locals.companyInvestments).to.deep.equal(
+            investmentProjects
+          )
+          expect(this.resMock.locals.showSearch).to.equal(false)
+          done()
+        })
       })
 
       it('should render search', (done) => {
@@ -151,9 +124,7 @@ describe('Investment start controller', () => {
 
         this.controller.getHandler(
           {
-            session: {
-              token,
-            },
+            ...stubRequest,
             query: {
               search: true,
             },
@@ -170,9 +141,7 @@ describe('Investment start controller', () => {
     describe('when query contains a search term', () => {
       it('should render results', async () => {
         this.reqMock = {
-          session: {
-            token,
-          },
+          ...stubRequest,
           query: {
             term: 'samsung',
           },
@@ -265,9 +234,7 @@ describe('Investment start controller', () => {
 
         this.controller.postHandler(
           {
-            session: {
-              token,
-            },
+            ...stubRequest,
             body: {
               company_id: '12345',
             },

--- a/src/apps/investments/controllers/create/equity-source.js
+++ b/src/apps/investments/controllers/create/equity-source.js
@@ -41,13 +41,13 @@ async function getHandler(req, res, next) {
 
   try {
     const companyInvestments = await getCompanyInvestmentProjects(
-      req.session.token,
+      req,
       companyId
     )
 
     if (searchTerm) {
       searchResult = await searchForeignCompanies({
-        token: req.session.token,
+        req,
         page: req.query.page,
         searchTerm,
       }).then(

--- a/src/apps/investments/controllers/edit-history.js
+++ b/src/apps/investments/controllers/edit-history.js
@@ -15,11 +15,10 @@ const renderProjectsView = (req, res) => {
 
 const fetchProjectsHistoryHandler = async (req, res, next) => {
   try {
-    const { token } = req.session
     const { page } = req.query
 
     const { results, count } = await getInvestmentProjectAuditLog(
-      token,
+      req,
       req.params.investmentId,
       page
     )

--- a/src/apps/investments/controllers/evidence.js
+++ b/src/apps/investments/controllers/evidence.js
@@ -2,9 +2,8 @@ const { getEvidenceForInvestment } = require('../apps/evidence/repos')
 
 async function renderEvidenceView(req, res, next) {
   try {
-    const token = req.session.token
     const investmentId = req.params.investmentId
-    const evidence = await getEvidenceForInvestment(token, investmentId)
+    const evidence = await getEvidenceForInvestment(req, investmentId)
 
     return res
       .breadcrumb('Evidence')

--- a/src/apps/investments/controllers/projects.js
+++ b/src/apps/investments/controllers/projects.js
@@ -20,7 +20,7 @@ const SECTOR = FILTER_CONSTANTS.INVESTMENT_PROJECTS.SECTOR.NAME
 
 const renderProjectsView = async (req, res, next) => {
   try {
-    const { token, user } = req.session
+    const { user } = req.session
     const currentAdviserId = user.id
     const queryString = QUERY_STRING
     const sortForm = merge({}, investmentSortForm, {
@@ -28,8 +28,8 @@ const renderProjectsView = async (req, res, next) => {
       children: [{ value: req.query.sortby }],
     })
 
-    const sectorOptions = await getOptions(token, SECTOR, { queryString })
-    const advisers = await getAdvisers(token)
+    const sectorOptions = await getOptions(req, SECTOR, { queryString })
+    const advisers = await getAdvisers(req)
     const currentAdvisers =
       get(res.locals, 'interaction.dit_participants') &&
       res.locals.interaction.dit_participants.map(
@@ -49,7 +49,7 @@ const renderProjectsView = async (req, res, next) => {
     })
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
-      token,
+      req,
       filtersFields,
       req.query
     )

--- a/src/apps/investments/controllers/propositions.js
+++ b/src/apps/investments/controllers/propositions.js
@@ -9,12 +9,11 @@ const {
 
 async function renderPropositionList(req, res, next) {
   try {
-    const token = req.session.token
     const page = req.query.page || '1'
     const investmentId = req.params.investmentId
 
     const propositions = await getPropositionsForInvestment(
-      token,
+      req,
       investmentId,
       page
     ).then(

--- a/src/apps/investments/controllers/status.js
+++ b/src/apps/investments/controllers/status.js
@@ -26,7 +26,7 @@ function renderStatusPage(req, res) {
 
 async function postStatus(req, res, next) {
   try {
-    await updateInvestment(req.session.token, req.params.investmentId, {
+    await updateInvestment(req, req.params.investmentId, {
       status: req.body.status,
     })
 

--- a/src/apps/investments/controllers/ukcompany.js
+++ b/src/apps/investments/controllers/ukcompany.js
@@ -12,7 +12,7 @@ async function selectUKCompany(req, res, next) {
   }
 
   try {
-    await updateInvestment(req.session.token, req.params.investmentId, {
+    await updateInvestment(req, req.params.investmentId, {
       uk_company: req.query.company,
     })
 
@@ -28,7 +28,6 @@ async function selectUKCompany(req, res, next) {
 
 async function searchForUKCompany(req, res, next) {
   const searchTerm = req.query.term
-  const token = req.session.token
 
   if (!searchTerm) {
     return next()
@@ -38,7 +37,7 @@ async function searchForUKCompany(req, res, next) {
     res.locals.searchTerm = searchTerm
 
     res.locals.results = await searchCompanies({
-      token,
+      req,
       searchTerm,
       page: req.query.page,
       isUkBased: true,
@@ -66,7 +65,7 @@ function renderCompanyResults(req, res) {
 
 async function removeUKCompany(req, res, next) {
   try {
-    await updateInvestment(req.session.token, req.params.investmentId, {
+    await updateInvestment(req, req.params.investmentId, {
       uk_company: null,
     })
 

--- a/src/apps/investments/middleware/evidence.js
+++ b/src/apps/investments/middleware/evidence.js
@@ -15,10 +15,9 @@ function setEvidenceReturnUrl(req, res, next) {
 
 async function getDownloadLink(req, res, next) {
   try {
-    const token = req.session.token
     const evidenceId = req.params.evidenceId
     const investmentId = req.params.investmentId
-    const s3 = await fetchDownloadLink(token, investmentId, evidenceId)
+    const s3 = await fetchDownloadLink(req, investmentId, evidenceId)
 
     return res.redirect(s3.document_url)
   } catch (error) {
@@ -28,11 +27,10 @@ async function getDownloadLink(req, res, next) {
 
 async function deleteEvidence(req, res, next) {
   try {
-    const token = req.session.token
     const evidenceId = req.params.evidenceId
     const investmentId = req.params.investmentId
 
-    await requestDeleteEvidence(token, investmentId, evidenceId).then(() => {
+    await requestDeleteEvidence(req, investmentId, evidenceId).then(() => {
       req.flash('success', 'Evidence item deleted')
       res.redirect(res.locals.returnLink)
     })

--- a/src/apps/investments/middleware/forms/__test__/project-management.test.js
+++ b/src/apps/investments/middleware/forms/__test__/project-management.test.js
@@ -7,6 +7,12 @@ const investmentData = require('../../../../../../test/unit/data/investment/inve
 const advisorData = require('../../../../../../test/unit/data/investment/interaction/advisers.json')
 const { projectManagementLabels } = require('../../../labels')
 
+const stubRequest = {
+  session: {
+    token: 'mock-token',
+  },
+}
+
 describe('Investment form middleware - project magement', () => {
   describe('#populateForm', () => {
     beforeEach(() => {
@@ -42,49 +48,25 @@ describe('Investment form middleware - project magement', () => {
         project_assurance_adviser: investmentData.project_assurance_adviser.id,
       }
 
-      this.controller.populateForm(
-        {
-          session: {
-            token: 'mock-token',
-          },
-        },
-        this.resMock,
-        () => {
-          expect(this.resMock.locals.form.state).to.deep.equal(
-            expectedFormState
-          )
-          done()
-        }
-      )
+      this.controller.populateForm(stubRequest, this.resMock, () => {
+        expect(this.resMock.locals.form.state).to.deep.equal(expectedFormState)
+        done()
+      })
     })
 
     it('should include labels for the form', (done) => {
-      this.controller.populateForm(
-        {
-          session: {
-            token: 'mock-token',
-          },
-        },
-        this.resMock,
-        () => {
-          expect(this.resMock.locals.form.labels).to.deep.equal(
-            projectManagementLabels.edit
-          )
-          done()
-        }
-      )
+      this.controller.populateForm(stubRequest, this.resMock, () => {
+        expect(this.resMock.locals.form.labels).to.deep.equal(
+          projectManagementLabels.edit
+        )
+        done()
+      })
     })
 
     context(
       'when the investment data contains project management information',
       () => {
         beforeEach(async () => {
-          this.reqMock = {
-            session: {
-              token: 'mock-token',
-            },
-          }
-
           this.resMock = {
             locals: {
               paths,
@@ -97,7 +79,7 @@ describe('Investment form middleware - project magement', () => {
           }
 
           await this.controller.populateForm(
-            this.reqMock,
+            stubRequest,
             this.resMock,
             this.nextSpy
           )
@@ -156,26 +138,21 @@ describe('Investment form middleware - project magement', () => {
       })
 
       it('updates the investment data', (done) => {
-        this.controller.handleFormPost(
-          {
-            session: {
-              token: 'mock-token',
-            },
-            params: {
-              investmentId: investmentData.id,
-            },
-            body: this.body,
+        const req = {
+          ...stubRequest,
+          params: {
+            investmentId: investmentData.id,
           },
-          this.resMock,
-          () => {
-            expect(this.updateInvestmentStub).to.be.calledWith(
-              'mock-token',
-              investmentData.id,
-              this.body
-            )
-            done()
-          }
-        )
+          body: this.body,
+        }
+        this.controller.handleFormPost(req, this.resMock, () => {
+          expect(this.updateInvestmentStub).to.be.calledWith(
+            req,
+            investmentData.id,
+            this.body
+          )
+          done()
+        })
       })
 
       it('continues onto the next middleware with no errors', (done) => {

--- a/src/apps/investments/middleware/forms/client-relationship-management.js
+++ b/src/apps/investments/middleware/forms/client-relationship-management.js
@@ -24,7 +24,7 @@ async function populateForm(req, res, next) {
       investment,
       'investor_company.one_list_group_global_account_manager.last_name'
     )
-    const advisersResponse = await getAdvisers(req.session.token)
+    const advisersResponse = await getAdvisers(req)
     const clientRelationshipManagerOptions = filterActiveAdvisers({
       advisers: advisersResponse.results,
       includeAdviser: clientRelationshipManager,
@@ -58,7 +58,7 @@ async function populateForm(req, res, next) {
 async function handleFormPost(req, res, next) {
   try {
     res.locals.projectId = req.params.investmentId
-    await updateInvestment(req.session.token, res.locals.projectId, {
+    await updateInvestment(req, res.locals.projectId, {
       client_relationship_manager: req.body.client_relationship_manager,
     })
     next()

--- a/src/apps/investments/middleware/forms/details.js
+++ b/src/apps/investments/middleware/forms/details.js
@@ -32,22 +32,21 @@ async function populateForm(req, res, next) {
   try {
     const investment = transformFromApi(res.locals.investment)
     const createdOn = get(investment, 'created_on')
-    const token = req.session.token
 
     const {
       equityCompany,
       equityCompanyInvestment,
-    } = await getEquityCompanyDetails(token, equityCompanyId)
+    } = await getEquityCompanyDetails(req, equityCompanyId)
 
     const contacts = get(equityCompany, 'contacts', []).map(
       transformContactToOption
     )
 
-    const investmentTypes = await getOptions(token, 'investment-type', {
+    const investmentTypes = await getOptions(req, 'investment-type', {
       createdOn,
     })
     const referralSourceActivities = await getOptions(
-      token,
+      req,
       'referral-source-activity',
       { createdOn }
     )
@@ -61,7 +60,7 @@ async function populateForm(req, res, next) {
       investment
     )
 
-    const advisersResponse = await getAdvisers(token)
+    const advisersResponse = await getAdvisers(req)
 
     const clientRelationshipManagers = filterActiveAdvisers({
       advisers: advisersResponse.results,
@@ -86,39 +85,37 @@ async function populateForm(req, res, next) {
         investmentTypes,
         referralSourceActivities,
         investmentTypesObj: buildMetaDataObj(investmentTypes),
-        fdi: await getOptions(token, 'fdi-type', { createdOn }),
+        fdi: await getOptions(req, 'fdi-type', { createdOn }),
         referralSourceActivitiesObj: buildMetaDataObj(referralSourceActivities),
         referralSourceMarketing: await getOptions(
-          token,
+          req,
           'referral-source-marketing',
           { createdOn }
         ),
         referralSourceWebsite: await getOptions(
-          token,
+          req,
           'referral-source-website',
           { createdOn }
         ),
-        primarySectors: await getOptions(token, 'sector', { createdOn }),
+        primarySectors: await getOptions(req, 'sector', { createdOn }),
         businessActivities: await getOptions(
-          token,
+          req,
           'investment-business-activity',
           { createdOn }
         ),
         investmentSpecificProgramme: await getOptions(
-          token,
+          req,
           'investment-specific-programme',
           { createdOn }
         ),
         investmentInvestorType: await getOptions(
-          token,
+          req,
           'investment-investor-type',
           { createdOn }
         ),
-        investmentInvolvement: await getOptions(
-          token,
-          'investment-involvement',
-          { createdOn }
-        ),
+        investmentInvolvement: await getOptions(req, 'investment-involvement', {
+          createdOn,
+        }),
       },
     })
 
@@ -167,9 +164,9 @@ function handleFormPost(req, res, next) {
   }
 
   if (projectId) {
-    saveMethod = updateInvestment(req.session.token, projectId, formattedBody)
+    saveMethod = updateInvestment(req, projectId, formattedBody)
   } else {
-    saveMethod = createInvestmentProject(req.session.token, formattedBody)
+    saveMethod = createInvestmentProject(req, formattedBody)
   }
 
   saveMethod

--- a/src/apps/investments/middleware/forms/project-management.js
+++ b/src/apps/investments/middleware/forms/project-management.js
@@ -15,7 +15,7 @@ async function populateForm(req, res, next) {
       'project_assurance_adviser.id'
     )
 
-    const advisersResponse = await getAdvisers(req.session.token)
+    const advisersResponse = await getAdvisers(req)
 
     const projectManagers = filterActiveAdvisers({
       advisers: advisersResponse.results,
@@ -52,7 +52,7 @@ async function populateForm(req, res, next) {
 
 function handleFormPost(req, res, next) {
   res.locals.projectId = req.params.investmentId
-  updateInvestment(req.session.token, res.locals.projectId, req.body)
+  updateInvestment(req, res.locals.projectId, req.body)
     .then(() => next())
     .catch((err) => {
       if (err.statusCode === 400) {

--- a/src/apps/investments/middleware/forms/project-stage.js
+++ b/src/apps/investments/middleware/forms/project-stage.js
@@ -2,7 +2,7 @@ const logger = require('../../../../config/logger')
 const { updateInvestment } = require('../../repos')
 
 function handleFormPost(req, res, next, projectId = req.params.investmentId) {
-  updateInvestment(req.session.token, projectId, {
+  updateInvestment(req, projectId, {
     stage: {
       id: req.body.next_project_stage,
     },

--- a/src/apps/investments/middleware/forms/requirements.js
+++ b/src/apps/investments/middleware/forms/requirements.js
@@ -6,14 +6,14 @@ const { requirementsFormConfig } = require('../../macros')
 const { getOptions } = require('../../../../lib/options')
 const { buildFormWithStateAndErrors } = require('../../../builders')
 
-async function getFormOptions(token, createdOn) {
+async function getFormOptions(req, createdOn) {
   return {
-    strategicDrivers: await getOptions(token, 'investment-strategic-driver', {
+    strategicDrivers: await getOptions(req, 'investment-strategic-driver', {
       createdOn,
     }),
-    countries: await getOptions(token, 'country', { createdOn }),
-    ukRegions: await getOptions(token, 'uk-region', { createdOn }),
-    partners: await getOptions(token, 'investment-delivery-partner', {
+    countries: await getOptions(req, 'country', { createdOn }),
+    ukRegions: await getOptions(req, 'uk-region', { createdOn }),
+    partners: await getOptions(req, 'investment-delivery-partner', {
       createdOn,
     }),
   }
@@ -39,10 +39,7 @@ async function populateForm(req, res, next) {
   try {
     const { investment } = res.locals
     const { projects } = res.locals.paths
-    const options = await getFormOptions(
-      req.session.token,
-      investment.created_on
-    )
+    const options = await getFormOptions(req, investment.created_on)
     const body = res.locals.formattedBody || investment
 
     res.locals.requirementsForm = assign(
@@ -72,11 +69,7 @@ async function handleFormPost(req, res, next) {
       return next()
     }
 
-    await updateInvestment(
-      req.session.token,
-      investmentId,
-      res.locals.formattedBody
-    )
+    await updateInvestment(req, investmentId, res.locals.formattedBody)
     req.flash('success', 'Investment requirements updated')
     res.redirect(`${projects}/${investmentId}/details`)
   } catch (err) {

--- a/src/apps/investments/middleware/forms/team-members.js
+++ b/src/apps/investments/middleware/forms/team-members.js
@@ -74,12 +74,11 @@ function transformErrorResponseToFormErrors(error) {
 
 async function populateTeamEditForm(req, res, next) {
   try {
-    const { token } = req.session
     const { investmentId } = req.params
     const { projects } = res.locals.paths
     const path = `${projects}/${investmentId}`
 
-    const { results: advisers } = await getAdvisers(token)
+    const { results: advisers } = await getAdvisers(req)
 
     const teamMembers = transformInvestmentTeamMemberstoTeamMemberArray(
       res.locals.investment
@@ -97,7 +96,6 @@ async function populateTeamEditForm(req, res, next) {
 }
 
 async function postTeamEdit(req, res, next) {
-  const { token } = req.session
   const { investmentId } = req.params
   const { projects } = res.locals.paths
   const path = `${projects}/${investmentId}`
@@ -105,7 +103,7 @@ async function postTeamEdit(req, res, next) {
   const teamMembersArray = transformFormToTeamMemberArray(req.body)
 
   try {
-    await updateInvestmentTeamMembers(token, investmentId, teamMembersArray)
+    await updateInvestmentTeamMembers(req, investmentId, teamMembersArray)
     req.flash('success', 'Investment details updated')
     return res.redirect(`${path}/team`)
   } catch (exception) {
@@ -120,7 +118,7 @@ async function postTeamEdit(req, res, next) {
     }
   }
 
-  const { results: advisers } = await getAdvisers(token)
+  const { results: advisers } = await getAdvisers(req)
   const fields = transformTeamMemberArrayToFields(teamMembersArray, advisers)
   res.locals.form = assign({}, res.locals.form, makeForm(path, fields))
 

--- a/src/apps/investments/middleware/forms/value.js
+++ b/src/apps/investments/middleware/forms/value.js
@@ -8,7 +8,6 @@ const { assign, get, merge } = require('lodash')
 const { valueLabels } = require('../../labels')
 
 async function populateForm(req, res, next) {
-  const token = req.session.token
   const investment = get(res, 'locals.investment', {})
   const createdOn = investment.created_on
 
@@ -20,14 +19,14 @@ async function populateForm(req, res, next) {
       gross_value_added_message: grossValueAddedMessage(investment),
     }),
     options: {
-      averageSalaryRange: await getOptions(token, 'salary-range', {
+      averageSalaryRange: await getOptions(req, 'salary-range', {
         createdOn,
       }),
-      fdiValue: await getOptions(token, 'fdi-value', {
+      fdiValue: await getOptions(req, 'fdi-value', {
         createdOn,
         sorted: false,
       }),
-      likelihoodToLand: await getOptions(token, 'likelihood-to-land', {
+      likelihoodToLand: await getOptions(req, 'likelihood-to-land', {
         createdOn,
         sorted: false,
       }),
@@ -46,7 +45,7 @@ async function handleFormPost(req, res, next) {
   const formattedBody = transformInvestmentValueFormBodyToApiRequest(req.body)
 
   try {
-    await updateInvestment(req.session.token, investmentId, formattedBody)
+    await updateInvestment(req, investmentId, formattedBody)
     req.flash('success', 'Investment value updated')
     res.redirect(`${projects}/${investmentId}/details`)
   } catch (err) {

--- a/src/apps/investments/middleware/propositions.js
+++ b/src/apps/investments/middleware/propositions.js
@@ -15,10 +15,7 @@ function setPropositionsEntityName(req, res, next) {
 
 async function setCompanyDetailsWithPropositions(req, res, next) {
   try {
-    const investment = await getInvestment(
-      req.session.token,
-      req.params.investmentId
-    )
+    const investment = await getInvestment(req, req.params.investmentId)
     res.locals.company = investment.investor_company
     next()
   } catch (error) {

--- a/src/apps/investments/middleware/shared.js
+++ b/src/apps/investments/middleware/shared.js
@@ -21,7 +21,7 @@ function getNextStage(currentStage, projectStages) {
 }
 
 function getCompanyDetails(req, res, next) {
-  getDitCompany(req.session.token, req.params.companyId)
+  getDitCompany(req, req.params.companyId)
     .then((company) => {
       res.locals.company = company
       return next()
@@ -45,9 +45,9 @@ async function getInvestmentDetails(req, res, next) {
     return next()
   }
   try {
-    const investment = await getInvestment(req.session.token, investmentId)
+    const investment = await getInvestment(req, investmentId)
     const investorCompany = await getDitCompany(
-      req.session.token,
+      req,
       get(investment, 'investor_company.id')
     )
     const ukCompanyId = get(investment, 'uk_company.id')
@@ -67,7 +67,7 @@ async function getInvestmentDetails(req, res, next) {
     )
 
     if (ukCompanyId) {
-      const companyDetails = await getDitCompany(req.session.token, ukCompanyId)
+      const companyDetails = await getDitCompany(req, ukCompanyId)
       investment.uk_company = Object.assign(
         {},
         investment.uk_company,
@@ -77,7 +77,7 @@ async function getInvestmentDetails(req, res, next) {
 
     if (clientRelationshipManagerId) {
       const clientRelationshipManager = await getAdviser(
-        req.session.token,
+        req,
         clientRelationshipManagerId
       )
       investment.client_relationship_manager = clientRelationshipManager

--- a/src/apps/investments/middleware/team.js
+++ b/src/apps/investments/middleware/team.js
@@ -20,10 +20,7 @@ async function expandTeamMembers(req, res, next) {
     const teamMembers = []
 
     for (const teamMember of res.locals.investment.team_members) {
-      const teamMemberAdvisor = await getAdviser(
-        req.session.token,
-        teamMember.adviser.id
-      )
+      const teamMemberAdvisor = await getAdviser(req, teamMember.adviser.id)
       teamMembers.push({
         adviser: teamMemberAdvisor,
         role: teamMember.role,

--- a/src/apps/investments/repos.js
+++ b/src/apps/investments/repos.js
@@ -2,34 +2,34 @@ const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 const { getDitCompany } = require('../companies/repos')
 
-function getCompanyInvestmentProjects(token, companyId, page = 1) {
+function getCompanyInvestmentProjects(req, companyId, page = 1) {
   const limit = 10
   const offset = limit * (page - 1)
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment?investor_company_id=${companyId}&limit=${limit}&offset=${offset}`
   )
 }
 
-function getInvestment(token, investmentId) {
+function getInvestment(req, investmentId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment/${investmentId}`
   )
 }
 
-function updateInvestment(token, investmentId, body) {
-  return authorisedRequest(token, {
+function updateInvestment(req, investmentId, body) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v3/investment/${investmentId}`,
     method: 'PATCH',
     body,
   })
 }
 
-function getEquityCompanyDetails(token, equityCompanyId) {
+function getEquityCompanyDetails(req, equityCompanyId) {
   const promises = [
-    getDitCompany(token, equityCompanyId),
-    getCompanyInvestmentProjects(token, equityCompanyId),
+    getDitCompany(req, equityCompanyId),
+    getCompanyInvestmentProjects(req, equityCompanyId),
   ]
 
   return Promise.all(promises).then(
@@ -42,25 +42,25 @@ function getEquityCompanyDetails(token, equityCompanyId) {
   )
 }
 
-function createInvestmentProject(token, body) {
-  return authorisedRequest(token, {
+function createInvestmentProject(req, body) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v3/investment`,
     method: 'POST',
     body,
   })
 }
 
-function getInvestmentProjectAuditLog(token, investmentId, page = 1) {
+function getInvestmentProjectAuditLog(req, investmentId, page = 1) {
   const limit = 10
   const offset = limit * (page - 1)
-  return authorisedRequest(token, {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v3/investment/${investmentId}/audit`,
     qs: { limit, offset },
   })
 }
 
-function archiveInvestmentProject(token, investmentId, reason) {
-  return authorisedRequest(token, {
+function archiveInvestmentProject(req, investmentId, reason) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v3/investment/${investmentId}/archive`,
     method: 'POST',
     body: {
@@ -69,19 +69,19 @@ function archiveInvestmentProject(token, investmentId, reason) {
   })
 }
 
-function unarchiveInvestmentProject(token, investmentId) {
-  return authorisedRequest(token, {
+function unarchiveInvestmentProject(req, investmentId) {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v3/investment/${investmentId}/unarchive`,
     method: 'POST',
   })
 }
 
 async function updateInvestmentTeamMembers(
-  token,
+  req,
   investmentId,
   investmentTeamMembers
 ) {
-  return authorisedRequest(token, {
+  return authorisedRequest(req, {
     url: `${config.apiRoot}/v3/investment/${investmentId}/team-member`,
     method: 'PUT',
     body: investmentTeamMembers,

--- a/src/apps/my-pipeline/controllers/add.js
+++ b/src/apps/my-pipeline/controllers/add.js
@@ -3,13 +3,12 @@ const { getOptions } = require('../../../lib/options')
 async function renderAddToPipeline(req, res, next) {
   try {
     const { company } = res.locals
-    const { token } = req.session
 
     res.render('my-pipeline/views/pipeline-form', {
       props: {
         companyId: company.id,
         companyName: company.name,
-        sectors: await getOptions(token, 'sector'),
+        sectors: await getOptions(req, 'sector'),
         contacts: company.contacts,
       },
     })

--- a/src/apps/my-pipeline/controllers/edit.js
+++ b/src/apps/my-pipeline/controllers/edit.js
@@ -3,12 +3,11 @@ const { getOptions } = require('../../../lib/options')
 async function renderEditPipeline(req, res, next) {
   try {
     const { pipelineItemId } = req.params
-    const { token } = req.session
 
     res.render('my-pipeline/views/pipeline-form', {
       props: {
         pipelineItemId,
-        sectors: await getOptions(token, 'sector'),
+        sectors: await getOptions(req, 'sector'),
       },
     })
   } catch (e) {

--- a/src/apps/omis/__test__/middleware.test.js
+++ b/src/apps/omis/__test__/middleware.test.js
@@ -61,7 +61,7 @@ describe('OMIS middleware', () => {
         )
 
         expect(this.getDitCompanyStub).to.have.been.calledWith(
-          this.reqMock.session.token,
+          this.reqMock,
           this.companyId
         )
       })
@@ -141,7 +141,7 @@ describe('OMIS middleware', () => {
         )
 
         expect(this.getByIdStub).to.have.been.calledWith(
-          this.reqMock.session.token,
+          this.reqMock,
           this.orderId
         )
       })

--- a/src/apps/omis/apps/create/controllers/__test__/company.test.js
+++ b/src/apps/omis/apps/create/controllers/__test__/company.test.js
@@ -271,7 +271,7 @@ describe('OMIS create company controller', () => {
 
         it('should call search', () => {
           expect(this.searchCompaniesStub).to.have.been.calledWith({
-            token: '12345',
+            req: this.reqMock,
             page: undefined,
             searchTerm: 'search term',
           })

--- a/src/apps/omis/apps/create/controllers/__test__/confirm.test.js
+++ b/src/apps/omis/apps/create/controllers/__test__/confirm.test.js
@@ -140,7 +140,7 @@ describe('OMIS create confirm controller', () => {
       })
 
       it('should call save method on order model', () => {
-        expect(this.orderSaveStub).to.have.been.calledWith('token-12345', {
+        expect(this.orderSaveStub).to.have.been.calledWith(this.reqMock, {
           foo: 'bar',
           fizz: 'buzz',
         })

--- a/src/apps/omis/apps/create/controllers/company.js
+++ b/src/apps/omis/apps/create/controllers/company.js
@@ -61,7 +61,7 @@ class CompanyController extends CreateController {
     if (searchTerm) {
       try {
         res.locals.searchResult = await searchCompanies({
-          token: req.session.token,
+          req,
           page: req.query.page,
           searchTerm,
         }).then(

--- a/src/apps/omis/apps/create/controllers/confirm.js
+++ b/src/apps/omis/apps/create/controllers/confirm.js
@@ -29,7 +29,7 @@ class ConfirmController extends CreateController {
     unset(data, 'errors')
 
     try {
-      const order = await Order.save(req.session.token, data)
+      const order = await Order.save(req, data)
       req.sessionModel.set('order-id', order.id)
 
       next()

--- a/src/apps/omis/apps/create/controllers/market.js
+++ b/src/apps/omis/apps/create/controllers/market.js
@@ -4,7 +4,7 @@ const { CreateController } = require('../../../controllers')
 class MarketController extends CreateController {
   async configure(req, res, next) {
     try {
-      const markets = await getOptions(req.session.token, 'omis-market')
+      const markets = await getOptions(req, 'omis-market')
 
       req.form.options.fields.primary_market.options = markets
       super.configure(req, res, next)

--- a/src/apps/omis/apps/create/controllers/sector.js
+++ b/src/apps/omis/apps/create/controllers/sector.js
@@ -6,7 +6,7 @@ const { CreateController } = require('../../../controllers')
 class SectorController extends CreateController {
   async configure(req, res, next) {
     try {
-      const sectors = await getOptions(req.session.token, 'sector')
+      const sectors = await getOptions(req, 'sector')
 
       req.form.options.fields.sector.options = sectors
       super.configure(req, res, next)

--- a/src/apps/omis/apps/edit/controllers/__test__/assignees.test.js
+++ b/src/apps/omis/apps/edit/controllers/__test__/assignees.test.js
@@ -258,7 +258,7 @@ describe('OMIS edit subscribers controller', () => {
       it('should call force save assignees method', () => {
         expect(this.forceSaveAssigneesStub).to.have.been.calledOnce
         expect(this.forceSaveAssigneesStub).to.have.been.calledWith(
-          tokenMock,
+          this.reqMock,
           orderMock.id,
           [
             {
@@ -294,7 +294,7 @@ describe('OMIS edit subscribers controller', () => {
       it('should call save assignees method', () => {
         expect(this.saveAssigneesStub).to.have.been.calledOnce
         expect(this.saveAssigneesStub).to.have.been.calledWith(
-          tokenMock,
+          this.reqMock,
           orderMock.id,
           [
             {

--- a/src/apps/omis/apps/edit/controllers/__test__/subscribers.test.js
+++ b/src/apps/omis/apps/edit/controllers/__test__/subscribers.test.js
@@ -215,7 +215,7 @@ describe('OMIS edit subscribers controller', () => {
       it('should force save assignees', () => {
         expect(this.saveSubscribersStub).to.have.been.calledOnce
         expect(this.saveSubscribersStub).to.have.been.calledWith(
-          tokenMock,
+          this.reqMock,
           orderMock.id,
           [
             {

--- a/src/apps/omis/apps/edit/controllers/assignee-time.js
+++ b/src/apps/omis/apps/edit/controllers/assignee-time.js
@@ -6,8 +6,7 @@ const { Order } = require('../../../models')
 class EditAssigneeTimeController extends EditController {
   async configure(req, res, next) {
     const orderId = get(res.locals, 'order.id')
-    const token = get(req.session, 'token')
-    const assignees = await Order.getAssignees(token, orderId)
+    const assignees = await Order.getAssignees(req, orderId)
 
     if (!assignees.length) {
       req.form.options.hidePrimaryFormAction = true
@@ -36,11 +35,7 @@ class EditAssigneeTimeController extends EditController {
     })
 
     try {
-      await Order.saveAssignees(
-        req.session.token,
-        res.locals.order.id,
-        filter(assignees)
-      )
+      await Order.saveAssignees(req, res.locals.order.id, filter(assignees))
       next()
     } catch (error) {
       next(error)

--- a/src/apps/omis/apps/edit/controllers/assignees.js
+++ b/src/apps/omis/apps/edit/controllers/assignees.js
@@ -11,9 +11,8 @@ class EditAssigneesController extends EditController {
       const orderId = get(res.locals, 'order.id')
       const canEditOrder = get(res.locals, 'order.canEditOrder')
       const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
-      const token = get(req.session, 'token')
-      const advisers = await getAdvisers(token)
-      const assignees = await Order.getAssignees(token, orderId)
+      const advisers = await getAdvisers(req)
+      const assignees = await Order.getAssignees(req, orderId)
       const options = advisers.results.map(transformObjectToOption)
 
       req.form.options.fields.assignees.options = sortBy(options, 'label')
@@ -46,12 +45,11 @@ class EditAssigneesController extends EditController {
     try {
       const orderId = get(res.locals, 'order.id')
       const canEditOrder = get(res.locals, 'order.canEditOrder')
-      const token = get(req.session, 'token')
 
       if (canEditOrder) {
-        await Order.forceSaveAssignees(token, orderId, assignees)
+        await Order.forceSaveAssignees(req, orderId, assignees)
       } else {
-        await Order.saveAssignees(token, orderId, assignees)
+        await Order.saveAssignees(req, orderId, assignees)
       }
 
       next()

--- a/src/apps/omis/apps/edit/controllers/billing-address.js
+++ b/src/apps/omis/apps/edit/controllers/billing-address.js
@@ -5,7 +5,7 @@ const { EditController } = require('../../../controllers')
 
 class EditBillingAddressController extends EditController {
   async configure(req, res, next) {
-    const countries = await getOptions(req.session.token, 'country')
+    const countries = await getOptions(req, 'country')
     req.form.options.fields.billing_address_country.options = countries
 
     if (req.form.options.disableFormAction) {

--- a/src/apps/omis/apps/edit/controllers/cancel-order.js
+++ b/src/apps/omis/apps/edit/controllers/cancel-order.js
@@ -36,12 +36,11 @@ class CancelOrderController extends EditController {
   }
 
   async saveValues(req, res, next) {
-    const token = req.session.token
     const orderId = get(res.locals, 'order.id')
     const data = req.form.values
 
     try {
-      await Order.cancel(token, orderId, data)
+      await Order.cancel(req, orderId, data)
       next()
     } catch (error) {
       next(error)

--- a/src/apps/omis/apps/edit/controllers/complete-order.js
+++ b/src/apps/omis/apps/edit/controllers/complete-order.js
@@ -10,8 +10,7 @@ class CompleteOrderController extends EditController {
     }
 
     const orderId = get(res.locals, 'order.id')
-    const token = get(req.session, 'token')
-    const assignees = await Order.getAssignees(token, orderId)
+    const assignees = await Order.getAssignees(req, orderId)
 
     if (!assignees.length) {
       req.form.options.hidePrimaryFormAction = true
@@ -51,12 +50,8 @@ class CompleteOrderController extends EditController {
     })
 
     try {
-      await Order.saveAssignees(
-        req.session.token,
-        res.locals.order.id,
-        filter(assignees)
-      )
-      await Order.complete(req.session.token, res.locals.order.id)
+      await Order.saveAssignees(req, res.locals.order.id, filter(assignees))
+      await Order.complete(req, res.locals.order.id)
       next()
     } catch (error) {
       next(error)

--- a/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
+++ b/src/apps/omis/apps/edit/controllers/edit-lead-assignee.js
@@ -11,7 +11,7 @@ async function editLeadAssignee(req, res, next) {
   }
 
   try {
-    const allAssignees = await Order.getAssignees(req.session.token, orderId)
+    const allAssignees = await Order.getAssignees(req, orderId)
     const assignees = allAssignees.map((assignee) => {
       return Object.assign(assignee, {
         is_lead: assignee.adviser.id === adviserId,
@@ -19,7 +19,7 @@ async function editLeadAssignee(req, res, next) {
     })
     const leadAdviser = find(assignees, { adviser: { id: adviserId } })
 
-    await Order.saveAssignees(req.session.token, orderId, assignees)
+    await Order.saveAssignees(req, orderId, assignees)
 
     req.flash(
       'success',

--- a/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
+++ b/src/apps/omis/apps/edit/controllers/payment-reconciliation.js
@@ -59,7 +59,7 @@ class EditPaymentReconciliationController extends EditController {
     let invoice
 
     try {
-      invoice = await Order.getInvoice(req.session.token, res.locals.order.id)
+      invoice = await Order.getInvoice(req, res.locals.order.id)
     } catch (error) {
       logger.error(error)
     }
@@ -84,7 +84,7 @@ class EditPaymentReconciliationController extends EditController {
       // TODO: Support adding of multiple payments
       // API accepts an array of payment objects
       // This solution sends the only payment captured in an array to solve this
-      await Order.savePayments(req.session.token, res.locals.order.id, [data])
+      await Order.savePayments(req, res.locals.order.id, [data])
       next()
     } catch (err) {
       if (err.statusCode === 409) {

--- a/src/apps/omis/apps/edit/controllers/subscribers.js
+++ b/src/apps/omis/apps/edit/controllers/subscribers.js
@@ -13,9 +13,8 @@ class EditSubscribersController extends EditController {
     try {
       const orderId = get(res.locals, 'order.id')
       const canEditAdvisers = get(res.locals, 'order.canEditAdvisers')
-      const token = get(req.session, 'token')
-      const advisers = await getAdvisers(token)
-      const subscribers = await Order.getSubscribers(token, orderId)
+      const advisers = await getAdvisers(req)
+      const subscribers = await Order.getSubscribers(req, orderId)
       const options = advisers.results.map(transformObjectToOption)
 
       req.form.options.disableFormAction = !canEditAdvisers
@@ -41,11 +40,7 @@ class EditSubscribersController extends EditController {
     const subscribers = subscribersTransform.map(transformIdToObject)
 
     try {
-      await Order.saveSubscribers(
-        req.session.token,
-        res.locals.order.id,
-        subscribers
-      )
+      await Order.saveSubscribers(req, res.locals.order.id, subscribers)
       next()
     } catch (error) {
       next(error)

--- a/src/apps/omis/apps/list/controllers.js
+++ b/src/apps/omis/apps/list/controllers.js
@@ -22,10 +22,10 @@ const exportOptions = {
  * including a flat version of the sector list
  *
  */
-async function getFormOptions(token, res) {
-  const omisMarketOptions = await getOptions(token, 'omis-market')
-  const regionOptions = await getOptions(token, 'uk-region')
-  const sectorOptions = await getOptions(token, 'sector', {
+async function getFormOptions(req, res) {
+  const omisMarketOptions = await getOptions(req, 'omis-market')
+  const regionOptions = await getOptions(req, 'uk-region')
+  const sectorOptions = await getOptions(req, 'sector', {
     queryString: '?level__lte=0',
   })
   return {
@@ -43,15 +43,9 @@ async function getFormOptions(token, res) {
  * request query
  *
  */
-async function getFiltersFields(token, query, res) {
-  const filtersFields = omisFiltersFields(await getFormOptions(token, res))
-  const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
-    token,
-    filtersFields,
-    query
-  )
-
-  return filtersFieldsWithSelectedOptions
+async function getFiltersFields(req, query, res) {
+  const filtersFields = omisFiltersFields(await getFormOptions(req, res))
+  return await buildFieldsWithSelectedEntities(req, filtersFields, query)
 }
 
 /**
@@ -71,11 +65,11 @@ function getSortForm(query) {
  */
 async function renderList(req, res, next) {
   try {
-    const { token, user } = req.session
+    const { user } = req.session
     const query = req.query
 
     const sortForm = getSortForm(query)
-    const filtersFields = await getFiltersFields(token, query, res)
+    const filtersFields = await getFiltersFields(req, query, res)
     const selectedFilters = buildSelectedFiltersSummary(filtersFields, query)
     const exportAction = await buildExportAction(
       qs.stringify(req.query),

--- a/src/apps/omis/apps/view/__test__/middleware.test.js
+++ b/src/apps/omis/apps/view/__test__/middleware.test.js
@@ -163,7 +163,7 @@ describe('OMIS View middleware', () => {
       it('should call getContact with correct arguments', () => {
         expect(this.getContactStub).to.have.been.calledOnce
         expect(this.getContactStub).to.have.been.calledWith(
-          '12345',
+          this.reqMock,
           'contact-id'
         )
       })
@@ -238,7 +238,7 @@ describe('OMIS View middleware', () => {
       it('should call getAssigneesStub with correct arguments', () => {
         expect(this.getAssigneesStub).to.have.been.calledOnce
         expect(this.getAssigneesStub).to.have.been.calledWith(
-          '12345',
+          this.reqMock,
           '123456789'
         )
       })
@@ -314,7 +314,7 @@ describe('OMIS View middleware', () => {
       it('should call getAssigneesStub with correct arguments', () => {
         expect(this.getSubscribersStub).to.have.been.calledOnce
         expect(this.getSubscribersStub).to.have.been.calledWith(
-          '12345',
+          this.reqMock,
           '123456789'
         )
       })
@@ -389,7 +389,7 @@ describe('OMIS View middleware', () => {
 
           it('should make quote request', () => {
             expect(this.getQuoteStub).to.have.been.calledWith(
-              this.reqMock.session.token,
+              this.reqMock,
               this.resMock.locals.order.id
             )
           })
@@ -450,7 +450,7 @@ describe('OMIS View middleware', () => {
 
         it('should make quote request', () => {
           expect(this.getQuoteStub).to.have.been.calledWith(
-            this.reqMock.session.token,
+            this.reqMock,
             this.resMock.locals.order.id
           )
         })

--- a/src/apps/omis/apps/view/middleware.js
+++ b/src/apps/omis/apps/view/middleware.js
@@ -25,7 +25,7 @@ async function setContact(req, res, next) {
   }
 
   try {
-    res.locals.order.contact = await getContact(req.session.token, contactId)
+    res.locals.order.contact = await getContact(req, contactId)
     next()
   } catch (error) {
     next(error)
@@ -37,10 +37,7 @@ async function setAssignees(req, res, next) {
 
   if (orderId) {
     try {
-      res.locals.assignees = await Order.getAssignees(
-        req.session.token,
-        orderId
-      )
+      res.locals.assignees = await Order.getAssignees(req, orderId)
     } catch (error) {
       return next(error)
     }
@@ -53,10 +50,7 @@ async function setSubscribers(req, res, next) {
 
   if (orderId) {
     try {
-      res.locals.subscribers = await Order.getSubscribers(
-        req.session.token,
-        orderId
-      )
+      res.locals.subscribers = await Order.getSubscribers(req, orderId)
     } catch (error) {
       return next(error)
     }
@@ -70,7 +64,7 @@ async function setQuoteSummary(req, res, next) {
 
   if (orderStatus === 'quote_awaiting_acceptance') {
     try {
-      const quote = await Order.getQuote(req.session.token, orderId)
+      const quote = await Order.getQuote(req, orderId)
       quote.expires_on = new Date(quote.expires_on + 'T23:59:59')
 
       res.locals.quote = assign({}, quote, {
@@ -96,7 +90,7 @@ async function setQuotePreview(req, res, next) {
   }
 
   try {
-    const quote = await Order.previewQuote(req.session.token, id)
+    const quote = await Order.previewQuote(req, id)
     quote.expires_on = new Date(quote.expires_on + 'T23:59:59')
 
     res.locals.quote = quote
@@ -140,7 +134,7 @@ async function setQuote(req, res, next) {
   }
 
   try {
-    const quote = await Order.getQuote(req.session.token, res.locals.order.id)
+    const quote = await Order.getQuote(req, res.locals.order.id)
     quote.expires_on = new Date(quote.expires_on + 'T23:59:59')
 
     res.locals.quote = assign({}, quote, {
@@ -157,10 +151,7 @@ async function setQuote(req, res, next) {
 
 async function setInvoice(req, res, next) {
   try {
-    res.locals.invoice = await Order.getInvoice(
-      req.session.token,
-      res.locals.order.id
-    )
+    res.locals.invoice = await Order.getInvoice(req, res.locals.order.id)
   } catch (error) {
     logger.error(error)
   }
@@ -170,10 +161,7 @@ async function setInvoice(req, res, next) {
 
 async function setPayments(req, res, next) {
   try {
-    const payments = await Order.getPayments(
-      req.session.token,
-      res.locals.order.id
-    )
+    const payments = await Order.getPayments(req, res.locals.order.id)
 
     res.locals.payments = payments.map(transformPaymentToView)
   } catch (error) {
@@ -188,7 +176,7 @@ async function generateQuote(req, res, next) {
   const clientEmail = get(res.locals, 'order.contact.email') || 'client'
 
   try {
-    await Order.createQuote(req.session.token, orderId)
+    await Order.createQuote(req, orderId)
 
     req.flash('success', `Quote sent ${clientEmail}`)
     res.redirect(`/omis/${orderId}`)
@@ -219,7 +207,7 @@ async function cancelQuote(req, res, next) {
   const orderId = get(res.locals, 'order.id')
 
   try {
-    await Order.cancelQuote(req.session.token, orderId)
+    await Order.cancelQuote(req, orderId)
 
     req.flash('success', 'Quote successfully cancelled.')
     res.redirect(`/omis/${orderId}`)

--- a/src/apps/omis/controllers/__test__/create.test.js
+++ b/src/apps/omis/controllers/__test__/create.test.js
@@ -273,7 +273,7 @@ describe('OMIS CreateController', () => {
         it('should call get company method', () => {
           expect(this.getDitCompanyStub).to.be.calledOnce
           expect(this.getDitCompanyStub).to.be.calledWith(
-            '12345',
+            this.reqMock,
             companyMock.id
           )
         })
@@ -308,7 +308,7 @@ describe('OMIS CreateController', () => {
         it('should call get company method', () => {
           expect(this.getDitCompanyStub).to.be.calledOnce
           expect(this.getDitCompanyStub).to.be.calledWith(
-            '12345',
+            this.reqMock,
             companyMock.id
           )
         })

--- a/src/apps/omis/controllers/__test__/edit.test.js
+++ b/src/apps/omis/controllers/__test__/edit.test.js
@@ -55,7 +55,7 @@ describe('OMIS EditController', () => {
 
       it('should call save method on order model', () => {
         expect(this.orderUpdateStub).to.have.been.calledWith(
-          'sessionToken',
+          this.reqMock,
           updateMockData.id,
           {
             foo: 'bar',

--- a/src/apps/omis/controllers/create.js
+++ b/src/apps/omis/controllers/create.js
@@ -53,7 +53,7 @@ class CreateController extends FormController {
 
     if (companyId) {
       try {
-        res.locals.company = await getDitCompany(req.session.token, companyId)
+        res.locals.company = await getDitCompany(req, companyId)
       } catch (error) {
         logger.error(error)
       }

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -20,11 +20,7 @@ const { Order } = require('../models')
 class EditController extends FormController {
   async saveValues(req, res, next) {
     try {
-      await Order.update(
-        req.session.token,
-        res.locals.order.id,
-        req.form.values
-      )
+      await Order.update(req, res.locals.order.id, req.form.values)
 
       next()
     } catch (error) {

--- a/src/apps/omis/middleware.js
+++ b/src/apps/omis/middleware.js
@@ -7,7 +7,7 @@ const labels = require('./locales/en/default')
 
 async function setCompany(req, res, next, companyId) {
   try {
-    res.locals.company = await getDitCompany(req.session.token, companyId)
+    res.locals.company = await getDitCompany(req, companyId)
     next()
   } catch (error) {
     next(error)
@@ -16,7 +16,7 @@ async function setCompany(req, res, next, companyId) {
 
 async function setOrder(req, res, next, orderId) {
   try {
-    const order = await Order.getById(req.session.token, orderId)
+    const order = await Order.getById(req, orderId)
     const activeOrder = !['cancelled', 'complete'].includes(order.status)
 
     res.locals.order = assign({}, order, {

--- a/src/apps/omis/models.js
+++ b/src/apps/omis/models.js
@@ -2,124 +2,121 @@ const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
 const Order = {
-  save(token, data) {
-    return authorisedRequest(token, {
+  save(req, data) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order`,
       method: 'POST',
       body: data,
     })
   },
 
-  update(token, id, data) {
-    return authorisedRequest(token, {
+  update(req, id, data) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}`,
       method: 'PATCH',
       body: data,
     })
   },
 
-  saveSubscribers(token, id, body) {
-    return authorisedRequest(token, {
+  saveSubscribers(req, id, body) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/subscriber-list`,
       method: 'PUT',
       body,
     })
   },
 
-  getAssignees(token, id) {
+  getAssignees(req, id) {
     return authorisedRequest(
-      token,
+      req,
       `${config.apiRoot}/v3/omis/order/${id}/assignee`
     )
   },
 
-  saveAssignees(token, id, body) {
-    return authorisedRequest(token, {
+  saveAssignees(req, id, body) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/assignee`,
       method: 'PATCH',
       body,
     })
   },
 
-  forceSaveAssignees(token, id, body) {
-    return authorisedRequest(token, {
+  forceSaveAssignees(req, id, body) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/assignee?force-delete=1`,
       method: 'PATCH',
       body,
     })
   },
 
-  getSubscribers(token, id) {
+  getSubscribers(req, id) {
     return authorisedRequest(
-      token,
+      req,
       `${config.apiRoot}/v3/omis/order/${id}/subscriber-list`
     )
   },
 
-  getById(token, id) {
-    return authorisedRequest(token, `${config.apiRoot}/v3/omis/order/${id}`)
+  getById(req, id) {
+    return authorisedRequest(req, `${config.apiRoot}/v3/omis/order/${id}`)
   },
 
-  previewQuote(token, id) {
-    return authorisedRequest(token, {
+  previewQuote(req, id) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/quote/preview`,
       method: 'POST',
     })
   },
 
-  getQuote(token, id) {
-    return authorisedRequest(
-      token,
-      `${config.apiRoot}/v3/omis/order/${id}/quote`
-    )
+  getQuote(req, id) {
+    return authorisedRequest(req, `${config.apiRoot}/v3/omis/order/${id}/quote`)
   },
 
-  createQuote(token, id) {
-    return authorisedRequest(token, {
+  createQuote(req, id) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/quote`,
       method: 'POST',
     })
   },
 
-  cancelQuote(token, id) {
-    return authorisedRequest(token, {
+  cancelQuote(req, id) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/quote/cancel`,
       method: 'POST',
     })
   },
 
-  getInvoice(token, id) {
+  getInvoice(req, id) {
     return authorisedRequest(
-      token,
+      req,
       `${config.apiRoot}/v3/omis/order/${id}/invoice`
     )
   },
 
-  getPayments(token, id) {
+  getPayments(req, id) {
     return authorisedRequest(
-      token,
+      req,
       `${config.apiRoot}/v3/omis/order/${id}/payment`
     )
   },
 
-  savePayments(token, id, body) {
-    return authorisedRequest(token, {
+  savePayments(req, id, body) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/payment`,
       method: 'POST',
       body,
     })
   },
 
-  complete(token, id, body) {
-    return authorisedRequest(token, {
+  complete(req, id, body) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/complete`,
       method: 'POST',
       body,
     })
   },
 
-  cancel(token, id, body) {
-    return authorisedRequest(token, {
+  cancel(req, id, body) {
+    return authorisedRequest(req, {
       url: `${config.apiRoot}/v3/omis/order/${id}/cancel`,
       method: 'POST',
       body,

--- a/src/apps/propositions/controllers/list.js
+++ b/src/apps/propositions/controllers/list.js
@@ -14,15 +14,14 @@ const SECTOR = FILTER_CONSTANTS.PROPOSITIONS.SECTOR.NAME
 
 async function renderPropositionList(req, res, next) {
   try {
-    const token = req.session.token
     const queryString = QUERY_STRING
     const currentAdviserId = get(req.session, 'user.id')
-    const channels = await getOptions(token, 'communication-channel', {
+    const channels = await getOptions(req, 'communication-channel', {
       includeDisabled: true,
     })
-    const teams = await getOptions(token, 'team', { includeDisabled: true })
+    const teams = await getOptions(req, 'team', { includeDisabled: true })
 
-    const sectorOptions = await getOptions(token, SECTOR, { queryString })
+    const sectorOptions = await getOptions(req, SECTOR, { queryString })
 
     const filtersFields = collectionFilterFields({
       teams,
@@ -32,7 +31,7 @@ async function renderPropositionList(req, res, next) {
     })
 
     const filtersFieldsWithSelectedOptions = await buildFieldsWithSelectedEntities(
-      token,
+      req,
       filtersFields,
       req.query
     )

--- a/src/apps/propositions/middleware/__test__/details.test.js
+++ b/src/apps/propositions/middleware/__test__/details.test.js
@@ -77,9 +77,7 @@ describe('Proposition details middleware', () => {
       })
 
       it('should post to the API', () => {
-        expect(this.savePropositionStub).to.have.been.calledWith(
-          this.req.session.token
-        )
+        expect(this.savePropositionStub).to.have.been.calledWith(this.req)
         expect(this.savePropositionStub).to.have.been.calledOnce
         expect(this.savePropositionStub.firstCall.args[1]).to.deep.equal(
           transformed

--- a/src/apps/propositions/middleware/abandon.js
+++ b/src/apps/propositions/middleware/abandon.js
@@ -6,7 +6,7 @@ const { abandonProposition, fetchProposition } = require('../repos')
 async function postAbandon(req, res, next) {
   try {
     res.locals.requestBody = transformPropositionFormBodyToApiRequest(req.body)
-    await abandonProposition(req.session.token, res.locals.requestBody)
+    await abandonProposition(req, res.locals.requestBody)
 
     req.flash('success', 'Proposition abandoned')
 
@@ -31,10 +31,9 @@ async function postAbandon(req, res, next) {
 
 async function getPropositionDetails(req, res, next, propositionId) {
   try {
-    const token = req.session.token
     const { investment } = res.locals
     res.locals.proposition = await fetchProposition(
-      token,
+      req,
       propositionId,
       investment.id
     )

--- a/src/apps/propositions/middleware/complete.js
+++ b/src/apps/propositions/middleware/complete.js
@@ -38,10 +38,9 @@ async function postComplete(req, res, next) {
 
 async function getPropositionDetails(req, res, next, propositionId) {
   try {
-    const token = req.session.token
     const { investment } = res.locals
     res.locals.proposition = await fetchProposition(
-      token,
+      req,
       propositionId,
       investment.id
     )
@@ -54,8 +53,7 @@ async function getPropositionDetails(req, res, next, propositionId) {
 
 async function getPropositionOptions(req, res, next) {
   try {
-    const token = req.session.token
-    const advisers = await getAdvisers(token)
+    const advisers = await getAdvisers(req)
     const currentAdviser = get(res.locals, 'proposition.adviser.id')
     const activeAdvisers = filterActiveAdvisers({
       advisers: advisers.results,

--- a/src/apps/propositions/middleware/details.js
+++ b/src/apps/propositions/middleware/details.js
@@ -15,7 +15,7 @@ async function postDetails(req, res, next) {
   res.locals.requestBody = transformPropositionFormBodyToApiRequest(req.body)
 
   try {
-    await saveProposition(req.session.token, res.locals.requestBody)
+    await saveProposition(req, res.locals.requestBody)
 
     req.flash('success', 'Proposition created')
 
@@ -40,15 +40,14 @@ async function postDetails(req, res, next) {
 
 async function getPropositionDetails(req, res, next, propositionId) {
   try {
-    const token = req.session.token
     const { investment } = res.locals
     res.locals.proposition = await fetchProposition(
-      token,
+      req,
       propositionId,
       investment.id
     )
     res.locals.proposition.files = await fetchPropositionFiles(
-      token,
+      req,
       propositionId,
       investment.id
     )
@@ -61,8 +60,7 @@ async function getPropositionDetails(req, res, next, propositionId) {
 
 async function getPropositionOptions(req, res, next) {
   try {
-    const token = req.session.token
-    const advisers = await getAdvisers(token)
+    const advisers = await getAdvisers(req)
     const currentAdviser = get(res.locals, 'proposition.adviser.id')
     const activeAdvisers = filterActiveAdvisers({
       advisers: advisers.results,
@@ -81,11 +79,10 @@ async function getPropositionOptions(req, res, next) {
 
 async function getDownloadLink(req, res, next) {
   try {
-    const token = req.session.token
     const { propositionId, documentId } = req.params
     const { investment } = res.locals
     const s3 = await fetchDownloadLink(
-      token,
+      req,
       propositionId,
       investment.id,
       documentId

--- a/src/apps/propositions/repos.js
+++ b/src/apps/propositions/repos.js
@@ -1,28 +1,28 @@
 const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
-function fetchProposition(token, propositionId, investmentId) {
+function fetchProposition(req, propositionId, investmentId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment/${investmentId}/proposition/${propositionId}`
   )
 }
 
-function fetchPropositionFiles(token, propositionId, investmentId) {
+function fetchPropositionFiles(req, propositionId, investmentId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment/${investmentId}/proposition/${propositionId}/document`
   )
 }
 
-function fetchDownloadLink(token, propositionId, investmentId, documentId) {
+function fetchDownloadLink(req, propositionId, investmentId, documentId) {
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment/${investmentId}/proposition/${propositionId}/document/${documentId}/download`
   )
 }
 
-function saveProposition(token, proposition) {
+function saveProposition(req, proposition) {
   const options = {
     url: `${config.apiRoot}/v3/investment/${proposition.investment_project}/proposition`,
     method: 'POST',
@@ -34,17 +34,17 @@ function saveProposition(token, proposition) {
     options.method = 'PATCH'
   }
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
-function abandonProposition(token, proposition) {
+function abandonProposition(req, proposition) {
   const options = {
     url: `${config.apiRoot}/v3/investment/${proposition.investment_project}/proposition/${proposition.id}/abandon`,
     method: 'POST',
     body: proposition,
   }
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
 function completeProposition(req, res) {
@@ -53,22 +53,22 @@ function completeProposition(req, res) {
     method: 'POST',
   }
 
-  return authorisedRequest(req.session.token, options)
+  return authorisedRequest(req.session.req, options)
 }
 
 /**
  * Get propositions for a investment
  *
- * @param {string} token
+ * @param {string} req
  * @param {string} investmentId
  * @param {number} page
  * @return {Promise<Object[]>} Returns a promise that resolves to an array of API proposition objects
  */
-function getPropositionsForInvestment(token, investmentId, page) {
+function getPropositionsForInvestment(req, investmentId, page) {
   const limit = 10
   const offset = limit * (page - 1)
   return authorisedRequest(
-    token,
+    req,
     `${config.apiRoot}/v3/investment/${investmentId}/proposition?&limit=${limit}&offset=${offset}`
   )
 }

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -65,7 +65,7 @@ async function renderSearchResults(req, res) {
     searchTerm,
     searchEntity,
     requestBody: req.body,
-    token: req.session.token,
+    req,
     page: req.query.page,
   }).then(
     transformApiResponseToSearchCollection(

--- a/src/lib/__test__/authorised-request.test.js
+++ b/src/lib/__test__/authorised-request.test.js
@@ -38,3 +38,33 @@ describe('In dev', () => {
     })
   })
 })
+
+describe('With Zipkin headers', () => {
+  it('Should forward Zipkin headers', () => {
+    const options = {
+      url: 'http://example.com',
+    }
+    const request = {
+      session: {
+        token: 'fake-token',
+      },
+      headers: {
+        'x-b3-traceid': 'fake-trace-id',
+        'x-b3-spanid': 'fake-span-id',
+      },
+    }
+
+    const requestPromiseStub = sinon.stub().resolves({})
+    const { authorisedRequest } = proxyquire('../authorised-request', {
+      'request-promise': requestPromiseStub,
+    })
+
+    authorisedRequest(request, options)
+
+    expect(requestPromiseStub.firstCall.lastArg.headers).deep.equals({
+      Authorization: 'Bearer fake-token',
+      'x-b3-spanid': 'fake-span-id',
+      'x-b3-traceid': 'fake-trace-id',
+    })
+  })
+})

--- a/src/lib/authorised-request.js
+++ b/src/lib/authorised-request.js
@@ -4,6 +4,7 @@ const requestPromise = require('request-promise')
 
 const config = require('../config')
 const logger = require('../config/logger')
+const getZipkinHeaders = require('./get-zipkin-headers')
 
 function hasValue(value) {
   return !isNil(value)
@@ -25,10 +26,12 @@ function stripScripts(key, value) {
   return value
 }
 
-function parseOptions(opts, token) {
+function parseOptions(req, opts) {
+  const { token } = req.session
   const defaults = {
     headers: {
       ...opts.headers,
+      ...getZipkinHeaders(req),
       ...(token ? { Authorization: `Bearer ${token}` } : null),
     },
     json: true,
@@ -73,8 +76,8 @@ function logRequest(opts) {
 // Accepts options as keys on an object or encoded as a url
 // Responses are parsed to remove any embedded XSS attempts with
 // script tags
-function authorisedRequest(token, opts) {
-  const requestOptions = parseOptions(opts, token)
+function authorisedRequest(req, opts) {
+  const requestOptions = parseOptions(req, opts)
 
   logRequest(requestOptions)
   requestOptions.jsonReviver = stripScripts
@@ -92,8 +95,8 @@ function authorisedRequest(token, opts) {
 // Responses are not parsed for XSS attacks
 // See request-promise #90 does not work with streams
 // https://github.com/request/request-promise/issues/90
-function authorisedRawRequest(token, opts) {
-  const requestOptions = parseOptions(opts, token)
+function authorisedRawRequest(req, opts) {
+  const requestOptions = parseOptions(req, opts)
 
   logRequest(requestOptions)
 

--- a/src/lib/get-zipkin-headers.js
+++ b/src/lib/get-zipkin-headers.js
@@ -3,7 +3,9 @@ const { pickBy } = require('lodash')
 const ZIPKIN_HEADERS = ['x-b3-traceid', 'x-b3-spanid']
 
 function getZipkinHeaders(req) {
-  return pickBy(req.headers, (header) => header.toLowerCase() in ZIPKIN_HEADERS)
+  return pickBy(req.headers, (value, header) =>
+    ZIPKIN_HEADERS.includes(header.toLowerCase())
+  )
 }
 
 module.exports = getZipkinHeaders

--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -15,7 +15,7 @@ if (!config.isTest) {
   redisAsyncGet = redisClient.asyncGet()
 }
 
-async function fetchOptions(token, url) {
+async function fetchOptions(req, url) {
   let metaData = config.isTest ? null : await redisAsyncGet(url)
 
   if (metaData) {
@@ -30,7 +30,7 @@ async function fetchOptions(token, url) {
 }
 
 async function getOptions(
-  token,
+  req,
   key,
   {
     createdOn,
@@ -47,7 +47,7 @@ async function getOptions(
   } = {}
 ) {
   if (id) {
-    return getOptionsForId(token, key, id)
+    return getOptionsForId(req, key, id)
   }
 
   if (context) {
@@ -59,7 +59,7 @@ async function getOptions(
   }
 
   const url = `${config.apiRoot}/v4/metadata/${key}${queryString}`
-  let options = await fetchOptions(token, url)
+  let options = await fetchOptions(req, url)
 
   if (!includeDisabled) {
     options = options.filter(filterDisabledOption({ currentValue, createdOn }))
@@ -87,7 +87,7 @@ async function getOptions(
   return sorted ? sortBy(mappedOptions, sortPropertyName) : mappedOptions
 }
 
-async function getOptionsForId(token, key, id) {
+async function getOptionsForId(req, key, id) {
   const ids = castArray(id)
   const options = []
 
@@ -96,7 +96,7 @@ async function getOptionsForId(token, key, id) {
       key === 'adviser'
         ? `${config.apiRoot}/adviser/${ids[index]}/`
         : `${config.apiRoot}/v3/${key}/${ids[index]}`
-    const data = await authorisedRequest(token, url)
+    const data = await authorisedRequest(req, url)
     options.push({
       value: data.id,
       label: data.name,

--- a/src/middleware/__test__/user.test.js
+++ b/src/middleware/__test__/user.test.js
@@ -83,7 +83,7 @@ describe('user middleware', () => {
 
       it('should call authorised request', () => {
         expect(this.authorisedRequestStub).to.be.calledWith(
-          token,
+          this.reqMock,
           `${apiRoot}/whoami/`
         )
       })

--- a/src/middleware/features.js
+++ b/src/middleware/features.js
@@ -18,16 +18,15 @@ function parseFeatureData(featureData = []) {
 
 module.exports = async function features(req, res, next) {
   try {
-    const token = req.session.token
     const passThrough =
-      !token || /^\/(support|healthcheck|oauth)\b/.test(req.url)
+      !req.session.token || /^\/(support|healthcheck|oauth)\b/.test(req.url)
 
     if (passThrough) {
       res.locals.features = {}
       return next()
     }
 
-    const featureData = await authorisedRequest(token, flagUrl)
+    const featureData = await authorisedRequest(req, flagUrl)
     res.locals.features = parseFeatureData(featureData)
   } catch (error) {
     logger.error(`Unable to fetch feature flags: ${error}`)

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -16,7 +16,7 @@ async function userMiddleware(req, res, next) {
 
   try {
     const userResponse = await authorisedRequest(
-      token,
+      req,
       `${config.apiRoot}/whoami/`
     )
 

--- a/src/modules/search/__test__/services.test.js
+++ b/src/modules/search/__test__/services.test.js
@@ -10,6 +10,8 @@ const {
 } = require('../services')
 const buildMiddlewareParameters = require('../../../../test/unit/helpers/middleware-parameters-builder')
 
+const stubRequest = { session: { token: '1234' } }
+
 describe('Search service', () => {
   describe('#search', () => {
     context('when minimal parameters are populated', () => {
@@ -23,7 +25,7 @@ describe('Search service', () => {
           })
 
         this.actual = await search({
-          token: '1234',
+          req: stubRequest,
           searchTerm: 'search',
         })
       })
@@ -51,7 +53,7 @@ describe('Search service', () => {
           })
 
         this.actual = await search({
-          token: '1234',
+          req: stubRequest,
           searchTerm: 'search',
           searchEntity: 'company',
           requestBody: {
@@ -86,7 +88,7 @@ describe('Search service', () => {
           })
 
         this.actual = await search({
-          token: '1234',
+          req: stubRequest,
           searchTerm: 'search',
           searchEntity: 'company',
           requestBody: {
@@ -125,7 +127,7 @@ describe('Search service', () => {
         })
 
       this.actual = await searchCompanies({
-        token: '1234',
+        req: stubRequest,
         searchTerm: 'search',
         isUkBased: true,
         requestBody: {
@@ -159,7 +161,7 @@ describe('Search service', () => {
         })
 
       this.actual = await searchInvestments({
-        token: '1234',
+        req: stubRequest,
         searchTerm: 'search',
         filters: {
           field: true,
@@ -192,7 +194,7 @@ describe('Search service', () => {
         })
 
       this.actual = await searchForeignCompanies({
-        token: '1234',
+        req: stubRequest,
         searchTerm: 'search',
       })
     })
@@ -231,7 +233,7 @@ describe('Search service', () => {
         })
 
         await exportSearch({
-          token: '1234',
+          req: stubRequest,
           searchTerm: 'search',
           searchEntity: 'company',
           requestBody: {
@@ -270,7 +272,7 @@ describe('Search service', () => {
         })
 
         await exportSearch({
-          token: '1234',
+          req: stubRequest,
           searchTerm: 'search',
           searchEntity: 'entity',
           requestBody: {
@@ -297,7 +299,7 @@ describe('Search service', () => {
         })
 
       this.actual = await searchAutocomplete({
-        token: '1234',
+        req: stubRequest,
         searchEntity: 'company',
         searchTerm: 'search',
       })
@@ -325,7 +327,7 @@ describe('Search service', () => {
         })
 
       this.actual = await searchDnbCompanies({
-        token: '1234',
+        req: stubRequest,
         requestBody: {
           search_term: 'company',
           address_country: 'GB',

--- a/src/modules/search/middleware/collection.js
+++ b/src/modules/search/middleware/collection.js
@@ -7,7 +7,7 @@ function getCollection(searchEntity, entityDetails, ...itemTransformers) {
       res.locals.results = await search({
         searchEntity,
         requestBody: req.body,
-        token: req.session.token,
+        req,
         page: req.query.page,
         isAggregation: false,
       }).then(
@@ -30,7 +30,7 @@ function exportCollection(searchEntity) {
     return exportSearch({
       searchEntity,
       requestBody: req.body,
-      token: req.session.token,
+      req,
     })
       .then((apiReq) => {
         return apiReq.pipe(res)

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -26,7 +26,7 @@ const buildOptions = (isAggregation, searchUrl, body, entity) => {
 }
 
 function search({
-  token,
+  req,
   searchTerm: term = '',
   searchEntity,
   requestBody,
@@ -46,14 +46,14 @@ function search({
 
   const options = buildOptions(isAggregation, searchUrl, body, searchEntity)
 
-  return authorisedRequest(token, options).then((result) => {
+  return authorisedRequest(req, options).then((result) => {
     result.page = page
     return result
   })
 }
 
 function searchEntity(
-  token,
+  req,
   body,
   route,
   { apiVersion = 'v3', page = 1, limit = 10 }
@@ -71,14 +71,14 @@ function searchEntity(
     method: 'POST',
   }
 
-  return authorisedRequest(token, options).then((result) => {
+  return authorisedRequest(req, options).then((result) => {
     result.page = page
     return result
   })
 }
 
 function searchCompanies({
-  token,
+  req,
   searchTerm,
   isUkBased,
   page = 1,
@@ -86,7 +86,7 @@ function searchCompanies({
   requestBody = {},
 }) {
   return searchEntity(
-    token,
+    req,
     {
       ...requestBody,
       original_query: searchTerm,
@@ -99,14 +99,14 @@ function searchCompanies({
 }
 
 function searchInvestments({
-  token,
+  req,
   searchTerm,
   page = 1,
   limit = 10,
   filters = {},
 }) {
   return searchEntity(
-    token,
+    req,
     {
       ...filters,
       original_query: searchTerm,
@@ -117,9 +117,9 @@ function searchInvestments({
   )
 }
 
-function searchForeignCompanies({ token, searchTerm, page = 1, limit = 10 }) {
+function searchForeignCompanies({ req, searchTerm, page = 1, limit = 10 }) {
   return searchCompanies({
-    token,
+    req,
     searchTerm,
     page,
     limit,
@@ -127,7 +127,7 @@ function searchForeignCompanies({ token, searchTerm, page = 1, limit = 10 }) {
   })
 }
 
-function exportSearch({ token, searchTerm = '', searchEntity, requestBody }) {
+function exportSearch({ req, searchTerm = '', searchEntity, requestBody }) {
   const apiVersion = searchEntity === 'company' ? 'v4' : 'v3'
   const searchUrl = `${config.apiRoot}/${apiVersion}/search`
   const options = {
@@ -139,11 +139,11 @@ function exportSearch({ token, searchTerm = '', searchEntity, requestBody }) {
     },
   }
 
-  return authorisedRawRequest(token, options)
+  return authorisedRawRequest(req, options)
 }
 
 function searchAutocomplete({
-  token,
+  req,
   searchEntity,
   searchTerm = '',
   requestBody = {},
@@ -155,19 +155,19 @@ function searchAutocomplete({
 
   const options = buildOptions(true, searchUrl, body)
 
-  return authorisedRequest(token, options).then((result) => {
+  return authorisedRequest(req, options).then((result) => {
     return result
   })
 }
 
-function searchDnbCompanies({ token, requestBody = {} }) {
+function searchDnbCompanies({ req, requestBody = {} }) {
   const url = `${config.apiRoot}/v4/dnb/company-search`
   const options = buildOptions(false, url, {
     ...requestBody,
     page_size: 100,
   })
 
-  return authorisedRequest(token, options)
+  return authorisedRequest(req, options)
 }
 
 module.exports = {


### PR DESCRIPTION
## Description of change

Zipkin headers will now be forwarded when making API calls with `authorisedRequest()` to allow correlation tracing.

Corresponding API PR:
https://github.com/uktrade/data-hub-api/pull/2969