### PR TITLE
Add 'Add interaction' button to my projects list

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Details } from 'govuk-react'
+import Button from '@govuk-react/button'
+import { BLUE } from 'govuk-colours'
 import styled from 'styled-components'
 import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
 import { Tag } from '../../components'
+import { companies } from '../../../lib/urls'
 import InvestmentEstimatedLandDate from './InvestmentEstimatedLandDate'
 import InvestmentTimeline from './InvestmentTimeline'
 
@@ -38,9 +41,10 @@ const InvestmentListItem = ({
   stage,
   estimated_land_date,
   showDetails,
+  investor_company,
 }) => {
   return (
-    <li>
+    <li data-test="my-projects-list-item">
       <Tag
         colour="grey"
         data-test="project-status-tag"
@@ -48,7 +52,14 @@ const InvestmentListItem = ({
       >
         {stage.name}
       </Tag>
-      <div>+ Add Interaction...</div>
+
+      <Button
+        as="a"
+        buttonColour={BLUE}
+        href={companies.interactions.create(investor_company.id)}
+      >
+        Add interaction
+      </Button>
       <StyledDetails summary={name} open={showDetails}>
         <TimelineRow>
           <StyledInvestmentTimeline stage={stage} />

--- a/test/functional/cypress/specs/dashboard/add-interaction-button.spec.js
+++ b/test/functional/cypress/specs/dashboard/add-interaction-button.spec.js
@@ -1,0 +1,25 @@
+describe('Dashboard - My projects list', () => {
+  beforeEach(() => {
+    cy.setFeatureFlag(
+      'layoutTesting:9010dd28-9798-e211-a939-e4115bead28a',
+      true
+    )
+    cy.visit('/')
+    cy.get('[data-test="tablist"] span:first-child button').click()
+  })
+  after(() => {
+    cy.resetFeatureFlags()
+  })
+  it('should contain a button to add an interaction', () => {
+    cy.get('[data-test="my-projects-list-item"] > a')
+      .as('addInteractionLink')
+      .eq(0)
+      .should('have.text', 'Add interaction')
+
+    cy.get('@addInteractionLink').should(
+      'have.attr',
+      'href',
+      '/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/interactions/create'
+    )
+  })
+})


### PR DESCRIPTION
## Description of change
In the my "My projects" list of the new dashboard we need to add an "Add interaction" button alongside the investment projects so the user can quickly get to this user journey.

## Test instructions
- Run the new dashboard as per instructions from #3248
- Click on the "Add interaction" button, you should be directed to the "add interaction" form

## Screenshot
![Screenshot 2021-03-04 at 16 04 00](https://user-images.githubusercontent.com/10154302/109992621-589d2680-7d03-11eb-98ea-21982d7888b0.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
