### PR TITLE
Remove tab index and close options when tab loses focus

### DIFF
--- a/src/client/components/DropdownMenu/index.jsx
+++ b/src/client/components/DropdownMenu/index.jsx
@@ -51,7 +51,7 @@ const DropdownToggleButton = styled(SecondaryButton)`
 `
 
 export const DropdownButton = styled(SecondaryButton).attrs(() => ({
-  tabIndex: '-1',
+  tabIndex: 0,
   role: 'option',
   forwardedAs: Link,
 }))`
@@ -65,7 +65,6 @@ export const DropdownButton = styled(SecondaryButton).attrs(() => ({
 `
 const KEY_ARROW_UP = 38
 const KEY_ARROW_DOWN = 40
-const KEY_TAB = 9
 const KEY_ESC = 27
 const KEY_HOME = 36
 const KEY_END = 35
@@ -103,9 +102,6 @@ const DropdownMenu = ({
 
   const onKeyDown = (event) => {
     switch (event.keyCode) {
-      case KEY_TAB:
-        closeMenu()
-        break
       case KEY_ESC:
         closeMenu()
         buttonRef.current && buttonRef.current.focus()
@@ -135,7 +131,7 @@ const DropdownMenu = ({
       }
     }
     document.addEventListener('mousedown', clickOutside)
-    return () => document.removeEventListener('mousedown', clickOutside)
+    document.addEventListener('keyup', clickOutside)
   }, [])
 
   return (


### PR DESCRIPTION
## Description of change

As pointed out in the DAC report pages 72 - 73 we needed to remove the incorrect tab indexes as you couldn't tab through the options unless you used the arrow keys which is unexpected behaviour when using a screen reader.  

## Test instructions
1. View any company
2. Tab to the "View options" button and click enter
3. Tab through the options
4. Tab away and the options should close

## Screenshots
![Screenshot 2021-02-22 at 11 00 08](https://user-images.githubusercontent.com/10154302/108699475-31717880-74fd-11eb-9bf0-a2dd50e8bf39.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
