### PR TITLE
Fix an a11y issue when the empty state was wrapped in an ol

### DIFF
--- a/src/client/components/Pipeline/PipelineList.jsx
+++ b/src/client/components/Pipeline/PipelineList.jsx
@@ -20,7 +20,7 @@ import GetPipeLineData from './GetPipelineData'
 
 const StyledItemsCounter = styled('h1')`
   font-weight: ${FONT_WEIGHTS.bold};
-  margin: ${SPACING.SCALE_4} 0 -${SPACING.SCALE_2} 0;
+  margin: ${SPACING.SCALE_4} 0;
 `
 
 const PipelineList = ({
@@ -43,30 +43,29 @@ const PipelineList = ({
             <StyledItemsCounter>
               {pluralize('project', items.length, true)}
             </StyledItemsCounter>
-            <StyledOrderedList data-auto-id="pipelineList">
-              {items.length ? (
-                items.map((item) => (
+            {items.length ? (
+              <StyledOrderedList data-auto-id="pipelineList">
+                {items.map((item) => (
                   <ListItem key={item.id}>
                     <PipelineItem item={item} />
                   </ListItem>
-                ))
-              ) : (
-                <LoadingBox loading={progress} timeIn={0} timeOut={400}>
-                  <InsetText>
-                    My pipeline allows you to track the progress of your
-                    projects.
-                    <br />
-                    <br />
-                    For more information please see the{' '}
-                    <Link href={urls.external.helpCentre.pipeline()}>
-                      {' '}
-                      help centre article
-                    </Link>{' '}
-                    on how to use this feature.
-                  </InsetText>
-                </LoadingBox>
-              )}
-            </StyledOrderedList>
+                ))}
+              </StyledOrderedList>
+            ) : (
+              <LoadingBox loading={progress} timeIn={0} timeOut={400}>
+                <InsetText>
+                  My pipeline allows you to track the progress of your projects.
+                  <br />
+                  <br />
+                  For more information please see the{' '}
+                  <Link href={urls.external.helpCentre.pipeline()}>
+                    {' '}
+                    help centre article
+                  </Link>{' '}
+                  on how to use this feature.
+                </InsetText>
+              </LoadingBox>
+            )}
           </>
         )}
       </GetPipeLineData>


### PR DESCRIPTION
## Description of change

Fixes an accessibility issue when the `<div>` of the empty state of _My pipeline_ was wrapped in an `<ol>` which is not a valid markup.

## Test instructions

1. Go to `/my-pipeline`, `/my-pipeline/won` or `/my-pipeline/active`
2. Ensure that there are no items in the list under the _n projects_ heading and there's the "My pipeline allows you to track the progress of your projects..." empty state message.
3. Inspect the HTML markup of the empty state message
4. The markup of the empty state message must not be wrapped in an `<ol>`

## Screenshots

There's no visual change
