### PR TITLE
Update circleci config to ignore gh pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,25 +200,20 @@ workflows:
       - functional_tests: *ignore_ghpages
       - visual_tests: *ignore_ghpages
       - e2e_tests:
+          <<: *ignore_ghpages
           name: e2e_tests_<< matrix.staff >>
           matrix:
             parameters:
               staff: [da, lep]
-          filters:
-            branches:
-              ignore:
-                - gh-pages
       - e2e_tests_dit:
+          <<: *ignore_ghpages
           name: e2e_tests_dit
           matrix:
             parameters:
               staff: [dit]
       - release-storybook: *ignore_ghpages
       - merge-and-publish-coverage:
+          <<: *ignore_ghpages
           requires:
             - functional_tests
             - unit_tests
-          filters:
-            branches:
-              ignore:
-                - gh-pages


### PR DESCRIPTION
## Description of change

The intent of this PR is to ensure circleci jobs don't run when pushes are made to gh-pages branch

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
