### PR TITLE
Add company button to companies collection list page

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -58,6 +58,7 @@ const CompaniesCollection = ({
       baseDownloadLink="/companies/export"
       entityName="company"
       entityNamePlural="companies"
+      addItemUrl="/companies/create"
     >
       <CollectionFilters taskProps={collectionListMetadataTask}>
         <RoutedCheckboxGroupField

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -28,9 +28,6 @@ function getMetadataOptions(url) {
 
 /**
  * Get the hq type options as a list of values and labels
- *
- * Specifying a searchString uses the autocomplete feature to only show
- * matching results.
  */
 function getHeadquarterTypeOptions(url) {
   const hqTypes = {

--- a/src/apps/companies/client/transformers.js
+++ b/src/apps/companies/client/transformers.js
@@ -71,7 +71,6 @@ const transformCompanyToListItem = ({
     headingUrl: urls.companies.detail(id),
     badges,
     metadata: metadata.filter((item) => item.value),
-    type: 'company',
   }
 }
 

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -70,6 +70,7 @@ function FilteredCollectionHeader({
       href={addItemUrl}
       buttonColour={GREY_3}
       buttonTextColour={BLACK}
+      data-test="add-collection-item-button"
     >
       Add {collectionName}
     </Button>

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -30,6 +30,7 @@ const FilteredCollectionList = ({
   baseDownloadLink = null,
   entityName,
   entityNamePlural,
+  addItemUrl,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
@@ -42,6 +43,7 @@ const FilteredCollectionList = ({
               totalItems={count}
               collectionName={collectionName}
               selectedFilters={selectedFilters}
+              addItemUrl={addItemUrl}
             />
           )}
           {sortOptions && (

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -79,6 +79,13 @@ describe('Company Collections - React', () => {
     })
   })
 
+  it('should have a link to add company', () => {
+    cy.get('[data-test="add-collection-item-button"]')
+      .should('exist')
+      .should('contain', 'Add Company')
+      .should('have.attr', 'href', '/companies/create')
+  })
+
   it('should display a list of companies', () => {
     cy.get('@collectionList').should('have.length', 1)
     cy.get('@collectionItems').should('have.length', companyList.length)


### PR DESCRIPTION
## Description of change

Adds "Add Company" button to the company collection list page.

## Test instructions

A button to add a company should appear above the list of companies on the new company collection list page, here: `/companies/react` Clicking the link should navigate to the create company page (`/companies/create`)

## Screenshots
### Before

![Screenshot from 2021-06-03 14-34-28](https://user-images.githubusercontent.com/1234577/120653730-e14d6f00-c478-11eb-9531-65102c1f1cad.png)

### After

![Screenshot from 2021-06-03 14-34-17](https://user-images.githubusercontent.com/1234577/120653738-e3afc900-c478-11eb-8c2d-d065b14509ab.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
