### PR TITLE
Component/dismissable status message

### DIFF
--- a/src/client/components/ErrorSummary/index.jsx
+++ b/src/client/components/ErrorSummary/index.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { TEXT_COLOUR, ERROR_COLOUR, FOCUS_COLOUR } from 'govuk-colours'
+import { TEXT_COLOUR, ERROR_COLOUR } from 'govuk-colours'
 
 import { H2 } from '@govuk-react/heading'
 import Paragraph from '@govuk-react/paragraph'
@@ -15,7 +15,6 @@ import {
   FONT_SIZE,
   BORDER_WIDTH,
   BORDER_WIDTH_MOBILE,
-  FOCUS_WIDTH,
   LINE_HEIGHT,
   SPACING,
   MEDIA_QUERIES,
@@ -23,6 +22,8 @@ import {
 } from '@govuk-react/constants'
 
 import { spacing } from '@govuk-react/lib'
+
+import { focusMixin } from '../../styles'
 
 const StyledErrorText = styled(Link)({
   fontFamily: NTA_LIGHT,
@@ -55,10 +56,7 @@ const StyledErrorSummary = styled('div')(
     color: TEXT_COLOUR,
     padding: RESPONSIVE_4.mobile,
     border: `${BORDER_WIDTH_MOBILE} solid ${ERROR_COLOUR}`,
-    '&:focus': {
-      outline: `${FOCUS_WIDTH} solid ${FOCUS_COLOUR}`,
-      outlineOffset: '0',
-    },
+    ...focusMixin,
     [MEDIA_QUERIES.LARGESCREEN]: {
       padding: RESPONSIVE_4.tablet,
       border: `${BORDER_WIDTH} solid ${ERROR_COLOUR}`,

--- a/src/client/components/StatusMessage/Dismissable.jsx
+++ b/src/client/components/StatusMessage/Dismissable.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import StatusMessage from '.'
+import TextLikeButton from '../TextLikeButton'
 
 const StyledStatusMessage = styled(StatusMessage)({
   display: 'flex',
@@ -14,7 +15,7 @@ const DismissableStatusMessage = React.forwardRef(
   ({ children, onDismiss, ...props }, ref) => (
     <StyledStatusMessage {...props} ref={ref}>
       {children}
-      <TextLikeButton tabIndex={0} onClick={onDismiss}>
+      <TextLikeButton tabIndex={0} onClick={onDismiss} aria-label="dismiss">
         {'\u{2715}'}
       </TextLikeButton>
     </StyledStatusMessage>

--- a/src/client/components/StatusMessage/Dismissable.jsx
+++ b/src/client/components/StatusMessage/Dismissable.jsx
@@ -16,7 +16,7 @@ const DismissableStatusMessage = React.forwardRef(
     <StyledStatusMessage {...props} ref={ref}>
       {children}
       <TextLikeButton tabIndex={0} onClick={onDismiss} aria-label="dismiss">
-        {'\u{2715}'}
+        ✕
       </TextLikeButton>
     </StyledStatusMessage>
   )

--- a/src/client/components/StatusMessage/Dismissable.jsx
+++ b/src/client/components/StatusMessage/Dismissable.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import StatusMessage from '.'
+
+const StyledStatusMessage = styled(StatusMessage)({
+  display: 'flex',
+  alignItems: 'baseline',
+  justifyContent: 'space-between',
+})
+
+const DismissableStatusMessage = React.forwardRef(
+  ({ children, onDismiss, ...props }, ref) => (
+    <StyledStatusMessage {...props} ref={ref}>
+      {children}
+      <TextLikeButton tabIndex={0} onClick={onDismiss}>
+        {'\u{2715}'}
+      </TextLikeButton>
+    </StyledStatusMessage>
+  )
+)
+
+DismissableStatusMessage.propTypes = {
+  onDismiss: PropTypes.func,
+}
+
+export default DismissableStatusMessage

--- a/src/client/components/StatusMessage/__stories__/DismissableStatusMessage.stories.jsx
+++ b/src/client/components/StatusMessage/__stories__/DismissableStatusMessage.stories.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { ERROR_COLOUR } from 'govuk-colours'
+
+import DismissableStatusMessage from '../Dismissable'
+
+storiesOf('DismissableStatusMessage', module)
+  .add('Default', () => {
+    return <DismissableStatusMessage>An info message</DismissableStatusMessage>
+  })
+  .add('Custom colour', () => {
+    return (
+      <DismissableStatusMessage colour={ERROR_COLOUR}>
+        An error message
+      </DismissableStatusMessage>
+    )
+  })

--- a/src/client/components/TextLikeButton.js
+++ b/src/client/components/TextLikeButton.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+
+import { focusMixin } from '../styles'
+
+export default styled.button({
+  cursor: 'pointer',
+  background: 'none',
+  border: 'none',
+  fontSize: 'inherit',
+  fontFamily: 'inherit',
+  color: 'inherit',
+  '&:hover': {
+    fontWeight: 'bold',
+  },
+  ...focusMixin,
+})

--- a/src/client/styles.js
+++ b/src/client/styles.js
@@ -1,0 +1,9 @@
+import { FOCUS_COLOUR } from 'govuk-colours'
+import { FOCUS_WIDTH } from '@govuk-react/constants'
+
+export const focusMixin = {
+  '&:focus': {
+    outline: `${FOCUS_WIDTH} solid ${FOCUS_COLOUR}`,
+    outlineOffset: '0',
+  },
+}


### PR DESCRIPTION
## Description of change

Adds the new `DismissableStatusMessage` component, which adds a cancel button to the `StatusMessage`.

## Test instructions

1. Find the component in Storybook.
2. It should behave exactly as `StatusMessage`,
3. It should have an extra with a cross mark button on the right
4. The button should be aligned to the baseline of the message text
3. The button should be labelled "dismiss"
4. If a function is passed to the `onDismiss` prop, it should be called with an `ClickEvent` when the button is clicked

## Screenshots

<img width="735" alt="Screen Shot 2021-04-13 at 9 25 24 AM" src="https://user-images.githubusercontent.com/2333157/114521340-3bc90c80-9c3a-11eb-89e2-a5e3d7eda179.png">

