### PR TITLE
Upgraded Winston, swapped Churchill for Morgan (HTTP loggers)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1599,6 +1599,16 @@
         }
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -8809,14 +8819,6 @@
         "dayjs": "^1.8.29"
       }
     },
-    "churchill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/churchill/-/churchill-1.2.0.tgz",
-      "integrity": "sha1-tDe4TnGmWWRpSG8Vpr3ZUayl4tk=",
-      "requires": {
-        "random-string": "^0.2.0"
-      }
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -9173,6 +9175,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -9186,6 +9197,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "colorette": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
@@ -9195,6 +9215,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combine-errors": {
       "version": "3.0.3",
@@ -11911,6 +11940,11 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -13676,6 +13710,11 @@
         "pend": "~1.2.0"
       }
     },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+    },
     "fibers": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.3.tgz",
@@ -14063,6 +14102,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "focus-lock": {
       "version": "0.7.0",
@@ -15320,6 +15364,31 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
           "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        },
+        "winston": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+          "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
+          "requires": {
+            "async": "~1.0.0",
+            "colors": "1.0.x",
+            "cycle": "1.0.x",
+            "eyes": "0.1.x",
+            "isstream": "0.1.x",
+            "stack-trace": "0.0.x"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+              "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+            }
+          }
         }
       }
     },
@@ -16034,6 +16103,14 @@
         "exec-buffer": "^3.0.0",
         "is-png": "^2.0.0",
         "optipng-bin": "^6.0.0"
+      },
+      "dependencies": {
+        "is-png": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-png/-/is-png-2.0.0.tgz",
+          "integrity": "sha512-4KPGizaVGj2LK7xwJIz8o5B2ubu1D/vcQsgOGFEDlpcvgZHto4gBnyd0ig7Ws+67ixmwKoNmu0hYnpo6AaKb5g==",
+          "optional": true
+        }
       }
     },
     "imagemin-pngquant": {
@@ -16080,6 +16157,12 @@
           "requires": {
             "pump": "^3.0.0"
           }
+        },
+        "is-png": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-png/-/is-png-2.0.0.tgz",
+          "integrity": "sha512-4KPGizaVGj2LK7xwJIz8o5B2ubu1D/vcQsgOGFEDlpcvgZHto4gBnyd0ig7Ws+67ixmwKoNmu0hYnpo6AaKb5g==",
+          "optional": true
         },
         "is-stream": {
           "version": "2.0.0",
@@ -16770,28 +16853,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
       "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g=="
     },
-    "is-png": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
-      "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84="
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
     "is-potential-custom-element-name": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-png/-/is-png-2.0.0.tgz",
-      "integrity": "sha512-4KPGizaVGj2LK7xwJIz8o5B2ubu1D/vcQsgOGFEDlpcvgZHto4gBnyd0ig7Ws+67ixmwKoNmu0hYnpo6AaKb5g==",
-      "optional": true
     },
     "is-promise": {
       "version": "2.2.2",
@@ -17671,6 +17737,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
         }
       }
     },
@@ -17836,6 +17908,11 @@
       "requires": {
         "seed-random": "~2.2.0"
       }
+    },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "labeled-stream-splicer": {
       "version": "2.0.2",
@@ -19274,6 +19351,18 @@
             "object-assign": "^4.1.0"
           }
         }
+      }
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
       }
     },
     "loglevel": {
@@ -20788,6 +20877,38 @@
       "resolved": "https://registry.npmjs.org/monitor-event-loop-delay/-/monitor-event-loop-delay-1.0.0.tgz",
       "integrity": "sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q=="
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -21762,6 +21883,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -23686,11 +23815,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/random-poly-fill/-/random-poly-fill-1.0.1.tgz",
       "integrity": "sha512-bMOL0hLfrNs52+EHtIPIXxn2PxYwXb0qjnKruTjXiM/sKfYqj506aB2plFwWW1HN+ri724bAVVGparh4AtlJKw=="
-    },
-    "random-string": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/random-string/-/random-string-0.2.0.tgz",
-      "integrity": "sha1-pG5DdTUr7amg17DRntbTIezR2C0="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -26396,6 +26520,21 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "simplebar": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
@@ -28172,6 +28311,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -28502,6 +28646,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
       "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "trough": {
       "version": "1.0.5",
@@ -29894,205 +30043,8 @@
         "resq": "^1.6.0",
         "rgb2hex": "^0.2.0",
         "serialize-error": "^7.0.0",
-        "webdriver": "6.1.17"
+        "webdriver": "6.1.25"
       }
