### PR TITLE
Remove aria label from tab panel

### DIFF
--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -221,12 +221,7 @@ const TabNav = ({
                 )
               })}
             </StyledTablist>
-            <StyledTabpanel
-              role="tabpanel"
-              tabIndex={0}
-              aria-labelledby={createId(id, selectedIndex, routed)}
-              data-test="tabpanel"
-            >
+            <StyledTabpanel role="tabpanel" tabIndex={0} data-test="tabpanel">
               {getContent(tabs, tabKeys, selectedIndex)}
             </StyledTabpanel>
           </>


### PR DESCRIPTION
## Description of change
We currently have aria labels on the tab panels that don't refer to any content on the page so as pointed out on page 33 of the DAC report I have removed it.

## Test instructions
Go to the "My pipeline" tab on the homepage dashboard and inspect the HTML, you should not see a "aria-labelledby" attributes on any of the tab panels.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
