### PR TITLE
Add a banner to all Investment projects where the current stage is "Won"

### DIFF
--- a/src/apps/investments/views/template.njk
+++ b/src/apps/investments/views/template.njk
@@ -22,6 +22,13 @@
     currentStageName: investmentStatus.currentStage.name
   }) }}
 
+  {% if investmentStatus.currentStage.name === 'Won' and not investment.archived %}
+      {% call Message({ type: 'info' }) %}
+        This project has been verified as won. You should not make any changes to this project.<br>
+        If you would like to make changes, please contact the Investment Promotion Performance team.
+      {% endcall %}
+  {% endif %}
+
   {% if investment.archived %}
       {% call Message({ type: 'info' }) %}
         This investment project was archived on {{ investment.archived_on | formatDate }} by {{ investment.archived_by.first_name }} {{ investment.archived_by.last_name }}. <br>

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -37,6 +37,7 @@ module.exports = {
     investmentWithNoLink: require('./investment/investment-with-no-link.json'),
     investmentWithLink: require('./investment/investment-with-link.json'),
     newHotelFdi: require('./investment/new-hotel-fdi'),
+    stageWon: require('./investment/investment-stage-won.json'),
   },
   event: {
     oneDayExhibition: require('./event/one-day-exhibition'),

--- a/test/functional/cypress/fixtures/investment/investment-stage-won.json
+++ b/test/functional/cypress/fixtures/investment/investment-stage-won.json
@@ -1,0 +1,4 @@
+{
+  "id": "5e341b34-1fc8-4638-b4b1-a0922ecf403e",
+  "name": "Banner Won Ltd"
+}

--- a/test/functional/cypress/specs/investments/investment-project-details-spec.js
+++ b/test/functional/cypress/specs/investments/investment-project-details-spec.js
@@ -1,0 +1,31 @@
+const urls = require('../../../../../src/lib/urls')
+const { assertBreadcrumbs } = require('../../support/assertions')
+const fixtures = require('../../fixtures')
+const selectors = require('../../../../selectors')
+
+describe('Investment project details', () => {
+  context('When the current stage is at Won', () => {
+    before(() => {
+      cy.visit(
+        urls.investments.projects.details(fixtures.investment.stageWon.id)
+      )
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Investments: '/investments',
+        Projects: urls.investments.projects.index(),
+        [fixtures.investment.stageWon.name]: null,
+      })
+    })
+
+    it('should render a blue info banner', () => {
+      cy.get(selectors.message.info).should(
+        'have.text',
+        'This project has been verified as won. You should not make any changes to this project.' +
+          'If you would like to make changes, please contact the Investment Promotion Performance team.'
+      )
+    })
+  })
+})

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -2574,6 +2574,193 @@
       "project_arrived_in_triage_on": null,
       "proposal_deadline": null,
       "stage_log": []
