### PR TITLE
Ensure only dit uses multiple vms to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,10 +97,24 @@ jobs:
       - store_artifacts:
           path: visual-report
 
-  e2e_tests:
+  e2e_tests_dit:
     machine:
       docker_layer_caching: true
     parallelism: 3
+    parameters:
+      staff:
+        type: string
+    steps:
+      - checkout
+      - run_make:
+          label: Run e2e tests
+          target: start-e2e-<< parameters.staff >> e2e-tests-<< parameters.staff >>
+      - store_cypress_artifacts
+
+  e2e_tests:
+    machine:
+      docker_layer_caching: true
+    parallelism: 1
     parameters:
       staff:
         type: string
@@ -120,6 +134,7 @@ jobs:
       - run:
           name: Release storybook
           command: npm run storybook:release
+    
 
   merge-and-publish-coverage:
     docker:
@@ -185,11 +200,16 @@ workflows:
           name: e2e_tests_<< matrix.staff >>
           matrix:
             parameters:
-              staff: [dit, da, lep]
+              staff: [da, lep]
           filters:
             branches:
               ignore:
                 - gh-pages
+      - e2e_tests_dit:
+          name: e2e_tests_dit
+          matrix:
+            parameters:
+              staff: [dit]
       - release-storybook: *ignore_ghpages
       - merge-and-publish-coverage:
           requires:


### PR DESCRIPTION
## Description of change

The intent of this PR is to reduce the VMs used for lep and da test suites as the tests take less than a minute to run so no need to run them in parallel

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
