### PR TITLE
Add guidance text and link to event page for Trade Agreement related events

### DIFF
--- a/src/apps/events/views/edit.njk
+++ b/src/apps/events/views/edit.njk
@@ -1,4 +1,12 @@
 {% extends "_layouts/two-column.njk" %}
 
 {% block main_grid_left_column %}{% endblock %}
-{% block main_grid_right_column %}{{ Form(eventForm) }}{% endblock %}
+{% block main_grid_right_column %}
+    <p data-test="trade-agreement-text">
+        If your Event is set up to focus on a Trade Agreement or contributes to implementing a Trade Agreement then select that the event relates to a Trade Agreement and the relevant Agreement(s)
+    </p>
+    <a href="https://data-services-help.trade.gov.uk/data-hub/how-articles/recording-trade-agreement-activity/recording-trade-agreement-activity/" target="_blank" aria-label="opens in a new tab" data-test="trade-agreement-link">
+        See more guidance
+    </a>
+    {{ Form(eventForm) }}
+{% endblock %}

--- a/src/apps/events/views/edit.njk
+++ b/src/apps/events/views/edit.njk
@@ -2,11 +2,13 @@
 
 {% block main_grid_left_column %}{% endblock %}
 {% block main_grid_right_column %}
-    <p data-test="trade-agreement-text">
-        If your Event is set up to focus on a Trade Agreement or contributes to implementing a Trade Agreement then select that the event relates to a Trade Agreement and the relevant Agreement(s)
-    </p>
-    <a href="https://data-services-help.trade.gov.uk/data-hub/how-articles/recording-trade-agreement-activity/recording-trade-agreement-activity/" target="_blank" aria-label="opens in a new tab" data-test="trade-agreement-link">
-        See more guidance
-    </a>
+    {% if features.relatedTradeAgreements %}
+        <p data-test="trade-agreement-text">
+            If your Event is set up to focus on a Trade Agreement or contributes to implementing a Trade Agreement then select that the event relates to a Trade Agreement and the relevant Agreement(s)
+        </p>
+        <a href="https://data-services-help.trade.gov.uk/data-hub/how-articles/recording-trade-agreement-activity/recording-trade-agreement-activity/" target="_blank" aria-label="opens in a new tab" data-test="trade-agreement-link">
+            See more guidance
+        </a>
+    {% endif %}
     {{ Form(eventForm) }}
 {% endblock %}

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -60,4 +60,18 @@ describe('Event create', () => {
       .eq(1)
       .should('contain', 'Australia')
   })
+
+  it('should contain help information relating to trade agreements', () => {
+    cy.get('[data-test="trade-agreement-text"]').should(
+      'have.text',
+      'If your Event is set up to focus on a Trade Agreement or contributes to implementing a Trade Agreement then select that the event relates to a Trade Agreement and the relevant Agreement(s)'
+    )
+    cy.get('[data-test="trade-agreement-link"]')
+      .should(
+        'have.attr',
+        'href',
+        'https://data-services-help.trade.gov.uk/data-hub/how-articles/recording-trade-agreement-activity/recording-trade-agreement-activity/'
+      )
+      .should('have.attr', 'aria-label', 'opens in a new tab')
+  })
 })


### PR DESCRIPTION
## Description of change

Adds help text on what to do when adding a new event that is related to a Trade Agreement.
Change is put behind a feature flag of `eventHelpText` as the fields it refers to will be added in a following PR.

## Test instructions

New functional test added to `test/functional/cypress/specs/events/create-spec.js`. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/112181296-37d63b80-8bf4-11eb-8717-fbc148820e30.png)

### After

![image](https://user-images.githubusercontent.com/20663545/112181235-2856f280-8bf4-11eb-9866-8d27ad5a9e89.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
