### PR TITLE
Add actual land date filters

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -57,7 +57,7 @@ const ProjectsCollection = ({
       <CollectionFilters>
         <ToggleSection
           label="Company information"
-          id="projects.filters.company.information"
+          id="company-information-filters"
           isOpen={true}
         >
           <FilterAdvisersTypeahead
@@ -108,6 +108,16 @@ const ProjectsCollection = ({
             label="Estimated land date after"
             name="estimated_land_date_after"
             qsParamName="estimated_land_date_after"
+          />
+          <RoutedDateField
+            label="Actual land date before"
+            name="actual_land_date_before"
+            qsParamName="actual_land_date_before"
+          />
+          <RoutedDateField
+            label="Actual land date after"
+            name="actual_land_date_after"
+            qsParamName="actual_land_date_after"
           />
         </ToggleSection>
       </CollectionFilters>

--- a/src/apps/investments/client/projects/metadata/index.js
+++ b/src/apps/investments/client/projects/metadata/index.js
@@ -4,6 +4,8 @@ export { ukRegionOptions } from './uk-regions'
 
 export const estimatedLandDateBeforeLabel = 'Estimated land date before'
 export const estimatedLandDateAfterLabel = 'Estimated land date after'
+export const actualLandDateBeforeLabel = 'Actual land date before'
+export const actualLandDateAfterLabel = 'Actual land date after'
 
 export const sortOptions = [
   {

--- a/src/apps/investments/client/projects/state.js
+++ b/src/apps/investments/client/projects/state.js
@@ -2,11 +2,13 @@ import qs from 'qs'
 import dateFns from 'date-fns'
 
 import {
+  actualLandDateBeforeLabel,
+  actualLandDateAfterLabel,
   countryOptions,
   estimatedLandDateBeforeLabel,
   estimatedLandDateAfterLabel,
-  sortOptions,
   sectorOptions,
+  sortOptions,
   ukRegionOptions,
 } from './metadata'
 
@@ -27,6 +29,8 @@ const searchParamProps = ({
   uk_region = false,
   estimated_land_date_before = null,
   estimated_land_date_after = null,
+  actual_land_date_before = null,
+  actual_land_date_after = null,
 }) => ({
   adviser: parseVariablePropType(adviser),
   sector_descends: parseVariablePropType(sector_descends),
@@ -34,6 +38,8 @@ const searchParamProps = ({
   uk_region: parseVariablePropType(uk_region),
   estimated_land_date_before,
   estimated_land_date_after,
+  actual_land_date_before,
+  actual_land_date_after,
   sortby,
   page,
 })
@@ -69,6 +75,8 @@ export const state2props = ({ router, ...state }) => {
     uk_region = [],
     estimated_land_date_before,
     estimated_land_date_after,
+    actual_land_date_before,
+    actual_land_date_after,
   } = queryProps
 
   const selectedFilters = {
@@ -86,6 +94,14 @@ export const state2props = ({ router, ...state }) => {
     selectedEstimatedLandDatesAfter: buildDatesFilter(
       estimatedLandDateAfterLabel,
       estimated_land_date_after
+    ),
+    selectedActualLandDatesBefore: buildDatesFilter(
+      actualLandDateBeforeLabel,
+      actual_land_date_before
+    ),
+    selectedActualLandDatesAfter: buildDatesFilter(
+      actualLandDateAfterLabel,
+      actual_land_date_after
     ),
   }
 

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -83,11 +83,11 @@ function FilteredCollectionHeader({
             <StyledResultCount>{formattedTotal}</StyledResultCount>{' '}
             {counterSuffix}
           </StyledHeaderText>
-          <FilterReset>Remove all filters</FilterReset>
+          <FilterReset id="clear-filters">Remove all filters</FilterReset>
         </StyledDiv>
       </CollectionHeaderRow>
 
-      <CollectionHeaderRow>
+      <CollectionHeaderRow id="filter-chips">
         <RoutedFilterChips
           selectedOptions={selectedFilters.selectedAdvisers}
           qsParamName="adviser"
@@ -111,6 +111,14 @@ function FilteredCollectionHeader({
         <RoutedFilterChips
           selectedOptions={selectedFilters.selectedEstimatedLandDatesAfter}
           qsParamName="estimated_land_date_after"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedActualLandDatesBefore}
+          qsParamName="actual_land_date_before"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedActualLandDatesAfter}
+          qsParamName="actual_land_date_after"
         />
       </CollectionHeaderRow>
     </CollectionHeaderRowContainer>

--- a/src/client/components/ToggleSection/index.jsx
+++ b/src/client/components/ToggleSection/index.jsx
@@ -48,16 +48,20 @@ const StyledButton = styled('button')`
   }
 `
 
-const ToggleSection = ({ label, open, isOpen = false, children }) => {
-  return (
-    <ToggleContainer>
-      <StyledButton onClick={() => open(!isOpen)} isOpen={isOpen}>
-        <span>{label}</span>
-      </StyledButton>
-      <StyledDiv isOpen={isOpen}>{children}</StyledDiv>
-    </ToggleContainer>
-  )
-}
+const ToggleSection = ({
+  label,
+  open,
+  isOpen = false,
+  children,
+  id = null,
+}) => (
+  <ToggleContainer id={id}>
+    <StyledButton onClick={() => open(!isOpen)} isOpen={isOpen}>
+      <span>{label}</span>
+    </StyledButton>
+    <StyledDiv isOpen={isOpen}>{children}</StyledDiv>
+  </ToggleContainer>
+)
 
 export default multiInstance({
   name: 'ToggleSection',

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -5,8 +5,14 @@ const ADVANCED_ENGINEERING_SECTOR_ID = 'af959812-6095-e211-a939-e4115bead28a'
 const UK_COUNTRY_ID = '80756b9a-5d95-e211-a939-e4115bead28a'
 const SOUTH_EAST_UK_REGION_ID = '884cd12a-6095-e211-a939-e4115bead28a'
 
-const selectAdvisersTypeahead = (fieldName, input) =>
-  cy.get(fieldName).within(() => {
+/**
+ * Enter `input` into an advisers typeahead `element` and select the first result
+ *
+ * This waits for the adviser api request to complete before selecting the
+ * first option.
+ */
+const selectFirstAdvisersTypeaheadOption = ({ element, input }) =>
+  cy.get(element).within(() => {
     cy.server()
     cy.route('/api-proxy/adviser/?*').as('adviserResults')
     cy.get('div').eq(0).type(input)
@@ -14,52 +20,110 @@ const selectAdvisersTypeahead = (fieldName, input) =>
     cy.get('[class*="menu"] > div').click()
   })
 
-const assertTypehead = (element, label, placeholder, input, selectedOption) => {
+/**
+ * Enter `input` into a typeahead `element` and select the first result
+ */
+const selectFirstTypeaheadOption = ({ element, input }) => {
+  cy.get(element).type(input)
+  cy.get(element).find('[class*="menu"] > div').click()
+  cy.get(element).click()
+}
+
+/**
+ * Asserts that a typeahead `element` has the given `label` and `placeholder`
+ */
+const assertTypeaheadHasLabelAndPlaceholder = ({
+  element,
+  label,
+  placeholder,
+}) => {
   cy.get(element)
     .find('label')
     .should('have.text', label)
     .next()
     .should('contain', placeholder)
-    .find('div')
-    .eq(0)
-    .type(input)
-  cy.get(element).find('[class*="menu"] > div').click()
-  cy.get(element).click()
-  cy.get(element).should('contain', selectedOption)
 }
 
-const assertFilterIndicator = (count, label) => {
-  cy.get(`main article div + div button:nth-child(${count})`).should((el) => {
+/**
+ * Asserts that the typeahead `element` has the `expectedOption` selected
+ */
+const assertTypeaheadOptionSelected = ({ element, expectedOption }) => {
+  cy.get(element).should('contain', expectedOption)
+}
+
+/**
+ * Asserts that a chip indicator exists in the specified position
+ */
+const assertChipExists = ({ label, position }) => {
+  cy.get(`#filter-chips button:nth-child(${position})`).should((el) => {
     expect(el.text()).to.contain(label)
   })
 }
 
-const assertRemovedFilterIndicator = (element, placeholder = null) => {
-  cy.get('main article div + div button').click()
-  cy.get('main article div + div').should('be.empty')
+/**
+ * Tests that a typeahead functions correctly by inputing a value and selecting
+ */
+const testTypeahead = ({
+  element,
+  label,
+  placeholder,
+  input,
+  expectedOption,
+}) => {
+  assertTypeaheadHasLabelAndPlaceholder({ element, label, placeholder })
+  selectFirstTypeaheadOption({ element, input })
+  assertTypeaheadOptionSelected({ element, expectedOption })
+}
+
+/**
+ * Tests that clicking the first indicator button clears a filter element
+ */
+const testRemoveChip = ({ element, placeholder = null }) => {
+  cy.get('#filter-chips').as('filterChips').find('button').click()
+  cy.get('@filterChips').should('be.empty')
   placeholder && cy.get(element).should('contain', placeholder)
 }
 
 describe('Investments Collections Filter', () => {
   beforeEach(() => {
-    cy.get('aside button')
-      .next()
-      .find('#field-advisers')
-      .as('adviserFilter')
-      .next()
-      .as('sectorFilter')
-      .next()
-      .as('countryFilter')
-      .next()
-      .as('ukRegionFilter')
-      .next()
-      .as('estimatedDateBefore')
-      .next()
-      .as('estimatedDateAfter')
+    cy.get('#field-advisers').as('adviserFilter')
+    cy.get('#field-sector').as('sectorFilter')
+    cy.get('#field-country').as('countryFilter')
+    cy.get('#field-uk_region').as('ukRegionFilter')
+    cy.get('#field-estimated_land_date_before').as('estimatedDateBefore')
+    cy.get('#field-estimated_land_date_after').as('estimatedDateAfter')
+    cy.get('#field-actual_land_date_before').as('actualDateBefore')
+    cy.get('#field-actual_land_date_after').as('actualDateAfter')
   })
+
   context('when the url contains no state', () => {
     before(() => {
       cy.visit(urls.investments.projects.index())
+    })
+
+    it('should contain filter fields in the right order', () => {
+      cy.get('#company-information-filters')
+        .should('exist')
+        .find('button')
+        .should('exist')
+        .next()
+        .should('exist')
+        .find('*')
+        .should('have.id', 'field-advisers')
+        .next()
+        .should('have.id', 'field-sector')
+        .next()
+        .should('have.id', 'field-country')
+        .next()
+        .should('have.id', 'field-uk_region')
+        .next()
+        .should('have.id', 'field-estimated_land_date_before')
+        .next()
+        .should('have.id', 'field-estimated_land_date_after')
+        .next()
+        .should('have.id', 'field-actual_land_date_before')
+        .next()
+        .should('have.id', 'field-actual_land_date_after')
     })
 
     it('should filter by advisers', () => {
@@ -68,52 +132,70 @@ describe('Investments Collections Filter', () => {
         .find('label')
         .should('have.text', 'Advisers')
 
-      selectAdvisersTypeahead('@adviserFilter', 'puc')
+      selectFirstAdvisersTypeaheadOption({
+        element: '@adviserFilter',
+        input: 'puc',
+      })
       cy.get('@adviserFilter').should('contain', 'Puck Head')
-      assertFilterIndicator(1, 'Puck Head')
+      assertChipExists({ label: 'Puck Head', position: 1 })
     })
 
     it('should remove the advisers filter', () => {
-      assertRemovedFilterIndicator('@adviserFilter', 'Search advisers')
+      testRemoveChip({
+        element: '@adviserFilter',
+        placeholder: 'Search advisers',
+      })
     })
 
     it('should filter by sector', () => {
-      assertTypehead(
-        '@sectorFilter',
-        'Sector',
-        'Search sectors',
-        'adv',
-        'Advanced Engineering'
-      )
+      testTypeahead({
+        element: '@sectorFilter',
+        label: 'Sector',
+        placeholder: 'Search sectors',
+        input: 'adv',
+        expectedOption: 'Advanced Engineering',
+      })
     })
+
     it('should remove the sector filter', () => {
-      assertRemovedFilterIndicator('@sectorFilter', 'Search sectors')
+      testRemoveChip({
+        element: '@sectorFilter',
+        placeholder: 'Search sectors',
+      })
     })
 
     it('should filter by country', () => {
-      assertTypehead(
-        '@countryFilter',
-        'Country of origin',
-        'Search countries',
-        'sin',
-        'Singapore'
-      )
+      testTypeahead({
+        element: '@countryFilter',
+        label: 'Country of origin',
+        placeholder: 'Search countries',
+        input: 'sin',
+        expectedOption: 'Singapore',
+      })
     })
+
     it('should remove the country filter', () => {
-      assertRemovedFilterIndicator('@countryFilter', 'Search countries')
+      testRemoveChip({
+        element: '@countryFilter',
+        placeholder: 'Search countries',
+      })
     })
 
     it('should filter by uk region', () => {
-      assertTypehead(
-        '@ukRegionFilter',
-        'UK Region',
-        'Search UK regions',
-        'sou',
-        'South East'
-      )
+      testTypeahead({
+        element: '@ukRegionFilter',
+        label: 'UK Region',
+        placeholder: 'Search UK region',
+        input: 'sou',
+        expectedOption: 'South East',
+      })
     })
-    it('should remove the country filter', () => {
-      assertRemovedFilterIndicator('@countryFilter', 'Search countries')
+
+    it('should remove the uk region filter', () => {
+      testRemoveChip({
+        element: '@ukRegionFilter',
+        placeholder: 'Search UK regions',
+      })
     })
 
     it('should filter the estimated land date before', () => {
@@ -123,11 +205,14 @@ describe('Investments Collections Filter', () => {
         .next()
         .click()
         .type('2020-01-01')
-      assertFilterIndicator(1, 'Estimated land date before : 1 January 2020')
+      assertChipExists({
+        label: 'Estimated land date before : 1 January 2020',
+        position: 1,
+      })
     })
 
     it('should remove the estimated land date before filter', () => {
-      assertRemovedFilterIndicator('@estimatedDateBefore')
+      testRemoveChip({ element: '@estimatedDateBefore' })
     })
 
     it('should filter the estimated land date after', () => {
@@ -136,12 +221,49 @@ describe('Investments Collections Filter', () => {
         .should('have.text', 'Estimated land date after')
         .next()
         .click()
-        .type('2020-01-01')
-      assertFilterIndicator(1, 'Estimated land date after : 1 January 2020')
+        .type('2020-01-02')
+      assertChipExists({
+        label: 'Estimated land date after : 2 January 2020',
+        position: 1,
+      })
     })
 
     it('should remove the estimated land date before filter', () => {
-      assertRemovedFilterIndicator('@estimatedDateBefore')
+      testRemoveChip({ element: '@estimatedDateBefore' })
+    })
+
+    it('should filter the actual land date before', () => {
+      cy.get('@actualDateBefore')
+        .find('label')
+        .should('have.text', 'Actual land date before')
+        .next()
+        .click()
+        .type('2020-02-01')
+      assertChipExists({
+        label: 'Actual land date before : 1 February 2020',
+        position: 1,
+      })
+    })
+
+    it('should remove the actual land date before filter', () => {
+      testRemoveChip({ element: '@actualDateBefore' })
+    })
+
+    it('should filter the actual land date after', () => {
+      cy.get('@actualDateAfter')
+        .find('label')
+        .should('have.text', 'Actual land date after')
+        .next()
+        .click()
+        .type('2020-02-02')
+      assertChipExists({
+        label: 'Actual land date after : 2 February 2020',
+        position: 1,
+      })
+    })
+
+    it('should remove the actual land date before filter', () => {
+      testRemoveChip({ element: '@actualDateBefore' })
     })
   })
 
@@ -154,34 +276,57 @@ describe('Investments Collections Filter', () => {
           country: UK_COUNTRY_ID,
           uk_region: SOUTH_EAST_UK_REGION_ID,
           estimated_land_date_before: '2020-01-01',
-          estimated_land_date_after: '2020-01-01',
+          estimated_land_date_after: '2020-01-02',
+          actual_land_date_before: '2020-02-01',
+          actual_land_date_after: '2020-02-02',
         },
       })
     })
     it('should set the selected filter values and filter indicators', () => {
-      assertFilterIndicator(1, 'Puck Head')
+      assertChipExists({ position: 1, label: 'Puck Head' })
       cy.get('@adviserFilter').should('contain', 'Puck Head')
-      assertFilterIndicator(2, 'Advanced Engineering')
+      assertChipExists({ position: 2, label: 'Advanced Engineering' })
       cy.get('@sectorFilter').should('contain', 'Advanced Engineering')
-      assertFilterIndicator(3, 'United Kingdom')
+      assertChipExists({ position: 3, label: 'United Kingdom' })
       cy.get('@countryFilter').should('contain', 'United Kingdom')
-      assertFilterIndicator(4, 'South East')
+      assertChipExists({ position: 4, label: 'South East' })
       cy.get('@ukRegionFilter').should('contain', 'South East')
-      assertFilterIndicator(5, 'Estimated land date before : 1 January 2020')
+      assertChipExists({
+        label: 'Estimated land date before : 1 January 2020',
+        position: 5,
+      })
       cy.get('@estimatedDateBefore')
         .find('input')
         .should('have.attr', 'value', '2020-01-01')
-      assertFilterIndicator(6, 'Estimated land date after : 1 January 2020')
+      assertChipExists({
+        label: 'Estimated land date after : 2 January 2020',
+        position: 6,
+      })
       cy.get('@estimatedDateAfter')
         .find('input')
-        .should('have.attr', 'value', '2020-01-01')
+        .should('have.attr', 'value', '2020-01-02')
+      assertChipExists({
+        label: 'Actual land date before : 1 February 2020',
+        position: 7,
+      })
+      cy.get('@actualDateBefore')
+        .find('input')
+        .should('have.attr', 'value', '2020-02-01')
+      assertChipExists({
+        label: 'Actual land date after : 2 February 2020',
+        position: 8,
+      })
+      cy.get('@actualDateAfter')
+        .find('input')
+        .should('have.attr', 'value', '2020-02-02')
     })
 
     it('should clear all filters', () => {
-      cy.get('main article div + div button').as('filterIndicators')
-      cy.get('@filterIndicators').should('have.length', 6)
-      cy.get('main article div:first-child > button').click()
-      cy.get('@filterIndicators').should('have.length', 0)
+      cy.get('#filter-chips').find('button').as('chips')
+      cy.get('#clear-filters').as('clearFilters')
+      cy.get('@chips').should('have.length', 8)
+      cy.get('@clearFilters').click()
+      cy.get('@chips').should('have.length', 0)
       cy.get('@estimatedDateBefore')
         .find('input')
         .should('have.attr', 'value', '')

--- a/test/sandbox/routes/v3/search/investment-project.js
+++ b/test/sandbox/routes/v3/search/investment-project.js
@@ -2,6 +2,8 @@ var investmentProjects = require('../../../fixtures/v3/search/investment-project
 
 exports.investmentProjects = function (req, res) {
   const hasFilters = !!(
+    req.body.actual_land_date_before ||
+    req.body.actual_land_date_after ||
     req.body.estimated_land_date_before ||
     req.body.estimated_land_date_after ||
     req.body.sector_descends ||
@@ -38,10 +40,10 @@ exports.investmentProjects = function (req, res) {
   }
 }
 
+/**
+ * Mock a simple csv file for export
+ */
 exports.export = function (req, res) {
-  /*
-   * Mock a simple csv file for export
-   */
   res.header('Content-Type', 'text/csv')
   res.attachment('export.csv')
   res.send('a,b,c\n1,2,3')


### PR DESCRIPTION
## Description of change

Adds actual land date filters to the investment projects page.

I have also refactored the cypress tests for the filters to use ids instead of traversing the DOM tree. My justification for this is:

1. Tests should fail because the thing they are testing fails. If the structure of the page is changed, it will be confusing to see failed tests saying "it should filter the actual land date". I have added a new test 'it should contain filter fields in the right order' to ensure that the page is composed correctly without breaking other tests.
2. Related to number one, but using unusual descendant selectors can make the tests quite fragile, so a minor change to something unrelated could break all of the tests
3. Readability / maintainability and time taken to understand the code. It is not clear what long selectors like `main article div + div button` actually mean; by using ids, these selectors become quite a lot clearer, so the previous example would become `#filter-chips button`.

As part of the refactor, I have also changed the helper functions to use named props - this is to make it clearer what they are doing when you call them. I have also updated the names of a couple of 'assert' functions to be prefixed with 'test' because they actually perform actions that have side effects. Finally, I have also added a few docstrings to explain what the different functions do.

## Test instructions

There should now be filters for actual land date before and after. Selecting these filters should show a chip above the list of projects. Clicking on the chip should remove the filter, as should clicking 'remove all filters'.

## Screenshots

![Screenshot from 2020-12-04 17-23-59](https://user-images.githubusercontent.com/1234577/101194173-8bc51080-3655-11eb-8e4b-f70485eea9cb.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
