### PR TITLE
Prevent CSV formula injection when creating a company on DH

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -13,8 +13,9 @@ import {
 
 import {
   WEBSITE_REGEX,
-  GENERIC_PHONE_NUMBER_REGEX,
   NON_ASCII_REGEX,
+  GENERIC_PHONE_NUMBER_REGEX,
+  CSV_FORMULA_INJECTION_REGEX,
 } from './constants'
 
 const websiteValidator = (
@@ -47,6 +48,13 @@ const telephoneValidator = (
   return null
 }
 
+const nameValidator = (value) => {
+  return !value
+    ? 'Enter name'
+    : CSV_FORMULA_INJECTION_REGEX.test(value)
+    ? 'Enter a valid name'
+    : null
+}
 function CompanyNotFoundStep({ organisationTypes, country }) {
   return (
     <Step name="unhappy">
@@ -67,8 +75,8 @@ function CompanyNotFoundStep({ organisationTypes, country }) {
       <FieldInput
         label="Name of company"
         name="name"
-        required="Enter name"
         type="text"
+        validate={nameValidator}
       />
 
       <FieldInput

--- a/src/apps/companies/apps/add-company/client/constants.js
+++ b/src/apps/companies/apps/add-company/client/constants.js
@@ -12,3 +12,7 @@ export const GENERIC_PHONE_NUMBER_REGEX = /^$|([0-9]|#|\+|\s|\(|\))+$/
 
 // Non ASCII
 export const NON_ASCII_REGEX = /[^$|\x00-\x7F]/
+
+// Prevents CSV formula injection attacks
+// https://owasp.org/www-community/attacks/CSV_Injection
+export const CSV_FORMULA_INJECTION_REGEX = /^[=+-@]/

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -450,6 +450,22 @@ describe('Add company form', () => {
           ).should('not.contain', 'Enter a valid telephone number')
         })
       })
+      context('when an invalid organisation name is filled', () => {
+        before(() => {
+          cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).type(
+            '=INVESTIGATION LIMITED'
+          )
+          cy.get(selectors.companyAdd.continueButton).click()
+        })
+        it('should display invalid name error', () => {
+          cy.get(
+            selectors.companyAdd.newCompanyRecordForm.companyNameContainer
+          ).contains('Enter a valid name')
+        })
+        after(() => {
+          cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).clear()
+        })
+      })
       context(
         'when the form is submitted after filling the required fields, but the region and sector fields are not filled in',
         () => {

--- a/test/selectors/company/add-company.js
+++ b/test/selectors/company/add-company.js
@@ -38,6 +38,7 @@ module.exports = {
       soleTrader: 'label:contains("Sole Trader") input[type="radio"]',
     },
     companyName: 'input[name="name"]',
+    companyNameContainer: '#field-name',
     website: 'input[name="website"]',
     websiteContainer: '#field-website',
     telephone: 'input[name="telephone_number"]',


### PR DESCRIPTION
## Description of change

To perform a CSV formula injection attack on Data Hub the following is required:

1. An attacker needs to inject a payload into a Data Hub database table, currently this is possible when adding a company to Data Hub (unhappy path). Below I've added `localhost:8000` as the domain, however, in reality it would be the attackers domain.

<img width="1239" alt="csv-injection-attack" src="https://user-images.githubusercontent.com/964268/107927710-497e5080-6f6f-11eb-8ac2-0b24f5cd46c8.png">

2. Later a user downloads a list (<=5000) of companies into CSV format and subsequently opens the file in Excel. 

<img width="649" alt="download-companies" src="https://user-images.githubusercontent.com/964268/107928164-e5a85780-6f6f-11eb-9444-84fd10084d2d.png">

3. Once opened the payload is interpreted as an Excel formula and run. Now all the user has to do is click the hyperlink, there’s a high probability the user would do this as it’s from a trusted source, an action they've performed many times before. My version of Excel v16.45 didn’t even warn me.

<img width="1362" alt="excel" src="https://user-images.githubusercontent.com/964268/107928562-649d9000-6f70-11eb-8c40-3b9167dd2835.png">

4. Once the victim clicks the link, their browser will open and submit a request to the attacker’s domain along with the exfiltrated values from the specified cells.

<img width="868" alt="attackers-machine" src="https://user-images.githubusercontent.com/964268/107938056-b3e9bd80-6f7c-11eb-9151-116ec5123bb8.png">

**Solution**
We can mitigate the vulnerability by validating (backend and frontend) the company name when adding a company to Data Hub. A simple regular expression should suffice: `/^[=+-@]/`. Should the company name start with `=+-@` then an error message is displayed to the user.

**Important note: the information contained within the spreadsheet is publicly available from Companies House**

More can be found from OWASP: https://owasp.org/www-community/attacks/CSV_Injection

## Test instructions

Look for the company I've created on dev.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
