### PR TITLE
Add Trade Agreement fields to event form

### DIFF
--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -57,6 +57,7 @@ async function getEditOptions(req, createdOn, currentAdviser) {
 async function renderEditPage(req, res, next) {
   try {
     const eventData = transformEventResponseToFormBody(res.locals.event)
+    const featureFlags = res.locals.features
 
     const eventId = get(eventData, 'id', '')
     const eventName = get(eventData, 'name')
@@ -73,7 +74,7 @@ async function renderEditPage(req, res, next) {
     )
 
     const eventForm = buildFormWithStateAndErrors(
-      eventFormConfig(assign({}, { eventId }, options)),
+      eventFormConfig(assign({}, { eventId }, options), featureFlags),
       mergedData,
       get(res.locals, 'form.errors.messages')
     )

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -57,7 +57,6 @@ async function getEditOptions(req, createdOn, currentAdviser) {
 async function renderEditPage(req, res, next) {
   try {
     const eventData = transformEventResponseToFormBody(res.locals.event)
-    const featureFlags = res.locals.features
 
     const eventId = get(eventData, 'id', '')
     const eventName = get(eventData, 'name')
@@ -74,7 +73,9 @@ async function renderEditPage(req, res, next) {
     )
 
     const eventForm = buildFormWithStateAndErrors(
-      eventFormConfig(assign({}, { eventId }, options), featureFlags),
+      eventFormConfig(assign({}, { eventId }, options), {
+        ...res.locals.features,
+      }),
       mergedData,
       get(res.locals, 'form.errors.messages')
     )

--- a/src/apps/events/controllers/edit.js
+++ b/src/apps/events/controllers/edit.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: 0 */
-const { assign, merge, get, pickBy } = require('lodash')
+const { merge, get, pickBy } = require('lodash')
 
 const { eventFormConfig } = require('../macros')
 const { transformEventResponseToFormBody } = require('../transformers')
@@ -73,9 +73,7 @@ async function renderEditPage(req, res, next) {
     )
 
     const eventForm = buildFormWithStateAndErrors(
-      eventFormConfig(assign({}, { eventId }, options), {
-        ...res.locals.features,
-      }),
+      eventFormConfig({ eventId, ...options }, res.locals.features),
       mergedData,
       get(res.locals, 'form.errors.messages')
     )

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -22,6 +22,23 @@ const eventFormConfig = ({
     },
     children: [
       {
+        macroName: 'MultipleChoiceField',
+        type: 'radio',
+        name: 'related_trade_agreements_exist',
+        label: 'Are there related Trade Agreements',
+        modifier: 'inline',
+        options: [
+          {
+            label: 'Yes',
+            value: 'true',
+          },
+          {
+            label: 'No',
+            value: 'false',
+          },
+        ],
+      },
+      {
         macroName: 'AddAnother',
         buttonName: 'add_related_trade_agreement',
         name: 'related_trade_agreements',
@@ -34,7 +51,7 @@ const eventFormConfig = ({
             options: [
               {
                 label: 'No Related Trade Agreement',
-                value: '',
+                value: '0b371c90-e48a-40ea-a536-0968fb181f6c',
               },
               {
                 label: 'Australia',
@@ -67,6 +84,11 @@ const eventFormConfig = ({
             ],
           }),
         ],
+        modifier: 'subfield',
+        condition: {
+          name: 'related_trade_agreements_exist',
+          value: 'true',
+        },
       },
       {
         macroName: 'TextField',
@@ -154,6 +176,7 @@ const eventFormConfig = ({
         classes: 'c-form-group c-form-group--no-filter',
         placeholder: 'Search organiser',
         multipleSelect: false,
+        optional: true,
         options: advisers,
         target: 'metadata',
       },

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -90,7 +90,7 @@ const eventFormConfig = (
         label: 'Event name',
       },
       assign({}, globalFields.eventTypes, {
-        options: eventTypes,
+        options: { ...eventTypes },
       }),
       {
         macroName: 'DateFieldset',
@@ -105,7 +105,7 @@ const eventFormConfig = (
       assign({}, globalFields.locationTypes, {
         label: 'Event location type',
         optional: true,
-        options: locationTypes,
+        options: { ...locationTypes },
       }),
       {
         macroName: 'TextField',
@@ -137,14 +137,14 @@ const eventFormConfig = (
       },
       assign({}, globalFields.countries, {
         name: 'address_country',
-        options: countries,
+        options: { ...countries },
       }),
       assign({}, globalFields.ukRegions, {
         condition: {
           name: 'address_country',
           value: '80756b9a-5d95-e211-a939-e4115bead28a',
         },
-        options: ukRegions,
+        options: { ...ukRegions },
       }),
       {
         macroName: 'TextField',
@@ -157,7 +157,7 @@ const eventFormConfig = (
         name: 'lead_team',
         label: 'Team hosting the event',
         optional: false,
-        options: teams,
+        options: { ...teams },
       }),
       assign({}, globalFields.serviceDeliveryServices, {
         options: sortBy(services, (option) => option.label),
@@ -170,7 +170,7 @@ const eventFormConfig = (
         classes: 'c-form-group c-form-group--no-filter',
         placeholder: 'Search organiser',
         multipleSelect: false,
-        options: advisers,
+        options: { ...advisers },
         target: 'metadata',
       },
       {
@@ -203,7 +203,7 @@ const eventFormConfig = (
             isLabelHidden: true,
             persistsConditionalValue: true,
             optional: true,
-            options: teams,
+            options: { ...teams },
           }),
         ],
         modifier: 'subfield',
@@ -223,7 +223,7 @@ const eventFormConfig = (
             label: 'Related programmes',
             isLabelHidden: true,
             optional: true,
-            options: programmes,
+            options: { ...programmes },
           }),
         ],
       },
@@ -236,7 +236,7 @@ const eventFormConfig = (
         label: 'Event name',
       },
       assign({}, globalFields.eventTypes, {
-        options: eventTypes,
+        options: { ...eventTypes },
       }),
       {
         macroName: 'DateFieldset',
@@ -251,7 +251,7 @@ const eventFormConfig = (
       assign({}, globalFields.locationTypes, {
         label: 'Event location type',
         optional: true,
-        options: locationTypes,
+        options: { ...locationTypes },
       }),
       {
         macroName: 'TextField',
@@ -283,14 +283,14 @@ const eventFormConfig = (
       },
       assign({}, globalFields.countries, {
         name: 'address_country',
-        options: countries,
+        options: { ...countries },
       }),
       assign({}, globalFields.ukRegions, {
         condition: {
           name: 'address_country',
           value: '80756b9a-5d95-e211-a939-e4115bead28a',
         },
-        options: ukRegions,
+        options: { ...ukRegions },
       }),
       {
         macroName: 'TextField',
@@ -303,7 +303,7 @@ const eventFormConfig = (
         name: 'lead_team',
         label: 'Team hosting the event',
         optional: false,
-        options: teams,
+        options: { ...teams },
       }),
       assign({}, globalFields.serviceDeliveryServices, {
         options: sortBy(services, (option) => option.label),
@@ -349,7 +349,7 @@ const eventFormConfig = (
             isLabelHidden: true,
             persistsConditionalValue: true,
             optional: true,
-            options: teams,
+            options: { ...teams },
           }),
         ],
         modifier: 'subfield',
@@ -369,7 +369,7 @@ const eventFormConfig = (
             label: 'Related programmes',
             isLabelHidden: true,
             optional: true,
-            options: programmes,
+            options: { ...programmes },
           }),
         ],
       },

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -16,7 +16,7 @@ const eventFormConfig = (
   featureFlags
 ) => {
   let children
-  if (featureFlags?.relatedTradeAgreements) {
+  if (featureFlags && featureFlags.relatedTradeAgreements) {
     children = [
       {
         macroName: 'MultipleChoiceField',

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -22,6 +22,53 @@ const eventFormConfig = ({
     },
     children: [
       {
+        macroName: 'AddAnother',
+        buttonName: 'add_related_trade_agreement',
+        name: 'related_trade_agreements',
+        label: 'Related Trade Agreements',
+        children: [
+          assign({}, globalFields.tradeAgreements, {
+            name: 'related_trade_agreements',
+            label: 'Related Trade Agreements',
+            isLabelHidden: true,
+            options: [
+              {
+                label: 'No Related Trade Agreement',
+                value: '',
+              },
+              {
+                label: 'Australia',
+                value: '50370070-71f9-4ada-ae2c-cd0a737ba5e2',
+              },
+              {
+                label: 'Canada',
+                value: '50cf99fd-1150-421d-9e1c-b23750ebf5ca',
+              },
+              {
+                label: 'India',
+                value: '95ca9dcb-0da5-4bc2-a139-3e5b55c882f7',
+              },
+              {
+                label: 'Japan',
+                value: '05587f64-b976-425e-8763-3557c7936632',
+              },
+              {
+                label: 'Mexico',
+                value: '09787712-0d94-4137-a5f3-3f9131e681f0',
+              },
+              {
+                label: 'New Zealand',
+                value: 'f42da892-2b03-4f88-8a61-9efd8b132776',
+              },
+              {
+                label: 'USA',
+                value: '20e08a38-95a8-4250-bd5b-9d7f0dfc9387',
+              },
+            ],
+          }),
+        ],
+      },
+      {
         macroName: 'TextField',
         name: 'name',
         label: 'Event name',

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -1,4 +1,4 @@
-const { assign, sortBy } = require('lodash')
+const { sortBy } = require('lodash')
 const { globalFields } = require('../../macros')
 const urls = require('../../../lib/urls')
 
@@ -16,365 +16,380 @@ const eventFormConfig = (
   },
   featureFlags
 ) => {
-  let children
-  if (featureFlags && featureFlags.relatedTradeAgreements) {
-    children = [
-      {
-        macroName: 'MultipleChoiceField',
-        type: 'radio',
-        name: 'related_trade_agreements_exist',
-        label: 'Are there related Trade Agreements',
-        modifier: 'inline',
-        options: [
+  const children =
+    featureFlags && featureFlags.relatedTradeAgreements
+      ? [
           {
-            label: 'Yes',
-            value: 'true',
-          },
-          {
-            label: 'No',
-            value: 'false',
-          },
-        ],
-      },
-      {
-        macroName: 'AddAnother',
-        buttonName: 'add_related_trade_agreement',
-        name: 'related_trade_agreements',
-        label: 'Related Trade Agreements',
-        children: [
-          assign({}, globalFields.tradeAgreements, {
-            name: 'related_trade_agreements',
-            label: 'Related Trade Agreements',
-            isLabelHidden: true,
+            macroName: 'MultipleChoiceField',
+            type: 'radio',
+            name: 'related_trade_agreements_exist',
+            label: 'Are there related Trade Agreements',
+            modifier: 'inline',
             options: [
               {
-                label: 'Australia',
-                value: '50370070-71f9-4ada-ae2c-cd0a737ba5e2',
+                label: 'Yes',
+                value: 'true',
               },
               {
-                label: 'Canada',
-                value: '50cf99fd-1150-421d-9e1c-b23750ebf5ca',
-              },
-              {
-                label: 'India',
-                value: '95ca9dcb-0da5-4bc2-a139-3e5b55c882f7',
-              },
-              {
-                label: 'Japan',
-                value: '05587f64-b976-425e-8763-3557c7936632',
-              },
-              {
-                label: 'Mexico',
-                value: '09787712-0d94-4137-a5f3-3f9131e681f0',
-              },
-              {
-                label: 'New Zealand',
-                value: 'f42da892-2b03-4f88-8a61-9efd8b132776',
-              },
-              {
-                label: 'USA',
-                value: '20e08a38-95a8-4250-bd5b-9d7f0dfc9387',
+                label: 'No',
+                value: 'false',
               },
             ],
-          }),
-        ],
-        modifier: 'subfield',
-        condition: {
-          name: 'related_trade_agreements_exist',
-          value: 'true',
-        },
-      },
-      {
-        macroName: 'TextField',
-        name: 'name',
-        label: 'Event name',
-      },
-      assign({}, globalFields.eventTypes, {
-        options: { ...eventTypes },
-      }),
-      {
-        macroName: 'DateFieldset',
-        name: 'start_date',
-        label: 'Event start date',
-      },
-      {
-        macroName: 'DateFieldset',
-        name: 'end_date',
-        label: 'Event end date',
-      },
-      assign({}, globalFields.locationTypes, {
-        label: 'Event location type',
-        optional: true,
-        options: { ...locationTypes },
-      }),
-      {
-        macroName: 'TextField',
-        name: 'address_1',
-        label: 'Business and street',
-      },
-      {
-        macroName: 'TextField',
-        name: 'address_2',
-        label: 'Second line of address',
-        isLabelHidden: true,
-        optional: true,
-      },
-      {
-        macroName: 'TextField',
-        name: 'address_town',
-        label: 'Town or city',
-      },
-      {
-        macroName: 'TextField',
-        name: 'address_county',
-        label: 'County',
-      },
-      {
-        macroName: 'TextField',
-        name: 'postcode',
-        label: 'Postcode',
-        class: 'u-js-hidden',
-      },
-      assign({}, globalFields.countries, {
-        name: 'address_country',
-        options: { ...countries },
-      }),
-      assign({}, globalFields.ukRegions, {
-        condition: {
-          name: 'address_country',
-          value: '80756b9a-5d95-e211-a939-e4115bead28a',
-        },
-        options: { ...ukRegions },
-      }),
-      {
-        macroName: 'TextField',
-        type: 'textarea',
-        name: 'notes',
-        label: 'Event notes',
-        optional: true,
-      },
-      assign({}, globalFields.teams, {
-        name: 'lead_team',
-        label: 'Team hosting the event',
-        optional: false,
-        options: { ...teams },
-      }),
-      assign({}, globalFields.serviceDeliveryServices, {
-        options: sortBy(services, (option) => option.label),
-      }),
-      {
-        macroName: 'Typeahead',
-        name: 'organiser',
-        entity: 'adviser',
-        label: 'Organiser',
-        classes: 'c-form-group c-form-group--no-filter',
-        placeholder: 'Search organiser',
-        multipleSelect: false,
-        options: { ...advisers },
-        target: 'metadata',
-      },
-      {
-        macroName: 'MultipleChoiceField',
-        type: 'radio',
-        name: 'event_shared',
-        label: 'Is this a shared event',
-        optional: true,
-        modifier: 'inline',
-        options: [
-          {
-            label: 'Yes',
-            value: 'true',
           },
           {
-            label: 'No',
-            value: 'false',
+            macroName: 'AddAnother',
+            buttonName: 'add_related_trade_agreement',
+            name: 'related_trade_agreements',
+            label: 'Related Trade Agreements',
+            children: [
+              {
+                ...globalFields.tradeAgreements,
+                name: 'related_trade_agreements',
+                label: 'Related Trade Agreements',
+                isLabelHidden: true,
+                options: [
+                  {
+                    label: 'Australia',
+                    value: '50370070-71f9-4ada-ae2c-cd0a737ba5e2',
+                  },
+                  {
+                    label: 'Canada',
+                    value: '50cf99fd-1150-421d-9e1c-b23750ebf5ca',
+                  },
+                  {
+                    label: 'India',
+                    value: '95ca9dcb-0da5-4bc2-a139-3e5b55c882f7',
+                  },
+                  {
+                    label: 'Japan',
+                    value: '05587f64-b976-425e-8763-3557c7936632',
+                  },
+                  {
+                    label: 'Mexico',
+                    value: '09787712-0d94-4137-a5f3-3f9131e681f0',
+                  },
+                  {
+                    label: 'New Zealand',
+                    value: 'f42da892-2b03-4f88-8a61-9efd8b132776',
+                  },
+                  {
+                    label: 'USA',
+                    value: '20e08a38-95a8-4250-bd5b-9d7f0dfc9387',
+                  },
+                ],
+              },
+            ],
+            modifier: 'subfield',
+            condition: {
+              name: 'related_trade_agreements_exist',
+              value: 'true',
+            },
           },
-        ],
-      },
-      {
-        macroName: 'AddAnother',
-        buttonName: 'add_team',
-        name: 'teams',
-        label: 'Teams',
-        children: [
-          assign({}, globalFields.teams, {
-            name: 'teams',
-            label: 'Team',
-            isLabelHidden: true,
-            persistsConditionalValue: true,
+          {
+            macroName: 'TextField',
+            name: 'name',
+            label: 'Event name',
+          },
+          {
+            ...globalFields.eventTypes,
+            options: eventTypes,
+          },
+          {
+            macroName: 'DateFieldset',
+            name: 'start_date',
+            label: 'Event start date',
+          },
+          {
+            macroName: 'DateFieldset',
+            name: 'end_date',
+            label: 'Event end date',
+          },
+          {
+            ...globalFields.locationTypes,
+            label: 'Event location type',
             optional: true,
-            options: { ...teams },
-          }),
-        ],
-        modifier: 'subfield',
-        condition: {
-          name: 'event_shared',
-          value: 'true',
-        },
-      },
-      {
-        macroName: 'AddAnother',
-        buttonName: 'add_related_programme',
-        name: 'related_programmes',
-        label: 'Related programmes',
-        children: [
-          assign({}, globalFields.programmes, {
+            options: locationTypes,
+          },
+          {
+            macroName: 'TextField',
+            name: 'address_1',
+            label: 'Business and street',
+          },
+          {
+            macroName: 'TextField',
+            name: 'address_2',
+            label: 'Second line of address',
+            isLabelHidden: true,
+            optional: true,
+          },
+          {
+            macroName: 'TextField',
+            name: 'address_town',
+            label: 'Town or city',
+          },
+          {
+            macroName: 'TextField',
+            name: 'address_county',
+            label: 'County',
+          },
+          {
+            macroName: 'TextField',
+            name: 'postcode',
+            label: 'Postcode',
+            class: 'u-js-hidden',
+          },
+          {
+            ...globalFields.countries,
+            name: 'address_country',
+            options: countries,
+          },
+          {
+            ...globalFields.ukRegions,
+            condition: {
+              name: 'address_country',
+              value: '80756b9a-5d95-e211-a939-e4115bead28a',
+            },
+            options: ukRegions,
+          },
+          {
+            macroName: 'TextField',
+            type: 'textarea',
+            name: 'notes',
+            label: 'Event notes',
+            optional: true,
+          },
+          {
+            ...globalFields.teams,
+            name: 'lead_team',
+            label: 'Team hosting the event',
+            optional: false,
+            options: teams,
+          },
+          {
+            ...globalFields.serviceDeliveryServices,
+            options: sortBy(services, (option) => option.label),
+          },
+          {
+            macroName: 'Typeahead',
+            name: 'organiser',
+            entity: 'adviser',
+            label: 'Organiser',
+            classes: 'c-form-group c-form-group--no-filter',
+            placeholder: 'Search organiser',
+            multipleSelect: false,
+            options: advisers,
+            target: 'metadata',
+          },
+          {
+            macroName: 'MultipleChoiceField',
+            type: 'radio',
+            name: 'event_shared',
+            label: 'Is this a shared event',
+            optional: true,
+            modifier: 'inline',
+            options: [
+              {
+                label: 'Yes',
+                value: 'true',
+              },
+              {
+                label: 'No',
+                value: 'false',
+              },
+            ],
+          },
+          {
+            macroName: 'AddAnother',
+            buttonName: 'add_team',
+            name: 'teams',
+            label: 'Teams',
+            children: [
+              {
+                ...globalFields.teams,
+                name: 'teams',
+                label: 'Team',
+                isLabelHidden: true,
+                persistsConditionalValue: true,
+                optional: true,
+                options: teams,
+              },
+            ],
+            modifier: 'subfield',
+            condition: {
+              name: 'event_shared',
+              value: 'true',
+            },
+          },
+          {
+            macroName: 'AddAnother',
+            buttonName: 'add_related_programme',
             name: 'related_programmes',
             label: 'Related programmes',
+            children: [
+              {
+                ...globalFields.programmes,
+                name: 'related_programmes',
+                label: 'Related programmes',
+                isLabelHidden: true,
+                optional: true,
+                options: programmes,
+              },
+            ],
+          },
+        ]
+      : [
+          {
+            macroName: 'TextField',
+            name: 'name',
+            label: 'Event name',
+          },
+          {
+            ...globalFields.eventTypes,
+            options: eventTypes,
+          },
+          {
+            macroName: 'DateFieldset',
+            name: 'start_date',
+            label: 'Event start date',
+          },
+          {
+            macroName: 'DateFieldset',
+            name: 'end_date',
+            label: 'Event end date',
+          },
+          {
+            ...globalFields.locationTypes,
+            label: 'Event location type',
+            optional: true,
+            options: locationTypes,
+          },
+          {
+            macroName: 'TextField',
+            name: 'address_1',
+            label: 'Business and street',
+          },
+          {
+            macroName: 'TextField',
+            name: 'address_2',
+            label: 'Second line of address',
             isLabelHidden: true,
             optional: true,
-            options: { ...programmes },
-          }),
-        ],
-      },
-    ]
-  } else {
-    children = [
-      {
-        macroName: 'TextField',
-        name: 'name',
-        label: 'Event name',
-      },
-      assign({}, globalFields.eventTypes, {
-        options: { ...eventTypes },
-      }),
-      {
-        macroName: 'DateFieldset',
-        name: 'start_date',
-        label: 'Event start date',
-      },
-      {
-        macroName: 'DateFieldset',
-        name: 'end_date',
-        label: 'Event end date',
-      },
-      assign({}, globalFields.locationTypes, {
-        label: 'Event location type',
-        optional: true,
-        options: { ...locationTypes },
-      }),
-      {
-        macroName: 'TextField',
-        name: 'address_1',
-        label: 'Business and street',
-      },
-      {
-        macroName: 'TextField',
-        name: 'address_2',
-        label: 'Second line of address',
-        isLabelHidden: true,
-        optional: true,
-      },
-      {
-        macroName: 'TextField',
-        name: 'address_town',
-        label: 'Town or city',
-      },
-      {
-        macroName: 'TextField',
-        name: 'address_county',
-        label: 'County',
-      },
-      {
-        macroName: 'TextField',
-        name: 'postcode',
-        label: 'Postcode',
-        class: 'u-js-hidden',
-      },
-      assign({}, globalFields.countries, {
-        name: 'address_country',
-        options: { ...countries },
-      }),
-      assign({}, globalFields.ukRegions, {
-        condition: {
-          name: 'address_country',
-          value: '80756b9a-5d95-e211-a939-e4115bead28a',
-        },
-        options: { ...ukRegions },
-      }),
-      {
-        macroName: 'TextField',
-        type: 'textarea',
-        name: 'notes',
-        label: 'Event notes',
-        optional: true,
-      },
-      assign({}, globalFields.teams, {
-        name: 'lead_team',
-        label: 'Team hosting the event',
-        optional: false,
-        options: { ...teams },
-      }),
-      assign({}, globalFields.serviceDeliveryServices, {
-        options: sortBy(services, (option) => option.label),
-      }),
-      {
-        macroName: 'Typeahead',
-        name: 'organiser',
-        entity: 'adviser',
-        label: 'Organiser',
-        classes: 'c-form-group c-form-group--no-filter',
-        placeholder: 'Search organiser',
-        multipleSelect: false,
-        options: advisers,
-        target: 'metadata',
-      },
-      {
-        macroName: 'MultipleChoiceField',
-        type: 'radio',
-        name: 'event_shared',
-        label: 'Is this a shared event',
-        optional: true,
-        modifier: 'inline',
-        options: [
-          {
-            label: 'Yes',
-            value: 'true',
           },
           {
-            label: 'No',
-            value: 'false',
+            macroName: 'TextField',
+            name: 'address_town',
+            label: 'Town or city',
           },
-        ],
-      },
-      {
-        macroName: 'AddAnother',
-        buttonName: 'add_team',
-        name: 'teams',
-        label: 'Teams',
-        children: [
-          assign({}, globalFields.teams, {
+          {
+            macroName: 'TextField',
+            name: 'address_county',
+            label: 'County',
+          },
+          {
+            macroName: 'TextField',
+            name: 'postcode',
+            label: 'Postcode',
+            class: 'u-js-hidden',
+          },
+          {
+            ...globalFields.countries,
+            name: 'address_country',
+            options: countries,
+          },
+          {
+            ...globalFields.ukRegions,
+            condition: {
+              name: 'address_country',
+              value: '80756b9a-5d95-e211-a939-e4115bead28a',
+            },
+            options: ukRegions,
+          },
+          {
+            macroName: 'TextField',
+            type: 'textarea',
+            name: 'notes',
+            label: 'Event notes',
+            optional: true,
+          },
+          {
+            ...globalFields.teams,
+            name: 'lead_team',
+            label: 'Team hosting the event',
+            optional: false,
+            options: teams,
+          },
+          {
+            ...globalFields.serviceDeliveryServices,
+            options: sortBy(services, (option) => option.label),
+          },
+          {
+            macroName: 'Typeahead',
+            name: 'organiser',
+            entity: 'adviser',
+            label: 'Organiser',
+            classes: 'c-form-group c-form-group--no-filter',
+            placeholder: 'Search organiser',
+            multipleSelect: false,
+            options: advisers,
+            target: 'metadata',
+          },
+          {
+            macroName: 'MultipleChoiceField',
+            type: 'radio',
+            name: 'event_shared',
+            label: 'Is this a shared event',
+            optional: true,
+            modifier: 'inline',
+            options: [
+              {
+                label: 'Yes',
+                value: 'true',
+              },
+              {
+                label: 'No',
+                value: 'false',
+              },
+            ],
+          },
+          {
+            macroName: 'AddAnother',
+            buttonName: 'add_team',
             name: 'teams',
-            label: 'Team',
-            isLabelHidden: true,
-            persistsConditionalValue: true,
-            optional: true,
-            options: { ...teams },
-          }),
-        ],
-        modifier: 'subfield',
-        condition: {
-          name: 'event_shared',
-          value: 'true',
-        },
-      },
-      {
-        macroName: 'AddAnother',
-        buttonName: 'add_related_programme',
-        name: 'related_programmes',
-        label: 'Related programmes',
-        children: [
-          assign({}, globalFields.programmes, {
+            label: 'Teams',
+            children: [
+              {
+                ...globalFields.teams,
+                name: 'teams',
+                label: 'Team',
+                isLabelHidden: true,
+                persistsConditionalValue: true,
+                optional: true,
+                options: teams,
+              },
+            ],
+            modifier: 'subfield',
+            condition: {
+              name: 'event_shared',
+              value: 'true',
+            },
+          },
+          {
+            macroName: 'AddAnother',
+            buttonName: 'add_related_programme',
             name: 'related_programmes',
             label: 'Related programmes',
-            isLabelHidden: true,
-            optional: true,
-            options: { ...programmes },
-          }),
-        ],
-      },
-    ]
-  }
+            children: [
+              {
+                ...globalFields.programmes,
+                name: 'related_programmes',
+                label: 'Related programmes',
+                isLabelHidden: true,
+                optional: true,
+                options: programmes,
+              },
+            ],
+          },
+        ]
 
   return {
     method: 'post',

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -1,26 +1,23 @@
 const { assign, sortBy } = require('lodash')
 const { globalFields } = require('../../macros')
 
-const eventFormConfig = ({
-  eventId,
-  advisers,
-  eventTypes,
-  locationTypes,
-  countries,
-  teams,
-  services,
-  programmes,
-  ukRegions,
-}) => {
-  return {
-    method: 'post',
-    buttonText: eventId ? 'Save and return' : 'Add event',
-    returnText: eventId ? 'Return without saving' : 'Cancel',
-    returnLink: eventId ? `/events/${eventId}` : '/events',
-    hiddenFields: {
-      id: eventId,
-    },
-    children: [
+const eventFormConfig = (
+  {
+    eventId,
+    advisers,
+    eventTypes,
+    locationTypes,
+    countries,
+    teams,
+    services,
+    programmes,
+    ukRegions,
+  },
+  featureFlags
+) => {
+  let children
+  if (featureFlags.relatedTradeAgreements) {
+    children = [
       {
         macroName: 'MultipleChoiceField',
         type: 'radio',
@@ -49,10 +46,6 @@ const eventFormConfig = ({
             label: 'Related Trade Agreements',
             isLabelHidden: true,
             options: [
-              {
-                label: 'No Related Trade Agreement',
-                value: '0b371c90-e48a-40ea-a536-0968fb181f6c',
-              },
               {
                 label: 'Australia',
                 value: '50370070-71f9-4ada-ae2c-cd0a737ba5e2',
@@ -176,7 +169,6 @@ const eventFormConfig = ({
         classes: 'c-form-group c-form-group--no-filter',
         placeholder: 'Search organiser',
         multipleSelect: false,
-        optional: true,
         options: advisers,
         target: 'metadata',
       },
@@ -234,7 +226,164 @@ const eventFormConfig = ({
           }),
         ],
       },
-    ],
+    ]
+  } else {
+    children = [
+      {
+        macroName: 'TextField',
+        name: 'name',
+        label: 'Event name',
+      },
+      assign({}, globalFields.eventTypes, {
+        options: eventTypes,
+      }),
+      {
+        macroName: 'DateFieldset',
+        name: 'start_date',
+        label: 'Event start date',
+      },
+      {
+        macroName: 'DateFieldset',
+        name: 'end_date',
+        label: 'Event end date',
+      },
+      assign({}, globalFields.locationTypes, {
+        label: 'Event location type',
+        optional: true,
+        options: locationTypes,
+      }),
+      {
+        macroName: 'TextField',
+        name: 'address_1',
+        label: 'Business and street',
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_2',
+        label: 'Second line of address',
+        isLabelHidden: true,
+        optional: true,
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_town',
+        label: 'Town or city',
+      },
+      {
+        macroName: 'TextField',
+        name: 'address_county',
+        label: 'County',
+      },
+      {
+        macroName: 'TextField',
+        name: 'postcode',
+        label: 'Postcode',
+        class: 'u-js-hidden',
+      },
+      assign({}, globalFields.countries, {
+        name: 'address_country',
+        options: countries,
+      }),
+      assign({}, globalFields.ukRegions, {
+        condition: {
+          name: 'address_country',
+          value: '80756b9a-5d95-e211-a939-e4115bead28a',
+        },
+        options: ukRegions,
+      }),
+      {
+        macroName: 'TextField',
+        type: 'textarea',
+        name: 'notes',
+        label: 'Event notes',
+        optional: true,
+      },
+      assign({}, globalFields.teams, {
+        name: 'lead_team',
+        label: 'Team hosting the event',
+        optional: false,
+        options: teams,
+      }),
+      assign({}, globalFields.serviceDeliveryServices, {
+        options: sortBy(services, (option) => option.label),
+      }),
+      {
+        macroName: 'Typeahead',
+        name: 'organiser',
+        entity: 'adviser',
+        label: 'Organiser',
+        classes: 'c-form-group c-form-group--no-filter',
+        placeholder: 'Search organiser',
+        multipleSelect: false,
+        options: advisers,
+        target: 'metadata',
+      },
+      {
+        macroName: 'MultipleChoiceField',
+        type: 'radio',
+        name: 'event_shared',
+        label: 'Is this a shared event',
+        optional: true,
+        modifier: 'inline',
+        options: [
+          {
+            label: 'Yes',
+            value: 'true',
+          },
+          {
+            label: 'No',
+            value: 'false',
+          },
+        ],
+      },
+      {
+        macroName: 'AddAnother',
+        buttonName: 'add_team',
+        name: 'teams',
+        label: 'Teams',
+        children: [
+          assign({}, globalFields.teams, {
+            name: 'teams',
+            label: 'Team',
+            isLabelHidden: true,
+            persistsConditionalValue: true,
+            optional: true,
+            options: teams,
+          }),
+        ],
+        modifier: 'subfield',
+        condition: {
+          name: 'event_shared',
+          value: 'true',
+        },
+      },
+      {
+        macroName: 'AddAnother',
+        buttonName: 'add_related_programme',
+        name: 'related_programmes',
+        label: 'Related programmes',
+        children: [
+          assign({}, globalFields.programmes, {
+            name: 'related_programmes',
+            label: 'Related programmes',
+            isLabelHidden: true,
+            optional: true,
+            options: programmes,
+          }),
+        ],
+      },
+    ]
+  }
+
+  return {
+    method: 'post',
+    buttonText: eventId ? 'Save and return' : 'Add event',
+    returnText: eventId ? 'Return without saving' : 'Cancel',
+    returnLink: eventId ? `/events/${eventId}` : '/events',
+    hiddenFields: {
+      id: eventId,
+    },
+    children: children,
   }
 }
 

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -1,5 +1,6 @@
 const { assign, sortBy } = require('lodash')
 const { globalFields } = require('../../macros')
+const urls = require('../../../lib/urls')
 
 const eventFormConfig = (
   {
@@ -379,7 +380,7 @@ const eventFormConfig = (
     method: 'post',
     buttonText: eventId ? 'Save and return' : 'Add event',
     returnText: eventId ? 'Return without saving' : 'Cancel',
-    returnLink: eventId ? `/events/${eventId}` : '/events',
+    returnLink: eventId ? urls.events.details(eventId) : urls.events.index,
     hiddenFields: {
       id: eventId,
     },

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -22,7 +22,7 @@ const eventFormConfig = (
           {
             macroName: 'MultipleChoiceField',
             type: 'radio',
-            name: 'related_trade_agreements_exist',
+            name: 'has_related_trade_agreements',
             label: 'Are there related Trade Agreements',
             modifier: 'inline',
             options: [
@@ -81,7 +81,7 @@ const eventFormConfig = (
             ],
             modifier: 'subfield',
             condition: {
-              name: 'related_trade_agreements_exist',
+              name: 'has_related_trade_agreements',
               value: 'true',
             },
           },

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -16,7 +16,7 @@ const eventFormConfig = (
   featureFlags
 ) => {
   let children
-  if (featureFlags.relatedTradeAgreements) {
+  if (featureFlags?.relatedTradeAgreements) {
     children = [
       {
         macroName: 'MultipleChoiceField',

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -14,7 +14,7 @@ async function postDetails(req, res, next) {
   )
 
   try {
-    const result = await saveEvent(req, res.locals.requestBody)
+    const result = await saveEvent(req, res.locals.requestBody, featureFlags)
 
     if (!res.locals.event) {
       req.flash('success', 'Event created')

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -7,7 +7,11 @@ const {
 const { fetchEvent, saveEvent } = require('../repos')
 
 async function postDetails(req, res, next) {
-  res.locals.requestBody = transformEventFormBodyToApiRequest(req.body)
+  const featureFlags = res.locals.features
+  res.locals.requestBody = transformEventFormBodyToApiRequest(
+    req.body,
+    featureFlags
+  )
 
   try {
     const result = await saveEvent(req, res.locals.requestBody)

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -3,10 +3,8 @@ const { authorisedRequest } = require('../../lib/authorised-request')
 const { search } = require('../../modules/search/services')
 
 function saveEvent(req, event, featureFlags) {
-  let version = 'v3'
-  if (featureFlags && featureFlags.relatedTradeAgreement) {
-    version = 'v4'
-  }
+  const version =
+    featureFlags && featureFlags.relatedTradeAgreements ? 'v4' : 'v3'
   const options = {
     url: `${config.apiRoot}/${version}/event`,
     method: 'POST',

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -3,7 +3,7 @@ const { authorisedRequest } = require('../../lib/authorised-request')
 const { search } = require('../../modules/search/services')
 
 function saveEvent(req, event, featureFlags) {
-  const version = featureFlags.relatedTradeAgreements ? 'v4' : 'v3'
+  const version = featureFlags?.relatedTradeAgreements ? 'v4' : 'v3'
   const options = {
     url: `${config.apiRoot}/${version}/event`,
     method: 'POST',

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -2,9 +2,10 @@ const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 const { search } = require('../../modules/search/services')
 
-function saveEvent(req, event) {
+function saveEvent(req, event, featureFlags) {
+  const version = featureFlags.relatedTradeAgreements ? 'v4' : 'v3'
   const options = {
-    url: `${config.apiRoot}/v3/event`,
+    url: `${config.apiRoot}/${version}/event`,
     method: 'POST',
     body: event,
   }

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -3,7 +3,10 @@ const { authorisedRequest } = require('../../lib/authorised-request')
 const { search } = require('../../modules/search/services')
 
 function saveEvent(req, event, featureFlags) {
-  const version = featureFlags?.relatedTradeAgreements ? 'v4' : 'v3'
+  let version = 'v3'
+  if (featureFlags && featureFlags.relatedTradeAgreement) {
+    version = 'v4'
+  }
   const options = {
     url: `${config.apiRoot}/${version}/event`,
     method: 'POST',

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -187,13 +187,10 @@ function transformEventResponseToFormBody(props = {}) {
 function transformEventFormBodyToApiRequest(props, featureFlags) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
-  let related_trade_agreements
-  if (featureFlags && featureFlags.relatedTradeAgreements) {
-    castRelatedTradeAgreements()
-  } else {
-    related_trade_agreements = []
-  }
-
+  const related_trade_agreements =
+    featureFlags && featureFlags.relatedTradeAgreements
+      ? castRelatedTradeAgreements()
+      : []
   const teams = props.lead_team
     ? teamsArray.concat(props.lead_team)
     : teamsArray
@@ -209,17 +206,11 @@ function transformEventFormBodyToApiRequest(props, featureFlags) {
   })
 
   function castRelatedTradeAgreements() {
-    if (props.related_trade_agreements_exist === 'true') {
-      if (props.related_trade_agreements.length === 0) {
-        related_trade_agreements = null
-      } else {
-        related_trade_agreements = castCompactArray(
-          props.related_trade_agreements
-        )
-      }
-    } else if (props.related_trade_agreements_exist === 'false') {
-      related_trade_agreements = []
-    }
+    return props.related_trade_agreements_exist === 'true'
+      ? props.related_trade_agreements.length === 0
+        ? null
+        : castCompactArray(props.related_trade_agreements)
+      : []
   }
 }
 

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -187,6 +187,9 @@ function transformEventResponseToFormBody(props = {}) {
 function transformEventFormBodyToApiRequest(props) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
+  const related_trade_agreements = props.related_trade_agreements
+    ? castCompactArray(props.related_trade_agreements)
+    : null
   const teams = props.lead_team
     ? teamsArray.concat(props.lead_team)
     : teamsArray
@@ -198,6 +201,7 @@ function transformEventFormBodyToApiRequest(props) {
     teams: uniq(teams),
     organiser: organiser,
     related_programmes,
+    related_trade_agreements,
   })
 }
 

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -188,7 +188,7 @@ function transformEventFormBodyToApiRequest(props, featureFlags) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
   let related_trade_agreements
-  if (featureFlags?.relatedTradeAgreements) {
+  if (featureFlags && featureFlags.relatedTradeAgreements) {
     castRelatedTradeAgreements()
   } else {
     related_trade_agreements = []

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -187,9 +187,14 @@ function transformEventResponseToFormBody(props = {}) {
 function transformEventFormBodyToApiRequest(props) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
-  const related_trade_agreements = props.related_trade_agreements
-    ? castCompactArray(props.related_trade_agreements)
-    : null
+  let related_trade_agreements = null
+  if (props.related_trade_agreements_exist == 'true') {
+    related_trade_agreements = castCompactArray(props.related_trade_agreements)
+  } else if (props.related_trade_agreements_exist == 'false') {
+    related_trade_agreements = castCompactArray(
+      '0b371c90-e48a-40ea-a536-0968fb181f6c'
+    )
+  }
   const teams = props.lead_team
     ? teamsArray.concat(props.lead_team)
     : teamsArray

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -189,17 +189,7 @@ function transformEventFormBodyToApiRequest(props, featureFlags) {
   const related_programmes = castCompactArray(props.related_programmes)
   let related_trade_agreements
   if (featureFlags?.relatedTradeAgreements) {
-    if (props.related_trade_agreements_exist == 'true') {
-      if (props.related_trade_agreements.length === 0) {
-        related_trade_agreements = null
-      } else {
-        related_trade_agreements = castCompactArray(
-          props.related_trade_agreements
-        )
-      }
-    } else if (props.related_trade_agreements_exist == 'false') {
-      related_trade_agreements = []
-    }
+    castRelatedTradeAgreements()
   } else {
     related_trade_agreements = []
   }
@@ -217,6 +207,20 @@ function transformEventFormBodyToApiRequest(props, featureFlags) {
     related_programmes,
     related_trade_agreements,
   })
+
+  function castRelatedTradeAgreements() {
+    if (props.related_trade_agreements_exist === 'true') {
+      if (props.related_trade_agreements.length === 0) {
+        related_trade_agreements = null
+      } else {
+        related_trade_agreements = castCompactArray(
+          props.related_trade_agreements
+        )
+      }
+    } else if (props.related_trade_agreements_exist === 'false') {
+      related_trade_agreements = []
+    }
+  }
 }
 
 module.exports = {

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -206,7 +206,7 @@ function transformEventFormBodyToApiRequest(props, featureFlags) {
   })
 
   function castRelatedTradeAgreements() {
-    return props.related_trade_agreements_exist === 'true'
+    return props.has_related_trade_agreements === 'true'
       ? props.related_trade_agreements.length === 0
         ? null
         : castCompactArray(props.related_trade_agreements)

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -184,17 +184,25 @@ function transformEventResponseToFormBody(props = {}) {
   })
 }
 
-function transformEventFormBodyToApiRequest(props) {
+function transformEventFormBodyToApiRequest(props, featureFlags) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
-  let related_trade_agreements = null
-  if (props.related_trade_agreements_exist == 'true') {
-    related_trade_agreements = castCompactArray(props.related_trade_agreements)
-  } else if (props.related_trade_agreements_exist == 'false') {
+  let related_trade_agreements
+  if (featureFlags.relatedTradeAgreements) {
+    related_trade_agreements = null
+    if (props.related_trade_agreements_exist == 'true') {
+      related_trade_agreements = castCompactArray(
+        props.related_trade_agreements
+      )
+    } else if (props.related_trade_agreements_exist == 'false') {
+      related_trade_agreements = []
+    }
+  } else {
     related_trade_agreements = castCompactArray(
       '0b371c90-e48a-40ea-a536-0968fb181f6c'
     )
   }
+
   const teams = props.lead_team
     ? teamsArray.concat(props.lead_team)
     : teamsArray

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -189,18 +189,19 @@ function transformEventFormBodyToApiRequest(props, featureFlags) {
   const related_programmes = castCompactArray(props.related_programmes)
   let related_trade_agreements
   if (featureFlags.relatedTradeAgreements) {
-    related_trade_agreements = null
     if (props.related_trade_agreements_exist == 'true') {
-      related_trade_agreements = castCompactArray(
-        props.related_trade_agreements
-      )
+      if (props.related_trade_agreements.length === 0) {
+        related_trade_agreements = null
+      } else {
+        related_trade_agreements = castCompactArray(
+          props.related_trade_agreements
+        )
+      }
     } else if (props.related_trade_agreements_exist == 'false') {
       related_trade_agreements = []
     }
   } else {
-    related_trade_agreements = castCompactArray(
-      '0b371c90-e48a-40ea-a536-0968fb181f6c'
-    )
+    related_trade_agreements = []
   }
 
   const teams = props.lead_team

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -188,7 +188,7 @@ function transformEventFormBodyToApiRequest(props, featureFlags) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
   let related_trade_agreements
-  if (featureFlags.relatedTradeAgreements) {
+  if (featureFlags?.relatedTradeAgreements) {
     if (props.related_trade_agreements_exist == 'true') {
       if (props.related_trade_agreements.length === 0) {
         related_trade_agreements = null

--- a/src/apps/macros.js
+++ b/src/apps/macros.js
@@ -139,6 +139,47 @@ const globalFields = {
       return metadata.programmeOptions.map(transformObjectToOption)
     },
   },
+
+  tradeAgreements: {
+    macroName: 'MultipleChoiceField',
+    name: 'related_trade_agreements',
+    label: 'Related Trade Agreements',
+    initialOption: '-- Select related trade agreement --',
+    options: [
+      {
+        label: 'No Related Trade Agreement',
+        value: '',
+      },
+      {
+        label: 'Australia',
+        value: '50370070-71f9-4ada-ae2c-cd0a737ba5e2',
+      },
+      {
+        label: 'Canada',
+        value: '50cf99fd-1150-421d-9e1c-b23750ebf5ca',
+      },
+      {
+        label: 'India',
+        value: '95ca9dcb-0da5-4bc2-a139-3e5b55c882f7',
+      },
+      {
+        label: 'Japan',
+        value: '05587f64-b976-425e-8763-3557c7936632',
+      },
+      {
+        label: 'Mexico',
+        value: '09787712-0d94-4137-a5f3-3f9131e681f0',
+      },
+      {
+        label: 'New Zealand',
+        value: 'f42da892-2b03-4f88-8a61-9efd8b132776',
+      },
+      {
+        label: 'USA',
+        value: '20e08a38-95a8-4250-bd5b-9d7f0dfc9387',
+      },
+    ],
+  },
 }
 
 module.exports = {

--- a/src/apps/macros.js
+++ b/src/apps/macros.js
@@ -148,7 +148,7 @@ const globalFields = {
     options: [
       {
         label: 'No Related Trade Agreement',
-        value: '',
+        value: '0b371c90-e48a-40ea-a536-0968fb181f6c',
       },
       {
         label: 'Australia',

--- a/src/apps/macros.js
+++ b/src/apps/macros.js
@@ -147,10 +147,6 @@ const globalFields = {
     initialOption: '-- Select related trade agreement --',
     options: [
       {
-        label: 'No Related Trade Agreement',
-        value: '0b371c90-e48a-40ea-a536-0968fb181f6c',
-      },
-      {
         label: 'Australia',
         value: '50370070-71f9-4ada-ae2c-cd0a737ba5e2',
       },

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -44,4 +44,20 @@ describe('Event create', () => {
       .eq(1)
       .should('contain', 'Services')
   })
+
+  it('should allow a user to add multiple related trade agreements', () => {
+    cy.get(selectors.eventCreate.tradeAgreementExistsYes).click()
+    cy.get(selectors.eventCreate.relatedTradeAgreements).eq(0).select('Japan')
+    cy.get(selectors.eventCreate.addAnotherTradeAgreement).click()
+    cy.get(selectors.eventCreate.relatedTradeAgreements)
+      .eq(1)
+      .select('Australia')
+
+    cy.get(selectors.eventCreate.relatedTradeAgreements)
+      .eq(0)
+      .should('contain', 'Japan')
+    cy.get(selectors.eventCreate.relatedTradeAgreements)
+      .eq(1)
+      .should('contain', 'Australia')
+  })
 })

--- a/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+++ b/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
@@ -58,5 +58,9 @@
   {
     "code": "capital-investments-filters",
     "is_active": true
+  },
+  {
+    "code": "relatedTradeAgreements",
+    "is_active": true
   }
 ]

--- a/test/selectors/event/create.js
+++ b/test/selectors/event/create.js
@@ -40,4 +40,8 @@ module.exports = {
   addAnotherProgramme: 'input[name="add_related_programme"]',
   saveEvent: 'button:contains("Add event")',
   saveAndReturn: 'button:contains("Save and return")',
+  relatedTradeAgreements: '[name="related_trade_agreements"]',
+  addAnotherTradeAgreement: 'input[name="add_related_trade_agreement"]',
+  tradeAgreementExistsYes:
+    'label[for="field-related_trade_agreements_exist-1"]',
 }

--- a/test/selectors/event/create.js
+++ b/test/selectors/event/create.js
@@ -42,6 +42,5 @@ module.exports = {
   saveAndReturn: 'button:contains("Save and return")',
   relatedTradeAgreements: '[name="related_trade_agreements"]',
   addAnotherTradeAgreement: 'input[name="add_related_trade_agreement"]',
-  tradeAgreementExistsYes:
-    'label[for="field-related_trade_agreements_exist-1"]',
+  tradeAgreementExistsYes: 'label[for="field-has_related_trade_agreements-1"]',
 }

--- a/test/unit/data/events/event-data.json
+++ b/test/unit/data/events/event-data.json
@@ -38,6 +38,7 @@
       "name": "Example Programme"
     }
   ],
+  "related_trade_agreements_exist": true,
   "related_trade_agreements": [
     {
       "id": "6bd5f509-548c-47d1-a5bd-3cf9056a75a1",

--- a/test/unit/data/events/event-data.json
+++ b/test/unit/data/events/event-data.json
@@ -38,7 +38,7 @@
       "name": "Example Programme"
     }
   ],
-  "related_trade_agreements_exist": true,
+  "has_related_trade_agreements": true,
   "related_trade_agreements": [
     {
       "id": "6bd5f509-548c-47d1-a5bd-3cf9056a75a1",


### PR DESCRIPTION
## Description of change

Two new fields have been added to the Events form:
`Are there related Trade Agreements`
`Related Trade Agreements`

A feature flag of `relatedTradeAgreements` toggles these fields.

## Test instructions

Two new fields should be required fields when the feature flag is enabled.
When disabled, the fields should now show and should not be required.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/20663545/113129943-661ad300-9213-11eb-9b95-54e5e2e1018b.png)

### After
![image](https://user-images.githubusercontent.com/20663545/113129875-513e3f80-9213-11eb-8bac-902a68ea6b89.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
