### PR TITLE
Update date-fns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1508,6 +1508,12 @@
             "restore-cursor": "^1.0.1"
           }
         },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -10739,9 +10745,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
     },
     "dayjs": {
       "version": "1.8.35",
@@ -18393,6 +18399,12 @@
           "requires": {
             "restore-cursor": "^2.0.0"
           }
+        },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
         },
         "figures": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "css-loader": "^3.6.0",
     "csurf": "^1.9.0",
     "data-hub-components": "5.10.2",
-    "date-fns": "^1.29.0",
+    "date-fns": "^2.16.0",
     "del-cli": "^3.0.0",
     "details-element-polyfill": "^2.4.0",
     "dotenv": "^8.2.0",

--- a/src/apps/audit/transformers.js
+++ b/src/apps/audit/transformers.js
@@ -25,10 +25,12 @@ function transformAuditLogToListItem(labels = {}) {
   return function transformAuditLogItem(logEntry) {
     const changeCount =
       (logEntry.changes && Object.keys(logEntry.changes).length) || 0
-
     return {
       type: 'audit',
-      name: dateFns.format(logEntry.timestamp, DATE_TIME_MEDIUM_FORMAT),
+      name: dateFns
+        .format(dateFns.parseISO(logEntry.timestamp), DATE_TIME_MEDIUM_FORMAT)
+        .replace('AM', 'am')
+        .replace('PM', 'pm'),
       contentMetaModifier: 'stacked',
       meta: [
         {

--- a/src/apps/companies/apps/dnb-hierarchy/transformers.js
+++ b/src/apps/companies/apps/dnb-hierarchy/transformers.js
@@ -73,7 +73,9 @@ function transformCompanyToDnbHierarchyList({
   return {
     headingText: name,
     headingUrl: urls.companies.detail(id),
-    subheading: `Updated on ${formatDateTime(modified_on)}`,
+    subheading: `Updated on ${formatDateTime(modified_on)}`
+      .replace('AM', 'am')
+      .replace('PM', 'pm'),
     metadata,
     badges,
   }

--- a/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/transformers/transform-profile.js
@@ -11,7 +11,7 @@ const getRequiredChecksDetails = (type, date, adviser) => {
     type.name === requiredChecks.ISSUES_IDENTIFIED
   ) {
     details.push(
-      `Date of most recent background checks: ${formatDate(date, 'DD MM YYYY')}`
+      `Date of most recent background checks: ${formatDate(date, 'dd MM yyyy')}`
     )
     details.push(
       `Person responsible for most recent background checks: ${adviser.name}`

--- a/src/apps/investments/middleware/__test__/shared.test.js
+++ b/src/apps/investments/middleware/__test__/shared.test.js
@@ -1,9 +1,7 @@
 const { merge, cloneDeep } = require('lodash')
-const format = require('date-fns/format')
 const proxyquire = require('proxyquire')
 
 const paths = require('../../paths')
-const { DATE_TIME_MEDIUM_FORMAT } = require('../../../../common/constants')
 const investmentData = require('../../../../../test/unit/data/investment/investment-data.json')
 const investmentProjectStages = require('../../../../../test/unit/data/investment/investment-project-stages.json')
 
@@ -162,7 +160,7 @@ describe('Investment shared middleware', () => {
             },
             {
               label: 'Created on',
-              value: format(null, DATE_TIME_MEDIUM_FORMAT),
+              value: '14 Jun 2017, 2:52pm',
             },
           ],
           nextStage: {

--- a/src/apps/investments/middleware/shared.js
+++ b/src/apps/investments/middleware/shared.js
@@ -1,5 +1,5 @@
 const { get, upperFirst, camelCase } = require('lodash')
-const format = require('date-fns/format')
+const { format, parseISO } = require('date-fns')
 
 const metadata = require('../../../lib/metadata')
 const {
@@ -119,7 +119,12 @@ async function getInvestmentDetails(req, res, next) {
         },
         {
           label: 'Created on',
-          value: format(investment.created_on, DATE_TIME_MEDIUM_FORMAT),
+          value: format(
+            parseISO(investment.created_on),
+            DATE_TIME_MEDIUM_FORMAT
+          )
+            .replace('AM', 'am')
+            .replace('PM', 'pm'),
         },
       ],
       company: {

--- a/src/apps/omis/controllers/edit.js
+++ b/src/apps/omis/controllers/edit.js
@@ -77,7 +77,7 @@ class EditController extends FormController {
           return flatten([newValue])
         }
 
-        const parsedDate = dateFns.parse(newValue)
+        const parsedDate = dateFns.parseISO(newValue)
         if (
           dateFields.includes(key) &&
           newValue &&

--- a/src/apps/propositions/transformers.js
+++ b/src/apps/propositions/transformers.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 const { assign, capitalize, forEach, get, mapKeys, pickBy } = require('lodash')
-const { format, isValid } = require('date-fns')
+const { format, isValid, parseISO } = require('date-fns')
 
 const { transformDateObjectToDateString } = require('../transformers')
 const {
@@ -28,9 +28,9 @@ function transformPropositionResponseToForm({
     scope,
     adviser: get(adviser, 'id'),
     deadline: {
-      day: isValidDate ? format(deadline, 'DD') : '',
-      month: isValidDate ? format(deadline, 'MM') : '',
-      year: isValidDate ? format(deadline, 'YYYY') : '',
+      day: isValidDate ? format(parseISO(deadline), 'dd') : '',
+      month: isValidDate ? format(parseISO(deadline), 'MM') : '',
+      year: isValidDate ? format(parseISO(deadline), 'yyyy') : '',
     },
     investment_project: get(investment_project, 'id'),
   }

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 const { filter, keyBy, snakeCase, upperFirst } = require('lodash')
-const { isValid, format, parse } = require('date-fns')
+const { isValid, format, parseISO } = require('date-fns')
 
 const { hqLabels } = require('./companies/labels')
 
@@ -82,12 +82,12 @@ function transformDateObjectToDateString(key) {
 }
 
 function transformDateStringToDateObject(dateString) {
-  const isValidDate = dateString && isValid(parse(dateString))
+  const isValidDate = dateString && isValid(parseISO(dateString))
 
   return {
-    year: isValidDate ? format(dateString, 'YYYY') : '',
-    month: isValidDate ? format(dateString, 'MM') : '',
-    day: isValidDate ? format(dateString, 'DD') : '',
+    year: isValidDate ? format(parseISO(dateString), 'yyyy') : '',
+    month: isValidDate ? format(parseISO(dateString), 'MM') : '',
+    day: isValidDate ? format(parseISO(dateString), 'dd') : '',
   }
 }
 

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -4,9 +4,9 @@ const EXCHANGE_RATE_GBP_TO_USD = parseFloat(
   Number(1 / EXCHANGE_RATE_USD_TO_GBP).toFixed(4)
 )
 
-const DATE_LONG_FORMAT = 'D MMMM YYYY'
-const DATE_MEDIUM_FORMAT = 'D MMM YYYY'
-const DATE_TIME_MEDIUM_FORMAT = 'D MMM YYYY, h:mma'
+const DATE_LONG_FORMAT = 'd MMMM yyyy'
+const DATE_MEDIUM_FORMAT = 'd mmm yyyy'
+const DATE_TIME_MEDIUM_FORMAT = 'd MMM yyyy, h:mma'
 
 module.exports = {
   EXCHANGE_RATE_USD_TO_GBP,

--- a/src/config/nunjucks/__test__/filters.test.js
+++ b/src/config/nunjucks/__test__/filters.test.js
@@ -310,7 +310,7 @@ describe('nunjucks filters', () => {
 
       context('when a format is specified', () => {
         it('should return date in that format', () => {
-          const formattedDate = filters.formatDate('1/5/2010', 'DD/MM/YY')
+          const formattedDate = filters.formatDate('1/5/2010', 'dd/MM/yy')
 
           expect(formattedDate).to.equal('05/01/10')
         })
@@ -340,7 +340,7 @@ describe('nunjucks filters', () => {
         it('should return datetime in that format', () => {
           const formattedDate = filters.formatDateTime(
             '2017-08-16T14:18:28',
-            'DD/MM/YY HH:mm'
+            'dd/MM/yy HH:mm'
           )
 
           expect(formattedDate).to.equal('16/08/17 14:18')

--- a/src/config/nunjucks/filters.js
+++ b/src/config/nunjucks/filters.js
@@ -193,7 +193,10 @@ const filters = {
     if (!value) {
       return value
     }
-    const parsedDate = dateFns.parse(value)
+
+    const parsedDate = value.includes('-')
+      ? dateFns.parse(value, 'yyyy-MM-dd', new Date())
+      : dateFns.parse(value, 'MM/dd/yyyy', new Date())
 
     if (!dateFns.isValid(parsedDate)) {
       return value
@@ -206,13 +209,16 @@ const filters = {
       return value
     }
 
-    const parsedDate = dateFns.parse(value)
+    const parsedDate = dateFns.toDate(dateFns.parseISO(value))
 
     if (!dateFns.isValid(parsedDate)) {
       return value
     }
 
-    return dateFns.format(parsedDate, format)
+    return dateFns
+      .format(parsedDate, format)
+      .replace('AM', 'am')
+      .replace('PM', 'pm')
   },
 
   formatAddress: (address, join = ', ') => {

--- a/src/templates/_macros/common/from-now.njk
+++ b/src/templates/_macros/common/from-now.njk
@@ -7,7 +7,7 @@
 {% macro FromNow(props) %}
   {%- if props.datetime -%}
     <time
-      datetime="{{ props.datetime | formatDateTime('YYYY-MM-DDTHH:mm:ssZ') }}"
+      datetime="{{ props.datetime | formatDateTime('yyyy-MM-ddTHH:mm:ssZ') }}"
       title="{{ props.datetime | formatDateTime }}"
     >{{ props.datetime | fromNow }}</time>
   {%- endif -%}

--- a/test/unit/data/investment/investment-data.json
+++ b/test/unit/data/investment/investment-data.json
@@ -108,7 +108,7 @@
   "archived_on": null,
   "archived_reason": null,
   "archived_by": null,
-  "created_on": null,
+  "created_on": "2017-06-14T14:52:46.618779",
   "modified_on": "2017-06-14T14:52:46.618779",
   "total_investment": "100000",
   "foreign_equity_investment": "50000",


### PR DESCRIPTION
## Description of change
Before `v2` date-fns` used to apply more magic and accept dates as string such as "1/1/2020" or "1-1-2020" or timestamps and convert them to your desired format. After v2 they tightened up the rules on what you should pass to it for good reasons, ideally the only thing that should get passed to "date-fns" is a date object but throughout Data Hub this is not the case and to add to further confusion we have inconsistent date strings being passed to "date-fns".

This PR basically offers a patch over a bigger issue which is that we are passing various formatted human readable date strings at a level we shouldn't be. We should only offer "date-fns" a date object and that should come from the backend the formatting should only be done at the view layer. 

We have three options:

1. Accept this PR and address the bigger problem at a later date
2. Don't update `date-fns`
3. Ignore this and work on the bigger issue

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
