### PR TITLE
Add aria attributes to make clickable div accessible

### DIFF
--- a/src/client/components/EntityList/EntityListItem.jsx
+++ b/src/client/components/EntityList/EntityListItem.jsx
@@ -22,9 +22,7 @@ const StyledEntity = styled('div')`
   border: 1px solid ${GREY_2};
   ${FOCUSABLE};
 
-  ${({ isClickable }) =>
-    isClickable &&
-    `
+  &[role='button'] {
     cursor: pointer;
 
     h3 {
@@ -39,7 +37,7 @@ const StyledEntity = styled('div')`
         color: ${LINK_HOVER_COLOUR};
       }
     }
-  `}
+  }
 `
 
 const StyledHeading = styled(H3)`
@@ -57,15 +55,16 @@ const StyledInsetText = styled(InsetText)`
 `
 
 const EntityListItem = ({ id, onEntityClick, data, text, heading, meta }) => {
+  const isClickable = !!onEntityClick
   return (
     <StyledEntity
       key={`entity_${id}`}
-      tabIndex={onEntityClick ? 0 : undefined}
-      onClick={() => onEntityClick && onEntityClick(data)}
+      tabIndex={isClickable && 0}
+      role={isClickable && 'button'}
+      onClick={() => isClickable && onEntityClick(data)}
       onKeyDown={(e) =>
-        onEntityClick && e.keyCode === KEY_ENTER && onEntityClick(data)
+        isClickable && e.keyCode === KEY_ENTER && onEntityClick(data)
       }
-      isClickable={onEntityClick}
     >
       {heading && <StyledHeading>{heading}</StyledHeading>}
 


### PR DESCRIPTION
## Description of change
The `EntityListItem` component is wrapped with a `div` by default but when the data for this component of this item matches a certain condition it becomes clickable. The problem is that if you want a div to be clickable or actionable you need to enrich the mark up with aria attributes so screen readers treat the element like a button or a link. 

I did look at using a button element instead but this started to bloat what is already an overly complicated component in my opinion so I thought this was the less disruptive approach.

## Test instructions
The easiest way to see this in action is to run the mock stack.

1. Run mock stack
2. Go to create a company (add company)
3. Search for a company with any text such as "foo"
4. Examine the results, some are clickable and some are not.
5. Look at the attributes it renders when the item is clickable.

## Screenshots
![Screenshot 2021-04-22 at 12 33 33](https://user-images.githubusercontent.com/10154302/115708428-e393b800-a367-11eb-87a4-0eae364e0446.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
