### PR TITLE
Add component to show estimated land date for an investment project

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -1,8 +1,45 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { typography } from '@govuk-react/lib'
+import { SPACING } from '@govuk-react/constants'
+import { YELLOW, BLACK } from 'govuk-colours'
+import { format, endOfToday, differenceInDays } from 'date-fns'
+
+const StyledPanel = styled('div')`
+  padding: ${SPACING.SCALE_4};
+  color: ${BLACK};
+  background-color: ${YELLOW};
+`
+const StyledTitle = styled('h2')`
+  margin-top: ${SPACING.SCALE_4};
+  margin-bottom: ${SPACING.SCALE_4};
+  text-align: center;
+  font-size: ${typography.font({ size: 36, weight: 'bold' })};
+`
+const StyledBody = styled('div')`
+  text-align: center;
+  font-size: ${typography.font({ size: 16 })};
+`
+
+const getDifferenceInDays = (estimatedLandDate) => {
+  const today = endOfToday()
+  const difference = differenceInDays(estimatedLandDate, today)
+  return difference === 1
+    ? difference + ' day'
+    : difference === 0
+    ? 'Today'
+    : difference < 0
+    ? difference * -1 + ' days ago'
+    : difference + ' days'
+}
 
 const InvestmentEstimatedLandDate = ({ estimatedLandDate }) => (
-  <div>Estimated land date: {estimatedLandDate}</div>
+  <StyledPanel>
+    <StyledBody>Estimated land date</StyledBody>
+    <StyledTitle>{getDifferenceInDays(estimatedLandDate)}</StyledTitle>
+    <StyledBody>{format(estimatedLandDate, 'ddd, DD MMM YYYY')}</StyledBody>
+  </StyledPanel>
 )
 
 InvestmentEstimatedLandDate.propTypes = {

--- a/src/client/components/MyInvestmentProjects/__stories__/InvestmentEstimatedLandDate.stories.jsx
+++ b/src/client/components/MyInvestmentProjects/__stories__/InvestmentEstimatedLandDate.stories.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import InvestmentEstimatedLandDate from 'InvestmentEstimatedLandDate'
+import exampleReadme from './example.md'
+import usageReadme from './usage.md'
+import { addDays, subDays, endOfToday } from 'date-fns'
+
+const today = endOfToday()
+const futureDate = addDays(today, 100)
+const tomorrow = addDays(today, 1)
+const pastDate = subDays(today, 10)
+
+storiesOf('InvestmentEstimatedLandDate', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <InvestmentEstimatedLandDate estimatedLandDate={futureDate} />
+  ))
+  .add('estimatedLandDate is today', () => (
+    <InvestmentEstimatedLandDate estimatedLandDate={today} />
+  ))
+  .add('estimatedLandDate is tomorrow', () => (
+    <InvestmentEstimatedLandDate estimatedLandDate={tomorrow} />
+  ))
+  .add('estimatedLandDate is in the past', () => (
+    <InvestmentEstimatedLandDate estimatedLandDate={pastDate} />
+  ))

--- a/src/client/components/MyInvestmentProjects/__stories__/InvestmentEstimatedLandDate.stories.jsx
+++ b/src/client/components/MyInvestmentProjects/__stories__/InvestmentEstimatedLandDate.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import InvestmentEstimatedLandDate from 'InvestmentEstimatedLandDate'
+import InvestmentEstimatedLandDate from '../InvestmentEstimatedLandDate'
 import exampleReadme from './example.md'
 import usageReadme from './usage.md'
 import { addDays, subDays, endOfToday } from 'date-fns'

--- a/src/client/components/MyInvestmentProjects/__stories__/example.md
+++ b/src/client/components/MyInvestmentProjects/__stories__/example.md
@@ -1,0 +1,7 @@
+### Import
+
+```js
+import InvestmentEstimatedLandDate from 'InvestmentEstimatedLandDate'
+```
+
+### Output

--- a/src/client/components/MyInvestmentProjects/__stories__/usage.md
+++ b/src/client/components/MyInvestmentProjects/__stories__/usage.md
@@ -1,0 +1,17 @@
+# InvestmentEstimatedLandDate
+
+### Description
+
+A box that displays the estimated land date for an investment project and the difference between the current date in days.
+
+### Usage
+
+```jsx
+<InvestmentEstimatedLandDate estimatedLandDate={project.estimated_land_date} />
+```
+
+### Properties
+
+| Prop                | Required | Default | Type | Description                                      |
+| :------------------ | :------- | :------ | :--- | :----------------------------------------------- |
+| `estimatedLandDate` | true     | ``      | Date | Contains the estimated land date for the project |


### PR DESCRIPTION
## Description of change

I'm not going to merge this until the dashboard skeleton PR has been merged.

As part of the personalised dashboards we needed to create a component that showed the estimated land date of an investment project.

I've used `InvestmentEstimatedLandDate` as a placeholder name, this will probably need to be changed. I've not added anything around what should happen if the estimated land date has passed, as I'm not sure if these projects would be included in the dashboard.

## Test instructions

Start Storybook and go to the new section `InvestmentEstimatedLandDate`.

## Screenshots

<img width="190" alt="Screenshot 2021-01-26 at 12 20 11" src="https://user-images.githubusercontent.com/36161814/105844574-58598f00-5fd1-11eb-8820-d717db30420d.png">

<details>
<summary>If the expected date is tomorrow</summary>
<img width="196" alt="Screenshot 2021-01-26 at 12 20 50" src="https://user-images.githubusercontent.com/36161814/105844602-64dde780-5fd1-11eb-883d-c898b7160dab.png">
</details>

<details>
<summary>If the estimated date is today</summary>
<img width="189" alt="Screenshot 2021-01-26 at 12 20 38" src="https://user-images.githubusercontent.com/36161814/105844593-5ee80680-5fd1-11eb-9aab-ccd65717a480.png">
</details>

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
