### PR TITLE
Added route for new react companies list page

### DIFF
--- a/src/apps/companies/__test__/router.test.js
+++ b/src/apps/companies/__test__/router.test.js
@@ -5,6 +5,7 @@ describe('Company router', () => {
     const paths = router.stack.filter((r) => r.route).map((r) => r.route.path)
     expect(paths).to.deep.equal([
       '/',
+      '/react',
       '/export',
       '/:companyId/archive',
       '/:companyId/unarchive',

--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const CompaniesCollection = (props) => {
+  return (
+    <div>
+      <h2>Companies Collection</h2>
+      <span>Adviser ID: {props.currentAdviserId}</span>
+    </div>
+  )
+}
+
+export default CompaniesCollection

--- a/src/apps/companies/controllers/companies.js
+++ b/src/apps/companies/controllers/companies.js
@@ -1,0 +1,20 @@
+const renderCompaniesView = async (req, res, next) => {
+  try {
+    const { user } = req.session
+    const currentAdviserId = user.id
+
+    const props = {
+      title: 'Companies',
+      heading: 'Companies',
+      currentAdviserId,
+    }
+
+    return res.render('companies/views/companies', { props })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderCompaniesView,
+}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -20,6 +20,9 @@ const {
 const { renderCompanyList } = require('./controllers/list')
 const { renderDetails } = require('./controllers/details')
 
+// New react view (in progress) - to replace 'renderCompanyList' when finished
+const { renderCompaniesView } = require('./controllers/companies')
+
 const { renderBusinessDetails } = require('./apps/business-details/controllers')
 
 const { renderOrders } = require('./controllers/orders')
@@ -98,6 +101,8 @@ router.get(
   getCollection('company', ENTITIES, transformCompanyToListItem),
   renderCompanyList
 )
+// New react route (to replace the old companies list route above when complete)
+router.get(urls.companies.react.index.route, renderCompaniesView)
 
 router.get(
   urls.companies.export.route,

--- a/src/apps/companies/views/companies.njk
+++ b/src/apps/companies/views/companies.njk
@@ -1,0 +1,11 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-column-full">
+      {% component 'react-slot', {
+        id: 'companies-collection',
+        props: props
+      }
+      %}
+  </div>
+{% endblock %}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -40,6 +40,7 @@ import DeletePipelineItemForm from '../apps/my-pipeline/client/DeletePipelineIte
 import Dashboard from './components/Dashboard'
 import PersonalisedDashboard from './components/PersonalisedDashboard'
 import CompanyLocalHeader from './components/CompanyLocalHeader'
+import CompaniesCollection from '../apps/companies/client/CompaniesCollection.jsx'
 import InvestmentProjectsCollection from '../apps/investments/client/projects/ProjectsCollection.jsx'
 import Opportunities from '../apps/investments/client/opportunities/Details/Opportunities.jsx'
 import IEBanner from '../apps/dashboard/client/IEBanner'
@@ -354,6 +355,9 @@ function App() {
       <Mount selector="#footer">{() => <Footer />}</Mount>
       <Mount selector="#investment-projects-collection">
         {(props) => <InvestmentProjectsCollection {...props} />}
+      </Mount>
+      <Mount selector="#companies-collection">
+        {(props) => <CompaniesCollection {...props} />}
       </Mount>
       <Mount selector="#ie-banner">{() => <IEBanner />}</Mount>
     </Provider>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -97,6 +97,10 @@ module.exports = {
     signout: url('/oauth/sign-out'),
   },
   companies: {
+    // React routes (Work in progress) - to be released on completion
+    react: {
+      index: url('/companies', '/react'),
+    },
     index: url('/companies'),
     create: url('/companies', '/create'),
     export: url('/companies', '/export'),

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -1,0 +1,17 @@
+import { assertBreadcrumbs } from '../../support/assertions'
+import { companies } from '../../../../../src/lib/urls'
+
+describe('Company Collections - React', () => {
+  before(() => {
+    // Visit the new react companies page - note this will need to be changed
+    // to `companies.index()` when ready
+    cy.visit(companies.react.index())
+  })
+
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: '/',
+      Companies: null,
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Adds a new route for the react version of the companies list page. When this page is complete, we will need to replace the existing companies page with this.

For the moment this just shows a basic page with very little content (to be populated in later tickets)

## Test instructions

Visit 'companies/react' and see the react page - this will be quite empty until we add the collection list.

## Screenshots

![Screenshot from 2021-05-14 13-55-23](https://user-images.githubusercontent.com/1234577/118273644-1ab73e00-b4bc-11eb-801e-b254ae9908e9.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
