### PR TITLE
Display empty Outstanding propositions message + UX refinements

### DIFF
--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -20,6 +20,11 @@ const StyledSubHeading = styled(H3)`
   margin-bottom: ${SPACING.SCALE_2};
 `
 
+const StyledSubHeadingEmpty = styled(StyledSubHeading)`
+  color: ${DARK_GREY};
+  margin: 0;
+`
+
 const StyledProjectLink = styled('a')`
   display: block;
   font-size: ${FONT_SIZE.SIZE_19};
@@ -61,37 +66,45 @@ const StyledDetails = styled('div')`
   padding-right: ${SPACING.SCALE_3};
 `
 
-const OutstandingPropositions = ({ results, count }) => {
-  return (
-    <div data-test="outstanding-propositions">
-      <StyledSubHeading>Outstanding propositions ({count})</StyledSubHeading>
-      <StyledList data-test="outstanding-propositions-list">
-        {results.map(({ id, investment_project, name, deadline }) => (
-          <StyledListItem key={id}>
-            <StyledDetails>
-              <StyledProjectLink
-                href={urls.investments.projects.propositions(
-                  investment_project.id
-                )}
-              >
-                {name}
-              </StyledProjectLink>
-              <StyledProjectCode data-test="outstanding-proposition-project-code">
-                {investment_project.project_code}
-              </StyledProjectCode>
-              <StyledDueDate data-test="outstanding-proposition-deadline">
-                Due {format(new Date(deadline), DATE_DAY_LONG_FORMAT)}
-              </StyledDueDate>
-            </StyledDetails>
-            <StyledDueCountdown data-test="outstanding-proposition-countdown">
-              {getDifferenceInDaysLabel(deadline)}
-            </StyledDueCountdown>
-          </StyledListItem>
-        ))}
-      </StyledList>
-    </div>
-  )
-}
+const OutstandingPropositions = ({ results, count }) => (
+  <>
+    {!!results.length ? (
+      <div data-test="outstanding-propositions">
+        <StyledSubHeading data-test="outstanding-propositions-heading">
+          Outstanding propositions ({count})
+        </StyledSubHeading>
+        <StyledList data-test="outstanding-propositions-list">
+          {results.map(({ id, investment_project, name, deadline }) => (
+            <StyledListItem key={id}>
+              <StyledDetails>
+                <StyledProjectLink
+                  href={urls.investments.projects.propositions(
+                    investment_project.id
+                  )}
+                >
+                  {name}
+                </StyledProjectLink>
+                <StyledProjectCode data-test="outstanding-proposition-project-code">
+                  {investment_project.project_code}
+                </StyledProjectCode>
+                <StyledDueDate data-test="outstanding-proposition-deadline">
+                  Due {format(new Date(deadline), DATE_DAY_LONG_FORMAT)}
+                </StyledDueDate>
+              </StyledDetails>
+              <StyledDueCountdown data-test="outstanding-proposition-countdown">
+                {getDifferenceInDaysLabel(deadline)}
+              </StyledDueCountdown>
+            </StyledListItem>
+          ))}
+        </StyledList>
+      </div>
+    ) : (
+      <StyledSubHeadingEmpty data-test="outstanding-propositions-empty">
+        Projects with propositions due soon will be displayed here.
+      </StyledSubHeadingEmpty>
+    )}
+  </>
+)
 
 OutstandingPropositions.propTypes = {
   count: PropTypes.number.isRequired,

--- a/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
@@ -1,45 +1,51 @@
 import React from 'react'
 import styled from 'styled-components'
 import { GREY_3 } from 'govuk-colours'
+import Link from '@govuk-react/link'
 import { SPACING, FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 
 import { companies, interactions } from '../../../lib/urls'
 import { format } from '../../utils/date-utils'
 import { DARK_GREY } from '../../utils/colors'
 
-const StyledDiv = styled('div')`
-  height: 100%;
-  background-color: ${GREY_3};
-  padding: 9px ${SPACING.SCALE_2} 8px ${SPACING.SCALE_2};
-`
+const StyledDiv = styled('div')({
+  height: '100%',
+  backgroundColor: GREY_3,
+  padding: `9px ${SPACING.SCALE_2} 8px ${SPACING.SCALE_2}`,
+})
 
-const StyledHeader = styled('h3')`
-  font-size: ${FONT_SIZE.SIZE_16};
-  font-weight: ${FONT_WEIGHTS.bold};
-  margin-bottom: 0;
-`
+const StyledHeader = styled('h3')({
+  fontSize: FONT_SIZE.SIZE_16,
+  fontWeight: FONT_WEIGHTS.bold,
+  marginBottom: 0,
+})
 
-const StyledDL = styled('dl')`
-  font-size: ${FONT_SIZE.SIZE_16};
-`
+const StyledDL = styled('dl')({
+  fontSize: FONT_SIZE.SIZE_16,
+})
 
-const StyledDT = styled('dt')`
-  color: ${DARK_GREY};
-  float: left;
-  clear: left;
-  margin-right: 5px;
-`
+const lineHeightMixin = {
+  lineHeight: '24px',
+}
 
-const StyledDD = styled('dd')`
-  margin-left: 0px;
-`
+const StyledDT = styled('dt')({
+  color: DARK_GREY,
+  float: 'left',
+  clear: 'left',
+  marginRight: '5px',
+  ...lineHeightMixin,
+})
 
-const Truncate = styled('span')`
-  display: block;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-`
+const StyledDD = styled('dd')({
+  ...lineHeightMixin,
+})
+
+const Truncate = styled('span')({
+  display: 'block',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+})
 
 const InvestmentDetails = ({
   investor,
@@ -52,7 +58,9 @@ const InvestmentDetails = ({
     <StyledDL>
       <StyledDT>Investor:</StyledDT>
       <StyledDD>
-        <a href={companies.details(investor.id)}>{investor.name}</a>
+        <Link href={companies.details(investor.id)}>
+          <Truncate>{investor.name}</Truncate>
+        </Link>
       </StyledDD>
       <StyledDT>Sector:</StyledDT>
       <StyledDD>

--- a/src/client/components/ProgressIndicator.jsx
+++ b/src/client/components/ProgressIndicator.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import LoadingBox from '@govuk-react/loading-box'
+import { SPACING } from '@govuk-react/constants'
 import styled from 'styled-components'
 
 const StyledRoot = styled.div({
@@ -7,7 +8,9 @@ const StyledRoot = styled.div({
 })
 
 const StyledLoadingBox = styled(LoadingBox)({
-  height: '30px',
+  height: SPACING.SCALE_5,
+  marginTop: SPACING.SCALE_5,
+  marginBottom: SPACING.SCALE_3,
 })
 
 const ProgressIndicator = ({ message }) => (

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -6,33 +6,33 @@ const UNIVERSITY_PROJECT_ID = '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
 const UNIVERSITY_PROPOSITION_NAME = 'Univeristy Proposition'
 
 describe('Dashboard reminders', () => {
-  before(() => {
-    cy.setUserFeatures(['personalised-dashboard'])
-    cy.visit('/')
-  })
-
-  after(() => {
-    cy.resetUser()
-  })
-
-  beforeEach(() => {
-    cy.get('[data-test="investment-reminders"]').as('investmentReminders')
-    cy.get('[data-test="investment-reminders-section"]')
-      .as('investmentRemindersSection')
-      .find('[data-test="toggle-section-button"]')
-      .as('investmentRemindersToggleButton')
-      .find('[data-test="toggle-section-button-content"]')
-      .as('investmentRemindersHeading')
-    cy.get('@investmentRemindersSection')
-      .find('[data-test="notification-badge"]')
-      .as('investmentRemindersBadge')
-    cy.get('[data-test="outstanding-propositions"]')
-      .as('outstandingPropositions')
-      .find('[data-test="outstanding-propositions-list"]')
-      .as('outstandingPropositionsList')
-  })
-
   context('View reminders', () => {
+    before(() => {
+      cy.setUserFeatures(['personalised-dashboard'])
+      cy.visit('/')
+    })
+
+    after(() => {
+      cy.resetUser()
+    })
+
+    beforeEach(() => {
+      cy.get('[data-test="investment-reminders"]').as('investmentReminders')
+      cy.get('[data-test="investment-reminders-section"]')
+        .find('[data-test="toggle-section-button-content"]')
+        .as('investmentRemindersHeading')
+      cy.get('[data-test="investment-reminders-section"]')
+        .find('[data-test="notification-badge"]')
+        .as('investmentRemindersBadge')
+      cy.get('[data-test="outstanding-propositions-heading"]').as(
+        'outstandingPropositionsHeading'
+      )
+      cy.get('[data-test="outstanding-propositions"]')
+        .as('outstandingPropositions')
+        .find('[data-test="outstanding-propositions-list"]')
+        .as('outstandingPropositionsList')
+    })
+
     it('should contain a notification badge in the reminders heading', () => {
       cy.get('@investmentRemindersHeading').should('contain.text', 'Reminders')
       cy.get('@investmentRemindersBadge').should('have.text', '3')
@@ -44,6 +44,12 @@ describe('Dashboard reminders', () => {
         .should('have.length', 1)
         .find('[data-test="outstanding-propositions-list"]')
         .should('have.length', 1)
+    })
+
+    it('should contain a heading', () => {
+      cy.get('@outstandingPropositionsHeading')
+        .should('have.text', 'Outstanding propositions (3)')
+        .should('have.css', 'color', 'rgb(212, 53, 28)')
     })
 
     it('should display each of the outstanding propositions', () => {
@@ -76,9 +82,55 @@ describe('Dashboard reminders', () => {
     })
   })
 
+  context('View empty reminders', () => {
+    before(() => {
+      cy.setUserFeatures(['personalised-dashboard'])
+      cy.intercept('GET', '/api-proxy/v4/proposition', {
+        body: {
+          count: 0,
+          results: [],
+        },
+      }).as('apiRequest')
+      cy.visit('/')
+      cy.wait('@apiRequest')
+    })
+
+    after(() => {
+      cy.resetUser()
+    })
+
+    it('should contain a heading', () => {
+      cy.get('[data-test="outstanding-propositions-empty"]')
+        .should(
+          'have.text',
+          'Projects with propositions due soon will be displayed here.'
+        )
+        .should('have.css', 'color', 'rgb(80, 90, 95)')
+    })
+
+    it('should not contain a notification badge in the reminders heading', () => {
+      cy.get('[data-test="investment-reminders-section"]')
+        .find('[data-test="notification-badge"]')
+        .should('not.exist')
+    })
+
+    it('should not contain a list', () => {
+      cy.get('[data-test="outstanding-propositions-list"]').should('not.exist')
+    })
+  })
+
   context('Toggle section', () => {
     before(() => {
+      cy.setUserFeatures(['personalised-dashboard'])
       cy.visit('/')
+      cy.get('[data-test="investment-reminders"]').as('investmentReminders')
+      cy.get('[data-test="investment-reminders-section"]')
+        .find('[data-test="toggle-section-button"]')
+        .as('investmentRemindersToggleButton')
+    })
+
+    after(() => {
+      cy.resetUser()
     })
 
     it('should be in a togglable section that starts opened', () => {


### PR DESCRIPTION
## Description of change
Display a message to the user when they do not have any Outstanding propositions

## Screenshots
**Display Outstanding propositions message when there aren't any.**
<img width="355" alt="propositions" src="https://user-images.githubusercontent.com/964268/115505382-48b8b200-a271-11eb-8ecc-978060812475.png">

**Align both the details and next steps list items.**
<img width="745" alt="alignment" src="https://user-images.githubusercontent.com/964268/115506101-620e2e00-a272-11eb-8cb3-6af4a761b5e9.png">

**Investor company truncation.**
<img width="341" alt="investor-truncation" src="https://user-images.githubusercontent.com/964268/115505668-b95fce80-a271-11eb-859e-e8d60aa26248.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
