### PR TITLE
Add hq type filter to companies page

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -1,10 +1,23 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import { COMPANIES__LOADED } from '../../../client/actions'
-import { FilteredCollectionList } from '../../../client/components'
+import urls from '../../../lib/urls'
+import {
+  COMPANIES__LOADED,
+  COMPANIES__SET_COMPANIES_METADATA,
+} from '../../../client/actions'
+import {
+  CollectionFilters,
+  FilteredCollectionList,
+  RoutedCheckboxGroupField,
+} from '../../../client/components'
 
-import { TASK_GET_COMPANIES_LIST, ID, state2props } from './state'
+import {
+  ID,
+  TASK_GET_COMPANIES_LIST,
+  TASK_GET_COMPANIES_METADATA,
+  state2props,
+} from './state'
 
 const CompaniesCollection = ({
   payload,
@@ -23,6 +36,18 @@ const CompaniesCollection = ({
     },
   }
 
+  const collectionListMetadataTask = {
+    name: TASK_GET_COMPANIES_METADATA,
+    id: ID,
+    progressMessage: 'loading metadata',
+    startOnRender: {
+      payload: {
+        headquarterTypeOptions: urls.metadata.headquarterType(),
+      },
+      onSuccessDispatch: COMPANIES__SET_COMPANIES_METADATA,
+    },
+  }
+
   return (
     <FilteredCollectionList
       {...props}
@@ -33,7 +58,18 @@ const CompaniesCollection = ({
       baseDownloadLink="/companies/export"
       entityName="company"
       entityNamePlural="companies"
-    ></FilteredCollectionList>
+    >
+      <CollectionFilters taskProps={collectionListMetadataTask}>
+        <RoutedCheckboxGroupField
+          legend="Type"
+          name="headquarter_type"
+          qsParam="headquarter_type"
+          options={optionMetadata.headquarterTypeOptions}
+          selectedOptions={selectedFilters.selectedHeadquarterTypes}
+          data-test="headquarter-type-filter"
+        />
+      </CollectionFilters>
+    </FilteredCollectionList>
   )
 }
 

--- a/src/apps/companies/client/labels.js
+++ b/src/apps/companies/client/labels.js
@@ -1,0 +1,1 @@
+export const headquarterTypeLabel = 'Type'

--- a/src/apps/companies/client/reducer.js
+++ b/src/apps/companies/client/reducer.js
@@ -1,7 +1,11 @@
-import { COMPANIES__LOADED } from '../../../client/actions'
+import {
+  COMPANIES__LOADED,
+  COMPANIES__SET_COMPANIES_METADATA,
+} from '../../../client/actions'
 
 const initialState = {
   results: [],
+  metadata: {},
   isComplete: false,
 }
 
@@ -12,6 +16,11 @@ export default (state = initialState, { type, result }) => {
         ...state,
         ...result,
         isComplete: true,
+      }
+    case COMPANIES__SET_COMPANIES_METADATA:
+      return {
+        ...state,
+        metadata: result,
       }
     default:
       return state

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -1,10 +1,16 @@
 import qs from 'qs'
 
 export const TASK_GET_COMPANIES_LIST = 'TASK_GET_COMPANIES_LIST'
+export const TASK_GET_COMPANIES_METADATA = 'TASK_GET_COMPANIES_METADATA'
 
 export const ID = 'companiesList'
 
-const searchParamProps = ({ page = 1 }) => ({ page: parseInt(page, 10) })
+import { headquarterTypeLabel } from './labels'
+
+const searchParamProps = ({ page = 1, headquarter_type = false }) => ({
+  page: parseInt(page, 10),
+  headquarter_type,
+})
 
 const collectionListPayload = (paramProps) => {
   return Object.fromEntries(
@@ -13,15 +19,41 @@ const collectionListPayload = (paramProps) => {
 }
 
 /**
+ * Build the options filter to include value, label and category label
+ */
+const buildOptionsFilter = ({ options = [], value, categoryLabel = '' }) => {
+  const optionsFilter = options.filter((option) => value.includes(option.value))
+  if (categoryLabel) {
+    return optionsFilter.map(({ value, label }) => ({
+      value,
+      label,
+      categoryLabel,
+    }))
+  } else {
+    return optionsFilter
+  }
+}
+
+/**
  * Convert both location and redux state to props
  */
 export const state2props = ({ router, ...state }) => {
   const queryProps = qs.parse(router.location.search.slice(1))
   const filteredQueryProps = collectionListPayload(queryProps)
+  const { headquarter_type = [] } = queryProps
+  const { metadata } = state[ID]
+
+  const selectedFilters = {
+    selectedHeadquarterTypes: buildOptionsFilter({
+      options: metadata.headquarterTypeOptions,
+      value: headquarter_type,
+      categoryLabel: headquarterTypeLabel,
+    }),
+  }
   return {
     ...state[ID],
     payload: filteredQueryProps,
-    optionMetadata: { sortOptions: [] },
-    selectedFilters: {},
+    optionMetadata: { sortOptions: [], ...metadata },
+    selectedFilters,
   }
 }

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -15,4 +15,60 @@ function getCompanies({ limit = 10, page, ...rest }) {
     .then(({ data }) => transformResponseToCompanyCollection(data), handleError)
 }
 
-export { getCompanies }
+/**
+ * Get metadata options as a list of values and labels
+ */
+function getMetadataOptions(url) {
+  return axios
+    .get(url)
+    .then(({ data }) =>
+      data.map(({ id, name }) => ({ value: id, label: name }))
+    )
+}
+
+/**
+ * Get the hq type options as a list of values and labels
+ *
+ * Specifying a searchString uses the autocomplete feature to only show
+ * matching results.
+ */
+function getHeadquarterTypeOptions(url) {
+  const hqTypes = {
+    ukhq: 'UK HQ',
+    ghq: 'Global HQ',
+    ehq: 'European HQ',
+  }
+  return getMetadataOptions(url).then((items) =>
+    items.map(({ value, label }) => ({
+      value,
+      label: hqTypes[label] || label,
+    }))
+  )
+}
+
+/**
+ * Get the options for each of the given metadata urls.
+ *
+ * Waits until all urls have been fetched before generating a result.
+ *
+ * @param {object} metadataUrls - a lookup of category names to the api url
+ *
+ * @returns {promise} - the promise containing a list of options for each category
+ */
+function getCompaniesMetadata(metadataUrls) {
+  const optionCategories = Object.keys(metadataUrls)
+  return Promise.all(
+    optionCategories.map((name) =>
+      name == 'headquarterTypeOptions'
+        ? getHeadquarterTypeOptions(metadataUrls[name])
+        : getMetadataOptions(metadataUrls[name])
+    ),
+    handleError
+  ).then((results) =>
+    Object.fromEntries(
+      results.map((options, index) => [optionCategories[index], options])
+    )
+  )
+}
+
+export { getCompanies, getCompaniesMetadata }

--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -9,6 +9,8 @@
  * describing what it does, concatenated by double underscore.
  */
 export const COMPANIES__LOADED = 'COMPANIES__LOADED'
+export const COMPANIES__SET_COMPANIES_METADATA =
+  'COMPANIES__SET_COMPANIES_METADATA'
 
 export const COMPANY_LISTS__LISTS_LOADED = 'COMPANY_LISTS__LISTS_LOADED'
 export const COMPANY_LISTS__SELECT = 'COMPANY_LISTS__SELECT'

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -207,6 +207,10 @@ function FilteredCollectionHeader({
           qsParamName="uk_regions_of_interest"
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedHeadquarterTypes}
+          qsParamName="headquarter_type"
+        />
+        <RoutedFilterChips
           selectedOptions={
             selectedFilters.selectedInvestableCapital?.min
               ? [

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -92,8 +92,14 @@ import * as manageAdviser from '../apps/companies/apps/advisers/client/tasks'
 import { DNB__CHECK_PENDING_REQUEST } from '../apps/companies/apps/business-details/client/state'
 import * as dnbCheck from '../apps/companies/apps/business-details/client/tasks'
 
-import { TASK_GET_COMPANIES_LIST } from '../apps/companies/client/state'
-import { getCompanies } from '../apps/companies/client/tasks'
+import {
+  TASK_GET_COMPANIES_LIST,
+  TASK_GET_COMPANIES_METADATA,
+} from '../apps/companies/client/state'
+import {
+  getCompanies,
+  getCompaniesMetadata,
+} from '../apps/companies/client/tasks'
 
 import { TASK_GET_PROFILES_LIST } from '../apps/investments/client/profiles/state'
 import * as investmentProfilesTasks from '../apps/investments/client/profiles/tasks'
@@ -201,6 +207,7 @@ function App() {
           investmentProfilesTasks.getLargeCapitalProfiles,
         [TASK_GET_PROJECTS_LIST]: getInvestmentProjects.getProjects,
         [TASK_GET_COMPANIES_LIST]: getCompanies,
+        [TASK_GET_COMPANIES_METADATA]: getCompaniesMetadata,
         [TASK_GET_ADVISER_NAME]: getInvestmentProjects.getAdviserNames,
         [TASK_GET_INVESTMENTS_PROJECTS_METADATA]:
           getInvestmentProjects.getMetadata,

--- a/test/functional/cypress/specs/companies/filter-react-spec.js
+++ b/test/functional/cypress/specs/companies/filter-react-spec.js
@@ -1,0 +1,83 @@
+import { companies } from '../../../../../src/lib/urls'
+
+import {
+  assertCheckboxGroupOption,
+  assertCheckboxGroupNoneSelected,
+  assertChipExists,
+} from '../../support/assertions'
+import { clickCheckboxGroupOption } from '../../support/actions'
+
+const GLOBAL_HQ_ID = '43281c5e-92a4-4794-867b-b4d5f801e6f3'
+
+/**
+ * Tests that clicking the first indicator button clears a filter element
+ */
+const testRemoveChip = ({ element, placeholder = null }) => {
+  cy.get('#filter-chips').as('filterChips').find('button').click()
+  cy.get('@filterChips').should('be.empty')
+  placeholder && cy.get(element).should('contain', placeholder)
+}
+
+describe('Investments Collections Filter', () => {
+  context('when the url contains no state', () => {
+    beforeEach(() => {
+      // Visit the new react companies page - note this will need to be changed
+      // to `companies.index()` when ready
+      cy.visit(companies.react.index())
+      cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
+    })
+
+    it('should filter by Headquarter Type', () => {
+      cy.get('@hqTypeFilter')
+        .find('label')
+        .as('hqTypeOptions')
+        .should('have.length', 3)
+      cy.get('@hqTypeOptions').eq(0).should('contain', 'Global HQ')
+      cy.get('@hqTypeOptions').eq(1).should('contain', 'European HQ')
+      cy.get('@hqTypeOptions').eq(2).should('contain', 'UK HQ')
+      clickCheckboxGroupOption({
+        element: '@hqTypeFilter',
+        value: GLOBAL_HQ_ID,
+      })
+      assertCheckboxGroupOption({
+        element: '@hqTypeFilter',
+        value: GLOBAL_HQ_ID,
+        checked: true,
+      })
+      assertChipExists({ label: 'Global HQ', position: 1 })
+
+      testRemoveChip({ element: '@hqTypeFilter' })
+    })
+  })
+
+  context('when the url contains state', () => {
+    beforeEach(() => {
+      // Visit the new react companies page - note this will need to be changed
+      // to `companies.index()` when ready
+      cy.visit(companies.react.index(), {
+        qs: {
+          headquarter_type: GLOBAL_HQ_ID,
+        },
+      })
+      cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
+    })
+
+    it('should set the selected filter values and filter indicators', () => {
+      assertChipExists({ position: 1, label: 'Global HQ' })
+      assertCheckboxGroupOption({
+        element: '@hqTypeFilter',
+        value: GLOBAL_HQ_ID,
+        checked: true,
+      })
+    })
+
+    it('should clear all filters', () => {
+      cy.get('#filter-chips').find('button').as('chips')
+      cy.get('#clear-filters').as('clearFilters')
+      cy.get('@chips').should('have.length', 1)
+      cy.get('@clearFilters').click()
+      cy.get('@chips').should('have.length', 0)
+      assertCheckboxGroupNoneSelected('@hqTypeFilter')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Adds "HQ Type Filter" to the new react companies collection list page. This includes chips to represent the filters and url route updates.

Note that the sort by and other filters still need to be added.

## Test instructions

Go to /companies/react and check:

- url is updated to represent the filters applied in the format `headquarter_type[0]=<uuid>&headquarter_type[1]=<uuid>...`
- chips appear above the filtered results to state each of the headquarter type filters applied
- results are filtered accordingly

_What should I see?_

![Screenshot from 2021-06-02 11-05-21](https://user-images.githubusercontent.com/1234577/120462311-b7ba1800-c392-11eb-83e0-f7af1fc5aec1.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
