### PR TITLE
Search bar repositioning based on the latest wireframe

### DIFF
--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -27,6 +27,15 @@ const SearchContainer = styled(Container)`
   ${MEDIA_QUERIES.TABLET} {
     padding: ${SPACING.SCALE_3} 0;
   }
+
+  ${MEDIA_QUERIES.DESKTOP} {
+    padding: ${SPACING.SCALE_4} 0;
+  }
+
+  @media only screen and (min-width: 960px) {
+    margin: 0 auto;
+    max-width: 960px;
+  }
 `
 
 const PersonalisedDashboard = ({ id, adviser, csrfToken }) => (

--- a/src/client/components/Search/index.jsx
+++ b/src/client/components/Search/index.jsx
@@ -10,11 +10,11 @@ import SearchButton from '../SearchButton'
 const StyledSearchContainer = styled('div')`
   position: relative;
   width: 100%;
-  max-width: 900px;
 `
 
 const StyledSearchInput = styled(Input)`
   width: 100%;
+  border: 0;
 `
 
 const Search = ({ csrfToken }) => (

--- a/src/client/components/SearchButton/index.jsx
+++ b/src/client/components/SearchButton/index.jsx
@@ -6,14 +6,14 @@ import VisuallyHidden from '@govuk-react/visually-hidden'
 
 const StyledButton = styled('button')`
   position: absolute;
-  top: 1px;
-  right: 1px;
-  border: 0px;
-  margin: 0px;
+  top: 0;
+  right: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
   cursor: pointer;
   padding: 10px;
   overflow: hidden;
-  border-radius: 0;
   box-sizing: border-box;
   width: ${({ size }) => `${size}px`};
   height: ${({ size }) => `${size}px`};
@@ -21,7 +21,7 @@ const StyledButton = styled('button')`
 `
 
 const SearchButton = ({
-  size = 38,
+  size = 40,
   colour = WHITE,
   backgroundColour = BLACK,
 }) => (


### PR DESCRIPTION
## Description of change
Reposition the search bar inline with the latest wireframe so the width is 960px and aligns to the Data Hub page header.

## Screenshots
<img width="1267" alt="repositioning" src="https://user-images.githubusercontent.com/964268/110630220-ffb70d80-819c-11eb-9566-16556ebd4e97.png">

### Removal of black border on the input field
<img width="1241" alt="Screenshot 2021-03-10 at 13 24 28" src="https://user-images.githubusercontent.com/964268/110636476-33e1fc80-81a4-11eb-8c80-5b6dffed3755.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