+    },
+    {
+
+      "id": "5e341b34-1fc8-4638-b4b1-a0922ecf403e",
+      "incomplete_fields": [],
+      "name": "Banner Won Ltd",
+      "project_code": "DHP-00000010",
+      "description": "Investment project with edit banner info",
+      "anonymous_description": "",
+      "allow_blank_estimated_land_date": true,
+      "estimated_land_date": null,
+      "actual_land_date": "2021-06-01",
+      "quotable_as_public_case_study": null,
+      "likelihood_to_land": null,
+      "priority": null,
+      "approved_commitment_to_invest": null,
+      "approved_fdi": null,
+      "approved_good_value": null,
+      "approved_high_value": null,
+      "approved_landed": null,
+      "approved_non_fdi": null,
+      "investment_type": {
+        "name": "FDI",
+        "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+      },
+      "stage": {
+        "name": "Won",
+        "id": "945ea6d1-eee3-4f5b-9144-84a75b71b8e6"
+      },
+      "status": "ongoing",
+      "reason_delayed": null,
+      "reason_abandoned": null,
+      "date_abandoned": null,
+      "reason_lost": null,
+      "date_lost": null,
+      "country_lost_to": null,
+      "investor_company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "investor_type": null,
+      "investor_company_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "intermediate_company": null,
+      "level_of_involvement": null,
+      "specific_programme": null,
+      "client_contacts": [
+        {
+          "name": "Dean Cox",
+          "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+        }
+      ],
+      "client_relationship_manager": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "client_relationship_manager_team": {
+        "name": "CBBC North EAST",
+        "id": "602b971d-5df6-e511-888e-e4115bead28a"
+      },
+      "referral_source_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "referral_source_activity": {
+        "name": "None",
+        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+      },
+      "referral_source_activity_website": null,
+      "referral_source_activity_marketing": null,
+      "referral_source_activity_event": null,
+      "fdi_type": {
+        "name": "Creation of new site or activity",
+        "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+      },
+      "sector": {
+        "name": "Renewable Energy : Wind : Onshore",
+        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+      },
+      "business_activities": [
+        {
+          "name": "Retail",
+          "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+        }
+      ],
+      "other_business_activity": null,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2016-01-05T15:00:00Z",
+      "modified_on": "2016-01-05T19:00:00Z",
+      "comments": "",
+      "country_investment_originates_from": null,
+      "level_of_involvement_simplified": "unspecified",
+      "fdi_value": null,
+      "total_investment": "1000000",
+      "foreign_equity_investment": "200000",
+      "government_assistance": true,
+      "some_new_jobs": null,
+      "number_new_jobs": 20,
+      "will_new_jobs_last_two_years": null,
+      "average_salary": {
+        "name": "Below £25,000",
+        "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+      },
+      "number_safeguarded_jobs": 1,
+      "r_and_d_budget": false,
+      "non_fdi_r_and_d_budget": true,
+      "associated_non_fdi_r_and_d_project": null,
+      "new_tech_to_uk": true,
+      "export_revenue": true,
+      "value_complete": false,
+      "client_cannot_provide_total_investment": false,
+      "client_cannot_provide_foreign_investment": false,
+      "client_requirements": "Anywhere",
+      "site_decided": false,
+      "address_1": "10 Northings Road",
+      "address_2": null,
+      "address_town": "London",
+      "address_postcode": "W1 2AB",
+      "competitor_countries": [],
+      "allow_blank_possible_uk_regions": true,
+      "uk_region_locations": [],
+      "actual_uk_regions": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "delivery_partners": [
+        {
+          "name": "New Anglia LEP",
+          "id": "cdcc392e-0bf1-e511-8ffa-e4115bead28a"
+        },
+        {
+          "name": "North Eastern LEP",
+          "id": "6e85b4e3-0df1-e511-8ffa-e4115bead28a"
+        }
+      ],
+      "strategic_drivers": [
+        {
+          "name": "Access to market",
+          "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+        }
+      ],
+      "client_considering_other_countries": false,
+      "uk_company_decided": null,
+      "uk_company": {
+        "name": "Mercury Ltd",
+        "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+      },
+      "requirements_complete": true,
+      "project_manager_requested_on": null,
+      "project_manager_request_status": null,
+      "project_manager": {
+        "name": "Michael Wining",
+        "first_name": "Michael",
+        "last_name": "Wining",
+        "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
+      },
+      "project_assurance_adviser": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "project_manager_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "project_assurance_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "team_complete": true,
+      "team_members": [],
+      "project_arrived_in_triage_on": null,
+      "proposal_deadline": null,
+      "stage_log": []
     }
   ]
 }


### PR DESCRIPTION
## Description of change

Added a banner to the Investment projects details page where the stage is at `Won` informing the user not to edit the project. 

## Screenshots
### Before

<img width="1451" alt="before" src="https://user-images.githubusercontent.com/964268/103406259-02b8d080-4b52-11eb-806a-aeb986878b3e.png">

### After

<img width="1451" alt="after" src="https://user-images.githubusercontent.com/964268/103406257-fe8cb300-4b51-11eb-97e0-204e8c8430d7.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
