### PR TITLE
Ensure the tag doesn't wrap over multiple lines

### DIFF
--- a/src/client/components/Tag/index.jsx
+++ b/src/client/components/Tag/index.jsx
@@ -7,6 +7,7 @@ import TAG_COLOURS from './colours'
 const StyledTag = styled(GovUkTag)`
   background-color: ${(props) => TAG_COLOURS[props.colour].background};
   color: ${(props) => TAG_COLOURS[props.colour].colour};
+  white-space: nowrap;
 `
 
 const Tag = ({ colour, children, ...props }) => (


### PR DESCRIPTION
## Description of change
Prevent the Stage tag from wrapping when the investment project name it too long.

## Test instructions
Go to the new personalised dashboard

## Screenshots
### Before

<img width="757" alt="before" src="https://user-images.githubusercontent.com/964268/120608858-8cdecb00-c449-11eb-8d22-426c3cd3fd2a.png">

### After

<img width="757" alt="after" src="https://user-images.githubusercontent.com/964268/120608915-9e27d780-c449-11eb-8ad9-cc89089eab96.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