-    },
-    "webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-      "dev": true
-    },
-    "webpack": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
-      "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
-      "requires": {
-        "acorn": "^5.0.0",
-        "acorn-dynamic-import": "^2.0.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "async": "^2.1.2",
-        "enhanced-resolve": "^3.4.0",
-        "escope": "^3.6.0",
-        "interpret": "^1.0.0",
-        "json-loader": "^0.5.4",
-        "json5": "^0.5.1",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^2.0.0",
-        "source-map": "^0.5.3",
-        "supports-color": "^4.2.1",
-        "tapable": "^0.2.7",
-        "uglifyjs-webpack-plugin": "^0.4.6",
-        "watchpack": "^1.4.0",
-        "webpack-sources": "^1.0.1",
-        "yargs": "^8.0.2"
-      },
-      "dependencies": {
-        "@sindresorhus/is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.0.0.tgz",
-          "integrity": "sha512-kqA5I6Yun7PBHk8WN9BBP1c7FfN2SrD05GuVSEYPqDb4nerv7HqYfgBfMIKmT/EuejURkJKLZuLyGKGs6WEG9w==",
-          "dev": true
-        },
-        "@wdio/protocols": {
-          "version": "6.1.25",
-          "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.1.25.tgz",
-          "integrity": "sha512-C84qqh5J6nE1zTjwF3svDUah3FvoUzMUGeRe8w//QPBcJIGNRgmVLgeFV7Cp2EwI5ag+BUfXExQ0bFtcZYHIVA==",
-          "dev": true
-        },
-        "cacheable-request": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-          "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-          "dev": true,
-          "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^4.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "decompress-response": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-          "dev": true,
-          "requires": {
-            "mimic-response": "^3.1.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "got": {
-          "version": "11.5.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.5.0.tgz",
-          "integrity": "sha512-vOZEcEaK0b6x11uniY0HcblZObKPRO75Jvz53VKuqGSaKCM/zEt0sj2LGYVdqDYJzO3wYdG+FPQQ1hsgoXy7vQ==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "^3.0.0",
-            "@szmarczak/http-timer": "^4.0.5",
-            "@types/cacheable-request": "^6.0.1",
-            "@types/responselike": "^1.0.0",
-            "cacheable-lookup": "^5.0.3",
-            "cacheable-request": "^7.0.1",
-            "decompress-response": "^6.0.0",
-            "http2-wrapper": "^1.0.0-beta.4.8",
-            "lowercase-keys": "^2.0.0",
-            "p-cancelable": "^2.0.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "http-cache-semantics": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-          "dev": true
-        },
-        "http2-wrapper": {
-          "version": "1.0.0-beta.5.2",
-          "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-          "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
-          "dev": true,
-          "requires": {
-            "quick-lru": "^5.1.1",
-            "resolve-alpn": "^1.0.0"
-          }
-        },
-        "json-buffer": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-          "dev": true
-        },
-        "keyv": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-          "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
-          "dev": true,
-          "requires": {
-            "json-buffer": "3.0.1"
-          }
-        },
-        "lodash.merge": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-          "dev": true
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
-        },
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "dev": true
-        },
-        "normalize-url": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-          "dev": true
-        },
-        "p-cancelable": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-          "dev": true
-        },
-        "quick-lru": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-          "dev": true
-        },
-        "responselike": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-          "dev": true,
-          "requires": {
-            "lowercase-keys": "^2.0.0"
-          }
-        },
-        "webdriver": {
-          "version": "6.1.25",
-          "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.1.25.tgz",
-          "integrity": "sha512-JXXcZ8VwRTDJLHpEcWt7uy4524T21zxseumihwMcCNiDUmbsSDaxZ0iKA2j4m9NbCzu7dqJJs8/ma7qc+mhxUQ==",
-          "dev": true,
-          "requires": {
-            "@wdio/config": "6.1.14",
-            "@wdio/logger": "6.0.16",
-            "@wdio/protocols": "6.1.25",
-            "@wdio/utils": "6.1.17",
-            "got": "^11.0.2",
-            "lodash.merge": "^4.6.1"
-          }
-        }
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
     },
     "webpack": {
       "version": "4.44.1",
@@ -30507,28 +30459,50 @@
       }
     },
     "winston": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
-      "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
       "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
       },
       "dependencies": {
         "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
         },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@govuk-react/constants": "^0.7.1",
     "@hapi/hawk": "^8.0.0",
     "@hapi/joi": "^17.1.1",
-    "constate": "^2.0.0",
     "@sentry/browser": "^5.15.5",
     "@storybook/addon-actions": "^6.0.21",
     "@storybook/addon-knobs": "^5.3.18",
@@ -78,12 +77,12 @@
     "bodybuilder": "^2.2.21",
     "case": "^1.5.5",
     "chrono-node": "^2.1.8",
