### PR TITLE
Remove role attribute off the dropdown menu options

### DIFF
--- a/src/client/components/DropdownMenu/index.jsx
+++ b/src/client/components/DropdownMenu/index.jsx
@@ -52,7 +52,6 @@ const DropdownToggleButton = styled(SecondaryButton)`
 
 export const DropdownButton = styled(SecondaryButton).attrs(() => ({
   tabIndex: 0,
-  role: 'option',
   forwardedAs: Link,
 }))`
   ${spacing.responsive({


### PR DESCRIPTION
## Description of change

In the `DropdownMenu` component we need to remove `role="option"` on each of the links within the menu as this causes confusion for screen readers. More details can be found in the DAC report on page 30, the simplest solution was to just remove the attribute.

## Test instructions
View a company and inspect the links on the "View options" dropdown component and you shouldn't see these "role" attributes on the dropdown links anymore. 

## Screenshots
![Screenshot 2021-04-22 at 14 21 50](https://user-images.githubusercontent.com/10154302/115722462-ed70e780-a376-11eb-9cb2-624f3f171f32.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
