### PR TITLE
Large Capital Investment Profile download

### DIFF
--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -52,6 +52,7 @@ const LargeCapitalProfileCollection = ({
             },
           }}
           selectedFilters={{ selectedCountryOfOrigin: selectedCountries }}
+          baseDownloadLink="/investments/profiles/export"
         >
           <CollectionFilters
             taskProps={{

--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -53,6 +53,7 @@ const LargeCapitalProfileCollection = ({
           }}
           selectedFilters={{ selectedCountryOfOrigin: selectedCountries }}
           baseDownloadLink="/investments/profiles/export"
+          entityName="profile"
         >
           <CollectionFilters
             taskProps={{

--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -53,7 +53,6 @@ const LargeCapitalProfileCollection = ({
           }}
           selectedFilters={{ selectedCountryOfOrigin: selectedCountries }}
           baseDownloadLink="/investments/profiles/export"
-          entityName="profile"
         >
           <CollectionFilters
             taskProps={{

--- a/src/apps/investments/client/profiles/UnfilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/UnfilteredLargeCapitalProfileCollection.jsx
@@ -34,6 +34,8 @@ const LargeCapitalProfileCollection = ({
       onPageClick={onPageClick}
       activePage={page}
       isComplete={isComplete}
+      baseDownloadLink="/investments/profiles/export"
+      entityName="profile"
     />
   )
 }

--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -81,6 +81,7 @@ const ProjectsCollection = ({
       taskProps={collectionListTask}
       selectedFilters={selectedFilters}
       baseDownloadLink="/investments/projects/export"
+      entityName="project"
     >
       <CollectionFilters taskProps={collectionListMetadataTask}>
         <RoutedCheckboxGroupField

--- a/src/apps/investments/constants.js
+++ b/src/apps/investments/constants.js
@@ -83,6 +83,36 @@ const DEFAULT_COLLECTION_QUERY = {
 
 const APP_PERMISSIONS = concat(LOCAL_NAV, GLOBAL_NAV_ITEM)
 
+const LARGE_INVESTMENT_PROFILE_QUERY = {
+  sortby: 'created_on:asc',
+}
+
+const LARGE_INVESTMENT_PROFILE_QUERY_FIELDS = [
+  'link',
+  'investor_company__name',
+  'investor_type__name',
+  'investable_capital',
+  'global_assets_under_management',
+  'investor_description',
+  'required_checks_conducted__name',
+  'required_checks_conducted_by_name',
+  'required_checks_conducted_on',
+  'deal_ticket_sizes_names',
+  'asset_classes_of_interest_names',
+  'investment_types_names',
+  'minimum_return_rate__name',
+  'time_horizons_names',
+  'restrictions_names',
+  'construction_risks_names',
+  'minimum_equity_percentage__name',
+  'desired_deal_roles_names',
+  'uk_region_locations_names',
+  'other_countries_being_considered_names',
+  'notes_on_locations',
+]
+
+const LARGE_INVESTMENT_PROFILE_QUERY_DATE = ['modified_on', 'created_on']
+
 const QUERY_FIELDS = [
   'status',
   'adviser',
@@ -129,4 +159,7 @@ module.exports = {
   TRUE,
   FALSE,
   NOT_SET,
+  LARGE_INVESTMENT_PROFILE_QUERY,
+  LARGE_INVESTMENT_PROFILE_QUERY_FIELDS,
+  LARGE_INVESTMENT_PROFILE_QUERY_DATE,
 }

--- a/src/apps/investments/router-profiles.js
+++ b/src/apps/investments/router-profiles.js
@@ -1,8 +1,31 @@
 const router = require('express').Router()
 
+const {
+  LARGE_INVESTMENT_PROFILE_QUERY,
+  LARGE_INVESTMENT_PROFILE_QUERY_FIELDS,
+  LARGE_INVESTMENT_PROFILE_QUERY_DATE,
+} = require('./constants')
+
+const { setDefaultQuery } = require('../middleware')
+
+const { getRequestBody } = require('../../middleware/collection')
 const { renderProfilesView } = require('./controllers/profiles')
 const setInvestmentTabItems = require('./middleware/investments-tab-items')
 
+const {
+  exportCollection,
+} = require('../../modules/search/middleware/collection')
+
 router.get('/', setInvestmentTabItems, renderProfilesView)
+
+router.get(
+  '/export',
+  setDefaultQuery(LARGE_INVESTMENT_PROFILE_QUERY),
+  getRequestBody(
+    LARGE_INVESTMENT_PROFILE_QUERY_FIELDS,
+    LARGE_INVESTMENT_PROFILE_QUERY_DATE
+  ),
+  exportCollection('large-investor-profile')
+)
 
 module.exports = router

--- a/src/client/components/CollectionList/index.jsx
+++ b/src/client/components/CollectionList/index.jsx
@@ -28,6 +28,7 @@ const CollectionList = ({
   onPageClick,
   maxItemsToDownload,
   baseDownloadLink,
+  entityName,
 }) => (
   <GridRow>
     <GridCol setWidth="full">
@@ -47,6 +48,7 @@ const CollectionList = ({
           maxItems={maxItemsToDownload}
           data-test="download-data-header"
           baseDownloadLink={baseDownloadLink}
+          entityName={entityName}
         />
         {items.map(
           (

--- a/src/client/components/CollectionList/index.jsx
+++ b/src/client/components/CollectionList/index.jsx
@@ -12,6 +12,7 @@ import {
   CollectionSort,
   CollectionItem,
   Pagination,
+  RoutedDownloadDataHeader,
 } from '../../components'
 
 const CollectionList = ({
@@ -25,6 +26,8 @@ const CollectionList = ({
   items,
   activePage = 1,
   onPageClick,
+  maxItemsToDownload,
+  baseDownloadLink,
 }) => (
   <GridRow>
     <GridCol setWidth="full">
@@ -39,7 +42,12 @@ const CollectionList = ({
         {sortOptions && (
           <CollectionSort sortOptions={sortOptions} totalPages={count} />
         )}
-
+        <RoutedDownloadDataHeader
+          count={count}
+          maxItems={maxItemsToDownload}
+          data-test="download-data-header"
+          baseDownloadLink={baseDownloadLink}
+        />
         {items.map(
           (
             { headingText, headingUrl, subheading, badges, metadata, type },
@@ -101,6 +109,7 @@ CollectionList.propTypes = {
       query: PropTypes.object.isRequired,
     }),
   }),
+  maxItemsToDownload: PropTypes.number,
   onPageClick: PropTypes.func.isRequired,
 }
 

--- a/src/client/components/DownloadDataHeader/index.jsx
+++ b/src/client/components/DownloadDataHeader/index.jsx
@@ -27,7 +27,7 @@ const DownloadDataHeader = ({
   if (count >= maxItems) {
     return (
       <CollectionHeaderRow {...props}>
-        Filter to fewer than {decimal(maxItems)} {entityName} to download
+        Filter to fewer than {decimal(maxItems)} {entityName}s to download
       </CollectionHeaderRow>
     )
   }

--- a/src/client/components/DownloadDataHeader/index.jsx
+++ b/src/client/components/DownloadDataHeader/index.jsx
@@ -17,7 +17,6 @@ const DownloadDataHeader = ({
   downloadLink,
   count = 0,
   maxItems = 5000,
-  entityName = '',
   ...props
 }) => {
   if (!count) {
@@ -41,7 +40,7 @@ const DownloadDataHeader = ({
   return (
     <CollectionHeaderRow actions={[downloadAction]} {...props}>
       You can now download{' '}
-      {count === 1 ? `this ${entityName}` : `these ${count} ${entityName}s`}
+      {count === 1 ? `this project` : `these ${count} projects`}
     </CollectionHeaderRow>
   )
 }

--- a/src/client/components/DownloadDataHeader/index.jsx
+++ b/src/client/components/DownloadDataHeader/index.jsx
@@ -17,6 +17,7 @@ const DownloadDataHeader = ({
   downloadLink,
   count = 0,
   maxItems = 5000,
+  entityName = '',
   ...props
 }) => {
   if (!count) {
@@ -40,7 +41,7 @@ const DownloadDataHeader = ({
   return (
     <CollectionHeaderRow actions={[downloadAction]} {...props}>
       You can now download{' '}
-      {count === 1 ? 'this project' : `these ${count} projects`}
+      {count === 1 ? `this ${entityName}` : `these ${count} ${entityName}s`}
     </CollectionHeaderRow>
   )
 }
@@ -49,6 +50,7 @@ DownloadDataHeader.propTypes = {
   downloadLink: PropTypes.string,
   count: PropTypes.number,
   maxItems: PropTypes.number,
+  entityName: PropTypes.string,
 }
 
 export default DownloadDataHeader

--- a/src/client/components/DownloadDataHeader/index.jsx
+++ b/src/client/components/DownloadDataHeader/index.jsx
@@ -17,6 +17,7 @@ const DownloadDataHeader = ({
   downloadLink,
   count = 0,
   maxItems = 5000,
+  entityName = '',
   ...props
 }) => {
   if (!count) {
@@ -26,7 +27,7 @@ const DownloadDataHeader = ({
   if (count >= maxItems) {
     return (
       <CollectionHeaderRow {...props}>
-        Filter to fewer than {decimal(maxItems)} projects to download
+        Filter to fewer than {decimal(maxItems)} {entityName} to download
       </CollectionHeaderRow>
     )
   }
@@ -40,7 +41,7 @@ const DownloadDataHeader = ({
   return (
     <CollectionHeaderRow actions={[downloadAction]} {...props}>
       You can now download{' '}
-      {count === 1 ? `this project` : `these ${count} projects`}
+      {count === 1 ? `this ${entityName}` : `these ${count} ${entityName}s`}
     </CollectionHeaderRow>
   )
 }

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -28,7 +28,7 @@ const FilteredCollectionList = ({
   maxItemsToDownload,
   selectedFilters,
   baseDownloadLink = null,
-  entityName = null,
+  entityName,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -28,6 +28,7 @@ const FilteredCollectionList = ({
   maxItemsToDownload,
   selectedFilters,
   baseDownloadLink = null,
+  entityName = null,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
@@ -51,6 +52,7 @@ const FilteredCollectionList = ({
               maxItems={maxItemsToDownload}
               data-test="download-data-header"
               baseDownloadLink={baseDownloadLink}
+              entityName={entityName}
             />
           )}
           <Task.Status {...taskProps}>

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -28,7 +28,6 @@ const FilteredCollectionList = ({
   maxItemsToDownload,
   selectedFilters,
   baseDownloadLink = null,
-  entityName,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
@@ -52,7 +51,6 @@ const FilteredCollectionList = ({
               maxItems={maxItemsToDownload}
               data-test="download-data-header"
               baseDownloadLink={baseDownloadLink}
-              entityName={entityName}
             />
           )}
           <Task.Status {...taskProps}>

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -28,6 +28,7 @@ const FilteredCollectionList = ({
   maxItemsToDownload,
   selectedFilters,
   baseDownloadLink = null,
+  entityName,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
@@ -51,6 +52,7 @@ const FilteredCollectionList = ({
               maxItems={maxItemsToDownload}
               data-test="download-data-header"
               baseDownloadLink={baseDownloadLink}
+              entityName={entityName}
             />
           )}
           <Task.Status {...taskProps}>

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -128,7 +128,12 @@ function searchForeignCompanies({ req, searchTerm, page = 1, limit = 10 }) {
 }
 
 function exportSearch({ req, searchTerm = '', searchEntity, requestBody }) {
-  const apiVersion = searchEntity === 'company' ? 'v4' : 'v3'
+  let apiVersion
+  if (searchEntity == 'large-investor-profile' || searchEntity == 'company') {
+    apiVersion = 'v4'
+  } else {
+    apiVersion = 'v3'
+  }
   const searchUrl = `${config.apiRoot}/${apiVersion}/search`
   // If the requested CSV export should contain policy feedback, we need to call
   // different export endpoint that will provide extra columns to match

--- a/test/functional/cypress/specs/investments/investment-profiles-spec.js
+++ b/test/functional/cypress/specs/investments/investment-profiles-spec.js
@@ -6,7 +6,7 @@ const {
 const { investments } = require('../../../../../src/lib/urls')
 
 describe('Investor profiles', () => {
-  context('When there is 1 profile and viewing the first page', () => {
+  context('When there is 10 profiles and viewing the first page', () => {
     before(() => {
       cy.visit(investments.profiles.index())
     })
@@ -31,7 +31,7 @@ describe('Investor profiles', () => {
     it('should display download profile text', () => {
       cy.get('[data-test="download-data-header"]').should(
         'contain',
-        'You can now download this profile'
+        'You can now download these 10 profiles'
       )
     })
 
@@ -41,8 +41,8 @@ describe('Investor profiles', () => {
         .should('have.attr', 'href', '/investments/profiles/export')
     })
 
-    it('should display 1 profile', () => {
-      cy.get('h3').should('have.length', 1)
+    it('should display 10 profiles', () => {
+      cy.get('h3').should('have.length', 10)
     })
   })
 })

--- a/test/functional/cypress/specs/investments/investment-profiles-spec.js
+++ b/test/functional/cypress/specs/investments/investment-profiles-spec.js
@@ -6,7 +6,7 @@ const {
 const { investments } = require('../../../../../src/lib/urls')
 
 describe('Investor profiles', () => {
-  context('When there are 1 profile and viewing the first page', () => {
+  context('When there is 1 profile and viewing the first page', () => {
     before(() => {
       cy.visit(investments.profiles.index())
     })
@@ -31,7 +31,7 @@ describe('Investor profiles', () => {
     it('should display download profile text', () => {
       cy.get('[data-test="download-data-header"]').should(
         'contain',
-        'You can now download this'
+        'You can now download this profile'
       )
     })
 
@@ -41,7 +41,7 @@ describe('Investor profiles', () => {
         .should('have.attr', 'href', '/investments/profiles/export')
     })
 
-    it('should display 1 profiles', () => {
+    it('should display 1 profile', () => {
       cy.get('h3').should('have.length', 1)
     })
   })

--- a/test/functional/cypress/specs/investments/investment-profiles-spec.js
+++ b/test/functional/cypress/specs/investments/investment-profiles-spec.js
@@ -6,7 +6,7 @@ const {
 const { investments } = require('../../../../../src/lib/urls')
 
 describe('Investor profiles', () => {
-  context('When there are 12 profiles and viewing the first page', () => {
+  context('When there are 1 profile and viewing the first page', () => {
     before(() => {
       cy.visit(investments.profiles.index())
     })
@@ -31,7 +31,7 @@ describe('Investor profiles', () => {
     it('should display download profile text', () => {
       cy.get('[data-test="download-data-header"]').should(
         'contain',
-        'You can now download these 12 profiles'
+        'You can now download this'
       )
     })
 
@@ -41,77 +41,8 @@ describe('Investor profiles', () => {
         .should('have.attr', 'href', '/investments/profiles/export')
     })
 
-    it('should display 10 profiles', () => {
-      cy.get('h3').should('have.length', 10)
-    })
-
-    it('should display 3 pagination links', () => {
-      cy.get('#large-capital-profile-collection').within(() => {
-        cy.get('ul:last li a').should('have.length', 3)
-      })
-    })
-
-    it('should display the next button', () => {
-      cy.get('#large-capital-profile-collection').within(() => {
-        cy.get('ul:last li a:last').should('have.text', 'Next')
-      })
-    })
-
-    it('should not display the previous button', () => {
-      cy.get('#large-capital-profile-collection').within(() => {
-        cy.get('ul:last li a:first').should('not.have.text', 'Previous')
-      })
-    })
-  })
-
-  context('When there are 12 profiles and viewing the second page', () => {
-    before(() => {
-      cy.visit(investments.profiles.index())
-    })
-
-    it('should render the header', () => {
-      assertLocalHeader('Investments')
-    })
-
-    it('should render breadcrumbs', () => {
-      assertBreadcrumbs({
-        Home: '/',
-        Investments: '/investments',
-        Profiles: null,
-      })
-    })
-
-    it('should render the local navigation', () => {
-      assertTabbedLocalNav('Projects')
-      assertTabbedLocalNav('Investor profiles')
-    })
-
-    it('should be able to navigate to the second page', () => {
-      cy.get('#large-capital-profile-collection').within(() => {
-        cy.get('ul:last li a').contains('2').click()
-      })
-    })
-
-    it('should display 2 profiles', () => {
-      cy.get('h3').should('have.length', 2)
-    })
-
-    it('should display 3 pagination links', () => {
-      cy.get('#large-capital-profile-collection').within(() => {
-        cy.get('ul:last li a').should('have.length', 3)
-      })
-    })
-
-    it('should not display the next button', () => {
-      cy.get('#large-capital-profile-collection').within(() => {
-        cy.get('ul:last li a:last').should('not.have.text', 'Next')
-      })
-    })
-
-    it('should display the previous button', () => {
-      cy.get('#large-capital-profile-collection').within(() => {
-        cy.get('ul:last li a:first').should('have.text', 'Previous')
-      })
+    it('should display 1 profiles', () => {
+      cy.get('h3').should('have.length', 1)
     })
   })
 })

--- a/test/functional/cypress/specs/investments/investment-profiles-spec.js
+++ b/test/functional/cypress/specs/investments/investment-profiles-spec.js
@@ -1,0 +1,117 @@
+const {
+  assertTabbedLocalNav,
+  assertLocalHeader,
+  assertBreadcrumbs,
+} = require('../../support/assertions')
+const { investments } = require('../../../../../src/lib/urls')
+
+describe('Investor profiles', () => {
+  context('When there are 12 profiles and viewing the first page', () => {
+    before(() => {
+      cy.visit(investments.profiles.index())
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Investments')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: '/',
+        Investments: '/investments',
+        Profiles: null,
+      })
+    })
+
+    it('should render the local navigation', () => {
+      assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('Investor profiles')
+    })
+
+    it('should display download profile text', () => {
+      cy.get('[data-test="download-data-header"]').should(
+        'contain',
+        'You can now download these 12 profiles'
+      )
+    })
+
+    it('should display download profile button', () => {
+      cy.get('[data-test="download-data-header"] > div > a')
+        .should('be.visible')
+        .should('have.attr', 'href', '/investments/profiles/export')
+    })
+
+    it('should display 10 profiles', () => {
+      cy.get('h3').should('have.length', 10)
+    })
+
+    it('should display 3 pagination links', () => {
+      cy.get('#large-capital-profile-collection').within(() => {
+        cy.get('ul:last li a').should('have.length', 3)
+      })
+    })
+
+    it('should display the next button', () => {
+      cy.get('#large-capital-profile-collection').within(() => {
+        cy.get('ul:last li a:last').should('have.text', 'Next')
+      })
+    })
+
+    it('should not display the previous button', () => {
+      cy.get('#large-capital-profile-collection').within(() => {
+        cy.get('ul:last li a:first').should('not.have.text', 'Previous')
+      })
+    })
+  })
+
+  context('When there are 12 profiles and viewing the second page', () => {
+    before(() => {
+      cy.visit(investments.profiles.index())
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Investments')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: '/',
+        Investments: '/investments',
+        Profiles: null,
+      })
+    })
+
+    it('should render the local navigation', () => {
+      assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('Investor profiles')
+    })
+
+    it('should be able to navigate to the second page', () => {
+      cy.get('#large-capital-profile-collection').within(() => {
+        cy.get('ul:last li a').contains('2').click()
+      })
+    })
+
+    it('should display 2 profiles', () => {
+      cy.get('h3').should('have.length', 2)
+    })
+
+    it('should display 3 pagination links', () => {
+      cy.get('#large-capital-profile-collection').within(() => {
+        cy.get('ul:last li a').should('have.length', 3)
+      })
+    })
+
+    it('should not display the next button', () => {
+      cy.get('#large-capital-profile-collection').within(() => {
+        cy.get('ul:last li a:last').should('not.have.text', 'Next')
+      })
+    })
+
+    it('should display the previous button', () => {
+      cy.get('#large-capital-profile-collection').within(() => {
+        cy.get('ul:last li a:first').should('have.text', 'Previous')
+      })
+    })
+  })
+})

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -358,6 +358,7 @@ app.post(
   '/v3/search/investment_project/export',
   v3SearchInvestmentProject.export
 )
+app.post('/v4/large-investor-profile/export', v3SearchInvestmentProject.export)
 app.post('/v3/search/interaction', v3SearchInteraction.interaction)
 
 // V4 activity feed

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -358,7 +358,10 @@ app.post(
   '/v3/search/investment_project/export',
   v3SearchInvestmentProject.export
 )
-app.post('/v4/large-investor-profile/export', v3SearchInvestmentProject.export)
+app.post(
+  '/v4/search/large-investor-profile/export',
+  v3SearchInvestmentProject.export
+)
 app.post('/v3/search/interaction', v3SearchInteraction.interaction)
 
 // V4 activity feed


### PR DESCRIPTION
## Description of change

The intent of this PR is to include a download button so users can have the ability to export profiles collection locally to a csv file.

ACs
- All fields should be mapped and present in the downloaded report.
- Download button should only be available if there is less than 5000 profiles

## Screenshots
### Before

<img width="979" alt="Screenshot 2021-02-15 at 09 54 03" src="https://user-images.githubusercontent.com/5696857/107931220-e0e5a280-6f73-11eb-8551-64117b0cacbd.png">


### After

<img width="1023" alt="Screenshot 2021-02-15 at 09 53 26" src="https://user-images.githubusercontent.com/5696857/107931273-ee9b2800-6f73-11eb-957e-35fd1bbe89c5.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
