### PR TITLE
Restart express server on change rather than re-spawning it

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "node --use-strict src/server.js",
     "start:coverage": "nyc --silent npm run start",
     "build": "npm run clean && webpack",
-    "develop": "NODE_ENV=development npm run watch:js:client -- --env backend=true",
+    "develop": "NODE_ENV=development npm run watch:js:client -- --env development",
     "watch:test": "npm run test:unit -- -w",
     "watch:js:client": "webpack --watch --progress",
     "watch:js:server": "nodemon $NODE_DEBUG_OPTION --inspect --ignore 'src/**/__test__/**/*'",


### PR DESCRIPTION
## Description of change

This is part of the work to enable hot reloading - this doesn't actually do hot reloading, but fixes a problem where webpack was spawning new express server instances each time a file changed. This should therefore make the dev server run a lot more quickly and there should be fewer issues with memory running out.

## Test instructions

Run the dev server and see that everything works as expected. Any changes you make should be reflected after refreshing the page (future work should make this happen without a refresh).

This needs to work through docker as well as natively.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
