### PR TITLE
Upgrade cypress version from 5x to 6x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/sre-docker-registry/data-hub-frontend-dependencies:1.0.3
+FROM gcr.io/sre-docker-registry/data-hub-frontend-dependencies:1.0.4
 
 ENV NPM_CONFIG_LOGLEVEL    warn
 ENV NPM_CONFIG_UNSAFE_PERM true

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -53,4 +53,4 @@ RUN apt-get install -y xvfb xdg-utils libgtk-3-0 lsb-release libappindicator3-1 
 # Install cypress
 COPY package.json .
 COPY package-lock.json .
-RUN npm install cypress@5.5.0
+RUN npm install cypress@6.4.0

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -22,7 +22,7 @@ Prerequisite:
 ## Creating Docker container for CircleCI
 
 ```bash
-export VERSION=1.0.3 # Increment this version each time when you edit Dockerfile.
+export VERSION=1.0.4 # Increment this version each time when you edit Dockerfile.
 
 Ensure you have gcloud sdk and you are logged in following their instructions:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13504,14 +13504,15 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "cypress": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.5.0.tgz",
-      "integrity": "sha512-UHEiTca8AUTevbT2pWkHQlxoHtXmbq+h6Eiu/Mz8DqpNkF98zjTBLv/HFiKJUU5rQzp9EwSWtms33p5TWCJ8tQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.5.0.tgz",
+      "integrity": "sha512-ol/yTAqHrQQpYBjxLlRSvZf4DOb9AhaQNVlwdOZgJcBHZOOa52/p/6/p3PPcvzjWGOMG6Yq0z4G+jrbWyk/9Dg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
+        "@types/node": "12.12.50",
         "@types/sinonjs__fake-timers": "^6.0.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.1.2",
@@ -13521,9 +13522,10 @@
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-table3": "~0.6.0",
-        "commander": "^4.1.1",
+        "commander": "^5.1.0",
         "common-tags": "^1.8.0",
-        "debug": "^4.1.1",
+        "dayjs": "^1.9.3",
+        "debug": "4.3.2",
         "eventemitter2": "^6.4.2",
         "execa": "^4.0.2",
         "executable": "^4.1.1",
@@ -13537,7 +13539,7 @@
         "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.27.0",
+        "moment": "^2.29.1",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.4.1",
         "ramda": "~0.26.1",
@@ -13549,6 +13551,12 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.12.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
+          "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -13583,6 +13591,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
         "cross-spawn": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -13592,6 +13606,15 @@
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "execa": {
@@ -13631,19 +13654,25 @@
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             }
           }
         },
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "get-stream": {
@@ -13668,13 +13697,13 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "log-symbols": {
@@ -13685,12 +13714,6 @@
           "requires": {
             "chalk": "^4.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         },
         "npm-run-path": {
           "version": "4.0.1",
@@ -13756,9 +13779,9 @@
           }
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "chai-subset": "^1.6.0",
     "chromedriver": "^88.0.0",
     "codeclimate-test-reporter": "^0.5.0",
-    "cypress": "^5.5.0",
+    "cypress": "^6.4.0",
     "cypress-image-diff-js": "1.8.2",
     "eslint": "^7.19.0",
     "eslint-config-prettier": "^7.2.0",

--- a/test/end-to-end/cypress/specs/DIT/business-hierarchy-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/business-hierarchy-spec.js
@@ -127,12 +127,12 @@ describe('Business hierarchy', () => {
 
     it('should hide subsidiaries links for archived companies', () => {
       cy.get(selectors.companySubsidiaries().linkASubsidiaryToHierarchy).should(
-        'not.be.visible'
+        'not.exist'
       )
 
       cy.get(selectors.companySubsidiaries().oneLinkedSubsidiary).click()
       cy.get(selectors.companySubsidiariesLink().removeSubsidiary).should(
-        'not.be.visible'
+        'not.exist'
       )
       cy.get(selectors.companySubsidiaries().whyNoSubLink).should('be.visible')
     })

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -43,9 +43,7 @@ describe('Company activity feed', () => {
     })
 
     it('should not display the activity feed', () => {
-      cy.get(selectors.companyActivity.activityFeed.item(1)).should(
-        'not.be.visible'
-      )
+      cy.get(selectors.companyActivity.activityFeed.item(1)).should('not.exist')
     })
 
     it('should display the "There are no activities to show." message', () => {
@@ -97,7 +95,7 @@ describe('Company activity feed', () => {
 
     it('should not display the "There are no activities to show." message', () => {
       cy.get(selectors.companyActivity.activityFeed.noActivites).should(
-        'not.be.visible'
+        'not.exist'
       )
     })
   })
@@ -149,7 +147,7 @@ describe('Company activity feed', () => {
 
     it('should not display the pending D&B investigation message', () => {
       cy.get(selectors.companyActivity.pendingDnbInvestigationMessage).should(
-        'not.be.visible'
+        'not.exist'
       )
     })
   })

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -97,7 +97,7 @@ describe('Add company form', () => {
     it('should not display an error message', () => {
       cy.get(selectors.companyAdd.form)
         .contains('Specify location of the company')
-        .should('not.be.visible')
+        .should('not.exist')
     })
 
     it('should display an error message when no location is selected', () => {
@@ -161,21 +161,21 @@ describe('Add company form', () => {
     })
 
     it('should not display the"Back" button', () => {
-      cy.get(selectors.companyAdd.backButton).should('not.be.visible')
+      cy.get(selectors.companyAdd.backButton).should('not.exist')
     })
 
     it('should not display the "Continue" button', () => {
-      cy.get(selectors.companyAdd.continueButton).should('not.be.visible')
+      cy.get(selectors.companyAdd.continueButton).should('not.exist')
     })
 
     it('should display an error message when the "Company name" field is not filled in', () => {
       cy.get(selectors.companyAdd.entitySearch.searchButton).click()
       cy.get(selectors.companyAdd.form).should('contain', 'Enter company name')
       cy.get(selectors.companyAdd.entitySearch.results.someCompanyName).should(
-        'not.be.visible'
+        'not.exist'
       )
       cy.get(selectors.companyAdd.entitySearch.results.someOtherCompany).should(
-        'not.be.visible'
+        'not.exist'
       )
     })
 
@@ -301,27 +301,37 @@ describe('Add company form', () => {
     })
 
     it('should display the manual entry form', () => {
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.charity
-      ).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType
           .governmentDepartmentOrOtherPublicBody
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType
           .limitedCompany
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType
           .limitedPartnership
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType.partnership
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
         'be.visible'
       )
@@ -483,27 +493,37 @@ describe('Add company form', () => {
     })
 
     it('should display the manual entry form', () => {
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.charity
-      ).should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType
           .governmentDepartmentOrOtherPublicBody
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType
           .limitedCompany
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType
           .limitedPartnership
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType.partnership
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader
-      ).should('be.visible')
+      )
+        .parent()
+        .should('be.visible')
       cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
         'be.visible'
       )
@@ -522,7 +542,7 @@ describe('Add company form', () => {
     it('should hide the UK-related fields', () => {
       cy.get(
         selectors.companyAdd.newCompanyRecordForm.address.findUkAddress
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
   })
 

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -21,7 +21,7 @@ const assertSummaryTable = ({ dataAutoId, heading, showEditLink, content }) => {
   cy.get(summaryTableSelector).find('caption').should('contain', heading)
   cy.get(summaryTableSelector)
     .contains('Edit')
-    .should(showEditLink ? 'be.visible' : 'not.be.visible')
+    .should(showEditLink ? 'be.visible' : 'not.exist')
 
   if (typeof content !== 'undefined') {
     Array.isArray(content)
@@ -97,7 +97,7 @@ describe('Companies business details', () => {
       it('should not display the "Pending Change Request" box', () => {
         cy.contains(
           'Changes to these business details are currently being reviewed.'
-        ).should('not.be.visible')
+        ).should('not.exist')
       })
 
       it('should display the "Are these business details right?" details summary', () => {
@@ -213,9 +213,7 @@ describe('Companies business details', () => {
       })
 
       it('should not display the "Pending Change Request" text', () => {
-        cy.contains('Checking for pending change requests').should(
-          'not.be.visible'
-        )
+        cy.contains('Checking for pending change requests').should('not.exist')
       })
 
       it('should render breadcrumbs', () => {

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-spec.js
@@ -111,7 +111,7 @@ describe('D&B Company hierarchy', () => {
     it('should now show explanation why the D&B hierarchy might have fewer records than manual one', () => {
       cy.contains(
         "Why aren't all manually linked subsidiaries listed here?"
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
   })
 

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -141,13 +141,8 @@ describe('Company Export tab', () => {
 
         cy.contains('8 results').parent().parent().as(LIST_ALIAS)
 
-        cy.get('@' + LIST_ALIAS)
-          .find('ul:last li a:last')
-          .should('not.have.text', 'Next')
-
-        cy.get('@' + LIST_ALIAS)
-          .find('ul:last li a:first')
-          .should('not.have.text', 'Previous')
+        cy.get('@' + LIST_ALIAS).should('not.contain', 'Next')
+        cy.get('@' + LIST_ALIAS).should('not.contain', 'Previous')
 
         cy.contains(
           'Ut eius quisquam qui quaerat adipisci dolorum sit similique.'

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -102,10 +102,10 @@ describe('Match a company', () => {
 
       it('should not display the search results', () => {
         cy.get(selectors.companyMatch.find.results.someCompany).should(
-          'not.be.visible'
+          'not.exist'
         )
         cy.get(selectors.companyMatch.find.results.someOtherCompany).should(
-          'not.be.visible'
+          'not.exist'
         )
       })
     }

--- a/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
@@ -27,7 +27,7 @@ describe('Dashboard - feature flag', () => {
         cy.visit('/')
       })
       it('should show the default dashboard layout', () => {
-        cy.get('[data-test="dashboard"]').should('not.be.visible')
+        cy.get('[data-test="dashboard"]').should('not.exist')
       })
       it('should NOT append a query param for GA tracking', () => {
         cy.url('[data-test="dashboard"]').should(
@@ -45,7 +45,7 @@ describe('Dashboard - feature flag', () => {
       cy.visit('/')
     })
     it('should show the default dashboard layout', () => {
-      cy.get('[data-test="dashboard"]').should('not.be.visible')
+      cy.get('[data-test="dashboard"]').should('not.exist')
     })
     it('should NOT append a query param for GA tracking', () => {
       cy.url('[data-test="dashboard"]').should(
@@ -62,7 +62,7 @@ describe('Dashboard - feature flag', () => {
       cy.visit('/')
     })
     it('should show the default dashboard layout', () => {
-      cy.get('[data-test="dashboard"]').should('not.be.visible')
+      cy.get('[data-test="dashboard"]').should('not.exist')
     })
     it('should NOT append a query param for GA tracking', () => {
       cy.url('[data-test="dashboard"]').should(

--- a/test/functional/cypress/specs/events/attendees-spec.js
+++ b/test/functional/cypress/specs/events/attendees-spec.js
@@ -85,7 +85,7 @@ describe('Event Attendees', () => {
     })
 
     it('should not display add attendees button for disabled events', () => {
-      cy.get(selectors.entityCollection.addAttendee).should('not.be.visible')
+      cy.get(selectors.entityCollection.addAttendee).should('not.exist')
     })
 
     it('should display a message indicating that you cannot add an event attendee', () => {

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -10,7 +10,7 @@ describe('Event create', () => {
     cy.get(selectors.eventCreate.ukRegion).should('be.visible')
 
     cy.get(selectors.eventCreate.addressCountry).select('Uganda')
-    cy.get(selectors.eventCreate.ukRegion).should('not.be.visible')
+    cy.get(selectors.eventCreate.ukRegion).should('not.exist')
   })
 
   it('should toggle teams section when interacting with shared options', () => {
@@ -18,7 +18,7 @@ describe('Event create', () => {
     cy.get(selectors.eventCreate.teams).should('be.visible')
 
     cy.get(selectors.eventCreate.sharedNo).click()
-    cy.get(selectors.eventCreate.teams).should('not.be.visible')
+    cy.get(selectors.eventCreate.teams).should('not.exist')
   })
 
   it('should allow user to add multiple shared teams', () => {

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -10,7 +10,7 @@ describe('Event create', () => {
     cy.get(selectors.eventCreate.ukRegion).should('be.visible')
 
     cy.get(selectors.eventCreate.addressCountry).select('Uganda')
-    cy.get(selectors.eventCreate.ukRegion).should('not.exist')
+    cy.get(selectors.eventCreate.ukRegion).should('not.be.visible')
   })
 
   it('should toggle teams section when interacting with shared options', () => {
@@ -18,7 +18,7 @@ describe('Event create', () => {
     cy.get(selectors.eventCreate.teams).should('be.visible')
 
     cy.get(selectors.eventCreate.sharedNo).click()
-    cy.get(selectors.eventCreate.teams).should('not.exist')
+    cy.get(selectors.eventCreate.teams).should('not.be.visible')
   })
 
   it('should allow user to add multiple shared teams', () => {

--- a/test/functional/cypress/specs/events/details-spec.js
+++ b/test/functional/cypress/specs/events/details-spec.js
@@ -49,7 +49,7 @@ describe('Event Details', () => {
     })
 
     it('should hide edit event button for disabled events', () => {
-      cy.get(selectors.entityCollection.editEvent).should('not.be.visible')
+      cy.get(selectors.entityCollection.editEvent).should('not.exist')
     })
   })
 })

--- a/test/functional/cypress/specs/events/sort-spec.js
+++ b/test/functional/cypress/specs/events/sort-spec.js
@@ -65,6 +65,6 @@ describe('Event Collections Sort', () => {
 
   it('should only show sort option if there is more than 1 result', () => {
     cy.get(selectors.filter.name).type('FilterByEvent').type('{enter}')
-    cy.get(selectors.entityCollection.sort).should('not.be.visible')
+    cy.get(selectors.entityCollection.sort).should('not.exist')
   })
 })

--- a/test/functional/cypress/specs/interaction/complete-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/complete-interaction-spec.js
@@ -50,15 +50,15 @@ describe('Complete interaction', () => {
       )
       cy.get(
         selectors.interaction.complete.archivedReason.clientCancelled
-      ).should('not.exist')
+      ).should('not.be.visible')
       cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should(
-        'not.exist'
+        'not.be.visible'
       )
       cy.get(selectors.interaction.complete.archivedReason.rescheduled).should(
-        'not.exist'
+        'not.be.visible'
       )
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.exist'
+        'not.be.visible'
       )
       cy.get(selectors.interaction.complete.actions.continue).should(
         'be.visible'
@@ -80,7 +80,7 @@ describe('Complete interaction', () => {
         'be.visible'
       )
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.exist'
+        'not.be.visible'
       )
 
       cy.get(selectors.interaction.complete.archivedReason.rescheduled).click()
@@ -92,21 +92,21 @@ describe('Complete interaction', () => {
         selectors.interaction.complete.archivedReason.clientCancelled
       ).click()
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.exist'
+        'not.be.visible'
       )
 
       cy.get(selectors.interaction.complete.meetingHappen.yes).click()
       cy.get(
         selectors.interaction.complete.archivedReason.clientCancelled
-      ).should('not.exist')
+      ).should('not.be.visible')
       cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should(
-        'not.exist'
+        'not.be.visible'
       )
       cy.get(selectors.interaction.complete.archivedReason.rescheduled).should(
-        'not.exist'
+        'not.be.visible'
       )
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.exist'
+        'not.be.visible'
       )
     })
   })

--- a/test/functional/cypress/specs/interaction/complete-interaction-spec.js
+++ b/test/functional/cypress/specs/interaction/complete-interaction-spec.js
@@ -50,15 +50,15 @@ describe('Complete interaction', () => {
       )
       cy.get(
         selectors.interaction.complete.archivedReason.clientCancelled
-      ).should('not.be.visible')
+      ).should('not.exist')
       cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should(
-        'not.be.visible'
+        'not.exist'
       )
       cy.get(selectors.interaction.complete.archivedReason.rescheduled).should(
-        'not.be.visible'
+        'not.exist'
       )
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.be.visible'
+        'not.exist'
       )
       cy.get(selectors.interaction.complete.actions.continue).should(
         'be.visible'
@@ -80,7 +80,7 @@ describe('Complete interaction', () => {
         'be.visible'
       )
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.be.visible'
+        'not.exist'
       )
 
       cy.get(selectors.interaction.complete.archivedReason.rescheduled).click()
@@ -92,21 +92,21 @@ describe('Complete interaction', () => {
         selectors.interaction.complete.archivedReason.clientCancelled
       ).click()
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.be.visible'
+        'not.exist'
       )
 
       cy.get(selectors.interaction.complete.meetingHappen.yes).click()
       cy.get(
         selectors.interaction.complete.archivedReason.clientCancelled
-      ).should('not.be.visible')
+      ).should('not.exist')
       cy.get(selectors.interaction.complete.archivedReason.ditCancelled).should(
-        'not.be.visible'
+        'not.exist'
       )
       cy.get(selectors.interaction.complete.archivedReason.rescheduled).should(
-        'not.be.visible'
+        'not.exist'
       )
       cy.get(selectors.interaction.complete.rescheduledDate.field).should(
-        'not.be.visible'
+        'not.exist'
       )
     })
   })

--- a/test/functional/cypress/specs/interaction/interaction-details-spec.js
+++ b/test/functional/cypress/specs/interaction/interaction-details-spec.js
@@ -71,13 +71,13 @@ describe('Interaction details', () => {
         selectors.interaction.details.interaction.actions.editInteraction(
           params
         )
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
 
     it('should not render the "Why can I not complete this interaction?" details summary', () => {
       cy.get(
         selectors.interaction.details.interaction.whyCanINotComplete
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
   })
 
@@ -128,7 +128,7 @@ describe('Interaction details', () => {
         selectors.interaction.details.interaction.actions.completeInteraction(
           params
         )
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
 
     it('should not render the "Edit interaction" button', () => {
@@ -136,7 +136,7 @@ describe('Interaction details', () => {
         selectors.interaction.details.interaction.actions.editInteraction(
           params
         )
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
 
     it('should render the "Why can I not complete this interaction?" details summary', () => {
@@ -193,7 +193,7 @@ describe('Interaction details', () => {
         selectors.interaction.details.interaction.actions.completeInteraction(
           params
         )
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
 
     it('should not render the "Edit interaction" button', () => {
@@ -201,13 +201,13 @@ describe('Interaction details', () => {
         selectors.interaction.details.interaction.actions.editInteraction(
           params
         )
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
 
     it('should not render the "Why can I not complete this interaction?" details summary', () => {
       cy.get(
         selectors.interaction.details.interaction.whyCanINotComplete
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
   })
 
@@ -264,7 +264,7 @@ describe('Interaction details', () => {
       const completeInteraction = selectors.interaction.details.interaction.actions.completeInteraction(
         params
       )
-      cy.get(completeInteraction).should('not.be.visible')
+      cy.get(completeInteraction).should('not.exist')
     })
 
     it('should render the "Edit interaction" button', () => {
@@ -278,7 +278,7 @@ describe('Interaction details', () => {
     it('should not render the "Why can I not complete this interaction?" details summary', () => {
       cy.get(
         selectors.interaction.details.interaction.whyCanINotComplete
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
   })
 
@@ -335,7 +335,7 @@ describe('Interaction details', () => {
       const completeInteraction = selectors.interaction.details.interaction.actions.completeInteraction(
         params
       )
-      cy.get(completeInteraction).should('not.be.visible')
+      cy.get(completeInteraction).should('not.exist')
     })
 
     it('should render the "Edit interaction" button', () => {
@@ -349,7 +349,7 @@ describe('Interaction details', () => {
     it('should not render the "Why can I not complete this interaction?" details summary', () => {
       cy.get(
         selectors.interaction.details.interaction.whyCanINotComplete
-      ).should('not.be.visible')
+      ).should('not.exist')
     })
   })
 

--- a/test/functional/cypress/specs/investments/admin-page-spec.js
+++ b/test/functional/cypress/specs/investments/admin-page-spec.js
@@ -113,7 +113,7 @@ describe('Update the project stage', () => {
       })
       it('should no longer show the flash message when the page is refreshed', () => {
         cy.reload()
-        cy.contains('div', 'Project stage saved').should('not.be.visible')
+        cy.contains('div', 'Project stage saved').should('not.exist')
       })
     }
   )

--- a/test/functional/cypress/specs/investments/investment-project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/investment-project-edit-value-spec.js
@@ -61,7 +61,7 @@ describe('Edit the value details of a project', () => {
       cy.contains('Edit value').click()
     })
     it('should not display the Project Value field on the edit value page', () => {
-      cy.contains('label', 'Project value').should('not.be.visible')
+      cy.contains('label', 'Project value').should('not.exist')
     })
   })
   context('When both dates are after 01/04/2020', () => {
@@ -70,7 +70,7 @@ describe('Edit the value details of a project', () => {
       cy.contains('Edit value').click()
     })
     it('should not display the Project Value field on the edit value page', () => {
-      cy.contains('label', 'Project value').should('not.be.visible')
+      cy.contains('label', 'Project value').should('not.exist')
     })
   })
   context('When both land date fields are empty', () => {
@@ -79,7 +79,7 @@ describe('Edit the value details of a project', () => {
       cy.contains('Edit value').click()
     })
     it('should not display the Project Value field on the edit value page', () => {
-      cy.contains('label', 'Project value').should('not.be.visible')
+      cy.contains('label', 'Project value').should('not.exist')
     })
   })
 })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -299,7 +299,7 @@ describe('My pipeline app', () => {
         .parent()
         .find('input')
         .then((element) => {
-          cy.get(element).should('be.visible')
+          cy.get(element).should('exist')
           cy.wrap(element).check()
           cy.wrap(element).should('be.checked')
           cy.wait('@pipelineGet').then((xhr) => {


### PR DESCRIPTION
## Description of change

The intent of this PR is to upgrade cypress version to 6.x so we keep up to date with all the features and breaking changes that come along with them.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
