### PR TITLE
Remove old Trade Agreement feature flags

### DIFF
--- a/src/apps/events/__test__/repos.test.js
+++ b/src/apps/events/__test__/repos.test.js
@@ -59,7 +59,7 @@ describe('Event repos', () => {
 
         expect(this.authorisedRequestStub).to.be.calledWith(
           stubRequest,
-          sinon.match({ url: `${config.apiRoot}/v3/event/${eventMock.id}` })
+          sinon.match({ url: `${config.apiRoot}/v4/event/${eventMock.id}` })
         )
       })
 

--- a/src/apps/events/macros/event-edit-form.js
+++ b/src/apps/events/macros/event-edit-form.js
@@ -2,366 +2,208 @@ const { sortBy } = require('lodash')
 const { globalFields } = require('../../macros')
 const urls = require('../../../lib/urls')
 
-const eventFormConfig = (
-  {
-    eventId,
-    advisers,
-    eventTypes,
-    locationTypes,
-    countries,
-    teams,
-    services,
-    programmes,
-    ukRegions,
-    tradeAgreements,
-  },
-  featureFlags
-) => {
-  const children =
-    featureFlags && featureFlags.relatedTradeAgreements
-      ? [
-          {
-            macroName: 'MultipleChoiceField',
-            type: 'radio',
-            name: 'has_related_trade_agreements',
-            label: 'Does the Event relate to a Trade Agreement?',
-            modifier: 'inline',
-            options: [
-              {
-                label: 'Yes',
-                value: 'true',
-              },
-              {
-                label: 'No',
-                value: 'false',
-              },
-            ],
-          },
-          {
-            macroName: 'AddAnother',
-            buttonName: 'add_related_trade_agreement',
-            name: 'related_trade_agreements',
-            label: 'Related Trade Agreements',
-            children: [
-              {
-                ...globalFields.tradeAgreements,
-                name: 'related_trade_agreements',
-                label: 'Related Trade Agreements',
-                isLabelHidden: true,
-                options: tradeAgreements,
-              },
-            ],
-            modifier: 'subfield',
-            condition: {
-              name: 'has_related_trade_agreements',
-              value: 'true',
-            },
-          },
-          {
-            macroName: 'TextField',
-            name: 'name',
-            label: 'Event name',
-          },
-          {
-            ...globalFields.eventTypes,
-            options: eventTypes,
-          },
-          {
-            macroName: 'DateFieldset',
-            name: 'start_date',
-            label: 'Event start date',
-          },
-          {
-            macroName: 'DateFieldset',
-            name: 'end_date',
-            label: 'Event end date',
-          },
-          {
-            ...globalFields.locationTypes,
-            label: 'Event location type',
-            optional: true,
-            options: locationTypes,
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_1',
-            label: 'Business and street',
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_2',
-            label: 'Second line of address',
-            isLabelHidden: true,
-            optional: true,
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_town',
-            label: 'Town or city',
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_county',
-            label: 'County',
-          },
-          {
-            macroName: 'TextField',
-            name: 'postcode',
-            label: 'Postcode',
-            class: 'u-js-hidden',
-          },
-          {
-            ...globalFields.countries,
-            name: 'address_country',
-            options: countries,
-          },
-          {
-            ...globalFields.ukRegions,
-            condition: {
-              name: 'address_country',
-              value: '80756b9a-5d95-e211-a939-e4115bead28a',
-            },
-            options: ukRegions,
-          },
-          {
-            macroName: 'TextField',
-            type: 'textarea',
-            name: 'notes',
-            label: 'Event notes',
-            optional: true,
-          },
-          {
-            ...globalFields.teams,
-            name: 'lead_team',
-            label: 'Team hosting the event',
-            optional: false,
-            options: teams,
-          },
-          {
-            ...globalFields.serviceDeliveryServices,
-            options: sortBy(services, (option) => option.label),
-          },
-          {
-            macroName: 'Typeahead',
-            name: 'organiser',
-            entity: 'adviser',
-            label: 'Organiser',
-            classes: 'c-form-group c-form-group--no-filter',
-            placeholder: 'Search organiser',
-            multipleSelect: false,
-            options: advisers,
-            target: 'metadata',
-          },
-          {
-            macroName: 'MultipleChoiceField',
-            type: 'radio',
-            name: 'event_shared',
-            label: 'Is this a shared event?',
-            optional: true,
-            modifier: 'inline',
-            options: [
-              {
-                label: 'Yes',
-                value: 'true',
-              },
-              {
-                label: 'No',
-                value: 'false',
-              },
-            ],
-          },
-          {
-            macroName: 'AddAnother',
-            buttonName: 'add_team',
-            name: 'teams',
-            label: 'Teams',
-            children: [
-              {
-                ...globalFields.teams,
-                name: 'teams',
-                label: 'Team',
-                isLabelHidden: true,
-                persistsConditionalValue: true,
-                optional: true,
-                options: teams,
-              },
-            ],
-            modifier: 'subfield',
-            condition: {
-              name: 'event_shared',
-              value: 'true',
-            },
-          },
-          {
-            macroName: 'AddAnother',
-            buttonName: 'add_related_programme',
-            name: 'related_programmes',
-            label: 'Related programmes',
-            children: [
-              {
-                ...globalFields.programmes,
-                name: 'related_programmes',
-                label: 'Related programmes',
-                isLabelHidden: true,
-                optional: true,
-                options: programmes,
-              },
-            ],
-          },
-        ]
-      : [
-          {
-            macroName: 'TextField',
-            name: 'name',
-            label: 'Event name',
-          },
-          {
-            ...globalFields.eventTypes,
-            options: eventTypes,
-          },
-          {
-            macroName: 'DateFieldset',
-            name: 'start_date',
-            label: 'Event start date',
-          },
-          {
-            macroName: 'DateFieldset',
-            name: 'end_date',
-            label: 'Event end date',
-          },
-          {
-            ...globalFields.locationTypes,
-            label: 'Event location type',
-            optional: true,
-            options: locationTypes,
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_1',
-            label: 'Business and street',
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_2',
-            label: 'Second line of address',
-            isLabelHidden: true,
-            optional: true,
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_town',
-            label: 'Town or city',
-          },
-          {
-            macroName: 'TextField',
-            name: 'address_county',
-            label: 'County',
-          },
-          {
-            macroName: 'TextField',
-            name: 'postcode',
-            label: 'Postcode',
-            class: 'u-js-hidden',
-          },
-          {
-            ...globalFields.countries,
-            name: 'address_country',
-            options: countries,
-          },
-          {
-            ...globalFields.ukRegions,
-            condition: {
-              name: 'address_country',
-              value: '80756b9a-5d95-e211-a939-e4115bead28a',
-            },
-            options: ukRegions,
-          },
-          {
-            macroName: 'TextField',
-            type: 'textarea',
-            name: 'notes',
-            label: 'Event notes',
-            optional: true,
-          },
-          {
-            ...globalFields.teams,
-            name: 'lead_team',
-            label: 'Team hosting the event',
-            optional: false,
-            options: teams,
-          },
-          {
-            ...globalFields.serviceDeliveryServices,
-            options: sortBy(services, (option) => option.label),
-          },
-          {
-            macroName: 'Typeahead',
-            name: 'organiser',
-            entity: 'adviser',
-            label: 'Organiser',
-            classes: 'c-form-group c-form-group--no-filter',
-            placeholder: 'Search organiser',
-            multipleSelect: false,
-            options: advisers,
-            target: 'metadata',
-          },
-          {
-            macroName: 'MultipleChoiceField',
-            type: 'radio',
-            name: 'event_shared',
-            label: 'Is this a shared event?',
-            optional: true,
-            modifier: 'inline',
-            options: [
-              {
-                label: 'Yes',
-                value: 'true',
-              },
-              {
-                label: 'No',
-                value: 'false',
-              },
-            ],
-          },
-          {
-            macroName: 'AddAnother',
-            buttonName: 'add_team',
-            name: 'teams',
-            label: 'Teams',
-            children: [
-              {
-                ...globalFields.teams,
-                name: 'teams',
-                label: 'Team',
-                isLabelHidden: true,
-                persistsConditionalValue: true,
-                optional: true,
-                options: teams,
-              },
-            ],
-            modifier: 'subfield',
-            condition: {
-              name: 'event_shared',
-              value: 'true',
-            },
-          },
-          {
-            macroName: 'AddAnother',
-            buttonName: 'add_related_programme',
-            name: 'related_programmes',
-            label: 'Related programmes',
-            children: [
-              {
-                ...globalFields.programmes,
-                name: 'related_programmes',
-                label: 'Related programmes',
-                isLabelHidden: true,
-                optional: true,
-                options: programmes,
-              },
-            ],
-          },
-        ]
+const eventFormConfig = ({
+  eventId,
+  advisers,
+  eventTypes,
+  locationTypes,
+  countries,
+  teams,
+  services,
+  programmes,
+  ukRegions,
+  tradeAgreements,
+}) => {
+  const children = [
+    {
+      macroName: 'MultipleChoiceField',
+      type: 'radio',
+      name: 'has_related_trade_agreements',
+      label: 'Does the Event relate to a Trade Agreement?',
+      modifier: 'inline',
+      options: [
+        {
+          label: 'Yes',
+          value: 'true',
+        },
+        {
+          label: 'No',
+          value: 'false',
+        },
+      ],
+    },
+    {
+      macroName: 'AddAnother',
+      buttonName: 'add_related_trade_agreement',
+      name: 'related_trade_agreements',
+      label: 'Related Trade Agreements',
+      children: [
+        {
+          ...globalFields.tradeAgreements,
+          name: 'related_trade_agreements',
+          label: 'Related Trade Agreements',
+          isLabelHidden: true,
+          options: tradeAgreements,
+        },
+      ],
+      modifier: 'subfield',
+      condition: {
+        name: 'has_related_trade_agreements',
+        value: 'true',
+      },
+    },
+    {
+      macroName: 'TextField',
+      name: 'name',
+      label: 'Event name',
+    },
+    {
+      ...globalFields.eventTypes,
+      options: eventTypes,
+    },
+    {
+      macroName: 'DateFieldset',
+      name: 'start_date',
+      label: 'Event start date',
+    },
+    {
+      macroName: 'DateFieldset',
+      name: 'end_date',
+      label: 'Event end date',
+    },
+    {
+      ...globalFields.locationTypes,
+      label: 'Event location type',
+      optional: true,
+      options: locationTypes,
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_1',
+      label: 'Business and street',
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_2',
+      label: 'Second line of address',
+      isLabelHidden: true,
+      optional: true,
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_town',
+      label: 'Town or city',
+    },
+    {
+      macroName: 'TextField',
+      name: 'address_county',
+      label: 'County',
+    },
+    {
+      macroName: 'TextField',
+      name: 'postcode',
+      label: 'Postcode',
+      class: 'u-js-hidden',
+    },
+    {
+      ...globalFields.countries,
+      name: 'address_country',
+      options: countries,
+    },
+    {
+      ...globalFields.ukRegions,
+      condition: {
+        name: 'address_country',
+        value: '80756b9a-5d95-e211-a939-e4115bead28a',
+      },
+      options: ukRegions,
+    },
+    {
+      macroName: 'TextField',
+      type: 'textarea',
+      name: 'notes',
+      label: 'Event notes',
+      optional: true,
+    },
+    {
+      ...globalFields.teams,
+      name: 'lead_team',
+      label: 'Team hosting the event',
+      optional: false,
+      options: teams,
+    },
+    {
+      ...globalFields.serviceDeliveryServices,
+      options: sortBy(services, (option) => option.label),
+    },
+    {
+      macroName: 'Typeahead',
+      name: 'organiser',
+      entity: 'adviser',
+      label: 'Organiser',
+      classes: 'c-form-group c-form-group--no-filter',
+      placeholder: 'Search organiser',
+      multipleSelect: false,
+      options: advisers,
+      target: 'metadata',
+    },
+    {
+      macroName: 'MultipleChoiceField',
+      type: 'radio',
+      name: 'event_shared',
+      label: 'Is this a shared event?',
+      optional: true,
+      modifier: 'inline',
+      options: [
+        {
+          label: 'Yes',
+          value: 'true',
+        },
+        {
+          label: 'No',
+          value: 'false',
+        },
+      ],
+    },
+    {
+      macroName: 'AddAnother',
+      buttonName: 'add_team',
+      name: 'teams',
+      label: 'Teams',
+      children: [
+        {
+          ...globalFields.teams,
+          name: 'teams',
+          label: 'Team',
+          isLabelHidden: true,
+          persistsConditionalValue: true,
+          optional: true,
+          options: teams,
+        },
+      ],
+      modifier: 'subfield',
+      condition: {
+        name: 'event_shared',
+        value: 'true',
+      },
+    },
+    {
+      macroName: 'AddAnother',
+      buttonName: 'add_related_programme',
+      name: 'related_programmes',
+      label: 'Related programmes',
+      children: [
+        {
+          ...globalFields.programmes,
+          name: 'related_programmes',
+          label: 'Related programmes',
+          isLabelHidden: true,
+          optional: true,
+          options: programmes,
+        },
+      ],
+    },
+  ]
 
   return {
     method: 'post',

--- a/src/apps/events/repos.js
+++ b/src/apps/events/repos.js
@@ -2,11 +2,9 @@ const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 const { search } = require('../../modules/search/services')
 
-function saveEvent(req, event, featureFlags) {
-  const version =
-    featureFlags && featureFlags.relatedTradeAgreements ? 'v4' : 'v3'
+function saveEvent(req, event) {
   const options = {
-    url: `${config.apiRoot}/${version}/event`,
+    url: `${config.apiRoot}/v4/event`,
     method: 'POST',
     body: event,
   }

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -184,13 +184,10 @@ function transformEventResponseToFormBody(props = {}) {
   })
 }
 
-function transformEventFormBodyToApiRequest(props, featureFlags) {
+function transformEventFormBodyToApiRequest(props) {
   const teamsArray = castCompactArray(props.teams)
   const related_programmes = castCompactArray(props.related_programmes)
-  const related_trade_agreements =
-    featureFlags && featureFlags.relatedTradeAgreements
-      ? castRelatedTradeAgreements()
-      : []
+  const related_trade_agreements = castRelatedTradeAgreements()
   const teams = props.lead_team
     ? teamsArray.concat(props.lead_team)
     : teamsArray

--- a/src/apps/events/views/edit.njk
+++ b/src/apps/events/views/edit.njk
@@ -2,13 +2,11 @@
 
 {% block main_grid_left_column %}{% endblock %}
 {% block main_grid_right_column %}
-    {% if features.relatedTradeAgreements %}
         <p data-test="trade-agreement-text">
             If your Event is set up to focus on a Trade Agreement or contributes to implementing a Trade Agreement then select that the event relates to a Trade Agreement and the relevant Agreement(s)
         </p>
         <a href="https://data-services-help.trade.gov.uk/data-hub/how-articles/trade-agreement-activity/recording-trade-agreement-activity/" target="_blank" aria-label="opens in a new tab" data-test="trade-agreement-link">
             See more guidance
         </a>
-    {% endif %}
     {{ Form(eventForm) }}
 {% endblock %}

--- a/src/apps/interactions/__stories__/InteractionDetails.stories.jsx
+++ b/src/apps/interactions/__stories__/InteractionDetails.stories.jsx
@@ -12,7 +12,6 @@ const DEFAULT_INTERACTION = {
       { value: '65f1a4cc-0171-4db8-8768-0428bd99dd71', label: '' },
     ],
   },
-  isTradeAgreementInteractionEnabled: true,
 }
 
 storiesOf('Company Interactions', module)
@@ -21,10 +20,4 @@ storiesOf('Company Interactions', module)
   })
   .add('With Trade Agreement', () => (
     <InteractionDetailsForm {...DEFAULT_INTERACTION}></InteractionDetailsForm>
-  ))
-  .add('Without Trade Agreement', () => (
-    <InteractionDetailsForm
-      {...DEFAULT_INTERACTION}
-      isTradeAgreementInteractionEnabled={false}
-    ></InteractionDetailsForm>
   ))

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -59,7 +59,6 @@ const InteractionDetailsForm = ({
   wasPolicyFeedbackProvided,
   initialValues,
   progress = false,
-  isTradeAgreementInteractionEnabled = false,
   has_related_trade_agreements,
   related_trade_agreements,
   ...props
@@ -106,7 +105,6 @@ const InteractionDetailsForm = ({
                       values,
                       companyId,
                       referralId,
-                      isTradeAgreementInteractionEnabled,
                     },
                     onSuccessDispatch: ADD_INTERACTION_FORM__SUBMIT,
                   })
@@ -124,13 +122,7 @@ const InteractionDetailsForm = ({
                   <LoadingBox loading={progress}>
                     {(!initialValues.theme || !initialValues.kind) && (
                       <MultiInstanceForm.Step name="interaction_type">
-                        {() => (
-                          <StepInteractionType
-                            isTradeAgreementInteractionEnabled={
-                              isTradeAgreementInteractionEnabled
-                            }
-                          />
-                        )}
+                        {() => <StepInteractionType />}
                       </MultiInstanceForm.Step>
                     )}
 
@@ -184,7 +176,6 @@ InteractionDetailsForm.propTypes = {
   returnLink: PropTypes.string,
   progress: PropTypes.bool,
   initialValues: PropTypes.object,
-  isTradeAgreementInteractionEnabled: PropTypes.bool,
   ...StepInteractionDetails.propTypes,
 }
 

--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -27,7 +27,7 @@ const getTradeAgreementOnChangeHandler = (setFieldValue) => (e) => {
   setInteractionKindFieldValues(setFieldValue, e)
 }
 
-const StepInteractionType = ({ isTradeAgreementInteractionEnabled }) => {
+const StepInteractionType = () => {
   const { setFieldValue } = useFormContext()
   const exportOption = {
     label: 'Export',
@@ -92,26 +92,26 @@ const StepInteractionType = ({ isTradeAgreementInteractionEnabled }) => {
       />
     ),
   }
-  const configuredFieldRadiosOptions = isTradeAgreementInteractionEnabled
-    ? [exportOption, investmentOption, tradeAgreementOption, otherOption]
-    : [exportOption, investmentOption, otherOption]
+  const configuredFieldRadiosOptions = [
+    exportOption,
+    investmentOption,
+    tradeAgreementOption,
+    otherOption,
+  ]
+
   return (
     <>
-      {isTradeAgreementInteractionEnabled && (
-        <InsetText data-test="trade-agreement-guide">
-          Select ‘Trade agreement’ if your interaction was set up to focus on,
-          or contributes to, implementing a trade agreement.
-          <br />
-          <br />
-          Read more{' '}
-          <NewWindowLink
-            href={urls.external.helpCentre.tradeagreementGuidance()}
-          >
-            information and guidance
-          </NewWindowLink>{' '}
-          on this section.
-        </InsetText>
-      )}
+      <InsetText data-test="trade-agreement-guide">
+        Select ‘Trade agreement’ if your interaction was set up to focus on, or
+        contributes to, implementing a trade agreement.
+        <br />
+        <br />
+        Read more{' '}
+        <NewWindowLink href={urls.external.helpCentre.tradeagreementGuidance()}>
+          information and guidance
+        </NewWindowLink>{' '}
+        on this section.
+      </InsetText>
 
       <FieldRadios
         name="theme"

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -93,19 +93,12 @@ export function restoreState() {
   return JSON.parse(stateFromStorage)
 }
 
-export function saveInteraction({
-  values,
-  companyId,
-  referralId,
-  isTradeAgreementInteractionEnabled,
-}) {
+export function saveInteraction({ values, companyId, referralId }) {
   window.sessionStorage.removeItem(STORE_ID)
-
-  const interactionVersion = isTradeAgreementInteractionEnabled ? 'v4' : 'v3'
 
   const endpoint = referralId
     ? `/api-proxy/v4/company-referral/${referralId}/complete`
-    : `/api-proxy/${interactionVersion}/interaction`
+    : `/api-proxy/v4/interaction`
 
   const request = values.id ? axios.patch : axios.post
 

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -162,8 +162,7 @@ const getInitialFormValues = (req, res) => {
 
 async function renderInteractionDetailsForm(req, res, next) {
   try {
-    const { company, interaction, referral, investment, contact, features } =
-      res.locals
+    const { company, interaction, referral, investment, contact } = res.locals
 
     const [
       services,
@@ -208,8 +207,6 @@ async function renderInteractionDetailsForm(req, res, next) {
           policyIssueTypes,
           communicationChannels,
           countries,
-          isTradeAgreementInteractionEnabled:
-            features['trade-agreement-interaction-v4-endpoint'],
           relatedTradeAgreements,
         },
       })

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -3,11 +3,7 @@ const { getDitCompany } = require('../../companies/repos')
 
 async function getInteractionDetails(req, res, next, interactionId) {
   try {
-    const interaction = await fetchInteraction(
-      req,
-      interactionId,
-      res.locals.features['trade-agreement-interaction-v4-endpoint']
-    )
+    const interaction = await fetchInteraction(req, interactionId)
     res.locals.interaction = interaction
 
     if (!res.locals.company) {

--- a/src/apps/interactions/repos.js
+++ b/src/apps/interactions/repos.js
@@ -1,15 +1,10 @@
 const config = require('../../config')
 const { authorisedRequest } = require('../../lib/authorised-request')
 
-function fetchInteraction(
-  req,
-  interactionId,
-  isTradeAgreementInteractionEnabled
-) {
-  const interactionVersion = isTradeAgreementInteractionEnabled ? 'v4' : 'v3'
+function fetchInteraction(req, interactionId) {
   return authorisedRequest(
     req,
-    `${config.apiRoot}/${interactionVersion}/interaction/${interactionId}`
+    `${config.apiRoot}/v4/interaction/${interactionId}`
   )
 }
 

--- a/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
@@ -29,7 +29,7 @@ describe('DA add Investment Project interaction', () => {
 
   context('DA completes the form and clicks "Add interaction"', () => {
     before(() => {
-      cy.server().route('POST', '/api-proxy/v3/interaction').as('post')
+      cy.server().route('POST', '/api-proxy/v4/interaction').as('post')
 
       cy.visit(
         investments.projects.interactions.createType(

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -7,6 +7,14 @@ const { assertKeyValueTable } = require('../../support/assertions')
 const today = Cypress.moment()
 
 const createEvent = () => {
+  cy.get(selectors.eventCreate.tradeAgreementExistsYes).click()
+  cy.get(selectors.eventCreate.relatedTradeAgreements)
+    .eq(0)
+    .select('UK-Australia Mutual Recognition Agreement')
+  cy.get(selectors.eventCreate.addAnotherTradeAgreement).click()
+  cy.get(selectors.eventCreate.relatedTradeAgreements)
+    .eq(1)
+    .select('UK-India Free Trade Agreement')
   cy.get(selectors.eventCreate.eventName).type('Eventful event')
   cy.get(selectors.eventCreate.eventType).select('Account management')
   cy.get(selectors.eventCreate.startDateDay).type(today.format('DD'))
@@ -47,7 +55,10 @@ describe('Event', () => {
 
     it('should throw validation messages for required fields', () => {
       cy.get(selectors.eventCreate.saveEvent).click()
-
+      cy.get(selectors.eventCreate.tradeAgreementError).should(
+        'contain',
+        'This field is required.'
+      )
       cy.get(selectors.eventCreate.nameError).should(
         'contain',
         'This field may not be blank.'
@@ -145,7 +156,9 @@ describe('Event', () => {
       cy.contains('Add attendee').click()
       cy.get('input').type('John')
       cy.contains('button', 'Search').click()
-      cy.get('main li > a').should('contain', 'Johnny Cakeman').click()
+      cy.get('[data-test="item-contact-0"] a')
+        .should('contain', 'Johnny Cakeman')
+        .click()
       cy.contains('Event attendee added')
     })
     it('Should not be able to add a duplicate attendee', () => {

--- a/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
@@ -28,7 +28,7 @@ describe('LEP add Investment Project interaction', () => {
 
   context('LEP completes the form and clicks "Add interaction"', () => {
     before(() => {
-      cy.server().route('POST', '/api-proxy/v3/interaction').as('post')
+      cy.server().route('POST', '/api-proxy/v4/interaction').as('post')
 
       cy.visit(
         investments.projects.interactions.createType(

--- a/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+++ b/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
@@ -60,14 +60,6 @@
     "is_active": true
   },
   {
-    "code": "trade-agreement-interaction-v4-endpoint",
-    "is_active": true
-  },
-  {
-    "code": "relatedTradeAgreements",
-    "is_active": true
-  },
-  {
     "code": "state-filter",
     "is_active": true
   }

--- a/test/selectors/event/create.js
+++ b/test/selectors/event/create.js
@@ -43,4 +43,6 @@ module.exports = {
   relatedTradeAgreements: '[name="related_trade_agreements"]',
   addAnotherTradeAgreement: 'input[name="add_related_trade_agreement"]',
   tradeAgreementExistsYes: 'label[for="field-has_related_trade_agreements-1"]',
+  tradeAgreementError:
+    '#group-field-has_related_trade_agreements .c-form-group__error-message',
 }


### PR DESCRIPTION
## Description of change

Remove two old feature flags `relatedTradeAgreements` (located in Events) and `trade-agreement-interaction-v4-endpoint` (located in Interactions). These features have been deployed to live. 

## Test instructions

When adding an interaction, on the main interaction page there will be Trade Agreement guidance text and the options Export, Investment, Trade Agreement, and Other will be visible. When any of these options are selected, a  'Does this interaction relate to a named trade agreement?' yes/no question will be visible. If yes is selected, a 'Related named trade agreement(s)' multi-select will be visible. 

When adding an event, there will be Trade Agreement guidance text visible. There will be a 'Does the Event related to a Trade Agreement?' yes/no question.  If yes is selected, a 'Related named trade agreement(s)' multi-select will be visible. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
