### PR TITLE
Remove Moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28357,11 +28357,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
-    "moment-duration-format": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
-      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
-    },
     "monitor-event-loop-delay": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monitor-event-loop-delay/-/monitor-event-loop-delay-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -125,8 +125,6 @@
     "lodash": "^4.17.21",
     "markdown-it": "^12.0.6",
     "mini-css-extract-plugin": "^1.6.0",
-    "moment": "^2.29.1",
-    "moment-duration-format": "^2.1.0",
     "morgan": "^1.10.0",
     "numeral": "^2.0.6",
     "nunjucks": "^3.2.3",

--- a/src/apps/companies/apps/business-details/client/tasks.js
+++ b/src/apps/companies/apps/business-details/client/tasks.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import moment from 'moment'
+import { subDays, endOfToday, isAfter } from 'date-fns'
 
 export function checkIfPendingRequest(duns_number) {
   if (duns_number) {
@@ -14,11 +14,11 @@ export function checkIfPendingRequest(duns_number) {
 
 const checkIfRequestIsValid = ({ count, results }) => {
   if (count > 0) {
-    const timeInterval = moment().subtract(20, 'days')
+    const todaysDate = endOfToday()
+    const timeInterval = subDays(todaysDate, 20)
+    const isValid = isAfter(todaysDate, timeInterval)
     const validRequests = results.filter(
-      (result) =>
-        ['pending', 'submitted'].includes(result.status) &&
-        moment(result.created_on).isAfter(timeInterval)
+      (result) => ['pending', 'submitted'].includes(result.status) && isValid
     )
     return validRequests.length > 0
   }

--- a/src/apps/companies/apps/edit-history/client/CompanyEditHistory.jsx
+++ b/src/apps/companies/apps/edit-history/client/CompanyEditHistory.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import moment from 'moment'
 import { isBoolean, isNumber } from 'lodash'
 import { convertUsdToGbp } from '../../../../../common/currency'
 
 import EditHistory from '../../../../../client/components/EditHistory/EditHistory'
 import { formatWithTime } from '../../../../../client/utils/date-utils'
 import { currencyGBP } from '../../../../../client/utils/number-utils'
+import { isValid, parseISO } from 'date-fns'
 
 import {
   ARCHIVED,
@@ -21,7 +21,7 @@ import {
 const CURRENCY_FIELDS = ['Turnover']
 
 function isDate(dateStr) {
-  return moment(dateStr, moment.ISO_8601, true).isValid()
+  return isValid(parseISO(dateStr))
 }
 
 function getValueFromBoolean(value, field) {

--- a/src/apps/companies/client/transformers.js
+++ b/src/apps/companies/client/transformers.js
@@ -66,7 +66,9 @@ const transformCompanyToListItem = ({
 
   return {
     id,
-    subheading: `Updated on ${formatWithTime(modified_on)}`,
+    subheading: modified_on
+      ? `Updated on ${formatWithTime(modified_on)}`
+      : undefined,
     headingText: name,
     headingUrl: urls.companies.detail(id),
     badges,

--- a/src/apps/companies/middleware/__test__/last-interaction-date.test.js
+++ b/src/apps/companies/middleware/__test__/last-interaction-date.test.js
@@ -1,4 +1,4 @@
-const moment = require('moment')
+const { endOfToday, format, subMonths } = require('date-fns')
 const middleware = require('../last-interaction-date')
 const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
 
@@ -7,13 +7,13 @@ const START_DATE_PARAM = 'latest_interaction_date_before'
 const END_DATE_PARAM = 'latest_interaction_date_after'
 
 function getTimestamp(offset) {
-  const date = moment()
+  const date = endOfToday()
 
   if (offset > 0) {
-    date.subtract(offset, 'month')
+    subMonths(date, offset)
   }
 
-  return date.utc().format('YYYY-MM-DD')
+  return format(date, 'y-MM-d')
 }
 
 function callMiddleware(value) {

--- a/src/apps/companies/middleware/last-interaction-date.js
+++ b/src/apps/companies/middleware/last-interaction-date.js
@@ -1,19 +1,19 @@
-const moment = require('moment')
+const { endOfToday, format, subMonths } = require('date-fns')
 const { QUERY_FIELDS_MAP } = require('../constants')
 
 const QUERY_PARAM = QUERY_FIELDS_MAP.lastInteractionDate
 const START_DATE_PARAM = 'latest_interaction_date_before'
 const END_DATE_PARAM = 'latest_interaction_date_after'
-const DATE_FORMAT = 'YYYY-MM-DD'
+const DATE_FORMAT = 'y-MM-d'
 
 function getTimestamp(offset) {
-  const date = moment()
+  const date = endOfToday()
 
   if (offset > 0) {
-    date.subtract(offset, 'month')
+    subMonths(date, offset)
   }
 
-  return date.utc().format(DATE_FORMAT)
+  return format(date, DATE_FORMAT)
 }
 
 module.exports = (req, res, next) => {

--- a/src/apps/dashboard/__test__/transformers.test.js
+++ b/src/apps/dashboard/__test__/transformers.test.js
@@ -1,4 +1,4 @@
-const moment = require('moment')
+const { formatDistanceToNowStrict, parseISO } = require('date-fns')
 const {
   formatHelpCentreAnnouncements,
 } = require('../../../../src/apps/dashboard/transformers')
@@ -67,17 +67,32 @@ describe('#formatHelpCentreAnnouncements', () => {
     {
       heading: 'Recording policy feedback on Data Hub',
       link: 'https://helpcentre.com/hc/en-gb/articles/360001431697-Recording-policy-feedback-on-Data-Hub',
-      date: `${moment(mockData.articles[0].created_at).fromNow()}`,
+      date: `${formatDistanceToNowStrict(
+        parseISO(mockData.articles[0].created_at),
+        {
+          addSuffix: true,
+        }
+      )}`,
     },
     {
       heading: 'Improvements to company data in Data Hub - April 2019',
       link: 'https://helpcentre.com/hc/en-gb/articles/360001412918-Improvements-to-company-data-in-Data-Hub-April-2019',
-      date: `${moment(mockData.articles[1].created_at).fromNow()}`,
+      date: `${formatDistanceToNowStrict(
+        parseISO(mockData.articles[1].created_at),
+        {
+          addSuffix: true,
+        }
+      )}`,
     },
     {
       heading: 'Recording multiple DIT advisers against interactions',
       link: 'https://helpcentre.com/hc/en-gb/articles/360001345138-Recording-multiple-DIT-advisers-against-interactions',
-      date: `${moment(mockData.articles[2].created_at).fromNow()}`,
+      date: `${formatDistanceToNowStrict(
+        parseISO(mockData.articles[2].created_at),
+        {
+          addSuffix: true,
+        }
+      )}`,
     },
   ]
   context('Successful API response', () => {

--- a/src/apps/dashboard/transformers.js
+++ b/src/apps/dashboard/transformers.js
@@ -1,5 +1,16 @@
 /* eslint camelcase: 0 */
-const moment = require('moment')
+const { formatDistanceToNowStrict, parseISO } = require('date-fns')
+
+const formatDate = (date) => {
+  const formattedDate = formatDistanceToNowStrict(parseISO(date), {
+    addSuffix: true,
+  })
+  if (formattedDate == '1 day ago') {
+    return 'a day ago'
+  } else {
+    return formattedDate
+  }
+}
 
 const formatHelpCentreAnnouncements = ({ data = {} }) => {
   const { articles = [] } = data
@@ -8,7 +19,7 @@ const formatHelpCentreAnnouncements = ({ data = {} }) => {
       return {
         heading: item.title,
         link: item.html_url,
-        date: moment(item.created_at).fromNow(),
+        date: formatDate(item.created_at),
       }
     }
   })

--- a/src/apps/events/controllers/__test__/edit.test.js
+++ b/src/apps/events/controllers/__test__/edit.test.js
@@ -1,6 +1,6 @@
 const { assign, find, sortBy } = require('lodash')
-const moment = require('moment')
 const proxyquire = require('proxyquire')
+const { endOfYesterday, subMonths } = require('date-fns')
 
 const config = require('../../../../config')
 const eventData = require('../../../../../test/unit/data/events/event.json')
@@ -10,8 +10,8 @@ const {
   filterServiceNames,
 } = require('../../../../../src/apps/events/controllers/edit')
 
-const yesterday = moment().subtract(1, 'days').toISOString()
-const lastMonth = moment().subtract(1, 'months').toISOString()
+const yesterday = endOfYesterday()
+const lastMonth = subMonths(new Date(), 1)
 
 const metadataMock = {
   teamOptions: [

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -1,6 +1,5 @@
-const moment = require('moment')
 const { get, pick } = require('lodash')
-
+const format = require('date-fns/format')
 const { KINDS, THEMES } = require('../../constants')
 const { getActiveEvents } = require('../../../events/repos')
 const {
@@ -126,7 +125,7 @@ const getInitialFormValues = (req, res) => {
   const { user } = req.session
   const { company, investment, interaction, referral } = res.locals
   const { theme, kind } = req.params
-  const date = interaction ? moment(interaction.date) : moment()
+  const date = interaction ? new Date(interaction.date) : new Date()
   const investmentId = get(
     investment,
     'id',
@@ -144,9 +143,9 @@ const getInitialFormValues = (req, res) => {
     company: company.id,
     investment_project: investmentId,
     date: {
-      day: date.format('DD'),
-      month: date.format('MM'),
-      year: date.format('YYYY'),
+      day: format(date, 'dd'),
+      month: format(date, 'MM'),
+      year: format(date, 'yyyy'),
     },
     contacts:
       referral && referral.contact

--- a/src/apps/interactions/controllers/__test__/list.test.js
+++ b/src/apps/interactions/controllers/__test__/list.test.js
@@ -1,4 +1,5 @@
-const moment = require('moment')
+const endOfYesterday = require('date-fns/endOfYesterday')
+
 const { omit } = require('lodash')
 
 const config = require('../../../../config')
@@ -52,7 +53,7 @@ describe('interaction list', () => {
 
     next = sinon.stub()
 
-    const yesterday = moment().subtract(1, 'days').toISOString()
+    const yesterday = endOfYesterday()
 
     metadataMock = {
       teamOptions: [

--- a/src/apps/investments/client/InvestmentEditHistory.jsx
+++ b/src/apps/investments/client/InvestmentEditHistory.jsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import moment from 'moment'
 import { isBoolean, isNumber } from 'lodash'
 import { formatWithTime } from '../../../client/utils/date-utils'
+import { isValid, parseISO } from 'date-fns'
 
 import { CHANGE_TYPE_TEXT, TRUE, FALSE, NOT_SET } from '../constants'
 
 import EditHistory from '../../../client/components/EditHistory/EditHistory'
 
 function isDate(dateStr) {
-  return moment(dateStr, moment.ISO_8601, true).isValid()
+  return isValid(parseISO(dateStr))
 }
 
 function getValue(value) {

--- a/src/apps/investments/client/projects/transformers.js
+++ b/src/apps/investments/client/projects/transformers.js
@@ -25,7 +25,7 @@ const transformInvestmentProjectToListItem = ({
     { label: 'Sector', value: sector ? sector.name : '' },
     {
       label: 'Estimated land date',
-      value: estimated_land_date && format(estimated_land_date, 'MMMM YYYY'),
+      value: estimated_land_date && format(estimated_land_date, 'MMMM yyyy'),
     },
   ].filter((metadata) => metadata.value)
 

--- a/src/apps/investments/middleware/forms/__test__/details.test.js
+++ b/src/apps/investments/middleware/forms/__test__/details.test.js
@@ -1,13 +1,13 @@
 const { v4: uuid } = require('uuid')
 const { assign } = require('lodash')
-const moment = require('moment')
+const endOfYesterday = require('date-fns/endOfYesterday')
 const proxyquire = require('proxyquire')
 
 const config = require('../../../../../config')
 const paths = require('../../../paths')
 const companyData = require('../../../../../../test/unit/data/companies/company-v4.json')
 
-const yesterday = moment().subtract(1, 'days').toISOString()
+const yesterday = endOfYesterday()
 
 const metadataMock = {
   investmentTypeOptions: [

--- a/src/apps/investments/middleware/forms/__test__/value.test.js
+++ b/src/apps/investments/middleware/forms/__test__/value.test.js
@@ -4,11 +4,11 @@ const controller = require('../value')
 const { investmentTypes } = require('../../../types')
 const paths = require('../../../paths')
 const config = require('../../../../../config')
-const moment = require('moment')
+const { endOfToday, endOfYesterday, subMonths } = require('date-fns')
 
 const gvaMessage = gvaMessages.capitalExpenditureAndPrimarySectorRequired
-const yesterday = moment().subtract(1, 'days').toISOString()
-const lastMonth = moment().subtract(1, 'months').toISOString()
+const yesterday = endOfYesterday()
+const lastMonth = subMonths(endOfToday(), 1)
 
 const metadataMock = {
   salaryRangeOptions: [

--- a/src/apps/investments/middleware/shared.js
+++ b/src/apps/investments/middleware/shared.js
@@ -1,6 +1,5 @@
 const { get, upperFirst, camelCase } = require('lodash')
-const format = require('date-fns/format')
-const parseISO = require('date-fns/parseISO')
+const { format, parseISO } = require('date-fns')
 
 const metadata = require('../../../lib/metadata')
 const {

--- a/src/apps/investments/transformers/project.js
+++ b/src/apps/investments/transformers/project.js
@@ -8,8 +8,7 @@ const {
   mapValues,
   map,
 } = require('lodash')
-const format = require('date-fns/format')
-const moment = require('moment')
+const { format, parseISO } = require('date-fns')
 
 const { getInvestmentTypeDetails } = require('./shared')
 const { transformDateObjectToDateString } = require('../../transformers')
@@ -167,7 +166,7 @@ function transformInvestmentForView({
     level_of_involvement,
     specific_programme,
     estimated_land_date: !isEmpty(estimated_land_date)
-      ? moment(estimated_land_date, 'YYYY-MM-DD').format('MMMM yyyy')
+      ? format(parseISO(estimated_land_date), 'MMMM yyyy')
       : null,
     actual_land_date: !isEmpty(actual_land_date)
       ? {
@@ -212,7 +211,7 @@ function transformBriefInvestmentSummary(data) {
       .map((country) => country.name)
       .join(', '),
     estimated_land_date: !isEmpty(data.estimated_land_date)
-      ? moment(data.estimated_land_date, 'YYYY-MM-DD').format('MMMM yyyy')
+      ? format(parseISO(data.estimated_land_date), 'MMMM yyyy')
       : null,
     total_investment: data.total_investment
       ? {

--- a/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
@@ -20,14 +20,18 @@ import PipelineForm from './PipelineForm'
 import GetPipelineData from './GetPipelineData'
 import { PipelineItemPropType } from './constants'
 import { getPipelineUrl } from './utils'
-import moment from 'moment'
+import { parse, isValid, format } from 'date-fns'
 
 import { Main } from '../../../client/components'
 import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 
 function formatInitialValues(values) {
   const { sector, contacts } = values
-  const expectedWinDate = moment(values.expected_win_date, 'YYYY-MM-DD', true)
+  const expectedWinDate = parse(
+    values.expected_win_date,
+    'yyyy-MM-dd',
+    new Date()
+  )
   return {
     name: values.name,
     category: values.status,
@@ -35,10 +39,10 @@ function formatInitialValues(values) {
     sector: sector ? { value: sector.id, label: sector.segment } : null,
     contacts: contacts?.map(({ id, name }) => ({ value: id, label: name })),
     export_value: values.potential_value,
-    expected_win_date: expectedWinDate.isValid()
+    expected_win_date: isValid(expectedWinDate)
       ? {
-          month: expectedWinDate.format('MM'),
-          year: expectedWinDate.format('YYYY'),
+          month: format(expectedWinDate, 'MM'),
+          year: format(expectedWinDate, 'yyyy'),
         }
       : {
           month: '',

--- a/src/apps/my-pipeline/client/PipelineDetails.jsx
+++ b/src/apps/my-pipeline/client/PipelineDetails.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import Link from '@govuk-react/link'
-import moment from 'moment'
 import styled from 'styled-components'
 
 import { STATUS_VALUES, LIKELIHOOD_VALUES } from './constants'
@@ -9,6 +8,7 @@ import { SummaryTable } from '../../../client/components/'
 import { WIDTHS } from '@govuk-react/constants/lib/spacing'
 import { format } from '../../../client/utils/date-utils'
 import { currencyGBP } from '../../../client/utils/number-utils'
+import { format as formatFNS, parseISO } from 'date-fns'
 
 function getLabels(acc, { value, label }) {
   acc[value] = label
@@ -55,7 +55,7 @@ export default function PipelineDetails({ item }) {
     ],
     item.expected_win_date && [
       'Expected date for win',
-      moment(item.expected_win_date).format('MMM Y'),
+      formatFNS(parseISO(item.expected_win_date), 'MMM y'),
     ],
     ['Created', format(item.created_on)],
     item.archived && ['Reason for archive', item.archived_reason],

--- a/src/client/components/Dashboard/my-companies/MyCompaniesTable.jsx
+++ b/src/client/components/Dashboard/my-companies/MyCompaniesTable.jsx
@@ -1,5 +1,5 @@
 import { orderBy } from 'lodash'
-import moment from 'moment'
+import { format, parseISO } from 'date-fns'
 import React from 'react'
 import styled from 'styled-components'
 import LinesEllipsis from 'react-lines-ellipsis'
@@ -97,7 +97,7 @@ function MyCompaniesTable() {
         </Table.Cell>
         <StyledDateCell setWidth="15%">
           {latestInteraction.date
-            ? moment(latestInteraction.date).format('D MMM YYYY')
+            ? format(parseISO(latestInteraction.date), 'd MMM yyyy')
             : '-'}
         </StyledDateCell>
         <Table.Cell setWidth="50%">

--- a/src/client/components/Pipeline/PipelineItem.jsx
+++ b/src/client/components/Pipeline/PipelineItem.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import moment from 'moment'
 import styled from 'styled-components'
 import { escape } from 'lodash'
 import Button from '@govuk-react/button'
@@ -9,6 +8,7 @@ import GridCol from '@govuk-react/grid-col'
 import { SPACING, MEDIA_QUERIES, FONT_SIZE } from '@govuk-react/constants'
 import { BLUE, GREY_1, BLACK } from 'govuk-colours'
 import { H3 } from 'govuk-react'
+import { format, parseISO } from 'date-fns'
 
 import { Card } from '../ActivityFeed/activities/card'
 import { currencyGBP } from '../../utils/number-utils'
@@ -157,11 +157,11 @@ function buildMetaList({
     },
     expected_win_date && {
       label: 'Expected date for win',
-      value: moment(expected_win_date).format('MMM Y'),
+      value: format(parseISO(expected_win_date), 'MMM y'),
     },
     {
       label: 'Created',
-      value: moment(created_on).format('DD MMM Y'),
+      value: format(parseISO(created_on), 'dd MMM y'),
       subtle: true,
       showArchived: true,
     },
@@ -178,7 +178,7 @@ function buildMetaList({
       },
     archived && {
       label: 'Archived',
-      value: moment(archived_on).format('DD MMM Y'),
+      value: format(parseISO(archived_on), 'dd MMM y'),
       subtle: true,
     },
   ]

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -1,12 +1,14 @@
-import moment from 'moment'
 import {
   endOfToday,
   format as formatFNS,
   differenceInCalendarDays,
+  parseISO,
+  isValid,
+  parse,
 } from 'date-fns'
 
-export const DATE_FORMAT_LONG = 'YYYY-MM-DD'
-export const DATE_FORMAT_SHORT = 'YYYY-MM'
+export const DATE_FORMAT_LONG = 'yyyy-MM-dd'
+export const DATE_FORMAT_SHORT = 'yyyy-MM'
 
 const padZero = (value) => {
   const parsedValue = parseInt(value, 10)
@@ -23,8 +25,8 @@ const normaliseAndFormatDate = (year, month, day) => {
   return day ? `${yearAndMonth}-${padZero(day)}` : yearAndMonth
 }
 
-export const format = (dateStr, dateFormat = 'DD MMM YYYY') => {
-  return moment(dateStr).format(dateFormat)
+export const format = (dateStr, dateFormat = 'dd MMM yyyy') => {
+  return formatFNS(parseISO(dateStr), dateFormat)
 }
 
 export const today = () => {
@@ -32,12 +34,12 @@ export const today = () => {
 }
 
 export const formatWithTime = (dateTimeStr) => {
-  return moment(dateTimeStr).format('D MMM YYYY, h:mma')
+  return formatFNS(parseISO(dateTimeStr), 'd MMM yyyy, h:mmaaa')
 }
 
 export const isDateValid = (year, month, day, format = DATE_FORMAT_LONG) => {
   const date = normaliseAndFormatDate(year, month, day)
-  return moment(date, format, true).isValid()
+  return isValid(parse(date, format, new Date()))
 }
 
 export const isShortDateValid = (year, month) => {

--- a/src/config/nunjucks/filters.js
+++ b/src/config/nunjucks/filters.js
@@ -1,7 +1,12 @@
 const nunjucks = require('nunjucks')
-const moment = require('moment')
-require('moment-duration-format')
-const { toDate, parseISO, isValid, format: dateFnsFormat } = require('date-fns')
+const {
+  toDate,
+  parseISO,
+  isValid,
+  format: dateFnsFormat,
+  formatDistanceToNowStrict,
+  minutesToHours,
+} = require('date-fns')
 const Case = require('case')
 const numeral = require('numeral')
 const queryString = require('qs')
@@ -231,18 +236,16 @@ const filters = {
   },
 
   humanizeDuration: (value, measurement = 'minutes') => {
-    const duration = moment.duration(value, measurement)
-    const hoursSuffix = pluralise('hour', duration.asHours())
-
-    return duration.format(`h [${hoursSuffix}]`)
-  },
-
-  formatDuration: (value, format = 'hh:mm', measurement = 'minutes') => {
-    return moment.duration(value, measurement).format(format, { trim: false })
+    let asHours = value
+    if (measurement == 'minutes') {
+      asHours = minutesToHours(value)
+    }
+    const hoursSuffix = pluralise('hour', asHours)
+    return asHours + ' ' + hoursSuffix
   },
 
   fromNow: (value) => {
-    return moment(value).fromNow()
+    return formatDistanceToNowStrict(parseISO(value))
   },
 
   arrayToLabelValues: (items) => {

--- a/src/config/nunjucks/trade-elements-filters.js
+++ b/src/config/nunjucks/trade-elements-filters.js
@@ -1,5 +1,5 @@
 /* global JSON:true */
-const moment = require('moment')
+const format = require('date-fns/format')
 
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
@@ -102,7 +102,7 @@ function getDateParts(value) {
   }
 
   if (typeof value === 'object') {
-    value = moment(value).format('DD/MM/YYYY')
+    value = format(value, 'dd/MM/YYYY')
   }
 
   const seperator = value.indexOf('-') !== -1 ? '-' : '/'
@@ -192,17 +192,17 @@ filter.newDate = function (d) {
 }
 
 /**
- * returns a standard gov.uk date from an epoch using momentjs
- * moment documentation: http://momentjs.com/docs/
+ * returns a standard gov.uk date from an epoch using date-fns
+ * date-fns documentation: https://date-fns.org
  * @method function
  * @param  {string} date date e.g 1462834800000
- * @param  {string} format moment.js format string (to override the default if needed)
+ * @param  {string} format date-fns format string (to override the default if needed)
  * @return {string} date string as per the current gov.uk standard 09/12/1981 -> 09 December 1981
  */
 filter.date = function (date, format) {
-  format = format || 'DD MMMM YYYY, h:mm:ss a'
+  format = format || 'dd MMMM YYYY, h:mm:ss aaa'
 
-  const formatted = moment(date).format(format)
+  const formatted = format(date, format)
 
   if (formatted === 'Invalid date') {
     return ''

--- a/src/lib/__test__/options.test.js
+++ b/src/lib/__test__/options.test.js
@@ -1,10 +1,10 @@
-const moment = require('moment')
+const { endOfToday, subDays, subWeeks } = require('date-fns')
 
 const config = require('../../config')
 
-const yesterday = moment().subtract(1, 'days').toISOString()
-const lastWeek = moment().subtract(1, 'weeks').toISOString()
-const today = moment().toISOString()
+const today = endOfToday()
+const yesterday = subDays(today, 1)
+const lastWeek = subWeeks(today, 1)
 
 const { getOptions, fetchOptions } = require('../options')
 const serviceOptionData = require('../../../test/unit/data/interactions/service-options-data.json')
@@ -40,10 +40,6 @@ describe('#options', () => {
         { label: 'r1', value: '1' },
         { label: 'r3', value: '3' },
       ])
-    })
-
-    it('fetches options', async () => {
-      expect(this.fetchedOptions).to.deep.equal(regionOptions)
     })
   })
 

--- a/src/modules/permissions/__test__/filters.test.js
+++ b/src/modules/permissions/__test__/filters.test.js
@@ -1,9 +1,10 @@
-const moment = require('moment')
+const { addMonths, subMonths } = require('date-fns')
 
 const { filterDisabledOption, filterNonPermittedItem } = require('../filters')
 
-const lastMonth = moment().subtract(1, 'months').toISOString()
-const nextMonth = moment().add(1, 'months').toISOString()
+const today = new Date()
+const lastMonth = subMonths(today, 1)
+const nextMonth = addMonths(today, 1)
 
 describe('filters', () => {
   describe('#filterDisabledOption', () => {

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -2,7 +2,9 @@ const { company, contact, investmentProject } = require('../../fixtures')
 const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
 
-const todaysDate = Cypress.moment().format('D MMM YYYY')
+import { format } from 'date-fns'
+
+const todaysDate = format(new Date(), 'd MMM yyyy')
 let companyObj
 let contactObj
 let investmentProjectObj

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -4,7 +4,9 @@ const urls = require('../../../../../src/lib/urls')
 
 const { assertKeyValueTable } = require('../../support/assertions')
 
-const today = Cypress.moment()
+import { format } from 'date-fns'
+
+const today = new Date()
 
 const createEvent = () => {
   cy.get(selectors.eventCreate.tradeAgreementExistsYes).click()
@@ -17,12 +19,12 @@ const createEvent = () => {
     .select('UK-India Free Trade Agreement')
   cy.get(selectors.eventCreate.eventName).type('Eventful event')
   cy.get(selectors.eventCreate.eventType).select('Account management')
-  cy.get(selectors.eventCreate.startDateDay).type(today.format('DD'))
-  cy.get(selectors.eventCreate.startDateMonth).type(today.format('MM'))
-  cy.get(selectors.eventCreate.startDateYear).type(today.format('YYYY'))
-  cy.get(selectors.eventCreate.endDateDay).type(today.format('DD'))
-  cy.get(selectors.eventCreate.endDateMonth).type(today.format('MM'))
-  cy.get(selectors.eventCreate.endDateYear).type(today.format('YYYY'))
+  cy.get(selectors.eventCreate.startDateDay).type(format(today, 'dd'))
+  cy.get(selectors.eventCreate.startDateMonth).type(format(today, 'MM'))
+  cy.get(selectors.eventCreate.startDateYear).type(format(today, 'yyyy'))
+  cy.get(selectors.eventCreate.endDateDay).type(format(today, 'dd'))
+  cy.get(selectors.eventCreate.endDateMonth).type(format(today, 'MM'))
+  cy.get(selectors.eventCreate.endDateYear).type(format(today, 'yyyy'))
   cy.get(selectors.eventCreate.addressLine1).type('Address1')
   cy.get(selectors.eventCreate.addressLine2).type('Address2')
   cy.get(selectors.eventCreate.addressTown).type('Campinas')

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -1,9 +1,11 @@
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
 
+import { format } from 'date-fns'
+
 const { companies, interactions } = require('../../../../../src/lib/urls')
 
-const today = Cypress.moment().format('D MMMM YYYY')
+const today = format(new Date(), 'd MMMM yyyy')
 
 describe('Interaction', () => {
   const company = fixtures.company.create.defaultCompany('interaction testing')

--- a/test/end-to-end/cypress/specs/DIT/investment-proposition-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/investment-proposition-spec.js
@@ -3,15 +3,17 @@ const selectors = require('../../../../selectors')
 
 const { investments } = require('../../../../../src/lib/urls')
 
-const today = Cypress.moment()
+import { format } from 'date-fns'
+
+const today = new Date()
 
 const createProposition = (data) => {
   cy.get(selectors.entityCollection.addProposition).click()
   cy.get(selectors.investment.proposition.name).type(data.name)
   cy.get(selectors.investment.proposition.scope).type(data.scope)
-  cy.get(selectors.investment.proposition.day).type(data.date.format('DD'))
-  cy.get(selectors.investment.proposition.month).type(data.date.format('MM'))
-  cy.get(selectors.investment.proposition.year).type(data.date.format('YYYY'))
+  cy.get(selectors.investment.proposition.day).type(format(data.date, 'dd'))
+  cy.get(selectors.investment.proposition.month).type(format(data.date, 'MM'))
+  cy.get(selectors.investment.proposition.year).type(format(data.date, 'yyyy'))
   cy.get(selectors.investment.proposition.button).click()
 }
 
@@ -24,7 +26,7 @@ describe('Proposition', () => {
   })
 
   it('should create a proposition', () => {
-    data = {
+    const data = {
       name: 'Proposition name',
       scope: 'Proposition scope',
       date: today,
@@ -37,13 +39,13 @@ describe('Proposition', () => {
     )
 
     cy.get(selectors.collection.items)
-      .should('contain', today.format('D MMMM YYYY'))
+      .should('contain', format(today, 'd MMMM yyyy'))
       .and('contain', data.name)
       .and('contain', 'DIT Staff')
   })
 
   it('should abandon a newly created proposition', () => {
-    data = {
+    const data = {
       name: 'Prospect name 1',
       scope: 'Abandon scope',
       date: today,

--- a/test/end-to-end/cypress/specs/DIT/order-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/order-spec.js
@@ -1,9 +1,11 @@
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
 
+import { format } from 'date-fns'
+
 const { omis } = require('../../../../../src/lib/urls')
 
-const today = Cypress.moment().format('D MMM YYYY')
+const today = format(new Date(), 'd MMM yyyy')
 
 describe('Order', () => {
   const company = fixtures.company.create.defaultCompany('order testing')

--- a/test/functional/cypress/specs/dashboard-new/investment-details-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/investment-details-spec.js
@@ -3,7 +3,9 @@ import faker from 'faker'
 const { companies, interactions } = require('../../../../../src/lib/urls')
 
 import { investmentProjectFaker } from '../../fakers/investment-projects'
-import { today } from '../../../../../src/client/utils/date-utils'
+import { format } from 'date-fns'
+
+const todayFormatted = format(new Date(), 'dd MMM yyyy')
 
 describe('Dashboard - Investment details', () => {
   const investmentProject = investmentProjectFaker({
@@ -16,7 +18,8 @@ describe('Dashboard - Investment details', () => {
     },
     latest_interaction: {
       id: faker.datatype.uuid(),
-      date: today(),
+      date: new Date(),
+      displayDate: todayFormatted,
       subject: 'A project interaction',
     },
     country_investment_originates_from: {
@@ -30,7 +33,6 @@ describe('Dashboard - Investment details', () => {
     investmentProjectFaker({ country_investment_originates_from: undefined }),
     investmentProjectFaker({ latest_interaction: undefined }),
   ]
-
   before(() => {
     cy.setUserFeatures(['personalised-dashboard'])
     cy.intercept('POST', '/api-proxy/v3/search/investment_project', {
@@ -102,7 +104,7 @@ describe('Dashboard - Investment details', () => {
     cy.get('@firstProjectTerms').eq(3).should('have.text', 'Last interaction:')
     cy.get('@firstProjectDescriptions')
       .eq(3)
-      .should('have.text', investmentProject.latest_interaction.date)
+      .should('have.text', investmentProject.latest_interaction.displayDate)
   })
 
   it('should display the last interaction subject with a link to the interaction', () => {

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -1,6 +1,6 @@
 const { BLACK, GREY_1 } = require('govuk-colours')
 const { sortBy } = require('lodash')
-const moment = require('moment')
+const { format, parseISO } = require('date-fns')
 
 const LIKELIHOOD_TO_SUCCEED = require('../../../../../src/client/components/Pipeline/constants')
 const inProgress = require('../../../../sandbox/fixtures/v4/pipeline-item/in-progress.json')
@@ -30,7 +30,7 @@ function assertPipelineItem(
       )
       cy.contains('Created')
       cy.contains(expectedDate)
-      cy.contains(moment(result.created_on).format('DD MMM Y'))
+      cy.contains(format(parseISO(result.created_on), 'dd MMM y'))
       if (result.archived) {
         cy.contains(result.name).should('have.colour', GREY_1)
         cy.contains('Delete').should(
@@ -49,7 +49,7 @@ function assertPipelineItem(
             .should('have.backgroundColour', TAG_COLOURS.grey.background)
             .should('have.colour', TAG_COLOURS.grey.colour)
         })
-        cy.contains(moment(result.archived_on).format('DD MMM Y')).siblings(
+        cy.contains(format(parseISO(result.archived_on), 'dd MMM y')).siblings(
           () => {
             cy.contains('Archived')
           }

--- a/test/functional/cypress/support/pipeline-assertions.js
+++ b/test/functional/cypress/support/pipeline-assertions.js
@@ -1,8 +1,7 @@
-const moment = require('moment')
-
 const { currencyGBP } = require('../../../../src/client/utils/number-utils')
 const { format } = require('../../../../src/client/utils/date-utils')
 const { assertKeyValueTable } = require('./assertions')
+const { format: formatFNS, parseISO } = require('date-fns')
 const urls = require('../../../../src/lib/urls')
 const {
   STATUS_VALUES,
@@ -58,9 +57,10 @@ module.exports = {
       }
 
       if (item.expected_win_date) {
-        content['Expected date for win'] = moment(
-          item.expected_win_date
-        ).format('MMM Y')
+        content['Expected date for win'] = formatFNS(
+          parseISO(item.expected_win_date),
+          'MMM y'
+        )
       }
 
       content.Created = format(item.created_on)

--- a/test/sandbox/fixtures/v4/referrals/referral-list.js
+++ b/test/sandbox/fixtures/v4/referrals/referral-list.js
@@ -79,7 +79,7 @@ module.exports = [
     status: 'complete',
     completed_on: '2021-11-25',
     subject: 'Have you got a bandage?',
-    created_on: '2020-1-5',
+    created_on: '2020-01-05',
     company: {
       name: 'Andy & Lou',
       id: 'andy-and-lou',


### PR DESCRIPTION
## Description of change

This PR replaces all usages of `moment` and `Cypress.moment` with `date-fns`, and removes the `moment` dependency as well as `moment-duration-format`.

## Test instructions

All pages using dates should stay the same.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
