### PR TITLE
Remove the no documents message

### DIFF
--- a/src/apps/events/__test__/transformers.test.js
+++ b/src/apps/events/__test__/transformers.test.js
@@ -188,9 +188,6 @@ describe('Event transformers', () => {
             },
             type: 'address',
           },
-          Documents: {
-            name: 'There are no files or documents',
-          },
           'Type of event': {
             id: '6031f993-a689-49af-9a11-942a8413a779',
             name: 'Outward mission',
@@ -232,9 +229,6 @@ describe('Event transformers', () => {
               town: 'Plymouth',
             },
             type: 'address',
-          },
-          Documents: {
-            name: 'There are no files or documents',
           },
           'Event end date': {
             type: 'date',

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -156,10 +156,6 @@ function transformEventResponseToViewRecord({
     Service: service,
   })
 
-  viewRecord.Documents = {
-    name: 'There are no files or documents',
-  }
-
   if (archived_documents_url_path) {
     viewRecord.Documents = {
       url: config.archivedDocumentsBaseUrl + archived_documents_url_path,

--- a/src/apps/interactions/controllers/__test__/details.test.js
+++ b/src/apps/interactions/controllers/__test__/details.test.js
@@ -49,13 +49,6 @@ describe('Interaction details controller', () => {
         ).to.exist
       })
 
-      it('should render the template with Document details', () => {
-        expect(
-          middlewareParameters.resMock.render.firstCall.args[1]
-            .interactionViewRecord.Documents
-        ).to.exist
-      })
-
       it('should render the template with canComplete as false', () => {
         expect(
           middlewareParameters.resMock.render.firstCall.args[1].canComplete
@@ -107,13 +100,6 @@ describe('Interaction details controller', () => {
         expect(
           middlewareParameters.resMock.render.firstCall.args[1]
             .interactionViewRecord
-        ).to.exist
-      })
-
-      it('should render the template with Document details', () => {
-        expect(
-          middlewareParameters.resMock.render.firstCall.args[1]
-            .interactionViewRecord.Documents
         ).to.exist
       })
 

--- a/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
@@ -440,9 +440,6 @@ describe('#transformInteractionResponsetoViewRecord', () => {
           id: '70c226d7-5d95-e211-a939-e4115bead28a',
           name: 'Email/Website',
         },
-        Documents: {
-          name: 'There are no files or documents',
-        },
         'Adviser(s)': ['Bob Lawson, The test team'],
       })
     })
@@ -482,9 +479,6 @@ describe('#transformInteractionResponsetoViewRecord', () => {
           'Policy feedback notes':
             'Labore\nculpa\nquas\ncupiditate\nvoluptatibus\nmagni.',
           'Policy issue types': 'EU exit',
-          Documents: {
-            name: 'There are no files or documents',
-          },
           'Date of interaction': {
             type: 'date',
             name: '2058-11-25',
@@ -619,9 +613,6 @@ describe('#transformInteractionResponsetoViewRecord', () => {
           },
           'Adviser(s)': ['Bob Lawson, The test team'],
           Event: 'No',
-          Documents: {
-            name: 'There are no files or documents',
-          },
         })
       })
     }
@@ -659,9 +650,6 @@ describe('#transformInteractionResponsetoViewRecord', () => {
         'Policy feedback notes':
           'Labore\nculpa\nquas\ncupiditate\nvoluptatibus\nmagni.',
         'Policy issue types': 'EU exit',
-        Documents: {
-          name: 'There are no files or documents',
-        },
         'Date of interaction': {
           type: 'date',
           name: '2058-11-25',
@@ -709,9 +697,6 @@ describe('#transformInteractionResponsetoViewRecord', () => {
           'Communication channel': {
             id: '70c226d7-5d95-e211-a939-e4115bead28a',
             name: 'Email/Website',
-          },
-          Documents: {
-            name: 'There are no files or documents',
           },
           'Policy issue types': 'Domestic',
           'Policy feedback notes':

--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 const { camelCase, pickBy, get } = require('lodash')
 
 const config = require('../../../config')
@@ -13,19 +12,6 @@ function transformEntityLink(entity, entityPath, noLinkText = null) {
         name: entity.name,
       }
     : noLinkText
-}
-
-function transformDocumentsLink(archivedDocumentsUrlPath) {
-  if (archivedDocumentsUrlPath) {
-    return {
-      url: config.archivedDocumentsBaseUrl + archivedDocumentsUrlPath,
-      name: 'View files and documents',
-      hint: '(will open another website)',
-      hintId: 'external-link-label',
-    }
-  }
-
-  return { name: 'There are no files or documents' }
 }
 
 function formatParticipantName(participant) {
@@ -133,13 +119,19 @@ function transformInteractionResponseToViewRecord(
     ),
     event: transformEntityLink(event, 'events', defaultEventText),
     communication_channel: communication_channel,
-    documents: canShowDocuments
-      ? transformDocumentsLink(archived_documents_url_path)
-      : null,
     policy_issue_types: getNames(policy_issue_types),
     policy_areas: getNames(policy_areas),
     policy_feedback_notes: policy_feedback_notes,
     ...getExportCountries(export_countries),
+  }
+
+  if (canShowDocuments && archived_documents_url_path) {
+    viewRecord.documents = {
+      url: config.archivedDocumentsBaseUrl + archived_documents_url_path,
+      name: 'View files and documents',
+      hint: '(will open another website)',
+      hintId: 'external-link-label',
+    }
   }
 
   return pickBy(getDataLabels(viewRecord, kindLabels))

--- a/test/functional/cypress/specs/events/details-spec.js
+++ b/test/functional/cypress/specs/events/details-spec.js
@@ -45,7 +45,6 @@ describe('Event Details', () => {
         'Other teams': 'CBBC North West',
         'Related programmes': 'Grown in Britain',
         Service: 'Events : UK Based',
-        Documents: 'There are no files or documents',
       })
     })
 

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -328,7 +328,6 @@ describe('Interaction details', () => {
           name: fixtures.investment.newHotelFdi.name,
         },
         'Communication channel': 'Email/Website',
-        Documents: 'There are no files or documents',
       })
     })
 


### PR DESCRIPTION
## Description of change

Removes the "Documents" row with the "There are no files or documents" message when there are no documents to show.

## Test instructions

1. Go to a detail page of an interaction which doesn't have any files/documents attached e.g. `/interactions/<id>`
2. The table should not contain the "Documents" row with the "There are no files or documents" message
3. If an interaction has documents attached, the "Documents" row should still be there.

## Screenshots
### Before

<img width="760" alt="Screen Shot 2020-12-09 at 12 27 38 PM" src="https://user-images.githubusercontent.com/2333157/101624442-d5c14400-3a11-11eb-8d8b-bedf39a7c0a3.png">


### After

<img width="769" alt="Screen Shot 2020-12-09 at 12 27 00 PM" src="https://user-images.githubusercontent.com/2333157/101624435-d3f78080-3a11-11eb-93da-de01d8e8645e.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
