### PR TITLE
Publish Storybook in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2.1
 
+ignore_ghpages: &ignore_ghpages
+  filters:
+    branches:
+      ignore:
+        - gh-pages
+
 jobs:
   lint:
     machine:
@@ -105,6 +111,16 @@ jobs:
           target: start-e2e-<< parameters.staff >> e2e-tests-<< parameters.staff >>
       - store_cypress_artifacts
 
+  release-storybook:
+    docker:
+      - image: node
+    steps:
+      - checkout
+      - run: npm ci
+      - run:
+          name: Release storybook
+          command: npm run storybook:release
+
   merge-and-publish-coverage:
     docker:
       - image: node
@@ -160,17 +176,26 @@ workflows:
   version: 2
   datahub:
     jobs:
-      - lint
-      - unit_tests
-      - unit_client_tests
-      - functional_tests
-      - visual_tests
+      - lint: *ignore_ghpages
+      - unit_tests: *ignore_ghpages
+      - unit_client_tests: *ignore_ghpages
+      - functional_tests: *ignore_ghpages
+      - visual_tests: *ignore_ghpages
       - e2e_tests:
           name: e2e_tests_<< matrix.staff >>
           matrix:
             parameters:
               staff: [dit, da, lep]
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+      - release-storybook: *ignore_ghpages
       - merge-and-publish-coverage:
           requires:
             - functional_tests
             - unit_tests
+          filters:
+            branches:
+              ignore:
+                - gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ yalc.lock
 # Ignore bin scripts
 .bin
 
+# Ignore gh pages for Storybook
+storybook-static/

--- a/package-lock.json
+++ b/package-lock.json
@@ -15161,6 +15161,16 @@
         }
       }
     },
+    "git-directory-deploy": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/git-directory-deploy/-/git-directory-deploy-1.5.1.tgz",
+      "integrity": "sha1-xPrYwnDWeNXzCfvd6sHtpgytf9I=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.14.2",
+        "minimist": "^1.1.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "storybook": "start-storybook",
+    "storybook:build": "rimraf storybook-static && build-storybook --quiet",
+    "storybook:release": "npm run storybook:build && cp -R ./.circleci ./storybook-static/.circleci && git-directory-deploy --directory storybook-static --branch gh-pages",
     "clean": "del .build cypress-coverage",
     "start": "node --use-strict src/server.js",
     "start:coverage": "nyc --silent npm run start",
@@ -196,6 +198,7 @@
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.8",
     "faker": "^4.1.0",
+    "git-directory-deploy": "^1.5.1",
     "html": "^1.0.0",
     "istanbul": "^0.4.5",
     "istanbul-lib-coverage": "^3.0.0",


### PR DESCRIPTION
## Description of change
We need to regularly publish Storybook so that designers and developers can be assured that the components and patterns they are looking are up to date. This PR just adds an additional job to publish Storybook to Github pages after every PR is merged.

## Test instructions
All components and patterns should now be published to - https://uktrade.github.io/data-hub-frontend

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
