### PR TITLE
Add simple form fields to Opportunity Details form

### DIFF
--- a/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
@@ -11,6 +11,7 @@ import {
   Main,
   Step,
   FieldInput,
+  FieldTextarea,
   FormStateful,
 } from '../../../../../client/components'
 
@@ -43,6 +44,19 @@ function OpportunityDetailsForm(state) {
                     name="name"
                     type="text"
                     required="Please enter a name to continue"
+                  />
+                  <FieldTextarea
+                    label="Opportunity description"
+                    name="description"
+                    type="text"
+                    required="Please enter a description to continue"
+                  />
+                  <FieldInput
+                    label="Gross development value (GDV)"
+                    hint="Enter the total amount in GB pounds"
+                    name="opportunityValue"
+                    type="number"
+                    required="Please enter a value to continue"
                   />
                 </Step>
               </Main>

--- a/src/apps/investments/client/opportunities/Details/tasks.js
+++ b/src/apps/investments/client/opportunities/Details/tasks.js
@@ -54,6 +54,8 @@ export function saveOpportunityDetails({ values, opportunityId }) {
   return apiProxyAxios
     .patch(`v4/large-capital-opportunity/${opportunityId}`, {
       name: values.name,
+      description: values.description,
+      opportunity_value: values.opportunityValue,
     })
     .then(({ data }) => {
       return data

--- a/test/functional/cypress/specs/investments/investment-opportunity-details.js
+++ b/test/functional/cypress/specs/investments/investment-opportunity-details.js
@@ -94,12 +94,16 @@ describe('UK Opportunity edit details functionality', () => {
       '#opportunity_details_toggle > div > [data-test="toggle-section-button"]'
     ).click()
     cy.contains('Edit').click()
-    cy.get('input[name="name"]').type('Egg Shop')
+    cy.get('#name').type('Egg Shop')
+    cy.get('#description').type('A very good description')
+    cy.get('#opportunityValue').type('123456')
     cy.contains('Submit').click()
     cy.intercept(
       `PATCH', '/v4/large-capital-opportunity/${fixtures.investment.incompleteOpportunity.id}`,
       (req) => {
         expect(req.body).to.include('Egg Shop')
+        expect(req.body).to.include('A very good description')
+        expect(req.body).to.include('123456')
       }
     )
     cy.get('#opportunity-details').should('contain', 'Edit')


### PR DESCRIPTION
## Description of change

This PR adds two additional fields to the Opportunity Details form. These are just simple fields that take in the opportunity description and the opportunity value, and update them accordingly. 

## Test instructions

Go to investments - UK opportunities - click an opportunity - click Opportunity details toggle - click edit - make some changes- click submit. You should see your new changes in the details summary table that you're redirected to. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
