### PR TITLE
Add meta titles for accessibility

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -27,6 +27,8 @@ async function renderActivityFeed(req, res, next) {
     dnbRelatedCompaniesCount,
   } = res.locals
 
+  res.locals.title = `Activities - ${company.name} - Companies`
+
   const breadcrumbs = [
     { link: urls.dashboard(), text: 'Home' },
     { link: urls.companies.index(), text: 'Companies' },

--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -23,6 +23,8 @@ function renderLeadAdvisers(req, res) {
   } = res.locals
   const { name, team, email } = companyToLeadITA(company) || {}
 
+  res.locals.title = `Lead adviser - ${company.name} - Companies`
+
   res.render('companies/views/lead-advisers', {
     props: {
       hasAccountManager: !!company.one_list_group_global_account_manager,

--- a/src/apps/companies/apps/exports/controllers.js
+++ b/src/apps/companies/apps/exports/controllers.js
@@ -57,6 +57,8 @@ function renderExports(req, res) {
     exportCountriesInformation,
   } = transformCompanyToExportDetailsView(company)
 
+  res.locals.title = `Export - ${company.name} - Companies`
+
   res.render('companies/apps/exports/views/index', {
     props: {
       isArchived,

--- a/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/controllers/profile.js
@@ -142,6 +142,8 @@ const renderProfile = async (req, res, next) => {
       )
     }
 
+    res.locals.title = `Large capitail profile - ${company.name} - Companies`
+
     res.render(
       'companies/apps/investments/large-capital-profile/views/profile',
       {

--- a/src/apps/companies/apps/investments/projects/controllers/list.js
+++ b/src/apps/companies/apps/investments/projects/controllers/list.js
@@ -32,6 +32,8 @@ async function renderProjects(req, res, next) {
       )
     )
 
+    res.locals.title = `Investments - ${company.name} - Companies`
+
     res.render('companies/apps/investments/projects/views/list', {
       results,
       actionButtons,

--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -27,6 +27,8 @@ function renderContacts(req, res) {
         },
       ]
 
+  res.locals.title = `Contacts - ${company.name} - Companies`
+
   res.render('companies/views/contacts', {
     sortForm,
     filtersFields,

--- a/src/apps/companies/controllers/orders.js
+++ b/src/apps/companies/controllers/orders.js
@@ -33,6 +33,8 @@ async function renderOrders(req, res, next) {
       )
     )
 
+    res.locals.title = `Orders - ${company.name} - Companies`
+
     res.render('companies/views/orders', {
       results,
       actionButtons,

--- a/src/apps/my-pipeline/controllers/add.js
+++ b/src/apps/my-pipeline/controllers/add.js
@@ -4,6 +4,8 @@ async function renderAddToPipeline(req, res, next) {
   try {
     const { company } = res.locals
 
+    res.locals.title = `Add to your pipeline - ${company.name} - Companies`
+
     res.render('my-pipeline/views/pipeline-form', {
       props: {
         companyId: company.id,

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -19,6 +19,13 @@ describe('Company activity feed', () => {
       cy.visit(urls.companies.activity.index(fixtures.company.venusLtd.id))
     })
 
+    it('should render a meta title', () => {
+      cy.title().should(
+        'eq',
+        'Activities - Venus Ltd - Companies - DIT Data Hub'
+      )
+    })
+
     it('should display the activity header', () => {
       cy.get(selectors.companyCollection().heading).should(
         'have.text',

--- a/test/functional/cypress/specs/companies/contact-spec.js
+++ b/test/functional/cypress/specs/companies/contact-spec.js
@@ -8,6 +8,13 @@ describe('Companies Contact', () => {
       cy.visit(urls.companies.contacts(fixtures.company.archivedLtd.id))
     })
 
+    it('should render a meta title', () => {
+      cy.title().should(
+        'eq',
+        'Contacts - Archived Ltd - Companies - DIT Data Hub'
+      )
+    })
+
     it('should not display the "Add contact" button', () => {
       cy.get(
         selectors

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -62,6 +62,10 @@ describe('Company Export tab', () => {
         visitExportIndex(fixtures.company.dnbCorp.id)
       })
 
+      it('should render a meta title', () => {
+        cy.title().should('eq', 'Export - DnB Corp - Companies - DIT Data Hub')
+      })
+
       it('should render breadcrumbs', () => {
         assertBreadcrumbs({
           Home: '/',

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -9,6 +9,13 @@ describe('Company Investment Project Collection', () => {
     cy.visit(urls.companies.investments.companyInvestmentProjects(dnbCorp))
   })
 
+  it('should render a meta title', () => {
+    cy.title().should(
+      'eq',
+      'Investments - Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978 - Companies - DIT Data Hub'
+    )
+  })
+
   it('should load investment collection where projects have no sector', () => {
     cy.get(selectors.collection.items).first().should('not.have.text', 'Sector')
   })

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -14,6 +14,13 @@ describe('Company Investments and Large capital profile', () => {
   context('when viewing the 3 tabs', () => {
     before(() => cy.visit(largeCapitalProfile))
 
+    it('should render a meta title', () => {
+      cy.title().should(
+        'eq',
+        'Large capitail profile - One List Corp - Companies - DIT Data Hub'
+      )
+    })
+
     it('should display an "Investments projects" tab with the correct URL', () => {
       cy.get(selectors.tabs.investmentProjects)
         .find('a')

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -9,6 +9,13 @@ describe('Lead advisers', () => {
       cy.get(selectors.tabbedLocalNav().item(3)).click()
     })
 
+    it('should render a meta title', () => {
+      cy.title().should(
+        'eq',
+        'Lead adviser - Mars Exports Ltd - Companies - DIT Data Hub'
+      )
+    })
+
     it('should display the "Lead Adviser" tab in the navigation', () => {
       cy.get(selectors.tabbedLocalNav().item(3)).should(
         'contain',

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -7,6 +7,10 @@ describe('Company OMIS Collections', () => {
     cy.visit(urls.companies.orders(fixtures.company.oneListCorp.id))
   })
 
+  it('should render a meta title', () => {
+    cy.title().should('eq', 'Orders - One List Corp - Companies - DIT Data Hub')
+  })
+
   it('should display a list of orders with the total result', () => {
     cy.get(selectors.entityCollection.collectionResult).should('contain', 264)
     cy.get(selectors.entityCollection.entities)

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -19,6 +19,13 @@ describe('Company add to pipeline form', () => {
       cy.visit(urls.companies.pipelineAdd(minimallyMinimal.id))
     })
 
+    it('should render a meta title', () => {
+      cy.title().should(
+        'eq',
+        'Add to your pipeline - Minimally Minimal Ltd - Companies - DIT Data Hub'
+      )
+    })
+
     it('should render the breadcrumbs', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),


### PR DESCRIPTION
## Description of change

As part of the accessibility audit from the DAC (Digital Accessibility Centre) we need to update the meta titles for certain pages listed in the audit (pages 34 - 37). 

Below is a list of titles I updated including the format requested by the DAC: 

### Companies
Activity tab - `Activities - [company name] - Companies`
Contacts tab - `Contacts - [company name] - Companies`
Lead adviser tab - `Lead adviser - [company name] - Companies`
Investment tab
- Investments tab - `Investments - [company name] - Companies`
- Large capital profile tab - `Large capital profile- [company name] - Companies`
Export tab - `Export - [company name] - Companies`
Orders tab - `Orders - [company name] - Companies`

### Add to pipeline
Add to your pipeline - `Add to your pipeline - [company name] - Companies`

Tests added for each updated page title.

## Test instructions

Nothing should change visually, you need to view the pages and read the meta titles.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
