### PR TITLE
Restore greeting action

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,13 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: "Welcome to Data Hub! You're doing great :-)"
+          pr-message: "Welcome to Data Hub! You're doing great :-)"


### PR DESCRIPTION
## Description of change

A few weeks ago we had to remove the `greeting` GitHub action as it had broken and there wasn't a confirmed fix from the action maintainers (see the r[emoval PR](https://github.com/uktrade/data-hub-frontend/pull/3037) for more context).

Since the removal GitHub have fixed the action, so I'm putting it back for now.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
