### PR TITLE
Add company name filter to company collection list page

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -10,6 +10,7 @@ import {
   CollectionFilters,
   FilteredCollectionList,
   RoutedCheckboxGroupField,
+  RoutedInputField,
 } from '../../../client/components'
 
 import {
@@ -68,6 +69,14 @@ const CompaniesCollection = ({
           options={optionMetadata.headquarterTypeOptions}
           selectedOptions={selectedFilters.selectedHeadquarterTypes}
           data-test="headquarter-type-filter"
+        />
+        <RoutedInputField
+          id="CompanyCollection.name"
+          qsParam="name"
+          name="name"
+          label="Company name"
+          placeholder="Search company name"
+          data-test="company-name-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/companies/client/labels.js
+++ b/src/apps/companies/client/labels.js
@@ -1,1 +1,2 @@
 export const headquarterTypeLabel = 'Type'
+export const companyNameLabel = 'Company Name'

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -5,11 +5,16 @@ export const TASK_GET_COMPANIES_METADATA = 'TASK_GET_COMPANIES_METADATA'
 
 export const ID = 'companiesList'
 
-import { headquarterTypeLabel } from './labels'
+import { companyNameLabel, headquarterTypeLabel } from './labels'
 
-const searchParamProps = ({ page = 1, headquarter_type = false }) => ({
+const searchParamProps = ({
+  page = 1,
+  headquarter_type = false,
+  name = false,
+}) => ({
   page: parseInt(page, 10),
   headquarter_type,
+  name,
 })
 
 const collectionListPayload = (paramProps) => {
@@ -40,7 +45,7 @@ const buildOptionsFilter = ({ options = [], value, categoryLabel = '' }) => {
 export const state2props = ({ router, ...state }) => {
   const queryProps = qs.parse(router.location.search.slice(1))
   const filteredQueryProps = collectionListPayload(queryProps)
-  const { headquarter_type = [] } = queryProps
+  const { headquarter_type = [], name } = queryProps
   const { metadata } = state[ID]
 
   const selectedFilters = {
@@ -49,6 +54,15 @@ export const state2props = ({ router, ...state }) => {
       value: headquarter_type,
       categoryLabel: headquarterTypeLabel,
     }),
+    selectedName: name
+      ? [
+          {
+            value: name,
+            label: name,
+            categoryLabel: companyNameLabel,
+          },
+        ]
+      : [],
   }
   return {
     ...state[ID],

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -36,10 +36,12 @@ function getHeadquarterTypeOptions(url) {
     ehq: 'European HQ',
   }
   return getMetadataOptions(url).then((items) =>
-    items.map(({ value, label }) => ({
-      value,
-      label: hqTypes[label] || label,
-    }))
+    items
+      .map(({ value, label }) => ({
+        value,
+        label: hqTypes[label] || label,
+      }))
+      .sort((item1, item2) => item1.label > item2.label)
   )
 }
 

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -124,6 +124,10 @@ function FilteredCollectionHeader({
           qsParamName="investor_company_name"
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedName}
+          qsParamName="name"
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedDealTicketSize}
           qsParamName="deal_ticket_size"
         />

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -49,6 +49,7 @@ export { default as Step } from './Form/elements/Step'
 export { default as SecondaryButton } from './SecondaryButton'
 export { default as ReadMore } from './ReadMore'
 export { default as RoutedAdvisersTypeahead } from './RoutedAdvisersTypeahead'
+export { default as RoutedInputField } from './RoutedInputField'
 export { default as RoutedTypeahead } from './RoutedTypeahead'
 export {
   DashboardToggleSection,

--- a/test/functional/cypress/specs/companies/filter-react-spec.js
+++ b/test/functional/cypress/specs/companies/filter-react-spec.js
@@ -25,6 +25,7 @@ describe('Investments Collections Filter', () => {
       // to `companies.index()` when ready
       cy.visit(companies.react.index())
       cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
+      cy.get('[data-test="company-name-filter"]').as('companyNameFilter')
     })
 
     it('should filter by Headquarter Type', () => {
@@ -47,6 +48,16 @@ describe('Investments Collections Filter', () => {
       assertChipExists({ label: 'Global HQ', position: 1 })
 
       testRemoveChip({ element: '@hqTypeFilter' })
+    })
+
+    it('should filter by Company Name', () => {
+      cy.get('@companyNameFilter').type('Test Company{enter}').blur()
+
+      cy.get('@companyNameFilter').should('have.value', 'Test Company')
+      assertChipExists({ label: 'Test Company', position: 1 })
+
+      testRemoveChip({ element: '@companyNameFilter' })
+      cy.get('@companyNameFilter').should('have.value', '')
     })
   })
 


### PR DESCRIPTION
## Description of change

Adds a filter by company name to the new react company collection list page

See https://uktrade.atlassian.net/browse/RR-26

## Test instructions

Visit `/companies/react` - you should now have a company name filter - applying this filter should filter the results by company name. The url should also include a get parameter for `name`. A chip should also appear above the list of results.

## Screenshots
### Before

![Screenshot from 2021-06-04 12-45-36](https://user-images.githubusercontent.com/1234577/120796543-d820d880-c532-11eb-88b2-f1e7454cf84b.png)

### After

![Screenshot from 2021-06-04 12-46-22](https://user-images.githubusercontent.com/1234577/120796581-e3740400-c532-11eb-917d-06f5b3ef7b6c.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
