### PR TITLE
Add stage filtering and sorting of investment projects - personalised dashboard

### DIFF
--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -6,7 +6,7 @@
  *
  * The name and value of the constants must be the same.
  * The name should be the name of the component the action relates to and a verb
- * describing what it does, concattenated by double underscore.
+ * describing what it does, concatenated by double underscore.
  */
 export const COMPANY_LISTS__LISTS_LOADED = 'COMPANY_LISTS__LISTS_LOADED'
 export const COMPANY_LISTS__SELECT = 'COMPANY_LISTS__SELECT'
@@ -106,4 +106,7 @@ export const INVESTMENTS_PROFILES__FILTER_OPTIONS_LOADED =
   'INVESTMENTS_PROFILES__FILTER_OPTIONS_LOADED'
 
 export const MY_INVESTMENTS__LIST_LOADED = 'MY_INVESTMENTS__LIST_LOADED'
-export const MY_INVESTMENTS__PAGE_SELECTED = 'MY_INVESTMENTS__PAGE_SELECTED'
+export const MY_INVESTMENTS__PAGINATION_CLICK =
+  'MY_INVESTMENTS__PAGINATION_CLICK'
+export const MY_INVESTMENTS__FILTER_CHANGE = 'MY_INVESTMENTS__FILTER_CHANGE'
+export const MY_INVESTMENTS__SORT_CHANGE = 'MY_INVESTMENTS__SORT_CHANGE'

--- a/src/client/components/MyInvestmentProjects/InvestmentList.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentList.jsx
@@ -1,14 +1,20 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
 
 import InvestmentListItem from './InvestmentListItem'
 
