### PR TITLE
Fix a bug when RoutedPagination didn't highlight the selected page

### DIFF
--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -25,7 +25,6 @@ const FilteredCollectionList = ({
   isComplete,
   children,
   collectionName,
-  activePage = 1,
   maxItemsToDownload,
   selectedFilters,
   baseDownloadLink,
@@ -62,7 +61,6 @@ const FilteredCollectionList = ({
                   <RoutedPagination
                     qsParamName="page"
                     totalPages={totalPages}
-                    activePage={activePage}
                   />
                 </>
               )

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -43,7 +43,7 @@ const FilteredCollectionList = ({
             />
           )}
           {sortOptions && (
-            <CollectionSort sortOptions={sortOptions} totalPages={count} />
+            <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
           )}
           <RoutedDownloadDataHeader
             count={count}

--- a/src/client/components/RoutedPagination/index.jsx
+++ b/src/client/components/RoutedPagination/index.jsx
@@ -7,10 +7,13 @@ import Pagination from '../Pagination'
 const RoutedPagination = ({ qsParamName, ...props }) => (
   <Route>
     {({ location, history }) => {
-      const qsParams = qs.parse(location.search.slice(1))
+      const { page: activePage = '1', ...qsParams } = qs.parse(
+        location.search.slice(1)
+      )
       return (
         <Pagination
           {...props}
+          activePage={parseInt(activePage, 10)}
           onPageClick={(page) => {
             history.push({
               search: qs.stringify({


### PR DESCRIPTION
## Description of change

Fixed a bug in the `RoutedPagination` when the active page was always page 1.

## Test instructions

1. Go to `/investments/projects`
2. Scroll all the way down to see the pagination
3. Select page 2
4. The pagination should now highlight the page 2 as selected