### PR TITLE
Update aria-labels of duplicate links

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -49,6 +49,7 @@ const LOCAL_NAV = [
       'investment.view_all_investmentproject',
       'investment.view_associated_investmentproject',
     ],
+    ariaDescription: 'Company investments',
   },
   {
     path: 'exports',
@@ -59,6 +60,7 @@ const LOCAL_NAV = [
     path: 'orders',
     label: 'Orders',
     permissions: ['order.view_order'],
+    ariaDescription: 'Company orders',
   },
 ]
 

--- a/src/apps/investments/constants.js
+++ b/src/apps/investments/constants.js
@@ -28,6 +28,7 @@ const LOCAL_NAV = [
       'interaction.view_associated_investmentproject_interaction',
       'interaction.view_all_interaction',
     ],
+    ariaDescription: 'Investment interactions',
   },
   {
     path: 'propositions',

--- a/src/client/components/CompanyLists/Table.jsx
+++ b/src/client/components/CompanyLists/Table.jsx
@@ -180,6 +180,7 @@ const CompaniesTable = ({ companies }) => (
             <SecondaryButton
               as={StyledButtonLink}
               href={urls.companies.interactions.create(id)}
+              aria-label={`Add interaction with ${name}`}
             >
               Add interaction
             </SecondaryButton>

--- a/src/templates/_macros/common/local-nav.njk
+++ b/src/templates/_macros/common/local-nav.njk
@@ -9,7 +9,9 @@
   {% if props %}
     <nav class="{{ 'c-local-nav' | applyClassModifiers(props.modifier) }}" aria-label="local navigation">
       {% for item in props.items %}
-        <a class="{{ 'c-local-nav__link' | applyClassModifiers(props.modifier) }} {{ 'is-active' if item.isActive }}" href="{{item.url}}">{{ item.label }}</a>
+        <a class="{{ 'c-local-nav__link' | applyClassModifiers(props.modifier) }} {{ 'is-active' if item.isActive }}" href="{{item.url}}" 
+          {% if item.ariaDescription %} aria-label="{{ item.ariaDescription }}" {% endif %}
+        >{{ item.label }}</a>
       {% endfor %}
     </nav>
   {% endif %}

--- a/src/templates/_macros/common/tabbed-local-nav.njk
+++ b/src/templates/_macros/common/tabbed-local-nav.njk
@@ -11,7 +11,9 @@
         {% for item in props.items %}
           <li class="govuk-tabs__list-item govuk-tabs__list-item--full">
             <a class="govuk-tabs__tab {{ 'govuk-tabs__tab--selected' if item.isActive }}"
-               href="{{ item.url }}">
+              href="{{ item.url }}"
+              {% if item.ariaDescription %} aria-label="{{ item.ariaDescription }}" {% endif %}
+            >
               {{ item.label }}
             </a>
           </li>

--- a/src/templates/_macros/form/entity-search-form.njk
+++ b/src/templates/_macros/form/entity-search-form.njk
@@ -56,9 +56,9 @@
             {% set isCurrentPage = item.entity === props.entityType %}
             <li class="c-entity-search__aggregations-item {{ 'is-active' if isCurrentPage }}">
               {% if isCurrentPage %}
-                {{ item.text }}
+                <span aria-label="{{item.text}} search results">{{ item.text }}</span>
               {% else %}
-                <a class="c-entity-search__aggregations-link" href="{{ urls.search.type(item.path) }}?term={{ props.searchTerm }}">{{ item.text }}</a>
+                <a class="c-entity-search__aggregations-link" href="{{ urls.search.type(item.path) }}?term={{ props.searchTerm }}"  aria-label="{{item.text}} search results">{{ item.text }}</a>
               {% endif %}
               <span class="c-entity-search__aggregations-count">({{ item.count | formatNumber }})</span>
             </li>


### PR DESCRIPTION
## Description of change
As part of the accessibility audit changes, we needed to differentiate for screen readers any links that had the same label but pointed to different destinations, e.g. 'Orders' below:

<img width="598" alt="Screenshot 2020-09-22 at 13 57 09" src="https://user-images.githubusercontent.com/23265724/93885066-9f5e0d80-fcdb-11ea-844a-0bb754a9ead3.png">

After checking with our content designers, the following changes have been made:

1. **Company activity feed**: add an aria-label of 'Company orders' and 'Company investments' to the Order and Investment tabs
1. **Search results**: add aria-label of 'companies search results' / 'investment search results' etc. for the different search tabs
1. **Investment project > individual company page**: add aria-label of ‘Investment interactions’ to 'Investments' link in sidebar
1. **My companies view**: add aria-label of 'Add interaction with {COMPANY NAME}' to 'Add interaction' buttons


## Test instructions
The described pages should be available at:
1. [heroku deployment link] > Companies > click on the first company name
1. [heroku deployment link]/search/companies?term=Google 
1. [heroku deployment link] > Investments > click on the first investment listed
1. [heroku deployment link]/

The `aria-label`s should be visible in your browser inspector OR use [WAVE](https://wave.webaim.org/)/[Axe](https://www.deque.com/axe/) to confirm there are no duplicate links.


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
