### PR TITLE
Stringify basename so createBrowserHistory can parse successfully

### DIFF
--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import queryString from 'qs'
 import React from 'react'
 import { createBrowserHistory } from 'history'
 import {
@@ -73,12 +74,14 @@ const history = createBrowserHistory({
   // The baseURI is set to the <base/> tag by the spaFallbackSpread
   // middleware, which should be applied to each Express route where
   // react-router is expected to be used.
-  basename: new URL(
-    document.baseURI ||
-      // IE doesn't support baseURI so we need to access base.href manually
-      document.querySelector('base')?.href ||
-      document.location.href
-  ).pathname,
+  basename: queryString.stringify(
+    new URL(
+      document.baseURI ||
+        // IE doesn't support baseURI so we need to access base.href manually
+        document.querySelector('base')?.href ||
+        document.location.href
+    ).pathname
+  ),
 })
 
 const store = createStore(

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -157,6 +157,27 @@ function assertAcrossTabs(callback) {
 }
 
 describe('My pipeline app', () => {
+  context('when query string is used by analytic team', () => {
+    before(() => {
+      cy.visit(
+        `${urls.pipeline.index()}?
+        some_source=averylongquery&othersource=anotherlongquery`
+      )
+    })
+
+    it('should render the sub tab nav', () => {
+      cy.get('[data-auto-id="pipelineSubTabNav"]').within(() => {
+        cy.contains('To do').should('have.attr', 'aria-selected', 'true')
+        cy.contains('In progress')
+        cy.contains('Done')
+      })
+    })
+
+    it('should render the item counter', () => {
+      cy.contains('4 projects')
+    })
+  })
+
   context('When viewing the to do status', () => {
     before(() => {
       cy.visit(urls.pipeline.index())


### PR DESCRIPTION
## Description of change

The intent of this PR is to fix the history object used by `connectRouter` by stringifying the `basename` which enables `createBrowserHistory` to parse `pathname` and `search` successfully

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