+const StyledOrderedList = styled('ol')`
+  margin-top: ${SPACING.SCALE_3};
+`
+
 const InvestmentList = ({ items }) => (
-  <>
+  <StyledOrderedList>
     {items.map((item) => (
       <InvestmentListItem key={item.id} {...item} />
     ))}
-  </>
+  </StyledOrderedList>
 )
 
 InvestmentList.propTypes = {

--- a/src/client/components/MyInvestmentProjects/InvestmentListFilter.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListFilter.jsx
@@ -1,5 +1,20 @@
 import React from 'react'
 
-const InvestmentListFilter = ({}) => <>Stage filter...</>
+import { Select } from '../../components'
+
+const InvestmentListFilter = ({ options, onChange }) => (
+  <Select
+    label="Stage"
+    input={{
+      onChange,
+    }}
+  >
+    {options.map(({ id, name }, index) => (
+      <option value={id} aria-label={name} key={index}>
+        {name}
+      </option>
+    ))}
+  </Select>
+)
 
 export default InvestmentListFilter

--- a/src/client/components/MyInvestmentProjects/InvestmentListHeader.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListHeader.jsx
@@ -1,13 +1,12 @@
-import React from 'react'
+import styled from 'styled-components'
 
-import InvestmentListFilter from './InvestmentListFilter'
-import InvestmentListSort from './InvestmentListSort'
-
-const InvestmentListHeader = () => (
-  <>
-    <InvestmentListFilter />
-    <InvestmentListSort />
-  </>
-)
+const InvestmentListHeader = styled('header')`
+  background-color: #f8f8f8;
+  display: flex;
+  justify-content: flex-end;
+  label:first-child {
+    margin-right: 15px;
+  }
+`
 
 export default InvestmentListHeader

--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -7,11 +7,13 @@ import InvestmentTimeline from './InvestmentTimeline'
 
 const InvestmentListItem = ({ name, stage, estimated_land_date }) => {
   return (
-    <Details summary={name}>
-      <div>+ Add Interaction...</div>
-      <InvestmentTimeline stage={stage} />
-      <InvestmentEstimatedLandDate estimatedLandDate={estimated_land_date} />
-    </Details>
+    <li>
+      <Details summary={name}>
+        <div>+ Add Interaction...</div>
+        <InvestmentTimeline stage={stage} />
+        <InvestmentEstimatedLandDate estimatedLandDate={estimated_land_date} />
+      </Details>
+    </li>
   )
 }
 

--- a/src/client/components/MyInvestmentProjects/InvestmentListSort.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListSort.jsx
@@ -1,5 +1,20 @@
 import React from 'react'
 
-const InvestmentListSort = ({}) => <>Sort by...</>
+import { Select } from '../../components'
+
+const InvestmentListSort = ({ options, onChange }) => (
+  <Select
+    label="Sort by"
+    input={{
+      onChange,
+    }}
+  >
+    {options.map(({ value, name }, index) => (
+      <option value={value} aria-label={name} key={index}>
+        {name}
+      </option>
+    ))}
+  </Select>
+)
 
 export default InvestmentListSort

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -1,0 +1,49 @@
+export const STAGE_OPTIONS = [
+  {
+    name: 'All stages',
+    id: 'all-stages',
+  },
+  {
+    name: 'Prospect',
+    id: '8a320cc9-ae2e-443e-9d26-2f36452c2ced',
+  },
+  {
+    name: 'Assign PM',
+    id: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
+  },
+  {
+    name: 'Active',
+    id: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+  },
+  {
+    name: 'Verify win',
+    id: '49b8f6f3-0c50-4150-a965-2c974f3149e3',
+  },
+  {
+    name: 'Won',
+    id: '945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
+  },
+]
+
+export const SORT_OPTIONS = [
+  {
+    name: 'Most recently created',
+    value: 'created_on:desc',
+  },
+  {
+    name: 'Earliest land date',
+    value: 'estimated_land_date:asc',
+  },
+  {
+    name: 'Latest land date',
+    value: 'estimated_land_date:desc',
+  },
+  {
+    name: 'Project name (A-Z)',
+    value: 'name:asc',
+  },
+  {
+    name: 'Project name (Z-A)',
+    value: 'name:desc',
+  },
+]

--- a/src/client/components/MyInvestmentProjects/index.jsx
+++ b/src/client/components/MyInvestmentProjects/index.jsx
@@ -5,32 +5,53 @@ import { connect } from 'react-redux'
 import { ID, TASK_GET_MY_INVESTMENTS_LIST, state2props } from './state'
 import {
   MY_INVESTMENTS__LIST_LOADED,
-  MY_INVESTMENTS__PAGE_SELECTED,
+  MY_INVESTMENTS__PAGINATION_CLICK,
+  MY_INVESTMENTS__FILTER_CHANGE,
+  MY_INVESTMENTS__SORT_CHANGE,
 } from '../../actions'
 import Task from '../Task'
 
 import InvestmentListHeader from './InvestmentListHeader'
+import InvestmentListFilter from './InvestmentListFilter'
+import InvestmentListSort from './InvestmentListSort'
 import InvestmentList from './InvestmentList'
 import Pagination from '../Pagination/'
+
+import { STAGE_OPTIONS, SORT_OPTIONS } from './constants'
 
 const MyInvestmentProjects = ({
   results,
   count,
   itemsPerPage,
   page,
-  onPageClick,
+  filter,
+  sort,
+  onPaginationClick,
+  onFilterChange,
+  onSortChange,
   adviser,
 }) => (
   <article>
-    <InvestmentListHeader />
+    <InvestmentListHeader>
+      <InvestmentListFilter
+        options={STAGE_OPTIONS}
+        onChange={(event) => onFilterChange(event.target.value)}
+      />
+      <InvestmentListSort
+        options={SORT_OPTIONS}
+        onChange={(event) => onSortChange(event.target.value)}
+      />
+    </InvestmentListHeader>
     <Task.Status
       name={TASK_GET_MY_INVESTMENTS_LIST}
       id={ID}
       progressMessage="Loading your investment projects"
       startOnRender={{
         payload: {
-          page,
           adviser,
+          page,
+          filter,
+          sort,
         },
         onSuccessDispatch: MY_INVESTMENTS__LIST_LOADED,
       }}
@@ -41,7 +62,7 @@ const MyInvestmentProjects = ({
           <Pagination
             totalPages={Math.ceil(count / itemsPerPage)}
             activePage={page}
-            onPageClick={onPageClick}
+            onPageClick={onPaginationClick}
           />
         </>
       )}
@@ -54,17 +75,30 @@ MyInvestmentProjects.propTypes = {
   count: PropTypes.number.isRequired,
   itemsPerPage: PropTypes.number.isRequired,
   page: PropTypes.number.isRequired,
-  onPageClick: PropTypes.func.isRequired,
+  onFilterChange: PropTypes.func.isRequired,
+  onSortChange: PropTypes.func.isRequired,
+  onPaginationClick: PropTypes.func.isRequired,
   adviser: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }).isRequired,
 }
 
 export default connect(state2props, (dispatch) => ({
-  onPageClick: (page) => {
+  onFilterChange: (filter) =>
     dispatch({
-      type: MY_INVESTMENTS__PAGE_SELECTED,
+      type: MY_INVESTMENTS__FILTER_CHANGE,
+      filter,
+      page: 1,
+    }),
+  onSortChange: (sort) =>
+    dispatch({
+      type: MY_INVESTMENTS__SORT_CHANGE,
+      sort,
+      page: 1,
+    }),
+  onPaginationClick: (page) =>
+    dispatch({
+      type: MY_INVESTMENTS__PAGINATION_CLICK,
       page,
-    })
-  },
+    }),
 }))(MyInvestmentProjects)

