### PR TITLE
Add query string params to help url for analytics

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+import qs from 'qs'
 import React from 'react'
 import { connect } from 'react-redux'
 import { H3 } from '@govuk-react/heading'
@@ -176,6 +178,14 @@ const StepInteractionDetails = ({
   const selectedService = services.find((s) => s.value === selectedServiceId)
   const isServiceDelivery = values.kind === KINDS.SERVICE_DELIVERY
 
+  const helpUrl = (position) =>
+    urls.external.policyFeedbackHelp +
+    '?' +
+    qs.stringify({
+      ..._.pick(values, ['theme', 'kind']),
+      'link-pos': 'box-' + position,
+    })
+
   return (
     <>
       <H3 as="h2">Service</H3>
@@ -186,9 +196,7 @@ const StepInteractionDetails = ({
         intelligence section.
         <br />
         <br />
-        <NewWindowLink href={urls.external.policyFeedbackHelp}>
-          See more guidance
-        </NewWindowLink>
+        <NewWindowLink href={helpUrl(1)}>See more guidance</NewWindowLink>
       </InsetText>
 
       <FieldSelect
@@ -354,7 +362,7 @@ const StepInteractionDetails = ({
           <FieldHelp
             helpSummary="Help with policy issue types"
             helpText="A policy type is the broad category/categories that the information fits into."
-            footerUrl={urls.external.policyFeedbackHelp}
+            footerUrl={helpUrl(2)}
             footerUrlDescription="See more guidance"
           />
 
@@ -370,7 +378,7 @@ const StepInteractionDetails = ({
           <FieldHelp
             helpSummary="Help with policy area(s)"
             helpText="A policy area is the specific area that the information fits into. Completing this enables the correct team(s) to find the information and input into their reports to support businesses and ministers effectively."
-            footerUrl={urls.external.policyFeedbackHelp}
+            footerUrl={helpUrl(3)}
             footerUrlDescription="See more guidance"
           />
 
@@ -400,7 +408,7 @@ const StepInteractionDetails = ({
                 decisions or job creation/losses)? If so, provide details.
               </>
             }
-            footerUrl={urls.external.policyFeedbackHelp}
+            footerUrl={helpUrl(4)}
             footerUrlDescription="See more guidance"
           />
         </>


### PR DESCRIPTION
## Description of change

Adds query string params to the _See more guidance_ links so the various links can be distinguished in Google Analytics.

## Test instructions

1. Go to a company page of the company of your choice
2. Click the _Add interaction_ button
3. Select the _Export option -> A standard interaction_ from the radio group
4. Click the _Continue_ button
5. All the _See more guidance_ links on the next page should have a query string `?theme=export&kind=interaction&link-pos=box-n` where `n` is a number from 1 to 4.
6. Repeat step 3 for all possible combinations of radio buttons. The first level of radio buttons is represented in the query string as `theme` with values `export`, `investment` and `other`; the second level is represented as `kind` with possible values `interaction` and `service_delivery`.

