### PR TITLE
Added a new react contacts express route

### DIFF
--- a/src/apps/contacts/__test__/router.test.js
+++ b/src/apps/contacts/__test__/router.test.js
@@ -1,0 +1,20 @@
+const router = require('../router')
+
+describe('Contacts router', () => {
+  it('should define contacts routes', () => {
+    const paths = router.stack.filter((r) => r.route).map((r) => r.route.path)
+    expect(paths).to.deep.equal([
+      '/',
+      '/react',
+      '/export',
+      '/create',
+      '/:contactId',
+      '/:contactId/details',
+      '/:contactId/edit',
+      '/:id/archive',
+      '/:id/unarchive',
+      '/:contactId/audit',
+      '/:contactId/documents',
+    ])
+  })
+})

--- a/src/apps/contacts/client/ContactsCollection.jsx
+++ b/src/apps/contacts/client/ContactsCollection.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const ContactsCollection = () => {
+  return (
+    <div>
+      <h2>Contacts Collection to go here...</h2>
+    </div>
+  )
+}
+
+export default ContactsCollection

--- a/src/apps/contacts/controllers/contacts.js
+++ b/src/apps/contacts/controllers/contacts.js
@@ -1,0 +1,16 @@
+const renderContactsView = async (req, res, next) => {
+  try {
+    const props = {
+      title: 'Contacts',
+      heading: 'Contacts',
+    }
+
+    return res.render('contacts/views/contacts', { props })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderContactsView,
+}

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -22,6 +22,7 @@ const {
 } = require('../middleware')
 const { getCommon, getDetails } = require('./controllers/details')
 const { renderContactList } = require('./controllers/list')
+const { renderContactsView } = require('./controllers/contacts')
 const { postDetails, editDetails } = require('./controllers/edit')
 const { archiveContact, unarchiveContact } = require('./controllers/archive')
 const { renderDocuments } = require('./controllers/documents')
@@ -40,6 +41,9 @@ router.get(
   getCollection('contact', ENTITIES, transformContactToListItem),
   renderContactList
 )
+
+// New react route (to replace the old companies list route above when complete)
+router.get(urls.contacts.react.index.route, renderContactsView)
 
 router.get(
   '/export',

--- a/src/apps/contacts/views/contacts.njk
+++ b/src/apps/contacts/views/contacts.njk
@@ -1,0 +1,11 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-column-full">
+      {% component 'react-slot', {
+        id: 'contacts-collection',
+        props: props
+      }
+      %}
+  </div>
+{% endblock %}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -41,6 +41,7 @@ import Dashboard from './components/Dashboard'
 import PersonalisedDashboard from './components/PersonalisedDashboard'
 import CompanyLocalHeader from './components/CompanyLocalHeader'
 import CompaniesCollection from '../apps/companies/client/CompaniesCollection.jsx'
+import ContactsCollection from '../apps/contacts/client/ContactsCollection.jsx'
 import InvestmentProjectsCollection from '../apps/investments/client/projects/ProjectsCollection.jsx'
 import Opportunities from '../apps/investments/client/opportunities/Details/Opportunities.jsx'
 import IEBanner from '../apps/dashboard/client/IEBanner'
@@ -358,6 +359,9 @@ function App() {
       </Mount>
       <Mount selector="#companies-collection">
         {(props) => <CompaniesCollection {...props} />}
+      </Mount>
+      <Mount selector="#contacts-collection">
+        {(props) => <ContactsCollection {...props} />}
       </Mount>
       <Mount selector="#ie-banner">{() => <IEBanner />}</Mount>
     </Provider>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -207,6 +207,10 @@ module.exports = {
     rename: url('/company-lists', '/:listId/rename'),
   },
   contacts: {
+    // React routes (Work in progress) - to be released on completion
+    react: {
+      index: url('/contacts', '/react'),
+    },
     index: url('/contacts'),
     export: url('/contacts', '/export'),
     audit: url('/contacts', '/:contactId/audit'),

--- a/test/functional/cypress/specs/contacts/collection-react-spec.js
+++ b/test/functional/cypress/specs/contacts/collection-react-spec.js
@@ -1,0 +1,21 @@
+import { assertBreadcrumbs } from '../../support/assertions'
+import { contacts } from '../../../../../src/lib/urls'
+
+describe('Contacts Collections - React', () => {
+  before(() => {
+    // Visit the new react companies page - note this will need to be changed
+    // to `contacts.index()` when ready
+    cy.visit(contacts.react.index())
+  })
+
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: '/',
+      Contacts: null,
+    })
+  })
+
+  it('should render a title', () => {
+    cy.get('h1').should('have.text', 'Contacts')
+  })
+})


### PR DESCRIPTION
## Description of change

Adds a new `/contacts/react` express route simply displaying a title. This page will be developed in increments, finally ensuring it's identical to the current page `/contacts` which is in the old tech stack.

 Once complete we will swap `/contacts/react` for `/contacts` making it invisible to users.

## Test instructions

Simply navigate to `/contacts/react`

## Screenshots
<img width="1448" alt="contacts" src="https://user-images.githubusercontent.com/964268/118946026-ede8a800-b94d-11eb-8d89-1de4ac98b9eb.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
