### PR TITLE
Update e2e test urls

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -19,7 +19,7 @@ services:
       ELASTIC_APM_SERVER_URL: http://es-apm:8200
 
   mock-sso:
-    image: quay.io/uktrade/mock-sso:latest
+    image: gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
     ports:
       - 8080:8080
     environment:
@@ -28,7 +28,7 @@ services:
       MOCK_SSO_EMAIL_USER_ID: test@gov.uk
 
   api:
-    image: quay.io/uktrade/data-hub-api:develop
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:develop
     env_file: .env
     environment:
       DEBUG: 'False'
@@ -52,7 +52,7 @@ services:
     command: /app/setup-uat.sh || echo "all ood"
 
   celery:
-    image: quay.io/uktrade/data-hub-api:develop
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:develop
     env_file: .env
     depends_on:
       - postgres
@@ -77,7 +77,7 @@ services:
       POSTGRES_PASSWORD: password
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'


### PR DESCRIPTION
## Description of change

The `docker-compose.e2e` file was still using Elasticsearch v6, I have updated it to v7. There were also several quay.io URLs still in use, I have updated these to the GCR equivalent.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
