### PR TITLE
Remove download button for Export wins collection results

### DIFF
--- a/src/client/components/DownloadDataHeader/index.jsx
+++ b/src/client/components/DownloadDataHeader/index.jsx
@@ -20,7 +20,7 @@ const DownloadDataHeader = ({
   entityName = '',
   ...props
 }) => {
-  if (!count) {
+  if (!count || !downloadLink) {
     return null
   }
 

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -372,6 +372,10 @@ describe('Company Export tab', () => {
         visitExports(fixtures.company.marsExportsLtd.id)
       })
 
+      it('should not display a download data header', () => {
+        cy.get('[data-test="download-data-header"]').should('not.exist')
+      })
+
       it('should have the correct count and number of visible results', () => {
         cy.contains('15 results')
         cy.get(exportSelectors.exportWins.listItemHeadings).should(


### PR DESCRIPTION
## Description of change
We need to remove the download button from the Export wins collection list page. Not all collection lists should have this option as in the context of "Export wins" there is no API for this to happen.

## Test instructions
- You will need to see a company with Export wins, run the functional test and you will see that the button no longer displays.

## Screenshots

### Before
![Screenshot 2021-03-11 at 11 19 54](https://user-images.githubusercontent.com/10154302/110779971-183a2d00-825c-11eb-9b04-49b2620257cd.png)

## After
![Screenshot 2021-03-11 at 11 23 18](https://user-images.githubusercontent.com/10154302/110780078-343dce80-825c-11eb-9d71-d757c439f204.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
