### PR TITLE
Add project status tag to investment projects list

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -4,6 +4,7 @@ import { Details } from 'govuk-react'
 import styled from 'styled-components'
 import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
+import { Tag } from '../../components'
 import InvestmentEstimatedLandDate from './InvestmentEstimatedLandDate'
 import InvestmentTimeline from './InvestmentTimeline'
 
@@ -40,8 +41,15 @@ const InvestmentListItem = ({
 }) => {
   return (
     <li>
+      <Tag
+        colour="grey"
+        data-test="project-status-tag"
+        aria-label="project status"
+      >
+        {stage.name}
+      </Tag>
+      <div>+ Add Interaction...</div>
       <StyledDetails summary={name} open={showDetails}>
-        <div>+ Add Interaction...</div>
         <TimelineRow>
           <StyledInvestmentTimeline stage={stage} />
           <StyledInvestmentEstimatedLandDate

--- a/src/client/components/Tag/index.jsx
+++ b/src/client/components/Tag/index.jsx
@@ -9,8 +9,10 @@ const StyledTag = styled(GovUkTag)`
   color: ${(props) => TAG_COLOURS[props.colour].colour};
 `
 
-const Tag = ({ colour, children }) => (
-  <StyledTag colour={colour}>{children}</StyledTag>
+const Tag = ({ colour, children, ...props }) => (
+  <StyledTag colour={colour} {...props}>
+    {children}
+  </StyledTag>
 )
 
 Tag.propTypes = {

--- a/test/functional/cypress/specs/dashboard/project-status-tag.spec.js
+++ b/test/functional/cypress/specs/dashboard/project-status-tag.spec.js
@@ -1,0 +1,34 @@
+describe('Dashboard - Investment project status', () => {
+  beforeEach(() => {
+    cy.setFeatureFlag(
+      'layoutTesting:9010dd28-9798-e211-a939-e4115bead28a',
+      true
+    )
+    cy.visit('/')
+    cy.get('[data-test="tablist"] span:first-child button').click()
+  })
+  after(() => {
+    cy.resetFeatureFlags()
+  })
+  it('should contain statuses for each project', () => {
+    const expected = [
+      'Won',
+      'Prospect',
+      'Active',
+      'Active',
+      'Active',
+      'Assign PM',
+      'Active',
+      'Prospect',
+      'Verify win',
+      'Prospect',
+    ]
+
+    cy.get('[data-test="project-status-tag"]').each(($el, i) =>
+      expect($el.text()).to.equal(expected[i])
+    )
+    cy.get('[aria-label~="project"]').each(($el) =>
+      expect($el.attr('aria-label')).to.equal('project status')
+    )
+  })
+})


### PR DESCRIPTION
## Description of change
We need to add a status tag that indicates where the user is in the process of an Investment project lifecycle.

## Test instructions
- Run the new dashboard as per instructions from #3248
- You should see a status badge against each list item

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
