### PR TITLE
Add the investor type filter

### DIFF
--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -16,6 +16,7 @@ const QS_PARAMS = {
   countryOfOrigin: 'country_of_origin',
   assetClassesOfInterest: 'asset_classes_of_interest',
   investorCompanyName: 'investor_company_name',
+  investorTypes: 'investor_type',
 }
 
 const resolveSelectedOptions = (values = [], options = []) =>
@@ -40,6 +41,10 @@ const LargeCapitalProfileCollection = ({
         qsParams[QS_PARAMS.assetClassesOfInterest],
         filterOptions.assetClassesOfInterest
       )
+      const selectedInvestorTypes = resolveSelectedOptions(
+        qsParams[QS_PARAMS.investorTypes],
+        filterOptions.investorTypes
+      )
 
       const resolveSelectedInvestorCompanyName = () => {
         const companyName = qsParams[QS_PARAMS.investorCompanyName]
@@ -60,6 +65,7 @@ const LargeCapitalProfileCollection = ({
               payload: {
                 page: parseInt(qsParams.page, 10),
                 countryOfOrigin: qsParams[QS_PARAMS.countryOfOrigin],
+                investorTypes: qsParams[QS_PARAMS.investorTypes],
                 assetClassesOfInterest:
                   qsParams[QS_PARAMS.assetClassesOfInterest],
                 investorCompanyName: qsParams[QS_PARAMS.investorCompanyName],
@@ -73,11 +79,12 @@ const LargeCapitalProfileCollection = ({
             selectedCountryOfOrigin: selectedCountries,
             selectedAssetClassesOfInterest,
             selectedInvestorCompanyName: resolveSelectedInvestorCompanyName(),
+            selectedInvestorTypes,
           }}
         >
           <CollectionFilters
             taskProps={{
-              name: 'Large investment profiles',
+              name: 'Large investment profiles filters',
               id: 'investments/profiles',
               startOnRender: {
                 onSuccessDispatch:
@@ -111,6 +118,16 @@ const LargeCapitalProfileCollection = ({
               name="investor-company-name"
               label="Company name"
               placeholder="Search company name"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Investor type"
+              name="investor-type"
+              qsParam={QS_PARAMS.investorTypes}
+              placeholder="Search investor type"
+              options={filterOptions.investorTypes}
+              selectedOptions={selectedInvestorTypes}
+              data-test="investor-type-filter"
             />
           </CollectionFilters>
         </FilteredCollectionList>

--- a/src/apps/investments/client/profiles/tasks.js
+++ b/src/apps/investments/client/profiles/tasks.js
@@ -6,6 +6,7 @@ export function getLargeCapitalProfiles({
   countryOfOrigin,
   assetClassesOfInterest,
   investorCompanyName,
+  investorTypes,
 }) {
   let offset = limit * (parseInt(page, 10) - 1) || 0
   return apiProxyAxios
@@ -13,6 +14,7 @@ export function getLargeCapitalProfiles({
       limit,
       offset,
       country_of_origin: countryOfOrigin,
+      investor_type: investorTypes,
       asset_classes_of_interest: assetClassesOfInterest,
       ...(investorCompanyName
         ? { investor_company_name: investorCompanyName }
@@ -29,7 +31,11 @@ export const loadFilterOptions = () =>
   Promise.all([
     apiProxyAxios.get('/v4/metadata/country'),
     apiProxyAxios.get('/v4/metadata/capital-investment/asset-class-interest'),
-  ]).then(([{ data: countries }, { data: classes }]) => ({
-    countries: countries.map(idName2valueLabel),
-    assetClassesOfInterest: classes.map(idName2valueLabel),
-  }))
+    apiProxyAxios.get('/v4/metadata/capital-investment/investor-type'),
+  ]).then(
+    ([{ data: countries }, { data: classes }, { data: investorTypes }]) => ({
+      countries: countries.map(idName2valueLabel),
+      assetClassesOfInterest: classes.map(idName2valueLabel),
+      investorTypes: investorTypes.map(idName2valueLabel),
+    })
+  )

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -162,6 +162,10 @@ function FilteredCollectionHeader({
           qsParamName="level_of_involvement_simplified"
           showCategoryLabels={true}
         />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedInvestorTypes}
+          qsParamName="investor_type"
+        />
       </CollectionHeaderRow>
     </CollectionHeaderRowContainer>
   )

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -167,8 +167,9 @@ function App() {
           getInvestmentProjects.getMetadata,
         [TASK_GET_MY_INVESTMENTS_LIST]:
           myInvestmentProjects.fetchMyInvestmentsList,
-        'Large investment profiles': investmentProfilesTasks.loadFilterOptions,
         [TASK_GET_INVESTMENT_SUMMARY_DATA_RANGES]: fetchInvestmentSummaryDataRanges,
+        'Large investment profiles filters':
+          investmentProfilesTasks.loadFilterOptions,
       }}
     >
       <Mount selector="#add-company-form">

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -117,6 +117,28 @@ describe('Investor profiles filters', () => {
     ],
   })
 
+  typeaheadFilterTestCases({
+    filterName: 'Investor type',
+    selector: 'investor-type-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Fund of funds'],
+        expectedNumberOfResults: 1,
+      },
+      {
+        options: ['Family office'],
+        expectedNumberOfResults: 1,
+      },
+      {
+        options: ['Fund of funds', 'Family office'],
+        expectedNumberOfResults: 2,
+      },
+    ],
+  })
+
   inputFilterTestCases({
     filterName: 'Company name',
     placeholder: 'Search company name',

--- a/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
+++ b/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
@@ -300,7 +300,10 @@
                 "notes_on_locations",
                 "other_countries_being_considered"
             ],
-            "investor_type": null,
+            "investor_type": {
+                "name": "Fund of funds",
+                "id": "ab084390-36bd-460d-ae7e-f33f173f5356"
+            },
             "investable_capital": null,
             "global_assets_under_management": null,
             "investor_description": "",
@@ -463,7 +466,10 @@
                 "notes_on_locations",
                 "other_countries_being_considered"
             ],
-            "investor_type": null,
+            "investor_type": {
+                "name": "Family office",
+                "id": "f40d02f8-1233-4dc5-959d-373ee916c7f6"
+            },
             "investable_capital": null,
             "global_assets_under_management": null,
             "investor_description": "",

--- a/test/sandbox/routes/v4/search/large-investor-profile/results.js
+++ b/test/sandbox/routes/v4/search/large-investor-profile/results.js
@@ -4,6 +4,7 @@ exports.largeInvestorProfile = function (req, res) {
   const countryOfOriginFilter = req.body.country_of_origin || []
   const assetClassesOfInterestFilter = req.body.asset_classes_of_interest || []
   const investorCompanyNameFilter = req.body.investor_company_name
+  const investorTypesFilter = req.body.investor_type || []
 
   const filtered = largeCapitalProfile.results
     .filter(({ country_of_origin }) =>
@@ -24,6 +25,11 @@ exports.largeInvestorProfile = function (req, res) {
         ? name
             .toLowerCase()
             .includes(req.body.investor_company_name.toLowerCase())
+        : true
+    )
+    .filter(({ investor_type }) =>
+      investorTypesFilter.length
+        ? investor_type && investorTypesFilter.includes(investor_type.id)
         : true
     )
 


### PR DESCRIPTION
## Description of change

Adds the _Investor type_ filter.

## Test instructions

1. Go to `/investments/profiles`
2. There should be a new _Investor type_ typeahead filter
3. If the filter is clear, it should not affect the search results
4. If the filter has options selected, it should filter the results accordingly
