### PR TITLE
Fix heading structure of ActivityFeed

### DIFF
--- a/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
@@ -28,7 +28,7 @@ const StyledCheckboxContainer = styled('div')`
   }
 `
 
-const StyledTitle = styled('h4')`
+const StyledTitle = styled('div')`
   margin-right: ${SPACING.SCALE_4};
   white-space: nowrap;
 `

--- a/src/client/components/ActivityFeed/activities/card/CardHeader.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardHeader.jsx
@@ -97,6 +97,7 @@ const CardHeader = ({
   heading,
   startTime,
   badge,
+  headingLevel = 3,
 }) => (
   <>
     {company && company.name && (
@@ -109,8 +110,9 @@ const CardHeader = ({
         )}
 
         {subHeading && <StyledSubHeading>{subHeading}</StyledSubHeading>}
-
-        {heading && <StyledHeading level={2}>{heading}</StyledHeading>}
+        {heading && (
+          <StyledHeading level={headingLevel}>{heading}</StyledHeading>
+        )}
       </StyledHeadingWrapper>
 
       <StyledMetaItems>
@@ -139,16 +141,6 @@ CardHeader.propTypes = {
     text: PropTypes.string,
     borderColour: PropTypes.string,
   }),
-}
-
-CardHeader.defaultProps = {
-  startTime: null,
-  heading: null,
-  blockText: null,
-  subHeading: null,
-  company: null,
-  badge: null,
-  sourceType: null,
 }
 
 export default CardHeader

--- a/src/client/components/ReferralList/Referral.jsx
+++ b/src/client/components/ReferralList/Referral.jsx
@@ -46,6 +46,7 @@ const Referral = ({
           {subject}
         </Link>
       }
+      headingLevel={2}
       startTime={date}
       badge={
         dateAccepted


### PR DESCRIPTION
## Description of change

Fixes heading level inconsistency in the activity stream.

## Test instructions

* The activity stream item heading should now be a H3
* The _Filter by_ should not be a heading
* The item heading of the referral list on the dashboard should not be affected by this change

## Screenshots

There should be no visible change

