### PR TITLE
Add filters for investor requirements

### DIFF
--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -18,6 +18,14 @@ const QS_PARAMS = {
   investorCompanyName: 'investor_company_name',
   investorTypes: 'investor_type',
   requiredChecksConducted: 'required_checks_conducted',
+  dealTicketSize: 'deal_ticket_size',
+  investmentTypes: 'investment_type',
+  minimumReturnRate: 'minimum_return_rate',
+  timeHorizon: 'time_horizon',
+  restrictions: 'restriction',
+  constructionRisk: 'construction_risk',
+  minimumEquityPercentage: 'minimum_equity_percentage',
+  desiredDealRole: 'desired_deal_role',
 }
 
 const resolveSelectedOptions = (values = [], options = []) =>
@@ -50,6 +58,38 @@ const LargeCapitalProfileCollection = ({
         qsParams[QS_PARAMS.requiredChecksConducted],
         filterOptions.requiredChecksConducted
       )
+      const selectedDealTicketSize = resolveSelectedOptions(
+        qsParams[QS_PARAMS.dealTicketSize],
+        filterOptions.dealTicketSize
+      )
+      const selectedInvestmentTypes = resolveSelectedOptions(
+        qsParams[QS_PARAMS.investmentTypes],
+        filterOptions.investmentTypes
+      )
+      const selectedMinimumReturnRate = resolveSelectedOptions(
+        qsParams[QS_PARAMS.minimumReturnRate],
+        filterOptions.minimumReturnRate
+      )
+      const selectedTimeHorizon = resolveSelectedOptions(
+        qsParams[QS_PARAMS.timeHorizon],
+        filterOptions.timeHorizon
+      )
+      const selectedRestrictions = resolveSelectedOptions(
+        qsParams[QS_PARAMS.restrictions],
+        filterOptions.restrictions
+      )
+      const selectedConstructionRisk = resolveSelectedOptions(
+        qsParams[QS_PARAMS.constructionRisk],
+        filterOptions.constructionRisk
+      )
+      const selectedMinimumEquityPercentage = resolveSelectedOptions(
+        qsParams[QS_PARAMS.minimumEquityPercentage],
+        filterOptions.minimumEquityPercentage
+      )
+      const selectedDesiredDealRole = resolveSelectedOptions(
+        qsParams[QS_PARAMS.desiredDealRole],
+        filterOptions.desiredDealRole
+      )
 
       const resolveSelectedInvestorCompanyName = () => {
         const companyName = qsParams[QS_PARAMS.investorCompanyName]
@@ -76,6 +116,15 @@ const LargeCapitalProfileCollection = ({
                 investorCompanyName: qsParams[QS_PARAMS.investorCompanyName],
                 requiredChecksConducted:
                   qsParams[QS_PARAMS.requiredChecksConducted],
+                dealTicketSize: qsParams[QS_PARAMS.dealTicketSize],
+                investmentTypes: qsParams[QS_PARAMS.investmentTypes],
+                minimumReturnRate: qsParams[QS_PARAMS.minimumReturnRate],
+                timeHorizon: qsParams[QS_PARAMS.timeHorizon],
+                restrictions: qsParams[QS_PARAMS.restrictions],
+                constructionRisk: qsParams[QS_PARAMS.constructionRisk],
+                minimumEquityPercentage:
+                  qsParams[QS_PARAMS.minimumEquityPercentage],
+                desiredDealRole: qsParams[QS_PARAMS.desiredDealRole],
               },
               onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
             },
@@ -88,6 +137,14 @@ const LargeCapitalProfileCollection = ({
             selectedInvestorCompanyName: resolveSelectedInvestorCompanyName(),
             selectedInvestorTypes,
             selectedRequiredChecksConducted,
+            selectedDealTicketSize,
+            selectedInvestmentTypes,
+            selectedMinimumReturnRate,
+            selectedTimeHorizon,
+            selectedRestrictions,
+            selectedConstructionRisk,
+            selectedMinimumEquityPercentage,
+            selectedDesiredDealRole,
           }}
         >
           <CollectionFilters
@@ -115,7 +172,7 @@ const LargeCapitalProfileCollection = ({
               legend="Asset class of interest"
               name="asset-class-of-interest"
               qsParam={QS_PARAMS.assetClassesOfInterest}
-              placeholder="Search countries"
+              placeholder="Search asset classes"
               options={filterOptions.assetClassesOfInterest}
               selectedOptions={selectedAssetClassesOfInterest}
               data-test="asset-class-of-interest-filter"
@@ -146,6 +203,86 @@ const LargeCapitalProfileCollection = ({
               options={filterOptions.requiredChecksConducted}
               selectedOptions={selectedRequiredChecksConducted}
               data-test="required-checks-conducted-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Deal ticket size"
+              name="deal-ticket-size"
+              qsParam={QS_PARAMS.dealTicketSize}
+              placeholder="Search ticket sizes"
+              options={filterOptions.dealTicketSize}
+              selectedOptions={selectedDealTicketSize}
+              data-test="deal-ticket-size-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Types of investment"
+              name="types-of-investment"
+              qsParam={QS_PARAMS.investmentTypes}
+              placeholder="Search types"
+              options={filterOptions.investmentTypes}
+              selectedOptions={selectedInvestmentTypes}
+              data-test="types-of-investment-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Minimum Return Rate"
+              name="minimum-return-rate"
+              qsParam={QS_PARAMS.minimumReturnRate}
+              placeholder="Search return rates"
+              options={filterOptions.minimumReturnRate}
+              selectedOptions={selectedMinimumReturnRate}
+              data-test="minimum-return-rate-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Time horizon tenor"
+              name="time-horizon-tenor"
+              qsParam={QS_PARAMS.timeHorizon}
+              placeholder="Search time horizons"
+              options={filterOptions.timeHorizon}
+              selectedOptions={selectedTimeHorizon}
+              data-test="time-horizon-tenor-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Restrictions and Conditions"
+              name="restrictions-conditions"
+              qsParam={QS_PARAMS.restrictions}
+              placeholder="Search restrictions"
+              options={filterOptions.restrictions}
+              selectedOptions={selectedRestrictions}
+              data-test="restrictions-conditions-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Construction risk"
+              name="construction-risk"
+              qsParam={QS_PARAMS.constructionRisk}
+              placeholder="Search risks"
+              options={filterOptions.constructionRisk}
+              selectedOptions={selectedConstructionRisk}
+              data-test="construction-risk-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Minimum equity percentage"
+              name="minimum-equity-percentage"
+              qsParam={QS_PARAMS.minimumEquityPercentage}
+              placeholder="Search percentages"
+              options={filterOptions.minimumEquityPercentage}
+              selectedOptions={selectedMinimumEquityPercentage}
+              data-test="minimum-equity-percentage-filter"
+            />
+            <RoutedTypeahead
+              isMulti={true}
+              legend="Desired deal role"
+              name="desired-deal-role"
+              qsParam={QS_PARAMS.desiredDealRole}
+              placeholder="Search deal roles"
+              options={filterOptions.desiredDealRole}
+              selectedOptions={selectedDesiredDealRole}
+              data-test="desired-deal-role-filter"
             />
           </CollectionFilters>
         </FilteredCollectionList>

--- a/src/apps/investments/client/profiles/reducer.js
+++ b/src/apps/investments/client/profiles/reducer.js
@@ -13,6 +13,14 @@ const initialState = {
   filterOptions: {
     countries: [],
     assetClassesOfInterest: [],
+    dealTicketSize: [],
+    investmentTypes: [],
+    minimumReturnRate: [],
+    timeHorizon: [],
+    restrictions: [],
+    constructionRisk: [],
+    minimumEquityPercentage: [],
+    desiredDealRole: [],
   },
 }
 

--- a/src/apps/investments/client/profiles/tasks.js
+++ b/src/apps/investments/client/profiles/tasks.js
@@ -8,6 +8,14 @@ export function getLargeCapitalProfiles({
   investorCompanyName,
   investorTypes,
   requiredChecksConducted,
+  dealTicketSize,
+  investmentTypes,
+  minimumReturnRate,
+  timeHorizon,
+  restrictions,
+  constructionRisk,
+  minimumEquityPercentage,
+  desiredDealRole,
 }) {
   let offset = limit * (parseInt(page, 10) - 1) || 0
   return apiProxyAxios
@@ -18,6 +26,14 @@ export function getLargeCapitalProfiles({
       investor_type: investorTypes,
       asset_classes_of_interest: assetClassesOfInterest,
       required_checks_conducted: requiredChecksConducted,
+      deal_ticket_size: dealTicketSize,
+      investment_type: investmentTypes,
+      minimum_return_rate: minimumReturnRate,
+      time_horizon: timeHorizon,
+      restriction: restrictions,
+      construction_risk: constructionRisk,
+      minimum_equity_percentage: minimumEquityPercentage,
+      desired_deal_role: desiredDealRole,
       ...(investorCompanyName
         ? { investor_company_name: investorCompanyName }
         : {}),
@@ -29,6 +45,11 @@ export function getLargeCapitalProfiles({
 
 const idName2valueLabel = ({ id, name }) => ({ value: id, label: name })
 
+const mapOptionsWithCategory = (options, category) =>
+  options.map((option) =>
+    Object.assign(idName2valueLabel(option), { categoryLabel: category })
+  )
+
 export const loadFilterOptions = () =>
   Promise.all([
     apiProxyAxios.get('/v4/metadata/country'),
@@ -37,16 +58,45 @@ export const loadFilterOptions = () =>
     apiProxyAxios.get(
       '/v4/metadata/capital-investment/required-checks-conducted'
     ),
+    apiProxyAxios.get('/v4/metadata/capital-investment/deal-ticket-size'),
+    apiProxyAxios.get(
+      'v4/metadata/capital-investment/large-capital-investment-type'
+    ),
+    apiProxyAxios.get('/v4/metadata/capital-investment/return-rate'),
+    apiProxyAxios.get('/v4/metadata/capital-investment/time-horizon'),
+    apiProxyAxios.get('/v4/metadata/capital-investment/restriction'),
+    apiProxyAxios.get('/v4/metadata/capital-investment/construction-risk'),
+    apiProxyAxios.get('/v4/metadata/capital-investment/equity-percentage'),
+    apiProxyAxios.get('/v4/metadata/capital-investment/desired-deal-role'),
   ]).then(
     ([
       { data: countries },
       { data: classes },
       { data: investorTypes },
       { data: requiredChecksConducted },
+      { data: ticketSizes },
+      { data: investmentTypes },
+      { data: returnRates },
+      { data: timeHorizons },
+      { data: restrictions },
+      { data: constructionRisks },
+      { data: equityPercentages },
+      { data: dealRoles },
     ]) => ({
       countries: countries.map(idName2valueLabel),
       assetClassesOfInterest: classes.map(idName2valueLabel),
       investorTypes: investorTypes.map(idName2valueLabel),
       requiredChecksConducted: requiredChecksConducted.map(idName2valueLabel),
+      dealTicketSize: ticketSizes.map(idName2valueLabel),
+      investmentTypes: investmentTypes.map(idName2valueLabel),
+      minimumReturnRate: mapOptionsWithCategory(returnRates, 'Min Return Rate'),
+      timeHorizon: timeHorizons.map(idName2valueLabel),
+      restrictions: restrictions.map(idName2valueLabel),
+      constructionRisk: constructionRisks.map(idName2valueLabel),
+      minimumEquityPercentage: mapOptionsWithCategory(
+        equityPercentages,
+        'Min Equity %'
+      ),
+      desiredDealRole: dealRoles.map(idName2valueLabel),
     })
   )

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -121,6 +121,36 @@ function FilteredCollectionHeader({
           qsParamName="investor_company_name"
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedDealTicketSize}
+          qsParamName="deal_ticket_size"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedMinimumReturnRate}
+          qsParamName="minimum_return_rate"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedTimeHorizon}
+          qsParamName="time_horizon"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedRestrictions}
+          qsParamName="restriction"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedConstructionRisk}
+          qsParamName="construction_risk"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedMinimumEquityPercentage}
+          qsParamName="minimum_equity_percentage"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedDesiredDealRole}
+          qsParamName="desired_deal_role"
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedUkRegions}
           qsParamName="uk_region"
         />

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -179,4 +179,186 @@ describe('Investor profiles filters', () => {
       },
     ],
   })
+
+  typeaheadFilterTestCases({
+    filterName: 'Deal ticket size',
+    selector: 'deal-ticket-size-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Up to £49 million'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['£50-99 million'],
+        expectedNumberOfResults: 4,
+      },
+      {
+        options: ['Up to £49 million', '£50-99 million'],
+        expectedNumberOfResults: 5,
+      },
+    ],
+  })
+
+  typeaheadFilterTestCases({
+    filterName: 'Investment type',
+    selector: 'types-of-investment-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Direct Investment in Project Equity'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Venture capital funds'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: [
+          'Direct Investment in Project Equity',
+          'Venture capital funds',
+        ],
+        expectedNumberOfResults: 3,
+      },
+    ],
+  })
+
+  typeaheadFilterTestCases({
+    filterName: 'Minimum return rate',
+    selector: 'minimum-return-rate-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['5-10%'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['10-15%'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['5-10%', '10-15%'],
+        expectedNumberOfResults: 4,
+      },
+    ],
+  })
+
+  typeaheadFilterTestCases({
+    filterName: 'Time horizon tenor',
+    selector: 'time-horizon-tenor-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Up to 5 years'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['15 years +'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Up to 5 years', '15 years +'],
+        expectedNumberOfResults: 3,
+      },
+    ],
+  })
+
+  typeaheadFilterTestCases({
+    filterName: 'Restrictions and Conditions',
+    selector: 'restrictions-conditions-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Require board seat'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Inflation adjustment'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Require board seat', 'Inflation adjustment'],
+        expectedNumberOfResults: 3,
+      },
+    ],
+  })
+
+  typeaheadFilterTestCases({
+    filterName: 'Construction risk',
+    selector: 'construction-risk-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Greenfield (construction risk)'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Brownfield (some construction risk)'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: [
+          'Greenfield (construction risk)',
+          'Brownfield (some construction risk)',
+        ],
+        expectedNumberOfResults: 3,
+      },
+    ],
+  })
+
+  typeaheadFilterTestCases({
+    filterName: 'Minimum equity percentage',
+    selector: 'minimum-equity-percentage-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['1-19%'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['50% +'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['1-19%', '50% +'],
+        expectedNumberOfResults: 4,
+      },
+    ],
+  })
+
+  typeaheadFilterTestCases({
+    filterName: 'Desired deal role',
+    selector: 'desired-deal-role-filter',
+    cases: [
+      {
+        expectedNumberOfResults: 10,
+      },
+      {
+        options: ['Lead manager / deal structure'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Co-lead manager'],
+        expectedNumberOfResults: 2,
+      },
+      {
+        options: ['Lead manager / deal structure', 'Co-lead manager'],
+        expectedNumberOfResults: 3,
+      },
+    ],
+  })
 })

