### PR TITLE
Apply bespoke order and labels to investment summary date picker

### DIFF
--- a/src/client/components/DataSummaryPicker/index.jsx
+++ b/src/client/components/DataSummaryPicker/index.jsx
@@ -47,9 +47,10 @@ const DataSummaryPicker = ({
             onSelectDataRange(e.target.value)
           },
         }}
+        data-test="data-summary-select"
       >
         {dataRanges.map(({ label, name }) => (
-          <option value={name} key={name}>
+          <option value={name} key={name} data-test="data-summary-option">
             {label}
           </option>
         ))}

--- a/src/client/components/InvestmentProjectSummary/utils.js
+++ b/src/client/components/InvestmentProjectSummary/utils.js
@@ -19,20 +19,26 @@ export const investmentSummaryAsDataRanges = (investmentSummary) => {
       const oneYearAgo = subYears(now, 1)
       const oneYearAhead = addYears(now, 1)
 
-      let label, order
-      if (startDate <= now && endDate >= now) {
-        label = `Current financial year (${financial_year.label})`
-        order = 0
-      } else if (startDate <= oneYearAgo && endDate >= oneYearAgo) {
-        label = `Previous financial year (${financial_year.label})`
-        order = 1
-      } else if (startDate <= oneYearAhead && endDate >= oneYearAhead) {
-        label = 'Upcoming financial year'
-        order = 2
-      } else {
-        label = financial_year.label
-        order = 3
-      }
+      const { label, order } =
+        startDate <= now && endDate >= now
+          ? {
+              label: `Current financial year (${financial_year.label})`,
+              order: 0,
+            }
+          : startDate <= oneYearAgo && endDate >= oneYearAgo
+          ? {
+              label: `Previous financial year (${financial_year.label})`,
+              order: 1,
+            }
+          : startDate <= oneYearAhead && endDate >= oneYearAhead
+          ? {
+              label: 'Upcoming financial year',
+              order: 2,
+            }
+          : {
+              label: financial_year.label,
+              order: 3,
+            }
 
       return {
         label,

--- a/src/client/components/InvestmentProjectSummary/utils.js
+++ b/src/client/components/InvestmentProjectSummary/utils.js
@@ -1,14 +1,13 @@
-import { get } from 'lodash'
 import { addYears, subYears } from 'date-fns'
 
 /**
  * Converts investment summary received by the API into data ranges
  * that the chart component can work with
  */
-export const investmentSummaryAsDataRanges = (investmentSummary) => {
-  const annualSummaries = get(investmentSummary, 'annual_summaries', [])
-  const adviserId = get(investmentSummary, 'adviser_id')
-
+export const investmentSummaryAsDataRanges = ({
+  annual_summaries: annualSummaries,
+  adviser_id: adviserId,
+}) => {
   const labelledSummaries = annualSummaries.map(
     ({ financial_year, totals }) => {
       const { start, end } = financial_year
@@ -52,7 +51,6 @@ export const investmentSummaryAsDataRanges = (investmentSummary) => {
     }
   )
 
-  return labelledSummaries
-    .sort((a, b) => a.order > b.order)
-    .map(({ order, ...rest }) => ({ ...rest }))
+  labelledSummaries.sort((a, b) => a.order - b.order)
+  return labelledSummaries.map(({ order, ...rest }) => ({ ...rest }))
 }

--- a/src/client/components/InvestmentProjectSummary/utils.js
+++ b/src/client/components/InvestmentProjectSummary/utils.js
@@ -1,4 +1,5 @@
 import { get } from 'lodash'
+import { addYears, subYears } from 'date-fns'
 
 /**
  * Converts investment summary received by the API into data ranges
@@ -8,20 +9,44 @@ export const investmentSummaryAsDataRanges = (investmentSummary) => {
   const annualSummaries = get(investmentSummary, 'annual_summaries', [])
   const adviserId = get(investmentSummary, 'adviser_id')
 
-  return annualSummaries.map(({ financial_year, totals }) => {
-    const now = new Date()
-    const { start, end } = financial_year
-    const label =
-      new Date(start) <= now && new Date(end) >= now
-        ? 'Current financial year'
-        : financial_year.label
-    return {
-      label,
-      name: financial_year.start,
-      range: Object.entries(totals).map(([, props]) => ({
-        ...props,
-        link: `/investments/projects?stage=${props.id}&adviser=${adviserId}`,
-      })),
+  const labelledSummaries = annualSummaries.map(
+    ({ financial_year, totals }) => {
+      const { start, end } = financial_year
+      const startDate = new Date(start)
+      const endDate = new Date(end)
+
+      const now = new Date()
+      const oneYearAgo = subYears(now, 1)
+      const oneYearAhead = addYears(now, 1)
+
+      let label, order
+      if (startDate <= now && endDate >= now) {
+        label = `Current financial year (${financial_year.label})`
+        order = 0
+      } else if (startDate <= oneYearAgo && endDate >= oneYearAgo) {
+        label = `Previous financial year (${financial_year.label})`
+        order = 1
+      } else if (startDate <= oneYearAhead && endDate >= oneYearAhead) {
+        label = 'Upcoming financial year'
+        order = 2
+      } else {
+        label = financial_year.label
+        order = 3
+      }
+
+      return {
+        label,
+        order,
+        name: financial_year.start,
+        range: Object.entries(totals).map(([, props]) => ({
+          ...props,
+          link: `/investments/projects?stage=${props.id}&adviser=${adviserId}`,
+        })),
+      }
     }
-  })
+  )
+
+  return labelledSummaries
+    .sort((a, b) => a.order > b.order)
+    .map(({ order, ...rest }) => ({ ...rest }))
 }

--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -97,6 +97,7 @@ const PersonalisedDashboard = ({
               id="investment-project-summary-section"
               isOpen={true}
               variant={VARIANTS.PRIMARY}
+              data-test="investment-project-summary-section"
             >
               <InvestmentProjectSummary adviser={adviser} />
             </ToggleSection>

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -56,3 +56,9 @@ export const getDifferenceInDays = (dateIn) => {
     ? difference * -1 + ' days ago'
     : difference + ' days'
 }
+
+export const getFinancialYearStart = (date) =>
+  date.getMonth() < 4 ? date.getFullYear() - 1 : date.getFullYear()
+
+export const generateFinancialYearLabel = (yearStart) =>
+  `${yearStart}-${(yearStart + 1).toString().slice(-2)}`

--- a/test/functional/cypress/specs/dashboard-new/investment-project-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/investment-project-summary-spec.js
@@ -1,0 +1,56 @@
+import {
+  getFinancialYearStart,
+  generateFinancialYearLabel,
+} from '../../../../../src/client/utils/date-utils'
+
+describe('Investment projects summary', () => {
+  beforeEach(() => {
+    cy.setFeatureFlag(
+      'layoutTesting:9010dd28-9798-e211-a939-e4115bead28a',
+      true
+    )
+    cy.visit('/')
+    cy.get('[data-test="investment-project-summary-section"]').as(
+      'investmentProjectsSummarySection'
+    )
+  })
+  after(() => {
+    cy.resetFeatureFlags()
+  })
+
+  context('Date picker options', () => {
+    it('should contain a date select with options in the correct order', () => {
+      const yearStart = getFinancialYearStart(new Date())
+
+      const expectedOptions = [
+        {
+          label: `Current financial year (${generateFinancialYearLabel(
+            yearStart
+          )})`,
+          value: `${yearStart}-04-01`,
+        },
+        {
+          label: `Previous financial year (${generateFinancialYearLabel(
+            yearStart - 1
+          )})`,
+          value: `${yearStart - 1}-04-01`,
+        },
+        {
+          label: 'Upcoming financial year',
+          value: `${yearStart + 1}-04-01`,
+        },
+      ]
+
+      cy.get('@investmentProjectsSummarySection')
+        .find('[data-test="data-summary-select"]')
+        .should('exist')
+        .find('[data-test="data-summary-option"]')
+        .should('have.length', 3)
+        .each(($el, index) => {
+          cy.wrap($el)
+            .should('have.text', expectedOptions[index].label)
+            .should('have.attr', 'value', expectedOptions[index].value)
+        })
+    })
+  })
+})

--- a/test/sandbox/routes/v4/adviser/adviser.js
+++ b/test/sandbox/routes/v4/adviser/adviser.js
@@ -1,5 +1,25 @@
 const investmentSummary = require('../../../fixtures/v4/adviser/investment-summary.json')
 
 exports.investmentSummary = function (req, res) {
-  res.json(investmentSummary)
+  const { annual_summaries, ...rest } = investmentSummary
+  const now = new Date()
+  const currentFinancialYearStart =
+    now.getMonth() < 4 ? now.getFullYear() - 1 : now.getFullYear()
+  const currentInvestmentSummary = {
+    annual_summaries: annual_summaries.map(
+      ({ financial_year, ...annualSummaryProps }, i) => {
+        const startYear = currentFinancialYearStart + 1 - i
+        return {
+          financial_year: {
+            label: `${startYear}-${(startYear + 1).toString().slice(-2)}`,
+            start: `${startYear}-04-01`,
+            end: `${startYear + 1}-03-31`,
+          },
+          ...annualSummaryProps,
+        }
+      }
+    ),
+    ...rest,
+  }
+  res.json(currentInvestmentSummary)
 }


### PR DESCRIPTION
## Description of change

Applies a bespoke order and label to each year in the investment project summary date picker as shown in the [designs](https://glc39r.axshare.com/#id=w5q8qc&p=projectlistcollapsed_mvp). This goes:

- Current financial year (2020-21)
- Previous financial year (2019-20)
- Upcoming financial year

## Test instructions

With the new dashboard feature flag enabled, check the investment project summary section. The drop down should show options in the order specified above, consistent with the [designs](https://glc39r.axshare.com/#id=w5q8qc&p=projectlistcollapsed_mvp).

Picking each option should show the relevant totals on the chart.

## Screenshots


### Before

![Screenshot from 2021-03-17 12-26-14](https://user-images.githubusercontent.com/1234577/111467737-b3c81380-871c-11eb-81f3-2f37f5dd0c50.png)

### After

![Screenshot from 2021-03-17 12-29-43](https://user-images.githubusercontent.com/1234577/111467763-baef2180-871c-11eb-9fdb-147dd84f38d0.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
