### PR TITLE
Change collection item heading to H2

### DIFF
--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -47,13 +47,13 @@
           </div>
         {% endif %}
 
-        <h3 class="c-entity__title">
+        <h2 class="c-entity__title">
           {% if props.id and not props.isBlockLink %}
             <a href="{{ url }}" class="c-entity__link">{{ highlightedName }}</a>
           {% else %}
             {{ highlightedName }}
           {% endif %}
-        </h3>
+        </h2>
 
         {% if props.subTitle %}
           {{ SubTitle(props.subTitle) }}

--- a/test/selectors/company/subsidiaries-link.js
+++ b/test/selectors/company/subsidiaries-link.js
@@ -6,7 +6,7 @@ module.exports = () => {
       button: '.c-entity-search__button',
       result(number) {
         return {
-          title: `.c-entity-list__item:nth-child(${number}) h3 a`,
+          title: `.c-entity-list__item:nth-child(${number}) h2 a`,
         }
       },
     },


### PR DESCRIPTION
## Description of change

Changes collection item heading to H2.

## Test instructions

The item headings of all the collection pages should now be changed from `H3` to `H2`.
https://trello.com/c/6LEUHS0C/40-missing-h1s-and-visual-headings

## Screenshots

Nothing should change visually.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
