### PR TITLE
Fix investment project search link

### DIFF
--- a/src/apps/investments/transformers/collection.js
+++ b/src/apps/investments/transformers/collection.js
@@ -27,7 +27,7 @@ function transformInvestmentProjectToListItem({
 
   const metadata = [
     { label: 'Investor', value: investor_company.name },
-    { label: 'Sector', value: sector.name },
+    { label: 'Sector', value: sector ? sector.name : '' },
     {
       label: 'Estimated land date',
       value: estimated_land_date && format(estimated_land_date, 'MMMM YYYY'),

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -172,6 +172,10 @@ module.exports = {
     },
     investments: {
       companyInvestment: url('/companies', '/:companyId/investments'),
+      companyInvestmentProjects: url(
+        '/companies',
+        '/:companyId/investments/projects'
+      ),
       largeCapitalProfile: url(
         '/companies',
         '/:companyId/investments/large-capital-profile'

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -1,0 +1,15 @@
+const fixtures = require('../../../fixtures')
+const selectors = require('../../../../../selectors')
+const urls = require('../../../../../../src/lib/urls')
+
+const { dnbCorp } = fixtures.company
+
+describe('Company Investment Project Collection', () => {
+  before(() => {
+    cy.visit(urls.companies.investments.companyInvestmentProjects(dnbCorp))
+  })
+
+  it('should load investment collection where projects have no sector', () => {
+    cy.get(selectors.collection.items).first().should('not.have.text', 'Sector')
+  })
+})

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -93,10 +93,6 @@
         "name": "Creation of new site or activity",
         "id": "f8447013-cfdc-4f35-a146-6619665388b3"
       },
-      "sector": {
-        "name": "Renewable Energy : Wind : Onshore",
-        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
-      },
       "business_activities": [
         {
           "name": "Retail",


### PR DESCRIPTION
## Description of change

Currently there is a failure to load the collection page when the user tries to access a collection with investment projects with no sector. This PR intent is to ensure that transmorfers does not complain if it receives no sector field from the backend.

You can reproduce the issue in production loading the below URL:

https://www.datahub.trade.gov.uk/companies/6cd41cdf-a098-e211-a939-e4115bead28a/investments/projects

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
