### PR TITLE
Fix - Dashboard should not break when a user is not associated with a team...

### DIFF
--- a/src/middleware/layout-testing.js
+++ b/src/middleware/layout-testing.js
@@ -1,4 +1,4 @@
-const { isEmpty } = require('lodash')
+const { isEmpty, get } = require('lodash')
 const logger = require('../config/logger')
 
 /**
@@ -23,12 +23,10 @@ module.exports = (queryParam) => (req, res, next) => {
     )
 
   if (!isEmpty(layoutTestingFeature)) {
-    const {
-      dit_team: { id },
-    } = res.locals.user
+    const userTeamId = get(res.locals.user.dit_team, 'id')
     const [featureFlag] = layoutTestingFeature
-    const [, teamId] = featureFlag.split(':')
-    res.locals.isLayoutTesting = teamId === id
+    const [, featureTeamId] = featureFlag.split(':')
+    res.locals.isLayoutTesting = featureTeamId === userTeamId
     if (res.locals.isLayoutTesting && isEmpty(req.query)) {
       return res.redirect(`${req.originalUrl}?layoutTesting=${queryParam}`)
     }

--- a/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
@@ -38,6 +38,23 @@ describe('Dashboard - feature flag', () => {
     }
   )
 
+  context('when a feature flag is set and your are NOT in any team', () => {
+    beforeEach(() => {
+      cy.setUserDitTeam(null)
+      cy.setFeatureFlag('layoutTesting:1234', true)
+      cy.visit('/')
+    })
+    it('should show the default dashboard layout', () => {
+      cy.get('[data-test="dashboard"]').should('not.be.visible')
+    })
+    it('should NOT append a query param for GA tracking', () => {
+      cy.url('[data-test="dashboard"]').should(
+        'not.contain',
+        '?layoutTesting=dashboard'
+      )
+    })
+  })
+
   context('when there is no feature flag', () => {
     beforeEach(() => {
       cy.resetUserDitTeam()


### PR DESCRIPTION
## Description of change
If a user is not assigned to a team the middleware from PR #3248 fails as it tries to look for a team id associated with the user. To fix this I have guarded against no id, so now if the user is not assigned to a team they will just see the default layout/dashboard.

## Test instructions
- In django remove the team you are associated with under "Teams"
- Go to the home page and everything should work as normal

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
