### PR TITLE
Added companies collection to new react companies page

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -1,12 +1,42 @@
 import React from 'react'
+import { connect } from 'react-redux'
 
-const CompaniesCollection = (props) => {
+import { COMPANIES__LOADED } from '../../../client/actions'
+import { FilteredCollectionList } from '../../../client/components'
+
+import { TASK_GET_COMPANIES_LIST, ID, state2props } from './state'
+
+const CompaniesCollection = ({
+  payload,
+  currentAdviserId,
+  optionMetadata,
+  selectedFilters,
+  ...props
+}) => {
+  payload.page = parseInt(payload.page) || 1
+
+  const collectionListTask = {
+    name: TASK_GET_COMPANIES_LIST,
+    id: ID,
+    progressMessage: 'loading companies',
+    startOnRender: {
+      payload,
+      onSuccessDispatch: COMPANIES__LOADED,
+    },
+  }
+
   return (
-    <div>
-      <h2>Companies Collection</h2>
-      <span>Adviser ID: {props.currentAdviserId}</span>
-    </div>
+    <FilteredCollectionList
+      {...props}
+      collectionName="Company"
+      sortOptions={optionMetadata.sortOptions}
+      taskProps={collectionListTask}
+      selectedFilters={selectedFilters}
+      baseDownloadLink="/companies/export"
+      entityName="company"
+      entityNamePlural="companies"
+    ></FilteredCollectionList>
   )
 }
 
-export default CompaniesCollection
+export default connect(state2props)(CompaniesCollection)

--- a/src/apps/companies/client/reducer.js
+++ b/src/apps/companies/client/reducer.js
@@ -1,6 +1,6 @@
 import { COMPANIES__LOADED } from '../../../client/actions'
 
-import { transformCompanyToListItem } from '../transformers'
+import { transformCompanyToCollectionListItem } from '../transformers'
 
 const initialState = {
   results: [],
@@ -13,7 +13,7 @@ export default (state = initialState, { type, result }) => {
       return {
         ...state,
         count: result.count,
-        results: result.results?.map(transformCompanyToListItem),
+        results: result.results?.map(transformCompanyToCollectionListItem),
         isComplete: true,
       }
     default:

--- a/src/apps/companies/client/reducer.js
+++ b/src/apps/companies/client/reducer.js
@@ -1,0 +1,22 @@
+import { COMPANIES__LOADED } from '../../../client/actions'
+
+import { transformCompanyToListItem } from '../transformers'
+
+const initialState = {
+  results: [],
+  isComplete: false,
+}
+
+export default (state = initialState, { type, result }) => {
+  switch (type) {
+    case COMPANIES__LOADED:
+      return {
+        ...state,
+        count: result.count,
+        results: result.results?.map(transformCompanyToListItem),
+        isComplete: true,
+      }
+    default:
+      return state
+  }
+}

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -1,0 +1,27 @@
+import qs from 'qs'
+
+export const TASK_GET_COMPANIES_LIST = 'TASK_GET_COMPANIES_LIST'
+
+export const ID = 'companiesList'
+
+const searchParamProps = ({ page = 1 }) => ({ page })
+
+const collectionListPayload = (paramProps) => {
+  return Object.fromEntries(
+    Object.entries(searchParamProps(paramProps)).filter((v) => v[1])
+  )
+}
+
+/**
+ * Convert both location and redux state to props
+ */
+export const state2props = ({ router, ...state }) => {
+  const queryProps = qs.parse(router.location.search.slice(1))
+  const filteredQueryProps = collectionListPayload(queryProps)
+  return {
+    ...state[ID],
+    payload: filteredQueryProps,
+    optionMetadata: { sortOptions: [] },
+    selectedFilters: {},
+  }
+}

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -1,12 +1,6 @@
 import axios from 'axios'
 
-function handleError(error) {
-  const message = error.response.data.detail
-  return Promise.reject({
-    message,
-    ...error,
-  })
-}
+const handleError = (error) => Promise.reject(Error(error.response.data.detail))
 
 function getCompanies({ limit = 10, page, ...rest }) {
   let offset = limit * (parseInt(page, 10) - 1) || 0

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -1,0 +1,23 @@
+import axios from 'axios'
+
+function handleError(error) {
+  const message = error.response.data.detail
+  return Promise.reject({
+    message,
+    ...error,
+  })
+}
+
+function getCompanies({ limit = 10, page, ...rest }) {
+  let offset = limit * (parseInt(page, 10) - 1) || 0
+
+  return axios
+    .post('/api-proxy/v4/search/company', {
+      limit,
+      offset,
+      ...rest,
+    })
+    .then(({ data }) => data, handleError)
+}
+
+export { getCompanies }

--- a/src/apps/companies/transformers/company-to-collection-list-item.js
+++ b/src/apps/companies/transformers/company-to-collection-list-item.js
@@ -1,0 +1,76 @@
+const { get } = require('lodash')
+
+const labels = require('../labels')
+const urls = require('../../../lib/urls')
+
+const { addressToString } = require('../../../common/addresses')
+const { formatLongDate, formatMediumDateTime } = require('../../../common/date')
+
+module.exports = function transformCompanyToListItem({
+  id,
+  name,
+  sector,
+  uk_region,
+  trading_names,
+  address,
+  modified_on,
+  headquarter_type,
+  global_headquarters,
+  latest_interaction_date,
+} = {}) {
+  if (!id) {
+    return
+  }
+
+  const metadata = [
+    {
+      label: 'Sector',
+      value: get(sector, 'name'),
+    },
+    {
+      label: 'Global HQ',
+      value: get(global_headquarters, 'name'),
+    },
+    {
+      label: labels.address.companyAddress,
+      value: addressToString(address),
+    },
+  ]
+
+  if (trading_names && trading_names.length) {
+    metadata.push({
+      label: labels.hqLabels.trading_names,
+      value: trading_names.join(', '),
+    })
+  }
+
+  if (latest_interaction_date) {
+    metadata.push({
+      label: 'Last interaction date',
+      value: formatLongDate(latest_interaction_date),
+    })
+  }
+
+  if (headquarter_type) {
+    metadata.push({
+      label: 'Headquarter type',
+      value: labels.hqLabels[get(headquarter_type, 'name')],
+    })
+  }
+
+  const badges = [
+    { text: get(address, 'country.name') },
+    { text: get(uk_region, 'name') },
+    { text: labels.hqLabels[get(headquarter_type, 'name')] },
+  ].filter((item) => item.text)
+
+  return {
+    id,
+    subheading: `Updated on ${formatMediumDateTime(modified_on)}`,
+    headingText: name,
+    headingUrl: urls.companies.detail(id),
+    badges,
+    metadata: metadata.filter((item) => item.value),
+    type: 'company',
+  }
+}

--- a/src/apps/companies/transformers/company-to-list-item.js
+++ b/src/apps/companies/transformers/company-to-list-item.js
@@ -4,9 +4,6 @@ const { get } = require('lodash')
 const labels = require('../labels')
 const urls = require('../../../lib/urls')
 
-const { addressToString } = require('../../../common/addresses')
-const { formatLongDate, formatMediumDateTime } = require('../../../common/date')
-
 module.exports = function transformCompanyToListItem({
   id,
   name,
@@ -25,27 +22,19 @@ module.exports = function transformCompanyToListItem({
   }
 
   const meta = []
-  const metadata = []
-  const badges = []
 
   if (trading_names && trading_names.length) {
     meta.push({
       label: labels.hqLabels.trading_names,
       value: trading_names,
     })
-    metadata.push({
-      label: labels.hqLabels.trading_names,
-      value: trading_names.join(', '),
-    })
   }
 
   if (sector) {
-    const sectorMeta = {
+    meta.push({
       label: 'Sector',
       value: get(sector, 'name'),
-    }
-    meta.push(sectorMeta)
-    metadata.push(sectorMeta)
+    })
   }
 
   if (address && address.country) {
@@ -54,7 +43,6 @@ module.exports = function transformCompanyToListItem({
       type: 'badge',
       value: get(address, 'country.name'),
     })
-    badges.push({ text: get(address, 'country.name') })
   }
 
   if (uk_based) {
@@ -63,40 +51,23 @@ module.exports = function transformCompanyToListItem({
       type: 'badge',
       value: get(uk_region, 'name'),
     })
-    badges.push({ text: get(uk_region, 'name') })
   }
 
   if (headquarter_type) {
-    const hqLabel = labels.hqLabels[get(headquarter_type, 'name')]
     meta.push({
       label: 'Headquarter type',
       type: 'badge',
-      value: hqLabel,
+      value: labels.hqLabels[get(headquarter_type, 'name')],
     })
   }
 
   if (global_headquarters) {
     const { name: ghqName, id: ghqId } = global_headquarters
-    const globalHqMeta = {
+
+    meta.push({
       label: 'Global HQ',
       value: ghqName,
       url: urls.companies.detail(ghqId),
-    }
-
-    meta.push(globalHqMeta)
-    metadata.push(globalHqMeta)
-  }
-
-  if (latest_interaction_date) {
-    meta.push({
-      type: 'date',
-      label: 'Last interaction date',
-      value: latest_interaction_date,
-    })
-    metadata.push({
-      type: 'date',
-      label: 'Last interaction date',
-      value: formatLongDate(latest_interaction_date),
     })
   }
 
@@ -106,10 +77,13 @@ module.exports = function transformCompanyToListItem({
     value: address,
   })
 
-  metadata.push({
-    label: labels.address.companyAddress,
-    value: addressToString(address),
-  })
+  if (latest_interaction_date) {
+    meta.push({
+      type: 'date',
+      label: 'Last interaction date',
+      value: latest_interaction_date,
+    })
+  }
 
   return {
     id,
@@ -122,11 +96,5 @@ module.exports = function transformCompanyToListItem({
       label: 'Updated on',
     },
     type: 'company',
-    // For react collection list:
-    headingUrl: urls.companies.detail(id),
-    headingText: name,
-    subheading: `Updated on ${formatMediumDateTime(modified_on)}`,
-    badges: badges.filter((item) => item.text),
-    metadata: metadata.filter((item) => item.value),
   }
 }

--- a/src/apps/companies/transformers/index.js
+++ b/src/apps/companies/transformers/index.js
@@ -1,9 +1,11 @@
 const transformCompanyToListItem = require('./company-to-list-item')
+const transformCompanyToCollectionListItem = require('./company-to-collection-list-item')
 const transformCompanyToSubsidiaryListItem = require('./company-to-subsidiary-list-item')
 const transformCoreTeamToCollection = require('./one-list-core-team-to-collection')
 
 module.exports = {
   transformCompanyToListItem,
+  transformCompanyToCollectionListItem,
   transformCompanyToSubsidiaryListItem,
   transformCoreTeamToCollection,
 }

--- a/src/apps/investments/client/projects/tasks.js
+++ b/src/apps/investments/client/projects/tasks.js
@@ -1,12 +1,6 @@
 import axios from 'axios'
 
-function handleError(error) {
-  const message = error.response.data.detail
-  return Promise.reject({
-    message,
-    ...error,
-  })
-}
+const handleError = (error) => Promise.reject(Error(error.response.data.detail))
 
 function getProjects({ limit = 10, page, ...rest }) {
   let offset = limit * (parseInt(page, 10) - 1) || 0

--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -8,6 +8,8 @@
  * The name should be the name of the component the action relates to and a verb
  * describing what it does, concatenated by double underscore.
  */
+export const COMPANIES__LOADED = 'COMPANIES__LOADED'
+
 export const COMPANY_LISTS__LISTS_LOADED = 'COMPANY_LISTS__LISTS_LOADED'
 export const COMPANY_LISTS__SELECT = 'COMPANY_LISTS__SELECT'
 export const COMPANY_LISTS__COMPANIES_LOADED = 'COMPANY_LISTS__COMPANIES_LOADED'

--- a/src/client/components/Badge/index.jsx
+++ b/src/client/components/Badge/index.jsx
@@ -14,7 +14,7 @@ const StyledBadge = styled('span')`
 `
 
 const Badge = ({ label, borderColour, children }) => (
-  <StyledBadge borderColour={borderColour}>
+  <StyledBadge data-test="badge" borderColour={borderColour}>
     {label && <VisuallyHidden>{label}</VisuallyHidden>}
     {children}
   </StyledBadge>

--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -61,7 +61,7 @@ const CollectionItem = ({
   const summaryMessage = type ? `View ${type} details` : 'View details'
 
   return (
-    <ItemWrapper>
+    <ItemWrapper data-test="collection-item">
       {badges && (
         <StyledBadgesWrapper>
           {badges.map((badge) => (

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -33,7 +33,7 @@ const FilteredCollectionList = ({
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
-    <GridRow>
+    <GridRow data-test="collection-list">
       {children}
       <GridCol setWidth="two-thirds">
         <article>

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -61,8 +61,8 @@ const FilteredCollectionList = ({
             {() =>
               isComplete && (
                 <>
-                  {results.map((item, i) => (
-                    <CollectionItem {...item} key={i} />
+                  {results.map((item) => (
+                    <CollectionItem {...item} key={item.id} />
                   ))}
                   <RoutedPagination
                     qsParamName="page"

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -29,6 +29,7 @@ const FilteredCollectionList = ({
   selectedFilters,
   baseDownloadLink = null,
   entityName,
+  entityNamePlural,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
@@ -53,6 +54,7 @@ const FilteredCollectionList = ({
               data-test="download-data-header"
               baseDownloadLink={baseDownloadLink}
               entityName={entityName}
+              entityNamePlural={entityNamePlural}
             />
           )}
           <Task.Status {...taskProps}>

--- a/src/client/components/Metadata/MetadataItem.jsx
+++ b/src/client/components/Metadata/MetadataItem.jsx
@@ -13,7 +13,7 @@ const StyledItemLabel = styled('span')`
 
 function MetadataItem({ label, children }) {
   return (
-    <StyledMetaWrapper>
+    <StyledMetaWrapper data-test="metadata-item">
       {label && <StyledItemLabel>{label}</StyledItemLabel>} {children}
     </StyledMetaWrapper>
   )

--- a/src/client/components/Metadata/index.jsx
+++ b/src/client/components/Metadata/index.jsx
@@ -17,7 +17,7 @@ const StyledMetadataWrapper = styled('div')`
 
 const Metadata = ({ rows }) =>
   rows && (
-    <StyledMetadataWrapper>
+    <StyledMetadataWrapper data-test="metadata">
       {rows.map(({ label, value }) => (
         <MetadataItem key={label} label={label}>
           {value}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -92,6 +92,9 @@ import * as manageAdviser from '../apps/companies/apps/advisers/client/tasks'
 import { DNB__CHECK_PENDING_REQUEST } from '../apps/companies/apps/business-details/client/state'
 import * as dnbCheck from '../apps/companies/apps/business-details/client/tasks'
 
+import { TASK_GET_COMPANIES_LIST } from '../apps/companies/client/state'
+import { getCompanies } from '../apps/companies/client/tasks'
+
 import { TASK_GET_PROFILES_LIST } from '../apps/investments/client/profiles/state'
 import * as investmentProfilesTasks from '../apps/investments/client/profiles/tasks'
 
@@ -194,6 +197,7 @@ function App() {
         [TASK_GET_PROFILES_LIST]:
           investmentProfilesTasks.getLargeCapitalProfiles,
         [TASK_GET_PROJECTS_LIST]: getInvestmentProjects.getProjects,
+        [TASK_GET_COMPANIES_LIST]: getCompanies,
         [TASK_GET_ADVISER_NAME]: getInvestmentProjects.getAdviserNames,
         [TASK_GET_INVESTMENTS_PROJECTS_METADATA]:
           getInvestmentProjects.getMetadata,

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -80,6 +80,9 @@ import investmentProfileReducer from '../apps/investments/client/profiles/reduce
 import { ID as INVESTMENT_PROJECTS_ID } from '../apps/investments/client/projects/state'
 import investmentProjectsReducer from '../apps/investments/client/projects/reducer'
 
+import { ID as COMPANIES_ID } from '../apps/companies/client/state'
+import companiesReducer from '../apps/companies/client/reducer'
+
 import { ID as CHECK_FOR_INVESTMENTS_ID } from './components/PersonalisedDashboard/state'
 import personalDashboardReducer from './components/PersonalisedDashboard/reducer'
 
@@ -119,6 +122,7 @@ const store = createStore(
     router: connectRouter(history),
     tasks,
     [COMPANY_LISTS_STATE_ID]: companyListsReducer,
+    [COMPANIES_ID]: companiesReducer,
     [EXPORTS_HISTORY_ID]: exportsHistoryReducer,
     [REFERRALS_DETAILS_STATE_ID]: referralsReducer,
     [REFERRALS_SEND_ID]: referralsSendReducer,

--- a/src/common/addresses.js
+++ b/src/common/addresses.js
@@ -1,0 +1,9 @@
+const { get } = require('lodash')
+
+const addressToString = (address) =>
+  ['line_1', 'line_2', 'area', 'town', 'county', 'postcode', 'country.name']
+    .map((component) => get(address, component))
+    .filter((value) => value)
+    .join(', ')
+
+module.exports = { addressToString }

--- a/src/common/date.js
+++ b/src/common/date.js
@@ -1,5 +1,9 @@
-const format = require('date-fns/format')
-const { DATE_LONG_FORMAT, DATE_MEDIUM_FORMAT } = require('./constants')
+const { format } = require('date-fns')
+const {
+  DATE_LONG_FORMAT,
+  DATE_MEDIUM_FORMAT,
+  DATE_TIME_MEDIUM_FORMAT,
+} = require('./constants')
 
 function formatLongDate(dateString = []) {
   if (dateString) {
@@ -15,6 +19,12 @@ function formatMediumDate(dateString = []) {
   }
 
   return null
+}
+
+function formatMediumDateTime(dateString) {
+  if (dateString) {
+    return format(parseDateString(dateString), DATE_TIME_MEDIUM_FORMAT)
+  }
 }
 
 function parseDateString(dateString) {
@@ -51,6 +61,7 @@ function transformValueForApi({ year, month, day = 1 }) {
 module.exports = {
   formatLongDate,
   formatMediumDate,
+  formatMediumDateTime,
   parseDateString,
   transformValueForApi,
 }

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -33,6 +33,7 @@ const ALLOWLIST = [
   '/v4/search/large-investor-profile',
   '/v4/large-capital-opportunity/:id',
   '/v4/large-capital-opportunity',
+  '/v4/search/company',
   '/v4/search/large-capital-opportunity',
 ]
 

--- a/test/functional/cypress/fakers/addresses.js
+++ b/test/functional/cypress/fakers/addresses.js
@@ -1,0 +1,16 @@
+import faker from 'faker'
+
+const addressFaker = (overrides = {}) => ({
+  line_1: faker.address.streetAddress(),
+  line_2: faker.address.streetName(),
+  town: faker.address.city(),
+  county: faker.address.county(),
+  postcode: 'AB1 2DE',
+  country: {
+    id: faker.datatype.uuid(),
+    name: faker.address.country(),
+  },
+  ...overrides,
+})
+
+export { addressFaker }

--- a/test/functional/cypress/fakers/addresses.js
+++ b/test/functional/cypress/fakers/addresses.js
@@ -5,7 +5,7 @@ const addressFaker = (overrides = {}) => ({
   line_2: faker.address.streetName(),
   town: faker.address.city(),
   county: faker.address.county(),
-  postcode: 'AB1 2DE',
+  postcode: faker.address.zipCode(),
   country: {
     id: faker.datatype.uuid(),
     name: faker.address.country(),

--- a/test/functional/cypress/fakers/companies.js
+++ b/test/functional/cypress/fakers/companies.js
@@ -1,0 +1,34 @@
+import faker from 'faker'
+import jsf from 'json-schema-faker'
+
+import apiSchema from '../../../api-schema.json'
+
+import { addressFaker } from './addresses'
+import { listFaker } from './utils'
+
+/**
+ * Generate fake data for a single company.
+ *
+ * Starts by generating data based on the json schema, adds some defaults and
+ * merges in overrides.
+ */
+const companyFaker = (overrides = {}) => ({
+  ...jsf.generate(apiSchema.components.schemas.Company),
+  id: faker.datatype.uuid(),
+  address: addressFaker(),
+  registered_address: addressFaker(),
+  ...overrides,
+})
+
+/**
+ * Generate fake data for a list of companies.
+ *
+ * The number of items is determined by the length (default is 1).
+ * Overrides are applied to all items in the list (default is {}).
+ */
+const companyListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: companyFaker, length, overrides })
+
+export { companyFaker, companyListFaker }
+
+export default companyListFaker

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -1,11 +1,45 @@
 import { assertBreadcrumbs } from '../../support/assertions'
 import { companies } from '../../../../../src/lib/urls'
 
+import { companyFaker, companyListFaker } from '../../fakers/companies'
+
 describe('Company Collections - React', () => {
+  const company1 = companyFaker({
+    address: {
+      line_1: 'Level 6, Avenue K Tower',
+      line_2: '156 Jalan Ampang',
+      town: 'Kuala Lumpur',
+      postcode: '50450',
+      country: {
+        id: 'malaysia-123',
+        name: 'Malaysia',
+      },
+    },
+    sector: {
+      id: 'b1959812-6095-e211-a939-e4115bead28a',
+      name: 'Energy',
+    },
+  })
+  const otherCompanies = companyListFaker(9)
+  const companyList = [company1, ...otherCompanies]
+
   before(() => {
+    cy.intercept('POST', '/api-proxy/v4/search/company', {
+      body: {
+        count: companyList.length,
+        results: companyList,
+      },
+    }).as('apiRequest')
     // Visit the new react companies page - note this will need to be changed
     // to `companies.index()` when ready
     cy.visit(companies.react.index())
+    cy.wait('@apiRequest')
+  })
+
+  beforeEach(() => {
+    cy.get('[data-test="collection-list"]').as('collectionList')
+    cy.get('[data-test="collection-item"]').as('collectionItems')
+    cy.get('@collectionItems').eq(0).as('firstListItem')
   })
 
   it('should render breadcrumbs', () => {
@@ -13,5 +47,27 @@ describe('Company Collections - React', () => {
       Home: '/',
       Companies: null,
     })
+  })
+
+  it('should display a list of companies', () => {
+    cy.get('@collectionList').should('have.length', 1)
+    cy.get('@collectionItems').should('have.length', companyList.length)
+  })
+
+  it('should contain country badge', () => {
+    cy.get('@firstListItem')
+      .find('[data-test="badge"]')
+      .eq(0)
+      .should('contain', 'Malaysia')
+  })
+
+  it('should contain company sector and primary address', () => {
+    cy.get('@firstListItem')
+      .find('[data-test="metadata"]')
+      .should('contain', 'Energy')
+      .and(
+        'contain',
+        'Level 6, Avenue K Tower, 156 Jalan Ampang, Kuala Lumpur, 50450, Malaysia'
+      )
   })
 })

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -20,8 +20,36 @@ describe('Company Collections - React', () => {
       name: 'Energy',
     },
   })
-  const otherCompanies = companyListFaker(9)
-  const companyList = [company1, ...otherCompanies]
+  const company2 = companyFaker({
+    trading_names: ['Company Corp', 'Company Ltd'],
+    headquarter_type: {
+      id: 'ukhq-id',
+      name: 'ukhq',
+    },
+    uk_region: {
+      id: '874cd12a-6095-e211-a939-e4115bead28a',
+      name: 'London',
+    },
+  })
+  const company3 = companyFaker({
+    address: {
+      line_1: '123 Fake Street',
+      line_2: 'Fake Borough',
+      town: 'New York',
+      postcode: '12345',
+    },
+    headquarter_type: {
+      id: 'ghq-id',
+      name: 'ghq',
+    },
+    global_headquarters: {
+      id: 'company-id',
+      name: 'Company Ltd, New York',
+    },
+    uk_region: null,
+  })
+  const otherCompanies = companyListFaker(7)
+  const companyList = [company1, company2, company3, ...otherCompanies]
 
   before(() => {
     cy.intercept('POST', '/api-proxy/v4/search/company', {
@@ -40,6 +68,8 @@ describe('Company Collections - React', () => {
     cy.get('[data-test="collection-list"]').as('collectionList')
     cy.get('[data-test="collection-item"]').as('collectionItems')
     cy.get('@collectionItems').eq(0).as('firstListItem')
+    cy.get('@collectionItems').eq(1).as('secondListItem')
+    cy.get('@collectionItems').eq(2).as('thirdListItem')
   })
 
   it('should render breadcrumbs', () => {
@@ -69,5 +99,32 @@ describe('Company Collections - React', () => {
         'contain',
         'Level 6, Avenue K Tower, 156 Jalan Ampang, Kuala Lumpur, 50450, Malaysia'
       )
+  })
+
+  it('should contain trading names', () => {
+    cy.get('@secondListItem')
+      .find('[data-test="metadata"]')
+      .should('contain', 'Company Corp, Company Ltd')
+  })
+
+  it('should contain UK HQ Badge', () => {
+    cy.get('@secondListItem')
+      .find('[data-test="badge"]')
+      .should('contain', 'UK HQ')
+  })
+
+  it('should contain UK Region Badge', () => {
+    cy.get('@secondListItem')
+      .find('[data-test="badge"]')
+      .should('contain', 'London')
+  })
+
+  it('should contain Global HQ Badge', () => {
+    cy.get('@thirdListItem')
+      .find('[data-test="badge"]')
+      .should('contain', 'Global HQ')
+    cy.get('@thirdListItem')
+      .find('[data-test="metadata"]')
+      .should('contain', company3.global_headquarters.name)
   })
 })


### PR DESCRIPTION
## Description of change

Adds the collection list to the new react companies page. Note that this does not include filters or sort by. You may also notice that other elements need some work before this is fully ready (for example the download header should say "companies" instead of "companys"), but this is just to give a platform to build out the other filters etc.

## Test instructions

Go to `/companies/react` and see the new page. Note that many features including the filters are not there yet.

## Screenshots
### Before

![Screenshot from 2021-05-19 14-02-09](https://user-images.githubusercontent.com/1234577/118817189-dd332600-b8aa-11eb-8f8f-31644cac7434.png)

### After

![Screenshot from 2021-05-19 13-57-41](https://user-images.githubusercontent.com/1234577/118817003-abba5a80-b8aa-11eb-97f6-73285aa87115.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
