### PR TITLE
Cypress commands for the testfixtureapi.

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -38,6 +38,7 @@ services:
       ES_APM_ENABLED: 'False'
       COLUMNS: 80
       DJANGO_SUPERUSER_SSO_EMAIL_USER_ID: test@gov.uk
+      ALLOW_TEST_FIXTURE_SETUP: 'True'
     ports:
       - 8000:8000
     depends_on:

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -178,6 +178,26 @@ Cypress.Commands.add('resetFeatureFlags', () => {
   return cy.request('POST', `${backend_url}${uri}`)
 })
 
+Cypress.Commands.add('reseed', () => {
+  backend_url = Cypress.env('sandbox_url')
+  uri = '/testfixtureapi/reset-fixtures/'
+  return cy.request('POST', `${backend_url}${uri}`)
+})
+
+Cypress.Commands.add('createUser', (userData) => {
+  backend_url = Cypress.env('sandbox_url')
+  uri = '/testfixtureapi/create-user/'
+  return cy.request('POST', `${backend_url}${uri}`, userData)
+})
+
+Cypress.Commands.add('loadFixture', (fixture) => {
+  backend_url = Cypress.env('sandbox_url')
+  uri = '/testfixtureapi/load-fixture/'
+  return cy.request('POST', `${backend_url}${uri}`, {
+    fixture: fixture,
+  })
+})
+
 // This command helps us to check colours in cypress as cypress always return rgb, and our govuk-colours library uses hexes.
 const compareColor = (color, property) => (targetElement) => {
   const tempElement = document.createElement('div')

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -36,6 +36,38 @@ describe('Advisors', () => {
 })
 
 describe('Contacts', () => {
+  const company = {
+    pk: '1233379c-341c-4da4-b825-bf8d47b26baa',
+    model: 'company.company',
+    fields: {
+      name: '1 2 3 testing',
+      business_type: '98d14e94-5d95-e211-a939-e4115bead28a',
+      employee_range: '41afd8d0-5d95-e211-a939-e4115bead28a',
+      turnover_range: '7a4cd12a-6095-e211-a939-e4115bead28a',
+      export_to_countries: [
+        '82756b9a-5d95-e211-a939-e4115bead28a',
+        '83756b9a-5d95-e211-a939-e4115bead28a',
+      ],
+      future_interest_countries: ['37afd8d0-5d95-e211-a939-e4115bead28a'],
+      sector: '355f977b-8ac3-e211-a646-e4115bead28a',
+      address_1: '100 Path',
+      address_town: 'A town',
+      address_postcode: '12345',
+      address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
+      registered_address_1: '100 Path',
+      registered_address_town: 'A town',
+      registered_address_postcode: '12345',
+      registered_address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
+      description: 'This is a dummy company for testing',
+      created_on: '2017-10-16T11:00:00Z',
+      modified_on: '2017-11-16T11:00:00Z',
+    },
+  }
+
+  before(() => {
+    cy.loadFixture([company])
+  })
+
   const data = {
     name: 'Company',
     lastName: 'Contact',
@@ -46,7 +78,7 @@ describe('Contacts', () => {
   }
 
   it('should create a contact for a given company', () => {
-    cy.visit(contacts.create(lambdaPlc.id))
+    cy.visit(contacts.create(company.pk))
     userActions.contacts.create(data)
 
     cy.get(selectors.message.successful).should('contain', 'Added new contact')
@@ -54,14 +86,14 @@ describe('Contacts', () => {
     assertKeyValueTable('bodyMainContent', {
       'Job title': 'Coffee machine operator',
       'Phone number': '(44) 0778877778800',
-      Address: "12 St George's Road, Paris, 75001, France",
+      Address: '100 Path, A town, 12345, United States',
       Email: 'company.contact@dit.com',
       'Email marketing': 'Cannot be marketed to',
     })
   })
 
   it('should display the newly created contact in company contact collection page', () => {
-    cy.visit(companies.activity.index(lambdaPlc.id))
+    cy.visit(companies.activity.index(company.pk))
 
     cy.contains('Company contacts').click()
     cy.get(selectors.collection.items)


### PR DESCRIPTION
## Description of change

This add a Cypress commands that call new `testfixtureapi` API endpoints:

`.reseed()` - this command deletes all database records, except Metadata.

`.createUser({
  dit_team_id: <uuid>,
  email: <email>,
  first_name: <first name>,
  last_name: <last name>,
  sso_email_user_id: <sso email user id>,
  token: <token>,
})` - this command creates a user

All fields are required. The `token` is a token used to authenticate the user requests to the API.
The command should be issued after calling `reseed()` as it deletes all users.

`loadFixture({
  fixture: [
    ...list of database fixtures in Django JSON format
  ],
})`

The command will load fixtures passed on into the API database. Any model available in the API can be created via this command.

The PR contains an example test where `loadFixture()` command is being used.

The `docker-compose` file with a container description for end to end tests has added `ALLOW_TEST_FIXTURE_SETUP` set to `True` in the `api` section, so that the `testfixtureapi` endpoints can be enabled. This environment variable should only be used during tests.

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
