### PR TITLE
View related trade agreement details on Events Detail page

### DIFF
--- a/src/apps/events/__test__/transformers.test.js
+++ b/src/apps/events/__test__/transformers.test.js
@@ -143,6 +143,7 @@ describe('Event transformers', () => {
             name: 'Jeff Smith',
           },
           'Related programmes': ['Example Programme'],
+          'Related Trade Agreements': [],
           'Event start date': {
             type: 'date',
             name: '2017-11-10',
@@ -197,6 +198,7 @@ describe('Event transformers', () => {
           Notes: null,
           Organiser: null,
           'Related programmes': [],
+          'Related Trade Agreements': [],
           'Event date': {
             type: 'date',
             name: null,
@@ -254,6 +256,7 @@ describe('Event transformers', () => {
             name: 'Jeff Smith',
           },
           'Related programmes': ['Example Programme'],
+          'Related Trade Agreements': [],
           'Event start date': {
             type: 'date',
             name: '2017-11-10',

--- a/src/apps/events/__test__/transformers.test.js
+++ b/src/apps/events/__test__/transformers.test.js
@@ -143,7 +143,7 @@ describe('Event transformers', () => {
             name: 'Jeff Smith',
           },
           'Related programmes': ['Example Programme'],
-          'Related Trade Agreements': [],
+          'Related Trade Agreements': ['Japan'],
           'Event start date': {
             type: 'date',
             name: '2017-11-10',
@@ -256,7 +256,7 @@ describe('Event transformers', () => {
             name: 'Jeff Smith',
           },
           'Related programmes': ['Example Programme'],
-          'Related Trade Agreements': [],
+          'Related Trade Agreements': ['Japan'],
           'Event start date': {
             type: 'date',
             name: '2017-11-10',

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -106,11 +106,13 @@ function transformEventResponseToViewRecord({
   organiser,
   teams,
   related_programmes,
+  related_trade_agreements,
   service,
   archived_documents_url_path,
 }) {
   teams = teams || []
   related_programmes = related_programmes || []
+  related_trade_agreements = related_trade_agreements || []
 
   const transformedEvent = {
     'Type of event': event_type,
@@ -153,6 +155,9 @@ function transformEventResponseToViewRecord({
     Organiser: organiser,
     'Other teams': otherTeams.map((x) => x.name),
     'Related programmes': related_programmes.map((item) => item.name),
+    'Related Trade Agreements': related_trade_agreements.map(
+      (item) => item.name
+    ),
     Service: service,
   })
 

--- a/test/functional/cypress/specs/events/details-spec.js
+++ b/test/functional/cypress/specs/events/details-spec.js
@@ -21,6 +21,7 @@ describe('Event Details', () => {
       Organiser: 'John Rogers',
       'Other teams': 'CBBC North West',
       'Related programmes': 'Grown in Britain',
+      'Related Trade Agreements': 'UK - Japan',
       Service: 'Events : UK Based',
       Documents: 'View files and documents (will open another website)',
     })
@@ -44,6 +45,7 @@ describe('Event Details', () => {
         Organiser: 'John Rogers',
         'Other teams': 'CBBC North West',
         'Related programmes': 'Grown in Britain',
+        'Related Trade Agreements': '',
         Service: 'Events : UK Based',
       })
     })

--- a/test/sandbox/fixtures/v3/event/single-event.json
+++ b/test/sandbox/fixtures/v3/event/single-event.json
@@ -38,6 +38,12 @@
           "id": "d352a68f-aaf4-4c43-b39d-9bca67a8322e"
       }
   ],
+  "related_trade_agreements": [
+    {
+        "name": "UK - Japan",
+        "id": "3117da1b-a776-4b03-af7e-2487d931491c"
+    }
+  ],
   "start_date": "2021-01-01",
   "teams": [
       {

--- a/test/unit/data/events/event-data.json
+++ b/test/unit/data/events/event-data.json
@@ -38,6 +38,12 @@
       "name": "Example Programme"
     }
   ],
+  "related_trade_agreements": [
+    {
+      "id": "6bd5f509-548c-47d1-a5bd-3cf9056a75a1",
+      "name": "Japan"
+    }
+  ],
   "service": {
     "id": "9484b82b-3499-e211-a939-e4115bead28a",
     "name": "Account Management"


### PR DESCRIPTION
## Description of change

A new field has been added to the event object and this PR allows the event details to show that field.

## Test instructions

A new field on the events detail page. If you add and remove Related Trade Agreements in django admin, you should see this updated on the event details page.

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/112453533-b5628e80-8d4f-11eb-8a4a-e9fe4f07b4a6.png)

### After

<img width="978" alt="Screenshot 2021-03-25 at 09 50 39" src="https://user-images.githubusercontent.com/20663545/112453462-9f54ce00-8d4f-11eb-8897-a12d3be5cf29.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
