### PR TITLE
Add retry capability to cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -13,5 +13,6 @@
     "codeCoverage": {
       "url": "http://localhost:3000/__coverage__"
     }
-  }
+  },
+  "retries": 3
 }

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -165,12 +165,8 @@ describe('Company Collections Filter', () => {
 
   it('should filter by UK postcode', () => {
     const POSTCODE = 'GL11'
-    cy.contains('UK postcode')
-      .closest('.c-form-group')
-      .within(() => {
-        cy.contains('Search multiple postcodes separated by a comma')
-        cy.get('input').type(POSTCODE).type('{enter}')
-      })
+    cy.get(selectors.filter.ukPostcode).should('be.visible')
+    cy.get(selectors.filter.ukPostcode).clear().type(POSTCODE).type('{enter}')
 
     cy.wait('@filterResults').then((xhr) => {
       expect(xhr.url).to.contain(`uk_postcode=${POSTCODE}`)

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -278,13 +278,16 @@ describe('My pipeline app', () => {
         .parent()
         .find('input')
         .then((element) => {
+          cy.get(element).should('be.visible')
           cy.wrap(element).check()
           cy.wrap(element).should('be.checked')
+          cy.wait('@pipelineGet').then((xhr) => {
+            expect(xhr.url).to.contain('archived')
+          })
           cy.wrap(element).uncheck()
           cy.wrap(element).should('not.be.checked')
-          cy.wait(['@pipelineGet', '@pipelineGet']).then((xhr) => {
-            expect(xhr[0].url).to.contain('archived')
-            expect(xhr[1].url).to.not.contain('archived')
+          cy.wait('@pipelineGet').then((xhr) => {
+            expect(xhr.url).to.not.contain('archived')
           })
         })
     })
@@ -337,6 +340,7 @@ describe('My pipeline app', () => {
       cy.server()
       cy.visit(urls.pipeline.index())
       cy.route('GET', '/api-proxy/v4/pipeline-item*').as('pipelineGet')
+      cy.wait('@pipelineGet')
     })
 
     it('should sort by most recently created by default', () => {
@@ -374,12 +378,11 @@ describe('My pipeline app', () => {
           .parent()
           .find('select')
           .then((element) => {
-            cy.wait('@pipelineGet').then(() => {
-              cy.wrap(element).select('Project Name A-Z')
-              cy.wait('@pipelineGet').then((xhr) => {
-                expect(xhr.url).to.contain(`sortby=name`)
-                expect(xhr.url).to.contain('archived=false')
-              })
+            cy.wrap(element).select('Project Name A-Z')
+            cy.get(element).should('contain', 'Project Name A-Z')
+            cy.wait('@pipelineGet').then((xhr) => {
+              expect(xhr.url).to.contain(`sortby=name`)
+              expect(xhr.url).to.contain('archived=false')
             })
           })
       })
@@ -389,12 +392,11 @@ describe('My pipeline app', () => {
           .parent()
           .find('select')
           .then((element) => {
-            cy.wait('@pipelineGet').then(() => {
-              cy.wrap(element).select('Most recently updated')
-              cy.wait('@pipelineGet').then((xhr) => {
-                expect(xhr.url).to.contain(`sortby=-modified_on`)
-                expect(xhr.url).to.contain('archived=false')
-              })
+            cy.wrap(element).select('Most recently updated')
+            cy.wrap(element).should('contain', 'Most recently updated')
+            cy.wait('@pipelineGet').then((xhr) => {
+              expect(xhr.url).to.contain(`sortby=-modified_on`)
+              expect(xhr.url).to.contain('archived=false')
             })
           })
       })
@@ -405,12 +407,11 @@ describe('My pipeline app', () => {
           .find('select')
           .then((element) => {
             cy.wrap(element).select('Most recently updated')
-            cy.wait(['@pipelineGet', '@pipelineGet']).then(() => {
-              cy.wrap(element).select('Most recently created')
-              cy.wait('@pipelineGet').then((xhr) => {
-                expect(xhr.url).to.contain(`sortby=-created_on`)
-                expect(xhr.url).to.contain('archived=false')
-              })
+            cy.wait('@pipelineGet')
+            cy.wrap(element).select('Most recently created')
+            cy.wait('@pipelineGet').then((xhr) => {
+              expect(xhr.url).to.contain(`sortby=-created_on`)
+              expect(xhr.url).to.contain('archived=false')
             })
           })
       })
@@ -425,6 +426,7 @@ describe('My pipeline app', () => {
             cy.wrap(element).check()
             cy.wrap(element).should('be.checked')
           })
+        cy.wait('@pipelineGet')
       })
 
       it('should add sortby=name query string', () => {
@@ -432,12 +434,10 @@ describe('My pipeline app', () => {
           .parent()
           .find('select')
           .then((element) => {
-            cy.wait(['@pipelineGet', '@pipelineGet']).then(() => {
-              cy.wrap(element).select('Project Name A-Z')
-              cy.wait('@pipelineGet').then((xhr) => {
-                expect(xhr.url).to.contain(`sortby=name`)
-                expect(xhr.url).to.not.contain('archived')
-              })
+            cy.wrap(element).select('Project Name A-Z')
+            cy.wait('@pipelineGet').then((xhr) => {
+              expect(xhr.url).to.contain(`sortby=name`)
+              expect(xhr.url).to.not.contain('archived')
             })
           })
       })
@@ -447,12 +447,10 @@ describe('My pipeline app', () => {
           .parent()
           .find('select')
           .then((element) => {
-            cy.wait(['@pipelineGet', '@pipelineGet']).then(() => {
-              cy.wrap(element).select('Most recently updated')
-              cy.wait('@pipelineGet').then((xhr) => {
-                expect(xhr.url).to.contain(`sortby=-modified_on`)
-                expect(xhr.url).to.not.contain('archived')
-              })
+            cy.wrap(element).select('Most recently updated')
+            cy.wait('@pipelineGet').then((xhr) => {
+              expect(xhr.url).to.contain(`sortby=-modified_on`)
+              expect(xhr.url).to.not.contain('archived')
             })
           })
       })
@@ -463,15 +461,12 @@ describe('My pipeline app', () => {
           .find('select')
           .then((element) => {
             cy.wrap(element).select('Most recently updated')
-            cy.wait(['@pipelineGet', '@pipelineGet', '@pipelineGet']).then(
-              () => {
-                cy.wrap(element).select('Most recently created')
-                cy.wait('@pipelineGet').then((xhr) => {
-                  expect(xhr.url).to.contain(`sortby=-created_on`)
-                  expect(xhr.url).to.not.contain('archived')
-                })
-              }
-            )
+            cy.wait('@pipelineGet')
+            cy.wrap(element).select('Most recently created')
+            cy.wait('@pipelineGet').then((xhr) => {
+              expect(xhr.url).to.contain(`sortby=-created_on`)
+              expect(xhr.url).to.not.contain('archived')
+            })
           })
       })
     })
@@ -488,8 +483,9 @@ describe('My pipeline app', () => {
         .parent()
         .find('select')
         .then((element) => {
+          cy.wrap(element).should('be.visible')
           cy.wrap(element).select('Most recently updated')
-          cy.wait(['@pipelineGet', '@pipelineGet']).then(() => {
+          cy.wait('@pipelineGet').then(() => {
             expectedOutcomeList.forEach((expectedData, index) => {
               assertPipelineItem(index, expectedData, {
                 ...leads,

--- a/test/selectors/filter.js
+++ b/test/selectors/filter.js
@@ -3,6 +3,7 @@ module.exports = {
   statusActive: '[for="field-archived-1"]',
   statusInactive: '[for="field-archived-2"]',
   ukRegion: '#group-field-uk_region',
+  ukPostcode: '#field-uk_postcode',
   country: '#group-field-country',
   sector: '#group-field-sector_descends',
   exportingTo: '#group-field-export_to_countries',


### PR DESCRIPTION
## Description of change

The intent of this PR is to add retry capability to cypress tests to reduce the flakyness of our test jobs

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
