### PR TITLE
Remove both My referrals and My Pipeline tabs from the new dashboard

### DIFF
--- a/src/client/components/DashboardTabs/index.jsx
+++ b/src/client/components/DashboardTabs/index.jsx
@@ -4,8 +4,6 @@ import styled from 'styled-components'
 
 import urls from '../../../lib/urls'
 import CompanyLists from '../CompanyLists'
-import ReferralList from '../ReferralList'
-import Pipeline from '../Pipeline'
 import MyInvestmentProjects from '../MyInvestmentProjects'
 import TabNav from '../TabNav'
 
@@ -27,14 +25,6 @@ const DashboardTabs = ({ id, adviser }) => (
         [urls.dashboard()]: {
           label: 'My companies lists',
           content: <CompanyLists />,
-        },
-        [urls.companies.referrals.list()]: {
-          label: 'My referrals',
-          content: <ReferralList id={`${id}:ReferralList`} />,
-        },
-        [urls.pipeline.index()]: {
-          label: 'My pipeline',
-          content: <Pipeline />,
         },
       }}
     />


### PR DESCRIPTION
## Description of change
Investment project users of the _new dashboard_ have no requirement to view either `My referrals` or `My pipeline`.

## Test instructions
- You need to view the new dashboard, for instructions see #3269 

## Screenshots
### Before

<img width="799" alt="before" src="https://user-images.githubusercontent.com/964268/110825632-2dc74b00-828c-11eb-8970-47533d2ea875.png">


### After

<img width="799" alt="after" src="https://user-images.githubusercontent.com/964268/110825662-33bd2c00-828c-11eb-80a1-dec65b427f7e.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
