### PR TITLE
Updates the reminders component to match updated designs

### DIFF
--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -4,11 +4,13 @@ import styled from 'styled-components'
 import { format } from 'date-fns'
 
 import { H3 } from '@govuk-react/heading'
-import { LINK_COLOUR, RED, TEXT, GREY_1 } from 'govuk-colours'
+import { LINK_COLOUR, RED, TEXT } from 'govuk-colours'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
+import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
 import urls from '../../../lib/urls'
 import { getDifferenceInDaysLabel } from '../../utils/date-utils'
+import { DARK_GREY } from '../../utils/colors'
 
 const StyledSubHeading = styled(H3)`
   color: ${RED};
@@ -25,9 +27,9 @@ const StyledProjectLink = styled('a')`
 `
 
 const StyledProjectCode = styled('div')`
-  margin: ${SPACING.SCALE_2} 0;
+  margin: ${SPACING.SCALE_1} 0;
   font-size: ${FONT_SIZE.SIZE_16};
-  color: ${GREY_1};
+  color: ${DARK_GREY};
 `
 
 const StyledDueDate = styled('span')`
@@ -37,6 +39,7 @@ const StyledDueDate = styled('span')`
 
 const StyledDueCountdown = styled('span')`
   text-align: right;
+  white-space: nowrap;
   font-size: ${FONT_SIZE.SIZE_16};
   color: ${TEXT};
 `
@@ -49,11 +52,13 @@ const StyledList = styled('ul')`
 
 const StyledListItem = styled('li')`
   margin-bottom: ${SPACING.SCALE_4};
-`
-
-const StyledDeadline = styled('div')`
   display: flex;
   justify-content: space-between;
+  align-items: flex-end;
+`
+
+const StyledDetails = styled('div')`
+  padding-right: ${SPACING.SCALE_3};
 `
 
 const OutstandingPropositions = ({ results, count }) => {
@@ -63,24 +68,24 @@ const OutstandingPropositions = ({ results, count }) => {
       <StyledList data-test="outstanding-propositions-list">
         {results.map(({ id, investment_project, name, deadline }) => (
           <StyledListItem key={id}>
-            <StyledProjectLink
-              href={urls.investments.projects.propositions(
-                investment_project.id
-              )}
-            >
-              {name}
-            </StyledProjectLink>
-            <StyledProjectCode data-test="outstanding-proposition-project-code">
-              {investment_project.project_code}
-            </StyledProjectCode>
-            <StyledDeadline>
+            <StyledDetails>
+              <StyledProjectLink
+                href={urls.investments.projects.propositions(
+                  investment_project.id
+                )}
+              >
+                {name}
+              </StyledProjectLink>
+              <StyledProjectCode data-test="outstanding-proposition-project-code">
+                {investment_project.project_code}
+              </StyledProjectCode>
               <StyledDueDate data-test="outstanding-proposition-deadline">
-                Due {format(new Date(deadline), 'dd MMM yyyy')}
+                Due {format(new Date(deadline), DATE_DAY_LONG_FORMAT)}
               </StyledDueDate>
-              <StyledDueCountdown data-test="outstanding-proposition-countdown">
-                {getDifferenceInDaysLabel(deadline)}
-              </StyledDueCountdown>
-            </StyledDeadline>
+            </StyledDetails>
+            <StyledDueCountdown data-test="outstanding-proposition-countdown">
+              {getDifferenceInDaysLabel(deadline)}
+            </StyledDueCountdown>
           </StyledListItem>
         ))}
       </StyledList>

--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { format } from 'date-fns'
 
 import { H3 } from '@govuk-react/heading'
-import { LINK_COLOUR, RED, TEXT } from 'govuk-colours'
+import { LINK_COLOUR, RED, TEXT, GREY_1 } from 'govuk-colours'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import urls from '../../../lib/urls'
@@ -24,14 +24,18 @@ const StyledProjectLink = styled('a')`
   color: ${LINK_COLOUR};
 `
 
+const StyledProjectCode = styled('div')`
+  margin: ${SPACING.SCALE_2} 0;
+  font-size: ${FONT_SIZE.SIZE_16};
+  color: ${GREY_1};
+`
+
 const StyledDueDate = styled('span')`
-  margin-top: ${SPACING.SCALE_1};
   font-size: ${FONT_SIZE.SIZE_16};
   color: ${TEXT};
 `
 
 const StyledDueCountdown = styled('span')`
-  margin-top: ${SPACING.SCALE_1};
   text-align: right;
   font-size: ${FONT_SIZE.SIZE_16};
   color: ${TEXT};
@@ -44,7 +48,7 @@ const StyledList = styled('ul')`
 `
 
 const StyledListItem = styled('li')`
-  margin-bottom: ${SPACING.SCALE_3};
+  margin-bottom: ${SPACING.SCALE_4};
 `
 
 const StyledDeadline = styled('div')`
@@ -57,16 +61,18 @@ const OutstandingPropositions = ({ results, count }) => {
     <div data-test="outstanding-propositions">
       <StyledSubHeading>Outstanding propositions ({count})</StyledSubHeading>
       <StyledList data-test="outstanding-propositions-list">
-        {results.map(({ id, investment_project, deadline }) => (
+        {results.map(({ id, investment_project, name, deadline }) => (
           <StyledListItem key={id}>
             <StyledProjectLink
-              href={urls.investments.projects.proposition(
-                investment_project.id,
-                id
+              href={urls.investments.projects.propositions(
+                investment_project.id
               )}
             >
-              {investment_project.project_code}
+              {name}
             </StyledProjectLink>
+            <StyledProjectCode data-test="outstanding-proposition-project-code">
+              {investment_project.project_code}
+            </StyledProjectCode>
             <StyledDeadline>
               <StyledDueDate data-test="outstanding-proposition-deadline">
                 Due {format(new Date(deadline), 'dd MMM yyyy')}

--- a/src/client/components/InvestmentReminders/tasks.js
+++ b/src/client/components/InvestmentReminders/tasks.js
@@ -7,7 +7,7 @@ export const fetchOutstandingPropositions = ({ adviser }) =>
         adviser_id: adviser.id,
         status: 'ongoing',
         sortby: 'deadline',
-        limit: 5,
+        limit: 3,
       },
     })
     .then(({ data }) => data)

--- a/src/client/components/NotificationBadge/index.jsx
+++ b/src/client/components/NotificationBadge/index.jsx
@@ -9,8 +9,9 @@ const StyledNotificationSpan = styled('span')`
   font-weight: ${FONT_WEIGHTS.bold};
   color: ${WHITE};
   display: inline-block;
+  height: 1em;
   min-width: 15px;
-  padding: 5px 8px 2px 8px;
+  padding: 0 6px 2px;
   border-radius: 75px;
   background-color: ${RED};
   text-align: center;

--- a/src/client/components/ToggleSection/PrimaryToggleSection.jsx
+++ b/src/client/components/ToggleSection/PrimaryToggleSection.jsx
@@ -36,6 +36,7 @@ const StyledButton = styled('button')`
     background: transparent;
     border: none;
     font-size: ${FONT_SIZE.SIZE_19};
+    font-family: inherit;
     color: ${BLUE};
     cursor: pointer;
     font-weight: ${FONT_WEIGHTS.regular};
@@ -64,6 +65,7 @@ const ButtonContent = styled('span')`
 
 const BadgeContainer = styled('span')`
   margin-left: ${SPACING.SCALE_1};
+  padding: ${SPACING.SCALE_3} 0;
 `
 
 const PrimaryToggleSection = ({

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -1,9 +1,9 @@
 const { format } = require('date-fns')
 const urls = require('../../../../../src/lib/urls')
 
-const NEW_RESTAURANT_PROJECT_CODE = 'DHP-00000004'
-const NEW_RESTAURANT_PROJECT_ID = '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
-const LIST_OF_CITIES_PROPOSITON_ID = '3322750d-a645-4460-b584-8f9254459246'
+const UNIVERSITY_PROJECT_CODE = 'DHP-00000004'
+const UNIVERSITY_PROJECT_ID = '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
+const UNIVERSITY_PROPOSITION_NAME = 'Univeristy Proposition'
 
 describe('Dashboard reminders', () => {
   beforeEach(() => {
@@ -34,7 +34,7 @@ describe('Dashboard reminders', () => {
   context('View reminders', () => {
     it('should contain a notification badge in the reminders heading', () => {
       cy.get('@investmentRemindersHeading').should('contain.text', 'Reminders')
-      cy.get('@investmentRemindersBadge').should('have.text', '5')
+      cy.get('@investmentRemindersBadge').should('have.text', '3')
     })
 
     it('should contain elements in the correct order', () => {
@@ -48,21 +48,22 @@ describe('Dashboard reminders', () => {
     it('should display each of the outstanding propositions', () => {
       cy.get('@outstandingPropositionsList')
         .find('li')
-        .should('have.length', '5')
+        .should('have.length', '3')
         .first()
         .as('outstandingProposition')
 
       cy.get('@outstandingProposition')
         .find('a')
-        .should('have.text', NEW_RESTAURANT_PROJECT_CODE)
+        .should('have.text', UNIVERSITY_PROPOSITION_NAME)
         .should(
           'have.attr',
           'href',
-          urls.investments.projects.proposition(
-            NEW_RESTAURANT_PROJECT_ID,
-            LIST_OF_CITIES_PROPOSITON_ID
-          )
+          urls.investments.projects.propositions(UNIVERSITY_PROJECT_ID)
         )
+
+      cy.get('@outstandingProposition')
+        .find('[data-test="outstanding-proposition-project-code"]')
+        .should('have.text', UNIVERSITY_PROJECT_CODE)
 
       cy.get('@outstandingProposition')
         .find('[data-test="outstanding-proposition-deadline"]')

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -67,7 +67,7 @@ describe('Dashboard reminders', () => {
 
       cy.get('@outstandingProposition')
         .find('[data-test="outstanding-proposition-deadline"]')
-        .should('have.text', `Due ${format(new Date(), 'dd MMM yyyy')}`)
+        .should('have.text', `Due ${format(new Date(), 'E, dd MMM yyyy')}`)
 
       cy.get('@outstandingProposition')
         .find('[data-test="outstanding-proposition-countdown"]')

--- a/test/sandbox/fixtures/v4/proposition/outstanding_propositions.json
+++ b/test/sandbox/fixtures/v4/proposition/outstanding_propositions.json
@@ -1,12 +1,12 @@
 {
-    "count": 5,
+    "count": 3,
     "next": null,
     "previous": null,
     "results": [
         {
             "id": "3322750d-a645-4460-b584-8f9254459246",
             "investment_project": {
-                "name": "New restaurant",
+                "name": "University buildings",
                 "project_code": "DHP-00000004",
                 "id": "18750b26-a8c3-41b2-8d3a-fb0b930c2270"
             },
@@ -18,7 +18,7 @@
             },
             "deadline": "2021-04-01",
             "status": "ongoing",
-            "name": "List of cities",
+            "name": "Univeristy Proposition",
             "scope": "Parks and unemployment",
             "details": "Provided all materials.",
             "created_on": "2017-06-15T15:00:00Z",
@@ -39,7 +39,7 @@
         {
             "id": "45eef900-bd85-4679-824b-a74369cb6f18",
             "investment_project": {
-                "name": "New restaurant",
+                "name": "New restaurant with quite a big name going over two lines",
                 "project_code": "DHP-00000005",
                 "id": "18750b26-a8c3-41b2-8d3a-fb0b930c2270"
             },
@@ -51,7 +51,7 @@
             },
             "deadline": "2020-05-01",
             "status": "ongoing",
-            "name": "List of cities",
+            "name": "Park Proposal",
             "scope": "Parks",
             "details": "Initial scope was wrong.",
             "created_on": "2017-06-15T14:00:00Z",
@@ -72,7 +72,7 @@
         {
             "id": "74a7eafa-4582-4304-8027-022a75df4948",
             "investment_project": {
-                "name": "New restaurant",
+                "name": "Super Casino",
                 "project_code": "DHP-00000006",
                 "id": "18750b26-a8c3-41b2-8d3a-fb0b930c2270"
             },
@@ -83,72 +83,6 @@
                 "id": "5a644146-5298-4741-91f3-d5d7558adf47"
             },
             "deadline": "2020-05-05",
-            "status": "ongoing",
-            "name": "Superb prospect",
-            "scope": "Everything",
-            "details": "",
-            "created_on": "2017-06-15T12:00:00Z",
-            "created_by": {
-                "name": "Michael Wining",
-                "first_name": "Michael",
-                "last_name": "Wining",
-                "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
-            },
-            "modified_on": "2017-06-15T12:00:00Z",
-            "modified_by": {
-                "name": "Michael Wining",
-                "first_name": "Michael",
-                "last_name": "Wining",
-                "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
-            }
-        },
-        {
-            "id": "45eef900-bd85-4679-824b-a74369cb6f19",
-            "investment_project": {
-                "name": "University buildings",
-                "project_code": "DHP-00000007",
-                "id": "18750b26-a8c3-41b2-8d3a-fb0b930c2270"
-            },
-            "adviser": {
-                "name": "Paula Churing",
-                "first_name": "Paula",
-                "last_name": "Churing",
-                "id": "5a644146-5298-4741-91f3-d5d7558adf47"
-            },
-            "deadline": "2021-06-08",
-            "status": "ongoing",
-            "name": "List of cities",
-            "scope": "Parks",
-            "details": "Initial scope was wrong.",
-            "created_on": "2017-06-15T14:00:00Z",
-            "created_by": {
-                "name": "Michael Wining",
-                "first_name": "Michael",
-                "last_name": "Wining",
-                "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
-            },
-            "modified_on": "2017-06-15T14:30:00Z",
-            "modified_by": {
-                "name": "Michael Wining",
-                "first_name": "Michael",
-                "last_name": "Wining",
-                "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
-            }
-        },
-        {
-            "id": "74a7eafa-4582-4304-8027-022a75df4949",
-            "investment_project": {
-                "name": "Sports centre",
-                "project_code": "DHP-00000008",
-                "id": "18750b26-a8c3-41b2-8d3a-fb0b930c2270"
-            },
-            "adviser": {
-                "name": "Paula Churing",
-                "first_name": "Paula",
-                "last_name": "Churing",
-                "id": "5a644146-5298-4741-91f3-d5d7558adf47"
-            },
-            "deadline": "2021-06-09",
             "status": "ongoing",
             "name": "Superb prospect",
             "scope": "Everything",

--- a/test/sandbox/fixtures/v4/proposition/outstanding_propositions.json
+++ b/test/sandbox/fixtures/v4/proposition/outstanding_propositions.json
@@ -51,7 +51,7 @@
             },
             "deadline": "2020-05-01",
             "status": "ongoing",
-            "name": "Park Proposal",
+            "name": "Big Multiline Park Proposal With a Long Descriptive Name",
             "scope": "Parks",
             "details": "Initial scope was wrong.",
             "created_on": "2017-06-15T14:00:00Z",


### PR DESCRIPTION
**Marked as DO NOT MERGE until design is checked by Anna**

## Description of change

Updates the reminders component to match the [updated designs](https://glc39r.axshare.com/#id=ozm45m&p=spec_reminders&g=1).

## Test instructions

With the dashboard feature flag enabled, the top left should show a reminders component containing 3 outstanding propositions. The proposition name should link to the list of propositions for the project.

## Screenshots
### Before

![Screenshot from 2021-04-01 12-45-26](https://user-images.githubusercontent.com/1234577/113289470-2b369f00-92e8-11eb-9da8-28d38cc9c73c.png)

### After

![Screenshot from 2021-04-06 09-22-22](https://user-images.githubusercontent.com/1234577/113681265-abc71800-96b9-11eb-9215-941107e33df6.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
