### PR TITLE
Feature/filter uk region

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -89,6 +89,16 @@ const ProjectsCollection = ({
             selectedOptions={selectedFilters.selectedCountries}
             options={optionMetadata.countryOptions}
           />
+          <RoutedTypeahead
+            {...props}
+            isMulti={true}
+            label="UK Region"
+            name="uk_region"
+            qsParam="uk_region"
+            placeholder="Search UK regions..."
+            selectedOptions={selectedFilters.selectedUkRegions}
+            options={optionMetadata.ukRegionOptions}
+          />
           <RoutedDateField
             label="Estimated land date before"
             name="estimated_land_date_before"

--- a/src/apps/investments/client/projects/metadata/index.js
+++ b/src/apps/investments/client/projects/metadata/index.js
@@ -1,5 +1,6 @@
 export { countryOptions } from './countries'
 export { sectorOptions } from './sectors'
+export { ukRegionOptions } from './uk-regions'
 
 export const estimatedLandDateBeforeLabel = 'Estimated land date before'
 export const estimatedLandDateAfterLabel = 'Estimated land date after'

--- a/src/apps/investments/client/projects/metadata/uk-regions.js
+++ b/src/apps/investments/client/projects/metadata/uk-regions.js
@@ -1,0 +1,92 @@
+export const ukRegionOptions = [
+  {
+    value: '1718e330-6095-e211-a939-e4115bead28a',
+    label: 'All',
+  },
+  {
+    value: '934cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Alderney',
+  },
+  {
+    value: '8b4cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Channel Islands',
+  },
+  {
+    label: 'East Midlands',
+    value: '844cd12a-6095-e211-a939-e4115bead28a',
+  },
+  {
+    label: 'East of England',
+    value: '864cd12a-6095-e211-a939-e4115bead28a',
+  },
+  {
+    value: '8a4cd12a-6095-e211-a939-e4115bead28a',
+    label: 'England',
+  },
+  {
+    value: '804cd12a-6095-e211-a939-e4115bead28a',
+    label: 'FDI Hub',
+  },
+  {
+    value: '904cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Guernsey',
+  },
+  {
+    value: '8f4cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Isle of Man',
+  },
+  {
+    value: '924cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Jersey',
+  },
+  {
+    value: '874cd12a-6095-e211-a939-e4115bead28a',
+    label: 'London',
+  },
+  {
+    value: '814cd12a-6095-e211-a939-e4115bead28a',
+    label: 'North East',
+  },
+  {
+    value: '8e4cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Northern Ireland',
+  },
+  {
+    value: '824cd12a-6095-e211-a939-e4115bead28a',
+    label: 'North West',
+  },
+  {
+    value: '914cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Sark',
+  },
+  {
+    value: '8c4cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Scotland',
+  },
+  {
+    value: '884cd12a-6095-e211-a939-e4115bead28a',
+    label: 'South East',
+  },
+  {
+    value: '894cd12a-6095-e211-a939-e4115bead28a',
+    label: 'South West',
+  },
+  {
+    value: 'e1dd40e9-3dfd-e311-8a2b-e4115bead28a',
+    label: 'UKTI Dubai Hub',
+  },
+  {
+    value: '8d4cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Wales',
+  },
+  {
+    value: '854cd12a-6095-e211-a939-e4115bead28a',
+    label: 'West Midlands',
+  },
+  {
+    value: '834cd12a-6095-e211-a939-e4115bead28a',
+    label: 'Yorkshire and The Humber',
+  },
+]
+
+export default ukRegionOptions

--- a/src/apps/investments/client/projects/state.js
+++ b/src/apps/investments/client/projects/state.js
@@ -3,10 +3,11 @@ import dateFns from 'date-fns'
 
 import {
   countryOptions,
-  sortOptions,
-  sectorOptions,
   estimatedLandDateBeforeLabel,
   estimatedLandDateAfterLabel,
+  sortOptions,
+  sectorOptions,
+  ukRegionOptions,
 } from './metadata'
 
 export const TASK_GET_PROJECTS_LIST = 'TASK_GET_PROJECTS_LIST'
@@ -23,12 +24,14 @@ const searchParamProps = ({
   adviser = false,
   sector_descends = false,
   country = false,
+  uk_region = false,
   estimated_land_date_before = null,
   estimated_land_date_after = null,
 }) => ({
   adviser: parseVariablePropType(adviser),
   sector_descends: parseVariablePropType(sector_descends),
   country: parseVariablePropType(country),
+  uk_region: parseVariablePropType(uk_region),
   estimated_land_date_before,
   estimated_land_date_after,
   sortby,
@@ -63,6 +66,7 @@ export const state2props = ({ router, ...state }) => {
   const {
     sector_descends = [],
     country = [],
+    uk_region = [],
     estimated_land_date_before,
     estimated_land_date_after,
   } = queryProps
@@ -72,8 +76,9 @@ export const state2props = ({ router, ...state }) => {
       label: advisers.name,
       value: advisers.id,
     })),
-    selectedCountries: listSelectedFilters(countryOptions, country),
     selectedSectors: listSelectedFilters(sectorOptions, sector_descends),
+    selectedCountries: listSelectedFilters(countryOptions, country),
+    selectedUkRegions: listSelectedFilters(ukRegionOptions, uk_region),
     selectedEstimatedLandDatesBefore: buildDatesFilter(
       estimatedLandDateBeforeLabel,
       estimated_land_date_before
@@ -87,7 +92,12 @@ export const state2props = ({ router, ...state }) => {
   return {
     ...state[ID],
     payload: filteredQueryProps,
-    optionMetadata: { countryOptions, sortOptions, sectorOptions },
+    optionMetadata: {
+      countryOptions,
+      sortOptions,
+      sectorOptions,
+      ukRegionOptions,
+    },
     selectedFilters,
   }
 }

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -101,6 +101,10 @@ function FilteredCollectionHeader({
           qsParamName="country"
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedUkRegions}
+          qsParamName="uk_region"
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedEstimatedLandDatesBefore}
           qsParamName="estimated_land_date_before"
         />

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -3,6 +3,7 @@ import urls from '../../../../../src/lib/urls'
 const PUCK_ADVISER_ID = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
 const ADVANCED_ENGINEERING_SECTOR_ID = 'af959812-6095-e211-a939-e4115bead28a'
 const UK_COUNTRY_ID = '80756b9a-5d95-e211-a939-e4115bead28a'
+const SOUTH_EAST_UK_REGION_ID = '884cd12a-6095-e211-a939-e4115bead28a'
 
 const selectAdvisersTypeahead = (fieldName, input) =>
   cy.get(fieldName).within(() => {
@@ -49,6 +50,8 @@ describe('Investments Collections Filter', () => {
       .as('sectorFilter')
       .next()
       .as('countryFilter')
+      .next()
+      .as('ukRegionFilter')
       .next()
       .as('estimatedDateBefore')
       .next()
@@ -100,6 +103,19 @@ describe('Investments Collections Filter', () => {
       assertRemovedFilterIndicator('@countryFilter', 'Search countries')
     })
 
+    it('should filter by uk region', () => {
+      assertTypehead(
+        '@ukRegionFilter',
+        'UK Region',
+        'Search UK regions',
+        'sou',
+        'South East'
+      )
+    })
+    it('should remove the country filter', () => {
+      assertRemovedFilterIndicator('@countryFilter', 'Search countries')
+    })
+
     it('should filter the estimated land date before', () => {
       cy.get('@estimatedDateBefore')
         .find('label')
@@ -136,6 +152,7 @@ describe('Investments Collections Filter', () => {
           adviser: PUCK_ADVISER_ID,
           sector_descends: ADVANCED_ENGINEERING_SECTOR_ID,
           country: UK_COUNTRY_ID,
+          uk_region: SOUTH_EAST_UK_REGION_ID,
           estimated_land_date_before: '2020-01-01',
           estimated_land_date_after: '2020-01-01',
         },
@@ -148,11 +165,13 @@ describe('Investments Collections Filter', () => {
       cy.get('@sectorFilter').should('contain', 'Advanced Engineering')
       assertFilterIndicator(3, 'United Kingdom')
       cy.get('@countryFilter').should('contain', 'United Kingdom')
-      assertFilterIndicator(4, 'Estimated land date before : 1 January 2020')
+      assertFilterIndicator(4, 'South East')
+      cy.get('@ukRegionFilter').should('contain', 'South East')
+      assertFilterIndicator(5, 'Estimated land date before : 1 January 2020')
       cy.get('@estimatedDateBefore')
         .find('input')
         .should('have.attr', 'value', '2020-01-01')
-      assertFilterIndicator(5, 'Estimated land date after : 1 January 2020')
+      assertFilterIndicator(6, 'Estimated land date after : 1 January 2020')
       cy.get('@estimatedDateAfter')
         .find('input')
         .should('have.attr', 'value', '2020-01-01')
@@ -160,7 +179,7 @@ describe('Investments Collections Filter', () => {
 
     it('should clear all filters', () => {
       cy.get('main article div + div button').as('filterIndicators')
-      cy.get('@filterIndicators').should('have.length', 5)
+      cy.get('@filterIndicators').should('have.length', 6)
       cy.get('main article div:first-child > button').click()
       cy.get('@filterIndicators').should('have.length', 0)
       cy.get('@estimatedDateBefore')
@@ -172,31 +191,7 @@ describe('Investments Collections Filter', () => {
       cy.get('@adviserFilter').should('contain', 'Search advisers...')
       cy.get('@sectorFilter').should('contain', 'Search sectors...')
       cy.get('@countryFilter').should('contain', 'Search countries...')
+      cy.get('@ukRegionFilter').should('contain', 'Search UK regions...')
     })
   })
 })
-
-//   it('should filter by uk region', () => {
-//     const { typeahead } = selectors.filter
-//     const { ukRegion } = selectors.filter.investments
-//     cy.get(typeahead(ukRegion).selectedOption)
-//       .click()
-//       .get(typeahead(ukRegion).textInput)
-//       .type('North East')
-//       .get(typeahead(ukRegion).options)
-//       .should('have.length', 1)
-//       .get(typeahead(ukRegion).textInput)
-//       .type('{enter}')
-//       .type('{esc}')
-
-//     cy.wait('@filterResults').then((xhr) => {
-//       expect(xhr.url).to.contain(
-//         'uk_region_location=814cd12a-6095-e211-a939-e4115bead28a'
-//       )
-//     })
-
-//     cy.get(selectors.entityCollection.entities)
-//       .children()
-//       .should('have.length', 2)
-//   })
-// })

--- a/test/sandbox/routes/v3/search/investment-project.js
+++ b/test/sandbox/routes/v3/search/investment-project.js
@@ -6,6 +6,7 @@ exports.investmentProjects = function (req, res) {
     req.body.estimated_land_date_after ||
     req.body.sector_descends ||
     req.body.country ||
+    req.body.uk_region ||
     req.body.adviser
   )
 


### PR DESCRIPTION
## Description of change

Adds UK region filter to investments page.

## Test instructions

On `investments/projects`, you should now see the filter by uk region typeahead filter. You should be able to choose multiple regions. Once selected, the regions should appear as chips that can be cleared.

## Screenshots

![Screenshot from 2020-12-03 12-29-33](https://user-images.githubusercontent.com/1234577/101018433-67890700-3563-11eb-8b15-48b1bd8f229e.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
