### PR TITLE
Add missing ID's to all the new React filters in Investment Projects for GA tracking

### DIFF
--- a/src/client/components/CheckboxGroupField/index.jsx
+++ b/src/client/components/CheckboxGroupField/index.jsx
@@ -66,6 +66,7 @@ const CheckboxGroupField = ({
   loadOptions = null,
   selectedOptions = [],
   onChange = () => null,
+  id,
   ...props
 }) => {
   const [options, setOptions] = useState(initialOptions)
@@ -92,7 +93,7 @@ const CheckboxGroupField = ({
         'Loading...'
       ) : (
         <MultiChoice>
-          {options.map((option) => {
+          {options.map((option, i) => {
             const {
               value: optionValue,
               label: optionLabel,
@@ -116,6 +117,7 @@ const CheckboxGroupField = ({
             }
             return (
               <Checkbox
+                id={`field-${name}-${i + 1}`}
                 key={optionValue}
                 name={name}
                 initialChecked={checked}

--- a/src/client/components/DateField/index.jsx
+++ b/src/client/components/DateField/index.jsx
@@ -34,7 +34,7 @@ const DateField = ({
   return (
     <StyledFieldWrapper {...{ name, label, legend, hint }} {...props}>
       <Input
-        id={name}
+        id={`field-${name}-1`}
         key={name}
         name={name}
         value={value}

--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -49,6 +49,7 @@ const FieldTypeahead = ({
       <StyledWrapper error={error}>
         {touched && error && <ErrorText>{error}</ErrorText>}
         <Typeahead
+          name={name}
           inputId={name}
           aria-label={label || legend}
           onBlur={onBlur}

--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -15,7 +15,7 @@ Option.propTypes = comps.Option.propTypes
 export const filterOption = ({ label = '' }, query) =>
   label.toLowerCase().includes(query.toLowerCase())
 
-const Typeahead = ({ options, styles, error, ...props }) => {
+const Typeahead = ({ options, styles, error, name, ...props }) => {
   const customisedProps = {
     styles: {
       ...(error ? errorStyles : defaultStyles),
@@ -30,9 +30,13 @@ const Typeahead = ({ options, styles, error, ...props }) => {
   return (
     <>
       {options ? (
-        <Select {...customisedProps} options={options} />
+        <Select
+          {...customisedProps}
+          options={options}
+          inputId={`field-${name}-1`}
+        />
       ) : (
-        <AsyncSelect {...customisedProps} />
+        <AsyncSelect {...customisedProps} inputId={`field-${name}-1`} />
       )}
     </>
   )

--- a/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-form-spec.js
@@ -253,7 +253,7 @@ function submitForm(kind, theme, values) {
 
       cy.contains(ELEMENT_IS_EVENT.legend).next().find('input').check('yes')
 
-      cy.get('#event').parent().selectTypeaheadOption('Sort event')
+      cy.get('#field-event-1').parent().selectTypeaheadOption('Sort event')
       // Searching directly for 'event' string causes a false positive as it matches other elements.
     }
 


### PR DESCRIPTION
## Description of change
We need to add ID's to on input fields within the new filter components as we have lost Google tracking on the new React collection list page (Investment Projects).

I have kept the format of the ID's the same as previous collection list pages. the format is `field-{name}-{number}` where name is the input name value and number is the number of input fields related to the fieldset group. If you only have one in the group then we only display a number "1" I would have removed this but it causes a duplicate ID with a parent element and if you remove this then you get a chain of failed tests as unfortunately some test selectors are using these ID's. Easiest solution is to use a number in the naming convention.

## Test instructions
- All tests should just pass
- Id's should be on every input element within the filters on the Investment project collection list page

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
