### PR TITLE
Add UserDetails component

### DIFF
--- a/src/client/components/UserDetails/_stories_/example.md
+++ b/src/client/components/UserDetails/_stories_/example.md
@@ -1,0 +1,7 @@
+### Import
+
+```js
+import UserDetails from 'UserDetails'
+```
+
+### Output

--- a/src/client/components/UserDetails/_stories_/usage.md
+++ b/src/client/components/UserDetails/_stories_/usage.md
@@ -1,0 +1,31 @@
+# UserDetails
+
+### Description
+
+Shows some details about the user when they go to the dashboard.
+
+### Usage
+
+```jsx
+<UserDetails
+  name={'User Name'}
+  last_login={sampleDate}
+  dit_team={sampleTeam}
+  job_title={'Developer'}
+/>
+```
+
+or
+
+```jsx
+<UserDetails {...adviser} />
+```
+
+### Properties
+
+| Prop         | Required | Default | Type   | Description                                                                     |
+| :----------- | :------- | :------ | :----- | :------------------------------------------------------------------------------ |
+| `name`       | true     | ``````  | string | The user's name                                                                 |
+| `last_login` | true     | ``````  | string | When the user last logged in                                                    |
+| `dit_team`   | true     | ``````  | string | The user's team. The country field is also taken from here.                     |
+| `job_title`  | false    | ``````  | string | The user's job title. Not required as we don't currently get this from the API. |

--- a/src/client/components/UserDetails/_stories_/userDetails.stories.jsx
+++ b/src/client/components/UserDetails/_stories_/userDetails.stories.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import UserDetails from 'UserDetails'
+import exampleReadme from './example.md'
+import usageReadme from './usage.md'
+import { endOfToday } from 'date-fns'
+
+const today = endOfToday()
+
+const sampleTeam = {
+  name: 'CRM Data',
+  country: {
+    name: 'United Kingdom',
+  },
+}
+
+storiesOf('UserDetails', module)
+  .addParameters({
+    options: { theme: undefined },
+    readme: {
+      content: exampleReadme,
+      sidebar: usageReadme,
+    },
+  })
+  .add('Default', () => (
+    <UserDetails
+      name={'User Name'}
+      last_login={today}
+      dit_team={sampleTeam}
+      job_title={'Developer'}
+    />
+  ))

--- a/src/client/components/UserDetails/index.jsx
+++ b/src/client/components/UserDetails/index.jsx
@@ -1,13 +1,42 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { typography } from '@govuk-react/lib'
+import { SPACING } from '@govuk-react/constants'
+import { format } from 'date-fns'
+import { GREY_1 } from 'govuk-colours'
 
-const UserDetails = ({ name, last_login, dit_team }) => (
-  <div>
-    <div>{name}</div>
-    <div>{last_login}</div>
-    <pre>{dit_team.name}</pre>
-    <pre>{dit_team.country.name}</pre>
-  </div>
+const StyledPanel = styled('div')`
+  padding: ${SPACING.SCALE_4};
+  border: 2px solid ${GREY_1};
+`
+const StyledName = styled('h2')`
+  margin-bottom: ${SPACING.SCALE_2};
+  text-align: left;
+  font-size: ${typography.font({ size: 19, weight: 'bold' })};
+`
+
+const StyledBody = styled('div')`
+  text-align: left;
+  align-self: stretch;
+  font-size: ${typography.font({ size: 16 })};
+`
+
+const StyledLoggedInDate = styled('div')`
+  margin-top: ${SPACING.SCALE_3};
+  text-align: left;
+  font-size: ${typography.font({ size: 16 })};
+`
+const UserDetails = ({ name, last_login, dit_team, job_title }) => (
+  <StyledPanel>
+    <StyledName>{name}</StyledName>
+    <StyledBody>{job_title}</StyledBody>
+    <StyledBody>{dit_team.name}</StyledBody>
+    <StyledBody>{dit_team.country.name}</StyledBody>
+    <StyledLoggedInDate>
+      Last logged in {format(last_login, 'dddd, DD MMM YYYY HH:mm ')}
+    </StyledLoggedInDate>
+  </StyledPanel>
 )
 
 UserDetails.propTypes = {


### PR DESCRIPTION
## Description of change

As part of the personalised dashboards work I've created a component that displays some basic info about the logged in user.
<img width="324" alt="Screenshot 2021-02-01 at 16 09 02" src="https://user-images.githubusercontent.com/36161814/106484758-d3c2b100-64a7-11eb-874d-cce9f233fa10.png">

Some of the data specified in the design lives in people finder, and we currently don't have a link set up between the two systems. Unfortunately the version of the `date-fns` we're using has limited support for timezones so I was unable to include the time zone.

## Test instructions

If you've set up the new dashboard, it will appear in the top left corner of the page. Otherwise run Storybook and go to the `UserDetails` component.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