--- a/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
+++ b/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
@@ -18,11 +18,8 @@
                 "required_checks_conducted"
             ],
             "incomplete_requirements_fields": [
-                "deal_ticket_sizes",
                 "investment_types",
-                "minimum_return_rate",
                 "time_horizons",
-                "construction_risks",
                 "minimum_equity_percentage",
                 "desired_deal_roles",
                 "restrictions",
@@ -40,11 +37,31 @@
             "required_checks_conducted": null,
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
-            "deal_ticket_sizes": [],
+            "deal_ticket_sizes": [
+                {
+                    "id": "56492c50-aa12-404d-a14e-1eaae24ac6ee",
+                    "name": "Up to £49 million",
+                    "disabled_on": null
+                },
+                {
+                    "id": "54df4ffb-5787-49b8-a7d2-ba33040fa32f",
+                    "name": "£50-99 million",
+                    "disabled_on": null
+                }
+            ],
             "investment_types": [],
-            "minimum_return_rate": null,
+            "minimum_return_rate": {
+                "id": "6ecbd7d2-e16a-4bfd-a4b9-8c9bca947302",
+                "name": "10-15%",
+                "disabled_on": null
+            },
             "time_horizons": [],
-            "construction_risks": [],
+            "construction_risks": [
+                {
+                    "id": "79cc3963-9376-4771-9cba-c1b3cc0ade33",
+                    "name": "Greenfield (construction risk)"
+                }
+            ],
             "minimum_equity_percentage": null,
             "desired_deal_roles": [],
             "restrictions": [],
@@ -70,14 +87,10 @@
                 "required_checks_conducted"
             ],
             "incomplete_requirements_fields": [
-                "deal_ticket_sizes",
                 "investment_types",
                 "minimum_return_rate",
-                "time_horizons",
-                "construction_risks",
                 "minimum_equity_percentage",
                 "desired_deal_roles",
-                "restrictions",
                 "asset_classes_of_interest"
             ],
             "incomplete_location_fields": [
@@ -92,14 +105,39 @@
             "required_checks_conducted": null,
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
-            "deal_ticket_sizes": [],
+            "deal_ticket_sizes": [
+                {
+                    "id": "56492c50-aa12-404d-a14e-1eaae24ac6ee",
+                    "name": "Up to £49 million",
+                    "disabled_on": null
+                }
+            ],
             "investment_types": [],
             "minimum_return_rate": null,
-            "time_horizons": [],
-            "construction_risks": [],
+            "time_horizons": [
+                {
+                    "id": "c4579a5e-4588-4952-a974-e03475a3f559",
+                    "name": "15 years +"
+                }
+            ],
+            "construction_risks": [
+                {
+                    "id": "79cc3963-9376-4771-9cba-c1b3cc0ade33",
+                    "name": "Greenfield (construction risk)"
+                },
+                {
+                    "id": "884deaf6-cb0c-4036-b78c-efd92cb10098",
+                    "name": "Brownfield (some construction risk)"
+                }
+            ],
             "minimum_equity_percentage": null,
             "desired_deal_roles": [],
-            "restrictions": [],
+            "restrictions": [
+                {
+                    "id": "daa293d4-e18e-44af-b139-bd1b4c4a9067",
+                    "name": "Inflation adjustment"
+                }
+            ],
             "asset_classes_of_interest": [],
             "uk_region_locations": [],
             "notes_on_locations": "",
@@ -124,10 +162,7 @@
             "incomplete_requirements_fields": [
                 "deal_ticket_sizes",
                 "investment_types",
-                "minimum_return_rate",
                 "time_horizons",
-                "construction_risks",
-                "minimum_equity_percentage",
                 "desired_deal_roles",
                 "restrictions",
                 "asset_classes_of_interest"
@@ -146,10 +181,23 @@
             "required_checks_conducted_by": null,
             "deal_ticket_sizes": [],
             "investment_types": [],
-            "minimum_return_rate": null,
+            "minimum_return_rate": {
+                "id": "6ecbd7d2-e16a-4bfd-a4b9-8c9bca947302",
+                "name": "10-15%",
+                "disabled_on": null
+            },
             "time_horizons": [],
-            "construction_risks": [],
-            "minimum_equity_percentage": null,
+            "construction_risks": [
+                {
+                    "id": "884deaf6-cb0c-4036-b78c-efd92cb10098",
+                    "name": "Brownfield (some construction risk)"
+                }
+            ],
+            "minimum_equity_percentage": {
+                "id": "488bf5ad-4c8e-4e6b-b339-182f291dcd76",
+                "name": "50% +",
+                "disabled_on": null
+            },
             "desired_deal_roles": [],
             "restrictions": [],
             "asset_classes_of_interest": [],
@@ -174,14 +222,10 @@
                 "required_checks_conducted"
             ],
             "incomplete_requirements_fields": [
-                "deal_ticket_sizes",
                 "investment_types",
                 "minimum_return_rate",
                 "time_horizons",
                 "construction_risks",
-                "minimum_equity_percentage",
-                "desired_deal_roles",
-                "restrictions",
                 "asset_classes_of_interest"
             ],
             "incomplete_location_fields": [
@@ -196,14 +240,39 @@
             "required_checks_conducted": null,
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
-            "deal_ticket_sizes": [],
+            "deal_ticket_sizes": [
+                {
+                    "id": "54df4ffb-5787-49b8-a7d2-ba33040fa32f",
+                    "name": "£50-99 million",
+                    "disabled_on": null
+                }
+            ],
             "investment_types": [],
             "minimum_return_rate": null,
             "time_horizons": [],
             "construction_risks": [],
-            "minimum_equity_percentage": null,
-            "desired_deal_roles": [],
-            "restrictions": [],
+            "minimum_equity_percentage": {
+                "id": "488bf5ad-4c8e-4e6b-b339-182f291dcd76",
+                "name": "50% +",
+                "disabled_on": null
+            },
+            "desired_deal_roles": [
+                {
+                    "id": "29d930e6-de2f-403d-87dc-764bc418d33a",
+                    "name": "Co-lead manager",
+                    "disabled_on": null
+                }
+            ],
+            "restrictions": [
+                {
+                    "id": "daa293d4-e18e-44af-b139-bd1b4c4a9067",
+                    "name": "Inflation adjustment"
+                },
+                {
+                    "id": "7dad0891-9174-437d-bb30-b610ac1ecd0a",
+                    "name": "Require board seat"
+                }
+            ],
             "asset_classes_of_interest": [],
             "uk_region_locations": [],
             "notes_on_locations": "",
@@ -229,10 +298,7 @@
                 "investment_types",
                 "minimum_return_rate",
                 "time_horizons",
-                "construction_risks",
-                "minimum_equity_percentage",
-                "desired_deal_roles",
-                "restrictions"
+                "construction_risks"
             ],
             "incomplete_location_fields": [
                 "uk_region_locations",
@@ -254,9 +320,29 @@
             "minimum_return_rate": null,
             "time_horizons": [],
             "construction_risks": [],
-            "minimum_equity_percentage": null,
-            "desired_deal_roles": [],
-            "restrictions": [],
+            "minimum_equity_percentage": {
+                "id": "f7b72f8b-399e-43b2-b7ef-f42a154ef916",
+                "name": "1-19%",
+                "disabled_on": null
+            },
+            "desired_deal_roles": [
+                {
+                    "id": "29d930e6-de2f-403d-87dc-764bc418d33a",
+                    "name": "Co-lead manager",
+                    "disabled_on": null
+                },
+                {
+                    "id": "efadc6bb-2a73-4627-8ce3-9dc2c34c3f31",
+                    "name": "Lead manager / deal structure",
+                    "disabled_on": null
+                }
+            ],
+            "restrictions": [
+                {
+                    "id": "7dad0891-9174-437d-bb30-b610ac1ecd0a",
+                    "name": "Require board seat"
+                }
+            ],
             "asset_classes_of_interest": [
                 {
                     "name": "Biofuel",
@@ -287,13 +373,9 @@
                 "required_checks_conducted"
             ],
             "incomplete_requirements_fields": [
-                "deal_ticket_sizes",
-                "investment_types",
                 "minimum_return_rate",
                 "time_horizons",
                 "construction_risks",
-                "minimum_equity_percentage",
-                "desired_deal_roles",
                 "restrictions",
                 "asset_classes_of_interest"
             ],
@@ -312,13 +394,34 @@
             "required_checks_conducted": null,
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
-            "deal_ticket_sizes": [],
-            "investment_types": [],
+            "deal_ticket_sizes": [
+                {
+                    "id": "54df4ffb-5787-49b8-a7d2-ba33040fa32f",
+                    "name": "£50-99 million",
+                    "disabled_on": null
+                }
+            ],
+            "investment_types": [
+                {
+                    "id": "4170d99a-02fc-46ee-8fd4-3fe786717708",
+                    "name": "Direct Investment in Project Equity"
+                }
+            ],
             "minimum_return_rate": null,
             "time_horizons": [],
             "construction_risks": [],
-            "minimum_equity_percentage": null,
-            "desired_deal_roles": [],
+            "minimum_equity_percentage": {
+                "id": "f7b72f8b-399e-43b2-b7ef-f42a154ef916",
+                "name": "1-19%",
+                "disabled_on": null
+            },
+            "desired_deal_roles": [
+                {
+                    "id": "efadc6bb-2a73-4627-8ce3-9dc2c34c3f31",
+                    "name": "Lead manager / deal structure",
+                    "disabled_on": null
+                }
+            ],
             "restrictions": [],
             "asset_classes_of_interest": [
                 {
@@ -345,10 +448,7 @@
                 "investor_description"
             ],
             "incomplete_requirements_fields": [
-                "deal_ticket_sizes",
-                "investment_types",
                 "minimum_return_rate",
-                "time_horizons",
                 "construction_risks",
                 "minimum_equity_percentage",
                 "desired_deal_roles",
@@ -370,10 +470,35 @@
             },
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
-            "deal_ticket_sizes": [],
-            "investment_types": [],
+            "deal_ticket_sizes": [
+                {
+                    "id": "54df4ffb-5787-49b8-a7d2-ba33040fa32f",
+                    "name": "£50-99 million",
+                    "disabled_on": null
+                }
+            ],
+            "investment_types": [
+                {
+                    "id": "4170d99a-02fc-46ee-8fd4-3fe786717708",
+                    "name": "Direct Investment in Project Equity"
+                },
+                {
+                    "id": "8feb6087-d61c-43bd-9bf1-3d9e1129432b",
+                    "name": "Venture capital funds",
+                    "disabled_on": null
+                }
+            ],
             "minimum_return_rate": null,
-            "time_horizons": [],
+            "time_horizons": [
+                {
+                    "id": "d2d1bdbb-c42a-459c-adaa-fce45ce08cc9",
+                    "name": "Up to 5 years"
+                },
+                {
+                    "id": "c4579a5e-4588-4952-a974-e03475a3f559",
+                    "name": "15 years +"
+                }
+            ],
             "construction_risks": [],
             "minimum_equity_percentage": null,
             "desired_deal_roles": [],
@@ -458,8 +583,6 @@
             ],
             "incomplete_requirements_fields": [
                 "deal_ticket_sizes",
-                "investment_types",
-                "minimum_return_rate",
                 "time_horizons",
                 "construction_risks",
                 "minimum_equity_percentage",
@@ -483,8 +606,18 @@
             "required_checks_conducted_on": null,
             "required_checks_conducted_by": null,
             "deal_ticket_sizes": [],
-            "investment_types": [],
-            "minimum_return_rate": null,
+            "investment_types": [
+                {
+                    "id": "8feb6087-d61c-43bd-9bf1-3d9e1129432b",
+                    "name": "Venture capital funds",
+                    "disabled_on": null
+                }
+            ],
+            "minimum_return_rate": {
+                "id": "65c9bc7a-af68-4549-a9c9-70cd73109617",
+                "name": "5-10%",
+                "disabled_on": null
+            },
             "time_horizons": [],
             "construction_risks": [],
             "minimum_equity_percentage": null,
@@ -518,8 +651,6 @@
             "incomplete_requirements_fields": [
                 "deal_ticket_sizes",
                 "investment_types",
-                "minimum_return_rate",
-                "time_horizons",
                 "construction_risks",
                 "minimum_equity_percentage",
                 "desired_deal_roles",
@@ -540,8 +671,17 @@
             "required_checks_conducted_by": null,
             "deal_ticket_sizes": [],
             "investment_types": [],
-            "minimum_return_rate": null,
-            "time_horizons": [],
+            "minimum_return_rate": {
+                "id": "65c9bc7a-af68-4549-a9c9-70cd73109617",
+                "name": "5-10%",
+                "disabled_on": null
+            },
+            "time_horizons": [
+                {
+                    "id": "d2d1bdbb-c42a-459c-adaa-fce45ce08cc9",
+                    "name": "Up to 5 years"
+                }
+            ],
             "construction_risks": [],
             "minimum_equity_percentage": null,
             "desired_deal_roles": [],

--- a/test/sandbox/routes/v4/search/large-investor-profile/results.js
+++ b/test/sandbox/routes/v4/search/large-investor-profile/results.js
@@ -6,6 +6,14 @@ exports.largeInvestorProfile = function (req, res) {
   const investorCompanyNameFilter = req.body.investor_company_name
   const investorTypesFilter = req.body.investor_type || []
   const requiredChecksConductedFilter = req.body.required_checks_conducted || []
+  const dealTicketSizeFilter = req.body.deal_ticket_size || []
+  const investmentTypesFilter = req.body.investment_type || []
+  const minimumReturnRateFilter = req.body.minimum_return_rate || []
+  const timeHorizonFilter = req.body.time_horizon || []
+  const restrictionsFilter = req.body.restriction || []
+  const constructionRiskFilter = req.body.construction_risk || []
+  const minimumEquityPercentageFilter = req.body.minimum_equity_percentage || []
+  const desiredDealRoleFilter = req.body.desired_deal_role || []
 
   const filtered = largeCapitalProfile.results
     .filter(({ country_of_origin }) =>
@@ -37,6 +45,66 @@ exports.largeInvestorProfile = function (req, res) {
       requiredChecksConductedFilter.length
         ? required_checks_conducted &&
           requiredChecksConductedFilter.includes(required_checks_conducted.id)
+        : true
+    )
+    .filter(({ deal_ticket_sizes = [] }) =>
+      dealTicketSizeFilter.length
+        ? _.intersection(
+            dealTicketSizeFilter,
+            deal_ticket_sizes.map((x) => x.id)
+          ).length
+        : true
+    )
+    .filter(({ investment_types = [] }) =>
+      investmentTypesFilter.length
+        ? _.intersection(
+            investmentTypesFilter,
+            investment_types.map((x) => x.id)
+          ).length
+        : true
+    )
+    .filter(({ minimum_return_rate }) =>
+      minimumReturnRateFilter.length
+        ? minimum_return_rate &&
+          minimumReturnRateFilter.includes(minimum_return_rate.id)
+        : true
+    )
+    .filter(({ time_horizons = [] }) =>
+      timeHorizonFilter.length
+        ? _.intersection(
+            timeHorizonFilter,
+            time_horizons.map((x) => x.id)
+          ).length
+        : true
+    )
+    .filter(({ restrictions = [] }) =>
+      restrictionsFilter.length
+        ? _.intersection(
+            restrictionsFilter,
+            restrictions.map((x) => x.id)
+          ).length
+        : true
+    )
+    .filter(({ construction_risks = [] }) =>
+      constructionRiskFilter.length
+        ? _.intersection(
+            constructionRiskFilter,
+            construction_risks.map((x) => x.id)
+          ).length
+        : true
+    )
+    .filter(({ minimum_equity_percentage }) =>
+      minimumEquityPercentageFilter.length
+        ? minimum_equity_percentage &&
+          minimumEquityPercentageFilter.includes(minimum_equity_percentage.id)
+        : true
+    )
+    .filter(({ desired_deal_roles = [] }) =>
+      desiredDealRoleFilter.length
+        ? _.intersection(
+            desiredDealRoleFilter,
+            desired_deal_roles.map((x) => x.id)
+          ).length
         : true
     )
 


### PR DESCRIPTION
## Description of change
This adds some 'investor requirement' filters for the Capital Investment Investor Profiles list.

## Test instructions

To view locally, visit: http://localhost:3000/investments/profiles and test out the filters from 'Deal ticket size' onwards.

## Known issues (prioritised to be fixed later)

- There is a large degree of repetition in the code, which we've agreed to spend time later this mission in refactoring
- There is a plan in the future to group some of the filters so that the UX is easier to parse.

## Screenshots
<img width="1233" alt="Screenshot 2021-03-08 at 16 54 02" src="https://user-images.githubusercontent.com/23265724/110353544-150e2980-802f-11eb-9762-30f4dd0c83d5.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
