### PR TITLE
Add and timeline component to the new dashboard

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -1,9 +1,36 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Details } from 'govuk-react'
+import styled from 'styled-components'
+import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
 import InvestmentEstimatedLandDate from './InvestmentEstimatedLandDate'
 import InvestmentTimeline from './InvestmentTimeline'
+
+const StyledDetails = styled(Details)`
+  > div {
+    border: none;
+    padding: 0;
+    margin-bottom: ${SPACING.SCALE_2};
+  }
+`
+
+const TimelineRow = styled('div')`
+  display: flex;
+  width: 100%;
+`
+
+const StyledInvestmentTimeline = styled(InvestmentTimeline)`
+  display: none;
+  width: 80%;
+  ${MEDIA_QUERIES.TABLET} {
+    display: block;
+  }
+`
+
+const StyledInvestmentEstimatedLandDate = styled(InvestmentEstimatedLandDate)`
+  width: 20%;
+`
 
 const InvestmentListItem = ({
   name,
@@ -13,11 +40,15 @@ const InvestmentListItem = ({
 }) => {
   return (
     <li>
-      <Details summary={name} open={showDetails}>
+      <StyledDetails summary={name} open={showDetails}>
         <div>+ Add Interaction...</div>
-        <InvestmentTimeline stage={stage} />
-        <InvestmentEstimatedLandDate estimatedLandDate={estimated_land_date} />
-      </Details>
+        <TimelineRow>
+          <StyledInvestmentTimeline stage={stage} />
+          <StyledInvestmentEstimatedLandDate
+            estimatedLandDate={estimated_land_date}
+          />
+        </TimelineRow>
+      </StyledDetails>
     </li>
   )
 }

--- a/src/client/components/MyInvestmentProjects/InvestmentTimeline.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentTimeline.jsx
@@ -1,7 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const InvestmentTimeline = ({ stage }) => <div>Stage: {stage.name}</div>
+import { Timeline } from '../../components'
+
+const InvestmentTimeline = ({ stage, ...props }) => (
+  <Timeline
+    stages={['Prospect', 'Assign PM', 'Active', 'Verify win', 'Won']}
+    currentStage={stage.name}
+    {...props}
+  />
+)
 
 InvestmentTimeline.propTypes = {
   stage: PropTypes.shape({

--- a/src/client/components/Timeline/index.jsx
+++ b/src/client/components/Timeline/index.jsx
@@ -40,9 +40,9 @@ const StyledLi = styled('li')`
     border-radius: 50%;
     border: 2px solid ${BLUE};
     background-color: ${({ isStageComplete }) =>
-      isStageComplete() ? WHITE : BLUE};
+      isStageComplete ? BLUE : WHITE};
     position: absolute;
-    left: -12px;
+    left: -13px;
   }
   span {
     display: block;
@@ -52,7 +52,7 @@ const StyledLi = styled('li')`
     padding: ${SPACING.SCALE_4} 0 0 0;
     display: table-cell;
     width: 25%;
-    border-top: 2px solid ${BLUE};
+    border-top: 3px solid ${BLUE};
     border-left: none;
     &:last-child {
       padding: ${SPACING.SCALE_4} 0 0 0;
@@ -71,22 +71,24 @@ const StyledLi = styled('li')`
   }
 `
 
-const Timeline = ({ stages, currentStage = '' }) => {
+const Timeline = ({ stages, currentStage = '', ...props }) => {
   const lowerCaseStageNames = stages.map((name) => name.toLowerCase())
   const stageIndex = lowerCaseStageNames.indexOf(currentStage.toLowerCase())
   return (
-    <TimelineContainer>
+    <TimelineContainer data-test="timeline" {...props}>
       <StyledOl>
-        {stages.map((stage, i) => (
-          <StyledLi
-            key={i}
-            isStageComplete={() =>
-              stageIndex === stages.length ? true : Boolean(stageIndex < i)
-            }
-          >
-            <span>{stage}</span>
-          </StyledLi>
-        ))}
+        {stages.map((stage, i) => {
+          const isComplete = i <= stageIndex
+          return (
+            <StyledLi
+              key={i}
+              isStageComplete={isComplete}
+              aria-label={isComplete ? 'stage complete' : 'stage incomplete'}
+            >
+              <span>{stage}</span>
+            </StyledLi>
+          )
+        })}
       </StyledOl>
     </TimelineContainer>
   )

--- a/test/functional/cypress/specs/dashboard/timeline.spec.js
+++ b/test/functional/cypress/specs/dashboard/timeline.spec.js
@@ -1,0 +1,33 @@
+describe('Dashboard timeline', () => {
+  beforeEach(() => {
+    cy.setFeatureFlag(
+      'layoutTesting:9010dd28-9798-e211-a939-e4115bead28a',
+      true
+    )
+    cy.visit('/')
+    cy.get('[data-test="tablist"] span:first-child button').click()
+  })
+  after(() => {
+    cy.resetFeatureFlags()
+  })
+  it('should contain timeline stages', () => {
+    cy.get('[data-test="timeline"]')
+      .eq(0)
+      .should('have.text', 'ProspectAssign PMActiveVerify winWon')
+  })
+  it('should indicate a current stage', () => {
+    const expected = [
+      'stage complete',
+      'stage incomplete',
+      'stage incomplete',
+      'stage incomplete',
+      'stage incomplete',
+    ]
+    cy.get('[data-test="timeline"]')
+      .eq(1)
+      .find('li')
+      .each(($el, i) => {
+        expect($el.attr('aria-label')).to.equal(expected[i])
+      })
+  })
+})

--- a/test/visual-component/cypress/specs/timeline/timeline.spec.js
+++ b/test/visual-component/cypress/specs/timeline/timeline.spec.js
@@ -1,0 +1,14 @@
+describe('Timeline', () => {
+  it('should render the default timeline correctly', () => {
+    cy.visit('/iframe.html?id=timeline--default')
+    cy.get('#root').should('be.visible').compareSnapshot('default')
+  })
+  it('should render the first stage of a timeline correctly', () => {
+    cy.visit('/iframe.html?id=timeline--first-stage')
+    cy.get('#root').should('be.visible').compareSnapshot('first-stage')
+  })
+  it('should render the complete timeline correctly', () => {
+    cy.visit('/iframe.html?id=timeline--complete')
+    cy.get('#root').should('be.visible').compareSnapshot('complete')
+  })
+})


### PR DESCRIPTION
## Description of change
This component is part of the new dashboard that is being built. To view the new dashboard refer to the instructions on this PR -  #3248 

## Test instructions
- Either create new projects using the actual API or refer to the mock API
- To view with the actual API follow instructions from #3248 
- To view with the mock API you will need to set a feature flag

Note: On mobile the timeline should disappear

_What should I see?_

## Screenshots
![Screenshot 2021-03-01 at 15 22 20](https://user-images.githubusercontent.com/10154302/109520005-ad426680-7aa3-11eb-90c1-d57a31d85bf3.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
