### PR TITLE
Fix/checkbox group field spacing

### DIFF
--- a/src/client/components/CheckboxGroupField/index.jsx
+++ b/src/client/components/CheckboxGroupField/index.jsx
@@ -9,13 +9,12 @@ import FieldWrapper from '../Form/elements/FieldWrapper'
 const StyledFieldWrapper = styled(FieldWrapper)`
   label {
     font-weight: normal;
+    margin-bottom: 4px;
   }
   label:not(:first-child) {
     padding-left: 20px;
   }
   input {
-    left: -10px;
-    top: -2px;
     + span {
       padding: 10px 15px 5px;
       &::before {


### PR DESCRIPTION
## Description of change

Reduces vertical spacing between checkboxes in `CheckboxGroupField` to `20px`.