### PR TITLE
Add comma to 'A service that you have provided' section on the interaction form

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -41,7 +41,7 @@ const StepInteractionType = () => {
                 },
                 {
                   label: 'A service that you have provided',
-                  hint: 'For example a significant assist or an event',
+                  hint: 'For example, a significant assist or an event',
                   value: KINDS.SERVICE_DELIVERY,
                   onChange: getOnChangeHandler('kind', setFieldValue),
                 },
@@ -73,7 +73,7 @@ const StepInteractionType = () => {
                 },
                 {
                   label: 'A service that you have provided',
-                  hint: 'For example a significant assist or an event',
+                  hint: 'For example, a significant assist or an event',
                   value: KINDS.SERVICE_DELIVERY,
                   onChange: getOnChangeHandler('kind', setFieldValue),
                 },


### PR DESCRIPTION
## Description of change
We had a ticket on the maintenance board for adding a comma to a section on the interaction form.

## Test instructions

Go to the interaction form and select 'Export'. The hint text for 'A service you have provided' now contains a comma.

## Screenshots

<img width="545" alt="Screenshot 2021-02-02 at 14 45 59" src="https://user-images.githubusercontent.com/36161814/106616753-ce2ba080-6565-11eb-9d4c-145151994c55.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
