### PR TITLE
Add telephone input validation

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -14,5 +14,5 @@
       "url": "http://localhost:3000/__coverage__"
     }
   },
-  "retries": 3
+  "retries": 1
 }

--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -11,23 +11,40 @@ import {
   FieldAddress,
 } from '../../../../../client/components'
 
-import { WEBSITE_REGEX } from './constants'
+import {
+  WEBSITE_REGEX,
+  GENERIC_PHONE_NUMBER_REGEX,
+  NON_ASCII_REGEX,
+} from './constants'
 
-const requiredWebsiteAndOrPhoneValidator = (
+const websiteValidator = (
   value,
   name,
   { values: { website, telephone_number } }
 ) => {
-  if (!telephone_number && !website) {
+  if (!website && !telephone_number) {
     return 'Enter a website or phone number'
+  } else if (website && !WEBSITE_REGEX.test(website)) {
+    return 'Enter a valid website URL'
   }
+  return null
+}
 
-  if (telephone_number && !website) {
-    return null
+const telephoneValidator = (
+  value,
+  name,
+  { values: { website, telephone_number } }
+) => {
+  if (!website && !telephone_number) {
+    return 'Enter a website or phone number'
+  } else if (
+    telephone_number &&
+    (!GENERIC_PHONE_NUMBER_REGEX.test(telephone_number) ||
+      NON_ASCII_REGEX.test(telephone_number))
+  ) {
+    return 'Enter a valid telephone number'
   }
-
-  // TODO: Move this validation to the component library
-  return !WEBSITE_REGEX.test(website) ? 'Enter a valid website URL' : null
+  return null
 }
 
 function CompanyNotFoundStep({ organisationTypes, country }) {
@@ -58,14 +75,14 @@ function CompanyNotFoundStep({ organisationTypes, country }) {
         label="Company's website"
         name="website"
         type="url"
-        validate={requiredWebsiteAndOrPhoneValidator}
+        validate={websiteValidator}
       />
 
       <FieldInput
         label="Company's telephone number"
         name="telephone_number"
         type="tel"
-        validate={requiredWebsiteAndOrPhoneValidator}
+        validate={telephoneValidator}
       />
 
       <FieldAddress

--- a/src/apps/companies/apps/add-company/client/constants.js
+++ b/src/apps/companies/apps/add-company/client/constants.js
@@ -11,4 +11,4 @@ export const WEBSITE_REGEX = /^(?:(?:(?:https?):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?!
 export const GENERIC_PHONE_NUMBER_REGEX = /^$|([0-9]|#|\+|\s|\(|\))+$/
 
 // Non ASCII
-export const NON_ASCII_REGEX = /[^\x00-\x7F]/g
+export const NON_ASCII_REGEX = /[^$|\x00-\x7F]/

--- a/src/apps/companies/apps/add-company/client/constants.js
+++ b/src/apps/companies/apps/add-company/client/constants.js
@@ -5,3 +5,10 @@ export const ISO_CODE = {
 // Based on https://gist.github.com/dperini/729294
 // Our version doesn't require protocol and don't accept ftp addresses.
 export const WEBSITE_REGEX = /^(?:(?:(?:https?):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i
+
+// Generic telephone regex without enforcing a format.
+// Valid: spaces, (), +, -, numbers and empty string
+export const GENERIC_PHONE_NUMBER_REGEX = /^$|([0-9]|#|\+|\s|\(|\))+$/
+
+// Non ASCII
+export const NON_ASCII_REGEX = /[^\x00-\x7F]/g

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -464,9 +464,9 @@ describe('Add company form', () => {
             cy.get(selectors.companyAdd.newCompanyRecordForm.website).type(
               'www.investigationlimited.com'
             )
-            cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).type(
-              '0123456789'
-            )
+            cy.get(selectors.companyAdd.newCompanyRecordForm.telephone)
+              .clear()
+              .type('0123456789')
             cy.get(
               selectors.companyAdd.newCompanyRecordForm.address.postcode
             ).type('SW1H 9AJ')

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -404,7 +404,7 @@ describe('Add company form', () => {
       context('when only the phone number is submitted', () => {
         before(() => {
           cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).type(
-            '0123456789'
+            '+01 (23) 456789'
           )
           cy.get(selectors.companyAdd.continueButton).click()
         })
@@ -426,9 +426,28 @@ describe('Add company form', () => {
           cy.get(selectors.companyAdd.continueButton).click()
         })
         it('should display invalid website URL error', () => {
-          cy.get(selectors.companyAdd.form).contains(
-            'Enter a valid website URL'
+          cy.get(
+            selectors.companyAdd.newCompanyRecordForm.websiteContainer
+          ).contains('Enter a valid website URL')
+          cy.get(
+            selectors.companyAdd.newCompanyRecordForm.telephoneContainer
+          ).should('not.contain', 'Enter a valid website URL')
+        })
+      })
+      context('when an invalid telephone number is filled', () => {
+        before(() => {
+          cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).type(
+            '©123123123'
           )
+          cy.get(selectors.companyAdd.continueButton).click()
+        })
+        it('should display invalid telephone number error', () => {
+          cy.get(
+            selectors.companyAdd.newCompanyRecordForm.telephoneContainer
+          ).contains('Enter a valid telephone number')
+          cy.get(
+            selectors.companyAdd.newCompanyRecordForm.websiteContainer
+          ).should('not.contain', 'Enter a valid telephone number')
         })
       })
       context(

--- a/test/selectors/company/add-company.js
+++ b/test/selectors/company/add-company.js
@@ -39,7 +39,9 @@ module.exports = {
     },
     companyName: 'input[name="name"]',
     website: 'input[name="website"]',
+    websiteContainer: '#field-website',
     telephone: 'input[name="telephone_number"]',
+    telephoneContainer: '#field-telephone_number',
     address: {
       postcode: 'input[name="postcode"]',
       findUkAddress: 'form button:contains("Find UK address")',


### PR DESCRIPTION
## Description of change

The intent of this PR is to enhance the validation around the telephone number when adding a company.

Validations added to the telephone field:
- non ascii characters
- no numeric values within the string provided for the telephone number
  - i.e `the company number is` will fail the validation, but `the company number is: 123123123` will pass the validation

In this PR we also enhanced the validation around website. Previously if a validation failed due to an invalid website input it would apply the same error message to the telephone number field.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
