### PR TITLE
Bump the datahub-header dependency up to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4508,9 +4508,9 @@
       }
     },
     "@uktrade/datahub-header": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.2.3.tgz",
-      "integrity": "sha512-sjbuihq1N0NpXnSHD5J3BUPY0lGvbdjNY4g9BD+uoZE+Q3L9JXM5DT4Ep+Lk211tydtFJ2iAl19R0l4O5mrDrw=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.2.5.tgz",
+      "integrity": "sha512-QekCmcLIakFxk8h7yKvi6CBc+mhrJGw0rOkrtjyaNBt0z7TRI+vwYdnvc/ReHP5ZWipFUFb6eIPUSObs9cSUTg=="
     },
     "@uktrade/wdio-image-diff-js": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@storybook/addon-knobs": "^5.3.18",
     "@storybook/addons": "^5.3.18",
     "@storybook/react": "^5.3.18",
-    "@uktrade/datahub-header": "1.2.3",
+    "@uktrade/datahub-header": "1.2.5",
     "autoprefixer": "^9.8.6",
     "axios": "^0.19.2",
     "babel-loader": "^8.1.0",


### PR DESCRIPTION
## Description of change

This PR bumps the npm datahub-header module up to v1.2.5. This update brings in a lighter blue shade for the right hand side user profile navigations only. This is part of the accessibility work that's currently active, as the contrast between the old blue text and the black background on the banner was not significant enough. This means those with low vision abilities would struggle to read the text. 

## Test instructions

You should be able to see that the blues on the beta tag and the sub app navigation remain the same blue as before (#005EA5) and the support, account, and sign out buttons on the right are a new lighter blue shade (#5694CA)

## Screenshots
### Before

<img width="1669" alt="Screenshot 2020-09-23 at 10 22 05" src="https://user-images.githubusercontent.com/46787754/93993440-a8f07f80-fd86-11ea-9938-31e9818c8090.png">


### After

<img width="1679" alt="Screenshot 2020-09-23 at 10 17 55" src="https://user-images.githubusercontent.com/46787754/93993277-75adf080-fd86-11ea-905e-bb6959b0f35b.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
