### PR TITLE
Make minor adjustments to field titles and link based upon user feedback

### DIFF
--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -23,7 +23,7 @@ const eventFormConfig = (
             macroName: 'MultipleChoiceField',
             type: 'radio',
             name: 'has_related_trade_agreements',
-            label: 'Are there related Trade Agreements',
+            label: 'Are there related Trade Agreements?',
             modifier: 'inline',
             options: [
               {
@@ -184,7 +184,7 @@ const eventFormConfig = (
             macroName: 'MultipleChoiceField',
             type: 'radio',
             name: 'event_shared',
-            label: 'Is this a shared event',
+            label: 'Is this a shared event?',
             optional: true,
             modifier: 'inline',
             options: [
@@ -337,7 +337,7 @@ const eventFormConfig = (
             macroName: 'MultipleChoiceField',
             type: 'radio',
             name: 'event_shared',
-            label: 'Is this a shared event',
+            label: 'Is this a shared event?',
             optional: true,
             modifier: 'inline',
             options: [

--- a/src/apps/events/views/edit.njk
+++ b/src/apps/events/views/edit.njk
@@ -6,7 +6,7 @@
         <p data-test="trade-agreement-text">
             If your Event is set up to focus on a Trade Agreement or contributes to implementing a Trade Agreement then select that the event relates to a Trade Agreement and the relevant Agreement(s)
         </p>
-        <a href="https://data-services-help.trade.gov.uk/data-hub/how-articles/recording-trade-agreement-activity/recording-trade-agreement-activity/" target="_blank" aria-label="opens in a new tab" data-test="trade-agreement-link">
+        <a href="https://data-services-help.trade.gov.uk/data-hub/how-articles/trade-agreement-activity/recording-trade-agreement-activity/" target="_blank" aria-label="opens in a new tab" data-test="trade-agreement-link">
             See more guidance
         </a>
     {% endif %}

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -70,7 +70,7 @@ describe('Event create', () => {
       .should(
         'have.attr',
         'href',
-        'https://data-services-help.trade.gov.uk/data-hub/how-articles/recording-trade-agreement-activity/recording-trade-agreement-activity/'
+        'https://data-services-help.trade.gov.uk/data-hub/how-articles/trade-agreement-activity/recording-trade-agreement-activity/'
       )
       .should('have.attr', 'aria-label', 'opens in a new tab')
   })


### PR DESCRIPTION
## Description of change

This PR adds question marks to two questions on the Events create form.
It also updates a link under "See more guidance" to point at a new page.

## Test instructions

With the `relatedTradeAgreements` flag enabled, you should now see "Are there related Trade Agreements" now reads "Are there related Trade Agreements?". The "See more guidance" link has also been updated.

With or without 'relatedTradeAgreements` flag enabled, you should now see "Is this a shared event" now reads as "Is this a shared event?"

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/114016262-93463180-9862-11eb-9fe9-1f0faa4ac115.png)

### After

![image](https://user-images.githubusercontent.com/20663545/114014629-b7087800-9860-11eb-8f5d-6d5dd1448996.png)
![image](https://user-images.githubusercontent.com/20663545/114014657-bf60b300-9860-11eb-88ac-ce7da995e361.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
