### PR TITLE
New dashboard layout for user testing...

### DIFF
--- a/src/apps/dashboard/index.js
+++ b/src/apps/dashboard/index.js
@@ -2,6 +2,7 @@ const router = require('express').Router()
 const urls = require('../../lib/urls')
 const { renderDashboard } = require('./controllers')
 const spaBasePath = require('../../middleware/spa-base-path')
+const layoutTesting = require('../../middleware/layout-testing')
 
 module.exports = {
   router: router.get(
@@ -14,6 +15,7 @@ module.exports = {
       urls.pipeline.won.mountPoint,
     ],
     spaBasePath(urls.dashboard.route),
+    layoutTesting('dashboard'),
     renderDashboard
   ),
 }

--- a/src/apps/dashboard/views/dashboard-prod.njk
+++ b/src/apps/dashboard/views/dashboard-prod.njk
@@ -1,0 +1,39 @@
+{% extends "_layouts/template.njk" %}
+{# For the accessibility work, the search bar has been amended to have hint text and placeholder text.
+It seems to be that the label and hint are coupled up somewhere, so a label is required to show a hint.
+As nunjucks is on it's way out, a label of an empty space has been used as a work around for this issue. #}
+{% block local_header %}
+  {% call LocalHeader({ modifier: 'dark-banner' }) %}
+    {{ EntitySearchForm({
+      inputName: 'term',
+      inputHint: 'Search for company, contact, event, investment project or OMIS order',
+      inputPlaceholder: 'Enter your search term(s)',
+      inputLabel: ' ',
+      isLabelHidden: false,
+      modifier: 'global',
+      action: urls.search.type('companies')
+    }) }}
+  {% endcall %}
+{% endblock %}
+
+{% block body_main_content %}
+<div class="grid-row dashboard">
+    <section class="govuk-grid-column-full">
+      {% component 'info-feed', {
+        heading: 'Data Hub updates',
+        feedLimit: 1,
+        dataFeed: articleFeed,
+        outboundLinkURL: helpCentre.announcementsURL,
+        outboundLinkText: 'View all updates'
+      } %}
+    </section>
+{% if user.hasPermission('company_list.view_companylist') %}
+  <div class="govuk-grid-column-full">
+      {% component 'react-slot', {
+        id: 'company-lists'
+      } %}
+  </div>
+{% endif %}
+</div>
+
+{% endblock %}

--- a/src/apps/dashboard/views/dashboard-test.njk
+++ b/src/apps/dashboard/views/dashboard-test.njk
@@ -1,0 +1,14 @@
+{% extends "_layouts/template.njk" %}
+{# For the accessibility work, the search bar has been amended to have hint text and placeholder text.
+It seems to be that the label and hint are coupled up somewhere, so a label is required to show a hint.
+As nunjucks is on it's way out, a label of an empty space has been used as a work around for this issue. #}
+{% block local_header %}
+{% endblock %}
+
+{% block body_main_content %}
+<div class="grid-row dashboard">
+  <div class="govuk-grid-column-full" data-test="dashboard">
+    New dashboard starts here...
+  </div>
+</div>
+{% endblock %}

--- a/src/apps/dashboard/views/dashboard-test.njk
+++ b/src/apps/dashboard/views/dashboard-test.njk
@@ -1,7 +1,4 @@
 {% extends "_layouts/template.njk" %}
-{# For the accessibility work, the search bar has been amended to have hint text and placeholder text.
-It seems to be that the label and hint are coupled up somewhere, so a label is required to show a hint.
-As nunjucks is on it's way out, a label of an empty space has been used as a work around for this issue. #}
 {% block local_header %}
 {% endblock %}
 

--- a/src/apps/dashboard/views/dashboard.njk
+++ b/src/apps/dashboard/views/dashboard.njk
@@ -1,39 +1,6 @@
-{% extends "_layouts/template.njk" %}
-{# For the accessibility work, the search bar has been amended to have hint text and placeholder text.
-It seems to be that the label and hint are coupled up somewhere, so a label is required to show a hint. 
-As nunjucks is on it's way out, a label of an empty space has been used as a work around for this issue. #}
-{% block local_header %}
-  {% call LocalHeader({ modifier: 'dark-banner' }) %}
-    {{ EntitySearchForm({
-      inputName: 'term',
-      inputHint: 'Search for company, contact, event, investment project or OMIS order',
-      inputPlaceholder: 'Enter your search term(s)',
-      inputLabel: ' ',
-      isLabelHidden: false,
-      modifier: 'global',
-      action: urls.search.type('companies')
-    }) }}
-  {% endcall %}
-{% endblock %}
+  {% if isLayoutTesting %}
+    {% include "./dashboard-test.njk" %}
+  {% else %}
+    {% include "./dashboard-prod.njk" %}
+  {% endif %}
 
-{% block body_main_content %}
-<div class="grid-row dashboard">
-    <section class="govuk-grid-column-full">
-      {% component 'info-feed', {
-        heading: 'Data Hub updates',
-        feedLimit: 1,
-        dataFeed: articleFeed,
-        outboundLinkURL: helpCentre.announcementsURL,
-        outboundLinkText: 'View all updates'
-      } %}
-    </section>
-{% if user.hasPermission('company_list.view_companylist') %}
-  <div class="govuk-grid-column-full">
-      {% component 'react-slot', {
-        id: 'company-lists'
-      } %}
-  </div>
-{% endif %}
-</div>
-
-{% endblock %}

--- a/src/middleware/layout-testing.js
+++ b/src/middleware/layout-testing.js
@@ -1,6 +1,15 @@
 const { isEmpty } = require('lodash')
 const logger = require('../config/logger')
 
+/**
+ * Allows a specific group of users to test a new layout. You need to set a feature flag in Django in the following
+ * format: layoutTesting:1234 where 1234 is an id of a specific team. Once set all users that fall into that team will
+ * be exposed to the new layout.
+ * @param {String} queryParam - Sets a query param in the url. "Foo" results in ?layoutTesting=foo This is for tracking
+ * via google analytics. Adding this middleware to a route will set a property/global variable called "isLayoutTesting"
+ * on res.locals, this variable can then be used to toggle layouts/components in any njk file.
+ */
+
 module.exports = (queryParam) => (req, res, next) => {
   const { features } = res.locals
   res.locals.isLayoutTesting = false

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -109,18 +109,17 @@ addLoggedCommand({
  * with a dash e.g. `'-GET'` if in a nested context like `.witin()`
  */
 Cypress.Commands.add('getDhTablistTab', (tablistLabel, tabLabel, options) => {
-  cy.getDhTablist(tablistLabel, options)
-    .getDhTab(tabLabel, { ...options, nestedLog: true })
+  cy.getDhTablist(tablistLabel, options).getDhTab(tabLabel, {
+    ...options,
+    nestedLog: true,
+  })
 })
 
 Cypress.Commands.add(
   'selectTypeaheadOption',
   { prevSubject: 'element' },
   (subject, text) => {
-    cy.wrap(subject)
-      .find('input')
-      .type(text, { force: true })
-      .type('{enter}')
+    cy.wrap(subject).find('input').type(text, { force: true }).type('{enter}')
 
     return cy.wrap(subject)
   }
@@ -160,9 +159,13 @@ Cypress.Commands.add(
   }
 )
 
-Cypress.Commands.add('getTypeaheadValues', { prevSubject: 'element'}, ( subject) => {
-  return cy.wrap(subject).find('div > div > div > div[class*="-multiValue"]')
-})
+Cypress.Commands.add(
+  'getTypeaheadValues',
+  { prevSubject: 'element' },
+  (subject) => {
+    return cy.wrap(subject).find('div > div > div > div[class*="-multiValue"]')
+  }
+)
 
 Cypress.Commands.add('setFeatureFlag', (name, isActive) => {
   const body = {
@@ -230,3 +233,11 @@ Cypress.Commands.overwrite(
     return originalFn(subject, expectation, ...args)
   }
 )
+
+Cypress.Commands.add('setUserDitTeam', (id) => {
+  return cy.request('PUT', `${Cypress.env('sandbox_url')}/whoami`, { id })
+})
+
+Cypress.Commands.add('resetUserDitTeam', () => {
+  return cy.request('POST', `${Cypress.env('sandbox_url')}/whoami`)
+})

--- a/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
@@ -5,6 +5,9 @@ describe('Dashboard - feature flag', () => {
       cy.setFeatureFlag('layoutTesting:1234', true)
       cy.visit('/')
     })
+    afterEach(() => {
+      cy.resetUserDitTeam()
+    })
     it('should show an alternative layout', () => {
       cy.get('[data-test="dashboard"]').should('be.visible')
     })
@@ -20,7 +23,6 @@ describe('Dashboard - feature flag', () => {
     'when a feature flag is set and your are NOT in the testing team',
     () => {
       beforeEach(() => {
-        cy.resetUserDitTeam()
         cy.setFeatureFlag('layoutTesting:1234', true)
         cy.visit('/')
       })

--- a/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
@@ -1,0 +1,55 @@
+describe('Dashboard - feature flag', () => {
+  context('when a feature flag is set and your are in the testing team', () => {
+    beforeEach(() => {
+      cy.setUserDitTeam('1234')
+      cy.setFeatureFlag('layoutTesting:1234', true)
+      cy.visit('/')
+    })
+    it('should show an alternative layout', () => {
+      cy.get('[data-test="dashboard"]').should('be.visible')
+    })
+    it('should append a query param for GA tracking', () => {
+      cy.url('[data-test="dashboard"]').should(
+        'contain',
+        '?layoutTesting=dashboard'
+      )
+    })
+  })
+
+  context(
+    'when a feature flag is set and your are NOT in the testing team',
+    () => {
+      beforeEach(() => {
+        cy.resetUserDitTeam()
+        cy.setFeatureFlag('layoutTesting:1234', true)
+        cy.visit('/')
+      })
+      it('should show the default dashboard layout', () => {
+        cy.get('[data-test="dashboard"]').should('not.be.visible')
+      })
+      it('should NOT append a query param for GA tracking', () => {
+        cy.url('[data-test="dashboard"]').should(
+          'not.contain',
+          '?layoutTesting=dashboard'
+        )
+      })
+    }
+  )
+
+  context('when there is no feature flag', () => {
+    beforeEach(() => {
+      cy.resetUserDitTeam()
+      cy.resetFeatureFlags()
+      cy.visit('/')
+    })
+    it('should show the default dashboard layout', () => {
+      cy.get('[data-test="dashboard"]').should('not.be.visible')
+    })
+    it('should NOT append a query param for GA tracking', () => {
+      cy.url('[data-test="dashboard"]').should(
+        'not.contain',
+        '?layoutTesting=dashboard'
+      )
+    })
+  })
+})

--- a/test/sandbox/routes/whoami.js
+++ b/test/sandbox/routes/whoami.js
@@ -1,5 +1,17 @@
 var whoami = require('../fixtures/whoami.json')
 
+var defaultTeamId = whoami.dit_team.id
+
 exports.whoami = function (req, res) {
+  res.json(whoami)
+}
+
+exports.setUserDitTeam = function (req, res) {
+  whoami.dit_team.id = req.body.id
+  res.json(whoami)
+}
+
+exports.resetUserDitTeam = function (req, res) {
+  whoami.dit_team.id = defaultTeamId
   res.json(whoami)
 }

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -430,6 +430,8 @@ app.post(
 
 // Whoami endpoint
 app.get('/whoami/', user.whoami)
+app.put('/whoami', user.setUserDitTeam)
+app.post('/whoami', user.resetUserDitTeam)
 
 // Help centre endpoint
 app.get('/help-centre/announcement', helpCentre.announcement)


### PR DESCRIPTION
## Description of change
We are currently designing a new dashboard and we need an alternative layout to test users against. We will use a piece of middleware called "layout-testing.js" which enables us to target a specific group of users (by team id) so we can gain feedback around the new layout and what components work well.

## Test instructions
To activate the new layout all you need to do is set a feature flag in the following format: `layoutTesting:1234` where `1234` is an id of a specific team. Once you set that team id you need to go into django and assign yourself to it, clear the session by logging out and then sign back in and you should see a new layout with the following text: "New dashboard starts here..." You should also see a query param in the url called `?layoutTesting=dashboard`, this is so we can track user behaviour around this specific layout.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
