### PR TITLE
Use dynamic data for e2e da

### DIFF
--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -80,7 +80,9 @@ function FilteredCollectionHeader({
       <CollectionHeaderRow actions={actions}>
         <StyledDiv>
           <StyledHeaderText>
-            <StyledResultCount>{formattedTotal}</StyledResultCount>{' '}
+            <StyledResultCount data-test="collectionCount">
+              {formattedTotal}
+            </StyledResultCount>{' '}
             {counterSuffix}
           </StyledHeaderText>
           <FilterReset id="clear-filters">Remove all filters</FilterReset>

--- a/test/end-to-end/cypress/fixtures/investment-project/create-investment.js
+++ b/test/end-to-end/cypress/fixtures/investment-project/create-investment.js
@@ -97,8 +97,92 @@ function newHotelCommitmentToInvest() {
   }
 }
 
+function newGolfCourseDA() {
+  return {
+    model: 'investment.investmentproject',
+    pk: uuidv4(),
+    fields: {
+      name: 'New golf course (DA)',
+      description: 'This is a dummy investment project for testing',
+      stage: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+      status: 'ongoing',
+      estimated_land_date: '2020-03-01',
+      investment_type: '9c364e64-2b28-401b-b2df-50e08b0bca44',
+      investor_company: 'b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+      client_contacts: ['7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b'],
+      client_relationship_manager: '5a644146-5298-4741-91f3-d5d7558adf47',
+      referral_source_adviser: 'e83a608e-84a4-11e6-ae22-56b6b6499611',
+      referral_source_activity: '0c4f8e74-d34f-4aca-b764-a44cdc2d0087',
+      fdi_type: 'f8447013-cfdc-4f35-a146-6619665388b3',
+      sector: '559c37e5-5f95-e211-a939-e4115bead28a',
+      business_activities: ['a2dbd807-ae52-421c-8d1d-88adfc7a506b'],
+      client_cannot_provide_total_investment: false,
+      total_investment: 1100000.0,
+      client_cannot_provide_foreign_investment: false,
+      foreign_equity_investment: 250000.0,
+      government_assistance: false,
+      number_new_jobs: 50,
+      average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+      site_decided: false,
+      client_considering_other_countries: false,
+      uk_region_locations: ['814cd12a-6095-e211-a939-e4115bead28a'],
+      client_requirements: 'Anywhere',
+      strategic_drivers: ['7cc42486-30bb-46d5-813d-6ad1c918ef08'],
+      project_manager: 'd7493b4e-5d7b-4834-98d9-28b78a74052a',
+      project_assurance_adviser: '7bad8082-4978-4fe8-a018-740257f01637',
+      created_on: '2017-08-16T10:00:00Z',
+      created_by: '5a644146-5298-4741-91f3-d5d7558adf47',
+      modified_on: '2017-09-18T13:00:00Z',
+      modified_by: '5a644146-5298-4741-91f3-d5d7558adf47',
+    },
+  }
+}
+
+function newZooLEP() {
+  return {
+    model: 'investment.investmentproject',
+    pk: uuidv4(),
+    fields: {
+      name: 'New zoo (LEP)',
+      description: 'This is a dummy investment project for testing',
+      stage: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+      status: 'ongoing',
+      estimated_land_date: '2020-02-01',
+      investment_type: '3e143372-496c-4d1e-8278-6fdd3da9b48b',
+      investor_company: 'b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+      client_contacts: ['6791d583-7a52-418f-a0d3-d8d527f20d43'],
+      client_relationship_manager: '5a644146-5298-4741-91f3-d5d7558adf47',
+      referral_source_adviser: 'e83a608e-84a4-11e6-ae22-56b6b6499611',
+      referral_source_activity: '0c4f8e74-d34f-4aca-b764-a44cdc2d0087',
+      fdi_type: 'f8447013-cfdc-4f35-a146-6619665388b3',
+      sector: '034be3be-5329-e511-b6bc-e4115bead28a',
+      business_activities: ['a2dbd807-ae52-421c-8d1d-88adfc7a506b'],
+      client_cannot_provide_total_investment: false,
+      total_investment: 1100000.0,
+      client_cannot_provide_foreign_investment: false,
+      foreign_equity_investment: 250000.0,
+      government_assistance: false,
+      number_new_jobs: 50,
+      average_salary: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
+      site_decided: false,
+      client_considering_other_countries: false,
+      uk_region_locations: ['814cd12a-6095-e211-a939-e4115bead28a'],
+      client_requirements: 'Anywhere',
+      strategic_drivers: ['7cc42486-30bb-46d5-813d-6ad1c918ef08'],
+      project_manager: 'd7493b4e-5d7b-4834-98d9-28b78a74052a',
+      project_assurance_adviser: '7bad8082-4978-4fe8-a018-740257f01637',
+      created_on: '2017-08-16T10:00:00Z',
+      created_by: '5a644146-5298-4741-91f3-d5d7558adf47',
+      modified_on: '2017-09-18T13:00:00Z',
+      modified_by: '5a644146-5298-4741-91f3-d5d7558adf47',
+    },
+  }
+}
+
 module.exports = {
   newHotelFdi,
   fancyDressManufacturing,
   newHotelCommitmentToInvest,
+  newGolfCourseDA,
+  newZooLEP,
 }

--- a/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
@@ -4,11 +4,12 @@ const selectors = require('../../../../selectors')
 
 describe('DA add Investment Project interaction', () => {
   context('The browser URL has updated', () => {
+    investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
+
     before(() => {
+      cy.loadFixture([investmentProjectNewGolf])
       cy.visit(
-        investments.projects.interactions.index(
-          fixtures.investmentProject.newGolfCourse.id
-        )
+        investments.projects.interactions.index(investmentProjectNewGolf.pk)
       )
     })
 
@@ -19,7 +20,7 @@ describe('DA add Investment Project interaction', () => {
         .should(
           'eq',
           investments.projects.interactions.createType(
-            fixtures.investmentProject.newGolfCourse.id,
+            investmentProjectNewGolf.pk,
             'investment',
             'interaction'
           )
@@ -28,12 +29,15 @@ describe('DA add Investment Project interaction', () => {
   })
 
   context('DA completes the form and clicks "Add interaction"', () => {
+    investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
+
     before(() => {
+      cy.loadFixture([investmentProjectNewGolf])
       cy.server().route('POST', '/api-proxy/v3/interaction').as('post')
 
       cy.visit(
         investments.projects.interactions.createType(
-          fixtures.investmentProject.newGolfCourse.id,
+          investmentProjectNewGolf.pk,
           'investment',
           'interaction'
         )

--- a/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
@@ -4,12 +4,11 @@ const selectors = require('../../../../selectors')
 
 describe('DA add Investment Project interaction', () => {
   context('The browser URL has updated', () => {
-    investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
-
     before(() => {
-      cy.loadFixture([investmentProjectNewGolf])
       cy.visit(
-        investments.projects.interactions.index(investmentProjectNewGolf.pk)
+        investments.projects.interactions.index(
+          fixtures.investmentProject.newGolfCourse.id
+        )
       )
     })
 
@@ -20,7 +19,7 @@ describe('DA add Investment Project interaction', () => {
         .should(
           'eq',
           investments.projects.interactions.createType(
-            investmentProjectNewGolf.pk,
+            fixtures.investmentProject.newGolfCourse.id,
             'investment',
             'interaction'
           )
@@ -29,15 +28,12 @@ describe('DA add Investment Project interaction', () => {
   })
 
   context('DA completes the form and clicks "Add interaction"', () => {
-    investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
-
     before(() => {
-      cy.loadFixture([investmentProjectNewGolf])
       cy.server().route('POST', '/api-proxy/v3/interaction').as('post')
 
       cy.visit(
         investments.projects.interactions.createType(
-          investmentProjectNewGolf.pk,
+          fixtures.investmentProject.newGolfCourse.id,
           'investment',
           'interaction'
         )

--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -46,12 +46,11 @@ describe('Collection', () => {
     })
 
     describe('interaction', () => {
-      investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
-
       before(() => {
-        cy.loadFixture([investmentProjectNewGolf])
         cy.visit(
-          investments.projects.interactions.index(investmentProjectNewGolf.pk)
+          investments.projects.interactions.index(
+            fixtures.investmentProject.newGolfCourse.id
+          )
         )
       })
 
@@ -61,11 +60,12 @@ describe('Collection', () => {
     })
 
     describe('proposition', () => {
-      investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
-
       before(() => {
-        cy.loadFixture([investmentProjectNewGolf])
-        cy.visit(investments.projects.propositions(investmentProjectNewGolf.pk))
+        cy.visit(
+          investments.projects.propositions(
+            fixtures.investmentProject.newGolfCourse.id
+          )
+        )
       })
 
       it('should return the results summary for a proposition collection', () => {
@@ -74,11 +74,10 @@ describe('Collection', () => {
     })
 
     describe('team', () => {
-      investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
-
       before(() => {
-        cy.loadFixture([investmentProjectNewGolf])
-        cy.visit(investments.projects.team(investmentProjectNewGolf.pk))
+        cy.visit(
+          investments.projects.team(fixtures.investmentProject.newGolfCourse.id)
+        )
       })
 
       it('should return the investment project team summary', () => {

--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -35,22 +35,23 @@ describe('Collection', () => {
   })
 
   context('investment', () => {
-    //   describe('projects', () => {
-    //     before(() => {
-    //       cy.visit(investments.projects.index())
-    //     })
+    describe('projects', () => {
+      before(() => {
+        cy.visit(investments.projects.index())
+      })
 
-    //     it('should return the results summary for a investment collection', () => {
-    //       checkCollection()
-    //     })
-    //   })
+      it('should return the results summary for a investment collection', () => {
+        checkCollection()
+      })
+    })
 
     describe('interaction', () => {
+      investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
+
       before(() => {
+        cy.loadFixture([investmentProjectNewGolf])
         cy.visit(
-          investments.projects.interactions.index(
-            fixtures.investmentProject.newGolfCourse.id
-          )
+          investments.projects.interactions.index(investmentProjectNewGolf.pk)
         )
       })
 
@@ -60,12 +61,11 @@ describe('Collection', () => {
     })
 
     describe('proposition', () => {
+      investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
+
       before(() => {
-        cy.visit(
-          investments.projects.propositions(
-            fixtures.investmentProject.newGolfCourse.id
-          )
-        )
+        cy.loadFixture([investmentProjectNewGolf])
+        cy.visit(investments.projects.propositions(investmentProjectNewGolf.pk))
       })
 
       it('should return the results summary for a proposition collection', () => {
@@ -74,10 +74,11 @@ describe('Collection', () => {
     })
 
     describe('team', () => {
+      investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
+
       before(() => {
-        cy.visit(
-          investments.projects.team(fixtures.investmentProject.newGolfCourse.id)
-        )
+        cy.loadFixture([investmentProjectNewGolf])
+        cy.visit(investments.projects.team(investmentProjectNewGolf.pk))
       })
 
       it('should return the investment project team summary', () => {

--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -41,7 +41,7 @@ describe('Collection', () => {
       })
 
       it('should return the results summary for a investment collection', () => {
-        checkCollection()
+        cy.get('[data-test="collectionCount"]').should('have.text', '1')
       })
     })
 

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -12,8 +12,11 @@ const { assertLocalNav } = require('../../support/assertions')
 
 describe('DA Permission', () => {
   describe('activity', () => {
+    const company = fixtures.company.create.corp()
+
     before(() => {
-      cy.visit(companies.detail(fixtures.company.oneListCorp.id))
+      cy.loadFixture([company])
+      cy.visit(companies.detail(company))
     })
 
     it('should display DA only tabs', () => {
@@ -44,8 +47,13 @@ describe('DA Permission', () => {
   })
 
   describe('contact details', () => {
+    const company = fixtures.company.create.defaultCompany('local nav da')
+    const contact = fixtures.contact.create(company.pk)
+
     before(() => {
-      cy.visit(contacts.details(fixtures.contact.johnnyCakeman.id))
+      cy.loadFixture([company])
+      cy.loadFixture([contact])
+      cy.visit(contacts.details(contact.pk))
     })
 
     it('should display DA only tabs', () => {
@@ -54,12 +62,11 @@ describe('DA Permission', () => {
   })
 
   describe('investment projects', () => {
+    investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
+
     before(() => {
-      cy.visit(
-        investments.projects.details(
-          fixtures.investmentProject.newGolfCourse.id
-        )
-      )
+      cy.loadFixture([investmentProjectNewGolf])
+      cy.visit(investments.projects.details(investmentProjectNewGolf.pk))
     })
 
     it('should display DA only tabs', () => {

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -16,7 +16,7 @@ describe('DA Permission', () => {
 
     before(() => {
       cy.loadFixture([company])
-      cy.visit(companies.detail(company))
+      cy.visit(companies.detail(company.pk))
     })
 
     it('should display DA only tabs', () => {
@@ -62,11 +62,12 @@ describe('DA Permission', () => {
   })
 
   describe('investment projects', () => {
-    investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
-
     before(() => {
-      cy.loadFixture([investmentProjectNewGolf])
-      cy.visit(investments.projects.details(investmentProjectNewGolf.pk))
+      cy.visit(
+        investments.projects.details(
+          fixtures.investmentProject.newGolfCourse.id
+        )
+      )
     })
 
     it('should display DA only tabs', () => {

--- a/test/end-to-end/cypress/specs/DA/permission-spec.js
+++ b/test/end-to-end/cypress/specs/DA/permission-spec.js
@@ -14,8 +14,11 @@ const { assertError } = require('../../support/assertions')
 describe('DA Permission', () => {
   describe('companies', () => {
     describe('exports', () => {
+      const company = fixtures.company.create.lambda('permission da')
+
       before(() => {
-        cy.visit(companies.exports.index(fixtures.company.lambdaPlc.id), {
+        cy.loadFixture([company])
+        cy.visit(companies.exports.index(company), {
           failOnStatusCode: false,
         })
       })
@@ -75,13 +78,13 @@ describe('DA Permission', () => {
 
   context('investment', () => {
     describe('investment document', () => {
+      investmentProjectNewGolf = fixtures.investmentProject.create.newGolfCourseDA()
+
       before(() => {
-        cy.visit(
-          investments.projects.documents(
-            fixtures.investmentProject.newGolfCourse.id
-          ),
-          { failOnStatusCode: false }
-        )
+        cy.loadFixture([investmentProjectNewGolf])
+        cy.visit(investments.projects.documents(investmentProjectNewGolf.pk), {
+          failOnStatusCode: false,
+        })
       })
 
       it('should prevent DA users from accessing the page', () => {
@@ -91,11 +94,12 @@ describe('DA Permission', () => {
     })
 
     describe('interaction', () => {
+      investmentProjectNewZoo = fixtures.investmentProject.create.newZooLEP()
+
       before(() => {
+        cy.loadFixture([investmentProjectNewZoo])
         cy.visit(
-          investments.projects.interactions.index(
-            fixtures.investmentProject.newZoo.id
-          ),
+          investments.projects.interactions.index(investmentProjectNewZoo.pk),
           { failOnStatusCode: false }
         )
       })
@@ -107,11 +111,12 @@ describe('DA Permission', () => {
     })
 
     describe('proposition', () => {
+      investmentProjectNewZoo = fixtures.investmentProject.create.newZooLEP()
+
       before(() => {
+        cy.loadFixture([investmentProjectNewZoo])
         cy.visit(
-          investments.projects.propositions(
-            fixtures.investmentProject.newZoo.id
-          ),
+          investments.projects.propositions(investmentProjectNewZoo.pk),
           { failOnStatusCode: false }
         )
       })
@@ -123,15 +128,13 @@ describe('DA Permission', () => {
     })
 
     describe('team', () => {
+      investmentProjectFancyDress = fixtures.investmentProject.create.fancyDressManufacturing()
+
       before(() => {
-        cy.visit(
-          investments.projects.team(
-            fixtures.investmentProject.fancyDressManufacturing.id
-          ),
-          {
-            failOnStatusCode: false,
-          }
-        )
+        cy.loadFixture([investmentProjectFancyDress])
+        cy.visit(investments.projects.team(investmentProjectFancyDress.pk), {
+          failOnStatusCode: false,
+        })
       })
 
       it("should prevent DA users from accessing a team they don't have access to", () => {
@@ -143,10 +146,13 @@ describe('DA Permission', () => {
 
   context('contacts', () => {
     describe('documents', () => {
+      const company = fixtures.company.create.defaultCompany('contact da')
+      const contact = fixtures.contact.create(company.pk)
+
       before(() => {
-        cy.visit(contacts.documents(fixtures.contact.johnnyCakeman.id), {
-          failOnStatusCode: false,
-        })
+        cy.loadFixture([company])
+        cy.loadFixture([contact])
+        cy.visit(contacts.documents(contact.pk), { failOnStatusCode: false })
       })
 
       it('should prevent DA users from accessing the page', () => {
@@ -156,11 +162,15 @@ describe('DA Permission', () => {
     })
 
     describe('interactions', () => {
+      const company = fixtures.company.create.defaultCompany('contact da')
+      const contact = fixtures.contact.create(company.pk)
+
       before(() => {
-        cy.visit(
-          contacts.contactInteractions(fixtures.contact.johnnyCakeman.id),
-          { failOnStatusCode: false }
-        )
+        cy.loadFixture([company])
+        cy.loadFixture([contact])
+        cy.visit(contacts.contactInteractions(contact.pk), {
+          failOnStatusCode: false,
+        })
       })
 
       it('should prevent DA users from accessing the page', () => {


### PR DESCRIPTION
## Description of change

The intent of this PR is to use dynamic data for our DA specs to increase flexibility when maintaining and creating new tests.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
