### PR TITLE
Add accessibility addon to Storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,7 @@ const { resolve } = require('../webpack.config')()
 
 module.exports = {
   stories: ['../src/**/*.stories.(js|jsx)$/'],
+  addons: ['@storybook/addon-a11y'],
   webpackFinal: async (config) => {
     return {
       ...config,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,6 +3006,264 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@storybook/addon-a11y": {
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.0.21.tgz",
+      "integrity": "sha512-jB6cOx8UwRjd2h04p6TBBwrZInaeE7w4NnmxWRW6Ifo3GLFiZFuI2oSWOe4LEKWWG1eTrk+285fd11zn0ihsTw==",
+      "requires": {
+        "@storybook/addons": "6.0.21",
+        "@storybook/api": "6.0.21",
+        "@storybook/channels": "6.0.21",
+        "@storybook/client-api": "6.0.21",
+        "@storybook/client-logger": "6.0.21",
+        "@storybook/components": "6.0.21",
+        "@storybook/core-events": "6.0.21",
+        "@storybook/theming": "6.0.21",
+        "axe-core": "^3.5.2",
+        "core-js": "^3.0.1",
+        "global": "^4.3.2",
+        "lodash": "^4.17.15",
+        "react-sizeme": "^2.5.2",
+        "regenerator-runtime": "^0.13.3",
+        "ts-dedent": "^1.1.1",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.0.21.tgz",
+          "integrity": "sha512-yDttNLc3vXqBxwK795ykgzTC6MpvuXDQuF4LHSlHZQe6wsMu1m3fljnbYdafJWdx6cNZwUblU3KYcR11PqhkPg==",
+          "requires": {
+            "@storybook/api": "6.0.21",
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "@storybook/router": "6.0.21",
+            "@storybook/theming": "6.0.21",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "regenerator-runtime": "^0.13.3"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.0.21.tgz",
+          "integrity": "sha512-cRRGf/KGFwYiDouTouEcDdp45N1AbYnAfvLqYZ3KuUTGZ+CiU/PN/vavkp07DQeM4FIQO8TLhzHdsLFpLT7Lkw==",
+          "requires": {
+            "@reach/router": "^1.3.3",
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.0.21",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.0.21",
+            "@types/reach__router": "^1.3.5",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^3.1.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "react": "^16.8.3",
+            "regenerator-runtime": "^0.13.3",
+            "store2": "^2.7.1",
+            "telejson": "^5.0.2",
+            "ts-dedent": "^1.1.1",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.0.21.tgz",
+          "integrity": "sha512-ArRnoaS+b7qpAku/SO27z/yjRDCXb37mCPYGX0ntPbiQajootUbGO7otfnjFkaP44hCEC9uDYlOfMU1hYU1N6A==",
+          "requires": {
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "qs": "^6.6.0",
+            "telejson": "^5.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.0.21.tgz",
+          "integrity": "sha512-G6gjcEotSwDmOlxSmOMgsO3VhQ42RLJK7kFp6D5eg0Q6S8vsypltdT8orxdu+6+AbcBrL+5Sla8lThzaCvXsVQ==",
+          "requires": {
+            "core-js": "^3.0.1",
+            "ts-dedent": "^1.1.1",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.0.21.tgz",
+          "integrity": "sha512-emBXd/ml6pc3G8gP3MsR9zQsAq1zZbqof9MxB51tG/jpTXdqWQ8ce1pt1tJS8Xj0QDM072jR6wsY+mmro0GZnA==",
+          "requires": {
+            "@storybook/addons": "6.0.21",
+            "@storybook/channel-postmessage": "6.0.21",
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "@storybook/csf": "0.0.1",
+            "@types/qs": "^6.9.0",
+            "@types/webpack-env": "^1.15.2",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "stable": "^0.1.8",
+            "store2": "^2.7.1",
+            "ts-dedent": "^1.1.1",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.0.21.tgz",
+          "integrity": "sha512-8aUEbhjXV+UMYQWukVYnp+kZafF+LD4Dm7eMo37IUZvt3VIjV1VvhxIDVJtqjk2vv0KZTepESFBkZQLmBzI9Zg==",
+          "requires": {
+            "core-js": "^3.0.1",
+            "global": "^4.3.2"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.0.21.tgz",
+          "integrity": "sha512-r6btqFW/rcXIU5v231EifZfdh9O0fy7bJDXwwDf8zVUgLx8JRc0VnSs3nvK3Is9HF1wZ9vjx/7Lh4rTIDZAjgg==",
+          "requires": {
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.0.21",
+            "@types/overlayscrollbars": "^1.9.0",
+            "@types/react-color": "^3.0.1",
+            "@types/react-syntax-highlighter": "11.0.4",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^3.1.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.10.2",
+            "polished": "^3.4.4",
+            "popper.js": "^1.14.7",
+            "react": "^16.8.3",
+            "react-color": "^2.17.0",
+            "react-dom": "^16.8.3",
+            "react-popper-tooltip": "^2.11.0",
+            "react-syntax-highlighter": "^12.2.1",
+            "react-textarea-autosize": "^8.1.1",
+            "ts-dedent": "^1.1.1"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.0.21.tgz",
+          "integrity": "sha512-p84fbPcsAhnqDhp+HJ4P8+vI2BqJus4IRoVAemLAwuPjyPElrV9UvOa/RHy1BN8Z6jXwFA+FFzfGl2kPJ3WYcA==",
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.0.21.tgz",
+          "integrity": "sha512-46SsKJfcd12lRrISnfrWhicJx8EylkgGDGohfH0n5p7inkkGOkKV8QFZoYPRKZueMXmUKpzJ0Z3HmVsLTCrCDw==",
+          "requires": {
+            "@reach/router": "^1.3.3",
+            "@types/reach__router": "^1.3.5",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.0.21.tgz",
+          "integrity": "sha512-n97DfB9kG6WrV1xBGDyeQibTrh8pBBCp3dSL3UTGH+KX3C2+4sm6QHlTgyekbi5FrbFEbnuZOKAS3YbLVONsRQ==",
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "6.0.21",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.4.4",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "highlight.js": {
+          "version": "9.15.10",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+          "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "lowlight": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
+          "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
+          "requires": {
+            "fault": "^1.0.2",
+            "highlight.js": "~9.15.0"
+          }
+        },
+        "react-syntax-highlighter": {
+          "version": "12.2.1",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
+          "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "~9.15.1",
+            "lowlight": "1.12.1",
+            "prismjs": "^1.8.4",
+            "refractor": "^2.4.1"
+          }
+        },
+        "react-textarea-autosize": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.2.0.tgz",
+          "integrity": "sha512-grajUlVbkx6VdtSxCgzloUIphIZF5bKr21OYMceWPKkniy7H0mRAT/AXPrRtObAe+zUePnNlBwUc4ivVjUGIjw==",
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "use-composed-ref": "^1.0.0",
+            "use-latest": "^1.0.0"
+          }
+        },
+        "telejson": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/telejson/-/telejson-5.0.2.tgz",
+          "integrity": "sha512-XCrDHGbinczsscs8LXFr9jDhvy37yBk9piB7FJrCfxE8oP66WDkolNMpaBkWYgQqB9dQGBGtTDzGQPedc9KJmw==",
+          "requires": {
+            "@types/is-function": "^1.0.0",
+            "global": "^4.4.0",
+            "is-function": "^1.0.2",
+            "is-regex": "^1.1.1",
+            "is-symbol": "^1.0.3",
+            "isobject": "^4.0.0",
+            "lodash": "^4.17.19",
+            "memoizerific": "^1.11.3"
+          }
+        }
+      }
+    },
     "@storybook/addon-actions": {
       "version": "6.0.25",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.0.25.tgz",
@@ -7812,8 +8070,7 @@
     "axe-core": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
-      "dev": true
+      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q=="
     },
     "axios": {
       "version": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@hapi/joi": "^17.1.1",
     "@sentry/browser": "^5.24.2",
     "@storybook/addon-actions": "^6.0.25",
+    "@storybook/addon-a11y": "^6.0.21",
     "@storybook/addon-knobs": "^5.3.18",
     "@storybook/addons": "^6.0.25",
     "@storybook/react": "^6.0.26",


### PR DESCRIPTION
## Description of change

This adds an [accessibility addon](https://www.npmjs.com/package/@storybook/addon-a11y) for Storybook. It tests our components using Axe and reports back on any accessibility issues.

## Test instructions

Run `npm run storybook` and open the local instance. There will be a new section in the sidebar called 'Accessibility'

<img width="811" alt="Screenshot 2020-09-24 at 13 22 49" src="https://user-images.githubusercontent.com/36161814/94144492-1aa0fa00-fe69-11ea-8402-0d787afaee6c.png">

If the component contains an accessibility issue then details will appear in this sidebar

<img width="373" alt="Screenshot 2020-09-24 at 13 25 21" src="https://user-images.githubusercontent.com/36161814/94144777-7cf9fa80-fe69-11ea-8b55-29d7ca6e998d.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
