### PR TITLE
Use data-test instead of data-cy

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -89,7 +89,7 @@ const ProjectsCollection = ({
           qsParam="stage"
           options={optionMetadata.projectStageOptions}
           selectedOptions={selectedFilters.selectedStages}
-          data-cy="stage-filter"
+          data-test="stage-filter"
         />
         <RoutedCheckboxGroupField
           legend="My Projects"
@@ -97,7 +97,7 @@ const ProjectsCollection = ({
           qsParam="adviser"
           options={[myProjectsOption]}
           selectedOptions={myProjectsSelected ? [myProjectsOption] : []}
-          data-cy="my-projects-filter"
+          data-test="my-projects-filter"
         />
         <RoutedAdvisersTypeahead
           taskProps={adviserListTask}
@@ -108,7 +108,7 @@ const ProjectsCollection = ({
           placeholder="Search advisers..."
           noOptionsMessage={() => <>No advisers found</>}
           selectedOptions={selectedFilters.selectedAdvisers}
-          data-cy="adviser-filter"
+          data-test="adviser-filter"
         />
         <RoutedTypeahead
           isMulti={true}
@@ -118,7 +118,7 @@ const ProjectsCollection = ({
           placeholder="Search sectors..."
           options={optionMetadata.sectorOptions}
           selectedOptions={selectedFilters.selectedSectors}
-          data-cy="sector-filter"
+          data-test="sector-filter"
         />
         <RoutedTypeahead
           isMulti={true}
@@ -128,7 +128,7 @@ const ProjectsCollection = ({
           placeholder="Search countries..."
           options={optionMetadata.countryOptions}
           selectedOptions={selectedFilters.selectedCountries}
-          data-cy="country-filter"
+          data-test="country-filter"
         />
         <RoutedTypeahead
           isMulti={true}
@@ -138,7 +138,7 @@ const ProjectsCollection = ({
           placeholder="Search UK regions..."
           options={optionMetadata.ukRegionOptions}
           selectedOptions={selectedFilters.selectedUkRegions}
-          data-cy="uk-region-filter"
+          data-test="uk-region-filter"
         />
         <RoutedCheckboxGroupField
           legend="Status"
@@ -146,7 +146,7 @@ const ProjectsCollection = ({
           qsParam="status"
           options={optionMetadata.projectStatusOptions}
           selectedOptions={selectedFilters.selectedProjectStatuses}
-          data-cy="project-status-filter"
+          data-test="project-status-filter"
         />
         <RoutedCheckboxGroupField
           legend="Type of investment"
@@ -154,7 +154,7 @@ const ProjectsCollection = ({
           qsParam="investment_type"
           options={optionMetadata.investmentTypeOptions}
           selectedOptions={selectedFilters.selectedInvestmentTypes}
-          data-cy="investment-type-filter"
+          data-test="investment-type-filter"
         />
         <RoutedCheckboxGroupField
           legend="Likelihood to land"
@@ -162,31 +162,31 @@ const ProjectsCollection = ({
           qsParam="likelihood_to_land"
           options={optionMetadata.likelihoodToLandOptions}
           selectedOptions={selectedFilters.selectedLikelihoodToLands}
-          data-cy="likelihood-to-land-filter"
+          data-test="likelihood-to-land-filter"
         />
         <RoutedDateField
           label="Estimated land date before"
           name="estimated_land_date_before"
           qsParamName="estimated_land_date_before"
-          data-cy="estimated-land-date-before-filter"
+          data-test="estimated-land-date-before-filter"
         />
         <RoutedDateField
           label="Estimated land date after"
           name="estimated_land_date_after"
           qsParamName="estimated_land_date_after"
-          data-cy="estimated-land-date-after-filter"
+          data-test="estimated-land-date-after-filter"
         />
         <RoutedDateField
           label="Actual land date before"
           name="actual_land_date_before"
           qsParamName="actual_land_date_before"
-          data-cy="actual-land-date-before-filter"
+          data-test="actual-land-date-before-filter"
         />
         <RoutedDateField
           label="Actual land date after"
           name="actual_land_date_after"
           qsParamName="actual_land_date_after"
-          data-cy="actual-land-date-after-filter"
+          data-test="actual-land-date-after-filter"
         />
         <RoutedCheckboxGroupField
           legend="Level of involvement specified"
@@ -194,7 +194,7 @@ const ProjectsCollection = ({
           qsParam="level_of_involvement_simplified"
           options={optionMetadata.involvementLevelOptions}
           selectedOptions={selectedFilters.selectedInvolvementLevels}
-          data-cy="involvement-level-filter"
+          data-test="involvement-level-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/client/components/ActivityFeed/ActivityFeed.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeed.jsx
@@ -146,7 +146,7 @@ export default class ActivityFeed extends React.Component {
     const hasFilters = isTypeFilterFlagEnabled || isGlobalUltimateFlagEnabled
 
     return (
-      <ActivityFeedContainer data-cy="activity-feed">
+      <ActivityFeedContainer data-test="activity-feed">
         <ActivityFeedHeader
           totalActivities={totalActivities}
           actions={actions}

--- a/src/client/components/Checkbox/index.jsx
+++ b/src/client/components/Checkbox/index.jsx
@@ -55,7 +55,7 @@ const Checkbox = ({
         setChecked(e.target.checked)
         onChange(e)
       }}
-      data-cy="checkbox"
+      data-test="checkbox"
       {...props}
     />
   )

--- a/src/client/components/CheckboxGroupField/index.jsx
+++ b/src/client/components/CheckboxGroupField/index.jsx
@@ -86,7 +86,7 @@ const CheckboxGroupField = ({
       legend={legend}
       name={name}
       hint={hint}
-      data-cy={`checkbox-group-field-${name}`}
+      data-test={`checkbox-group-field-${name}`}
       {...props}
     >
       {loading ? (

--- a/src/client/components/Dashboard/index.jsx
+++ b/src/client/components/Dashboard/index.jsx
@@ -15,7 +15,7 @@ const StyledDiv = styled('div')`
 `
 
 const Dashboard = ({ id }) => (
-  <StyledDiv data-cy="dashboard-tabs">
+  <StyledDiv data-test="dashboard-tabs">
     <TabNav
       id={`${id}.TabNav`}
       label="Dashboard"

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -49,7 +49,7 @@ const FilteredCollectionList = ({
           <RoutedDownloadDataHeader
             count={count}
             maxItems={maxItemsToDownload}
-            data-cy="download-data-header"
+            data-test="download-data-header"
             baseDownloadLink={baseDownloadLink}
           />
           <Task.Status {...taskProps}>

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -144,7 +144,7 @@ const TabNav = ({
             <StyledTablist
               tabindex={0}
               role="tablist"
-              data-cy="tablist"
+              data-test="tablist"
               aria-label={label}
               onKeyUp={({ keyCode }) => {
                 const totalTabs = tabKeys.length
@@ -202,7 +202,7 @@ const TabNav = ({
               role="tabpanel"
               tabIndex={0}
               aria-labelledby={createId(id, selectedIndex)}
-              data-cy="tabpanel"
+              data-test="tabpanel"
             >
               {getContent(tabs, tabKeys, selectedIndex)}
             </StyledTabpanel>

--- a/src/templates/_components/info-feed.njk
+++ b/src/templates/_components/info-feed.njk
@@ -24,18 +24,18 @@
  #}
 
 {% set feedLimit =  feedLimit | default(5) %}
-<div class="dashboard-section" data-cy="info-feed">
+<div class="dashboard-section" data-test="info-feed">
 {% if outboundLinkText %}
-  <a href="{{ outboundLinkURL }}" class="dashboard-section__top-link" target="_blank" data-cy="info-feed-top-link">
+  <a href="{{ outboundLinkURL }}" class="dashboard-section__top-link" target="_blank" data-test="info-feed-top-link">
     {{ outboundLinkText }}
   </a>
 {% endif %}
-{% if heading %} <h1 class="govuk-heading-m" data-cy="info-feed-heading">{{heading}}</h1> {% endif %}
+{% if heading %} <h1 class="govuk-heading-m" data-test="info-feed-heading">{{heading}}</h1> {% endif %}
 {% if subHeading %} <p class="dashboard-section__subheading">{{subHeading}}</p> {% endif %}
 {% if dataFeed.length %}
-  <ul data-cy="info-feed-list">
+  <ul data-test="info-feed-list">
     {% for item in dataFeed.slice(0, feedLimit) %}
-      <li data-cy="info-feed-list-item">
+      <li data-test="info-feed-list-item">
         <a href="{{ item.link }}" class="dashboard-section__info-feed-link" target="_blank">{{ item.heading }}</a>
         <span class="dashboard-section__info-feed-link-note">(Link opens in a new window)</span>
         <time class="dashboard-section__info-feed-date">{{ item.date }}</time>
@@ -43,6 +43,6 @@
     {% endfor %}
   </ul>
 {% else %}
-  <p class="dashboard-section__fallback-text" data-cy="info-feed-no-results">No updates available</p>
+  <p class="dashboard-section__fallback-text" data-test="info-feed-no-results">No updates available</p>
 {% endif %}
 </div>

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -178,7 +178,7 @@ describe('Company activity feed', () => {
   context('when viewing an export enquiry in the activity feed', () => {
     before(() => {
       cy.visit(urls.companies.activity.index(fixtures.company.venusLtd.id))
-      cy.get('[data-cy="activity-feed"] select').select('externalActivity')
+      cy.get('[data-test="activity-feed"] select').select('externalActivity')
       cy.get(selectors.companyActivity.activityFeed.item(1)).as('exportEnquiry')
     })
     it('should display an export enquiry with truncated comment', () => {

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -5,12 +5,12 @@ describe('Dashboard', () => {
   context('When the help centre API is available', () => {
     beforeEach(() => {
       cy.visit('/')
-      cy.get('[data-cy="info-feed"]')
+      cy.get('[data-test="info-feed"]')
         .as('infoFeed')
         .within(() => {
-          cy.get('[data-cy="info-feed-top-link"]').as('infoFeedTopLink')
-          cy.get('[data-cy="info-feed-heading"]').as('infoFeedHeading')
-          cy.get('[data-cy="info-feed-list"]').as('infoFeedList')
+          cy.get('[data-test="info-feed-top-link"]').as('infoFeedTopLink')
+          cy.get('[data-test="info-feed-heading"]').as('infoFeedHeading')
+          cy.get('[data-test="info-feed-list"]').as('infoFeedList')
         })
     })
 
@@ -30,7 +30,7 @@ describe('Dashboard', () => {
     it('should display the info feed list', () => {
       cy.get('@infoFeedList')
         .should('exist')
-        .find('[data-cy="info-feed-list-item"]')
+        .find('[data-test="info-feed-list-item"]')
         .should('have.length', 1)
         .first()
         .within(() => {
@@ -49,12 +49,12 @@ describe('Dashboard', () => {
   context('When the help centre API is unavailable', () => {
     beforeEach(() => {
       cy.visit('/', { qs: { test: 'help-centre-unavailable' } })
-      cy.get('[data-cy="info-feed"]').as('infoFeed')
+      cy.get('[data-test="info-feed"]').as('infoFeed')
     })
 
     it('should return an empty info feed', () => {
-      cy.get('[data-cy="info-feed-list"]').should('not.exist')
-      cy.get('[data-cy="info-feed-no-results"]')
+      cy.get('[data-test="info-feed-list"]').should('not.exist')
+      cy.get('[data-test="info-feed-no-results"]')
         .should('exist')
         .should('have.text', 'No updates available')
     })
@@ -63,12 +63,12 @@ describe('Dashboard', () => {
   context('When the help centre API returns no results', () => {
     beforeEach(() => {
       cy.visit('/', { qs: { test: 'help-centre-empty' } })
-      cy.get('[data-cy="info-feed"]').as('infoFeed')
+      cy.get('[data-test="info-feed"]').as('infoFeed')
     })
 
     it('should return an empty info feed', () => {
-      cy.get('[data-cy="info-feed-list"]').should('not.exist')
-      cy.get('[data-cy="info-feed-no-results"]')
+      cy.get('[data-test="info-feed-list"]').should('not.exist')
+      cy.get('[data-test="info-feed-no-results"]')
         .should('exist')
         .should('have.text', 'No updates available')
     })

--- a/test/functional/cypress/specs/investments/download-spec.js
+++ b/test/functional/cypress/specs/investments/download-spec.js
@@ -6,7 +6,7 @@ describe('Investment Project Collections', () => {
       cy.visit(investments.projects.index(), {
         qs: { page: 2, estimated_land_date_before: '2020-11-19' },
       })
-      cy.get('[data-cy="download-data-header"]')
+      cy.get('[data-test="download-data-header"]')
         .as('downloadDataHeader')
         .find('a')
         .as('downloadDataButton')
@@ -31,7 +31,7 @@ describe('Investment Project Collections', () => {
   context('when over 5,000 projects are returned', () => {
     before(() => {
       cy.visit(investments.projects.index())
-      cy.get('[data-cy="download-data-header"]').as('downloadDataHeader')
+      cy.get('[data-test="download-data-header"]').as('downloadDataHeader')
     })
 
     it('should show "filter to fewer than 5,000"', () => {

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -50,28 +50,32 @@ const testRemoveChip = ({ element, placeholder = null }) => {
 
 describe('Investments Collections Filter', () => {
   beforeEach(() => {
-    cy.get('[data-cy="stage-filter"]').as('stageFilter')
-    cy.get('[data-cy="my-projects-filter"]').as('myProjectsFilter')
-    cy.get('[data-cy="adviser-filter"]').as('adviserFilter')
-    cy.get('[data-cy="sector-filter"]').as('sectorFilter')
-    cy.get('[data-cy="country-filter"]').as('countryFilter')
-    cy.get('[data-cy="uk-region-filter"]').as('ukRegionFilter')
-    cy.get('[data-cy="project-status-filter"]').as('projectStatusFilter')
-    cy.get('[data-cy="investment-type-filter"]').as('investmentTypeFilter')
-    cy.get('[data-cy="likelihood-to-land-filter"]').as('likelihoodToLandFilter')
-    cy.get('[data-cy="estimated-land-date-before-filter"]').as(
+    cy.get('[data-test="stage-filter"]').as('stageFilter')
+    cy.get('[data-test="my-projects-filter"]').as('myProjectsFilter')
+    cy.get('[data-test="adviser-filter"]').as('adviserFilter')
+    cy.get('[data-test="sector-filter"]').as('sectorFilter')
+    cy.get('[data-test="country-filter"]').as('countryFilter')
+    cy.get('[data-test="uk-region-filter"]').as('ukRegionFilter')
+    cy.get('[data-test="project-status-filter"]').as('projectStatusFilter')
+    cy.get('[data-test="investment-type-filter"]').as('investmentTypeFilter')
+    cy.get('[data-test="likelihood-to-land-filter"]').as(
+      'likelihoodToLandFilter'
+    )
+    cy.get('[data-test="estimated-land-date-before-filter"]').as(
       'estimatedDateBeforeFilter'
     )
-    cy.get('[data-cy="estimated-land-date-after-filter"]').as(
+    cy.get('[data-test="estimated-land-date-after-filter"]').as(
       'estimatedDateAfterFilter'
     )
-    cy.get('[data-cy="actual-land-date-before-filter"]').as(
+    cy.get('[data-test="actual-land-date-before-filter"]').as(
       'actualDateBeforeFilter'
     )
-    cy.get('[data-cy="actual-land-date-after-filter"]').as(
+    cy.get('[data-test="actual-land-date-after-filter"]').as(
       'actualDateAfterFilter'
     )
-    cy.get('[data-cy="involvement-level-filter"]').as('involvementLevelFilter')
+    cy.get('[data-test="involvement-level-filter"]').as(
+      'involvementLevelFilter'
+    )
   })
 
   context('when the url contains no state', () => {

--- a/test/functional/cypress/specs/layout-spec.js
+++ b/test/functional/cypress/specs/layout-spec.js
@@ -14,9 +14,9 @@ describe('Layout', () => {
 
   describe('Tabs', () => {
     it('should display tabs in the right order', () => {
-      cy.get('[data-cy="dashboard-tabs"]')
+      cy.get('[data-test="dashboard-tabs"]')
         .should('exist')
-        .find('[data-cy="tablist"]')
+        .find('[data-test="tablist"]')
         .should('exist')
         .children()
         .should('have.length', 3)

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -429,7 +429,7 @@ const assertChipExists = ({ label, position }) => {
 const assertElementsInOrder = ({ parentElement, expectedIdentifiers }) => {
   let filterElement = cy.get(parentElement).first()
   for (const [index, identifier] of expectedIdentifiers.entries()) {
-    filterElement.should('have.attr', 'data-cy', identifier)
+    filterElement.should('have.attr', 'data-test', identifier)
     if (index !== expectedIdentifiers.length - 1) {
       filterElement.next()
     }


### PR DESCRIPTION
## Description of change

Rename `data-cy` test element identifiers to `data-test` which has been adopted on the main branch.

## Test instructions

Everything should look the same.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
