### PR TITLE
Fix/axios address lookup

### DIFF
--- a/src/lib/__test__/axios-hawk-request.test.js
+++ b/src/lib/__test__/axios-hawk-request.test.js
@@ -1,7 +1,11 @@
+/**
+ * Tests for axios version of hawk request
+ */
 const config = require('../../config')
 const rewire = require('rewire')
+const { StatusCodeError } = require('../errors')
 
-const modulePath = '../hawk-request'
+const modulePath = '../axios-hawk-request'
 
 const testDataHubCredentials = {
   id: 'test-key-id',
@@ -10,9 +14,13 @@ const testDataHubCredentials = {
 }
 const testClientHeaderArtifacts = { fake: 'artifacts' }
 const testRequestOptions = {
-  uri: `${config.apiRoot}/v4/metadata/countries`,
+  url: `${config.apiRoot}/v4/metadata/countries`,
   method: 'GET',
-  headers: { accept: 'application/json', Authorization: 'Fake header' },
+  headers: {
+    accept: 'application/json',
+    Authorization: 'Fake header',
+    'Content-Type': 'application/json',
+  },
 }
 
 describe('#hawkRequest: check getHawkHeader', () => {
@@ -27,7 +35,7 @@ describe('#hawkRequest: check getHawkHeader', () => {
         nonce: 'Sj_D4e',
         method: 'GET',
         resource: '/',
-        host: 'test-uri',
+        host: 'test-url',
         port: 80,
         hash: 'B0weABCsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=',
         ext: undefined,
@@ -44,7 +52,7 @@ describe('#hawkRequest: check getHawkHeader', () => {
     const getHawkHeader = this.hawkRequest.__get__('getHawkHeader')
 
     const requestOptionsStub = sinon.stub()
-    requestOptionsStub.uri = 'http://test-uri'
+    requestOptionsStub.url = 'http://test-url'
     requestOptionsStub.method = 'GET'
 
     const completeHeader = getHawkHeader(
@@ -53,12 +61,12 @@ describe('#hawkRequest: check getHawkHeader', () => {
     )
 
     expect(this.hawkHeaderStub).to.have.been.calledOnceWith(
-      requestOptionsStub.uri,
+      requestOptionsStub.url,
       requestOptionsStub.method,
       {
         credentials: testDataHubCredentials,
         payload: '',
-        contentType: '',
+        contentType: 'application/json',
       }
     )
     expect(completeHeader).to.equal(this.expectedHawkHeader)
@@ -72,11 +80,8 @@ describe('#hawkRequest: check sendHawkRequest', () => {
     this.configStub.hawkCredentials.dataHubBackend = testDataHubCredentials
     this.hawkRequest = rewire(modulePath)
     this.hawkRequest.__set__('config', this.configStub)
-    this.createPromiseRequestSpy = sinon.spy()
-    this.hawkRequest.__set__(
-      'createPromiseRequest',
-      this.createPromiseRequestSpy
-    )
+    this.hawkRequestPromiseSpy = sinon.spy()
+    this.hawkRequest.__set__('hawkRequestPromise', this.hawkRequestPromiseSpy)
 
     this.getHawkHeaderStub = sinon.stub().returns({
       artifacts: { fake: 'artifacts' },
@@ -86,13 +91,13 @@ describe('#hawkRequest: check sendHawkRequest', () => {
     this.hawkRequest.__set__('getHawkHeader', this.getHawkHeaderStub)
   })
 
-  it('fails when no uri provided', async () => {
+  it('fails when no url provided', async () => {
     await expect(this.hawkRequest()).to.be.rejectedWith(Error)
   })
 
-  it('calls createPromiseRequest', async () => {
+  it('calls hawkRequestPromise', async () => {
     await this.hawkRequest(config.apiRoot + '/v4/metadata/countries')
-    expect(this.createPromiseRequestSpy).to.have.been.calledOnceWith(
+    expect(this.hawkRequestPromiseSpy).to.have.been.calledOnceWith(
       testRequestOptions,
       testDataHubCredentials,
       {
@@ -102,7 +107,7 @@ describe('#hawkRequest: check sendHawkRequest', () => {
   })
 })
 
-describe('#hawkRequest: check createPromiseRequest', () => {
+describe('#hawkRequest: check hawkRequestPromise', () => {
   beforeEach(() => {
     this.configStub = sinon.stub()
     this.hawkRequest = rewire(modulePath)
@@ -114,13 +119,12 @@ describe('#hawkRequest: check createPromiseRequest', () => {
   })
 
   it('gets correct response', async () => {
-    this.hawkRequest.__set__('request', (requestOptions, cb) => {
-      const response = { statusCode: 200 }
-      cb(null, response, '{"fake":"reply"}')
-    })
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequest.__set__('request', () =>
+      Promise.resolve({ status: 200, data: { fake: 'reply' } })
+    )
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
-    await this.createPromiseRequest(
+    await this.hawkRequestPromise(
       testRequestOptions,
       testDataHubCredentials,
       testClientHeaderArtifacts
@@ -130,14 +134,13 @@ describe('#hawkRequest: check createPromiseRequest', () => {
   })
 
   it('fails when response status code is not 200', async () => {
-    this.hawkRequest.__set__('request', (requestOptions, cb) => {
-      const response = { statusCode: 500 }
-      cb(null, response, '{}')
-    })
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequest.__set__('request', () =>
+      Promise.reject(StatusCodeError('Server Error', 500))
+    )
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
     await expect(
-      this.createPromiseRequest(
+      this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
@@ -146,17 +149,16 @@ describe('#hawkRequest: check createPromiseRequest', () => {
   })
 
   it('fails when response is not valid', async () => {
-    this.hawkRequest.__set__('request', (requestOptions, cb) => {
-      const response = { statusCode: 401 }
-      cb(null, response, '{}')
-    })
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequest.__set__('request', () =>
+      Promise.resolve({ status: 401, data: {} })
+    )
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
     const authenticateStub = sinon.stub().returns(true)
     this.hawkRequest.__set__('hawk.client.authenticate', authenticateStub)
 
     await expect(
-      this.createPromiseRequest(
+      this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
@@ -164,7 +166,7 @@ describe('#hawkRequest: check createPromiseRequest', () => {
     ).to.be.rejectedWith(Error)
 
     expect(authenticateStub).to.be.calledOnceWith(
-      { statusCode: 401 },
+      { status: 401, data: {} },
       testDataHubCredentials,
       testClientHeaderArtifacts,
       { payload: '{}' }
@@ -172,17 +174,14 @@ describe('#hawkRequest: check createPromiseRequest', () => {
   })
 
   it('fails when authenticate throws', async () => {
-    this.hawkRequest.__set__('request', (requestOptions, cb) => {
-      const response = { statusCode: 200 }
-      cb(null, response, '{}')
-    })
-    this.createPromiseRequest = this.hawkRequest.__get__('createPromiseRequest')
+    this.hawkRequest.__set__('request', () => Promise.resolve({ status: 200 }))
+    this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
     const authenticateStub = sinon.stub().throws(Error)
     this.hawkRequest.__set__('hawk.client.authenticate', authenticateStub)
 
     await expect(
-      this.createPromiseRequest(
+      this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
@@ -190,7 +189,7 @@ describe('#hawkRequest: check createPromiseRequest', () => {
     ).to.be.rejectedWith(Error)
 
     expect(authenticateStub).to.be.calledOnceWith(
-      { statusCode: 200 },
+      { status: 200 },
       testDataHubCredentials,
       testClientHeaderArtifacts,
       { payload: '{}' }

--- a/src/lib/axios-hawk-request.js
+++ b/src/lib/axios-hawk-request.js
@@ -1,0 +1,93 @@
+/**
+ * This is the axios version of hawk request - unfortunately this is causing a
+ * bug on the postcode api at the moment, but this is left here to fix later.
+ */
+const hawk = require('@hapi/hawk')
+const config = require('../config')
+const request = require('./request')
+
+function getHawkHeader(credentials, requestOptions) {
+  if (config.isTest) {
+    return 'hawk-test-header'
+  }
+
+  const { url, method } = requestOptions
+
+  // Generate Authorization request header
+  // Ensure backend is using same protocol for hash generation
+  return hawk.client.header(url, method, {
+    credentials,
+    payload: '',
+    contentType: 'application/json',
+  })
+}
+
+async function hawkRequest(requestOptions, credentials, clientHeaderArtifacts) {
+  const response = await request({
+    validateStatus: (status) => status >= 200 && status < 500,
+    ...requestOptions,
+  })
+
+  if (!config.isTest) {
+    let isValid = false
+    try {
+      // Authenticate the server's response must use raw response body here
+      isValid = hawk.client.authenticate(
+        response,
+        credentials,
+        clientHeaderArtifacts,
+        { payload: JSON.stringify(response.data || {}) }
+      )
+    } catch (e) {
+      const err = new Error('Unable to validate response')
+      err.rootError = e
+      throw err
+    }
+
+    if (!isValid) {
+      throw new Error('Invalid response')
+    }
+  }
+
+  if (response.status >= 300) {
+    const error = new Error(
+      `Got a ${response.status} response code for ${requestOptions.uri}`
+    )
+    error.responseBody = response.data
+    throw error
+  }
+
+  return response.data
+}
+
+function hawkRequestPromise(...params) {
+  return new Promise((resolve, reject) =>
+    hawkRequest(...params)
+      .then((response) => resolve(response))
+      .catch((error) => reject(error))
+  )
+}
+
+async function sendHawkRequest(
+  url,
+  credentials = config.hawkCredentials.dataHubBackend
+) {
+  if (!url) {
+    throw new Error('Url is required')
+  }
+  const requestOptions = {
+    url,
+    method: 'GET',
+    headers: {
+      accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  }
+
+  const clientHeader = getHawkHeader(credentials, requestOptions)
+  requestOptions.headers.Authorization = clientHeader.header || clientHeader
+
+  return hawkRequestPromise(requestOptions, credentials, clientHeader.artifacts)
+}
+
+module.exports = sendHawkRequest

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,19 @@
+/**
+ * This error is thrown when a response gives a bad status code.
+ */
+class StatusCodeError extends Error {
+  constructor(message, statusCode) {
+    super(message)
+
+    this.message = `${statusCode} - ${JSON.stringify(message)}`
+    this.error = message
+    this.statusCode = statusCode
+
+    // Maintains proper stack trace for where our error was thrown
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, StatusCodeError)
+    }
+  }
+}
+
+module.exports = { StatusCodeError }

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const { isString } = require('lodash')
+const { StatusCodeError } = require('./errors')
 
 const logger = require('../config/logger')
 
@@ -23,24 +24,6 @@ const stripScript = (text) => {
     text = text.replace(SCRIPT_REGEX, '')
   }
   return text
-}
-
-/**
- * This error is thrown when a response gives a bad status code.
- */
-class StatusCodeError extends Error {
-  constructor(message, statusCode) {
-    super(message)
-
-    this.message = `${statusCode} - ${JSON.stringify(message)}`
-    this.error = message
-    this.statusCode = statusCode
-
-    // Maintains proper stack trace for where our error was thrown
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, StatusCodeError)
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
## Description of change

Rolls back hawk auth to use Request Promise - the axios code has been kept to fix later (since we need to migrate away from request promise).

## Test instructions

You need to connect to the staging environment backend as the dev env appears to be broken.

Try to add a company - when you reach the page where you select DIT sector and region it shouldn't break!

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
