### PR TITLE
Middleware for testing layouts

### DIFF
--- a/src/apps/layout-testing/index.js
+++ b/src/apps/layout-testing/index.js
@@ -1,0 +1,7 @@
+const router = require('./router')
+
+module.exports = {
+  displayName: 'Layout',
+  mountpath: '/layout-testing',
+  router,
+}

--- a/src/apps/layout-testing/router.js
+++ b/src/apps/layout-testing/router.js
@@ -1,0 +1,9 @@
+const router = require('express').Router()
+const { isProd } = require('../../config')
+const layoutTesting = require('../../middleware/layout-testing')
+
+router.get('/', layoutTesting('testing'), (req, res, next) => {
+  !isProd ? res.send(`Testing layout is ${res.locals.isLayoutTesting}`) : next()
+})
+
+module.exports = router

--- a/src/middleware/layout-testing.js
+++ b/src/middleware/layout-testing.js
@@ -1,30 +1,28 @@
 const { isEmpty } = require('lodash')
+const logger = require('../config/logger')
 
 module.exports = (queryParam) => (req, res, next) => {
   const { features } = res.locals
   res.locals.isLayoutTesting = false
-  const layoutTestingFeature = Object.keys(features).filter((x) =>
-    x.includes('layoutTesting')
+  const layoutTestingFeature = Object.keys(features).filter((feature) =>
+    feature.includes('layoutTesting')
   )
 
+  layoutTestingFeature.length > 1 &&
+    logger.warn(
+      'You can ONLY have one "layoutTesting" feature flag set at a time otherwise only the first one in the list will be used. Deactivate or remove one from Django admin.'
+    )
+
   if (!isEmpty(layoutTestingFeature)) {
-    if (layoutTestingFeature.length > 1) {
-      throw new Error(
-        'You can only have one "layoutTesting" feature running. Remove one of the features from admin.'
-      )
-    } else {
-      const {
-        dit_team: { id },
-      } = res.locals.user
-      const [featureFlag] = layoutTestingFeature
-      const [, teamId] = featureFlag.split(':')
-      res.locals.isLayoutTesting = teamId === id
-      if (res.locals.isLayoutTesting && isEmpty(req.query)) {
-        return res.redirect(`${req.originalUrl}?layoutTesting=${queryParam}`)
-      }
-      next()
+    const {
+      dit_team: { id },
+    } = res.locals.user
+    const [featureFlag] = layoutTestingFeature
+    const [, teamId] = featureFlag.split(':')
+    res.locals.isLayoutTesting = teamId === id
+    if (res.locals.isLayoutTesting && isEmpty(req.query)) {
+      return res.redirect(`${req.originalUrl}?layoutTesting=${queryParam}`)
     }
-  } else {
     next()
   }
 }

--- a/src/middleware/layout-testing.js
+++ b/src/middleware/layout-testing.js
@@ -1,0 +1,30 @@
+const { isEmpty } = require('lodash')
+
+module.exports = (queryParam) => (req, res, next) => {
+  const { features } = res.locals
+  res.locals.isLayoutTesting = false
+  const layoutTestingFeature = Object.keys(features).filter((x) =>
+    x.includes('layoutTesting')
+  )
+
+  if (!isEmpty(layoutTestingFeature)) {
+    if (layoutTestingFeature.length > 1) {
+      throw new Error(
+        'You can only have one "layoutTesting" feature running. Remove one of the features from admin.'
+      )
+    } else {
+      const {
+        dit_team: { id },
+      } = res.locals.user
+      const [featureFlag] = layoutTestingFeature
+      const [, teamId] = featureFlag.split(':')
+      res.locals.isLayoutTesting = teamId === id
+      if (res.locals.isLayoutTesting && isEmpty(req.query)) {
+        return res.redirect(`${req.originalUrl}?layoutTesting=${queryParam}`)
+      }
+      next()
+    }
+  } else {
+    next()
+  }
+}

--- a/src/middleware/layout-testing.js
+++ b/src/middleware/layout-testing.js
@@ -24,5 +24,7 @@ module.exports = (queryParam) => (req, res, next) => {
       return res.redirect(`${req.originalUrl}?layoutTesting=${queryParam}`)
     }
     next()
+  } else {
+    next()
   }
 }

