### PR TITLE
Add image-webpack-loader to Dependabot ignore list

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,3 +10,5 @@ update_configs:
           dependency_name: 'govuk-frontend'
       - match:
           dependency_name: 'govuk-colours'
+      - match:
+          dependency_name: 'image-webpack-loader'


### PR DESCRIPTION
## Description of change

Recently we have been having some issues with our Jenkins builds which were being caused by a dependency update for `image-webpack-loader` (see [this PR](https://github.com/uktrade/data-hub-frontend/pull/3023) for more context). In order to fix the issue we had to revert the update, and this PR will prevent the update from re-appearing until we have a more concrete solution.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
