### PR TITLE
Change task error heading to div

### DIFF
--- a/src/client/components/Task/Error.jsx
+++ b/src/client/components/Task/Error.jsx
@@ -39,7 +39,7 @@ const StyledSecondaryButton = styled(SecondaryButton)({
 
 const Err = ({ errorMessage, retry, noun }) => (
   <StyledRoot>
-    <H2 size="MEDIUM">Could not load {noun}</H2>
+    <H2 as="div">Could not load {noun}</H2>
     <p>Error: {errorMessage}</p>
     <StyledSecondaryButton onClick={retry}>Retry</StyledSecondaryButton>
   </StyledRoot>


### PR DESCRIPTION
## Description of change

Changed the H2 heading in the default `Task` error view to a `div`.

## Test instructions

The task error view should not have a H2 element.

## Screenshots

There should be no visible change.
