### PR TITLE
Wrap pipeline form elements in Fieldsets

### DIFF
--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -46,14 +46,14 @@ function PipelineForm({
         className="govuk-!-width-two-thirds"
       />
       <FieldRadios
-        label="Choose a status"
+        legend="Choose a status"
         name="category"
         required="Choose a status"
         options={statusOptions}
         initialValue={initialValue.category}
       />
       <FieldRadios
-        label="Likelihood to export (optional)"
+        legend="Likelihood to export (optional)"
         name="likelihood"
         options={likelihoodOptions.map(({ value, label }) => ({
           label,

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -2,7 +2,7 @@ const minimallyMinimal = require('../../../../sandbox/fixtures/v4/company/compan
 const lambdaPlc = require('../../../../sandbox/fixtures/v4/company/company-lambda-plc.json')
 const urls = require('../../../../../src/lib/urls')
 const {
-  assertFieldRadios,
+  assertFieldRadiosWithLegend,
   assertBreadcrumbs,
   assertFormButtons,
   assertFieldInput,
@@ -46,9 +46,9 @@ describe('Company add to pipeline form', () => {
 
     it('should render the status radio buttons', () => {
       cy.get(formSelectors.fields.status).then((element) => {
-        assertFieldRadios({
+        assertFieldRadiosWithLegend({
           element,
-          label: 'Choose a status',
+          legend: 'Choose a status',
           optionsCount: 3,
         })
       })
@@ -56,9 +56,9 @@ describe('Company add to pipeline form', () => {
 
     it('Should render the likelihood to export radio buttons', () => {
       cy.get(formSelectors.fields.likelihood).then((element) => {
-        assertFieldRadios({
+        assertFieldRadiosWithLegend({
           element,
-          label: 'Likelihood to export (optional)',
+          legend: 'Likelihood to export (optional)',
           optionsCount: 3,
         })
       })
@@ -143,9 +143,9 @@ describe('Company add to pipeline form', () => {
 
     it('should render the status radio buttons', () => {
       cy.get(formSelectors.fields.status).then((element) => {
-        assertFieldRadios({
+        assertFieldRadiosWithLegend({
           element,
-          label: 'Choose a status',
+          legend: 'Choose a status',
           optionsCount: 3,
         })
       })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
@@ -1,7 +1,7 @@
 const pipelineItemLambdaPlc = require('../../../../sandbox/fixtures/v4/pipeline-item/pipeline-item-lambda-plc.json')
 const urls = require('../../../../../src/lib/urls')
 const {
-  assertFieldRadios,
+  assertFieldRadiosWithLegend,
   assertBreadcrumbs,
   assertFieldInput,
   assertFieldTypeahead,
@@ -73,9 +73,9 @@ describe('Pipeline edit form', () => {
 
       it('should render the status radio buttons', () => {
         cy.get(formSelectors.fields.status).then((element) => {
-          assertFieldRadios({
+          assertFieldRadiosWithLegend({
             element,
-            label: 'Choose a status',
+            legend: 'Choose a status',
             optionsCount: 3,
             value: 'In progress',
           })
@@ -84,9 +84,9 @@ describe('Pipeline edit form', () => {
 
       it('Should render the likelihood to export radio buttons', () => {
         cy.get(formSelectors.fields.likelihood).then((element) => {
-          assertFieldRadios({
+          assertFieldRadiosWithLegend({
             element,
-            label: 'Likelihood to export (optional)',
+            legend: 'Likelihood to export (optional)',
             optionsCount: 3,
           })
         })
@@ -160,9 +160,9 @@ describe('Pipeline edit form', () => {
 
       it('should render the status radio buttons', () => {
         cy.get(formSelectors.fields.status).then((element) => {
-          assertFieldRadios({
+          assertFieldRadiosWithLegend({
             element,
-            label: 'Choose a status',
+            legend: 'Choose a status',
             optionsCount: 3,
             value: 'To do',
           })
@@ -171,9 +171,9 @@ describe('Pipeline edit form', () => {
 
       it('Should render the likelihood to export radio buttons', () => {
         cy.get(formSelectors.fields.likelihood).then((element) => {
-          assertFieldRadios({
+          assertFieldRadiosWithLegend({
             element,
-            label: 'Likelihood to export (optional)',
+            legend: 'Likelihood to export (optional)',
             optionsCount: 3,
             value: 'Medium',
           })


### PR DESCRIPTION
## Description of change

Some elements of the 'Add a company to your pipeline' form were not wrapped in fieldsets. I have done this by swapping out the `label` parameter to `legend`, which automatically wraps the element in a fieldset.

## Test instructions

Open the form and run [Wave](https://wave.webaim.org/extension/) on the page. There should be no alerts related to the radio buttons.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
