### PR TITLE
Add order collection page validation to increase e2e coverage

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/order-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/order-spec.js
@@ -10,7 +10,7 @@ describe('Order', () => {
     cy.visit(omis.create(fixtures.company.venusLtd.id))
   })
 
-  it('should create an order', () => {
+  it('should create an order and view collection page', () => {
     cy.contains('Continue').click()
     cy.get(selectors.omisCreate.contact).select('Johnny Cakeman')
     cy.get(selectors.omisCreate.continue).click()
@@ -30,5 +30,17 @@ describe('Order', () => {
       .should('contain', 'Venus Ltd')
       .and('contain', 'Brazil')
       .and('contain', today)
+
+    cy.contains('Orders (OMIS)').click()
+
+    cy.get(selectors.entityCollection.entityBadge(1)).should(
+      'contain',
+      'Brazil'
+    )
+    cy.get(selectors.collection.items)
+      .should('contain', 'Venus Ltd')
+      .and('contain', 'Johnny Cakeman')
+      .and('contain', 'North West')
+      .and('contain', 'Aerospace')
   })
 })


### PR DESCRIPTION
## Description of change

The intent of this PR is to increase the orders e2e spec to navigate to the collections page and assert the order has been created. This page caused us issues in production and if we had this check in place it would have warned us something was wrong.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
