### PR TITLE
Update field question following user feedback

### DIFF
--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -23,7 +23,7 @@ const eventFormConfig = (
             macroName: 'MultipleChoiceField',
             type: 'radio',
             name: 'has_related_trade_agreements',
-            label: 'Are there related Trade Agreements?',
+            label: 'Does the Event relate to a Trade Agreement?',
             modifier: 'inline',
             options: [
               {


### PR DESCRIPTION
## Description of change

Changes the new events field from: "Are there related Trade Agreements?" to "Does the Event relate to a Trade Agreement?" following user feedback

## Test instructions

With the feature flag `relatedTradeAgreements` enabled, there should now be a field "Does the Event relate to a Trade Agreement?".

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/114162605-2a71be80-9921-11eb-84ea-05fe84a1612b.png)

### After

![image](https://user-images.githubusercontent.com/20663545/114162521-14fc9480-9921-11eb-8e3d-55ef550286dc.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
