### PR TITLE
Move role attribute away from list element

### DIFF
--- a/src/templates/_macros/common/__test__/messages.test.js
+++ b/src/templates/_macros/common/__test__/messages.test.js
@@ -107,8 +107,12 @@ describe('MessageList macro', () => {
         })
       })
 
-      it('should render a parent ul element', () => {
-        expect(this.component.tagName.toLowerCase()).to.equal('ul')
+      it('should render a parent div element', () => {
+        expect(this.component.tagName.toLowerCase()).to.equal('div')
+      })
+
+      it('should render a role attribute', () => {
+        expect(this.component.getAttribute('role')).to.equal('alert')
       })
 
       it('should render correct amount of items', () => {
@@ -122,9 +126,9 @@ describe('MessageList macro', () => {
       })
 
       it('should be dismissable', () => {
-        expect(this.component.className.trim()).to.equal(
-          'c-message-list js-Messages'
-        )
+        expect(
+          this.component.querySelector('.c-message-list').className.trim()
+        ).to.equal('c-message-list js-Messages')
       })
     })
   })
@@ -137,7 +141,9 @@ describe('MessageList macro', () => {
           isDismissable: false,
         })
 
-        expect(component.className.trim()).to.equal('c-message-list')
+        expect(
+          component.querySelector('.c-message-list').className.trim()
+        ).to.equal('c-message-list')
       })
     })
   })

--- a/src/templates/_macros/common/messages.njk
+++ b/src/templates/_macros/common/messages.njk
@@ -32,25 +32,26 @@
 {% macro MessageList(props) %}
   {% if props.items|length %}
     {% set isDismissable = props.isDismissable | default(true) %}
+    <div role="alert">
+      <ul class="c-message-list {{ 'js-Messages' if isDismissable }}" data-test="flash" tabindex="-1">
+        {% for type, messages in props.items -%}
 
-    <ul class="c-message-list {{ 'js-Messages' if isDismissable }}" data-test="flash" tabindex="-1" role="alert">
-      {% for type, messages in props.items -%}
+          {% set parts = type | split(':') %}
+          {% set partsLength = parts | length %}
+          {% set hasBody = true if partsLength > 1 and parts[1] == 'with-body' else false %}
 
-        {% set parts = type | split(':') %}
-        {% set partsLength = parts | length %}
-        {% set hasBody = true if partsLength > 1 and parts[1] == 'with-body' else false %}
-
-        {%- for text in messages %}
-          {{ Message({
-            hasBody: hasBody,
-            id: (text.id if hasBody),
-            heading: (text.heading if hasBody),
-            text: (text.body if hasBody else text),
-            type: (parts[0] if hasBody else type),
-            element: 'li'
-          }) }}
+          {%- for text in messages %}
+            {{ Message({
+              hasBody: hasBody,
+              id: (text.id if hasBody),
+              heading: (text.heading if hasBody),
+              text: (text.body if hasBody else text),
+              type: (parts[0] if hasBody else type),
+              element: 'li'
+            }) }}
+          {% endfor %}
         {% endfor %}
-      {% endfor %}
-    </ul>
+      </ul>
+    </div>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Description of change
We have an accessibility issue around the alert box. As pointed out on page 32 of the DAC report we need to move the attribute `role="alert"` off the list element and onto a parent div container. The reason for this is that `role="alert"` is not appropriate for the list element.

## Test instructions
Create or delete a company list and view the html of the alert box, you should see the `role="alert"` has now been moved to the parent div.

## Screenshot
![Screenshot 2021-04-26 at 09 37 29](https://user-images.githubusercontent.com/10154302/116054330-78055f80-a673-11eb-865b-7f4c842203a6.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
