### PR TITLE
New Chip component

### DIFF
--- a/src/client/components/AdviserFilterChips/index.jsx
+++ b/src/client/components/AdviserFilterChips/index.jsx
@@ -2,11 +2,10 @@ import React from 'react'
 import { Chip } from '../../components'
 
 const AdviserFilterChips = ({ selectedAdvisers }) => {
-  const advisers = selectedAdvisers.map(({ advisers }) => advisers)
   return (
     <>
-      {advisers.map(({ name, id }) => (
-        <Chip label={name} key={id} />
+      {selectedAdvisers.map(({ advisers: { name, id } }) => (
+        <Chip key={id}>{name}</Chip>
       ))}
     </>
   )

--- a/src/client/components/AdviserFilterChips/index.jsx
+++ b/src/client/components/AdviserFilterChips/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Chip } from '../../components'
+
+const AdviserFilterChips = ({ selectedAdvisers }) => {
+  const advisers = selectedAdvisers.map(({ advisers }) => advisers)
+  return (
+    <>
+      {advisers.map(({ name, id }) => (
+        <Chip label={name} key={id} />
+      ))}
+    </>
+  )
+}
+
+export default AdviserFilterChips

--- a/src/client/components/Chip/__stories__/Chip.stories.jsx
+++ b/src/client/components/Chip/__stories__/Chip.stories.jsx
@@ -16,17 +16,17 @@ storiesOf('Chips', module)
   .add('Single', () => {
     return (
       <div>
-        <Chip label="Apple" />
+        <Chip>Apple</Chip>
       </div>
     )
   })
   .add('Multiple', () => {
     return (
       <div>
-        <Chip label="Apple" />
-        <Chip label="Pear" />
-        <Chip label="Orange" />
-        <Chip label="Bananna" />
+        <Chip>Apple</Chip>
+        <Chip>Pear</Chip>
+        <Chip>Orange</Chip>
+        <Chip>Banana</Chip>
       </div>
     )
   })

--- a/src/client/components/Chip/__stories__/Chip.stories.jsx
+++ b/src/client/components/Chip/__stories__/Chip.stories.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import Chip from '../'
+import exampleReadme from '../example.md'
+import usageReadme from '../usage.md'
+
+storiesOf('Chips', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Single', () => {
+    return (
+      <div>
+        <Chip label="Apple" />
+      </div>
+    )
+  })
+  .add('Multiple', () => {
+    return (
+      <div>
+        <Chip label="Apple" />
+        <Chip label="Pear" />
+        <Chip label="Orange" />
+        <Chip label="Bananna" />
+      </div>
+    )
+  })

--- a/src/client/components/Chip/example.md
+++ b/src/client/components/Chip/example.md
@@ -1,0 +1,6 @@
+### Import
+```js
+import Chip from 'components' // Path to the components index
+```
+
+### Output

--- a/src/client/components/Chip/index.jsx
+++ b/src/client/components/Chip/index.jsx
@@ -12,10 +12,10 @@ const StyledSpan = styled('span')`
   border-radius: ${SPACING.SCALE_2};
 `
 
-const Chip = ({ label }) => <StyledSpan>{label}</StyledSpan>
+const Chip = ({ children }) => <StyledSpan>{children}</StyledSpan>
 
 Chip.propTypes = {
-  label: PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
 }
 
 export default Chip

--- a/src/client/components/Chip/index.jsx
+++ b/src/client/components/Chip/index.jsx
@@ -2,13 +2,14 @@ import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { GREY_3 } from 'govuk-colours'
+import { SPACING } from '@govuk-react/constants'
 
 const StyledSpan = styled('span')`
   display: inline-block;
   padding: 12px;
   margin: 4px;
   background-color: ${GREY_3};
-  border-radius: 10px;
+  border-radius: ${SPACING.SCALE_2};
 `
 
 const Chip = ({ label }) => <StyledSpan>{label}</StyledSpan>

--- a/src/client/components/Chip/index.jsx
+++ b/src/client/components/Chip/index.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { GREY_3 } from 'govuk-colours'
+
+const StyledSpan = styled('span')`
+  display: inline-block;
+  padding: 12px;
+  margin: 4px;
+  background-color: ${GREY_3};
+  border-radius: 10px;
+`
+
+const Chip = ({ label }) => <StyledSpan>{label}</StyledSpan>
+
+Chip.propTypes = {
+  label: PropTypes.string.isRequired,
+}
+
+export default Chip

--- a/src/client/components/Chip/index.jsx
+++ b/src/client/components/Chip/index.jsx
@@ -1,21 +1,13 @@
-import React from 'react'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
 import { GREY_3 } from 'govuk-colours'
 import { SPACING } from '@govuk-react/constants'
 
-const StyledSpan = styled('span')`
+const Chip = styled('span')`
   display: inline-block;
   padding: 12px;
   margin: 4px;
   background-color: ${GREY_3};
   border-radius: ${SPACING.SCALE_2};
 `
-
-const Chip = ({ children }) => <StyledSpan>{children}</StyledSpan>
-
-Chip.propTypes = {
-  children: PropTypes.string.isRequired,
-}
 
 export default Chip

--- a/src/client/components/Chip/usage.md
+++ b/src/client/components/Chip/usage.md
@@ -1,0 +1,7 @@
+Chip
+=========
+
+### Description
+Chips are compact elements that represent an input, attribute, or action. A Chip could be used to display a list of selected filters in a collection list.
+
+

--- a/src/client/components/CollectionList/CollectionHeaderRow.jsx
+++ b/src/client/components/CollectionList/CollectionHeaderRow.jsx
@@ -24,9 +24,9 @@ const StyledActions = styled('div')`
   }
 `
 
-const CollectionHeaderRow = ({ primary, actions, children }) => {
+const CollectionHeaderRow = ({ primary, actions, children, ...rest }) => {
   return (
-    <StyledRowWrapper primary={primary}>
+    <StyledRowWrapper primary={primary} {...rest}>
       {children}
 
       {actions && <StyledActions>{actions}</StyledActions>}

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Button from '@govuk-react/button'
+import styled from 'styled-components'
+import pluralize from 'pluralize'
+import { H2 } from '@govuk-react/heading'
+import { BLACK, GREY_3 } from 'govuk-colours'
+import { HEADING_SIZES } from '@govuk-react/constants'
+import CollectionHeaderRow from '../CollectionList/CollectionHeaderRow'
+import { AdviserFilterChips } from '../../components'
+import { decimal } from '../../utils/number-utils'
+
+const StyledHeaderText = styled(H2)`
+  margin-top: 0;
+  font-weight: normal;
+  font-size: ${HEADING_SIZES.MEDIUM}px;
+  margin-bottom: 0;
+`
+
+const StyledLink = styled.a`
+  margin-bottom: 0;
+`
+
+const StyledResultCount = styled('span')`
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 1;
+`
+
+const CollectionHeaderRowContainer = styled('div')`
+  > div {
+    border: none;
+  }
+  border-bottom: 5px solid ${BLACK} !important;
+`
+
+function FilteredCollectionHeader({
+  totalItems,
+  collectionName = 'result',
+  addItemUrl,
+  selectedAdvisers,
+}) {
+  const formattedTotal = decimal(totalItems)
+  const counterSuffix = pluralize(collectionName, totalItems)
+  const hasFilters = selectedAdvisers.length > 0
+
+  const actions = addItemUrl && (
+    <Button
+      as={StyledLink}
+      href={addItemUrl}
+      buttonColour={GREY_3}
+      buttonTextColour={BLACK}
+    >
+      Add {collectionName}
+    </Button>
+  )
+
+  return (
+    <CollectionHeaderRowContainer>
+      <CollectionHeaderRow actions={actions}>
+        <StyledHeaderText>
+          <StyledResultCount>{formattedTotal}</StyledResultCount>
+          {` ${counterSuffix}`}
+        </StyledHeaderText>
+      </CollectionHeaderRow>
+      {hasFilters && (
+        <CollectionHeaderRow>
+          <AdviserFilterChips selectedAdvisers={selectedAdvisers} />
+        </CollectionHeaderRow>
+      )}
+    </CollectionHeaderRowContainer>
+  )
+}
+
+FilteredCollectionHeader.propTypes = {
+  totalItems: PropTypes.number.isRequired,
+  collectionName: PropTypes.string.isRequired,
+  addItemUrl: PropTypes.string,
+}
+
+FilteredCollectionHeader.defaultProps = {
+  addItemUrl: null,
+}
+
+export default FilteredCollectionHeader

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -59,8 +59,8 @@ function FilteredCollectionHeader({
     <CollectionHeaderRowContainer>
       <CollectionHeaderRow actions={actions}>
         <StyledHeaderText>
-          <StyledResultCount>{formattedTotal}</StyledResultCount>
-          {` ${counterSuffix}`}
+          <StyledResultCount>{formattedTotal}</StyledResultCount>{' '}
+          {counterSuffix}
         </StyledHeaderText>
       </CollectionHeaderRow>
       {hasFilters && (

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import pluralize from 'pluralize'
 import { H2 } from '@govuk-react/heading'
 import { BLACK, GREY_3 } from 'govuk-colours'
-import { HEADING_SIZES } from '@govuk-react/constants'
+import { HEADING_SIZES, SPACING } from '@govuk-react/constants'
 import CollectionHeaderRow from '../CollectionList/CollectionHeaderRow'
 import { AdviserFilterChips } from '../../components'
 import { decimal } from '../../utils/number-utils'
@@ -31,7 +31,7 @@ const CollectionHeaderRowContainer = styled('div')`
   > div {
     border: none;
   }
-  border-bottom: 5px solid ${BLACK} !important;
+  border-bottom: ${SPACING.SCALE_1} solid ${BLACK};
 `
 
 function FilteredCollectionHeader({

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -37,7 +37,7 @@ const CollectionHeaderRowContainer = styled('div')`
 function FilteredCollectionHeader({
   totalItems,
   collectionName = 'result',
-  addItemUrl,
+  addItemUrl = null,
   selectedAdvisers,
 }) {
   const formattedTotal = decimal(totalItems)
@@ -76,10 +76,6 @@ FilteredCollectionHeader.propTypes = {
   totalItems: PropTypes.number.isRequired,
   collectionName: PropTypes.string.isRequired,
   addItemUrl: PropTypes.string,
-}
-
-FilteredCollectionHeader.defaultProps = {
-  addItemUrl: null,
 }
 
 export default FilteredCollectionHeader

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -8,10 +8,10 @@ import { GridRow, GridCol } from 'govuk-react'
 import Task from '../../../client/components/Task'
 
 import {
-  CollectionHeader,
   CollectionSort,
   CollectionItem,
   RoutedPagination,
+  FilteredCollectionHeader,
 } from '../../components'
 
 const FilteredCollectionList = ({
@@ -24,6 +24,7 @@ const FilteredCollectionList = ({
   children,
   collectionName,
   activePage = 1,
+  selectedAdvisers,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
@@ -32,9 +33,10 @@ const FilteredCollectionList = ({
       <GridCol setWidth="two-thirds">
         <article>
           {isComplete && (
-            <CollectionHeader
+            <FilteredCollectionHeader
               totalItems={count}
               collectionName={collectionName}
+              selectedAdvisers={selectedAdvisers}
             />
           )}
           {sortOptions && (

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -43,3 +43,6 @@ export { default as FilterAdvisersTypeAhead } from './Filters/elements/FilterAdv
 export { default as ToggleSection } from './ToggleSection'
 export { default as RoutedPagination } from './RoutedPagination'
 export { default as FilteredCollectionList } from './FilteredCollectionList'
+export { default as FilteredCollectionHeader } from './FilteredCollectionList/FilteredCollectionHeader'
+export { default as AdviserFilterChips } from './AdviserFilterChips'
+export { default as Chip } from './Chip'


### PR DESCRIPTION
## Description of change
This Chip component is to be used to indicate what filters are currently selected on the new react collection list page. Currently we only have one filter (Adviser typeahead filter) so this work has been built around this feature for now until we bring in more filters. 

Trello - https://trello.com/c/LuGgtZGp/533-add-filter-indicator-to-the-react-investments-collection-list

Note: This is being merged into a feature branch NOT master as its part of the React collection list work.

## Test instructions
1. Run the app and visit the investment project collection page
2. Run storybook and you should see the documentation for it.

## Screenshots
![Screenshot 2020-11-02 at 12 45 16](https://user-images.githubusercontent.com/10154302/97869659-bf84e180-1d09-11eb-8c57-4443c668913e.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
