### PR TITLE
Fix broken storybook release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,10 +144,10 @@ jobs:
 
   release-storybook:
     docker:
-      - image: node
+      - image: node:12.18.0
     steps:
       - checkout
-      - run: npm install
+      - run: npm install storybook
       - run:
           name: Release storybook
           command: npm run storybook:release


### PR DESCRIPTION
## Description of change

Currently the Storybook release in CI is broken, this changes the config slightly to fix this issue.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
