### PR TITLE
Added OAUTH2_AUTH_URL to sample.env

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -10,7 +10,9 @@ services:
       POSTCODE_KEY: ${POSTCODE_KEY}
       OAUTH2_TOKEN_FETCH_URL: http://mock-sso:8080/o/token
       OAUTH2_USER_PROFILE_URL: http://mock-sso:8080/api/v1/user/me
-      OAUTH2_AUTH_URL: http://localhost:8080/o/authorize
+      # When running locally change to
+      # OAUTH2_AUTH_URL: http://localhost:8080/o/authorize
+      OAUTH2_AUTH_URL: http://mock-sso:8080/o/authorize
       OAUTH2_REDIRECT_URL: http://localhost:3000/oauth/callback
       OAUTH2_LOGOUT_URL: http://mock-sso:8080/o/logout
       OAUTH2_BYPASS_SSO: 'False'

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -10,7 +10,7 @@ services:
       POSTCODE_KEY: ${POSTCODE_KEY}
       OAUTH2_TOKEN_FETCH_URL: http://mock-sso:8080/o/token
       OAUTH2_USER_PROFILE_URL: http://mock-sso:8080/api/v1/user/me
-      OAUTH2_AUTH_URL: http://mock-sso:8080/o/authorize
+      OAUTH2_AUTH_URL: http://localhost:8080/o/authorize
       OAUTH2_REDIRECT_URL: http://localhost:3000/oauth/callback
       OAUTH2_LOGOUT_URL: http://mock-sso:8080/o/logout
       OAUTH2_BYPASS_SSO: 'False'

--- a/sample.env
+++ b/sample.env
@@ -24,6 +24,7 @@ HELP_CENTRE_API_FEED=http://api:8000/help-centre/announcement
 HELP_CENTRE_FEED_API_TOKEN=lookInVault
 HELP_CENTRE_URL=https://lookInVault.com/
 NODE_ENV=development
+OAUTH2_AUTH_URL=http://localhost:8080/o/authorize
 OAUTH2_BYPASS_SSO=true
 ONE_LIST_EMAIL=look@in.vault.com
 PERFORMANCE_DASHBOARDS_URL=https://lookInVault.com/


### PR DESCRIPTION
## Description of change

Adds the missing `OAUTH2_AUTH_URL` to `./sample.env` which is required for the project to run locally.

