### PR TITLE
changed date last updated filter

### DIFF
--- a/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
+++ b/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
@@ -54,10 +54,14 @@ const CompanyBusinessDetails = ({
   const isDnbCompany = !!businessDetails.duns_number
   const isArchived = !!businessDetails.archived
   const isBasedInUK = !!businessDetails.uk_based
-  const lastUpdated =
-    businessDetails.dnb_modified_on ||
-    businessDetails.modified_on ||
-    businessDetails.created_on
+  const lastUpdated = [
+    businessDetails.dnb_modified_on,
+    businessDetails.modified_on,
+    businessDetails.created_on,
+  ]
+    .filter(Boolean)
+    .sort()
+    .reverse()[0]
 
   return (
     <StyledRoot>

--- a/test/sandbox/fixtures/v4/company/company-one-list-corp.json
+++ b/test/sandbox/fixtures/v4/company/company-one-list-corp.json
@@ -9,6 +9,7 @@
   "duns_number": "123456789",
   "created_on": "2015-10-26T11:00:00Z",
   "modified_on": "2017-11-26T11:00:00Z",
+  "dnb_modified_on": "2017-11-25T11:00:00Z",
   "archived": false,
   "archived_documents_url_path": "",
   "archived_on": null,


### PR DESCRIPTION
## Description of change

_Last updated on_ value under company business details was confusing users because it was not displaying company's actual last updated value if last dnb change request update existed and was older than actual company date update.

[Here](https://www.datahub.trade.gov.uk/companies/f330bac2-4063-4eda-91f9-873d1d701fd2/business-details) is an example

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
