### PR TITLE
Add a safeguard around the country of a Data Hub business address

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -126,7 +126,7 @@ const CompanyLocalHeader = ({
                 company.address.town,
                 company.address.county,
                 company.address.postcode,
-                company.address.country.name,
+                company.address.country?.name,
               ])}
             </StyledAddress>
           </GridCol>


### PR DESCRIPTION
## Description of change
There are two ways that a company can be added to Data Hub, one via the `Add a company` journey, the other by `I still can't find what I'm looking for`. The former is D&B data, the latter is the user inputting the details.

After adding a company to Data Hub the address section can be edited by the user, however, the **country** cannot. The only way to change the country is within Django Admin. Currently, if you change the address from any country say `UK` (as an example) to `------` in Django Admin the country becomes `null`, consequently the FE blows up when viewing the company list page. This PR simply puts a safeguard around the country, so if the country is `null` it will not be shown.

**Country removed within Django Admin**
<img width="1309" alt="without-country" src="https://user-images.githubusercontent.com/964268/94801455-f8b1f500-03dd-11eb-956e-6d9115ee8c73.png">

**Country is defined**
<img width="1309" alt="with-country" src="https://user-images.githubusercontent.com/964268/94801513-0cf5f200-03de-11eb-9d55-df0b87220e26.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