--- a/src/client/components/MyInvestmentProjects/reducer.js
+++ b/src/client/components/MyInvestmentProjects/reducer.js
@@ -1,6 +1,8 @@
 import {
   MY_INVESTMENTS__LIST_LOADED,
-  MY_INVESTMENTS__PAGE_SELECTED,
+  MY_INVESTMENTS__PAGINATION_CLICK,
+  MY_INVESTMENTS__FILTER_CHANGE,
+  MY_INVESTMENTS__SORT_CHANGE,
 } from '../../actions'
 
 const initialState = {
@@ -8,9 +10,11 @@ const initialState = {
   results: [],
   itemsPerPage: 10,
   page: 1,
+  sort: 'created_on:desc',
+  filter: 'all-stages',
 }
 
-export default (state = initialState, { type, result, page }) => {
+export default (state = initialState, { type, result, page, filter, sort }) => {
   switch (type) {
     case MY_INVESTMENTS__LIST_LOADED:
       const { results, count } = result
@@ -19,11 +23,12 @@ export default (state = initialState, { type, result, page }) => {
         results,
         count,
       }
-    case MY_INVESTMENTS__PAGE_SELECTED:
-      return {
-        ...state,
-        page,
-      }
+    case MY_INVESTMENTS__PAGINATION_CLICK:
+      return { ...state, page }
+    case MY_INVESTMENTS__FILTER_CHANGE:
+      return { ...state, filter, page }
+    case MY_INVESTMENTS__SORT_CHANGE:
+      return { ...state, sort, page }
     default:
       return state
   }

--- a/src/client/components/MyInvestmentProjects/tasks.js
+++ b/src/client/components/MyInvestmentProjects/tasks.js
@@ -1,11 +1,24 @@
 import { apiProxyAxios } from '../Task/utils'
 
-export const fetchMyInvestmentsList = ({ limit = 10, page, adviser }) => {
+export const fetchMyInvestmentsList = ({
+  limit = 10,
+  page,
+  adviser,
+  sort,
+  filter,
+}) => {
+  const payload = {
+    limit,
+    offset: limit * (page - 1),
+    adviser: adviser.id,
+    sortby: sort,
+  }
+
+  if (filter !== 'all-stages') {
+    payload.stage = filter
+  }
+
   return apiProxyAxios
-    .post('/v3/search/investment_project', {
-      limit,
-      offset: limit * (page - 1),
-      adviser: [adviser.id],
-    })
+    .post('/v3/search/investment_project', payload)
     .then(({ data }) => data)
 }


### PR DESCRIPTION
## Description of change
Added investment project stage filtering and sorting

## Test instructions
To view the new dashboard follow these [instructions](https://github.com/uktrade/data-hub-frontend/pull/3248).

For this PR you will need a number of investment projects that you've created yourself.

**Filtering**
Ensure you have investment projects that are the various stages
1. Proposal
2. Assign PM
3. Active
4. Verify win
5. Won

**Sorting**
1. Most recently created
2. Earliest land date
3. Latest land date
4. Project name (A-Z)
5. Project name (Z-A)

## Screenshots
### Before

<img width="1449" alt="before" src="https://user-images.githubusercontent.com/964268/107223418-150a1200-6a0e-11eb-97cb-3cf660734198.png">

### After

<img width="1449" alt="after" src="https://user-images.githubusercontent.com/964268/107223435-1c312000-6a0e-11eb-868a-3a1b85c3dc81.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
