### PR TITLE
Disable Investment projects `show details` checkbox

### DIFF
--- a/src/client/components/ActivityFeed/ActivityFeedCheckbox.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeedCheckbox.jsx
@@ -40,8 +40,7 @@ const StyledCheckbox = styled(Checkbox)`
   }
 `
 
-const ActivityFeedCheckbox = (props) => {
-  const { children, ...rest } = props
+const ActivityFeedCheckbox = ({ children, ...rest }) => {
   return <StyledCheckbox {...rest}>{children}</StyledCheckbox>
 }
 
@@ -49,12 +48,8 @@ ActivityFeedCheckbox.propTypes = {
   children: PropTypes.node.isRequired,
   onChange: PropTypes.func.isRequired,
   checked: PropTypes.bool,
+  disabled: PropTypes.bool,
   name: PropTypes.string,
-}
-
-ActivityFeedCheckbox.defaultProps = {
-  checked: null,
-  name: null,
 }
 
 export default ActivityFeedCheckbox

--- a/src/client/components/MyInvestmentProjects/InvestmentListShowDetails.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListShowDetails.jsx
@@ -9,14 +9,10 @@ const CheckboxContainer = styled('div')`
   padding: ${SPACING.SCALE_2};
 `
 
-const InvestmentListShowDetails = ({ onChange, checked, children }) => {
+const InvestmentListShowDetails = ({ children, ...rest }) => {
   return (
     <CheckboxContainer>
-      <Checkbox
-        name="investmentListShowDetails"
-        onChange={onChange}
-        checked={checked}
-      >
+      <Checkbox name="investmentListShowDetails" {...rest}>
         {children}
       </Checkbox>
     </CheckboxContainer>
@@ -24,9 +20,10 @@ const InvestmentListShowDetails = ({ onChange, checked, children }) => {
 }
 
 InvestmentListShowDetails.propTypes = {
+  children: PropTypes.node.isRequired,
   onChange: PropTypes.func.isRequired,
   checked: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool.isRequired,
 }
 
 export default InvestmentListShowDetails

--- a/src/client/components/MyInvestmentProjects/index.jsx
+++ b/src/client/components/MyInvestmentProjects/index.jsx
@@ -37,14 +37,13 @@ const MyInvestmentProjects = ({
 }) => (
   <article>
     <InvestmentListHeader>
-      {results.length > 0 && (
-        <InvestmentListShowDetails
-          onChange={(event) => onShowDetailsChange(event.target.checked)}
-          checked={showDetails}
-        >
-          Show details
-        </InvestmentListShowDetails>
-      )}
+      <InvestmentListShowDetails
+        onChange={(event) => onShowDetailsChange(event.target.checked)}
+        checked={showDetails}
+        disabled={!results.length}
+      >
+        Show details
+      </InvestmentListShowDetails>
       <InvestmentListFilter
         options={STAGE_OPTIONS}
         onChange={(event) => onFilterChange(event.target.value)}

--- a/src/client/components/MyInvestmentProjects/reducer.js
+++ b/src/client/components/MyInvestmentProjects/reducer.js
@@ -13,7 +13,7 @@ const initialState = {
   page: 1,
   sort: 'created_on:desc',
   filter: 'all-stages',
-  showDetails: true,
+  showDetails: false,
 }
 
 export default (


### PR DESCRIPTION
## Description of change
When a stage filter has been applied to the Investment projects list (new dashboard) the API response may well be an empty array, when this happens it makes sense to disable the checkbox as there are no list items to expand.

## Checklist
[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
