### PR TITLE
Update links in Activity feed to improve accessibility

### DIFF
--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -51,7 +51,7 @@ export default class Interaction extends React.PureComponent {
           summary={`View ${transformed.typeText} details`}
           link={{
             url: transformed.url,
-            text: `Go to the ${transformed.typeText} detail page`,
+            text: `You can view more on the ${transformed.typeText} detail page`,
           }}
           showDetails={showDetails}
         >


### PR DESCRIPTION
## Description of change

As listed in the DAC report we need to make the links in the interaction cards within the activity feed more descriptive.

## Test instructions

1. View the activity feed on a company page

## Screenshots
### Before
![screenshot-1 (1)](https://user-images.githubusercontent.com/10154302/117296444-f7adde00-ae6c-11eb-9ca1-08dd4fb03336.png)


_Add a screenshot_

### After
![Screenshot 2021-05-06 at 13 13 37](https://user-images.githubusercontent.com/10154302/117296496-08f6ea80-ae6d-11eb-9885-d534892b9058.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
