### PR TITLE
Added functional tests for oauth flow

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -25,6 +25,7 @@ HELP_CENTRE_FEED_API_TOKEN=lookInVault
 HELP_CENTRE_URL=https://lookInVault.com/
 NODE_ENV=development
 OAUTH2_AUTH_URL=http://localhost:8080/o/authorize
+OAUTH2_LOGOUT_URL=http://localhost:8080/o/logout
 OAUTH2_BYPASS_SSO=true
 ONE_LIST_EMAIL=look@in.vault.com
 PERFORMANCE_DASHBOARDS_URL=https://lookInVault.com/

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -89,6 +89,11 @@ module.exports = {
     },
   },
   dashboard: url('/'),
+  oauth: {
+    redirect: url('/oauth'),
+    callback: url('/oauth/callback'),
+    signout: url('/oauth/sign-out'),
+  },
   personalisedDashboard: {
     myInvestmentProjects: url('/myinvestmentprojects'),
   },

--- a/test/functional/cypress/specs/oauth/oauth-spec.js
+++ b/test/functional/cypress/specs/oauth/oauth-spec.js
@@ -1,0 +1,105 @@
+const urls = require('../../../../../src/lib/urls')
+const qs = require('qs')
+
+/**
+ * Test that the OAuth redirect url redirects to the auth server with given state
+ */
+const testRedirectState = (expectedStatedId) => {
+  cy.request({
+    url: urls.oauth.redirect(),
+    followRedirect: false,
+  }).then((response) => {
+    expect(response.status).to.eq(302)
+    const location = new URL(response.redirectedToUrl)
+    const qsParams = qs.parse(location.search.slice(1))
+
+    expect(location.pathname).to.eq('/o/authorize')
+    expect(qsParams.idp).to.eq('cirrus')
+    expect(qsParams.state).to.eq(expectedStatedId)
+  })
+}
+
+/**
+ * Test that sign out redirects to oauth signout and clears session cookie
+ */
+const testSignOut = () => {
+  cy.request({
+    url: urls.oauth.signout(),
+    followRedirect: false,
+  }).then((response) => {
+    expect(response.status).to.eq(302)
+    const location = new URL(response.redirectedToUrl)
+    expect(location.pathname).to.eq('/o/logout')
+    cy.getCookie('datahub.sid').should('not.exist')
+  })
+}
+
+describe('Authenticating with OAuth', () => {
+  beforeEach(() => {
+    cy.clearCookies()
+    testSignOut()
+  })
+
+  context('when using redirect oauth', () => {
+    it('should set up and persist session state until logout', () => {
+      cy.request({
+        url: urls.oauth.redirect(),
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        const location = new URL(response.redirectedToUrl)
+        const { state, ...otherQsParams } = qs.parse(location.search.slice(1))
+
+        expect(location.pathname).to.eq('/o/authorize')
+        expect(otherQsParams.idp).to.eq('cirrus')
+
+        // Next response should use the same state id
+        testRedirectState(state)
+      })
+
+      cy.getCookie('datahub.sid').should('exist')
+      testSignOut()
+    })
+  })
+
+  context('when using callback oauth', () => {
+    it('should set up and persist session state until logout', () => {
+      cy.request({
+        url: urls.oauth.callback(),
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        const location = new URL(response.redirectedToUrl)
+
+        expect(location.pathname).to.eq(urls.oauth.redirect())
+
+        // Follow the redirect
+        cy.request({
+          url: response.redirectedToUrl,
+          followRedirect: false,
+        }).then((response) => {
+          expect(response.status).to.eq(302)
+          const location = new URL(response.redirectedToUrl)
+          const { state } = qs.parse(location.search.slice(1))
+          expect(location.pathname).to.eq('/o/authorize')
+
+          // The state should persist
+          testRedirectState(state)
+        })
+      })
+
+      // Next response to callback url should go to dashboard page
+      cy.request({
+        url: urls.oauth.callback(),
+        followRedirect: false,
+      }).then((response) => {
+        expect(response.status).to.eq(302)
+        const location = new URL(response.redirectedToUrl)
+        expect(location.pathname).to.eq('/')
+      })
+
+      cy.getCookie('datahub.sid').should('exist')
+      testSignOut()
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

As part of the axios test replacement work, this adds functional tests for oauth happy path. 

It is very difficult / impossible to get the same level of testing as the existing unit tests with functional tests since we cannot mock errors very easily. For this reason, I have not deleted the existing unit tests, but they will need to be replaced when axios replaces requests.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
