### PR TITLE
Add empty alt to DropdownMenu triangle image

### DIFF
--- a/src/client/components/DropdownMenu/index.jsx
+++ b/src/client/components/DropdownMenu/index.jsx
@@ -149,7 +149,7 @@ const DropdownMenu = ({
           ref={buttonRef}
           buttonShadowColour="transparent"
           onClick={() => onClick(!open)}
-          icon={<Icon src={trianglePng} active={open} />}
+          icon={<Icon src={trianglePng} active={open} alt="" />}
           aria-haspopup={true}
           aria-expanded={open}
           aria-controls="dropDownOptionsMenu"


### PR DESCRIPTION
## Description of change

As part of the accessibility audit, all images require an alt attribute of some sort. Any images that convey meaning need their meaning written in the alt text, and any that are mere decoration need to have empty alt text in order to let screen readers know to skip it. 

One of the two images they picked up on, was the little triangle in the CompanyLocalHeader's drop-down menu. This PR simply adds an empty alt attribute to the image as suggested by the auditors. 

## Test instructions

Check out this branch and boot up dev. Go to a company page's details and inspect the little triangle image on the dropdown in the header. You should see an empty alt attribute in the dev tools for this image. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
