### PR TITLE
Fix dashboard date bugs (financial year and format)

### DIFF
--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -69,7 +69,7 @@ const OutstandingPropositions = ({ results, count }) => {
             </StyledProjectLink>
             <StyledDeadline>
               <StyledDueDate data-test="outstanding-proposition-deadline">
-                Due {format(new Date(deadline), 'd MMM yyyy')}
+                Due {format(new Date(deadline), 'dd MMM yyyy')}
               </StyledDueDate>
               <StyledDueCountdown data-test="outstanding-proposition-countdown">
                 {getDifferenceInDaysLabel(deadline)}

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -61,7 +61,7 @@ export const getDifferenceInDaysLabel = (dateIn) => {
 }
 
 export const getFinancialYearStart = (date) =>
-  date.getMonth() < 4 ? date.getFullYear() - 1 : date.getFullYear()
+  date.getMonth() < 3 ? date.getFullYear() - 1 : date.getFullYear()
 
 export const generateFinancialYearLabel = (yearStart) =>
   `${yearStart}-${(yearStart + 1).toString().slice(-2)}`

--- a/test/sandbox/routes/v4/adviser/adviser.js
+++ b/test/sandbox/routes/v4/adviser/adviser.js
@@ -4,7 +4,7 @@ exports.investmentSummary = function (req, res) {
   const { annual_summaries, ...rest } = investmentSummary
   const now = new Date()
   const currentFinancialYearStart =
-    now.getMonth() < 4 ? now.getFullYear() - 1 : now.getFullYear()
+    now.getMonth() < 3 ? now.getFullYear() - 1 : now.getFullYear()
   const currentInvestmentSummary = {
     annual_summaries: annual_summaries.map(
       ({ financial_year, ...annualSummaryProps }, i) => {


### PR DESCRIPTION
## Description of change

Fixes two bugs that were failing the new dashboard tests:
- Financial year was starting in May not April
- Date format on investment reminders did not include a preceding 0 when less than 10

## Test instructions

Functional tests should now pass

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
