### PR TITLE
Update calculation in InvestmentEstimatedLandDate

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { typography } from '@govuk-react/lib'
 import { SPACING } from '@govuk-react/constants'
 import { YELLOW, BLACK } from 'govuk-colours'
-import { format, endOfToday, differenceInDays } from 'date-fns'
+import { format, endOfToday, differenceInCalendarDays } from 'date-fns'
 
 const StyledPanel = styled('div')`
   padding: ${SPACING.SCALE_4};
@@ -24,7 +24,7 @@ const StyledBody = styled('div')`
 
 const getDifferenceInDays = (estimatedLandDate) => {
   const today = endOfToday()
-  const difference = differenceInDays(estimatedLandDate, today)
+  const difference = differenceInCalendarDays(estimatedLandDate, today)
   return difference === 1
     ? difference + ' day'
     : difference === 0


### PR DESCRIPTION
## Description of change

This component was previously using the `date-fns`helper function `differenceInDays` to calculate the difference between today's date and the estimated land date. However, this function only counts full days, meaning that the current days is not included in the calculation.

I've updated the component to use `differenceInCalendarDays`, which will include the current day.

## Test instructions

Create a new investment project in the API with an estimated land date more than one day in the future. Go to the new dashboard (setup instructions are in #3248) and the countdown should display as expected.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
