### PR TITLE
Proposed unit test replacements

### DIFF
--- a/src/apps/companies/apps/add-company/__test__/controllers.test.js
+++ b/src/apps/companies/apps/add-company/__test__/controllers.test.js
@@ -83,6 +83,7 @@ describe('Add company form controllers', () => {
         )
       })
 
+      // TODO: Mostly covered by: test/functional/cypress/specs/companies/add-company-spec.js - is it worth adding a test checking the expected countries etc. appear or in the right format?
       it('should render the add company form template with fields', () => {
         const expectedTemplate =
           'companies/apps/add-company/views/client-container'
@@ -112,12 +113,14 @@ describe('Add company form controllers', () => {
         )
       })
 
+      // DONE: covered by test/functional/cypress/specs/companies/add-company-spec.js:37
       it('should add a breadcrumb', () => {
         expect(
           middlewareParameters.resMock.breadcrumb.firstCall
         ).to.be.calledWith('Add company')
       })
 
+      // TODO: find way to show errors not flagged (perhaps check for absence of error message for user?)
       it('should not call next() with an error', () => {
         expect(middlewareParameters.nextSpy).to.not.have.been.called
       })
@@ -143,6 +146,7 @@ describe('Add company form controllers', () => {
         )
       })
 
+      // TODO: mock error in form rendering in test/functional/cypress/specs/companies/add-company-spec.js - check for presence of error message
       it('should call next() with an error', () => {
         expect(middlewareParameters.nextSpy).to.have.been.calledOnceWithExactly(
           error
@@ -179,14 +183,14 @@ describe('Add company form controllers', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // NOTE: covered in tests here test/functional/cypress/specs/companies/add-company-spec.js:168
       it('should respond with JSON', () => {
         expect(middlewareParameters.resMock.json).to.be.calledOnceWithExactly({
           count: 0,
           results: [],
         })
       })
-
+      // TODO: as above, check for lack of error message
       it('should not call next() with an error', () => {
         expect(middlewareParameters.nextSpy).to.not.have.been.called
       })
@@ -216,11 +220,11 @@ describe('Add company form controllers', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // TODO: add a test case to test/functional/cypress/specs/companies/add-company-spec.js for when the search fails
       it('should not respond with JSON', () => {
         expect(middlewareParameters.resMock.json).to.not.have.been.called
       })
-
+      // TODO: as immediately above - is there an error message?
       it('should call next() with an error', () => {
         expect(middlewareParameters.nextSpy).to.have.been.calledOnceWithExactly(
           sinon.match({
@@ -261,20 +265,20 @@ describe('Add company form controllers', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // NOTE: covered in: test/functional/cypress/specs/companies/add-company-spec.js:297
       it('should flash a created message', () => {
         expect(middlewareParameters.reqMock.flash).to.be.calledOnceWithExactly(
           'success',
           'Company added to Data Hub'
         )
       })
-
+      // NOTE: covered in: test/functional/cypress/specs/companies/add-company-spec.js:282
       it('should respond with the created company', () => {
         expect(middlewareParameters.resMock.json).to.be.calledOnceWithExactly(
           companyCreateResponse
         )
       })
-
+      // TODO: add check there is no error to add-company-spec.js
       it('should not call next() with an error', async () => {
         expect(middlewareParameters.nextSpy).to.not.have.been.called
       })
@@ -302,15 +306,15 @@ describe('Add company form controllers', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // TODO: add test for 500 failure in adding a new DnB company in add-company.js
       it('should not flash a created message', () => {
         expect(middlewareParameters.reqMock.flash).to.not.have.been.called
       })
-
+      // TODO: as immediately above
       it('should not respond', () => {
         expect(middlewareParameters.resMock.json).to.not.have.been.called
       })
-
+      // TODO: as immediately above
       it('should call next() with an error', async () => {
         expect(middlewareParameters.nextSpy).to.have.been.calledOnceWithExactly(
           sinon.match({
@@ -383,20 +387,20 @@ describe('Add company form controllers', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // NOTE: covered in add-company-spec.js:516
       it('should flash a created message', () => {
         expect(middlewareParameters.reqMock.flash).to.be.calledOnceWithExactly(
           'success',
           'Company added to Data Hub'
         )
       })
-
+      // NOTE: covered in add-company-spec.js:510
       it('should respond with the created company', () => {
         expect(middlewareParameters.resMock.json).to.be.calledOnceWithExactly(
           companyCreateInvestigationResponse
         )
       })
-
+      // TODO: check absence of error
       it('should not call next() with an error', async () => {
         expect(middlewareParameters.nextSpy).to.not.have.been.called
       })
@@ -448,15 +452,15 @@ describe('Add company form controllers', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // TODO: add a test with a mocked 500 response to add-company-spec.js
       it('should not flash a created message', () => {
         expect(middlewareParameters.reqMock.flash).to.not.have.been.called
       })
-
+      // as above
       it('should not respond', () => {
         expect(middlewareParameters.resMock.json).to.not.have.been.called
       })
-
+      // as above
       it('should call next() with an error', async () => {
         expect(middlewareParameters.nextSpy).to.have.been.calledOnceWithExactly(
           sinon.match({

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/controllers.test.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/controllers.test.js
@@ -32,11 +32,11 @@ describe('D&B Company hierarchy', () => {
           middlewareParams.nextSpy
         )
       })
-
+      // NOTE: covered in test/functional/cypress/specs/companies/dnb-hierarchy-spec.js:29
       it('should render', () => {
         expect(middlewareParams.resMock.render).to.be.calledOnce
       })
-
+      // TODO: mostly covered in test/functional/cypress/specs/companies/dnb-hierarchy-spec.js, but could add a check for isGlobal HQ
       it('should render the activity feed template', () => {
         expect(middlewareParams.resMock.render).to.be.calledOnceWithExactly(
           'companies/apps/dnb-hierarchy/views/client-container',
@@ -49,23 +49,23 @@ describe('D&B Company hierarchy', () => {
           }
         )
       })
-
+      // NOTE: covered in test/functional/cypress/specs/companies/dnb-hierarchy-spec.js:39
       it('should add a breadcrumb', () => {
         expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
           'Test company',
           urls.companies.detail('1')
         )
-
+        // NOTE: as line 52
         expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
           'Business details',
           urls.companies.businessDetails('1')
         )
-
+        // NOTE: as line 52
         expect(middlewareParams.resMock.breadcrumb).to.have.been.calledWith(
           'Related companies'
         )
       })
-
+      // TODO: add something about not displaying an error
       it('should not call "next" with an error', async () => {
         expect(middlewareParams.nextSpy).to.not.have.been.called
       })
@@ -93,7 +93,7 @@ describe('D&B Company hierarchy', () => {
           middlewareParams.nextSpy
         )
       })
-
+      // TODO: add test to dnb-hierachy-spec.js about errors
       it('should call next with an error', async () => {
         expect(middlewareParams.nextSpy).to.have.been.calledWith(error)
       })
@@ -115,7 +115,7 @@ describe('D&B Company hierarchy', () => {
           middlewareParams.nextSpy
         )
       })
-
+      // TODO: add a test case for this case to dnb-hierachy-spec.js
       it('should call next() with an error', async () => {
         expect(middlewareParams.nextSpy).to.have.been.calledOnceWithExactly(
           sinon.match({
@@ -151,7 +151,7 @@ describe('D&B Company hierarchy', () => {
           middlewareParams.nextSpy
         )
       })
-
+      // NOTE: covered in: test/functional/cypress/specs/companies/dnb-hierarchy-spec.js:49
       it('should respond with a list of D&B hierarchy', () => {
         expect(middlewareParams.resMock.json).to.be.calledOnceWithExactly({
           count: 1,
@@ -172,7 +172,7 @@ describe('D&B Company hierarchy', () => {
           ],
         })
       })
-
+      // TODO: add check to dnb-hierachy-spec.js about not erroring
       it('should not call next() with an error', async () => {
         expect(middlewareParams.nextSpy).to.not.have.been.called
       })
@@ -199,7 +199,7 @@ describe('D&B Company hierarchy', () => {
           middlewareParams.nextSpy
         )
       })
-
+      // TODO: add 500 mock error case to functional test
       it('should not respond', () => {
         expect(middlewareParams.resMock.json).to.not.have.been.called
       })

--- a/src/apps/companies/middleware/__test__/collection.test.js
+++ b/src/apps/companies/middleware/__test__/collection.test.js
@@ -28,7 +28,7 @@ const headquarterTypes = [
     disabled_on: null,
   },
 ]
-
+// TODO: add new functional test to companies testing the views for HQ companies and subsidiaries (using the contexts outlined below). This could be in addition to: test/functional/cypress/specs/companies/dnb-hierarchy-spec.js (ensuring non D&B companies are covered if there is a business need)
 describe('Company collection middleware', () => {
   beforeEach(() => {
     this.nextSpy = sinon.spy()

--- a/src/apps/companies/middleware/__test__/hierarchies.test.js
+++ b/src/apps/companies/middleware/__test__/hierarchies.test.js
@@ -5,7 +5,7 @@ const { setGlobalHQ, removeGlobalHQ, addSubsidiary } = require('../hierarchies')
 
 const globalHeadquartersId = '1'
 const subsidiaryCompanyId = '2'
-
+// TODO: add new functional/e2e test to companies updating the Global HQ of  companies and subsidiaries (using the contexts outlined below). This could be in addition to: test/functional/cypress/specs/companies/dnb-hierarchy-spec.js (ensuring non D&B companies are covered if there is a business need)
 describe('Company hierarchies middleware', () => {
   describe('#setGlobalHQ', () => {
     context('when company update is successful', () => {

--- a/src/apps/company-lists/__test__/repos.test.js
+++ b/src/apps/company-lists/__test__/repos.test.js
@@ -30,6 +30,7 @@ describe('Company list repository', () => {
         },
       })
     })
+    // NOTE: this context is covered by the view-1 and view-2 company-list functional test specs
     context('when the list is successfully retrieved', () => {
       beforeEach(async () => {
         nock(config.apiRoot)
@@ -49,7 +50,7 @@ describe('Company list repository', () => {
         ).to.be.deep.equal(companyList)
       })
     })
-
+    // TODO: add fetching error context to the company-list view functional tests
     context('when there is an error retrieving the list', () => {
       beforeEach(async () => {
         nock(config.apiRoot).get(`/v4/company-list/${listId}`).reply(404)
@@ -70,7 +71,7 @@ describe('Company list repository', () => {
       })
     })
   })
-
+  // NOTE: covered in test/functional/cypress/specs/company-lists/create-spec.js
   describe('#createUserCompanyList', () => {
     beforeEach(() => {
       nock(config.apiRoot)
@@ -94,7 +95,7 @@ describe('Company list repository', () => {
       })
     })
   })
-
+  // TODO: add a functional test for this case - see line 111
   describe('#getListsCompanyIsIn', () => {
     beforeEach(() => {
       nock(config.apiRoot)
@@ -107,7 +108,7 @@ describe('Company list repository', () => {
       expect(companyList).to.deep.equal(companyListFixture)
     })
   })
-
+  // TODO: While this (and #getCompanyList) is exercised in test/functional/cypress/specs/company-lists/add-remove.spec.js, it might be worth updating that test to make the distinction clearer between the lists the company is already on for the user, and the lists it isn't
   describe('#getAllCompanyLists', () => {
     beforeEach(() => {
       nock(config.apiRoot)
@@ -120,7 +121,7 @@ describe('Company list repository', () => {
       expect(companyList).to.deep.equal(companyListFixture)
     })
   })
-
+  // TODO: as comment in line 111
   describe('#getCompanyList', () => {
     beforeEach(async () => {
       nock(config.apiRoot)
@@ -133,7 +134,7 @@ describe('Company list repository', () => {
       expect(companyList).to.deep.equal(companyListFixture)
     })
   })
-
+  // NOTE: covered in test/functional/cypress/specs/company-lists/delete-spec.js
   describe('#deleteCompanyList', () => {
     beforeEach(() => {
       nock(config.apiRoot).delete(`/v4/company-list/${listId}`).reply(204)
@@ -143,7 +144,7 @@ describe('Company list repository', () => {
       expect(() => deleteCompanyList(stubRequest, listId)).to.not.throw()
     })
   })
-
+  // TODO: add test for this to test/functional/cypress/specs/company-lists/add-remove.spec.js or to a new e2e test
   describe('#addCompanyToList', () => {
     beforeEach(() => {
       nock(config.apiRoot).put('/v4/company-list/1/item/2').reply(204)
@@ -153,7 +154,7 @@ describe('Company list repository', () => {
       expect(() => addCompanyToList(stubRequest, '1', '2')).to.not.throw()
     })
   })
-
+  // TODO: add test for this to test/functional/cypress/specs/company-lists/add-remove.spec.js, or to a new e2e test
   describe('#removeCompanyFromList', () => {
     beforeEach(() => {
       nock(config.apiRoot).delete('/v4/company-list/1/item/2').reply(204)

--- a/src/apps/company-lists/controllers/__test__/delete.test.js
+++ b/src/apps/company-lists/controllers/__test__/delete.test.js
@@ -35,14 +35,14 @@ describe('Delete company list controller', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // NOTE: covered in: test/functional/cypress/specs/company-lists/delete-spec.js
       it('renders the delete list page', () => {
         expect(middlewareParameters.resMock.render).to.be.calledWith(
           'company-lists/views/delete-list'
         )
         expect(middlewareParameters.resMock.render).to.have.been.calledOnce
       })
-
+      // NOTE: covered in: test/functional/cypress/specs/company-lists/delete-spec.js by displaying the content of the props
       it('passes props to react-slot', () => {
         const actualProps = middlewareParameters.resMock.render.getCall(0)
           .args[1].props
@@ -51,7 +51,7 @@ describe('Delete company list controller', () => {
           returnUrl: '/',
         })
       })
-
+      // NOTE: covered in test/functional/cypress/specs/company-lists/delete-spec.js:14
       it('adds a breadcrumb', () => {
         expect(
           middlewareParameters.resMock.breadcrumb.firstCall
@@ -69,7 +69,7 @@ describe('Delete company list controller', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // TODO: write a render error case in delete company list functional test
       it('forwards the error to the next middleware', () => {
         expect(middlewareParameters.nextSpy).to.be.called
         expect(middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(
@@ -92,14 +92,14 @@ describe('Delete company list controller', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // NOTE: covered by delete-spec.js:68
       it('sets a flash message', () => {
         expect(middlewareParameters.reqMock.flash).to.be.calledWith(
           'success',
           'List deleted'
         )
       })
-
+      // NOTE: covered by delete-spec.js as showing consequences of this reponse
       it('sends a response', () => {
         expect(middlewareParameters.resMock.send).to.be.calledWith()
       })
@@ -117,7 +117,7 @@ describe('Delete company list controller', () => {
           middlewareParameters.nextSpy
         )
       })
-
+      // NOTE: covered by delete-spec.js:73 onwards
       it('forwards the error to the next middleware', () => {
         expect(middlewareParameters.resMock.send).to.not.be.called
         expect(middlewareParameters.nextSpy).to.be.called

--- a/src/apps/contacts/controllers/__test__/edit.test.js
+++ b/src/apps/contacts/controllers/__test__/edit.test.js
@@ -52,8 +52,7 @@ describe('Contact controller, edit', () => {
     })
   })
 
-  // TODO - re-write to use newer test styles, contexts and
-  // forms generator.
+  // TODO - write a functional test for editing contacts
 
   describe('get', () => {
     beforeEach(() => {

--- a/src/apps/dashboard/__test__/controllers.test.js
+++ b/src/apps/dashboard/__test__/controllers.test.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire')
 
 var rpErrors = require('request-promise/errors')
-
+// TODO: write a functional test for the dashboard
 describe('dashboard controller', () => {
   beforeEach(() => {
     global.reqMock = Object.assign({}, globalReq, {

--- a/src/apps/events/attendees/controllers/__test__/find.test.js
+++ b/src/apps/events/attendees/controllers/__test__/find.test.js
@@ -36,7 +36,7 @@ describe('Find new event attendees controller', () => {
         this.res.locals.event = event
         await renderFindAttendee(this.req, this.res, this.nextSpy)
       })
-
+      // TODO: add breadcrumb tests to: test/functional/cypress/specs/events/attendees-spec.js
       it('should set the first part of the breadcrumb to a link back to attendee list', () => {
         expect(this.res.breadcrumb.firstCall.args).to.deep.equal([
           'A United Kingdom Get together',
@@ -44,6 +44,7 @@ describe('Find new event attendees controller', () => {
         ])
       })
 
+      // TODO: add breadcrumb tests to: test/functional/cypress/specs/events/attendees-spec.js
       it('should set the last part of the breadcrumb to incidate the user is adding an attendee', () => {
         expect(this.res.breadcrumb.callCount).to.eq(2)
         expect(this.res.breadcrumb.secondCall.args).to.deep.equal([
@@ -51,20 +52,24 @@ describe('Find new event attendees controller', () => {
         ])
       })
 
+      // TODO: add title check to: test/functional/cypress/specs/events/attendees-spec.js
       it('should set the page title to the title of the event', () => {
         expect(this.res.title).to.be.calledOnce
         expect(this.res.title).to.be.calledWith('A United Kingdom Get together')
       })
 
+      // NOTE: covered by test/functional/cypress/specs/events/attendees-spec.js
       it('should render the correct template', () => {
         expect(this.res.render).to.be.calledWith('events/attendees/views/find')
       })
 
+      // Not sure this is a necessary test if we're checking what is rendered in the functional test
       it('should not call next', () => {
         expect(this.nextSpy).to.not.be.called
       })
     })
 
+    // NOTE: not sure this is a meaningful test of functionality
     context('when called without an event', () => {
       beforeEach(async () => {
         await renderFindAttendee(this.req, this.res, this.nextSpy)
@@ -81,6 +86,7 @@ describe('Find new event attendees controller', () => {
     })
   })
 
+  // NOTE: some of this is exercised by the event-spec.js DIT e2e test, line 135 onwards - except where noted. Given that there are a few different scenarios, it may be worth rolling the missing scenarios into an updated and more thorough attendees-spec functional test
   describe('#findAttendee', () => {
     context('when called with an event', () => {
       beforeEach(() => {
@@ -194,12 +200,12 @@ describe('Find new event attendees controller', () => {
               'block-links'
             )
           })
-
+          // TODO: add checks to test/functional/cypress/specs/events/attendees-spec.js that check search term displayed to user
           it('should include the search term in the locals', () => {
             expect(this.res.locals.searchTerm).to.equal('Fred')
           })
         })
-
+        // TODO: add check to test/functional/cypress/specs/events/attendees-spec.js for paginated results
         context('with lots of results and asking for page 2', () => {
           beforeEach(async () => {
             this.req.query.page = '2'
@@ -252,7 +258,7 @@ describe('Find new event attendees controller', () => {
             expect(pagination.pages).to.have.length(5)
           })
         })
-
+        // TODO: add a duplicate attendee fixture to the attendees-spec test
         context('when one of the results is an existing attendee', () => {
           beforeEach(async () => {
             this.req.query.page = '1'
@@ -299,7 +305,7 @@ describe('Find new event attendees controller', () => {
             })
           })
         })
-
+        // TODO: add a search failure context test case to the attendees-spec functional test
         context('when there is an error searching for contacts', () => {
           beforeEach(async () => {
             this.req.query.page = '1'
@@ -333,7 +339,7 @@ describe('Find new event attendees controller', () => {
         })
       })
     })
-
+    // NOTE: as above, I'm not sure this is a helpful test
     context('when no event is supplied', () => {
       beforeEach(async () => {
         await findAttendee(this.req, this.res, this.nextSpy)

--- a/src/apps/events/attendees/controllers/__test__/list.test.js
+++ b/src/apps/events/attendees/controllers/__test__/list.test.js
@@ -35,7 +35,7 @@ describe('event attendees', () => {
 
     this.nextSpy = sinon.spy()
   })
-
+  // TODO: add test cases for no attendees to: test/functional/cypress/specs/events/attendees-spec.js
   context('when there are no attendees', () => {
     beforeEach(async () => {
       nock(config.apiRoot)
@@ -151,7 +151,7 @@ describe('event attendees', () => {
       await renderAttendees(this.req, this.res, this.nextSpy)
       this.properties = this.res.render.firstCall.args[1]
     })
-
+    // TODO: add pagination information (and >10 attendees case) to: test/functional/cypress/specs/events/attendees-spec.js
     it('should include pagination information', () => {
       expect(this.properties.attendees.pagination).to.not.be.null
     })
@@ -186,7 +186,7 @@ describe('event attendees', () => {
       expect(this.properties.attendees).to.have.property('actionButtons')
     })
   })
-
+  // TODO: add search error cases to: test/functional/cypress/specs/events/attendees-spec.js
   context('when there is an error fetching attendees', () => {
     beforeEach(async () => {
       nock(config.apiRoot)
@@ -211,7 +211,7 @@ describe('event attendees', () => {
       )
     })
   })
-
+  // TODO: add both incomplete and complete event checks to the attendees-spec.js
   context('when the event is incomplete', () => {
     context('when there is no service', () => {
       beforeEach(async () => {
@@ -235,7 +235,7 @@ describe('event attendees', () => {
         expect(this.properties.attendees).to.not.have.property('actionButtons')
       })
     })
-
+    // TODO: add this context to: test/functional/cypress/specs/events/attendees-spec.js
     context('when there is no lead team', () => {
       beforeEach(async () => {
         this.res.locals.event.lead_team = null
@@ -259,7 +259,7 @@ describe('event attendees', () => {
       })
     })
   })
-
+  // TODO: add this context to: test/functional/cypress/specs/events/attendees-spec.js
   context('when the event is disabled', () => {
     beforeEach(async () => {
       this.res.locals.event.disabled_on = '2018-07-16T11:22:43Z'

--- a/src/apps/events/middleware/__test__/details.test.js
+++ b/src/apps/events/middleware/__test__/details.test.js
@@ -78,16 +78,16 @@ describe('Event details middleware', () => {
     }
     this.nextSpy = sinon.spy()
   })
-
   describe('#postDetails', () => {
     context('when all fields are valid', () => {
+      // possible TODO: add api received data structure check to test/end-to-end/cypress/specs/DIT/event-spec.js
       it('should post to the API', async () => {
         await this.middleware.postDetails(this.req, this.res, this.nextSpy)
         expect(this.saveEventStub).to.have.been.calledWith(this.req)
         expect(this.saveEventStub).to.have.been.calledOnce
         expect(this.saveEventStub.firstCall.args[1]).to.deep.equal(expectedBody)
       })
-
+      // NOTE: covered in test/end-to-end/cypress/specs/DIT/event-spec.js:36
       it('should redirect on success', async () => {
         await this.middleware.postDetails(this.req, this.res, this.nextSpy)
 
@@ -95,7 +95,7 @@ describe('Event details middleware', () => {
         expect(this.res.redirect).to.be.calledWith('/events/1')
       })
     })
-
+    // TODO: add a context case for this to a new api received data structure check
     context('when selecting one event shared team', () => {
       it('should set teams as an array', async () => {
         const req = merge({}, this.req, {
@@ -114,6 +114,7 @@ describe('Event details middleware', () => {
         expect(this.saveEventStub).to.have.been.calledOnce
       })
 
+      // TODO: add a context case for this to a new api received data structure check
       it('should not add empty values to the event shared teams', async () => {
         const req = merge({}, this.req, {
           body: {
@@ -131,7 +132,7 @@ describe('Event details middleware', () => {
         expect(this.saveEventStub).to.have.been.calledOnce
       })
     })
-
+    // TODO: add a context case for this to the e2e test, checking the API not called
     context('when adding another event shared team', () => {
       it('should not POST to the API', async () => {
         const req = merge({}, this.req, {
@@ -157,7 +158,7 @@ describe('Event details middleware', () => {
         expect(this.nextSpy).to.have.been.calledOnce
       })
     })
-
+    // TODO: add a context case for this to a new api received data structure check
     context('when selecting one related programme', () => {
       it('should set related programmes as an array', async () => {
         const req = merge({}, this.req, {
@@ -175,7 +176,7 @@ describe('Event details middleware', () => {
         expect(this.saveEventStub).to.have.been.calledWith(req, expected)
         expect(this.saveEventStub).to.have.been.calledOnce
       })
-
+      // TODO: add a context case for this to a new api received data structure check
       it('should not add empty values to the event shared teams', async () => {
         const req = merge({}, this.req, {
           body: {
@@ -193,7 +194,7 @@ describe('Event details middleware', () => {
         expect(this.saveEventStub).to.have.been.calledOnce
       })
     })
-
+    // TODO: add a context case for this to the e2e test, checking the API not called
     context('when adding another related programme', () => {
       it('should not POST to the API', async () => {
         const req = merge({}, this.req, {
@@ -219,7 +220,7 @@ describe('Event details middleware', () => {
         expect(this.nextSpy).to.have.been.calledOnce
       })
     })
-
+    // TODO: add a error context case to the e2e test
     context('when there is a 400', () => {
       beforeEach(() => {
         this.saveEventStub.rejects({ statusCode: 400, error: 'error' })
@@ -238,7 +239,7 @@ describe('Event details middleware', () => {
         expect(this.nextSpy).have.been.calledOnce
       })
     })
-
+    // TODO: add a error context case to the e2e test
     context('when there is an error other than 400', () => {
       beforeEach(() => {
         this.saveEventStub.rejects({ statusCode: 500, error: 'error' })
@@ -261,7 +262,7 @@ describe('Event details middleware', () => {
       })
     })
   })
-
+  // NOTE: covered here: test/end-to-end/cypress/specs/DIT/event-spec.js
   describe('#getEventDetails', () => {
     context('when success', () => {
       it('should set event data on locals', async () => {

--- a/src/apps/investments/middleware/forms/__test__/requirements.test.js
+++ b/src/apps/investments/middleware/forms/__test__/requirements.test.js
@@ -54,7 +54,7 @@ function getFieldError(form, name) {
 
   return null
 }
-
+// TODO: add functional tests for editing investment requirements (or at least add an e2e test like: test/end-to-end/cypress/specs/DIT/investment-team-spec.js)
 describe('Investment requirements form middleware', () => {
   beforeEach(() => {
     this.reqMock = {

--- a/src/apps/investments/middleware/forms/__test__/team-members.test.js
+++ b/src/apps/investments/middleware/forms/__test__/team-members.test.js
@@ -7,6 +7,7 @@ const investmentData = require('../../../../../../test/unit/data/investment/inve
 const { teamMembersLabels } = require('../../../labels')
 const teamMembersController = require('../team-members')
 
+// TODO: add more depth to the test/end-to-end/cypress/specs/DIT/investment-team-spec.js e2e test (or add a functional test for different aspects of editing the investment team)
 describe('Investment form middleware - team members', () => {
   beforeEach(() => {
     this.nextStub = sinon.stub()

--- a/src/apps/oauth/__test__/controllers.test.js
+++ b/src/apps/oauth/__test__/controllers.test.js
@@ -2,6 +2,7 @@ const queryString = require('qs')
 const { assign, set } = require('lodash')
 const proxyquire = require('proxyquire')
 
+// TODO: update permission-specs in e2e tests (add one for the DIT case) to fully cover authentication
 describe('OAuth controller', () => {
   beforeEach(() => {
     this.mockUuid = sinon.stub().returns(this.mockUUIDvalue)

--- a/src/lib/__test__/authorised-request.test.js
+++ b/src/lib/__test__/authorised-request.test.js
@@ -1,4 +1,5 @@
 const proxyquire = require('proxyquire').noPreserveCache()
+// TODO: Rewrite when update the request package
 
 let NODE_TLS_REJECT_UNAUTHORIZED
 

--- a/src/middleware/__test__/features.test.js
+++ b/src/middleware/__test__/features.test.js
@@ -2,6 +2,7 @@ const proxyquire = require('proxyquire')
 
 const config = require('../../config')
 
+// TODO: check with team whether we are keeping this functionality; write functional test for feature flag
 describe('feature flag middleware', () => {
   beforeEach(() => {
     this.reqMock = {

--- a/src/modules/search/__test__/services.test.js
+++ b/src/modules/search/__test__/services.test.js
@@ -12,6 +12,7 @@ const buildMiddlewareParameters = require('../../../../test/unit/helpers/middlew
 
 const stubRequest = { session: { token: '1234' } }
 
+// TODO: add functional tests using Cypress for our search functions and views
 describe('Search service', () => {
   describe('#search', () => {
     context('when minimal parameters are populated', () => {

--- a/src/modules/search/middleware/__test__/collection-export.test.js
+++ b/src/modules/search/middleware/__test__/collection-export.test.js
@@ -1,5 +1,6 @@
 const config = require('../../../../config')
 
+// TODO: add an export collection data test (if possible) to test/end-to-end/cypress/specs/DIT/collection-spec.js
 describe('Collection middleware', () => {
   context('#collectionExport', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Description of change
As part of the work to replace the `request` module with `axios`, we need to replace a number of unit tests that rely too heavily on the request framework. This is an opportunity for us to replace these tests with functional and e2e tests that fit our preferred testing model. In the comments here are a number of proposed changes - they would be addressed in different PRs, I'm creating this PR as a reference for the Trello tickets.
