### PR TITLE
Axios stage 2 - swap out requests promise for axios

### DIFF
--- a/src/apps/api/services.js
+++ b/src/apps/api/services.js
@@ -1,4 +1,4 @@
-const rp = require('request-promise')
+const request = require('../../lib/request')
 const { trim } = require('lodash')
 
 const hawkRequest = require('../../lib/hawk-request')
@@ -14,8 +14,8 @@ function lookupAddress(postcode) {
       .replace('{postcode}', formattedPostcode)
       .replace('{api-key}', postcodeKey)
 
-    rp({ url, json: true })
-      .then((data) => {
+    request(url)
+      .then(({ data }) => {
         const parsed = parsePostcodeResult(data, postcode.toLocaleUpperCase())
         resolve(parsed)
       })

--- a/src/apps/company-lists/controllers/__test__/delete.test.js
+++ b/src/apps/company-lists/controllers/__test__/delete.test.js
@@ -1,5 +1,3 @@
-const requestErrors = require('request-promise/errors')
-
 const config = require('../../../../config')
 const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
 const {
@@ -122,7 +120,7 @@ describe('Delete company list controller', () => {
         expect(middlewareParameters.resMock.send).to.not.be.called
         expect(middlewareParameters.nextSpy).to.be.called
         expect(middlewareParameters.nextSpy.firstCall.args[0]).to.be.instanceof(
-          requestErrors.StatusCodeError
+          Error
         )
       })
     })

--- a/src/apps/dashboard/__test__/transformers.test.js
+++ b/src/apps/dashboard/__test__/transformers.test.js
@@ -5,7 +5,7 @@ const {
 const { omit } = require('lodash')
 
 describe('#formatHelpCentreAnnouncements', () => {
-  const mockResponse = {
+  const mockData = {
     count: 3,
     articles: [
       {
@@ -71,24 +71,24 @@ describe('#formatHelpCentreAnnouncements', () => {
       heading: 'Recording policy feedback on Data Hub',
       link:
         'https://helpcentre.com/hc/en-gb/articles/360001431697-Recording-policy-feedback-on-Data-Hub',
-      date: `${moment(mockResponse.articles[0].created_at).fromNow()}`,
+      date: `${moment(mockData.articles[0].created_at).fromNow()}`,
     },
     {
       heading: 'Improvements to company data in Data Hub - April 2019',
       link:
         'https://helpcentre.com/hc/en-gb/articles/360001412918-Improvements-to-company-data-in-Data-Hub-April-2019',
-      date: `${moment(mockResponse.articles[1].created_at).fromNow()}`,
+      date: `${moment(mockData.articles[1].created_at).fromNow()}`,
     },
     {
       heading: 'Recording multiple DIT advisers against interactions',
       link:
         'https://helpcentre.com/hc/en-gb/articles/360001345138-Recording-multiple-DIT-advisers-against-interactions',
-      date: `${moment(mockResponse.articles[2].created_at).fromNow()}`,
+      date: `${moment(mockData.articles[2].created_at).fromNow()}`,
     },
   ]
   context('Successful API response', () => {
     beforeEach(() => {
-      this.transformed = formatHelpCentreAnnouncements(mockResponse)
+      this.transformed = formatHelpCentreAnnouncements({ data: mockData })
     })
     it('should format Help centre articles', () => {
       expect(this.transformed).to.deep.equal(expected)
@@ -97,9 +97,11 @@ describe('#formatHelpCentreAnnouncements', () => {
 
   context('malformed api responses', () => {
     it('should return empty array', () => {
-      expect(formatHelpCentreAnnouncements({})).to.deep.equal([])
-      expect(formatHelpCentreAnnouncements(undefined)).to.deep.equal([])
-      expect(formatHelpCentreAnnouncements([])).to.deep.equal([])
+      expect(formatHelpCentreAnnouncements({ data: {} })).to.deep.equal([])
+      expect(formatHelpCentreAnnouncements({ data: undefined })).to.deep.equal(
+        []
+      )
+      expect(formatHelpCentreAnnouncements({ data: [] })).to.deep.equal([])
       expect(
         formatHelpCentreAnnouncements(omit(expected, ['articles']))
       ).to.deep.equal([])

--- a/src/apps/dashboard/controllers.js
+++ b/src/apps/dashboard/controllers.js
@@ -1,10 +1,10 @@
 const { get, pick } = require('lodash')
-const rp = require('request-promise')
 
 const GLOBAL_NAV_ITEMS = require('../global-nav-items')
 
 const { isPermittedRoute } = require('../middleware')
 const config = require('../../config')
+const request = require('../../lib/request')
 const { formatHelpCentreAnnouncements } = require('./transformers')
 
 async function renderDashboard(req, res, next) {
@@ -16,13 +16,10 @@ async function renderDashboard(req, res, next) {
     let articleFeed
 
     try {
-      const helpCentreArticleFeed = await rp({
-        uri: config.helpCentre.apiFeed,
-        auth: {
-          bearer: config.helpCentre.token,
-        },
-        qs: { test: req.query.test },
-        json: true,
+      const helpCentreArticleFeed = await request({
+        url: config.helpCentre.apiFeed,
+        headers: { Authorization: `Bearer ${config.helpCentre.token}` },
+        params: { test: req.query.test },
         timeout: 1000,
       })
       articleFeed = formatHelpCentreAnnouncements(helpCentreArticleFeed) || []

--- a/src/apps/dashboard/transformers.js
+++ b/src/apps/dashboard/transformers.js
@@ -1,8 +1,8 @@
 /* eslint camelcase: 0 */
 const moment = require('moment')
 
-const formatHelpCentreAnnouncements = (feed = {}) => {
-  const { articles = [] } = feed
+const formatHelpCentreAnnouncements = ({ data = {} }) => {
+  const { articles = [] } = data
   return articles.map((item) => {
     if (item.title && item.html_url && item.created_at) {
       return {

--- a/src/apps/documents/repos.js
+++ b/src/apps/documents/repos.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 const config = require('../../config')
-const request = require('request')
+const request = require('../../lib/request')
 const fs = require('fs')
 
 const { authorisedRequest } = require('../../lib/authorised-request')
@@ -21,21 +21,19 @@ function buildApiUrl(url, fields) {
 }
 
 function createRequest(req, urls, file) {
-  request(
-    {
-      url: urls.s3Url,
-      method: 'PUT',
-      body: fs.readFileSync(file.path),
+  request({
+    url: urls.s3Url,
+    method: 'PUT',
+    data: fs.readFileSync(file.path),
+    headers: {
+      'Content-Type': 'application/octet-stream',
     },
-    (error, response) => {
-      if (!error && response.statusCode === 200) {
-        authorisedRequest(req, {
-          url: urls.api,
-          method: 'POST',
-        })
-      }
-    }
-  )
+  }).then(() => {
+    authorisedRequest(req, {
+      url: urls.api,
+      method: 'POST',
+    })
+  })
 }
 
 function getDocumentUploadS3Url(req, { file, url, fields, textFields = {} }) {

--- a/src/apps/oauth/__test__/controllers.test.js
+++ b/src/apps/oauth/__test__/controllers.test.js
@@ -472,9 +472,7 @@ describe('OAuth controller', () => {
 
         it('should handle error as expected', () => {
           expect(this.nextSpy).to.have.been.calledOnce
-          expect(this.nextSpy.args[0][0].message).to.equal(
-            `Error: ${this.returnedError}`
-          )
+          expect(this.nextSpy.args[0][0].message).to.equal(this.returnedError)
         })
 
         it('token should be undefined', () => {

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -18,7 +18,6 @@ function getAccessToken(code) {
       client_secret: config.oauth.clientSecret,
       redirect_uri: config.oauth.redirectUri,
     },
-    json: true,
   }
 
   return request(options)
@@ -38,7 +37,6 @@ async function getSSOUserProfile(token) {
   const options = {
     url: config.oauth.userProfileUrl,
     headers: { Authorization: 'Bearer ' + token },
-    json: true,
   }
 
   try {

--- a/src/apps/oauth/controllers.js
+++ b/src/apps/oauth/controllers.js
@@ -1,17 +1,17 @@
-const request = require('request-promise')
 const queryString = require('qs')
 const { v4: uuid } = require('uuid')
 
 const { get, set, isUndefined } = require('lodash')
 
-const { saveSession } = require('./../../lib/session-helper')
+const request = require('../../lib/request')
+const { saveSession } = require('../../lib/session-helper')
 const config = require('../../config')
 
 function getAccessToken(code) {
   const options = {
     method: 'POST',
     url: config.oauth.tokenFetchUrl,
-    formData: {
+    data: {
       code,
       grant_type: 'authorization_code',
       client_id: config.oauth.clientId,
@@ -77,11 +77,11 @@ async function callbackOAuth(req, res, next) {
   }
 
   try {
-    const data = await getAccessToken(req.query.code)
-    const userProfile = await getSSOUserProfile(data.access_token)
+    const responseData = await getAccessToken(req.query.code)
+    const userProfile = await getSSOUserProfile(responseData.access_token)
 
-    set(req, 'session.token', data.access_token)
-    set(req, 'session.userProfile', userProfile)
+    set(req, 'session.token', responseData.data.access_token)
+    set(req, 'session.userProfile', userProfile.data)
     return res.redirect(req.session.returnTo || '/')
   } catch (error) {
     return next(error)

--- a/src/lib/__test__/authorised-request.test.js
+++ b/src/lib/__test__/authorised-request.test.js
@@ -54,14 +54,14 @@ describe('With Zipkin headers', () => {
       },
     }
 
-    const requestPromiseStub = sinon.stub().resolves({})
+    const requestStub = sinon.stub().resolves({})
     const { authorisedRequest } = proxyquire('../authorised-request', {
-      'request-promise': requestPromiseStub,
+      './request': requestStub,
     })
 
     authorisedRequest(request, options)
 
-    expect(requestPromiseStub.firstCall.lastArg.headers).deep.equals({
+    expect(requestStub.firstCall.lastArg.headers).deep.equals({
       Authorization: 'Bearer fake-token',
       'x-b3-spanid': 'fake-span-id',
       'x-b3-traceid': 'fake-trace-id',

--- a/src/lib/__test__/hawk-request.test.js
+++ b/src/lib/__test__/hawk-request.test.js
@@ -72,11 +72,8 @@ describe('#hawkRequest: check sendHawkRequest', () => {
     this.configStub.hawkCredentials.dataHubBackend = testDataHubCredentials
     this.hawkRequest = rewire(modulePath)
     this.hawkRequest.__set__('config', this.configStub)
-    this.createPromiseRequestSpy = sinon.spy()
-    this.hawkRequest.__set__(
-      'createPromiseRequest',
-      this.createPromiseRequestSpy
-    )
+    this.hawkRequestPromiseSpy = sinon.spy()
+    this.hawkRequest.__set__('hawkRequestPromise', this.hawkRequestPromiseSpy)
 
     this.getHawkHeaderStub = sinon.stub().returns({
       artifacts: { fake: 'artifacts' },
@@ -90,9 +87,9 @@ describe('#hawkRequest: check sendHawkRequest', () => {
     await expect(this.hawkRequest()).to.be.rejectedWith(Error)
   })
 
-  it('calls createPromiseRequest', async () => {
+  it('calls hawkRequestPromise', async () => {
     await this.hawkRequest(config.apiRoot + '/v4/metadata/countries')
-    expect(this.createPromiseRequestSpy).to.have.been.calledOnceWith(
+    expect(this.hawkRequestPromiseSpy).to.have.been.calledOnceWith(
       testRequestOptions,
       testDataHubCredentials,
       {
@@ -102,7 +99,7 @@ describe('#hawkRequest: check sendHawkRequest', () => {
   })
 })
 
-describe('#hawkRequest: check createPromiseRequest', () => {
+describe('#hawkRequest: check hawkRequestPromise', () => {
   beforeEach(() => {
     this.configStub = sinon.stub()
     this.hawkRequest = rewire(modulePath)
@@ -117,9 +114,9 @@ describe('#hawkRequest: check createPromiseRequest', () => {
     this.hawkRequest.__set__('request', () =>
       Promise.resolve({ status: 200, data: { fake: 'reply' } })
     )
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
-    await this.createPromiseRequest(
+    await this.hawkRequestPromise(
       testRequestOptions,
       testDataHubCredentials,
       testClientHeaderArtifacts
@@ -130,10 +127,10 @@ describe('#hawkRequest: check createPromiseRequest', () => {
 
   it('fails when response status code is not 200', async () => {
     this.hawkRequest.__set__('request', () => Promise.resolve({ status: 500 }))
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
     await expect(
-      this.createPromiseRequest(
+      this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
@@ -143,13 +140,13 @@ describe('#hawkRequest: check createPromiseRequest', () => {
 
   it('fails when response is not valid', async () => {
     this.hawkRequest.__set__('request', () => Promise.resolve({ status: 401 }))
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
     const authenticateStub = sinon.stub().returns(true)
     this.hawkRequest.__set__('hawk.client.authenticate', authenticateStub)
 
     await expect(
-      this.createPromiseRequest(
+      this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
@@ -166,13 +163,13 @@ describe('#hawkRequest: check createPromiseRequest', () => {
 
   it('fails when authenticate throws', async () => {
     this.hawkRequest.__set__('request', () => Promise.resolve({ status: 200 }))
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
     const authenticateStub = sinon.stub().throws(Error)
     this.hawkRequest.__set__('hawk.client.authenticate', authenticateStub)
 
     await expect(
-      this.createPromiseRequest(
+      this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts

--- a/src/lib/authorised-request.js
+++ b/src/lib/authorised-request.js
@@ -27,12 +27,14 @@ function stripScripts(key, value) {
 
 function parseConfig(req, opts) {
   const { token } = req.session
+  const { responseType = 'json' } = opts
   const defaults = {
     headers: {
       ...opts.headers,
       ...getZipkinHeaders(req),
       ...(token ? { Authorization: `Bearer ${token}` } : null),
     },
+    responseType,
     method: 'GET',
     proxy: config.proxy,
   }
@@ -96,7 +98,6 @@ async function authorisedRequest(req, opts) {
 // https://github.com/request/request-promise/issues/90
 function authorisedRawRequest(req, opts) {
   const requestConfig = parseConfig(req, opts)
-
   logRequest(requestConfig)
 
   return request(requestConfig)

--- a/src/lib/authorised-request.js
+++ b/src/lib/authorised-request.js
@@ -9,22 +9,6 @@ function hasValue(value) {
   return !isNil(value)
 }
 
-function stripScript(text) {
-  const SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi
-  while (SCRIPT_REGEX.test(text)) {
-    logger.warn('Found script tag in response')
-    text = text.replace(SCRIPT_REGEX, '')
-  }
-  return text
-}
-
-function stripScripts(key, value) {
-  if (isString(value)) {
-    return stripScript(value)
-  }
-  return value
-}
-
 function parseConfig(req, opts) {
   const { token } = req.session
   const { responseType = 'json' } = opts
@@ -72,14 +56,11 @@ function logRequest(opts) {
   })
 }
 
-// Accepts options as keys on an object or encoded as a url
-// Responses are parsed to remove any embedded XSS attempts with
-// script tags
+// Accepts options as keys on an object or encoded as a url and transforms data
 async function authorisedRequest(req, opts) {
   const requestConfig = parseConfig(req, opts)
 
   logRequest(requestConfig)
-  requestConfig.jsonReviver = stripScripts
 
   const logResponse = createResponseLogger(requestConfig)
   try {
@@ -93,9 +74,6 @@ async function authorisedRequest(req, opts) {
 }
 
 // Accepts options as keys on an object or encoded as a url
-// Responses are not parsed for XSS attacks
-// See request-promise #90 does not work with streams
-// https://github.com/request/request-promise/issues/90
 function authorisedRawRequest(req, opts) {
   const requestConfig = parseConfig(req, opts)
   logRequest(requestConfig)

--- a/src/lib/hawk-request.js
+++ b/src/lib/hawk-request.js
@@ -4,7 +4,7 @@ const request = require('./request')
 
 function getHawkHeader(credentials, requestOptions) {
   if (config.isTest) {
-    return { header: 'hawk-test-header' }
+    return 'hawk-test-header'
   }
 
   const { url, method } = requestOptions
@@ -80,7 +80,7 @@ async function sendHawkRequest(
   }
 
   const clientHeader = getHawkHeader(credentials, requestOptions)
-  requestOptions.headers.Authorization = clientHeader.header
+  requestOptions.headers.Authorization = { header: clientHeader.header }
 
   return createPromiseRequest(
     requestOptions,

--- a/src/lib/hawk-request.js
+++ b/src/lib/hawk-request.js
@@ -80,7 +80,7 @@ async function sendHawkRequest(
   }
 
   const clientHeader = getHawkHeader(credentials, requestOptions)
-  requestOptions.headers.Authorization = { header: clientHeader.header }
+  requestOptions.headers.Authorization = clientHeader.header || clientHeader
 
   return createPromiseRequest(
     requestOptions,

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -1,4 +1,29 @@
 const axios = require('axios')
+const { isString } = require('lodash')
+
+const logger = require('../config/logger')
+
+/**
+ * Strip scripts from JSON
+ *
+ * Note that this shouldn't be needed since everything should be escaped when
+ * it is rendered.
+ */
+const stripScripts = (key, value) => {
+  if (isString(value)) {
+    return stripScript(value)
+  }
+  return value
+}
+
+const stripScript = (text) => {
+  const SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi
+  while (SCRIPT_REGEX.test(text)) {
+    logger.warn('Found script tag in response')
+    text = text.replace(SCRIPT_REGEX, '')
+  }
+  return text
+}
 
 /**
  * This error is thrown when a response gives a bad status code.
@@ -25,8 +50,16 @@ class StatusCodeError extends Error {
  * breaking tests.
  */
 const request = async (props) => {
+  const baseConfig = isString(props) ? { url: props } : props
+  let transformResponse = [].concat(axios.defaults.transformResponse)
+  if (!props.responseType || props.responseType === 'json') {
+    transformResponse.push((data) =>
+      JSON.parse(JSON.stringify(data), stripScripts)
+    )
+  }
+
   try {
-    return await axios(props)
+    return await axios({ ...baseConfig, transformResponse })
   } catch (error) {
     const { response } = error
     if (response) {

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -7,6 +7,7 @@ class StatusCodeError extends Error {
   constructor(message, statusCode) {
     super(message)
 
+    this.message = `${statusCode} - ${JSON.stringify(message)}`
     this.error = message
     this.statusCode = statusCode
 

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -1,0 +1,39 @@
+const axios = require('axios')
+
+/**
+ * This error is thrown when a response gives a bad status code.
+ */
+class StatusCodeError extends Error {
+  constructor(message, statusCode) {
+    super(message)
+
+    this.error = message
+    this.statusCode = statusCode
+
+    // Maintains proper stack trace for where our error was thrown
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, StatusCodeError)
+    }
+  }
+}
+
+/**
+ * Axios request translator to ensure a consistent interface.
+ *
+ * By using this, we could go on to replace axios with another library without
+ * breaking tests.
+ */
+const request = async (props) => {
+  try {
+    return await axios(props)
+  } catch (error) {
+    const { response } = error
+    if (response) {
+      throw new StatusCodeError(response.data, response.status)
+    } else {
+      throw Error(error.toJSON().message)
+    }
+  }
+}
+
+module.exports = request

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -31,7 +31,11 @@ const request = async (props) => {
     if (response) {
       throw new StatusCodeError(response.data, response.status)
     } else {
-      throw Error(error.toJSON().message)
+      if (error.toJSON) {
+        throw Error(error.toJSON().message)
+      } else {
+        throw Error(error)
+      }
     }
   }
 }

--- a/src/modules/search/middleware/collection.js
+++ b/src/modules/search/middleware/collection.js
@@ -33,7 +33,9 @@ function exportCollection(searchEntity) {
       req,
     })
       .then((apiReq) => {
-        return apiReq.pipe(res)
+        res.set('Content-Type', apiReq.headers['content-type'])
+        res.set('Content-Disposition', apiReq.headers['content-disposition'])
+        return apiReq.data.pipe(res)
       })
       .catch((error) => {
         return next(error)

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -154,6 +154,7 @@ function exportSearch({ req, searchTerm = '', searchEntity, requestBody }) {
       ...requestBody,
       term: searchTerm,
     },
+    responseType: 'stream',
   }
 
   return authorisedRawRequest(req, options)

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -35,6 +35,7 @@ describe('LEP Permission', () => {
         'Companies',
         'Contacts',
         'Investments',
+        'Market Access',
         'Support',
       ])
     })

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -1,3 +1,4 @@
+const axios = require('axios')
 const chai = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
@@ -17,6 +18,9 @@ global.rootPath = `${process.cwd()}`
 global.rootPath = `${process.cwd()}`
 global.globalReq = reqres.req()
 global.globalRes = reqres.res()
+
+// Gets axios to work with nock: https://www.npmjs.com/package/nock#axios
+axios.defaults.adapter = require('axios/lib/adapters/http')
 
 process.env.TZ = 'Europe/London'
 


### PR DESCRIPTION
## Description of change

Swaps out requests promise for axios.

## Test instructions

Everything should continue to work as before, but with axios instead of requests promise.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
