### PR TITLE
Add my projects filter

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -27,6 +27,7 @@ import {
 
 const ProjectsCollection = ({
   payload,
+  currentAdviserId,
   optionMetadata,
   selectedFilters,
   ...props
@@ -65,6 +66,11 @@ const ProjectsCollection = ({
       onSuccessDispatch: INVESTMENTS__SET_PROJECTS_METADATA,
     },
   }
+  const myProjectsSelected = selectedFilters.selectedAdvisers
+    .map(({ value }) => value)
+    .includes(currentAdviserId)
+  const myProjectsOption = { label: 'My Projects', value: currentAdviserId }
+
   return (
     <FilteredCollectionList
       {...props}
@@ -82,6 +88,14 @@ const ProjectsCollection = ({
           options={optionMetadata.projectStageOptions}
           selectedOptions={selectedFilters.selectedStages}
           data-cy="stage-filter"
+        />
+        <RoutedCheckboxGroupField
+          label="My Projects"
+          name="my_projects"
+          qsParam="adviser"
+          options={[myProjectsOption]}
+          selectedOptions={myProjectsSelected ? [myProjectsOption] : []}
+          data-cy="my-projects-filter"
         />
         <RoutedAdvisersTypeahead
           taskProps={adviserListTask}

--- a/src/apps/investments/controllers/projects.js
+++ b/src/apps/investments/controllers/projects.js
@@ -1,9 +1,13 @@
 const renderProjectsView = async (req, res, next) => {
   try {
+    const { user } = req.session
+    const currentAdviserId = user.id
+
     const props = {
       title: 'Investment Projects',
       countLabel: 'project',
       heading: 'Investments',
+      currentAdviserId,
     }
 
     return res

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -15,7 +15,7 @@ import {
 } from '../../support/actions'
 
 const PROSPECT_STAGE_ID = '8a320cc9-ae2e-443e-9d26-2f36452c2ced'
-const PUCK_ADVISER_ID = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
+const MY_ADVISER_ID = '7d19d407-9aec-4d06-b190-d3f404627f21'
 const ADVANCED_ENGINEERING_SECTOR_ID = 'af959812-6095-e211-a939-e4115bead28a'
 const UK_COUNTRY_ID = '80756b9a-5d95-e211-a939-e4115bead28a'
 const SOUTH_EAST_UK_REGION_ID = '884cd12a-6095-e211-a939-e4115bead28a'
@@ -51,6 +51,7 @@ const testRemoveChip = ({ element, placeholder = null }) => {
 describe('Investments Collections Filter', () => {
   beforeEach(() => {
     cy.get('[data-cy="stage-filter"]').as('stageFilter')
+    cy.get('[data-cy="my-projects-filter"]').as('myProjectsFilter')
     cy.get('[data-cy="adviser-filter"]').as('adviserFilter')
     cy.get('[data-cy="sector-filter"]').as('sectorFilter')
     cy.get('[data-cy="country-filter"]').as('countryFilter')
@@ -81,6 +82,7 @@ describe('Investments Collections Filter', () => {
     it('should contain filter fields in the right order', () => {
       const expectedIdentifiers = [
         'stage-filter',
+        'my-projects-filter',
         'adviser-filter',
         'sector-filter',
         'country-filter',
@@ -117,6 +119,22 @@ describe('Investments Collections Filter', () => {
       assertChipExists({ label: 'Prospect', position: 1 })
 
       testRemoveChip({ element: '@stageFilter' })
+    })
+
+    it('should filter by my projects', () => {
+      clickCheckboxGroupOption({
+        element: '@myProjectsFilter',
+        value: MY_ADVISER_ID,
+      })
+      assertCheckboxGroupOption({
+        element: '@myProjectsFilter',
+        value: MY_ADVISER_ID,
+        checked: true,
+      })
+      cy.get('@adviserFilter').should('contain', 'Jimmy West')
+      assertChipExists({ label: 'Jimmy West', position: 1 })
+
+      testRemoveChip({ element: '@adviserFilter' })
     })
 
     it('should filter by advisers', () => {
@@ -312,7 +330,7 @@ describe('Investments Collections Filter', () => {
       cy.visit(urls.investments.projects.index(), {
         qs: {
           stage: PROSPECT_STAGE_ID,
-          adviser: PUCK_ADVISER_ID,
+          adviser: MY_ADVISER_ID,
           sector_descends: ADVANCED_ENGINEERING_SECTOR_ID,
           country: UK_COUNTRY_ID,
           uk_region: SOUTH_EAST_UK_REGION_ID,
@@ -334,8 +352,13 @@ describe('Investments Collections Filter', () => {
         value: PROSPECT_STAGE_ID,
         checked: true,
       })
-      assertChipExists({ position: 2, label: 'Puck Head' })
-      cy.get('@adviserFilter').should('contain', 'Puck Head')
+      assertChipExists({ position: 2, label: 'Jimmy West' })
+      assertCheckboxGroupOption({
+        element: '@myProjectsFilter',
+        value: MY_ADVISER_ID,
+        checked: true,
+      })
+      cy.get('@adviserFilter').should('contain', 'Jimmy West')
       assertChipExists({ position: 3, label: 'Advanced Engineering' })
       cy.get('@sectorFilter').should('contain', 'Advanced Engineering')
       assertChipExists({ position: 4, label: 'United Kingdom' })
@@ -416,6 +439,7 @@ describe('Investments Collections Filter', () => {
       cy.get('@countryFilter').should('contain', 'Search countries...')
       cy.get('@ukRegionFilter').should('contain', 'Search UK regions...')
       assertCheckboxGroupNoneSelected('@stageFilter')
+      assertCheckboxGroupNoneSelected('@myProjectsFilter')
       assertCheckboxGroupNoneSelected('@projectStatusFilter')
       assertCheckboxGroupNoneSelected('@investmentTypeFilter')
       assertCheckboxGroupNoneSelected('@likelihoodToLandFilter')

--- a/test/sandbox/routes/adviser.js
+++ b/test/sandbox/routes/adviser.js
@@ -19,7 +19,10 @@ exports.singleAdviser = function (req, res) {
   const adviserId = pathComponents[pathComponents.length - 2]
   let adviser = autoCompleteAdvisers.results.find(({ id }) => id === adviserId)
   if (!adviser) {
-    adviser = { ...singleAdviser, id: adviserId }
+    adviser = advisers.results.find(({ id }) => id === adviserId)
+    if (!adviser) {
+      adviser = { ...singleAdviser, id: adviserId }
+    }
   }
   res.json(adviser)
 }


### PR DESCRIPTION
## Description of change

Add a "My Projects" checkbox filter to the investment projects page.

## Test instructions

A new "My Projects" filter on the investment projects page. Applying the filter should filter by the current user's adviser id (should be Jimmy West on sandbox) - note that this will also update the advisers typeahead filter. A chip for your adviser id should appear when the checkbox is selected.

## Screenshots

![Screenshot from 2020-12-30 14-22-24](https://user-images.githubusercontent.com/1234577/103357228-8e772200-4aaa-11eb-831a-a28eb79c52d7.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
