### PR TITLE
Fix broken storybook release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - image: node
     steps:
       - checkout
-      - run: npm ci
+      - run: npm install
       - run:
           name: Release storybook
           command: npm run storybook:release


### PR DESCRIPTION
## Description of change

Currently the Storybook release in CI is broken, this changes the config slightly to fix this issue.


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
