### PR TITLE
Default sideEffects to false so webpack in prod mode works

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = (env) => ({
     devtoolModuleFilenameTemplate: '[absolute-resource-path]',
     devtoolFallbackModuleFilenameTemplate: '[absolute-resource-path]?[hash]',
   },
+  optimization: { sideEffects: false },
   plugins: [
     new MiniCssExtractPlugin({
       filename: config.isProd


### PR DESCRIPTION
## Description of change

TerserPlugin which is defaulted as part of `mode=production` has a regression when `sideEffect` has its defaulted value `true`. Setting this to false doesn't seem to impact much of the performance. Below is some documentation around this option in webpack:

https://webpack.js.org/configuration/optimization/#optimizationsideeffects

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
