### PR TITLE
Add a conditionally rendered ActivityFeed warning status to CompanyLocalHeader

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -30,6 +30,9 @@ async function renderActivityFeed(req, res, next) {
       : {
           company,
           breadcrumbs,
+          hasActivityFeedWarning: !!res.locals.features[
+            'activity-feed-display-incomplete-message'
+          ],
           flashMessages: res.locals.getMessages(),
           activityTypeFilter: FILTER_KEYS.dataHubActivity,
           activityTypeFilters: FILTER_ITEMS,

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -108,9 +108,9 @@ const CompanyLocalHeader = ({
   company,
   dnbRelatedCompaniesCount,
   returnUrl,
+  hasActivityFeedWarning,
 }) => {
   const queryString = returnUrl ? `${returnUrl}` : `/companies/${company.id}`
-
   return (
     <>
       <LocalHeader breadcrumbs={breadcrumbs} flashMessages={flashMessages}>
@@ -205,6 +205,17 @@ const CompanyLocalHeader = ({
             View full business details
           </a>
         </p>
+        {hasActivityFeedWarning && (
+          <StatusMessage>
+            Data Hub note: 09:30 Tuesday 20 October 2020. We are investigating
+            an error with displaying activities on Company records. When you add
+            an interaction, it will be saved. You can see it on Contact records
+            or the Interaction view. For any further questions, email&nbsp;
+            <a href="datahubsupport@uktrade.zendesk.com">
+              datahubsupport@uktrade.zendesk.com
+            </a>
+          </StatusMessage>
+        )}
       </LocalHeader>
 
       {company.archived && (


### PR DESCRIPTION
## Description of change

The ActivityFeed feature on the Company page has been having performance issues. While we investigate it, a temporary status message has been created that renders in the CompanyLocalHeader. It is dependent on a feature flag, which has so far been turned on in Dev. 

## Test instructions

On the Dev instance, click on companies, and select any company. On the Activity tab, you should see a status message appear in the local header of the page, which should disappear when you click on any other tab. 

## Screenshots
### Before

<img width="1140" alt="Screenshot 2020-10-23 at 14 46 41" src="https://user-images.githubusercontent.com/46787754/97011464-9e203a80-153e-11eb-94fb-5791bff47013.png">


### After

<img width="1177" alt="Screenshot 2020-10-23 at 14 51 25" src="https://user-images.githubusercontent.com/46787754/97011994-47ffc700-153f-11eb-812d-642249a40acb.png">


<img width="1135" alt="Screenshot 2020-10-23 at 14 51 38" src="https://user-images.githubusercontent.com/46787754/97012014-4d5d1180-153f-11eb-82ac-9577cb5a380c.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
