### PR TITLE
Get user feature flags direct from api instead of session

### DIFF
--- a/src/apps/dashboard/index.js
+++ b/src/apps/dashboard/index.js
@@ -2,7 +2,7 @@ const router = require('express').Router()
 const urls = require('../../lib/urls')
 const { renderDashboard } = require('./controllers')
 const spaBasePath = require('../../middleware/spa-base-path')
-const featureTesting = require('../../middleware/feature-testing')
+const userFeatures = require('../../middleware/user-features')
 
 module.exports = {
   router: router.get(
@@ -16,7 +16,7 @@ module.exports = {
       urls.pipeline.won(),
     ],
     spaBasePath(urls.dashboard.route),
-    featureTesting('personalised-dashboard'),
+    userFeatures('personalised-dashboard'),
     renderDashboard
   ),
 }


### PR DESCRIPTION
## Description of change

Changing feature flags for a user is now immediately effected and the user does not have to clear cookies.

## Test instructions

- Enable the "personalised-dashboard" feature for your user via django admin
- You should see the personalised dashboard on the homepage of datahub
- Disable the "personalised-dashboard" feature for your user via django admin
- You should see the personalised dashboard on the homepage of datahub

You can set your user's flags in the 'Other' section of django admin here: https://datahub-api-dev.london.cloudapps.digital/admin/company/advisor/<your-uuid>/change/

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
