### PR TITLE
Update archive link for improved accessibility

### DIFF
--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -113,6 +113,10 @@ const StyledLinkWrapper = styled('div')`
   }
 `
 
+const ArchiveMessage = styled('div')`
+  margin-top: 10px;
+`
+
 function buildMetaList({
   company,
   potential_value,
@@ -198,17 +202,14 @@ const PipelineItemMeta = ({
       <StyledLabel>{label}</StyledLabel>
       <Wrapper>
         {href ? <StyledLink href={href}>{value}</StyledLink> : value}
-        {!archived && showArchived && (
-          <>
-            {' '}
-            You can{' '}
-            <Link href={urls.pipeline.archive(id)}>
-              archive this project
-            </Link>{' '}
-            if it’s no longer active
-          </>
-        )}
       </Wrapper>
+      {!archived && showArchived && (
+        <ArchiveMessage>
+          You can{' '}
+          <Link href={urls.pipeline.archive(id)}>archive this project</Link> if
+          it’s no longer active
+        </ArchiveMessage>
+      )}
     </StyledListItem>
   )
 }

--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -107,10 +107,6 @@ const StyledLink = styled(Link)`
   text-decoration-line: none;
 `
 
-const StyledUnderlinedLink = styled(Link)`
-  margin-left: ${SPACING.SCALE_2};
-`
-
 const StyledLinkWrapper = styled('div')`
   a + a {
     margin-left: ${SPACING.SCALE_5};
@@ -203,9 +199,14 @@ const PipelineItemMeta = ({
       <Wrapper>
         {href ? <StyledLink href={href}>{value}</StyledLink> : value}
         {!archived && showArchived && (
-          <StyledUnderlinedLink href={urls.pipeline.archive(id)}>
-            Archive this project
-          </StyledUnderlinedLink>
+          <>
+            {' '}
+            You can{' '}
+            <Link href={urls.pipeline.archive(id)}>
+              archive this project
+            </Link>{' '}
+            if it’s no longer active
+          </>
         )}
       </Wrapper>
     </StyledListItem>

--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -191,6 +191,7 @@ const PipelineItemMeta = ({
   value,
   href,
   subtle,
+  name,
   id,
   archived,
   showArchived,
@@ -206,8 +207,13 @@ const PipelineItemMeta = ({
       {!archived && showArchived && (
         <ArchiveMessage>
           You can{' '}
-          <Link href={urls.pipeline.archive(id)}>archive this project</Link> if
-          it’s no longer active
+          <Link
+            href={urls.pipeline.archive(id)}
+            aria-label={`Archive the "${name}" project`}
+          >
+            archive this project
+          </Link>{' '}
+          if it’s no longer active
         </ArchiveMessage>
       )}
     </StyledListItem>
@@ -244,6 +250,7 @@ const PipelineItem = ({
               ({ label, value, href, subtle, showArchived }) => (
                 <PipelineItemMeta
                   key={label}
+                  name={name}
                   label={label}
                   value={value}
                   href={href}

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -43,7 +43,7 @@ function assertPipelineItem(
           'href',
           urls.pipeline.unarchive(result.id)
         )
-        cy.contains('Archive this project').should('not.exist')
+        cy.contains('archive this').should('not.exist')
         cy.get('span[aria-label="Likelihood to succeed"]').within(() => {
           cy.contains('Archived')
             .should('have.backgroundColour', TAG_COLOURS.grey.background)
@@ -63,7 +63,7 @@ function assertPipelineItem(
           'href',
           urls.pipeline.edit(result.id)
         )
-        cy.contains('Archive this project').should(
+        cy.contains('archive this').should(
           'have.attr',
           'href',
           urls.pipeline.archive(result.id)
@@ -75,7 +75,7 @@ function assertPipelineItem(
           'href',
           urls.pipeline.edit(result.id)
         )
-        cy.contains('Archive this project').should(
+        cy.contains('archive this').should(
           'have.attr',
           'href',
           urls.pipeline.archive(result.id)


### PR DESCRIPTION
## Description of change

According to the DAC report the archive link needs to be more descriptive. Updating the content with this change improves the accessibility.

## Test instructions
1. Go to the homepage dashboard
2. View projects in your pipeline

## Screenshots
### Before

![Screenshot 2021-05-06 at 16 40 30](https://user-images.githubusercontent.com/10154302/117326660-cbed2100-ae89-11eb-8d31-d32116c56bc9.png)

### After
![Screenshot 2021-05-07 at 11 38 50](https://user-images.githubusercontent.com/10154302/117438105-02c64400-af29-11eb-8107-6be2051a021a.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