--- a/test/functional/cypress/specs/middleware/testing-layout.spec.js
+++ b/test/functional/cypress/specs/middleware/testing-layout.spec.js
@@ -1,0 +1,53 @@
+describe('Testing layout feature flag', () => {
+  context(
+    'when I am in the team and "testingLayout" feature flag is turned on',
+    () => {
+      beforeEach(() => {
+        cy.setFeatureFlag(
+          'layoutTesting:9010dd28-9798-e211-a939-e4115bead28a',
+          true
+        )
+        cy.visit('/layout-testing')
+      })
+      it('should display a test layout', () => {
+        cy.get('body').should('have.text', 'Testing layout is true')
+      })
+      it('should include the query param for GA tracking', () => {
+        cy.url().should('contain', '?layoutTesting=testing')
+      })
+      after(() => {
+        cy.resetFeatureFlags()
+      })
+    }
+  )
+  context(
+    'when I am NOT in the team and "testingLayout" feature flag is turned on',
+    () => {
+      beforeEach(() => {
+        cy.setFeatureFlag('layoutTesting:123456', true)
+        cy.visit('/layout-testing')
+      })
+      it('should display a normal layout', () => {
+        cy.get('body').should('have.text', 'Testing layout is false')
+      })
+      it('should not contain any query params in the url', () => {
+        cy.url().should('eq', `${Cypress.config().baseUrl}/layout-testing`)
+      })
+      after(() => {
+        cy.resetFeatureFlags()
+      })
+    }
+  )
+
+  context('when "testingLayout" feature flag is turned off', () => {
+    beforeEach(() => {
+      cy.visit('/layout-testing')
+    })
+    it('should display a normal layout', () => {
+      cy.get('body').should('have.text', 'Testing layout is false')
+    })
+    it('should not contain any query params in the url', () => {
+      cy.url().should('eq', `${Cypress.config().baseUrl}/layout-testing`)
+    })
+  })
+})

--- a/test/sandbox/routes/v3/feature-flag/feature-flag.js
+++ b/test/sandbox/routes/v3/feature-flag/feature-flag.js
@@ -1,17 +1,18 @@
+const { isEmpty } = require('lodash')
 var defaultFeatureFlags = require('../../../fixtures/v3/feature-flag/feature-flag.json')
 
-let featureFlags = { ...defaultFeatureFlags }
+let featureFlags = [...defaultFeatureFlags]
 
 exports.featureFlag = function (req, res) {
-  return res.json(defaultFeatureFlags)
+  res.json(featureFlags.filter((x) => !isEmpty(x)))
 }
 
 exports.setSandboxFlag = function (req, res) {
-  featureFlags[req.body.code] = req.body
+  featureFlags['123'] = req.body
   res.json(featureFlags)
 }
 
 exports.resetSandboxFlags = function (req, res) {
-  featureFlags = { ...defaultFeatureFlags }
+  featureFlags = [...defaultFeatureFlags]
   res.json(featureFlags)
 }

--- a/test/sandbox/routes/v3/feature-flag/feature-flag.js
+++ b/test/sandbox/routes/v3/feature-flag/feature-flag.js
@@ -8,7 +8,7 @@ exports.featureFlag = function (req, res) {
 }
 
 exports.setSandboxFlag = function (req, res) {
-  featureFlags['123'] = req.body
+  featureFlags.push(req.body)
   res.json(featureFlags)
 }
 


### PR DESCRIPTION
## Description of change
As we are designing a new dashboard we need the ability to show a new design to a specific team so we can track user the behaviour via Google analytics.

### How this works

1. You set a feature flag in Django in this format layoutTesting:${id} where id is the team you wish to target so if the team id is "1234" the flag should be `layoutTesting:1234`
2. This then activates a global variable that nunjucks can access via express, the variable is a boolean and its called `isLayoutTesting`. (this gets set to the `res.locals`)
3. As we currently need nunjucks to mount React you will need to toggle the nunjucks template using the variable mentioned in point 2.

Note: Currently you can only have one feature flag starting with `layoutTesting`, if you have more than one the app will chose the first and log a message in the terminal that recommends you remove one from Django or at least deactivate it.

## Test instructions
1. You would have to toggle a layout using the boolean from `res.locals.isLayoutTesting` I would run the tests to see how this works. 
2. Run the `testing-layout.spec.js` 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
