### PR TITLE
Added check for submitted status

### DIFF
--- a/src/apps/companies/apps/business-details/client/tasks.js
+++ b/src/apps/companies/apps/business-details/client/tasks.js
@@ -5,7 +5,7 @@ export function checkIfPendingRequest(duns_number) {
   if (duns_number) {
     return axios
       .get(
-        `/api-proxy/v4/dnb/company-change-request?duns_number=${duns_number}&status=pending`
+        `/api-proxy/v4/dnb/company-change-request?duns_number=${duns_number}`
       )
       .then(({ data }) => checkIfRequestIsValid(data))
   }
@@ -17,7 +17,7 @@ const checkIfRequestIsValid = ({ count, results }) => {
     const timeInterval = moment().subtract(20, 'days')
     const validRequests = results.filter(
       (result) =>
-        result.status === 'pending' &&
+        ['pending', 'submitted'].includes(result.status) &&
         moment(result.created_on).isAfter(timeInterval)
     )
     return validRequests.length > 0


### PR DESCRIPTION
## Description of change
Change request banner was supposed to be displayed until dnb change request was resolved or up to 20 days. Function was currently only checking change requests in `pending` status which were around for at most a day and once change request was submitted to DnB, status was changed to `submitted` and app was not displaying change request banner anymore.

This should not be merged before changes in API are deployed.

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
