### PR TITLE
Hide inactive ITAs from typeahead for adding an advisor

### DIFF
--- a/src/apps/companies/apps/advisers/client/ManageAdviser.jsx
+++ b/src/apps/companies/apps/advisers/client/ManageAdviser.jsx
@@ -129,6 +129,7 @@ const Add = ({
                                 autocomplete: searchString,
                                 dit_team__role:
                                   '5e329c18-6095-e211-a939-e4115bead28a',
+                                is_active: 'true',
                               },
                             })
                             .then(({ data: { results } }) =>

--- a/test/end-to-end/cypress/specs/DIT/manage-adviser-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/manage-adviser-spec.js
@@ -43,6 +43,16 @@ describe('Manage Lead ITA', () => {
       "Lead adviser information updated.Send Sarah Gates an email to let them know they've been made Lead ITA.",
     replace: true,
   })
+  it('should not be able to add an advisor who is no longer active', () => {
+    cy.visit(urls.companies.detail(fixtures.company.lambdaPlc.id))
+    cy.get(selectors.tabbedLocalNav().item(3)).click()
+    cy.get('#lead-advisers a').contains('Replace Lead ITA').click()
+    cy.get('form label').next().next().selectTypeaheadOption('Ava')
+    cy.get('#form-errors').should(
+      'have.text',
+      'There is a problemSelect an ITA'
+    )
+  })
   it('should be able to remove an adviser', () => {
     cy.visit(urls.companies.detail(fixtures.company.lambdaPlc.id))
     cy.get(selectors.tabbedLocalNav().item(3)).click()


### PR DESCRIPTION
## Description of change

Bugfix: in the past, when searching for a lead ITA to add, the search would return inactive as well as active advisors.

## Test instructions

- Go to any non One List Company.
- Go to Lead Adviser tab
- Click ‘Add Lead ITA/Replace Lead ITA’
- Search for an advisor who is not active - you should not see their profile (if running locally with the [updated API data](https://github.com/uktrade/data-hub-api/pull/3264/files), you should not see Ava Walsh)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
