### PR TITLE
Add accessibility linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "parser": "babel-eslint",
   "extends": [
+    "plugin:jsx-a11y/recommended",
     "plugin:prettier/recommended",
     "prettier/react"
   ],

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-mocha": "^6.3.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
## Description of change

This activates an [ESLint addon for accessibility](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) within our codebase (it was added in the initial Prettier PR but not activated).

## Test instructions

Run `npm install` and open any JavaScript file. Go to [this page](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#supported-rules) and pick a rule (all rules have failure examples). Copy the failure code into the file and it should be detected by the linter.

<img width="511" alt="Screenshot 2020-09-21 at 09 48 21" src="https://user-images.githubusercontent.com/36161814/93748132-a4459300-fbef-11ea-8424-82d16af9be21.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
