### PR TITLE
Large capital investment filter grouping

### DIFF
--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -7,6 +7,7 @@ import {
   FilteredCollectionList,
   CollectionFilters,
   RoutedTypeahead,
+  ToggleSection,
 } from '../../../../client/components/'
 import RoutedInputField from '../../../../client/components/RoutedInputField'
 import RoutedNumericRangeField from '../../../../client/components/RoutedNumericRangeField'
@@ -185,153 +186,177 @@ const LargeCapitalProfileCollection = ({
               },
             }}
           >
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Country of origin"
-              name="country"
-              qsParam={QS_PARAMS.countryOfOrigin}
-              placeholder="Search countries"
-              options={filterOptions.countries}
-              selectedOptions={selectedCountries}
-              data-test="country-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Asset class of interest"
-              name="asset-class-of-interest"
-              qsParam={QS_PARAMS.assetClassesOfInterest}
-              placeholder="Search asset classes"
-              options={filterOptions.assetClassesOfInterest}
-              selectedOptions={selectedAssetClassesOfInterest}
-              data-test="asset-class-of-interest-filter"
-            />
-            <RoutedInputField
-              id="LargeCapitalProfileCollection.investor-company-name"
-              qsParam="investor_company_name"
-              name="investor-company-name"
-              label="Company name"
-              placeholder="Search company name"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Investor type"
-              name="investor-type"
-              qsParam={QS_PARAMS.investorTypes}
-              placeholder="Search investor type"
-              options={filterOptions.investorTypes}
-              selectedOptions={selectedInvestorTypes}
-              data-test="investor-type-filter"
-            />
-            <RoutedNumericRangeField
-              qsParam={QS_PARAMS.investableCapital}
-              id="LargeCapitalProfileCollection.investable-capital"
-              label="Investable capital"
-            />
-            <RoutedNumericRangeField
-              qsParam={QS_PARAMS.globalAssetsUnderManagement}
-              id="LargeCapitalProfileCollection.global-assets-under-management"
-              label="Global assets under management"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Check clearance"
-              name="required-checks-conducted"
-              qsParam={QS_PARAMS.requiredChecksConducted}
-              placeholder="Check clearance"
-              options={filterOptions.requiredChecksConducted}
-              selectedOptions={selectedRequiredChecksConducted}
-              data-test="required-checks-conducted-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Deal ticket size"
-              name="deal-ticket-size"
-              qsParam={QS_PARAMS.dealTicketSize}
-              placeholder="Search ticket sizes"
-              options={filterOptions.dealTicketSize}
-              selectedOptions={selectedDealTicketSize}
-              data-test="deal-ticket-size-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Types of investment"
-              name="types-of-investment"
-              qsParam={QS_PARAMS.investmentTypes}
-              placeholder="Search types"
-              options={filterOptions.investmentTypes}
-              selectedOptions={selectedInvestmentTypes}
-              data-test="types-of-investment-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Minimum Return Rate"
-              name="minimum-return-rate"
-              qsParam={QS_PARAMS.minimumReturnRate}
-              placeholder="Search return rates"
-              options={filterOptions.minimumReturnRate}
-              selectedOptions={selectedMinimumReturnRate}
-              data-test="minimum-return-rate-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Time horizon tenor"
-              name="time-horizon-tenor"
-              qsParam={QS_PARAMS.timeHorizon}
-              placeholder="Search time horizons"
-              options={filterOptions.timeHorizon}
-              selectedOptions={selectedTimeHorizon}
-              data-test="time-horizon-tenor-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Restrictions and Conditions"
-              name="restrictions-conditions"
-              qsParam={QS_PARAMS.restrictions}
-              placeholder="Search restrictions"
-              options={filterOptions.restrictions}
-              selectedOptions={selectedRestrictions}
-              data-test="restrictions-conditions-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Construction risk"
-              name="construction-risk"
-              qsParam={QS_PARAMS.constructionRisk}
-              placeholder="Search risks"
-              options={filterOptions.constructionRisk}
-              selectedOptions={selectedConstructionRisk}
-              data-test="construction-risk-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Minimum equity percentage"
-              name="minimum-equity-percentage"
-              qsParam={QS_PARAMS.minimumEquityPercentage}
-              placeholder="Search percentages"
-              options={filterOptions.minimumEquityPercentage}
-              selectedOptions={selectedMinimumEquityPercentage}
-              data-test="minimum-equity-percentage-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="Desired deal role"
-              name="desired-deal-role"
-              qsParam={QS_PARAMS.desiredDealRole}
-              placeholder="Search deal roles"
-              options={filterOptions.desiredDealRole}
-              selectedOptions={selectedDesiredDealRole}
-              data-test="desired-deal-role-filter"
-            />
-            <RoutedTypeahead
-              isMulti={true}
-              legend="UK regions of interest"
-              name="uk-regions-of-interest"
-              qsParam={QS_PARAMS.ukRegionsOfInterest}
-              placeholder="Search UK regions of interest"
-              options={filterOptions.ukRegionsOfInterest}
-              selectedOptions={selectedUkRegionsOfInterest}
-              data-test="uk-regions-of-interest"
-            />
+            <ToggleSection
+              id="FilteredLargeCapitalProfileCollection.core-filters"
+              label="Core filters"
+              variant="SECONDARY"
+            >
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Asset class"
+                name="asset-class"
+                qsParam={QS_PARAMS.assetClassesOfInterest}
+                placeholder="Search asset class"
+                options={filterOptions.assetClassesOfInterest}
+                selectedOptions={selectedAssetClassesOfInterest}
+                data-test="asset-class-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Country of origin"
+                name="country"
+                qsParam={QS_PARAMS.countryOfOrigin}
+                placeholder="Search countries"
+                options={filterOptions.countries}
+                selectedOptions={selectedCountries}
+                data-test="country-filter"
+              />
+              <RoutedInputField
+                id="LargeCapitalProfileCollection.investor-company-name"
+                qsParam="investor_company_name"
+                name="investor-company-name"
+                label="Company name"
+                placeholder="Search company name"
+              />
+            </ToggleSection>
+            <ToggleSection
+              id="FilteredLargeCapitalProfileCollection.investor-details-filters"
+              label="Investor details"
+              variant="SECONDARY"
+            >
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Investor type"
+                name="investor-type"
+                qsParam={QS_PARAMS.investorTypes}
+                placeholder="Search investor type"
+                options={filterOptions.investorTypes}
+                selectedOptions={selectedInvestorTypes}
+                data-test="investor-type-filter"
+              />
+              <RoutedNumericRangeField
+                qsParam={QS_PARAMS.globalAssetsUnderManagement}
+                id="LargeCapitalProfileCollection.global-assets-under-management"
+                label="Global assets under management"
+              />
+              <RoutedNumericRangeField
+                qsParam={QS_PARAMS.investableCapital}
+                id="LargeCapitalProfileCollection.investable-capital"
+                label="Investable capital"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Check clearance"
+                name="required-checks-conducted"
+                qsParam={QS_PARAMS.requiredChecksConducted}
+                placeholder="Search clearance"
+                options={filterOptions.requiredChecksConducted}
+                selectedOptions={selectedRequiredChecksConducted}
+                data-test="required-checks-conducted-filter"
+              />
+            </ToggleSection>
+            <ToggleSection
+              id="FilteredLargeCapitalProfileCollection.investor-requirements-filters"
+              label="Investor requirements"
+              variant="SECONDARY"
+            >
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Deal ticket size"
+                name="deal-ticket-size"
+                qsParam={QS_PARAMS.dealTicketSize}
+                placeholder="Search deal ticket size"
+                options={filterOptions.dealTicketSize}
+                selectedOptions={selectedDealTicketSize}
+                data-test="deal-ticket-size-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Types of investment"
+                name="types-of-investment"
+                qsParam={QS_PARAMS.investmentTypes}
+                placeholder="Search types of investment"
+                options={filterOptions.investmentTypes}
+                selectedOptions={selectedInvestmentTypes}
+                data-test="types-of-investment-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Minimum return rate"
+                name="minimum-return-rate"
+                qsParam={QS_PARAMS.minimumReturnRate}
+                placeholder="Search return rate"
+                options={filterOptions.minimumReturnRate}
+                selectedOptions={selectedMinimumReturnRate}
+                data-test="minimum-return-rate-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Time horizon"
+                name="time-horizon-tenor"
+                qsParam={QS_PARAMS.timeHorizon}
+                placeholder="Search time horizon"
+                options={filterOptions.timeHorizon}
+                selectedOptions={selectedTimeHorizon}
+                data-test="time-horizon-tenor-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Restrictions and conditions"
+                name="restrictions-conditions"
+                qsParam={QS_PARAMS.restrictions}
+                placeholder="Search restrictions"
+                options={filterOptions.restrictions}
+                selectedOptions={selectedRestrictions}
+                data-test="restrictions-conditions-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Construction risk"
+                name="construction-risk"
+                qsParam={QS_PARAMS.constructionRisk}
+                placeholder="Search construction risk"
+                options={filterOptions.constructionRisk}
+                selectedOptions={selectedConstructionRisk}
+                data-test="construction-risk-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Minimum equity percentage"
+                name="minimum-equity-percentage"
+                qsParam={QS_PARAMS.minimumEquityPercentage}
+                placeholder="Search equity percentage"
+                options={filterOptions.minimumEquityPercentage}
+                selectedOptions={selectedMinimumEquityPercentage}
+                data-test="minimum-equity-percentage-filter"
+              />
+              <RoutedTypeahead
+                isMulti={true}
+                legend="Desired deal role"
+                name="desired-deal-role"
+                qsParam={QS_PARAMS.desiredDealRole}
+                placeholder="Search desired deal role"
+                options={filterOptions.desiredDealRole}
+                selectedOptions={selectedDesiredDealRole}
+                data-test="desired-deal-role-filter"
+              />
+            </ToggleSection>
+            <ToggleSection
+              id="FilteredLargeCapitalProfileCollection.location-filters"
+              label="Location"
+              variant="SECONDARY"
+            >
+              <RoutedTypeahead
+                isMulti={true}
+                legend="UK regions of interest"
+                name="uk-regions-of-interest"
+                qsParam={QS_PARAMS.ukRegionsOfInterest}
+                placeholder="Search UK region"
+                options={filterOptions.ukRegionsOfInterest}
+                selectedOptions={selectedUkRegionsOfInterest}
+                data-test="uk-regions-of-interest"
+              />
+            </ToggleSection>
           </CollectionFilters>
         </FilteredCollectionList>
       )

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -1,5 +1,8 @@
 const urls = require('../../../../../src/lib/urls')
 
