### PR TITLE
Add Area Name (State/Province) to business details for US and Canadian addresses

### DIFF
--- a/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
@@ -19,6 +19,14 @@ const Address = ({ address, isRegistered }) => {
     )
       return <li>{address.area.name}</li>
   }
+  const renderCanadianArea = (address) => {
+    if (
+      address.country.id === '5daf72a6-5d95-e211-a939-e4115bead28a' &&
+      address.area &&
+      address.area.name
+    )
+      return <li>{address.area.name}</li>
+  }
   return (
     <Table.Cell>
       {isRegistered && <Badge>Registered</Badge>}
@@ -29,6 +37,7 @@ const Address = ({ address, isRegistered }) => {
         {address.county && <li>{address.county}</li>}
         {address.postcode && <li>{address.postcode}</li>}
         {renderUsArea(address)}
+        {renderCanadianArea(address)}
         {address.country && <li>{address.country.name}</li>}
       </StyledAddressList>
     </Table.Cell>

--- a/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
@@ -11,21 +11,10 @@ const StyledAddressList = styled('ul')`
 `
 
 const Address = ({ address, isRegistered }) => {
-  const renderUsArea = (address) => {
-    if (
-      address.country.id === '81756b9a-5d95-e211-a939-e4115bead28a' &&
-      address.area &&
-      address.area.name
-    )
+  const renderAdministrativeArea = (address) => {
+    if (address.area && address.area.name) {
       return <li>{address.area.name}</li>
-  }
-  const renderCanadianArea = (address) => {
-    if (
-      address.country.id === '5daf72a6-5d95-e211-a939-e4115bead28a' &&
-      address.area &&
-      address.area.name
-    )
-      return <li>{address.area.name}</li>
+    }
   }
   return (
     <Table.Cell>
@@ -36,8 +25,7 @@ const Address = ({ address, isRegistered }) => {
         {address.town && <li>{address.town}</li>}
         {address.county && <li>{address.county}</li>}
         {address.postcode && <li>{address.postcode}</li>}
-        {renderUsArea(address)}
-        {renderCanadianArea(address)}
+        {renderAdministrativeArea(address)}
         {address.country && <li>{address.country.name}</li>}
       </StyledAddressList>
     </Table.Cell>

--- a/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
@@ -11,6 +11,14 @@ const StyledAddressList = styled('ul')`
 `
 
 const Address = ({ address, isRegistered }) => {
+  const renderUsArea = (address) => {
+    if (
+      address.country.id === '81756b9a-5d95-e211-a939-e4115bead28a' &&
+      address.area &&
+      address.area.name
+    )
+      return <li>{address.area.name}</li>
+  }
   return (
     <Table.Cell>
       {isRegistered && <Badge>Registered</Badge>}
@@ -20,6 +28,7 @@ const Address = ({ address, isRegistered }) => {
         {address.town && <li>{address.town}</li>}
         {address.county && <li>{address.county}</li>}
         {address.postcode && <li>{address.postcode}</li>}
+        {renderUsArea(address)}
         {address.country && <li>{address.country.name}</li>}
       </StyledAddressList>
     </Table.Cell>

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -21,6 +21,8 @@ module.exports = {
     withContacts: require('../../../../test/sandbox/fixtures/v4/company/company-with-contacts.json'),
     oneListTierDita: require('../../../../test/sandbox/fixtures/v4/company/company-one-list-tier-d-ita.json'),
     addInteractionError: require('../../../../test/sandbox/fixtures/v4/company/company-validation-error.json'),
+    usCompany: require('../../../../test/sandbox/fixtures/v4/company/company-us-state.json'),
+    canadianCompany: require('../../../../test/sandbox/fixtures/v4/company/company-canada-province.json'),
   },
   contact: {
     deanCox: require('./contact/dean-cox'),

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -208,6 +208,64 @@ describe('Companies business details', () => {
   )
 
   context(
+    'when viewing business details for a US company with administrative area information',
+    () => {
+      before(() => {
+        cy.visit(urls.companies.businessDetails(fixtures.company.usCompany.id))
+      })
+
+      it('should display the state in the address', () => {
+        assertAddress({
+          address: [
+            '12 First Street',
+            'New York',
+            '765413',
+            'Texas',
+            'United States',
+          ],
+          registeredAddress: [
+            '12 First Street',
+            'New York',
+            '765413',
+            'Texas',
+            'United States',
+          ],
+        })
+      })
+    }
+  )
+
+  context(
+    'when viewing business details for a Canadian company with administrative area information',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.businessDetails(fixtures.company.canadianCompany.id)
+        )
+      })
+
+      it('should display province in the address', () => {
+        assertAddress({
+          address: [
+            '12 Second Street',
+            'Ottawa',
+            '765413',
+            'Ontario',
+            'Canada',
+          ],
+          registeredAddress: [
+            '12 Second Street',
+            'Ottawa',
+            '765413',
+            'Ontario',
+            'Canada',
+          ],
+        })
+      })
+    }
+  )
+
+  context(
     'when viewing business details for a Data Hub company on the One List in the UK',
     () => {
       before(() => {

--- a/test/sandbox/fixtures/v4/company/company-canada-province.json
+++ b/test/sandbox/fixtures/v4/company/company-canada-province.json
@@ -1,0 +1,174 @@
+{
+    "id": "b319d019-444a-4d2f-9e76-c70f84bb22f6",
+    "reference_code": "",
+    "name": "Texports Ltd",
+    "trading_names": [],
+    "uk_based": false,
+    "company_number": null,
+    "vat_number": "",
+    "duns_number": null,
+    "created_on": "2017-10-16T11:00:00Z",
+    "modified_on": "2017-11-16T11:00:00Z",
+    "archived": false,
+    "archived_documents_url_path": "",
+    "archived_on": null,
+    "archived_reason": null,
+    "archived_by": null,
+    "description": "This is a dummy company for testing",
+    "transferred_by": null,
+    "transferred_on": null,
+    "transferred_to": null,
+    "transfer_reason": "",
+    "website": null,
+    "business_type": {
+      "name": "Company",
+      "id": "98d14e94-5d95-e211-a939-e4115bead28a"
+    },
+    "one_list_group_tier": null,
+    "contacts": [
+      {
+        "id": "6791d583-7a52-418f-a0d3-d8d527f20d43",
+        "title": null,
+        "first_name": "Benjamina",
+        "last_name": "Clarksoon",
+        "name": "Benjamina Clarksoon",
+        "job_title": null,
+        "company": {
+          "name": "Mars Exports Ltd",
+          "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd"
+        },
+        "adviser": null,
+        "primary": false,
+        "telephone_countrycode": "1",
+        "telephone_number": "5551212",
+        "email": "benjamina@clarksoon.com",
+        "address_same_as_company": false,
+        "address_1": "7 usa drive",
+        "address_2": null,
+        "address_town": "washington",
+        "address_county": null,
+        "address_country": {
+          "name": "United States",
+          "id": "81756b9a-5d95-e211-a939-e4115bead28a"
+        },
+        "address_postcode": "ne38 0px",
+        "telephone_alternative": null,
+        "email_alternative": null,
+        "notes": "This is a dummy contact for testing",
+        "accepts_dit_email_marketing": false,
+        "archived": false,
+        "archived_documents_url_path": "",
+        "archived_on": null,
+        "archived_reason": null,
+        "archived_by": null,
+        "created_on": "2017-04-28T15:00:00Z",
+        "modified_on": "2016-04-05T00:00:00Z"
+      },
+      {
+        "id": "7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b",
+        "title": null,
+        "first_name": "Mark",
+        "last_name": "Halomi",
+        "name": "Mark Halomi",
+        "job_title": null,
+        "company": {
+          "name": "Mars Exports Ltd",
+          "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd"
+        },
+        "adviser": null,
+        "primary": false,
+        "telephone_countrycode": "1",
+        "telephone_number": "45457676",
+        "email": "mark@halomi.com",
+        "address_same_as_company": false,
+        "address_1": "24 sunny beach place",
+        "address_2": null,
+        "address_town": "california",
+        "address_county": null,
+        "address_country": {
+          "name": "United States",
+          "id": "81756b9a-5d95-e211-a939-e4115bead28a"
+        },
+        "address_postcode": "90001",
+        "telephone_alternative": null,
+        "email_alternative": null,
+        "notes": "This is a dummy contact for testing",
+        "accepts_dit_email_marketing": false,
+        "archived": false,
+        "archived_documents_url_path": "",
+        "archived_on": null,
+        "archived_reason": null,
+        "archived_by": null,
+        "created_on": "2017-04-28T15:00:00Z",
+        "modified_on": "2017-06-05T00:00:00Z"
+      }
+    ],
+    "employee_range": {
+      "name": "500+",
+      "id": "41afd8d0-5d95-e211-a939-e4115bead28a"
+    },
+    "number_of_employees": null,
+    "is_number_of_employees_estimated": null,
+    "export_to_countries": [
+      {
+        "name": "France",
+        "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      {
+        "name": "Germany",
+        "id": "83756b9a-5d95-e211-a939-e4115bead28a"
+      }
+    ],
+    "future_interest_countries": [
+      {
+        "name": "Yemen",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      }
+    ],
+    "headquarter_type": null,
+    "one_list_group_global_account_manager": null,
+    "global_headquarters": null,
+    "sector": {
+      "name": "Retail",
+      "id": "355f977b-8ac3-e211-a646-e4115bead28a"
+    },
+    "turnover_range": {
+      "name": "£33.5M+",
+      "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
+    },
+    "turnover": null,
+    "is_turnover_estimated": null,
+    "uk_region": null,
+    "export_experience_category": null,
+    "address": {
+      "line_1": "12 Second Street",
+      "line_2": "",
+      "town": "Ottawa",
+      "county": "",
+      "postcode": "765413",
+      "country": {
+        "name": "Canada",
+        "id": "5daf72a6-5d95-e211-a939-e4115bead28a"
+      },
+      "area": {
+        "id": "sampleONT",
+        "name": "Ontario"
+      }
+    },
+    "registered_address": {
+      "line_1": "12 Second Street",
+      "line_2": "",
+      "town": "Ottawa",
+      "county": "",
+      "postcode": "765413",
+      "country": {
+        "name": "Canada",
+        "id": "5daf72a6-5d95-e211-a939-e4115bead28a"
+      },
+      "area": {
+        "id": "sampleONT",
+        "name": "Ontario"
+      }
+    }
+  }
+  

--- a/test/sandbox/fixtures/v4/company/company-us-state.json
+++ b/test/sandbox/fixtures/v4/company/company-us-state.json
@@ -1,0 +1,173 @@
+{
+  "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868ab",
+  "reference_code": "",
+  "name": "Texports Ltd",
+  "trading_names": [],
+  "uk_based": false,
+  "company_number": null,
+  "vat_number": "",
+  "duns_number": null,
+  "created_on": "2017-10-16T11:00:00Z",
+  "modified_on": "2017-11-16T11:00:00Z",
+  "archived": false,
+  "archived_documents_url_path": "",
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "description": "This is a dummy company for testing",
+  "transferred_by": null,
+  "transferred_on": null,
+  "transferred_to": null,
+  "transfer_reason": "",
+  "website": null,
+  "business_type": {
+    "name": "Company",
+    "id": "98d14e94-5d95-e211-a939-e4115bead28a"
+  },
+  "one_list_group_tier": null,
+  "contacts": [
+    {
+      "id": "6791d583-7a52-418f-a0d3-d8d527f20d43",
+      "title": null,
+      "first_name": "Benjamina",
+      "last_name": "Clarksoon",
+      "name": "Benjamina Clarksoon",
+      "job_title": null,
+      "company": {
+        "name": "Mars Exports Ltd",
+        "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd"
+      },
+      "adviser": null,
+      "primary": false,
+      "telephone_countrycode": "1",
+      "telephone_number": "5551212",
+      "email": "benjamina@clarksoon.com",
+      "address_same_as_company": false,
+      "address_1": "7 usa drive",
+      "address_2": null,
+      "address_town": "washington",
+      "address_county": null,
+      "address_country": {
+        "name": "United States",
+        "id": "81756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "address_postcode": "ne38 0px",
+      "telephone_alternative": null,
+      "email_alternative": null,
+      "notes": "This is a dummy contact for testing",
+      "accepts_dit_email_marketing": false,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-04-28T15:00:00Z",
+      "modified_on": "2016-04-05T00:00:00Z"
+    },
+    {
+      "id": "7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b",
+      "title": null,
+      "first_name": "Mark",
+      "last_name": "Halomi",
+      "name": "Mark Halomi",
+      "job_title": null,
+      "company": {
+        "name": "Mars Exports Ltd",
+        "id": "b2c34b41-1d5a-4b4b-9249-7c53ff2868dd"
+      },
+      "adviser": null,
+      "primary": false,
+      "telephone_countrycode": "1",
+      "telephone_number": "45457676",
+      "email": "mark@halomi.com",
+      "address_same_as_company": false,
+      "address_1": "24 sunny beach place",
+      "address_2": null,
+      "address_town": "california",
+      "address_county": null,
+      "address_country": {
+        "name": "United States",
+        "id": "81756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "address_postcode": "90001",
+      "telephone_alternative": null,
+      "email_alternative": null,
+      "notes": "This is a dummy contact for testing",
+      "accepts_dit_email_marketing": false,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-04-28T15:00:00Z",
+      "modified_on": "2017-06-05T00:00:00Z"
+    }
+  ],
+  "employee_range": {
+    "name": "500+",
+    "id": "41afd8d0-5d95-e211-a939-e4115bead28a"
+  },
+  "number_of_employees": null,
+  "is_number_of_employees_estimated": null,
+  "export_to_countries": [
+    {
+      "name": "France",
+      "id": "82756b9a-5d95-e211-a939-e4115bead28a"
+    },
+    {
+      "name": "Germany",
+      "id": "83756b9a-5d95-e211-a939-e4115bead28a"
+    }
+  ],
+  "future_interest_countries": [
+    {
+      "name": "Yemen",
+      "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+    }
+  ],
+  "headquarter_type": null,
+  "one_list_group_global_account_manager": null,
+  "global_headquarters": null,
+  "sector": {
+    "name": "Retail",
+    "id": "355f977b-8ac3-e211-a646-e4115bead28a"
+  },
+  "turnover_range": {
+    "name": "£33.5M+",
+    "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
+  },
+  "turnover": null,
+  "is_turnover_estimated": null,
+  "uk_region": null,
+  "export_experience_category": null,
+  "address": {
+    "line_1": "12 First Street",
+    "line_2": "",
+    "town": "New York",
+    "county": "",
+    "postcode": "765413",
+    "country": {
+      "name": "United States",
+      "id": "81756b9a-5d95-e211-a939-e4115bead28a"
+    },
+    "area": {
+      "id": "foobarTX",
+      "name": "Texas"
+    }
+  },
+  "registered_address": {
+    "line_1": "12 First Street",
+    "line_2": "",
+    "town": "New York",
+    "county": "",
+    "postcode": "765413",
+    "country": {
+      "name": "United States",
+      "id": "81756b9a-5d95-e211-a939-e4115bead28a"
+    },
+    "area": {
+      "id": "foobarTX",
+      "name": "Texas"
+    }
+  }
+}

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -22,6 +22,8 @@ var companyList = require('../../../fixtures/v4/user/company-list.json')
 var companyOneListTierDIta = require('../../../fixtures/v4/company/company-one-list-tier-d-ita.json')
 var companyWithValidationError = require('../../../fixtures/v4/company/company-validation-error.json')
 var companyAudit = require('../../../fixtures/v4/company-audit/company-audit.json')
+var companyUsState = require('../../../fixtures/v4/company/company-us-state.json')
+var companyCanadianProvince = require('../../../fixtures/v4/company/company-canada-province.json')
 var exportWins = require('../../../fixtures/v4/company-export-wins/export-wins.json')
 var exportWinsPage1 = require('../../../fixtures/v4/company-export-wins/export-wins-page-1.json')
 var exportWinsPage2 = require('../../../fixtures/v4/company-export-wins/export-wins-page-2.json')
@@ -119,6 +121,8 @@ exports.company = function (req, res) {
     'w2c34b41-1d5a-4b4b-7685-7c53ff2868dg': companyOneListTierDIta,
     '4e6a4edb-55e3-4461-a88d-84d329ee7eb8': companyWithValidationError,
     '6df487c5-7c75-4672-8907-f74b49e6c635': companyWithExternalActivities,
+    'b2c34b41-1d5a-4b4b-9249-7c53ff2868ab': companyUsState,
+    'b319d019-444a-4d2f-9e76-c70f84bb22f6': companyCanadianProvince,
     'not-managed': _.assign({}, company, {
       name: 'Not Managed Company',
       id: 'not-managed',


### PR DESCRIPTION
## Description of change

The address fields on the business details page will now show administrative area information if it is relevant.

## Test instructions

Go to the business details for a US or Canadian company which has an assigned administrative area.
You should be able to see the name of that administrative area in the address details.

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/120457035-0ca75f80-c38e-11eb-8e1c-431fbff62440.png)

### After

![image](https://user-images.githubusercontent.com/20663545/120457003-04e7bb00-c38e-11eb-96c0-528eb9b5872a.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
