### PR TITLE
Fix sort by on reminders api call

### DIFF
--- a/src/client/components/PersonalisedDashboard/tasks.js
+++ b/src/client/components/PersonalisedDashboard/tasks.js
@@ -6,7 +6,7 @@ export const fetchOutstandingPropositions = ({ adviser }) =>
       params: {
         adviser_id: adviser.id,
         status: 'ongoing',
-        sortBy: 'deadline',
+        sortby: 'deadline',
         limit: 5,
       },
     })


### PR DESCRIPTION
## Description of change

The new dashboard reminders component was not sorting correctly because the query parameter was set incorrectly - this has now been fixed.

## Test instructions

With the new dashboard feature flag set, go to the dashboard page. The Reminders component should now appear with the nearest dates at the top.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
