### PR TITLE
Styled the TabNav component inline with the personalised dashboard design

### DIFF
--- a/src/client/components/PersonalisedDashboard/blue-theme.js
+++ b/src/client/components/PersonalisedDashboard/blue-theme.js
@@ -8,6 +8,9 @@ export default {
       fontWeight: 'bold',
       border: `2px solid ${BLUE}`,
     },
+    tabList: {
+      borderBottom: 0,
+    },
     tabPanel: {
       border: `2px solid ${BLUE}`,
       padding: '15px 15px 0 15px',

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -104,7 +104,8 @@ const StyledSelectedButton = styled(FocusableButton)({
 const StyledTablist = styled.div({
   borderBottom: 'none',
   [MEDIA_QUERIES.TABLET]: {
-    borderBottom: `1px solid ${BORDER_COLOUR}`,
+    borderBottom: ({ theme }) =>
+      get(theme, 'tabNav.tabList.borderBottom', `1px solid ${BORDER_COLOUR}`),
     '& > *:not(:last-child)': {
       marginRight: 5,
     },


### PR DESCRIPTION
## Description of change
Removed the bottom border on the TabList within the TabNav component
 
## Screenshots
### Before
<img width="630" alt="before" src="https://user-images.githubusercontent.com/964268/111287436-2365d200-863b-11eb-872e-c33fc6702e7c.png">


### After

<img width="630" alt="after" src="https://user-images.githubusercontent.com/964268/111287350-0cbf7b00-863b-11eb-8ccb-1c96b3057f70.png">



## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
