### PR TITLE
Support elasticsearch 7 activity stream

### DIFF
--- a/src/apps/companies/apps/activity-feed/client/ActivityFeedApp.jsx
+++ b/src/apps/companies/apps/activity-feed/client/ActivityFeedApp.jsx
@@ -115,7 +115,7 @@ export default class ActivityFeedApp extends React.Component {
     const { total, hits } = data.hits
 
     return {
-      total,
+      total: total.value,
       activities: hits.map((hit) => hit._source),
     }
   }

--- a/test/sandbox/fixtures/v4/activity-feed/activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/activities.json
@@ -8,7 +8,10 @@
     "failed": 0
   },
   "hits": {
-    "total": 1,
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
     "max_score": null,
     "hits": [
       {


### PR DESCRIPTION
## Description of change

Activity Stream has been having issues with the ingestion of data there has been a bump in version of elastic search  to version 7. There is a small breaking change
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response

before
```json
  "hits": {
    "total": 1
},
```


now
```json
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
```

## Test instructions

Activity stream show display the correct amount of numbers

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/5575331/92378128-34b6aa80-f0fd-11ea-8b89-41a7f83c7511.png)


### After

![image](https://user-images.githubusercontent.com/5575331/92378941-81e74c00-f0fe-11ea-8d72-c9bec1452295.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
