### PR TITLE
Inject a test parameter to test help centre api scenarios

### DIFF
--- a/src/apps/dashboard/controllers.js
+++ b/src/apps/dashboard/controllers.js
@@ -20,6 +20,7 @@ async function renderDashboard(req, res, next) {
         auth: {
           bearer: config.helpCentre.token,
         },
+        qs: { test: req.query.test },
         json: true,
         timeout: 1000,
       })

--- a/src/templates/_components/info-feed.njk
+++ b/src/templates/_components/info-feed.njk
@@ -43,6 +43,6 @@
     {% endfor %}
   </ul>
 {% else %}
-  <p class="dashboard-section__fallback-text">No updates available</p>
+  <p class="dashboard-section__fallback-text" data-cy="info-feed-no-results">No updates available</p>
 {% endif %}
 </div>

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -2,7 +2,7 @@ const EXPORTERS_TOOL_LINK =
   'https://uktrade.zendesk.com/hc/en-gb/articles/360001844497-Using-Sectors-in-the-Find-Exporters-Tool'
 
 describe('Dashboard', () => {
-  context('When viewing the info feed', () => {
+  context('When the help centre API is available', () => {
     beforeEach(() => {
       cy.visit('/')
       cy.get('[data-cy="info-feed"]')
@@ -43,6 +43,34 @@ describe('Dashboard', () => {
             .should('have.text', '(Link opens in a new window)')
           cy.get('time').should('exist').should('have.text', 'a day ago')
         })
+    })
+  })
+
+  context('When the help centre API is unavailable', () => {
+    beforeEach(() => {
+      cy.visit('/', { qs: { test: 'help-centre-unavailable' } })
+      cy.get('[data-cy="info-feed"]').as('infoFeed')
+    })
+
+    it('should return an empty info feed', () => {
+      cy.get('[data-cy="info-feed-list"]').should('not.exist')
+      cy.get('[data-cy="info-feed-no-results"]')
+        .should('exist')
+        .should('have.text', 'No updates available')
+    })
+  })
+
+  context('When the help centre API returns no results', () => {
+    beforeEach(() => {
+      cy.visit('/', { qs: { test: 'help-centre-empty' } })
+      cy.get('[data-cy="info-feed"]').as('infoFeed')
+    })
+
+    it('should return an empty info feed', () => {
+      cy.get('[data-cy="info-feed-list"]').should('not.exist')
+      cy.get('[data-cy="info-feed-no-results"]')
+        .should('exist')
+        .should('have.text', 'No updates available')
     })
   })
 })

--- a/test/sandbox/fixtures/help-centre/announcement.js
+++ b/test/sandbox/fixtures/help-centre/announcement.js
@@ -103,3 +103,15 @@ exports.announcement = {
   sort_by: 'position',
   sort_order: 'asc',
 }
+
+exports.emptyAnnouncement = {
+  count: 0,
+  next_page: null,
+  page: 1,
+  page_count: 1,
+  per_page: 30,
+  previous_page: null,
+  articles: [],
+  sort_by: 'position',
+  sort_order: 'asc',
+}

--- a/test/sandbox/routes/helpCentre.js
+++ b/test/sandbox/routes/helpCentre.js
@@ -1,5 +1,11 @@
 var announcementArticles = require('../fixtures/help-centre/announcement.js')
 
 exports.announcement = function (req, res) {
-  res.json(announcementArticles.announcement)
+  if (req.query.test === 'help-centre-unavailable') {
+    return res.status(503)
+  } else if (req.query.test === 'help-centre-empty') {
+    return res.json(announcementArticles.emptyAnnouncement)
+  } else {
+    return res.json(announcementArticles.announcement)
+  }
 }


### PR DESCRIPTION
For discussion. By replacing unit tests with functional tests, it was not possible to test scenarios where the help centre api was unavailable. This adapts the express code to look for a `test` get parameter that is then relayed to the api. The production api should ignore this parameter, but the sandbox api will use it to simulate different responses - in this case a "503 - Not available" response and a response with no results. 

I would expect a lot of other api calls would not need this test parameter and could get a similar effect by requesting specific objects - so, for example, a specific project id might prompt the sandbox api to respond with an error response.

I would be interested to hear what people think since this does mean changing production code purely to let us replace unit tests with functional ones.
