### PR TITLE
Investment project details list item refactor and truncation of sector

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
@@ -19,11 +19,19 @@ const StyledHeader = styled('h3')`
   margin-bottom: 0;
 `
 
-const StyledList = styled('ul')`
+const StyledDL = styled('dl')`
   font-size: ${FONT_SIZE.SIZE_16};
 `
-const StyledSpan = styled('span')`
+
+const StyledDT = styled('dt')`
   color: ${DARK_GREY};
+  float: left;
+  clear: left;
+  margin-right: 5px;
+`
+
+const StyledDD = styled('dd')`
+  margin-left: 0px;
 `
 
 const InvestmentDetails = ({
@@ -34,36 +42,32 @@ const InvestmentDetails = ({
 }) => (
   <StyledDiv data-test="investment-details">
     <StyledHeader>Details</StyledHeader>
-    <StyledList>
-      <li>
-        <StyledSpan>Investor: </StyledSpan>
+    <StyledDL>
+      <StyledDT>Investor:</StyledDT>
+      <StyledDD>
         <a href={companies.details(investor.id)}>{investor.name}</a>
-      </li>
-      <li>
-        <StyledSpan>Sector: </StyledSpan>
-        {sector.name}
-      </li>
+      </StyledDD>
+      <StyledDT>Sector:</StyledDT>
+      <StyledDD>{sector.name}</StyledDD>
       {countryOrigin && (
-        <li>
-          <StyledSpan>Country of origin: </StyledSpan>
-          {countryOrigin.name}
-        </li>
+        <>
+          <StyledDT>Country of origin:</StyledDT>
+          <StyledDD>{countryOrigin.name}</StyledDD>
+        </>
       )}
       {latestInteraction && (
         <>
-          <li>
-            <StyledSpan>Last interaction: </StyledSpan>
-            {format(latestInteraction.date)}
-          </li>
-          <li>
-            <StyledSpan>Interaction subject: </StyledSpan>
+          <StyledDT>Last interaction:</StyledDT>
+          <StyledDD>{format(latestInteraction.date)}</StyledDD>
+          <StyledDT>Interaction subject:</StyledDT>
+          <StyledDD>
             <a href={interactions.detail(latestInteraction.id)}>
               {latestInteraction.subject}
             </a>
-          </li>
+          </StyledDD>
         </>
       )}
-    </StyledList>
+    </StyledDL>
   </StyledDiv>
 )
 

--- a/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
@@ -34,6 +34,13 @@ const StyledDD = styled('dd')`
   margin-left: 0px;
 `
 
+const Truncate = styled('span')`
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`
+
 const InvestmentDetails = ({
   investor,
   sector,
@@ -48,7 +55,9 @@ const InvestmentDetails = ({
         <a href={companies.details(investor.id)}>{investor.name}</a>
       </StyledDD>
       <StyledDT>Sector:</StyledDT>
-      <StyledDD>{sector.name}</StyledDD>
+      <StyledDD>
+        <Truncate>{sector.name}</Truncate>
+      </StyledDD>
       {countryOrigin && (
         <>
           <StyledDT>Country of origin:</StyledDT>

--- a/test/functional/cypress/specs/dashboard-new/investment-details.spec.js
+++ b/test/functional/cypress/specs/dashboard-new/investment-details.spec.js
@@ -7,64 +7,81 @@ describe('Dashboard - Investment details', () => {
       true
     )
     cy.visit('/')
-    cy.get('[data-test="investment-details"]').as('allDetails')
+    cy.get('[data-test="investment-details"]').as('allInvestmentDetails')
+    cy.get('[data-test="investment-details"]').eq(0).as('firstProjectDetails')
     cy.get('[data-test="investment-details"]').eq(1).as('secondProjectDetails')
     cy.get('[data-test="investment-details"]').eq(2).as('thirdProjectDetails')
-    cy.get('[data-test="investment-details"]')
-      .eq(0)
-      .find('h3')
-      .as('header')
-      .next()
-      .find('li')
-      .as('listItem')
+    cy.get('@firstProjectDetails').find('dt').as('allTerms')
+    cy.get('@firstProjectDetails').find('dd').as('allDescriptions')
   })
+
   after(() => {
     cy.resetFeatureFlags()
   })
 
   it('should have a details section for each project', () => {
-    cy.get('@allDetails').should('have.length', 10)
+    cy.get('@allInvestmentDetails').should('have.length', 10)
   })
 
-  it('should display a header', () => {
-    cy.get('@header').should('have.text', 'Details')
+  it("should display 'Details' in a h3 header", () => {
+    cy.get('@firstProjectDetails').find('h3').should('have.text', 'Details')
   })
 
   it('should display the investor details with a link to the investor', () => {
-    cy.get('@listItem')
+    cy.get('@allTerms')
       .eq(0)
-      .should('have.text', 'Investor: Venus Ltd')
-      .find('a')
+      .should('have.text', 'Investor:')
+      .get('@allDescriptions')
+      .eq(0)
+      .children()
+      .should('have.text', 'Venus Ltd')
       .should(
         'have.attr',
         'href',
         companies.details('0f5216e0-849f-11e6-ae22-56b6b6499611')
       )
   })
+
   it('should display the sector details', () => {
-    cy.get('@listItem')
+    cy.get('@allTerms')
       .eq(1)
-      .should('have.text', 'Sector: Renewable Energy : Wind : Onshore')
+      .should('have.text', 'Sector:')
+      .get('@allDescriptions')
+      .eq(1)
+      .should('have.text', 'Renewable Energy : Wind : Onshore')
   })
+
   it('should display the country of origin details', () => {
-    cy.get('@listItem').eq(2).should('have.text', 'Country of origin: Italy')
+    cy.get('@allTerms')
+      .eq(2)
+      .should('have.text', 'Country of origin:')
+      .get('@allDescriptions')
+      .eq(2)
+      .should('have.text', 'Italy')
   })
+
   it('should display the date of the last interaction', () => {
-    cy.get('@listItem')
+    cy.get('@allTerms')
       .eq(3)
-      .should('have.text', 'Last interaction: 16 Mar 2021')
+      .should('have.text', 'Last interaction:')
+      .get('@allDescriptions')
+      .eq(3)
+      .should('have.text', '16 Mar 2021')
   })
+
   it('should display the last interaction subject with a link to the interaction', () => {
-    cy.get('@listItem')
+    cy.get('@allTerms')
       .eq(4)
-      .should('have.text', 'Interaction subject: A project interaction')
-      .find('a')
+      .should('have.text', 'Interaction subject:')
+      .get('@allDescriptions')
+      .eq(4)
+      .children()
+      .should('have.text', 'A project interaction')
       .should(
         'have.attr',
         'href',
         interactions.detail('3fd90013-4bcb-4c39-b8df-df264471ea85')
       )
-      .should('have.text', 'A project interaction')
   })
 
   context("when a project doesn't have a country of origin", () => {
@@ -72,13 +89,13 @@ describe('Dashboard - Investment details', () => {
       cy.get('@secondProjectDetails').should('not.contain', 'Country of origin')
     })
   })
+
   context("when a project doesn't have an interaction", () => {
     it('should not contain an interaction', () => {
-      cy.get('@thirdProjectDetails').should('not.contain', 'Last interaction')
-      cy.get('@thirdProjectDetails').should(
-        'not.contain',
-        'Interaction subject'
-      )
+      cy.get('@thirdProjectDetails')
+        .should('not.contain', 'Last interaction')
+        .get('@thirdProjectDetails')
+        .should('not.contain', 'Interaction subject')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Refactored the Investment project details list item to improve the markup and to easily apply truncation (ellipsis) to any element within.

## Before
<img width="752" alt="before-1" src="https://user-images.githubusercontent.com/964268/115277920-bdd69b00-a13c-11eb-83fe-749a89ecaac2.png">

## After
<img width="752" alt="after-1" src="https://user-images.githubusercontent.com/964268/115277939-c3cc7c00-a13c-11eb-8c81-bee9dda12ee6.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
