### PR TITLE
Adding padding to Investment project list item

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListItem.jsx
@@ -23,6 +23,11 @@ import InvestmentNextSteps from './InvestmentNextSteps'
 const ListItem = styled('li')`
   padding: ${SPACING.SCALE_2} 0;
   border-bottom: 2px solid ${GREY_1};
+  details {
+    &[open] {
+      padding-bottom: ${SPACING.SCALE_5};
+    }
+  }
   &:last-child {
     border-bottom: none;
   }


### PR DESCRIPTION
## Description
Minor cosmetic changes to an Investment project list item (new dashboard).

### After
<img width="784" alt="bottom-padding" src="https://user-images.githubusercontent.com/964268/115021969-9bcae780-9eb4-11eb-8a47-b362f65b1ebe.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