+const expandToggleSections = () =>
+  cy.get('[data-test="toggle-section-button"]').click({ multiple: true })
+
 const testTypeaheadFilter = ({
   selector,
   options = [],
@@ -12,6 +15,7 @@ const testTypeaheadFilter = ({
   context(`When ${optionsMessage} are selected`, () => {
     it(`There should be ${expectedNumberOfResults} items found`, () => {
       cy.visit(urls.investments.profiles.index())
+      expandToggleSections()
       cy.get(`[data-test="${selector}"]`).within((e) =>
         options.forEach((option) => cy.wrap(e).type(`${option}{enter}`))
       )
@@ -36,7 +40,7 @@ const testInputFilter = ({ selector, text, expectedNumberOfResults }) => {
   context(`When inputting text "${text}"`, () => {
     it(`There should be ${expectedNumberOfResults} items found`, () => {
       cy.visit(urls.investments.profiles.index())
-      // cy.get(`[placeholder="${placeholder}"]`).within((e) =>
+      expandToggleSections()
       cy.get(selector).within((e) => cy.wrap(e).type(text).blur())
       cy.contains(
         `${expectedNumberOfResults} Profile${
@@ -95,8 +99,8 @@ describe('Investor profiles filters', () => {
   })
 
   typeaheadFilterTestCases({
-    filterName: 'Asset class of interest',
-    selector: 'asset-class-of-interest-filter',
+    filterName: 'Asset class',
+    selector: 'asset-class-filter',
     cases: [
       {
         expectedNumberOfResults: 10,
@@ -341,7 +345,7 @@ describe('Investor profiles filters', () => {
   })
 
   typeaheadFilterTestCases({
-    filterName: 'Time horizon tenor',
+    filterName: 'Time horizon',
     selector: 'time-horizon-tenor-filter',
     cases: [
       {
@@ -363,7 +367,7 @@ describe('Investor profiles filters', () => {
   })
 
   typeaheadFilterTestCases({
-    filterName: 'Restrictions and Conditions',
+    filterName: 'Restrictions and conditions',
     selector: 'restrictions-conditions-filter',
     cases: [
       {


### PR DESCRIPTION
## Description of change

This wraps groups of filters on the `/investments/profiles` page in `ToggleSection`.

## Test instructions

1. Add and enable the `capital-investments-filters` feature flag
2. Go to the `/investments/profiles` page
3. The filters on the the left hand panel should now be grouped as per [this mockup](https://8c3nz4.axshare.com/#g=1&p=investment_-_lc_profiles_-_expanded). Note that not all the filters from the mockup are implemented yet.
4. The groups should be collapsible and collapsed by default
