### PR TITLE
Added country_investment_originates_from to QUERY_FIELDS

### DIFF
--- a/src/apps/investments/constants.js
+++ b/src/apps/investments/constants.js
@@ -97,6 +97,7 @@ const QUERY_FIELDS = [
   'client_relationship_manager',
   'likelihood_to_land',
   'level_of_involvement_simplified',
+  'country_investment_originates_from',
 ]
 
 const QUERY_DATE_FIELDS = [


### PR DESCRIPTION
## Description of change

On a maintenance board we have a live issue where `country_investment_originates_from` filter is not applied for Download under Investments / Projects  page.