### PR TITLE
Feature/check clearance filter

### DIFF
--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -17,6 +17,7 @@ const QS_PARAMS = {
   assetClassesOfInterest: 'asset_classes_of_interest',
   investorCompanyName: 'investor_company_name',
   investorTypes: 'investor_type',
+  requiredChecksConducted: 'required_checks_conducted',
 }
 
 const resolveSelectedOptions = (values = [], options = []) =>
@@ -45,6 +46,10 @@ const LargeCapitalProfileCollection = ({
         qsParams[QS_PARAMS.investorTypes],
         filterOptions.investorTypes
       )
+      const selectedRequiredChecksConducted = resolveSelectedOptions(
+        qsParams[QS_PARAMS.requiredChecksConducted],
+        filterOptions.requiredChecksConducted
+      )
 
       const resolveSelectedInvestorCompanyName = () => {
         const companyName = qsParams[QS_PARAMS.investorCompanyName]
@@ -69,6 +74,8 @@ const LargeCapitalProfileCollection = ({
                 assetClassesOfInterest:
                   qsParams[QS_PARAMS.assetClassesOfInterest],
                 investorCompanyName: qsParams[QS_PARAMS.investorCompanyName],
+                requiredChecksConducted:
+                  qsParams[QS_PARAMS.requiredChecksConducted],
               },
               onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
             },
@@ -80,6 +87,7 @@ const LargeCapitalProfileCollection = ({
             selectedAssetClassesOfInterest,
             selectedInvestorCompanyName: resolveSelectedInvestorCompanyName(),
             selectedInvestorTypes,
+            selectedRequiredChecksConducted,
           }}
         >
           <CollectionFilters
@@ -128,6 +136,16 @@ const LargeCapitalProfileCollection = ({
               options={filterOptions.investorTypes}
               selectedOptions={selectedInvestorTypes}
               data-test="investor-type-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Check clearance"
+              name="required-checks-conducted"
+              qsParam={QS_PARAMS.requiredChecksConducted}
+              placeholder="Check clearance"
+              options={filterOptions.requiredChecksConducted}
+              selectedOptions={selectedRequiredChecksConducted}
+              data-test="required-checks-conducted-filter"
             />
           </CollectionFilters>
         </FilteredCollectionList>

--- a/src/apps/investments/client/profiles/tasks.js
+++ b/src/apps/investments/client/profiles/tasks.js
@@ -7,6 +7,7 @@ export function getLargeCapitalProfiles({
   assetClassesOfInterest,
   investorCompanyName,
   investorTypes,
+  requiredChecksConducted,
 }) {
   let offset = limit * (parseInt(page, 10) - 1) || 0
   return apiProxyAxios
@@ -16,6 +17,7 @@ export function getLargeCapitalProfiles({
       country_of_origin: countryOfOrigin,
       investor_type: investorTypes,
       asset_classes_of_interest: assetClassesOfInterest,
+      required_checks_conducted: requiredChecksConducted,
       ...(investorCompanyName
         ? { investor_company_name: investorCompanyName }
         : {}),
@@ -32,10 +34,19 @@ export const loadFilterOptions = () =>
     apiProxyAxios.get('/v4/metadata/country'),
     apiProxyAxios.get('/v4/metadata/capital-investment/asset-class-interest'),
     apiProxyAxios.get('/v4/metadata/capital-investment/investor-type'),
+    apiProxyAxios.get(
+      '/v4/metadata/capital-investment/required-checks-conducted'
+    ),
   ]).then(
-    ([{ data: countries }, { data: classes }, { data: investorTypes }]) => ({
+    ([
+      { data: countries },
+      { data: classes },
+      { data: investorTypes },
+      { data: requiredChecksConducted },
+    ]) => ({
       countries: countries.map(idName2valueLabel),
       assetClassesOfInterest: classes.map(idName2valueLabel),
       investorTypes: investorTypes.map(idName2valueLabel),
+      requiredChecksConducted: requiredChecksConducted.map(idName2valueLabel),
     })
   )

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -166,6 +166,10 @@ function FilteredCollectionHeader({
           selectedOptions={selectedFilters.selectedInvestorTypes}
           qsParamName="investor_type"
         />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedRequiredChecksConducted}
+          qsParamName="required_checks_conducted"
+        />
       </CollectionHeaderRow>
     </CollectionHeaderRowContainer>
   )

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -139,6 +139,28 @@ describe('Investor profiles filters', () => {
     ],
   })
 
+  typeaheadFilterTestCases({
+    filterName: 'Check clearance',
+    selector: 'required-checks-conducted-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Cleared'],
+        expectedNumberOfResults: 1,
+      },
+      {
+        options: ['Issues identified'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Cleared', 'Issues identified'],
+        expectedNumberOfResults: 3,
+      },
+    ],
+  })
+
   inputFilterTestCases({
     filterName: 'Company name',
     placeholder: 'Search company name',

--- a/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
+++ b/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
@@ -222,8 +222,7 @@
                 "investor_type",
                 "investable_capital",
                 "global_assets_under_management",
-                "investor_description",
-                "required_checks_conducted"
+                "investor_description"
             ],
             "incomplete_requirements_fields": [
                 "deal_ticket_sizes",
@@ -244,7 +243,10 @@
             "investable_capital": null,
             "global_assets_under_management": null,
             "investor_description": "",
-            "required_checks_conducted": null,
+            "required_checks_conducted": {
+                "id": "02d6fc9b-fbb9-4621-b247-d86f2487898e",
+                "name": "Cleared"
+            },
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
             "deal_ticket_sizes": [],
@@ -340,8 +342,7 @@
                 "investor_type",
                 "investable_capital",
                 "global_assets_under_management",
-                "investor_description",
-                "required_checks_conducted"
+                "investor_description"
             ],
             "incomplete_requirements_fields": [
                 "deal_ticket_sizes",
@@ -363,7 +364,10 @@
             "investable_capital": null,
             "global_assets_under_management": null,
             "investor_description": "",
-            "required_checks_conducted": null,
+            "required_checks_conducted": {
+                "id": "9beab8fc-1094-49b4-97d0-37bc7a9de631",
+                "name": "Issues identified"
+            },
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
             "deal_ticket_sizes": [],
@@ -391,8 +395,7 @@
                 "investor_type",
                 "investable_capital",
                 "global_assets_under_management",
-                "investor_description",
-                "required_checks_conducted"
+                "investor_description"
             ],
             "incomplete_requirements_fields": [
                 "deal_ticket_sizes",
@@ -414,7 +417,10 @@
             "investable_capital": null,
             "global_assets_under_management": null,
             "investor_description": "",
-            "required_checks_conducted": null,
+            "required_checks_conducted": {
+                "id": "9beab8fc-1094-49b4-97d0-37bc7a9de631",
+                "name": "Issues identified"
+            },
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
             "deal_ticket_sizes": [],

--- a/test/sandbox/routes/v4/search/large-investor-profile/results.js
+++ b/test/sandbox/routes/v4/search/large-investor-profile/results.js
@@ -5,6 +5,7 @@ exports.largeInvestorProfile = function (req, res) {
   const assetClassesOfInterestFilter = req.body.asset_classes_of_interest || []
   const investorCompanyNameFilter = req.body.investor_company_name
   const investorTypesFilter = req.body.investor_type || []
+  const requiredChecksConductedFilter = req.body.required_checks_conducted || []
 
   const filtered = largeCapitalProfile.results
     .filter(({ country_of_origin }) =>
@@ -30,6 +31,12 @@ exports.largeInvestorProfile = function (req, res) {
     .filter(({ investor_type }) =>
       investorTypesFilter.length
         ? investor_type && investorTypesFilter.includes(investor_type.id)
+        : true
+    )
+    .filter(({ required_checks_conducted }) =>
+      requiredChecksConductedFilter.length
+        ? required_checks_conducted &&
+          requiredChecksConductedFilter.includes(required_checks_conducted.id)
         : true
     )
 


### PR DESCRIPTION
## Description of change

Adds the _Investor type_ filter.

## Test instructions

1. Go to `/investments/profiles`
2. There should be a new _Check clearance_ typeahead filter
3. If the filter is clear, it should not affect the search results
4. If the filter has options selected, it should filter the results accordingly
