### PR TITLE
Fix - Include the old props for njk Investments collection lists

### DIFF
--- a/src/apps/investments/transformers/__test__/collection.test.js
+++ b/src/apps/investments/transformers/__test__/collection.test.js
@@ -19,10 +19,6 @@ describe('Investment project transformers', () => {
         expect(this.transformedItem.headingText).to.equal(this.rawItem.name)
       })
 
-      it('should provide the type', () => {
-        expect(this.transformedItem.type).to.equal('project')
-      })
-
       it('should list the esimated land date as date', () => {
         expect(this.transformedItem.metadata[2]).to.deep.equal({
           label: 'Estimated land date',

--- a/src/apps/investments/transformers/collection.js
+++ b/src/apps/investments/transformers/collection.js
@@ -72,12 +72,11 @@ function transformInvestmentProjectToListItem({
       value: project_code,
       metadata,
     },
-    // end
     meta: compact(metaItems),
+    // end
     headingUrl: urls.investments.projects.details(id),
     headingText: name,
     subheading: `Project code ${project_code}`,
-    type: 'project',
     badges,
     metadata,
   }

--- a/src/apps/investments/transformers/collection.js
+++ b/src/apps/investments/transformers/collection.js
@@ -1,8 +1,12 @@
 /* eslint camelcase: 0 */
-const { isArray, assign } = require('lodash')
+const { isArray, assign, compact, pickBy } = require('lodash')
 const { format } = require('date-fns')
 
 const urls = require('../../../lib/urls')
+
+// TODO: Remove labels when all collection lists are reworked into React.
+const labels = require('../labels')
+// end
 
 function transformInvestmentProjectToListItem({
   id,
@@ -30,7 +34,46 @@ function transformInvestmentProjectToListItem({
     },
   ].filter((metadata) => metadata.value)
 
+  // TODO: Remove metaItems when all collection lists are reworked into React.
+  const metaItems = [
+    { key: 'stage', value: stage, type: 'badge' },
+    {
+      key: 'investment_type',
+      value: investment_type,
+      type: 'badge',
+      badgeModifier: 'secondary',
+    },
+    { key: 'status', value: status, type: 'badge', badgeModifier: 'secondary' },
+    { key: 'investor_company', value: investor_company },
+    { key: 'sector', value: sector },
+    {
+      key: 'estimated_land_date',
+      value: estimated_land_date,
+      type: 'dateMonthYear',
+      isInert: true,
+    },
+  ].map(({ key, value, type, badgeModifier, isInert }) => {
+    if (!value) return
+    return assign({}, pickBy({ value, type, badgeModifier, isInert }), {
+      label: labels.investmentProjectMetaItemLabels[key],
+    })
+  })
+  // end
+
   return {
+    // TODO: Remove all these props when all collection lists are reworked into React.
+    id,
+    name,
+    type: 'investments/project',
+    subTitle: {
+      type: 'project',
+      label: 'Project code',
+      badges,
+      value: project_code,
+      metadata,
+    },
+    // end
+    meta: compact(metaItems),
     headingUrl: urls.investments.projects.details(id),
     headingText: name,
     subheading: `Project code ${project_code}`,

--- a/src/apps/search/__test__/controllers.test.js
+++ b/src/apps/search/__test__/controllers.test.js
@@ -66,12 +66,6 @@ describe('Search Controller #renderSearchResults', () => {
         })
       )
     })
-
-    it('should transform investment projects data', () => {
-      expect(
-        this.renderFunction.getCall(0).args[1].results.items[0].type
-      ).to.equal('project')
-    })
   })
 
   context('for contacts', () => {


### PR DESCRIPTION
## Description of change
After merging #3255 there was a collection list in Investments which broke. This break was around the props being changed in `collection.js` transformer in the previous PR. As there were no functional or e2e tests around this particular collection list the tests never broke so we assumed all was okay. 

To gain confidence that no other investment collection lists will fail I have put the old props back(minus one we don't need "type") alongside the new so both types or investment collection lists (njk/React) will work. I have added TODO comments and a card in the React board - https://trello.com/c/D2X79F7Q/563-todo-remove-legacy-code-in-the-collectionjs-transformer-after-all-collection-lists-have-been-re-worked-into-react so when we do complete all collection lists we should remove this legacy code.

## Test instructions

All collection lists in Investments should work wether they are nunjucks or React.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
