### PR TITLE
Feature/investment projects numerical range filters

### DIFF
--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -9,6 +9,7 @@ import {
   RoutedTypeahead,
 } from '../../../../client/components/'
 import RoutedInputField from '../../../../client/components/RoutedInputField'
+import RoutedNumericRangeField from '../../../../client/components/RoutedNumericRangeField'
 import { TASK_GET_PROFILES_LIST, ID } from './state'
 import { INVESTMENTS__PROFILES_LOADED } from '../../../../client/actions'
 
@@ -26,6 +27,8 @@ const QS_PARAMS = {
   constructionRisk: 'construction_risk',
   minimumEquityPercentage: 'minimum_equity_percentage',
   desiredDealRole: 'desired_deal_role',
+  investableCapital: 'investable_capital',
+  globalAssetsUnderManagement: 'global_assets_under_management',
 }
 
 const resolveSelectedOptions = (values = [], options = []) =>
@@ -96,6 +99,20 @@ const LargeCapitalProfileCollection = ({
         return companyName ? [{ label: companyName, value: companyName }] : []
       }
 
+      const investableCapital = {
+        min: parseFloat(qsParams[`${QS_PARAMS.investableCapital}_min`]),
+        max: parseFloat(qsParams[`${QS_PARAMS.investableCapital}_max`]),
+      }
+
+      const globalAssetsUnderManagement = {
+        min: parseFloat(
+          qsParams[`${QS_PARAMS.globalAssetsUnderManagement}_min`]
+        ),
+        max: parseFloat(
+          qsParams[`${QS_PARAMS.globalAssetsUnderManagement}_max`]
+        ),
+      }
+
       return (
         <FilteredCollectionList
           count={count}
@@ -125,6 +142,8 @@ const LargeCapitalProfileCollection = ({
                 minimumEquityPercentage:
                   qsParams[QS_PARAMS.minimumEquityPercentage],
                 desiredDealRole: qsParams[QS_PARAMS.desiredDealRole],
+                investableCapital,
+                globalAssetsUnderManagement,
               },
               onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
             },
@@ -145,6 +164,8 @@ const LargeCapitalProfileCollection = ({
             selectedConstructionRisk,
             selectedMinimumEquityPercentage,
             selectedDesiredDealRole,
+            selectedInvestableCapital: investableCapital,
+            selectedGlobalAssetsUnderManagement: globalAssetsUnderManagement,
           }}
         >
           <CollectionFilters
@@ -193,6 +214,16 @@ const LargeCapitalProfileCollection = ({
               options={filterOptions.investorTypes}
               selectedOptions={selectedInvestorTypes}
               data-test="investor-type-filter"
+            />
+            <RoutedNumericRangeField
+              qsParam={QS_PARAMS.investableCapital}
+              id="LargeCapitalProfileCollection.investable-capital"
+              label="Investable capital"
+            />
+            <RoutedNumericRangeField
+              qsParam={QS_PARAMS.globalAssetsUnderManagement}
+              id="LargeCapitalProfileCollection.global-assets-under-management"
+              label="Global assets under management"
             />
             <RoutedTypeahead
               isMulti={true}

--- a/src/apps/investments/client/profiles/tasks.js
+++ b/src/apps/investments/client/profiles/tasks.js
@@ -16,6 +16,8 @@ export function getLargeCapitalProfiles({
   constructionRisk,
   minimumEquityPercentage,
   desiredDealRole,
+  investableCapital,
+  globalAssetsUnderManagement,
 }) {
   let offset = limit * (parseInt(page, 10) - 1) || 0
   return apiProxyAxios
@@ -36,6 +38,23 @@ export function getLargeCapitalProfiles({
       desired_deal_role: desiredDealRole,
       ...(investorCompanyName
         ? { investor_company_name: investorCompanyName }
+        : {}),
+      ...(globalAssetsUnderManagement.min
+        ? {
+            global_assets_under_management_start:
+              globalAssetsUnderManagement.min,
+          }
+        : {}),
+      ...(globalAssetsUnderManagement.max
+        ? {
+            global_assets_under_management_end: globalAssetsUnderManagement.max,
+          }
+        : {}),
+      ...(investableCapital.min
+        ? { investable_capital_start: investableCapital.min }
+        : {}),
+      ...(investableCapital.max
+        ? { investable_capital_end: investableCapital.max }
         : {}),
     })
     .then(({ data }) => {

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -202,7 +202,7 @@ function FilteredCollectionHeader({
         />
         <RoutedFilterChips
           selectedOptions={
-            selectedFilters.selectedInvestableCapital.min
+            selectedFilters.selectedInvestableCapital?.min
               ? [
                   {
                     categoryLabel: 'Investable capital min',
@@ -216,7 +216,7 @@ function FilteredCollectionHeader({
         />
         <RoutedFilterChips
           selectedOptions={
-            selectedFilters.selectedInvestableCapital.max
+            selectedFilters.selectedInvestableCapital?.max
               ? [
                   {
                     categoryLabel: 'Investable capital max',
@@ -230,7 +230,7 @@ function FilteredCollectionHeader({
         />
         <RoutedFilterChips
           selectedOptions={
-            selectedFilters.selectedGlobalAssetsUnderManagement.min
+            selectedFilters.selectedGlobalAssetsUnderManagement?.min
               ? [
                   {
                     categoryLabel: 'Global assets under management min',
@@ -245,7 +245,7 @@ function FilteredCollectionHeader({
         />
         <RoutedFilterChips
           selectedOptions={
-            selectedFilters.selectedGlobalAssetsUnderManagement.max
+            selectedFilters.selectedGlobalAssetsUnderManagement?.max
               ? [
                   {
                     categoryLabel: 'Global assets under management max',

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -200,6 +200,64 @@ function FilteredCollectionHeader({
           selectedOptions={selectedFilters.selectedRequiredChecksConducted}
           qsParamName="required_checks_conducted"
         />
+        <RoutedFilterChips
+          selectedOptions={
+            selectedFilters.selectedInvestableCapital.min
+              ? [
+                  {
+                    categoryLabel: 'Investable capital min',
+                    label: selectedFilters.selectedInvestableCapital.min,
+                  },
+                ]
+              : []
+          }
+          qsParamName="investable_capital_min"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
+          selectedOptions={
+            selectedFilters.selectedInvestableCapital.max
+              ? [
+                  {
+                    categoryLabel: 'Investable capital max',
+                    label: selectedFilters.selectedInvestableCapital.max,
+                  },
+                ]
+              : []
+          }
+          qsParamName="investable_capital_max"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
+          selectedOptions={
+            selectedFilters.selectedGlobalAssetsUnderManagement.min
+              ? [
+                  {
+                    categoryLabel: 'Global assets under management min',
+                    label:
+                      selectedFilters.selectedGlobalAssetsUnderManagement.min,
+                  },
+                ]
+              : []
+          }
+          qsParamName="global_assets_under_management_min"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
+          selectedOptions={
+            selectedFilters.selectedGlobalAssetsUnderManagement.max
+              ? [
+                  {
+                    categoryLabel: 'Global assets under management max',
+                    label:
+                      selectedFilters.selectedGlobalAssetsUnderManagement.max,
+                  },
+                ]
+              : []
+          }
+          qsParamName="global_assets_under_management_max"
+          showCategoryLabels={true}
+        />
       </CollectionHeaderRow>
     </CollectionHeaderRowContainer>
   )
@@ -209,6 +267,7 @@ FilteredCollectionHeader.propTypes = {
   totalItems: PropTypes.number.isRequired,
   collectionName: PropTypes.string.isRequired,
   addItemUrl: PropTypes.string,
+  // FIXME: This doesn't reflect the reality
   selectedFilters: PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.string,

--- a/src/client/components/RoutedInput/index.jsx
+++ b/src/client/components/RoutedInput/index.jsx
@@ -21,6 +21,7 @@ const RoutedInput = ({
   // being unrecognized input atributes
   dispatch,
   staticContext,
+  id,
   ...props
 }) => {
   // This is the only way we can reset the value when the query string param is

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -32,13 +32,12 @@ const testTypeaheadFilter = ({
   })
 }
 
-const testInputFilter = ({ placeholder, text, expectedNumberOfResults }) => {
+const testInputFilter = ({ selector, text, expectedNumberOfResults }) => {
   context(`When inputting text "${text}"`, () => {
     it(`There should be ${expectedNumberOfResults} items found`, () => {
       cy.visit(urls.investments.profiles.index())
-      cy.get(`[placeholder="${placeholder}"]`).within((e) =>
-        cy.wrap(e).type(text).blur()
-      )
+      // cy.get(`[placeholder="${placeholder}"]`).within((e) =>
+      cy.get(selector).within((e) => cy.wrap(e).type(text).blur())
       cy.contains(
         `${expectedNumberOfResults} Profile${
           expectedNumberOfResults > 1 ? 's' : ''
@@ -62,11 +61,11 @@ const typeaheadFilterTestCases = ({ filterName, selector, cases }) =>
     )
   )
 
-const inputFilterTestCases = ({ filterName, placeholder, cases }) =>
+const inputFilterTestCases = ({ filterName, selector, cases }) =>
   context(filterName, () =>
     cases.forEach((options) =>
       testInputFilter({
-        placeholder,
+        selector,
         ...options,
       })
     )
@@ -163,7 +162,7 @@ describe('Investor profiles filters', () => {
 
   inputFilterTestCases({
     filterName: 'Company name',
-    placeholder: 'Search company name',
+    selector: '[placeholder="Search company name"]',
     cases: [
       {
         text: 'foo',
@@ -176,6 +175,98 @@ describe('Investor profiles filters', () => {
       {
         text: 'bing',
         expectedNumberOfResults: 0,
+      },
+    ],
+  })
+
+  inputFilterTestCases({
+    filterName: 'Investable capital min',
+    selector: '[aria-label="Investable capital min"]',
+    cases: [
+      {
+        text: '1000',
+        expectedNumberOfResults: 3,
+      },
+      {
+        text: '1001',
+        expectedNumberOfResults: 2,
+      },
+      {
+        text: '2001',
+        expectedNumberOfResults: 1,
+      },
+      {
+        text: '3001',
+        expectedNumberOfResults: 0,
+      },
+    ],
+  })
+
+  inputFilterTestCases({
+    filterName: 'Investable capital max',
+    selector: '[aria-label="Investable capital max"]',
+    cases: [
+      {
+        text: '999',
+        expectedNumberOfResults: 0,
+      },
+      {
+        text: '1000',
+        expectedNumberOfResults: 1,
+      },
+      {
+        text: '2000',
+        expectedNumberOfResults: 2,
+      },
+      {
+        text: '3000',
+        expectedNumberOfResults: 3,
+      },
+    ],
+  })
+
+  inputFilterTestCases({
+    filterName: 'Global assets under management min',
+    selector: '[aria-label="Global assets under management min"]',
+    cases: [
+      {
+        text: '1000',
+        expectedNumberOfResults: 3,
+      },
+      {
+        text: '1001',
+        expectedNumberOfResults: 2,
+      },
+      {
+        text: '2001',
+        expectedNumberOfResults: 1,
+      },
+      {
+        text: '3001',
+        expectedNumberOfResults: 0,
+      },
+    ],
+  })
+
+  inputFilterTestCases({
+    filterName: 'Global assets under management max',
+    selector: '[aria-label="Global assets under management max"]',
+    cases: [
+      {
+        text: '999',
+        expectedNumberOfResults: 0,
+      },
+      {
+        text: '1000',
+        expectedNumberOfResults: 1,
+      },
+      {
+        text: '2000',
+        expectedNumberOfResults: 2,
+      },
+      {
+        text: '3000',
+        expectedNumberOfResults: 3,
       },
     ],
   })

--- a/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
+++ b/test/sandbox/fixtures/v4/investment/large-capital-profile-list10.json
@@ -368,7 +368,6 @@
             "incomplete_details_fields": [
                 "investor_type",
                 "investable_capital",
-                "global_assets_under_management",
                 "investor_description",
                 "required_checks_conducted"
             ],
@@ -388,8 +387,8 @@
                 "name": "Fund of funds",
                 "id": "ab084390-36bd-460d-ae7e-f33f173f5356"
             },
-            "investable_capital": null,
-            "global_assets_under_management": null,
+            "investable_capital": 1000,
+            "global_assets_under_management": 1000,
             "investor_description": "",
             "required_checks_conducted": null,
             "required_checks_conducted_on": null,
@@ -443,8 +442,6 @@
             },
             "incomplete_details_fields": [
                 "investor_type",
-                "investable_capital",
-                "global_assets_under_management",
                 "investor_description"
             ],
             "incomplete_requirements_fields": [
@@ -461,8 +458,8 @@
                 "other_countries_being_considered"
             ],
             "investor_type": null,
-            "investable_capital": null,
-            "global_assets_under_management": null,
+            "investable_capital": 2000,
+            "global_assets_under_management": 2000,
             "investor_description": "",
             "required_checks_conducted": {
                 "id": "9beab8fc-1094-49b4-97d0-37bc7a9de631",
@@ -518,8 +515,6 @@
             },
             "incomplete_details_fields": [
                 "investor_type",
-                "investable_capital",
-                "global_assets_under_management",
                 "investor_description"
             ],
             "incomplete_requirements_fields": [
@@ -539,8 +534,8 @@
                 "other_countries_being_considered"
             ],
             "investor_type": null,
-            "investable_capital": null,
-            "global_assets_under_management": null,
+            "investable_capital": 3000,
+            "global_assets_under_management": 3000,
             "investor_description": "",
             "required_checks_conducted": {
                 "id": "9beab8fc-1094-49b4-97d0-37bc7a9de631",

--- a/test/sandbox/routes/v4/search/large-investor-profile/results.js
+++ b/test/sandbox/routes/v4/search/large-investor-profile/results.js
@@ -15,6 +15,16 @@ exports.largeInvestorProfile = function (req, res) {
   const minimumEquityPercentageFilter = req.body.minimum_equity_percentage || []
   const desiredDealRoleFilter = req.body.desired_deal_role || []
 
+  const investableCapitalFilter = {
+    min: req.body.investable_capital_start,
+    max: req.body.investable_capital_end,
+  }
+
+  const globalAssetsUnderManagementFilter = {
+    min: req.body.global_assets_under_management_start,
+    max: req.body.global_assets_under_management_end,
+  }
+
   const filtered = largeCapitalProfile.results
     .filter(({ country_of_origin }) =>
       countryOfOriginFilter.length
@@ -106,6 +116,32 @@ exports.largeInvestorProfile = function (req, res) {
             desired_deal_roles.map((x) => x.id)
           ).length
         : true
+    )
+    .filter(({ investable_capital }) =>
+      investableCapitalFilter.min === undefined
+        ? true
+        : investable_capital &&
+          investable_capital >= investableCapitalFilter.min
+    )
+    .filter(({ investable_capital }) =>
+      investableCapitalFilter.max === undefined
+        ? true
+        : investable_capital &&
+          investable_capital <= investableCapitalFilter.max
+    )
+    .filter(({ global_assets_under_management }) =>
+      globalAssetsUnderManagementFilter.min === undefined
+        ? true
+        : global_assets_under_management &&
+          global_assets_under_management >=
+            globalAssetsUnderManagementFilter.min
+    )
+    .filter(({ global_assets_under_management }) =>
+      globalAssetsUnderManagementFilter.max === undefined
+        ? true
+        : global_assets_under_management &&
+          global_assets_under_management <=
+            globalAssetsUnderManagementFilter.max
     )
 
   res.json({


### PR DESCRIPTION
## Description of change

Adds the _Global assets under management_ and _Investable capital_ numerical range filters to the `/investments/profiles` page.

## Test instructions

1. Add and enable the `capital-investments-filters` feature flag
2. Go to the `/investments/profiles` page
3. You should see the _Global assets under management_ and _Investable capital_ numerical range filters on the left
4. The filters should work
