### PR TITLE
Removed passed date format from formatDate function call

### DIFF
--- a/src/apps/omis/apps/reconciliation/views/list-reconciliation.njk
+++ b/src/apps/omis/apps/reconciliation/views/list-reconciliation.njk
@@ -33,7 +33,7 @@
                 {{ item.reference }}
               </a>
             </td>
-            <td>{{ item.payment_due_date | formatDate('DD/MM/YYYY') }}</td>
+            <td>{{ item.payment_due_date | formatDate }}</td>
             <td>{{ item.company }}</td>
             <td align="right">{{ item.subtotal_cost | formatCurrency }}</td>
             <td align="right">{{ item.total_cost | formatCurrency }}</td>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -393,6 +393,7 @@ module.exports = {
     index: url('/omis'),
     export: url('/omis', '/export'),
     create: url('/omis/create?company=', ':companyId'),
+    reconciliation: url('/omis/reconciliation'),
     order: url('/omis', '/:orderId'),
     paymentReceipt: url('/omis', '/:orderId/payment-receipt'),
     quote: url('/omis', '/:orderId/quote'),

--- a/test/functional/cypress/specs/omis/reconciliation-spec.js
+++ b/test/functional/cypress/specs/omis/reconciliation-spec.js
@@ -1,0 +1,17 @@
+const selectors = require('../../../../selectors')
+const urls = require('../../../../../src/lib/urls')
+
+describe('Load reconciliation collection view', () => {
+  before(() => {
+    const queryParams = '?sortby=created_on%3Adesc&status=quote_accepted'
+    cy.visit(`${urls.omis.reconciliation()}${queryParams}`)
+  })
+
+  it('should display a list of orders', () => {
+    cy.get(selectors.entityCollection.collection)
+      .should('contain', 'MJF388/19')
+      .and('contain', 'Andy and Lou')
+      .and('contain', '£1,234,567.89')
+      .and('contain', 'Quote accepted')
+  })
+})

--- a/test/sandbox/routes/v3/search/order.js
+++ b/test/sandbox/routes/v3/search/order.js
@@ -11,7 +11,8 @@ exports.order = function (req, res) {
   if (
     // uk_region can be a string or an array of strings so we need to unify it
     // to allow the filter to work also when there are multiple regions selected.
-    _([req.body.uk_region]).flatten().indexOf(NORTH_WEST_REGION) >= 0
+    _([req.body.uk_region]).flatten().indexOf(NORTH_WEST_REGION) >= 0 ||
+    _([req.body.status]).flatten().indexOf('quote_accepted') >= 0
   ) {
     return res.json(filteredOrders)
   }


### PR DESCRIPTION
## Description of change

Omis reconciliation pages are currently broken because of the invalid date string being passed into `formatDate` function. Passed date format into `formatDate` was removed same as throughout all omis pages.

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
