### PR TITLE
Add sort to opportunities collection page

### DIFF
--- a/src/apps/investments/client/opportunities/List/UnfilteredLargeCapitalOpportunityCollection.jsx
+++ b/src/apps/investments/client/opportunities/List/UnfilteredLargeCapitalOpportunityCollection.jsx
@@ -11,6 +11,7 @@ import {
 const LargeCapitalOpportunityCollection = ({
   count,
   results,
+  payload,
   onPageClick,
   activePage,
   isComplete,
@@ -22,7 +23,7 @@ const LargeCapitalOpportunityCollection = ({
       id: ID,
       progressMessage: 'loading opportunities...',
       startOnRender: {
-        payload: { activePage },
+        payload: { payload, activePage },
         onSuccessDispatch: INVESTMENTS__OPPORTUNITIES_LOADED,
       },
     }}

--- a/src/apps/investments/client/opportunities/List/UnfilteredLargeCapitalOpportunityCollection.jsx
+++ b/src/apps/investments/client/opportunities/List/UnfilteredLargeCapitalOpportunityCollection.jsx
@@ -14,6 +14,7 @@ const LargeCapitalOpportunityCollection = ({
   onPageClick,
   activePage,
   isComplete,
+  optionMetadata,
 }) => (
   <CollectionList
     taskProps={{
@@ -35,6 +36,7 @@ const LargeCapitalOpportunityCollection = ({
     entityNamePlural="opportunities"
     addItemUrl="/investments/opportunities/create"
     baseDownloadLink="/investments/opportunities/export"
+    sortOptions={optionMetadata.sortOptions}
   />
 )
 

--- a/src/apps/investments/client/opportunities/List/metadata.js
+++ b/src/apps/investments/client/opportunities/List/metadata.js
@@ -1,0 +1,14 @@
+export const sortOptions = [
+  {
+    name: 'Most recently created',
+    value: 'created_on:desc',
+  },
+  {
+    name: 'Oldest created',
+    value: 'created_on:asc',
+  },
+  {
+    name: 'Opportunity name',
+    value: 'name:asc',
+  },
+]

--- a/src/apps/investments/client/opportunities/List/state.js
+++ b/src/apps/investments/client/opportunities/List/state.js
@@ -1,8 +1,30 @@
+import qs from 'qs'
+import { sortOptions } from './metadata'
+
 export const TASK_GET_OPPORTUNITIES_LIST = 'TASK_GET_OPPORTUNITIES_LIST'
 
 export const ID = 'opportunitiesList'
 
-export const state2props = ({ values, ...state }) => ({
-  ...state[ID],
-  values,
+const searchParamProps = ({ sortby = 'created_on:desc', page = 1 }) => ({
+  sortby,
+  page,
 })
+
+const collectionListPayload = (paramProps) => {
+  return Object.fromEntries(
+    Object.entries(searchParamProps(paramProps)).filter((v) => v[1])
+  )
+}
+
+export const state2props = ({ router, ...state }) => {
+  const { metadata } = state.opportunitiesList
+  const queryProps = qs.parse(router.location.search.slice(1))
+  const filteredQueryProps = collectionListPayload(queryProps)
+
+  return {
+    ...state[ID],
+    payload: filteredQueryProps,
+    optionMetadata: { sortOptions, ...metadata },
+    router,
+  }
+}

--- a/src/apps/investments/client/opportunities/List/tasks.js
+++ b/src/apps/investments/client/opportunities/List/tasks.js
@@ -5,9 +5,9 @@ const { format, parseISO } = require('date-fns')
 
 const { DATE_LONG_FORMAT } = require('../../../../../common/constants')
 
-export function getOpportunities({ activePage }) {
+export function getOpportunities({ activePage, payload }) {
   return apiProxyAxios
-    .get('/v4/large-capital-opportunity')
+    .post('/v4/search/large-capital-opportunity', { ...payload })
     .then(({ data } = data) => {
       const offset = activePage * 10 - 10
       const getArrayNames = (data) => data.map((d) => d.name)

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -33,6 +33,7 @@ const ALLOWLIST = [
   '/v4/search/large-investor-profile',
   '/v4/large-capital-opportunity/:id',
   '/v4/large-capital-opportunity',
+  '/v4/search/large-capital-opportunity',
 ]
 
 module.exports = (app) => {

--- a/test/functional/cypress/specs/investments/opportunity-sort-spec.js
+++ b/test/functional/cypress/specs/investments/opportunity-sort-spec.js
@@ -1,0 +1,42 @@
+const selectors = require('../../../../selectors')
+const { investments } = require('../../../../../src/lib/urls')
+
+describe('Investment Opportunity Collections Sort', () => {
+  beforeEach(() => {
+    cy.visit(investments.opportunities.index())
+    cy.get('#unfiltered-large-capital-opportunity-collection').should(
+      'contain',
+      '12 opportunities'
+    )
+    cy.intercept('/api-proxy/v4/search/large-capital-opportunity').as(
+      'sortResults'
+    )
+  })
+
+  it('should load sort by dropdown', () => {
+    cy.get(`${selectors.entityCollection.sortBy} option`).then((options) => {
+      const actual = [...options].map((o) => o.value)
+      expect(actual).to.deep.eq([
+        'created_on:desc',
+        'created_on:asc',
+        'name:asc',
+      ])
+    })
+  })
+
+  it('should sort by oldest opportunity', () => {
+    cy.get(selectors.entityCollection.sortBy).select('created_on:asc')
+
+    cy.wait('@sortResults').then((xhr) => {
+      expect(xhr.request.body.sortby).to.eq('created_on:asc')
+    })
+  })
+
+  it('should sort by name AZ', () => {
+    cy.get(selectors.entityCollection.sortBy).select('name:asc')
+
+    cy.wait('@sortResults').then((xhr) => {
+      expect(xhr.request.body.sortby).to.eq('name:asc')
+    })
+  })
+})

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -468,6 +468,10 @@ app.get(
   '/v4/large-capital-opportunity',
   v4Investment.getLargeCapitalOpportunityList
 )
+app.post(
+  '/v4/search/large-capital-opportunity',
+  v4Investment.getLargeCapitalOpportunityList
+)
 
 // V4 Proposition
 app.get('/v4/proposition', v4Proposition.propositions)

--- a/test/selectors/entity-collection.js
+++ b/test/selectors/entity-collection.js
@@ -21,5 +21,6 @@ module.exports = {
     return `article > ol > li:nth-child(${entityRow}) div.c-meta-list__item:nth-child(${badgeNum}) .c-badge`
   },
   sort: '#field-sortby',
+  sortBy: '[name="sortBy"] > select',
   totalValue: '.c-collection__total-cost__value',
 }


### PR DESCRIPTION
## Description of change

The intent of this PR is add sort functionality to UK Opportunities collection list page.

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

<img width="1011" alt="Screenshot 2021-05-10 at 07 51 04" src="https://user-images.githubusercontent.com/5696857/117617527-95065c00-b164-11eb-8cec-90aec84665d1.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
