### PR TITLE
Use alternative export link for policy feedback

### DIFF
--- a/src/modules/search/__test__/services.test.js
+++ b/src/modules/search/__test__/services.test.js
@@ -249,6 +249,47 @@ describe('Search service', () => {
       })
     })
 
+    context('when exporting policy feedback', () => {
+      beforeEach(async () => {
+        nock(config.apiRoot)
+          .post(`/v3/search/entity/policy-feedback`, {
+            field: true,
+            term: 'search',
+            was_policy_feedback_provided: true,
+          })
+          .reply(200, {
+            count: 0,
+            results: [],
+            aggregations: [],
+          })
+
+        this.middlewareParameters = buildMiddlewareParameters({
+          resMock: {
+            on: sinon.spy(),
+            emit: sinon.spy(),
+            end: sinon.spy(),
+            removeListener: sinon.spy(),
+          },
+        })
+
+        await exportSearch({
+          req: stubRequest,
+          searchTerm: 'search',
+          searchEntity: 'entity',
+          requestBody: {
+            was_policy_feedback_provided: true,
+            field: true,
+          },
+        }).then((response) => {
+          response.pipe(this.middlewareParameters.resMock)
+        })
+      })
+
+      it('should return the response', () => {
+        expect(this.middlewareParameters.resMock.on).to.be.called
+      })
+    })
+
     context('when exporting records that are not company', () => {
       beforeEach(async () => {
         nock(config.apiRoot)

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -130,8 +130,16 @@ function searchForeignCompanies({ req, searchTerm, page = 1, limit = 10 }) {
 function exportSearch({ req, searchTerm = '', searchEntity, requestBody }) {
   const apiVersion = searchEntity === 'company' ? 'v4' : 'v3'
   const searchUrl = `${config.apiRoot}/${apiVersion}/search`
+  // If the requested CSV export should contain policy feedback, we need to call
+  // different export endpoint that will provide extra columns to match
+  // Data Workspace export.
+  const exportApp =
+    requestBody && requestBody.was_policy_feedback_provided
+      ? 'policy-feedback'
+      : 'export'
+  const url = `${searchUrl}/${searchEntity}/${exportApp}`
   const options = {
-    url: `${searchUrl}/${searchEntity}/export`,
+    url: url,
     method: 'POST',
     body: {
       ...requestBody,


### PR DESCRIPTION
## Description of change

When "Includes policy feedback" is checked the interaction export must call `policy-feedback` export instead of the regular one. The new CSV is enhanced with columns to match Data Workspace endpoint. The corresponding DH API change has been merged.
I have not done an end to end test, because it looks like the file download functionality is not yet implemented in Cypress, but it is on the roadmap. I added a unit test instead to ensure the path is being replaced. I also tested the change manually end to end.

## Test instructions

To test the feature you need a latest API from develop branch. Run front end against that API version and go to Interactions collection page. Select "Includes policy feedback" filter and then click "Download". The downloaded CSV file should have more columns than a CSV downloaded without selecting "Includes policy feedback".

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
