### PR TITLE
Add investment projects 'next steps' component to the dashboard

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
@@ -8,6 +8,7 @@ import { format } from '../../utils/date-utils'
 import { DARK_GREY } from '../../utils/colors'
 
 const StyledDiv = styled('div')`
+  height: 100%;
   background-color: ${GREY_3};
   padding: 9px ${SPACING.SCALE_2} 8px ${SPACING.SCALE_2};
 `

--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -14,9 +14,11 @@ import {
 import icon from './assets/search-gov.uk.svg'
 import { Tag } from '../../components'
 import { companies, investments } from '../../../lib/urls'
+import { STAGES } from './constants'
 import InvestmentEstimatedLandDate from './InvestmentEstimatedLandDate'
 import InvestmentTimeline from './InvestmentTimeline'
 import InvestmentDetails from './InvestmentDetails'
+import InvestmentNextSteps from './InvestmentNextSteps'
 
 const ListItem = styled('li')`
   padding: ${SPACING.SCALE_3} 0;
@@ -31,6 +33,7 @@ const Row = styled('div')`
 
   ${MEDIA_QUERIES.LARGESCREEN} {
     display: flex;
+    align-items: stretch;
     justify-content: space-between;
     flex-wrap: wrap;
   }
@@ -42,7 +45,8 @@ const Row = styled('div')`
 const Col = styled('div')`
   margin-bottom: ${SPACING.SCALE_3};
   ${MEDIA_QUERIES.LARGESCREEN} {
-    width: calc(50% - ${SPACING.SCALE_3});
+    width: ${({ fullWidth }) =>
+      fullWidth ? '100%' : `calc(50% - ${SPACING.SCALE_2})`};
     margin-bottom: 0;
   }
 `
@@ -141,7 +145,9 @@ const InvestmentListItem = ({
   sector,
   country_investment_originates_from,
   latest_interaction,
+  incomplete_fields,
 }) => {
+  const hasStepsToComplete = !!incomplete_fields.length
   return (
     <ListItem data-test="projects-list-item">
       <ListItemHeaderContainer>
@@ -180,7 +186,7 @@ const InvestmentListItem = ({
           />
         </Row>
         <Row>
-          <Col>
+          <Col fullWidth={!hasStepsToComplete}>
             <InvestmentDetails
               investor={investor_company}
               sector={sector}
@@ -188,6 +194,15 @@ const InvestmentListItem = ({
               latestInteraction={latest_interaction}
             />
           </Col>
+          {hasStepsToComplete && (
+            <Col>
+              <InvestmentNextSteps
+                nextSteps={incomplete_fields}
+                nextStage={STAGES[STAGES.indexOf(stage.name) + 1]}
+                projectId={id}
+              />
+            </Col>
+          )}
         </Row>
       </StyledDetails>
     </ListItem>

--- a/src/client/components/MyInvestmentProjects/InvestmentNextSteps.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentNextSteps.jsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { SPACING, FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
+import { UnorderedList, ListItem } from 'govuk-react'
+
+import { investments } from '../../../lib/urls'
+import { INCOMPLETE_FIELDS } from './constants'
+import { rgba, FOCUS_COLOUR } from '../../utils/colors'
+
+const StyledDiv = styled('div')`
+  height: 100%;
+  /* Colour is in the Gov uk design system but not in our govuk-colors dependancy */
+  background-color: ${rgba(FOCUS_COLOUR, 0.2)};
+  padding: 9px ${SPACING.SCALE_2} 8px ${SPACING.SCALE_2};
+`
+
+const StyledHeader = styled('h3')`
+  font-size: ${FONT_SIZE.SIZE_16};
+  font-weight: ${FONT_WEIGHTS.bold};
+  margin-bottom: 0;
+`
+
+const StyledList = styled(UnorderedList)`
+  margin-bottom: 0;
+`
+
+const StyledListItem = styled(ListItem)`
+  font-size: ${FONT_SIZE.SIZE_16};
+  /* I can't see any other way to override this margin */
+  margin-bottom: 0 !important;
+  &::marker {
+    font-size: 22px;
+    line-height: 1;
+  }
+`
+
+const OverflowWrapper = styled('span')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  width: calc(100% - 8px);
+`
+
+const StyledLink = styled('a')`
+  font-size: ${FONT_SIZE.SIZE_16};
+`
+
+const InvestmentNextSteps = ({ nextSteps, nextStage, projectId }) => {
+  const stepsToComplete = Object.entries(INCOMPLETE_FIELDS)
+    .reduce(
+      (newObj, [key, value]) =>
+        nextSteps
+          ? nextSteps.includes(key)
+            ? [...newObj, value]
+            : newObj
+          : newObj,
+      []
+    )
+    .sort()
+
+  const totalSteps = stepsToComplete.length
+  const hasStepsToComplete = !!totalSteps
+  const additionalSteps = totalSteps >= 3 ? totalSteps - 3 : 0
+  const hasAdditonalSteps = !!additionalSteps
+
+  return (
+    <StyledDiv data-test="investment-steps">
+      <StyledHeader>Next step{totalSteps > 1 && 's'}</StyledHeader>
+      {hasStepsToComplete && (
+        <>
+          <StyledList listStyleType="bullet">
+            {stepsToComplete.map(
+              (step, i) =>
+                i <= 2 && (
+                  <StyledListItem key={i}>
+                    <OverflowWrapper>{step}</OverflowWrapper>
+                  </StyledListItem>
+                )
+            )}
+            {hasAdditonalSteps && (
+              <StyledListItem>
+                Plus {additionalSteps} additional field
+                {additionalSteps > 1 && 's'}
+              </StyledListItem>
+            )}
+          </StyledList>
+          <StyledLink href={investments.projects.details(projectId)}>
+            Add details to move to {nextStage} stage
+          </StyledLink>
+        </>
+      )}
+    </StyledDiv>
+  )
+}
+
+InvestmentNextSteps.propTypes = {
+  nextSteps: PropTypes.arrayOf(PropTypes.string),
+  nextStage: PropTypes.string.isRequired,
+  projectId: PropTypes.string.isRequired,
+}
+
+export default InvestmentNextSteps

--- a/src/client/components/MyInvestmentProjects/InvestmentTimeline.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentTimeline.jsx
@@ -2,13 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { Timeline } from '../../components'
+import { STAGES } from './constants'
 
 const InvestmentTimeline = ({ stage, ...props }) => (
-  <Timeline
-    stages={['Prospect', 'Assign PM', 'Active', 'Verify win', 'Won']}
-    currentStage={stage.name}
-    {...props}
-  />
+  <Timeline stages={STAGES} currentStage={stage.name} {...props} />
 )
 
 InvestmentTimeline.propTypes = {

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -51,7 +51,7 @@ export const SORT_OPTIONS = [
 export const INCOMPLETE_FIELDS = {
   client_cannot_provide_total_investment:
     'Includes capital, operational and R&D expenditure',
-  number_new_jobs: 'New jobs',
+  number_new_jobs: 'Number of new jobs',
   strategic_drivers: 'Strategic drivers behind this investment',
   client_requirements: 'Client requirements',
   client_considering_other_countries:

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -47,3 +47,42 @@ export const SORT_OPTIONS = [
     value: 'name:desc',
   },
 ]
+
+export const INCOMPLETE_FIELDS = {
+  client_cannot_provide_total_investment:
+    'Includes capital, operational and R&D expenditure',
+  number_new_jobs: 'New jobs',
+  strategic_drivers: 'Strategic drivers behind this investment',
+  client_requirements: 'Client requirements',
+  client_considering_other_countries:
+    'Is the client considering other countries?',
+  total_investment: 'Total investment',
+  uk_region_locations: 'Possible UK locations for this investment',
+  project_manager: 'Project Manager',
+  project_assurance_adviser: 'Project Assurance Adviser',
+  government_assistance:
+    'Is this project receiving government financial assistance?',
+  number_safeguarded_jobs: 'Number of safeguarded jobs',
+  r_and_d_budget:
+    'Does this project have budget for a research and development?',
+  non_fdi_r_and_d_budget:
+    'Is this project associated with a non-FDI R&D project?',
+  new_tech_to_uk:
+    'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?',
+  export_revenue:
+    'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?',
+  address_1: 'Street',
+  address_town: 'Town',
+  address_postcode: 'Postcode',
+  actual_uk_regions: 'UK regions landed',
+  actual_land_date: 'Actual land date',
+  average_salary: 'Average salary of new jobs',
+  client_cannot_provide_foreign_investment:
+    'Can client provide capital expenditure value?',
+  delivery_partners: 'Delivery partners',
+  competitor_countries: 'Competitor countries',
+  foreign_equity_investment: 'Foreign equity investment',
+  associated_non_fdi_r_and_d_project: 'Non-FDI R&D project',
+}
+
+export const STAGES = ['Prospect', 'Assign PM', 'Active', 'Verify win', 'Won']

--- a/src/client/utils/colors.js
+++ b/src/client/utils/colors.js
@@ -26,3 +26,4 @@ export const rgba = (colorHex, alpha) => `rgba(${hexToRgb(colorHex)},${alpha})`
 // - https://github.com/alphagov/govuk-frontend (referenced by GOV.UK Design System)
 export const DARK_GREY = '#505a5f'
 export const MID_GREY = '#b1b4b6'
+export const FOCUS_COLOUR = '#ffdd00'

--- a/test/functional/cypress/specs/dashboard-new/investment-project-next-steps.spec.js
+++ b/test/functional/cypress/specs/dashboard-new/investment-project-next-steps.spec.js
@@ -75,7 +75,7 @@ describe('Dashboard - Investment project next steps', () => {
           'Includes capital, operational and R&D expenditure'
         )
         .next()
-        .should('have.text', 'New jobs')
+        .should('have.text', 'Number of new jobs')
     })
     it('should display a link to the project details page', () => {
       cy.get('@lessThanThreeSteps')
@@ -126,7 +126,7 @@ describe('Dashboard - Investment project next steps', () => {
         .find('ul li')
         .should(
           'have.text',
-          'Client requirementsIncludes capital, operational and R&D expenditureNew jobsPlus 1 additional field'
+          'Client requirementsIncludes capital, operational and R&D expenditureNumber of new jobsPlus 1 additional field'
         )
     })
     it('should display a link to the project details page', () => {

--- a/test/functional/cypress/specs/dashboard-new/investment-project-next-steps.spec.js
+++ b/test/functional/cypress/specs/dashboard-new/investment-project-next-steps.spec.js
@@ -1,0 +1,143 @@
+const { investments } = require('../../../../../src/lib/urls')
+
+describe('Dashboard - Investment project next steps', () => {
+  beforeEach(() => {
+    cy.setFeatureFlag(
+      'layoutTesting:9010dd28-9798-e211-a939-e4115bead28a',
+      true
+    )
+    cy.visit('/')
+    cy.get('[data-test="tablist"] span:first-child button').click()
+    cy.get('[data-test="investment-steps"]').as('nexSteps')
+    cy.get('[data-test="project-details"]').eq(0).as('firstProjectDetails')
+    cy.get('[data-test="investment-steps"]').eq(0).as('moreThanThreeSteps')
+    cy.get('[data-test="investment-steps"]').eq(1).as('lessThanThreeSteps')
+    cy.get('[data-test="investment-steps"]').eq(2).as('oneAdditionalStep')
+    cy.get('[data-test="investment-steps"]').eq(7).as('oneStep')
+  })
+  after(() => {
+    cy.resetFeatureFlags()
+  })
+
+  it('should contain next steps for all list items', () => {
+    cy.get('@nexSteps').should('have.length', 9)
+  })
+
+  context('when I have no steps to complete', () => {
+    it('should not show next steps', () => {
+      cy.get('@firstProjectDetails')
+        .find('[data-test="investment-steps"]')
+        .should('not.have.exist')
+    })
+  })
+
+  context('when I have one step to complete', () => {
+    it('should show a title', () => {
+      cy.get('@oneStep').find('h3').should('have.text', 'Next step')
+    })
+    it('should show one list item', () => {
+      cy.get('@oneStep').find('ul li').should('have.length', 1)
+    })
+    it('should say that you have one additional step to action', () => {
+      cy.get('@oneStep')
+        .find('ul li')
+        .eq(0)
+        .should(
+          'have.text',
+          'Includes capital, operational and R&D expenditure'
+        )
+    })
+    it('should display a link to the project details page', () => {
+      cy.get('@oneStep')
+        .find('a')
+        .should('have.text', 'Add details to move to Won stage')
+        .should(
+          'have.attr',
+          'href',
+          investments.projects.details('ea3a03ba-b239-4956-b2fb-f35c91109674')
+        )
+    })
+  })
+
+  context('when I have less than 3 steps to complete', () => {
+    it('should show a title', () => {
+      cy.get('@lessThanThreeSteps').find('h3').should('have.text', 'Next steps')
+    })
+    it('should show two list items', () => {
+      cy.get('@lessThanThreeSteps').find('ul li').should('have.length', 2)
+    })
+    it('should say that you have additional steps to action', () => {
+      cy.get('@lessThanThreeSteps')
+        .find('ul li')
+        .eq(0)
+        .should(
+          'have.text',
+          'Includes capital, operational and R&D expenditure'
+        )
+        .next()
+        .should('have.text', 'New jobs')
+    })
+    it('should display a link to the project details page', () => {
+      cy.get('@lessThanThreeSteps')
+        .find('a')
+        .should('have.text', 'Add details to move to Verify win stage')
+        .should(
+          'have.attr',
+          'href',
+          investments.projects.details('0e686ea4-b8a2-4337-aec4-114d92ad4588')
+        )
+    })
+  })
+  context('when I have more than 3 steps to complete', () => {
+    it('should show a title', () => {
+      cy.get('@moreThanThreeSteps').find('h3').should('have.text', 'Next steps')
+    })
+    it('should show three list items', () => {
+      cy.get('@moreThanThreeSteps').find('ul li').should('have.length', 4)
+    })
+    it('should say that you have additional steps to action', () => {
+      cy.get('@moreThanThreeSteps')
+        .find('ul li')
+        .should(
+          'have.text',
+          'Actual land dateAverage salary of new jobsCan client provide capital expenditure value?Plus 23 additional fields'
+        )
+    })
+    it('should display a link to the project details page', () => {
+      cy.get('@moreThanThreeSteps')
+        .find('a')
+        .should('have.text', 'Add details to move to Assign PM stage')
+        .should(
+          'have.attr',
+          'href',
+          investments.projects.details('b30dee70-b2d6-48cf-9ce4-b9264854470c')
+        )
+    })
+  })
+  context('when I have 3 steps and only 1 addtional step', () => {
+    it('should show a title', () => {
+      cy.get('@oneAdditionalStep').find('h3').should('have.text', 'Next steps')
+    })
+    it('should show three list items', () => {
+      cy.get('@oneAdditionalStep').find('ul li').should('have.length', 4)
+    })
+    it('should say that you have additional steps to action', () => {
+      cy.get('@oneAdditionalStep')
+        .find('ul li')
+        .should(
+          'have.text',
+          'Client requirementsIncludes capital, operational and R&D expenditureNew jobsPlus 1 additional field'
+        )
+    })
+    it('should display a link to the project details page', () => {
+      cy.get('@oneAdditionalStep')
+        .find('a')
+        .should('have.text', 'Add details to move to Verify win stage')
+        .should(
+          'have.attr',
+          'href',
+          investments.projects.details('18750b26-a8c3-41b2-8d3a-fb0b930c2270')
+        )
+    })
+  })
+})

--- a/test/sandbox/fixtures/v3/search/investment-project.json
+++ b/test/sandbox/fixtures/v3/search/investment-project.json
@@ -2,6 +2,7 @@
   "count": 6023,
   "results": [
     {
+      "incomplete_fields": [],
       "actual_uk_regions": [
         {
           "id": "814cd12a-6095-e211-a939-e4115bead28a",
@@ -190,6 +191,39 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs",
+        "strategic_drivers",
+        "client_requirements",
+        "client_considering_other_countries",
+        "project_manager",
+        "project_assurance_adviser",
+        "client_cannot_provide_foreign_investment",
+        "government_assistance",
+        "number_safeguarded_jobs",
+        "r_and_d_budget",
+        "non_fdi_r_and_d_budget",
+        "new_tech_to_uk",
+        "export_revenue",
+        "address_1",
+        "address_town",
+        "address_postcode",
+        "actual_uk_regions",
+        "delivery_partners",
+        "actual_land_date",
+        "referral_source_activity_event",
+        "other_business_activity",
+        "referral_source_activity_marketing",
+        "referral_source_activity_website",
+        "fdi_type",
+        "total_investment",
+        "competitor_countries",
+        "uk_region_locations",
+        "foreign_equity_investment",
+        "average_salary",
+        "associated_non_fdi_r_and_d_project"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,
@@ -345,6 +379,10 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,
@@ -517,6 +555,12 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs",
+        "strategic_drivers",
+        "client_requirements"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,
@@ -714,6 +758,14 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs",
+        "strategic_drivers",
+        "client_requirements",
+        "client_considering_other_countries",
+        "project_manager"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,
@@ -893,6 +945,25 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs",
+        "strategic_drivers",
+        "client_requirements",
+        "client_considering_other_countries",
+        "project_manager",
+        "project_assurance_adviser",
+        "client_cannot_provide_foreign_investment",
+        "government_assistance",
+        "number_safeguarded_jobs",
+        "r_and_d_budget",
+        "non_fdi_r_and_d_budget",
+        "new_tech_to_uk",
+        "export_revenue",
+        "address_1",
+        "address_town",
+        "address_postcode"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,
@@ -1051,6 +1122,15 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs",
+        "strategic_drivers",
+        "client_requirements",
+        "client_considering_other_countries",
+        "project_manager",
+        "project_assurance_adviser"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,
@@ -1227,6 +1307,24 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs",
+        "strategic_drivers",
+        "client_requirements",
+        "client_considering_other_countries",
+        "project_manager",
+        "project_assurance_adviser",
+        "client_cannot_provide_foreign_investment",
+        "government_assistance",
+        "number_safeguarded_jobs",
+        "r_and_d_budget",
+        "non_fdi_r_and_d_budget",
+        "new_tech_to_uk",
+        "export_revenue",
+        "address_1",
+        "address_town"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,
@@ -1374,6 +1472,9 @@
       "government_assistance": null
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment"
+      ],
       "actual_uk_regions": [
         {
           "id": "814cd12a-6095-e211-a939-e4115bead28a",
@@ -1567,6 +1668,24 @@
       "government_assistance": true
     },
     {
+      "incomplete_fields": [
+        "client_cannot_provide_total_investment",
+        "number_new_jobs",
+        "strategic_drivers",
+        "client_requirements",
+        "client_considering_other_countries",
+        "project_manager",
+        "project_assurance_adviser",
+        "client_cannot_provide_foreign_investment",
+        "government_assistance",
+        "number_safeguarded_jobs",
+        "r_and_d_budget",
+        "non_fdi_r_and_d_budget",
+        "new_tech_to_uk",
+        "export_revenue",
+        "address_1",
+        "address_town"
+      ],
       "actual_uk_regions": [],
       "archived_by": null,
       "associated_non_fdi_r_and_d_project": null,


### PR DESCRIPTION
## Description of change
On the new dashboard within each project list item the user needs to see a high level overview of what are the next steps in the project lifecycle. This component will surface the next three steps of the process followed by a message indicating how many additional steps are left to do. The user will also be able to link out to the project details page. If the user has completed the project ie "Won" then the next steps component will not show.

For more info see - https://trello.com/c/V41BNwJa/469-create-next-steps-component

## Test instructions
- You will need to run the new dashboard, see #3248 for instructions on how to do this.

## Screenshots
![Screenshot 2021-03-31 at 15 48 02](https://user-images.githubusercontent.com/10154302/113163940-8d37cb80-9238-11eb-9c01-912e06409ceb.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
