### PR TITLE
Experiment - Override and increase the sites global grid container width (DO NOT MERGE)

### DIFF
--- a/assets/stylesheets/settings/_layout.scss
+++ b/assets/stylesheets/settings/_layout.scss
@@ -1,4 +1,4 @@
 @import "./typography";
 
-$site-width: 960px;
+$site-width: 1200px;
 $gutter: $baseline-grid-unit * 8;

--- a/assets/stylesheets/trumps/_layout.scss
+++ b/assets/stylesheets/trumps/_layout.scss
@@ -65,3 +65,9 @@
     }
   }
 }
+
+.govuk-width-container,
+.datahub-header--max-width .datahub-header__logo-container,
+.datahub-header--max-width .datahub-header__navigation {
+  @include site-width-container;
+}

--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -19,6 +19,9 @@ const StyledHeader = styled('div')`
 
 const StyledMain = styled(Main)`
   padding-top: 0;
+  > div {
+    max-width: 1200px;
+  }
 `
 
 const BreadcrumbsWrapper = styled(Breadcrumbs)`

--- a/src/client/components/Main/index.jsx
+++ b/src/client/components/Main/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { MEDIA_QUERIES, SPACING, SITE_WIDTH } from '@govuk-react/constants'
+import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
 const OuterContainer = styled('main')({
   paddingTop: SPACING.SCALE_5,
@@ -9,7 +9,7 @@ const OuterContainer = styled('main')({
 })
 
 export const InnerContainer = styled('div')({
-  maxWidth: SITE_WIDTH,
+  maxWidth: '1200px',
   marginLeft: SPACING.SCALE_3,
   marginRight: SPACING.SCALE_3,
   textAlign: 'left',


### PR DESCRIPTION
## Description of change
The new dashboard designs have a container width of 1200px and not the 960px we get from the Gov.uk design system. As this is a dependancy we will have to override these style rules. In the Nunjucks part of the application we following BEM naming and this type of override is usually done in the likes of a `trumps.scss` file as per changes in this PR. We also have to change other styles in the app such as the ones that are baked into components using styled components (React work). This seems to give us what we want, my only immediate concern is the change in site width when you visit the likes of Export wins, Find exports and Market access.

If we do want a 1200px wide container then I think this PR is probably the easiest to do it for now. Eventually we will need to re-work the Data Hub header anyway as at some point it will need to be re-worked as a React component (when we are closer to SPA).

Thoughts?
