### PR TITLE
Metadata proxy

### DIFF
--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -241,6 +241,123 @@ module.exports = {
       data: url('/investments/projects', '/:investmentId/edit-history/data'),
     },
   },
+  metadata: {
+    likelihoodToLand: url('/api-proxy/v4/metadata', '/likelihood-to-land'),
+    investmentInvestorType: url(
+      '/api-proxy/v4/metadata',
+      '/investment-investor-type'
+    ),
+    investmentInvolvement: url(
+      '/api-proxy/v4/metadata',
+      '/investment-involvement'
+    ),
+    investmentSpecificProgramme: url(
+      '/api-proxy/v4/metadata',
+      '/investment-specific-programme'
+    ),
+    investmentProjectStage: url(
+      '/api-proxy/v4/metadata',
+      '/investment-project-stage'
+    ),
+    investmentBusinessActivity: url(
+      '/api-proxy/v4/metadata',
+      '/investment-business-activity'
+    ),
+    investmentType: url('/api-proxy/v4/metadata', '/investment-type'),
+    investmentStrategicDriver: url(
+      '/api-proxy/v4/metadata',
+      '/investment-strategic-driver'
+    ),
+    orderServiceType: url('/api-proxy/v4/metadata', '/order-service-type'),
+    orderCancellationReason: url(
+      '/api-proxy/v4/metadata',
+      '/order-cancellation-reason'
+    ),
+    omisMarket: url('/api-proxy/v4/metadata', '/omis-market'),
+    salaryRange: url('/api-proxy/v4/metadata', '/salary-range'),
+    fdiValue: url('/api-proxy/v4/metadata', '/fdi-value'),
+    fdiType: url('/api-proxy/v4/metadata', '/fdi-type'),
+    turnover: url('/api-proxy/v4/metadata', '/turnover'),
+    sector: url('/api-proxy/v4/metadata', '/sector'),
+    locationType: url('/api-proxy/v4/metadata', '/location-type'),
+    eventType: url('/api-proxy/v4/metadata', '/event-type'),
+    programme: url('/api-proxy/v4/metadata', '/programme'),
+    businessType: url('/api-proxy/v4/metadata', '/business-type'),
+    evidenceTag: url('/api-proxy/v4/metadata', '/evidence-tag'),
+    employeeRange: url('/api-proxy/v4/metadata', '/employee-range'),
+    country: url('/api-proxy/v4/metadata', '/country'),
+    ukRegion: url('/api-proxy/v4/metadata', '/uk-region'),
+    referralSourceWebsite: url(
+      '/api-proxy/v4/metadata',
+      '/referral-source-website'
+    ),
+    referralSourceMarketing: url(
+      '/api-proxy/v4/metadata',
+      '/referral-source-marketing'
+    ),
+    referralSourceActivity: url(
+      '/api-proxy/v4/metadata',
+      '/referral-source-activity'
+    ),
+    headquarterType: url('/api-proxy/v4/metadata', '/headquarter-type'),
+    service: url('/api-proxy/v4/metadata', '/service'),
+    communicationChannel: url(
+      '/api-proxy/v4/metadata',
+      '/communication-channel'
+    ),
+    team: url('/api-proxy/v4/metadata', '/team'),
+    policyArea: url('/api-proxy/v4/metadata', '/policy-area'),
+    policyIssueType: url('/api-proxy/v4/metadata', '/policy-issue-type'),
+    serviceDeliveryStatus: url(
+      '/api-proxy/v4/metadata',
+      '/service-delivery-status'
+    ),
+    capitalInvestmentInvestorType: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/investor-type'
+    ),
+    capitalInvestmentRequiredChecksConducted: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/required-checks-conducted'
+    ),
+    capitalInvestmentDealTicketSize: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/deal-ticket-size'
+    ),
+    capitalInvestmentLargeCapitalInvestment: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/large-capital-investment'
+    ),
+    capitalInvestmentReturnRate: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/return-rate'
+    ),
+    capitalInvestmentTimeHorizon: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/time-horizon'
+    ),
+    capitalInvestmentRestriction: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/restriction'
+    ),
+    capitalInvestmentConstructionRisk: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/construction-risk'
+    ),
+    capitalInvestmentEquityPercentage: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/equity-percentage'
+    ),
+    capitalInvestmentDesiredDealRole: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/desired-deal-role'
+    ),
+    capitalInvestmentAssetClassInterest: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/asset-class-interest'
+    ),
+    oneListTier: url('/api-proxy/v4/metadata', '/one-list-tier'),
+  },
   omis: {
     index: url('/omis'),
     create: url('/omis/create?company=', ':companyId'),

--- a/src/middleware/metadata-api-proxy.js
+++ b/src/middleware/metadata-api-proxy.js
@@ -1,0 +1,69 @@
+const config = require('../config')
+const hawkRequest = require('../lib/hawk-request')
+
+const API_PROXY_PATH = '/api-proxy'
+
+const ALLOWLIST = [
+  '/v4/metadata/likelihood-to-land',
+  '/v4/metadata/investment-investor-type',
+  '/v4/metadata/investment-involvement',
+  '/v4/metadata/investment-specific-programme',
+  '/v4/metadata/investment-project-stage',
+  '/v4/metadata/investment-business-activity',
+  '/v4/metadata/investment-type',
+  '/v4/metadata/investment-strategic-driver',
+  '/v4/metadata/order-service-type',
+  '/v4/metadata/order-cancellation-reason',
+  '/v4/metadata/omis-market',
+  '/v4/metadata/salary-range',
+  '/v4/metadata/fdi-value',
+  '/v4/metadata/fdi-type',
+  '/v4/metadata/turnover',
+  '/v4/metadata/sector',
+  '/v4/metadata/location-type',
+  '/v4/metadata/event-type',
+  '/v4/metadata/programme',
+  '/v4/metadata/business-type',
+  '/v4/metadata/evidence-tag',
+  '/v4/metadata/employee-range',
+  '/v4/metadata/country',
+  '/v4/metadata/uk-region',
+  '/v4/metadata/referral-source-website',
+  '/v4/metadata/referral-source-marketing',
+  '/v4/metadata/referral-source-activity',
+  '/v4/metadata/headquarter-type',
+  '/v4/metadata/service',
+  '/v4/metadata/communication-channel',
+  '/v4/metadata/team',
+  '/v4/metadata/policy-area',
+  '/v4/metadata/policy-issue-type',
+  '/v4/metadata/service-delivery-status',
+  '/v4/metadata/capital-investment/investor-type',
+  '/v4/metadata/capital-investment/required-checks-conducted',
+  '/v4/metadata/capital-investment/deal-ticket-size',
+  '/v4/metadata/capital-investment/large-capital-investment-type',
+  '/v4/metadata/capital-investment/return-rate',
+  '/v4/metadata/capital-investment/time-horizon',
+  '/v4/metadata/capital-investment/restriction',
+  '/v4/metadata/capital-investment/construction-risk',
+  '/v4/metadata/capital-investment/equity-percentage',
+  '/v4/metadata/capital-investment/desired-deal-role',
+  '/v4/metadata/capital-investment/asset-class-interest',
+  '/v4/metadata/one-list-tier',
+]
+
+module.exports = (app) => {
+  app.use(
+    ALLOWLIST.map((apiPath) => API_PROXY_PATH + apiPath),
+    async (req, res, next) => {
+      try {
+        const metadataUrl = req.originalUrl.replace(API_PROXY_PATH, '')
+        const responseData = await hawkRequest(config.apiRoot + metadataUrl)
+        res.write(JSON.stringify(responseData))
+        res.send()
+      } catch (error) {
+        next(error)
+      }
+    }
+  )
+}

--- a/src/server.js
+++ b/src/server.js
@@ -43,6 +43,7 @@ const permissions = require('./middleware/permissions')
 const envSchema = require('./config/envSchema')
 const flashWithBody = require('./middleware/flash-with-body')
 const apiProxy = require('./middleware/api-proxy')
+const metadataApiProxy = require('./middleware/metadata-api-proxy')
 
 const routers = require('./apps/routers')
 
@@ -135,6 +136,7 @@ app.use(userLocals)
 app.use(headers)
 app.use(store())
 apiProxy(app)
+metadataApiProxy(app)
 // csrf middleware needs to come after the proxy path as it is not needed for the proxy and would block requests
 app.use(csrf())
 app.use(csrfToken())

--- a/test/end-to-end/cypress/specs/DIT/metadata-proxy-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/metadata-proxy-spec.js
@@ -1,0 +1,30 @@
+const { expect } = require('chai')
+const { metadata } = require('../../../../../src/lib/urls')
+
+describe('Metadata', () => {
+  it('endpoint should return headquarter type', () => {
+    cy.request(metadata.headquarterType()).as('headquarterType')
+    cy.get('@headquarterType').then((response) => {
+      expect(response.status).to.equal(200)
+      expect(response.body).to.equal(
+        JSON.stringify([
+          {
+            id: '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+            name: 'ukhq',
+            disabled_on: null,
+          },
+          {
+            id: 'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+            name: 'ehq',
+            disabled_on: null,
+          },
+          {
+            id: '43281c5e-92a4-4794-867b-b4d5f801e6f3',
+            name: 'ghq',
+            disabled_on: null,
+          },
+        ])
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

This adds a proxy to the backend metadata endpoints authenticated with Hawk.

Metadata endpoints are now accessible from the client by using the urls found under `metadata` key in the urls file. 

## Test instructions

For example, you can start the front end locally and then go to `http://localhost:3000/api-proxy/v4/metadata/one-list-tier`. If you see a JSON response, then it means it works. 

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