-    "churchill": "^1.2.0",
     "classlist.js": "^1.1.20150312",
     "compression": "^1.7.1",
     "connect-flash": "0.1.1",
     "connect-redis": "^5.0.0",
     "connected-react-router": "^6.8.0",
+    "constate": "^2.0.0",
     "cookie-parser": "^1.4.5",
     "core-js": "^2.5.7",
     "css-loader": "^4.3.0",
@@ -118,6 +117,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "moment": "^2.22.1",
     "moment-duration-format": "^2.1.0",
+    "morgan": "^1.10.0",
     "numeral": "^2.0.6",
     "nunjucks": "^3.2.2",
     "nunjucks-markdown": "^2.0.1",
@@ -157,7 +157,7 @@
     "webpack": "^4.44.1",
     "webpack-assets-manifest": "^3.1.1",
     "webpack-cli": "^3.3.12",
-    "winston": "^2.4.2"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.8.1",

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -89,10 +89,8 @@ const envSchema = Joi.object({
 
   // How much logging to output
   LOG_LEVEL: Joi.string()
-    .valid('emerg', 'alert', 'crit', 'error', 'warning', 'notice', 'info', 'debug')
+    .valid('error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly')
     .default('error'),
-  LOG_REQUESTS: Joi.bool(),
-  LOG_RESPONSES: Joi.bool(),
 
   // How long to store dropdown data etc for, in seconds. Defaults to 15 minutes
   METADATA_TTL: Joi.number().integer().default(15 * 60),

--- a/src/config/httpLogger.js
+++ b/src/config/httpLogger.js
@@ -1,0 +1,22 @@
+const morgan = require('morgan')
+
+const logger = require('./logger')
+const config = require('.')
+
+const format = config.isDev ? 'dev' : 'combined'
+
+const options = () => {
+  let isError
+  return {
+    skip: (req, res) => {
+      isError = res.statusCode >= 400
+      return false
+    },
+    stream: {
+      write: (msg) =>
+        isError ? logger.error(msg.trim()) : logger.http(msg.trim()),
+    },
+  }
+}
+
+module.exports = morgan(format, options())

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -71,8 +71,6 @@ const config = {
     ttl: envVars.SESSION_TTL,
   },
   logLevel: envVars.LOG_LEVEL,
-  logResponses: envVars.LOG_RESPONSES,
-  logRequests: envVars.LOG_REQUESTS,
   zen: {
     ticketsURL: envVars.ZEN_TICKETS_URL,
     token: envVars.ZEN_TOKEN,

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -1,36 +1,31 @@
 const winston = require('winston')
 
+const { createLogger, transports, format } = winston
+
 const config = require('./')
 
-const loggingTransports = []
-const exceptionTransports = []
-
-loggingTransports.push(
-  new winston.transports.Console({
-    level: config.logLevel,
-    json: false,
-    colorize: true,
-    handleExceptions: true,
-    humanReadableUnhandledException: true,
-  })
-)
+const logger = createLogger({
+  level: config.logLevel,
+  exitOnError: true,
+  transports: [
+    new transports.Console({
+      handleExceptions: true,
+      humanReadableUnhandledException: true,
+      format: format.combine(
+        format.colorize({ all: true }),
+        winston.format.splat(),
+        format.simple()
+      ),
+    }),
+  ],
+})
 
 if (config.isProd) {
-  exceptionTransports.push(
-    new winston.transports.Console({
-      json: true,
-      timestamp: true,
-      colorize: false,
-      stringify: true,
+  logger.exceptions.handle(
+    new transports.Console({
+      format: format.combine(format.timestamp(), format.json()),
     })
   )
 }
-
-const logger = new winston.Logger({
-  transports: loggingTransports,
-  exceptionHandlers: exceptionTransports,
-  exitOnError: true,
-})
-logger.cli()
 
 module.exports = logger

--- a/src/lib/authorised-request.js
+++ b/src/lib/authorised-request.js
@@ -5,16 +5,6 @@ const requestPromise = require('request-promise')
 const config = require('../config')
 const logger = require('../config/logger')
 
-const { logResponses: LOG_RESPONSE, logRequests: LOG_REQUEST } = config
-
-if (LOG_RESPONSE) {
-  logger.info('Logging responses from requests')
-}
-
-if (LOG_REQUEST) {
-  logger.info('Logging request options')
-}
-
 function hasValue(value) {
   return !isNil(value)
 }
@@ -66,32 +56,18 @@ function createResponseLogger(requestOpts) {
   return (data) => {
     const statusCode = (data && data.statusCode) || ''
     const responseInfo = `Response ${statusCode} for ${requestOpts.method} to ${requestOpts.url}:`
-    try {
-      logger.debug(responseInfo, JSON.stringify(data, null, 2))
-    } catch (e) {
-      logger.debug(responseInfo, data)
-    }
+    logger.debug(responseInfo, data)
     return data
   }
 }
 
 function logRequest(opts) {
   logger.debug(`Sending ${opts.method} to ${opts.url}`)
-
-  if (LOG_REQUEST) {
-    logger.debug(
-      'with request data:',
-      JSON.stringify(
-        {
-          headers: opts.headers,
-          body: opts.body,
-          qs: opts.qs,
-        },
-        null,
-        2
-      )
-    )
-  }
+  logger.debug('with request data:', {
+    headers: opts.headers,
+    body: opts.body,
+    qs: opts.qs,
+  })
 }
 
 // Accepts options as keys on an object or encoded as a url
@@ -105,15 +81,11 @@ function authorisedRequest(token, opts) {
 
   const r = requestPromise(requestOptions)
 
-  if (LOG_RESPONSE) {
-    const logResponse = createResponseLogger(requestOptions)
-    return r.then(logResponse, (err) => {
-      logResponse(err)
-      throw err
-    })
-  }
-
-  return r
+  const logResponse = createResponseLogger(requestOptions)
+  return r.then(logResponse, (err) => {
+    logResponse(err)
+    throw err
+  })
 }
 
 // Accepts options as keys on an object or encoded as a url

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -137,7 +137,7 @@ module.exports.fetchAll = (cb) => {
   function checkResults() {
     completeRequests += 1
     if (completeRequests === totalRequests) {
-      logger.debug('All metadataRepository requests complete')
+      logger.info('All metadataRepository requests complete')
       cb(caughtErrors)
     }
   }

--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -48,7 +48,7 @@ module.exports = {
     } else {
       logger.warn(msg)
       if (extra) {
-        logger.warn(JSON.stringify(extra))
+        logger.warn(extra)
       }
     }
   },
@@ -59,7 +59,7 @@ module.exports = {
     } else {
       logger.error(err.stack)
       if (extra) {
-        logger.error(JSON.stringify(extra))
+        logger.error(extra)
       }
     }
   },

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -8,7 +8,7 @@ module.exports = function headers(req, res, next) {
     req.url.indexOf('/javascripts') === -1 &&
     req.url.indexOf('/images') === -1
   ) {
-    logger.debug('Headers middleware -> Adding response headers')
+    logger.http('Headers middleware -> Adding response headers')
 
     res.set('Cache-Control', 'no-cache, no-store, must-revalidate, private')
     res.set('Pragma', 'no-cache')


### PR DESCRIPTION
## Description of change
- Upgraded Winston (logger) from 2.4.2 to 3.3.3 (breaking change).
- Removed Churchill (HTTP logger) as it's incompatible with the latest version of Winston. In addition, Churchill has not released anything in the last three years which is holding us back and needs to go.
- Introduced Morgan v3.3.3 (the latest and greatest) which suits our needs, is compatible with Winston and very popular.
- Leveraging NPM log levels (a Winston default) including the new `http` log level to log our HTTP traffic
- To view all log levels refer to `envSchema.js` they are also defined below.
- Removed both env vars `LOG_REQUESTS ` and `LOG_RESPONSES` which are superfluous. I'll remove both of these in Vault once approved.  You can view the HTTP request and response by setting the log level to `debug`. To view all HTTP traffic (without the request and response) set the log level to `http`. Initially I logged all HTTP traffic at the `http` log level (within `authorised-request.js`) but the output was too chatty. Obviously, you can change the log level to `info` but then you don't get any logs. To me, it makes sense to view the finer details of a HTTP call when the log level is set to `debug`.
Happy to listen to others on this, however, having both log levels and env vars feels like we're over complicating things.

If we're debugging an issue `LOG_LEVEL=debug` that's unrelated to HTTP traffic it could be argued that the output is too 
verbose and will make it harder to debug. If we find this is the case we should change how we log in `authorised-request.js`  
from `debug` to `silly`.

Our log levels are:

```
{ 
  error: 0, 
  warn: 1, 
  info: 2, 
  http: 3,   // new in Winston v3
  verbose: 4, 
  debug: 5, 
  silly: 6 
}
```

You can set the log level in your `.env`
`LOG_LEVEL=error` will only show `error` logs
`LOG_LEVEL=warn` will only show `warn` and `error`
`LOG_LEVEL=info` will only show `info`, `warn` and `error` and so on.

The recommended log level for development is `http`
`LOG_LEVEL=http`

**Typical output**
<img width="1176" alt="Screenshot 2020-09-08 at 16 53 54" src="https://user-images.githubusercontent.com/964268/92499589-f5b75080-f1f3-11ea-8d4c-2fa1e5391504.png">


[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
