### PR TITLE
Fix/open redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16614,20 +16614,10 @@
         "end-of-stream": "^1.4.1"
       }
     },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
-      "requires": {
-        "punycode": "^1.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -16704,11 +16694,6 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
-    },
-    "file-exists": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-0.1.1.tgz",
-      "integrity": "sha1-mT0//7W0nRH+/Mj0XCNVAnRAgDw="
     },
     "file-loader": {
       "version": "6.2.0",
@@ -29807,15 +29792,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
-    },
-    "slashify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slashify/-/slashify-1.0.0.tgz",
-      "integrity": "sha1-JEumpIR/0Hpklei4/b9FteQIlSg=",
-      "requires": {
-        "fast-url-parser": "^1.0.6-0",
-        "file-exists": "^0.1.1"
-      }
     },
     "slice-ansi": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16619,11 +16619,6 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
-    "fastest-levenshtein": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
-    },
     "fastest-stable-stringify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
@@ -31760,13 +31755,7 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
           "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "safe-buffer": "^5.1.2"
           },
           "dependencies": {
             "minizlib": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "sass": "^1.32.5",
     "sass-loader": "^10.0.4",
     "serve-favicon": "^2.5.0",
-    "slashify": "^1.0.0",
     "sniffr": "^1.1.4",
     "style-loader": "^2.0.0",
     "styled-components": "^5.2.1",
@@ -165,8 +164,8 @@
     "vue-template-compiler": "^2.6.12",
     "wdio-chromedriver-service": "^6.0.4",
     "webpack": "^4.45.0",
-    "webpack-cli": "^4.4.0",
     "webpack-assets-manifest": "^4.0.1",
+    "webpack-cli": "^4.4.0",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/src/middleware/__test__/fix-slashes.test.js
+++ b/src/middleware/__test__/fix-slashes.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest')
 const express = require('express')
+const router = require('express').Router()
 
 const fixSlashes = require('../fix-slashes')
 
@@ -14,6 +15,12 @@ describe('remove trailing slash middleware', () => {
     app.use(fixSlashes())
     app.get('/', respond)
     app.get('/about', respond)
+    router.get('/page', respond)
+    app.use('/directory', router)
+  })
+
+  it('leaves unslashed urls alone', (done) => {
+    request(app).get('/about').expect(200).end(done)
   })
 
   it('removes the trailing slash for a given url', (done) => {
@@ -26,6 +33,18 @@ describe('remove trailing slash middleware', () => {
 
   it('does not redirect the root url because of the trailing slash', (done) => {
     request(app).get('/').expect(200).end(done)
+  })
+
+  it('removes the trailing slash for a sub url', (done) => {
+    request(app)
+      .get('/directory/page/')
+      .expect(301)
+      .expect('Location', '/directory/page')
+      .end(done)
+  })
+
+  it('leaves unslashed sub urls alone', (done) => {
+    request(app).get('/directory/page').expect(200).end(done)
   })
 
   it('preserves the query parameters on redirect', (done) => {

--- a/src/middleware/__test__/fix-slashes.test.js
+++ b/src/middleware/__test__/fix-slashes.test.js
@@ -1,0 +1,154 @@
+const fixSlashes = require('../fix-slashes')
+const connect = require('connect')
+const expect = require('chai').expect
+const request = require('supertest')
+const query = require('connect-query')
+const fs = require('fs-extra')
+
+describe('remove trailing slash middleware', () => {
+  it('removes the trailing slash for a given url', (done) => {
+    const app = connect().use(fixSlashes())
+    request(app)
+      .get('/about/')
+      .expect(301)
+      .expect('Location', '/about')
+      .end(done)
+  })
+
+  it('does not redirect the root url because of the trailing slash', (done) => {
+    const app = connect().use(fixSlashes())
+    request(app).get('/').expect(404).end(done)
+  })
+
+  it('does not redirect for directory index files', (done) => {
+    fs.mkdirpSync('.tmp/about')
+    fs.writeFileSync('.tmp/about/index.html', 'index')
+    const app = connect().use(
+      fixSlashes({
+        root: '.tmp',
+      })
+    )
+    request(app)
+      .get('/about/')
+      .expect(404)
+      .expect((data) => {
+        expect(data.req.path).to.equal('/about/')
+      })
+      .end((err) => {
+        fs.removeSync('.tmp')
+        done(err)
+      })
+  })
+
+  it('handles custom directory index file names', (done) => {
+    fs.mkdirpSync('.tmp/about')
+    fs.writeFileSync('.tmp/about/custom.html', 'index')
+    const app = connect().use(
+      fixSlashes({
+        root: '.tmp',
+        index: 'custom.html',
+      })
+    )
+    request(app)
+      .get('/about/')
+      .expect(404)
+      .expect((data) => {
+        expect(data.req.path).to.equal('/about/')
+      })
+      .end((err) => {
+        fs.removeSync('.tmp')
+        done(err)
+      })
+  })
+
+  it('ignores the directory index rule', (done) => {
+    fs.mkdirpSync('.tmp/about')
+    fs.writeFileSync('.tmp/about/index.html', 'index')
+    const app = connect().use(
+      fixSlashes({
+        root: '.tmp',
+        directory: false,
+      })
+    )
+    request(app)
+      .get('/about/')
+      .expect(301)
+      .expect('Location', '/about')
+      .end((err) => {
+        fs.removeSync('.tmp')
+        done(err)
+      })
+  })
+
+  it('redirects directory index to have a trailing slash', (done) => {
+    fs.mkdirpSync('.tmp/about')
+    fs.writeFileSync('.tmp/about/index.html', 'index')
+    const app = connect().use(
+      fixSlashes({
+        root: '.tmp',
+      })
+    )
+    request(app)
+      .get('/about')
+      .expect((req) => {
+        expect(req.headers.location).to.equal('/about/')
+      })
+      .expect(301)
+      .end((err) => {
+        fs.removeSync('.tmp')
+        done(err)
+      })
+  })
+
+  it('preserves the query parameters on redirect', (done) => {
+    const app = connect().use(query()).use(fixSlashes())
+    request(app)
+      .get('/contact/?query=param')
+      .expect(301)
+      .expect('Location', '/contact?query=param')
+      .end(done)
+  })
+
+  it('preserves query parameters and slash on subdirectory directory index redirect', (done) => {
+    fs.mkdirpSync('.tmp/about')
+    fs.writeFileSync('.tmp/about/index.html', 'index')
+
+    const app = connect()
+      .use(query())
+      .use(
+        fixSlashes({
+          root: '.tmp',
+        })
+      )
+
+    request(app)
+      .get('/about?query=params')
+      .expect((req) => {
+        expect(req.headers.location).to.equal('/about/?query=params')
+      })
+      .expect(301)
+      .end((err) => {
+        fs.removeSync('.tmp')
+        done(err)
+      })
+  })
+
+  it('overrides the file exists method with a custom method', (done) => {
+    fs.mkdirpSync('.tmp')
+    fs.writeFileSync('.tmp/test.html', 'test')
+
+    const app = connect().use(
+      fixSlashes({
+        exists: () => false,
+      })
+    )
+
+    request(app)
+      .get('/.tmp/test.html')
+      .expect(404)
+      .end((err) => {
+        fs.removeSync('.tmp')
+        done(err)
+      })
+  })
+})

--- a/src/middleware/__test__/fix-slashes.test.js
+++ b/src/middleware/__test__/fix-slashes.test.js
@@ -1,13 +1,22 @@
-const fixSlashes = require('../fix-slashes')
-const connect = require('connect')
-const expect = require('chai').expect
 const request = require('supertest')
-const query = require('connect-query')
-const fs = require('fs-extra')
+const express = require('express')
+
+const fixSlashes = require('../fix-slashes')
 
 describe('remove trailing slash middleware', () => {
+  let app
+
+  beforeEach(function () {
+    let respond = (req, res) => {
+      res.send('done')
+    }
+    app = express()
+    app.use(fixSlashes())
+    app.get('/', respond)
+    app.get('/about', respond)
+  })
+
   it('removes the trailing slash for a given url', (done) => {
-    const app = connect().use(fixSlashes())
     request(app)
       .get('/about/')
       .expect(301)
@@ -16,139 +25,18 @@ describe('remove trailing slash middleware', () => {
   })
 
   it('does not redirect the root url because of the trailing slash', (done) => {
-    const app = connect().use(fixSlashes())
-    request(app).get('/').expect(404).end(done)
-  })
-
-  it('does not redirect for directory index files', (done) => {
-    fs.mkdirpSync('.tmp/about')
-    fs.writeFileSync('.tmp/about/index.html', 'index')
-    const app = connect().use(
-      fixSlashes({
-        root: '.tmp',
-      })
-    )
-    request(app)
-      .get('/about/')
-      .expect(404)
-      .expect((data) => {
-        expect(data.req.path).to.equal('/about/')
-      })
-      .end((err) => {
-        fs.removeSync('.tmp')
-        done(err)
-      })
-  })
-
-  it('handles custom directory index file names', (done) => {
-    fs.mkdirpSync('.tmp/about')
-    fs.writeFileSync('.tmp/about/custom.html', 'index')
-    const app = connect().use(
-      fixSlashes({
-        root: '.tmp',
-        index: 'custom.html',
-      })
-    )
-    request(app)
-      .get('/about/')
-      .expect(404)
-      .expect((data) => {
-        expect(data.req.path).to.equal('/about/')
-      })
-      .end((err) => {
-        fs.removeSync('.tmp')
-        done(err)
-      })
-  })
-
-  it('ignores the directory index rule', (done) => {
-    fs.mkdirpSync('.tmp/about')
-    fs.writeFileSync('.tmp/about/index.html', 'index')
-    const app = connect().use(
-      fixSlashes({
-        root: '.tmp',
-        directory: false,
-      })
-    )
-    request(app)
-      .get('/about/')
-      .expect(301)
-      .expect('Location', '/about')
-      .end((err) => {
-        fs.removeSync('.tmp')
-        done(err)
-      })
-  })
-
-  it('redirects directory index to have a trailing slash', (done) => {
-    fs.mkdirpSync('.tmp/about')
-    fs.writeFileSync('.tmp/about/index.html', 'index')
-    const app = connect().use(
-      fixSlashes({
-        root: '.tmp',
-      })
-    )
-    request(app)
-      .get('/about')
-      .expect((req) => {
-        expect(req.headers.location).to.equal('/about/')
-      })
-      .expect(301)
-      .end((err) => {
-        fs.removeSync('.tmp')
-        done(err)
-      })
+    request(app).get('/').expect(200).end(done)
   })
 
   it('preserves the query parameters on redirect', (done) => {
-    const app = connect().use(query()).use(fixSlashes())
     request(app)
-      .get('/contact/?query=param')
+      .get('/about/?query=param')
       .expect(301)
-      .expect('Location', '/contact?query=param')
+      .expect('Location', '/about?query=param')
       .end(done)
   })
 
-  it('preserves query parameters and slash on subdirectory directory index redirect', (done) => {
-    fs.mkdirpSync('.tmp/about')
-    fs.writeFileSync('.tmp/about/index.html', 'index')
-
-    const app = connect()
-      .use(query())
-      .use(
-        fixSlashes({
-          root: '.tmp',
-        })
-      )
-
-    request(app)
-      .get('/about?query=params')
-      .expect((req) => {
-        expect(req.headers.location).to.equal('/about/?query=params')
-      })
-      .expect(301)
-      .end((err) => {
-        fs.removeSync('.tmp')
-        done(err)
-      })
-  })
-
-  it('overrides the file exists method with a custom method', (done) => {
-    fs.mkdirpSync('.tmp')
-    fs.writeFileSync('.tmp/test.html', 'test')
-
-    const app = connect().use(
-      fixSlashes({
-        exists: () => false,
-      })
-    )
-
-    request(app)
-      .get('/.tmp/test.html')
-      .expect(404)
-      .end((err) => {
-        fs.removeSync('.tmp')
-        done(err)
-      })
+  it('does not redirect to another domain', (done) => {
+    request(app).get('///github.com/').expect(404).end(done)
   })
 })

--- a/src/middleware/fix-slashes.js
+++ b/src/middleware/fix-slashes.js
@@ -1,0 +1,116 @@
+const qs = require('querystring')
+const url = require('fast-url-parser')
+const join = require('path').join
+const fileExists = require('file-exists')
+const { trimEnd } = require('lodash')
+
+/**
+ * Removes trailing slashes.
+ *
+ * Taken from 'Slashify' (https://www.npmjs.com/package/slashify), but fixes a
+ * security bug whereby users could be redirected to another domain. The fix
+ * employs code from another package, 'Express Slash'
+ * https://www.npmjs.com/package/express-slash to validate that the resulting
+ * url exists in the app router.
+ */
+function fixSlashes(options) {
+  options = options || {}
+
+  const root = options.root || './'
+  const indexFile = options.index || 'index.html'
+  const leaveOnDirectory = options.directory === false ? false : true
+
+  if (options.exists) fileExists = options.exists
+
+  return function (req, res, next) {
+    const pathname = url.parse(req.url).pathname
+    let redirectPathname = false
+
+    const method = req.method.toLowerCase()
+
+    // Don't remove trailing slash on directory index file
+    if (leaveOnDirectory && isDirectoryIndex() && !hasTrailingSlash()) {
+      redirectPathname = join(pathname, '/')
+    } else if (leaveOnDirectory && isDirectoryIndex()) {
+      redirectPathname = false
+    } else if (pathname !== '/' && hasTrailingSlash()) {
+      redirectPathname = trimEnd(pathname, '/')
+    }
+
+    const match =
+      redirectPathname &&
+      testStackForMatch(req.app._router.stack, method, redirectPathname)
+    if (match) {
+      return redirect(redirectPathname)
+    } else {
+      // no redirect needed
+      next()
+    }
+
+    function redirect(redirectUrl) {
+      const query = qs.stringify(req.query)
+
+      redirectUrl += query ? '?' + query : ''
+      res.writeHead(301, { Location: redirectUrl })
+      res.end()
+    }
+
+    function isDirectoryIndex() {
+      return fileExists(join(root, req.url.split('?')[0], indexFile))
+    }
+
+    function hasTrailingSlash() {
+      return pathname.substr(-1) === '/'
+    }
+  }
+}
+
+/**
+ * Checks that the given path and method exist in the app's route stack.
+ *
+ * This is taken from 'Express Slash' https://www.npmjs.com/package/express-slash
+ */
+function testStackForMatch(stack, method, path) {
+  return stack.some(function (layer) {
+    const route = layer.route,
+      subStack = layer.handle.stack
+
+    // It's only a match if the stack layer is a route.
+    if (route) {
+      return route.methods[method] && layer.match(path)
+    }
+
+    if (subStack) {
+      // Trim any `.use()` prefix.
+      if (layer.path) {
+        path = trimPrefix(path, layer.path)
+      }
+
+      // Recurse into nested apps/routers.
+      return testStackForMatch(subStack, method, path)
+    }
+
+    return false
+  })
+}
+
+/**
+ * Remove the given prefix from a url.
+ *
+ * This is taken from 'Express Slash' https://www.npmjs.com/package/express-slash
+ */
+function trimPrefix(path, prefix) {
+  const charAfterPrefix = path.charAt(prefix.length)
+
+  if (charAfterPrefix === '/' || charAfterPrefix === '.') {
+    path = path.substring(prefix.length)
+
+    if (path.charAt(0) !== '/') {
+      path = '/' + path
+    }
+  }
+
+  return path
+}
+
+module.exports = fixSlashes

--- a/src/middleware/fix-slashes.js
+++ b/src/middleware/fix-slashes.js
@@ -12,8 +12,6 @@ function fixSlashes() {
   return function (req, res, next) {
     const pathname = req.path
 
-    // const method = req.method.toLowerCase()
-
     const redirectPathname = endsWith(pathname, '/')
       ? trimEnd(pathname, '/')
       : false

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,6 @@ const compression = require('compression')
 const express = require('express')
 const flash = require('connect-flash')
 const csrf = require('csurf')
-const slashify = require('slashify')
 
 const enforce = require('express-sslify')
 const favicon = require('serve-favicon')
@@ -44,6 +43,7 @@ const envSchema = require('./config/envSchema')
 const flashWithBody = require('./middleware/flash-with-body')
 const apiProxy = require('./middleware/api-proxy')
 const metadataApiProxy = require('./middleware/metadata-api-proxy')
+const fixSlashes = require('./middleware/fix-slashes')
 
 const routers = require('./apps/routers')
 
@@ -142,7 +142,7 @@ app.use(csrf())
 app.use(csrfToken())
 app.use(reactGlobalProps())
 // routing
-app.use(slashify())
+app.use(fixSlashes())
 app.use(routers)
 
 // Raven error handler must come before other error middleware


### PR DESCRIPTION
## Description of change

Fixes the bug identified here: https://trello.com/c/mBLy8wLQ/574-live-issue-open-redirect-vulnerability

Specifically, the "[slashify](https://www.npmjs.com/package/slashify)" npm package had a security flaw in which it was possible to get redirected to another domain. For example, `localhost:3000///github.com/` would redirect to github.com

I have removed the slashify package (which appears to be virtually dead) and built a new piece of middleware based on a stripped back version of slashify that also includes a check that the redirected path is internal. 

I investigated using [Express Slash](https://github.com/ericf/express-slash) which ensures that the redirected url is included in the express router but unfortunately, just replacing slashify with Express Slash did not work. It seems that this is because it does not work with sub-routes, where express continues to think that both /my-url and /my-url/ are equivalent, even when in strict mode. 

## Test instructions

The trailing slash should continue to be stripped from urls, so for example:

http://localhost:3000 => 200
http://localhost:3000/interactions => 200
http://localhost:3000/interactions/ => 301 http://localhost:3000/interactions
http://localhost:3000/interactions/?sortby=date&desc => 301 http://localhost:3000/interactions?sortby=date&desc
http://localhost:3000///github.com/ => 404 http://localhost:3000///github.com/

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
