### PR TITLE
Metadata API call failure discussion

### DIFF
--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -39,7 +39,7 @@ function getMetadata(path, key) {
       return responseData
     })
     .catch((err) => {
-      logger.error('Error fetching metadataRepository for url: %s', url)
+      // logger.error('Error fetching metadataRepository for url: %s', url)
       throw err
     })
 }

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -142,21 +142,27 @@ module.exports.fetchAll = (cb) => {
     }
   }
 
+  function delay(item, totalRequests) {
+    setTimeout(() => {
+      getMetadata(item[0], item[1])
+        .then((data) => {
+          if (item[2]) {
+            item[2](data)
+          }
+
+          checkResults()
+        })
+        .catch((err) => {
+          caughtErrors = caughtErrors || []
+          caughtErrors.push(err)
+          checkResults()
+        })
+    }, totalRequests * 50)
+  }
+
   for (const item of metadataItems) {
     totalRequests += 1
-    getMetadata(item[0], item[1])
-      .then((data) => {
-        if (item[2]) {
-          item[2](data)
-        }
-
-        checkResults()
-      })
-      .catch((err) => {
-        caughtErrors = caughtErrors || []
-        caughtErrors.push(err)
-        checkResults()
-      })
+    delay(item, totalRequests)
   }
 }
 


### PR DESCRIPTION
## Description of change

### Background
During development some developers like myself prefer to develop with a native local frontend pointing to the dev API in PaaS.

### Recent problem
Currently when the app starts up it makes 33 metadata API calls, around two thirds of those calls are succeeding, the rest are failing. If you start and stop the app a number of times the ratio changes. There was one particular time when there was only a single failure, the response from the API is quite random. What is consistent is that the app doesn't come up when pointing to dev. There has been no frontend changes the would attribute to this change in app behaviour. I've gone back to the beginning of September (a point in time when everything was working) and checked out a random commit hash to see if we had introduced something during the previous three weeks, but to no avail, the problem still persists in that earlier version (at the time there was no such problem) - even last week everything was fine during application startup.

The calls that are failing are all timing out. During testing I temporarily swapped out our HTTP client for another called `superagent`, here  I was able to apply multiple retries for each call that failed, however, due to the retries the app took too long to start which is obviously unworkable.

If you make any of these failed calls in Postman they will succeed, that's because we are only making a single call, the problem exposes itself when making lots of API calls in quick succession where the results vary as mentioned.

<img width="731" alt="Screenshot 2020-09-22 at 19 03 41" src="https://user-images.githubusercontent.com/964268/93919961-61c2aa00-fd06-11ea-8d7c-74a98ae068b1.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
