### PR TITLE
Estimated land date: RAG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
   && echo "Timezone: $(date +%z)"
 
 WORKDIR /usr/src/app
-WORKDIR /usr/src/app
 
 # Install dev packages
 COPY package.json .
 COPY package-lock.json .
-RUN npx npm-force-resolutions
 RUN npm install
 
 COPY . .

--- a/src/client/components/DashboardTabs/index.jsx
+++ b/src/client/components/DashboardTabs/index.jsx
@@ -12,7 +12,7 @@ const StyledDiv = styled('div')`
 `
 
 const DashboardTabs = ({ id, adviser }) => (
-  <StyledDiv data-cy="dashboard-tabs">
+  <StyledDiv data-test="dashboard-tabs">
     <TabNav
       id={`${id}.TabNav`}
       label="Dashboard"

--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -8,7 +8,7 @@ import { LINK_COLOUR, RED, TEXT } from 'govuk-colours'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import urls from '../../../lib/urls'
-import { getDifferenceInDays } from '../../utils/date-utils'
+import { getDifferenceInDaysLabel } from '../../utils/date-utils'
 
 const StyledSubHeading = styled(H3)`
   color: ${RED};
@@ -72,7 +72,7 @@ const OutstandingPropositions = ({ results, count }) => {
                 Due {format(new Date(deadline), 'd MMM yyyy')}
               </StyledDueDate>
               <StyledDueCountdown data-test="outstanding-proposition-countdown">
-                {getDifferenceInDays(deadline)}
+                {getDifferenceInDaysLabel(deadline)}
               </StyledDueCountdown>
             </StyledDeadline>
           </StyledListItem>

--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
-import { BLACK, BUTTON_COLOUR, GREY_3, RED, YELLOW } from 'govuk-colours'
+import { BLACK, BUTTON_COLOUR, GREY_2, RED, YELLOW } from 'govuk-colours'
 import { format } from 'date-fns'
 
 import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
@@ -28,7 +28,7 @@ const RedPanel = styled(StyledPanel)`
   background-color: ${rgba(RED, 0.4)};
 `
 const GreyPanel = styled(StyledPanel)`
-  background-color: ${rgba(GREY_3, 0.5)};
+  background-color: ${rgba(GREY_2, 0.5)};
 `
 
 const StyledTitle = styled('h2')`
@@ -55,10 +55,14 @@ const InvestmentEstimatedLandDate = ({ estimatedLandDate }) => {
       : GreyPanel
 
   return (
-    <Panel>
-      <StyledBody>Estimated land date</StyledBody>
-      <StyledTitle>{getDifferenceInDaysLabel(estimatedLandDate)}</StyledTitle>
-      <StyledBody>
+    <Panel data-test="estimated-land-date">
+      <StyledBody data-test="estimated-land-date-label">
+        Estimated land date
+      </StyledBody>
+      <StyledTitle data-test="estimated-land-date-countdown">
+        {getDifferenceInDaysLabel(estimatedLandDate)}
+      </StyledTitle>
+      <StyledBody data-test="estimated-land-date-date">
         {format(new Date(estimatedLandDate), DATE_DAY_LONG_FORMAT)}
       </StyledBody>
     </Panel>

--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -13,9 +13,12 @@ import {
 import { rgba } from '../../utils/colors'
 
 const StyledPanel = styled('div')`
-  padding: ${SPACING.SCALE_4};
+  padding: ${SPACING.SCALE_2};
   color: ${BLACK};
   background-color: ${YELLOW};
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `
 
 const GreenPanel = styled(StyledPanel)`
@@ -32,7 +35,7 @@ const GreyPanel = styled(StyledPanel)`
 `
 
 const StyledTitle = styled('h2')`
-  margin: ${SPACING.SCALE_1} 0;
+  margin: 0;
   text-align: center;
   font-size: ${FONT_SIZE.SIZE_24};
   font-weight: ${FONT_WEIGHTS.bold};

--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -32,8 +32,7 @@ const GreyPanel = styled(StyledPanel)`
 `
 
 const StyledTitle = styled('h2')`
-  margin-top: ${SPACING.SCALE_4};
-  margin-bottom: ${SPACING.SCALE_4};
+  margin: ${SPACING.SCALE_1} 0;
   text-align: center;
   font-size: ${FONT_SIZE.SIZE_24};
   font-weight: ${FONT_WEIGHTS.bold};

--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -1,39 +1,69 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { typography } from '@govuk-react/lib'
-import { SPACING } from '@govuk-react/constants'
-import { YELLOW, BLACK } from 'govuk-colours'
+import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
+import { BLACK, BUTTON_COLOUR, GREY_3, RED, YELLOW } from 'govuk-colours'
 import { format } from 'date-fns'
 
 import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
-import { getDifferenceInDays } from '../../utils/date-utils'
+import {
+  getDifferenceInDays,
+  getDifferenceInDaysLabel,
+} from '../../utils/date-utils'
+import { rgba } from '../../utils/colors'
 
 const StyledPanel = styled('div')`
   padding: ${SPACING.SCALE_4};
   color: ${BLACK};
   background-color: ${YELLOW};
 `
+
+const GreenPanel = styled(StyledPanel)`
+  background-color: ${rgba(BUTTON_COLOUR, 0.3)};
+`
+const AmberPanel = styled(StyledPanel)`
+  background-color: ${rgba(YELLOW, 0.5)};
+`
+const RedPanel = styled(StyledPanel)`
+  background-color: ${rgba(RED, 0.4)};
+`
+const GreyPanel = styled(StyledPanel)`
+  background-color: ${rgba(GREY_3, 0.5)};
+`
+
 const StyledTitle = styled('h2')`
   margin-top: ${SPACING.SCALE_4};
   margin-bottom: ${SPACING.SCALE_4};
   text-align: center;
-  font-size: ${typography.font({ size: 36, weight: 'bold' })};
+  font-size: ${FONT_SIZE.SIZE_24};
+  font-weight: ${FONT_WEIGHTS.bold};
 `
 const StyledBody = styled('div')`
   text-align: center;
-  font-size: ${typography.font({ size: 16 })};
+  font-size: ${FONT_SIZE.SIZE_14};
 `
 
-const InvestmentEstimatedLandDate = ({ estimatedLandDate }) => (
-  <StyledPanel>
-    <StyledBody>Estimated land date</StyledBody>
-    <StyledTitle>{getDifferenceInDays(estimatedLandDate)}</StyledTitle>
-    <StyledBody>
-      {format(new Date(estimatedLandDate), DATE_DAY_LONG_FORMAT)}
-    </StyledBody>
-  </StyledPanel>
-)
+const InvestmentEstimatedLandDate = ({ estimatedLandDate }) => {
+  const difference = getDifferenceInDays(estimatedLandDate)
+  const Panel =
+    difference >= 90
+      ? GreenPanel
+      : difference >= 30
+      ? AmberPanel
+      : difference >= 0
+      ? RedPanel
+      : GreyPanel
+
+  return (
+    <Panel>
+      <StyledBody>Estimated land date</StyledBody>
+      <StyledTitle>{getDifferenceInDaysLabel(estimatedLandDate)}</StyledTitle>
+      <StyledBody>
+        {format(new Date(estimatedLandDate), DATE_DAY_LONG_FORMAT)}
+      </StyledBody>
+    </Panel>
+  )
+}
 
 InvestmentEstimatedLandDate.propTypes = {
   estimatedLandDate: PropTypes.string.isRequired,

--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -43,7 +43,7 @@ const StyledBody = styled('div')`
   font-size: ${FONT_SIZE.SIZE_14};
 `
 
-const InvestmentEstimatedLandDate = ({ estimatedLandDate }) => {
+const InvestmentEstimatedLandDate = ({ estimatedLandDate, ...props }) => {
   const difference = getDifferenceInDays(estimatedLandDate)
   const Panel =
     difference >= 90
@@ -55,7 +55,7 @@ const InvestmentEstimatedLandDate = ({ estimatedLandDate }) => {
       : GreyPanel
 
   return (
-    <Panel data-test="estimated-land-date">
+    <Panel data-test="estimated-land-date" {...props}>
       <StyledBody data-test="estimated-land-date-label">
         Estimated land date
       </StyledBody>

--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -23,9 +23,15 @@ const ListItem = styled('li')`
 
 const Row = styled('div')`
   margin-bottom: ${SPACING.SCALE_3};
+
   ${MEDIA_QUERIES.LARGESCREEN} {
     display: flex;
     justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  ${MEDIA_QUERIES.DESKTOP} {
+    flex-wrap: nowrap;
   }
 `
 const Col = styled('div')`
@@ -55,6 +61,7 @@ const ListItemHeaderTagContainer = styled('div')`
 const ListItemHeaderActionContainer = styled('div')`
   flex: 0 1 170px;
   box-sizing: border-box;
+  white-space: nowrap;
 
   a {
     width: 100%;
@@ -90,23 +97,30 @@ const StyledDetails = styled(Details)`
     height: 30px;
     clip-path: none;
     background: url(${icon}) 0 0 no-repeat;
-    transform: rotate(0);
   }
 `
 
 const StyledInvestmentTimeline = styled(InvestmentTimeline)`
   display: none;
-  flex: 1 0;
   box-sizing: border-box;
 
-  ${MEDIA_QUERIES.TABLET} {
-    display: block;
+  ${MEDIA_QUERIES.LARGESCREEN} {
+    display: flex;
+    flex: 1 0 100%;
+  }
+
+  ${MEDIA_QUERIES.DESKTOP} {
+    flex: 1 0 330px;
   }
 `
 
 const StyledInvestmentEstimatedLandDate = styled(InvestmentEstimatedLandDate)`
-  flex: 0 1 170px;
+  flex: 1 1 100%;
   box-sizing: border-box;
+
+  ${MEDIA_QUERIES.DESKTOP} {
+    flex: 0 1 170px;
+  }
 `
 
 const InvestmentListItem = ({

--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -4,7 +4,12 @@ import { Details } from 'govuk-react'
 import Button from '@govuk-react/button'
 import { BLUE, GREY_1 } from 'govuk-colours'
 import styled from 'styled-components'
-import { MEDIA_QUERIES, SPACING, FONT_SIZE } from '@govuk-react/constants'
+import {
+  MEDIA_QUERIES,
+  SPACING,
+  FONT_SIZE,
+  FONT_WEIGHTS,
+} from '@govuk-react/constants'
 
 import icon from './assets/search-gov.uk.svg'
 import { Tag } from '../../components'
@@ -51,6 +56,7 @@ const ListItemHeaderContainer = styled('div')`
 const ListItemHeader = styled('h2')`
   flex-grow: 1;
   font-size: ${FONT_SIZE.SIZE_19};
+  font-weight: ${FONT_WEIGHTS.bold};
   margin: 0;
 `
 
@@ -59,7 +65,7 @@ const ListItemHeaderTagContainer = styled('div')`
 `
 
 const ListItemHeaderActionContainer = styled('div')`
-  flex: 0 1 170px;
+  flex: 0 1 152px;
   box-sizing: border-box;
   white-space: nowrap;
 
@@ -110,16 +116,17 @@ const StyledInvestmentTimeline = styled(InvestmentTimeline)`
   }
 
   ${MEDIA_QUERIES.DESKTOP} {
-    flex: 1 0 330px;
+    flex: 1 0 348px;
   }
 `
 
 const StyledInvestmentEstimatedLandDate = styled(InvestmentEstimatedLandDate)`
   flex: 1 1 100%;
   box-sizing: border-box;
+  min-height: 93px;
 
   ${MEDIA_QUERIES.DESKTOP} {
-    flex: 0 1 170px;
+    flex: 0 1 152px;
   }
 `
 

--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -53,7 +53,11 @@ const ListItemHeaderTagContainer = styled('div')`
 `
 
 const ListItemHeaderActionContainer = styled('div')`
+  flex: 0 1 170px;
+  box-sizing: border-box;
+
   a {
+    width: 100%;
     margin-bottom: 0;
   }
 `
@@ -92,14 +96,17 @@ const StyledDetails = styled(Details)`
 
 const StyledInvestmentTimeline = styled(InvestmentTimeline)`
   display: none;
-  width: 80%;
+  flex: 1 0;
+  box-sizing: border-box;
+
   ${MEDIA_QUERIES.TABLET} {
     display: block;
   }
 `
 
 const StyledInvestmentEstimatedLandDate = styled(InvestmentEstimatedLandDate)`
-  width: 20%;
+  flex: 0 1 170px;
+  box-sizing: border-box;
 `
 
 const InvestmentListItem = ({

--- a/src/client/components/MyInvestmentProjects/__stories__/InvestmentEstimatedLandDate.stories.jsx
+++ b/src/client/components/MyInvestmentProjects/__stories__/InvestmentEstimatedLandDate.stories.jsx
@@ -9,6 +9,7 @@ import { addDays, subDays, endOfToday } from 'date-fns'
 const today = endOfToday()
 const futureDate = addDays(today, 100)
 const tomorrow = addDays(today, 1)
+const twoMonthsAhead = addDays(today, 60)
 const pastDate = subDays(today, 10)
 
 storiesOf('InvestmentEstimatedLandDate', module)
@@ -27,6 +28,9 @@ storiesOf('InvestmentEstimatedLandDate', module)
   ))
   .add('estimatedLandDate is tomorrow', () => (
     <InvestmentEstimatedLandDate estimatedLandDate={tomorrow} />
+  ))
+  .add('estimatedLandDate is two months ahead', () => (
+    <InvestmentEstimatedLandDate estimatedLandDate={twoMonthsAhead} />
   ))
   .add('estimatedLandDate is in the past', () => (
     <InvestmentEstimatedLandDate estimatedLandDate={pastDate} />

--- a/src/client/components/MyInvestmentProjects/index.jsx
+++ b/src/client/components/MyInvestmentProjects/index.jsx
@@ -74,6 +74,7 @@ const MyInvestmentProjects = ({
         return (
           <>
             <InvestmentList
+              data-test="my-investment-projects-list"
               items={results}
               isPaginated={totalPages > 1}
               showDetails={showDetails}

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -192,7 +192,7 @@ const TabNav = ({
                 const Button = selected ? StyledSelectedButton : StyledButton
                 const tabId = createId(id, key, routed)
                 return (
-                  <StyledSpan key={tabId}>
+                  <StyledSpan key={tabId} data-test="tab-item">
                     <Button
                       role="tab"
                       focused={index === focusIndex}

--- a/src/client/components/Timeline/index.jsx
+++ b/src/client/components/Timeline/index.jsx
@@ -8,10 +8,7 @@ const TimelineContainer = styled('div')`
   background-color: ${GREY_3};
   padding: ${SPACING.SCALE_2};
   ${MEDIA_QUERIES.LARGESCREEN} {
-    padding: ${SPACING.SCALE_5} ${SPACING.SCALE_3};
-  }
-  ${MEDIA_QUERIES.DESKTOP} {
-    padding: ${SPACING.SCALE_5} ${SPACING.SCALE_4};
+    padding: ${SPACING.SCALE_5};
   }
 `
 
@@ -19,9 +16,9 @@ const StyledOl = styled('ol')`
   font-size: ${FONT_SIZE.SIZE_14};
   list-style-type: none;
   box-sizing: border-box;
-  padding: 0 0 0 ${SPACING.SCALE_4};
+  padding: 0 0 0 ${SPACING.SCALE_3};
   ${MEDIA_QUERIES.LARGESCREEN} {
-    padding: 0 ${SPACING.SCALE_4};
+    padding: 0 ${SPACING.SCALE_3};
     margin: 0;
     display: table;
     width: 100%;
@@ -45,7 +42,7 @@ const StyledLi = styled('li')`
     background-color: ${({ isStageComplete }) =>
       isStageComplete ? BLUE : WHITE};
     position: absolute;
-    left: -13px;
+    left: -12px;
   }
   span {
     display: block;

--- a/src/client/components/Timeline/index.jsx
+++ b/src/client/components/Timeline/index.jsx
@@ -6,9 +6,12 @@ import { MEDIA_QUERIES, SPACING, FONT_SIZE } from '@govuk-react/constants'
 
 const TimelineContainer = styled('div')`
   background-color: ${GREY_3};
-  padding: ${SPACING.SCALE_3};
+  padding: ${SPACING.SCALE_2};
   ${MEDIA_QUERIES.LARGESCREEN} {
-    padding: ${SPACING.SCALE_5};
+    padding: ${SPACING.SCALE_5} ${SPACING.SCALE_3};
+  }
+  ${MEDIA_QUERIES.DESKTOP} {
+    padding: ${SPACING.SCALE_5} ${SPACING.SCALE_4};
   }
 `
 

--- a/src/client/utils/colors.js
+++ b/src/client/utils/colors.js
@@ -1,0 +1,20 @@
+/**
+ * Convert a color hex to an rgb value
+ *
+ * Note that this currently only works with 6 digit hexes.
+ */
+export const hexToRgb = (colorHex) => {
+  const colorValue = parseInt(colorHex.replace('#', ''), 16)
+  return [
+    (colorValue >> 16) & 255,
+    (colorValue >> 8) & 255,
+    colorValue & 255,
+  ].join()
+}
+
+/**
+ * Convert a color hex and alpha to an rgba value
+ *
+ * Note that this currently only works with 6 digit hexes.
+ */
+export const rgba = (colorHex, alpha) => `rgba(${hexToRgb(colorHex)},${alpha})`

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -45,16 +45,19 @@ export const transformValueForAPI = ({ year, month, day = 1 }) => {
 }
 
 /**
- * Get the number of days left or days ago that an input date is as a string.
+ * Get the number of days to a given date as an integer.
  */
 export const getDifferenceInDays = (dateIn) => {
   const today = endOfToday()
-  const difference = differenceInCalendarDays(new Date(dateIn), today)
-  return difference === 1
-    ? difference + ' day'
-    : difference < 0
-    ? difference * -1 + ' days ago'
-    : difference + ' days'
+  return differenceInCalendarDays(new Date(dateIn), today)
+}
+
+/**
+ * Get the number of days left or days ago that an input date is as a string.
+ */
+export const getDifferenceInDaysLabel = (dateIn) => {
+  const difference = getDifferenceInDays(dateIn)
+  return Math.abs(difference) === 1 ? difference + ' day' : difference + ' days'
 }
 
 export const getFinancialYearStart = (date) =>

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -5,7 +5,7 @@ const EXCHANGE_RATE_GBP_TO_USD = parseFloat(
 )
 
 const DATE_LONG_FORMAT = 'd MMMM yyyy'
-const DATE_DAY_LONG_FORMAT = 'E dd MMMM yyyy'
+const DATE_DAY_LONG_FORMAT = 'E, dd MMM yyyy'
 const DATE_MEDIUM_FORMAT = 'd mmm yyyy'
 const DATE_TIME_MEDIUM_FORMAT = 'd MMM yyyy, h:mmaaa'
 

--- a/test/functional/cypress/specs/dashboard-new/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/estimated-land-date-spec.js
@@ -15,7 +15,7 @@ const assertEstimatedLandDate = ({ index, date, countdown, colour }) => {
 
   cy.get('@estimatedLandDate')
     .find('[data-test="estimated-land-date-date"]')
-    .should('have.text', format(date, 'E dd MMMM yyyy'))
+    .should('have.text', format(date, 'E, dd MMM yyyy'))
 }
 
 describe('Dashboard items - estimated land date', () => {

--- a/test/functional/cypress/specs/dashboard-new/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/estimated-land-date-spec.js
@@ -1,0 +1,82 @@
+import { addDays, format, subDays } from 'date-fns'
+
+const assertEstimatedLandDate = ({ index, date, countdown, colour }) => {
+  cy.get('@projectListItems')
+    .eq(index)
+    .find('[data-test="project-details"]')
+    .click()
+    .find('[data-test="estimated-land-date"]')
+    .as('estimatedLandDate')
+    .should('have.css', 'background-color', colour)
+
+  cy.get('@estimatedLandDate')
+    .find('[data-test="estimated-land-date-countdown"]')
+    .should('have.text', countdown)
+
+  cy.get('@estimatedLandDate')
+    .find('[data-test="estimated-land-date-date"]')
+    .should('have.text', format(date, 'E dd MMMM yyyy'))
+}
+
+describe('Dashboard items - estimated land date', () => {
+  beforeEach(() => {
+    cy.setFeatureFlag(
+      'layoutTesting:9010dd28-9798-e211-a939-e4115bead28a',
+      true
+    )
+    cy.visit('/')
+    cy.get('#dashboard\\.TabNav\\.tab\\._myinvestmentprojects').click()
+    cy.get('[data-test="projects-list-item"]').as('projectListItems')
+  })
+
+  after(() => {
+    cy.resetFeatureFlags()
+  })
+
+  context('My project list items - estimated land date', () => {
+    it('should show a grey panel when the project has under 0 days remaining', () => {
+      assertEstimatedLandDate({
+        index: 0,
+        date: subDays(new Date(), 14),
+        countdown: '-14 days',
+        colour: 'rgba(191, 193, 195, 0.5)',
+      })
+    })
+
+    it('should show a red panel when the project has 0 days remaining', () => {
+      assertEstimatedLandDate({
+        index: 1,
+        date: new Date(),
+        countdown: '0 days',
+        colour: 'rgba(212, 53, 28, 0.4)',
+      })
+    })
+
+    it('should show a red panel when the project has less than 30 days remaining', () => {
+      assertEstimatedLandDate({
+        index: 3,
+        date: addDays(new Date(), 28),
+        countdown: '28 days',
+        colour: 'rgba(212, 53, 28, 0.4)',
+      })
+    })
+
+    it('should show an amber panel when the project has between 30 and 89 days remaining', () => {
+      assertEstimatedLandDate({
+        index: 4,
+        date: addDays(new Date(), 42),
+        countdown: '42 days',
+        colour: 'rgba(255, 221, 0, 0.5)',
+      })
+    })
+
+    it('should show a green panel when the project has more than 89 days remaining', () => {
+      assertEstimatedLandDate({
+        index: 8,
+        date: addDays(new Date(), 98),
+        countdown: '98 days',
+        colour: 'rgba(0, 112, 60, 0.3)',
+      })
+    })
+  })
+})

--- a/test/sandbox/package-lock.json
+++ b/test/sandbox/package-lock.json
@@ -297,6 +297,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
+    "date-fns": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
+      "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/test/sandbox/package.json
+++ b/test/sandbox/package.json
@@ -3,6 +3,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "date-fns": "^2.19.0",
     "express": "^4.17.1",
     "ini": "^1.3.7",
     "lodash": "^4.17.19",

--- a/test/sandbox/routes/v3/search/investment-project.js
+++ b/test/sandbox/routes/v3/search/investment-project.js
@@ -1,6 +1,10 @@
-var investmentProjects = require('../../../fixtures/v3/search/investment-project.json')
+let investmentProjects = require('../../../fixtures/v3/search/investment-project.json')
+const { addDays, subDays } = require('date-fns')
 
 exports.investmentProjects = function (req, res) {
+  const today = new Date()
+  const oneFortnightAgo = subDays(today, 14)
+
   const hasFilters = !!(
     req.body.actual_land_date_before ||
     req.body.actual_land_date_after ||
@@ -17,11 +21,16 @@ exports.investmentProjects = function (req, res) {
     req.body.level_of_involvement_simplified
   )
 
+  const currentResults = investmentProjects.results.map((result, i) => ({
+    ...result,
+    estimated_land_date: addDays(oneFortnightAgo, i * 14),
+  }))
+
   if (req.body.uk_region_location) {
     var regionQuery = req.body.uk_region_location
     var regions = typeof regionQuery === 'string' ? [regionQuery] : regionQuery
     var ukRegionFilteredResults = _.filter(
-      investmentProjects.results,
+      currentResults,
       function (investmentProject) {
         return _.intersection(
           regions,
@@ -38,10 +47,13 @@ exports.investmentProjects = function (req, res) {
   } else if (hasFilters) {
     return res.json({
       count: 12,
-      results: investmentProjects.results,
+      results: currentResults,
     })
   } else {
-    return res.json(investmentProjects)
+    return res.json({
+      ...investmentProjects,
+      results: currentResults,
+    })
   }
 }
 


### PR DESCRIPTION
## Description of change

- Adds a Red / Amber / Green status colour to the Estimated Land Date for projects on the personalised dashboard, according to the values specified in the designs:
https://glc39r.axshare.com/#id=2mvr92&p=spec_list_item_details&g=1
- Date countdown format has changed to say (-1 day instead of 1 day ago and 0 days instead of today)
- Styles updated
- Made the timeline and land date look better when scaled to tablet size (although we do not have designs for this yet)

## Test instructions

With the personalised dashboard feature flag enabled, select "My Projects" on the dashboard page. When a project is expanded you should be able to see the estimated land date panel.

When the number of days remaining is:

- Below 0 - the colour should be grey
- 0 to 29 - red
- 30 to 89 - amber
- 90 and above - green

The styling should also be consistent with the designs.

## Screenshots
### Before

![Screenshot from 2021-03-22 15-32-49](https://user-images.githubusercontent.com/1234577/112015645-e8283f00-8b23-11eb-983c-38aa2071451a.png)

### After

![Screenshot from 2021-03-23 14-43-44](https://user-images.githubusercontent.com/1234577/112164997-4289d400-8be6-11eb-9e60-6f05c77ac1e3.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
