### PR TITLE
Add sector filter to companies collection list page

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -11,6 +11,7 @@ import {
   FilteredCollectionList,
   RoutedCheckboxGroupField,
   RoutedInputField,
+  RoutedTypeahead,
 } from '../../../client/components'
 
 import {
@@ -44,6 +45,7 @@ const CompaniesCollection = ({
     startOnRender: {
       payload: {
         headquarterTypeOptions: urls.metadata.headquarterType(),
+        sectorOptions: urls.metadata.sector(),
       },
       onSuccessDispatch: COMPANIES__SET_COMPANIES_METADATA,
     },
@@ -77,6 +79,16 @@ const CompaniesCollection = ({
           label="Company name"
           placeholder="Search company name"
           data-test="company-name-filter"
+        />
+        <RoutedTypeahead
+          isMulti={true}
+          legend="Sector"
+          name="sector"
+          qsParam="sector_descends"
+          placeholder="Search sectors"
+          options={optionMetadata.sectorOptions}
+          selectedOptions={selectedFilters.selectedSectors}
+          data-test="sector-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -10,6 +10,7 @@ import {
   CollectionFilters,
   FilteredCollectionList,
   RoutedCheckboxGroupField,
+  RoutedInputField,
 } from '../../../client/components'
 
 import {
@@ -68,6 +69,14 @@ const CompaniesCollection = ({
           options={optionMetadata.headquarterTypeOptions}
           selectedOptions={selectedFilters.selectedHeadquarterTypes}
           data-test="headquarter-type-filter"
+        />
+        <RoutedInputField
+          id="CompanyCollection.name"
+          qsParam="name"
+          name="name"
+          label="Company name"
+          placeholder="Search company name"
+          data-test="company-name-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/companies/client/labels.js
+++ b/src/apps/companies/client/labels.js
@@ -1,1 +1,2 @@
 export const headquarterTypeLabel = 'Type'
+export const companyNameLabel = 'Company Name'

--- a/src/apps/companies/client/labels.js
+++ b/src/apps/companies/client/labels.js
@@ -1,2 +1,3 @@
 export const headquarterTypeLabel = 'Type'
 export const companyNameLabel = 'Company Name'
+export const sectorLabel = 'Sector'

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -5,16 +5,21 @@ export const TASK_GET_COMPANIES_METADATA = 'TASK_GET_COMPANIES_METADATA'
 
 export const ID = 'companiesList'
 
-import { companyNameLabel, headquarterTypeLabel } from './labels'
+import { companyNameLabel, headquarterTypeLabel, sectorLabel } from './labels'
+
+const parseVariablePropType = (prop) =>
+  prop ? (Array.isArray(prop) ? prop : [prop]) : prop
 
 const searchParamProps = ({
   page = 1,
   headquarter_type = false,
   name = false,
+  sector_descends = false,
 }) => ({
   page: parseInt(page, 10),
   headquarter_type,
   name,
+  sector_descends: parseVariablePropType(sector_descends),
 })
 
 const collectionListPayload = (paramProps) => {
@@ -45,7 +50,7 @@ const buildOptionsFilter = ({ options = [], value, categoryLabel = '' }) => {
 export const state2props = ({ router, ...state }) => {
   const queryProps = qs.parse(router.location.search.slice(1))
   const filteredQueryProps = collectionListPayload(queryProps)
-  const { headquarter_type = [], name } = queryProps
+  const { headquarter_type = [], name, sector_descends = [] } = queryProps
   const { metadata } = state[ID]
 
   const selectedFilters = {
@@ -63,6 +68,11 @@ export const state2props = ({ router, ...state }) => {
           },
         ]
       : [],
+    selectedSectors: buildOptionsFilter({
+      options: metadata.sectorOptions,
+      value: sector_descends,
+      categoryLabel: sectorLabel,
+    }),
   }
   return {
     ...state[ID],

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -5,11 +5,16 @@ export const TASK_GET_COMPANIES_METADATA = 'TASK_GET_COMPANIES_METADATA'
 
 export const ID = 'companiesList'
 
-import { headquarterTypeLabel } from './labels'
+import { companyNameLabel, headquarterTypeLabel } from './labels'
 
-const searchParamProps = ({ page = 1, headquarter_type = false }) => ({
+const searchParamProps = ({
+  page = 1,
+  headquarter_type = false,
+  name = false,
+}) => ({
   page: parseInt(page, 10),
   headquarter_type,
+  name,
 })
 
 const collectionListPayload = (paramProps) => {
@@ -40,7 +45,7 @@ const buildOptionsFilter = ({ options = [], value, categoryLabel = '' }) => {
 export const state2props = ({ router, ...state }) => {
   const queryProps = qs.parse(router.location.search.slice(1))
   const filteredQueryProps = collectionListPayload(queryProps)
-  const { headquarter_type = [] } = queryProps
+  const { headquarter_type = [], name } = queryProps
   const { metadata } = state[ID]
 
   const selectedFilters = {
@@ -49,6 +54,15 @@ export const state2props = ({ router, ...state }) => {
       value: headquarter_type,
       categoryLabel: headquarterTypeLabel,
     }),
+    selectedName: name
+      ? [
+          {
+            value: name,
+            label: name,
+            categoryLabel: companyNameLabel,
+          },
+        ]
+      : [],
   }
   return {
     ...state[ID],

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -41,7 +41,7 @@ function getHeadquarterTypeOptions(url) {
         value,
         label: hqTypes[label] || label,
       }))
-      .sort((item1, item2) => item1.label > item2.label)
+      .sort((item1, item2) => (item1.label > item2.label ? 1 : -1))
   )
 }
 

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -46,6 +46,24 @@ function getHeadquarterTypeOptions(url) {
 }
 
 /**
+ * Get the top-level sector options as a list of values and labels
+ *
+ * Specifying a searchString uses the autocomplete feature to only show
+ * matching results.
+ */
+function getSectorOptions(url, searchString) {
+  return axios
+    .get(url, {
+      params: searchString ? { autocomplete: searchString } : {},
+    })
+    .then(({ data }) =>
+      data
+        .filter(({ level }) => level === 0)
+        .map(({ id, name }) => ({ value: id, label: name }))
+    )
+}
+
+/**
  * Get the options for each of the given metadata urls.
  *
  * Waits until all urls have been fetched before generating a result.
@@ -58,7 +76,9 @@ function getCompaniesMetadata(metadataUrls) {
   const optionCategories = Object.keys(metadataUrls)
   return Promise.all(
     optionCategories.map((name) =>
-      name == 'headquarterTypeOptions'
+      name == 'sectorOptions'
+        ? getSectorOptions(metadataUrls[name])
+        : name == 'headquarterTypeOptions'
         ? getHeadquarterTypeOptions(metadataUrls[name])
         : getMetadataOptions(metadataUrls[name])
     ),

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -36,10 +36,12 @@ function getHeadquarterTypeOptions(url) {
     ehq: 'European HQ',
   }
   return getMetadataOptions(url).then((items) =>
-    items.map(({ value, label }) => ({
-      value,
-      label: hqTypes[label] || label,
-    }))
+    items
+      .map(({ value, label }) => ({
+        value,
+        label: hqTypes[label] || label,
+      }))
+      .sort((item1, item2) => item1.label > item2.label)
   )
 }
 

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -124,10 +124,6 @@ function FilteredCollectionHeader({
           qsParamName="investor_company_name"
         />
         <RoutedFilterChips
-          selectedOptions={selectedFilters.selectedName}
-          qsParamName="name"
-        />
-        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedDealTicketSize}
           qsParamName="deal_ticket_size"
         />

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -124,6 +124,10 @@ function FilteredCollectionHeader({
           qsParamName="investor_company_name"
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedName}
+          qsParamName="name"
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedDealTicketSize}
           qsParamName="deal_ticket_size"
         />

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -51,7 +51,6 @@ export { default as ReadMore } from './ReadMore'
 export { default as RoutedAdvisersTypeahead } from './RoutedAdvisersTypeahead'
 export { default as RoutedInputField } from './RoutedInputField'
 export { default as RoutedTypeahead } from './RoutedTypeahead'
-export { default as RoutedInputField } from './RoutedInputField'
 export {
   DashboardToggleSection,
   NoHighlightToggleSection,

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -49,6 +49,7 @@ export { default as Step } from './Form/elements/Step'
 export { default as SecondaryButton } from './SecondaryButton'
 export { default as ReadMore } from './ReadMore'
 export { default as RoutedAdvisersTypeahead } from './RoutedAdvisersTypeahead'
+export { default as RoutedInputField } from './RoutedInputField'
 export { default as RoutedTypeahead } from './RoutedTypeahead'
 export { default as RoutedInputField } from './RoutedInputField'
 export {

--- a/test/functional/cypress/specs/companies/filter-react-spec.js
+++ b/test/functional/cypress/specs/companies/filter-react-spec.js
@@ -25,6 +25,7 @@ describe('Investments Collections Filter', () => {
       // to `companies.index()` when ready
       cy.visit(companies.react.index())
       cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
+      cy.get('[data-test="company-name-filter"]').as('companyNameFilter')
     })
 
     it('should filter by Headquarter Type', () => {
@@ -47,6 +48,16 @@ describe('Investments Collections Filter', () => {
       assertChipExists({ label: 'Global HQ', position: 1 })
 
       testRemoveChip({ element: '@hqTypeFilter' })
+    })
+
+    it('should filter by Company Name', () => {
+      cy.get('@companyNameFilter').type('Test Company{enter}').blur()
+
+      cy.get('@companyNameFilter').should('have.value', 'Test Company')
+      assertChipExists({ label: 'Test Company', position: 1 })
+
+      testRemoveChip({ element: '@companyNameFilter' })
+      cy.get('@companyNameFilter').should('have.value', '')
     })
   })
 

--- a/test/functional/cypress/specs/companies/filter-react-spec.js
+++ b/test/functional/cypress/specs/companies/filter-react-spec.js
@@ -1,22 +1,16 @@
 import { companies } from '../../../../../src/lib/urls'
 
+import { clickCheckboxGroupOption } from '../../support/actions'
 import {
   assertCheckboxGroupOption,
   assertCheckboxGroupNoneSelected,
   assertChipExists,
 } from '../../support/assertions'
-import { clickCheckboxGroupOption } from '../../support/actions'
+import { testTypeahead, testRemoveChip } from '../../support/tests'
 
 const GLOBAL_HQ_ID = '43281c5e-92a4-4794-867b-b4d5f801e6f3'
-
-/**
- * Tests that clicking the first indicator button clears a filter element
- */
-const testRemoveChip = ({ element, placeholder = null }) => {
-  cy.get('#filter-chips').as('filterChips').find('button').click()
-  cy.get('@filterChips').should('be.empty')
-  placeholder && cy.get(element).should('contain', placeholder)
-}
+const ADVANCED_ENGINEERING_SECTOR_ID = 'af959812-6095-e211-a939-e4115bead28a'
+const TEST_COMPANY_NAME_QUERY = 'Test Company'
 
 describe('Investments Collections Filter', () => {
   context('when the url contains no state', () => {
@@ -26,6 +20,7 @@ describe('Investments Collections Filter', () => {
       cy.visit(companies.react.index())
       cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
       cy.get('[data-test="company-name-filter"]').as('companyNameFilter')
+      cy.get('[data-test="sector-filter"]').as('sectorFilter')
     })
 
     it('should filter by Headquarter Type', () => {
@@ -33,8 +28,8 @@ describe('Investments Collections Filter', () => {
         .find('label')
         .as('hqTypeOptions')
         .should('have.length', 3)
-      cy.get('@hqTypeOptions').eq(0).should('contain', 'Global HQ')
-      cy.get('@hqTypeOptions').eq(1).should('contain', 'European HQ')
+      cy.get('@hqTypeOptions').eq(0).should('contain', 'European HQ')
+      cy.get('@hqTypeOptions').eq(1).should('contain', 'Global HQ')
       cy.get('@hqTypeOptions').eq(2).should('contain', 'UK HQ')
       clickCheckboxGroupOption({
         element: '@hqTypeFilter',
@@ -51,13 +46,30 @@ describe('Investments Collections Filter', () => {
     })
 
     it('should filter by Company Name', () => {
-      cy.get('@companyNameFilter').type('Test Company{enter}').blur()
+      cy.get('@companyNameFilter')
+        .type(`${TEST_COMPANY_NAME_QUERY}{enter}`)
+        .blur()
 
-      cy.get('@companyNameFilter').should('have.value', 'Test Company')
+      cy.get('@companyNameFilter').should('have.value', TEST_COMPANY_NAME_QUERY)
       assertChipExists({ label: 'Test Company', position: 1 })
 
       testRemoveChip({ element: '@companyNameFilter' })
       cy.get('@companyNameFilter').should('have.value', '')
+    })
+
+    it('should filter by sector', () => {
+      testTypeahead({
+        element: '@sectorFilter',
+        legend: 'Sector',
+        placeholder: 'Search sectors',
+        input: 'adv',
+        expectedOption: 'Advanced Engineering',
+      })
+
+      testRemoveChip({
+        element: '@sectorFilter',
+        placeholder: 'Search sectors',
+      })
     })
   })
 
@@ -68,27 +80,38 @@ describe('Investments Collections Filter', () => {
       cy.visit(companies.react.index(), {
         qs: {
           headquarter_type: GLOBAL_HQ_ID,
+          name: TEST_COMPANY_NAME_QUERY,
+          sector_descends: ADVANCED_ENGINEERING_SECTOR_ID,
         },
       })
       cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
+      cy.get('[data-test="company-name-filter"]').as('companyNameFilter')
+      cy.get('[data-test="sector-filter"]').as('sectorFilter')
     })
 
     it('should set the selected filter values and filter indicators', () => {
-      assertChipExists({ position: 1, label: 'Global HQ' })
+      assertChipExists({ position: 1, label: 'Advanced Engineering' })
+      assertChipExists({ position: 2, label: 'Global HQ' })
+      assertChipExists({ position: 3, label: TEST_COMPANY_NAME_QUERY })
       assertCheckboxGroupOption({
         element: '@hqTypeFilter',
         value: GLOBAL_HQ_ID,
         checked: true,
       })
+      cy.get('@companyNameFilter').should('have.value', TEST_COMPANY_NAME_QUERY)
+      cy.get('@sectorFilter').should('contain', 'Advanced Engineering')
     })
 
     it('should clear all filters', () => {
       cy.get('#filter-chips').find('button').as('chips')
       cy.get('#clear-filters').as('clearFilters')
-      cy.get('@chips').should('have.length', 1)
+      cy.get('@chips').should('have.length', 3)
       cy.get('@clearFilters').click()
       cy.get('@chips').should('have.length', 0)
+
       assertCheckboxGroupNoneSelected('@hqTypeFilter')
+      cy.get('@companyNameFilter').should('have.value', '')
+      cy.get('@sectorFilter').should('contain', 'Search sectors')
     })
   })
 })

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -5,14 +5,12 @@ import {
   assertCheckboxGroupNoneSelected,
   assertChipExists,
   assertElementsInOrder,
-  assertTypeaheadHints,
-  assertTypeaheadOptionSelected,
 } from '../../support/assertions'
 import {
   selectFirstAdvisersTypeaheadOption,
   clickCheckboxGroupOption,
-  selectFirstTypeaheadOption,
 } from '../../support/actions'
+import { testTypeahead, testRemoveChip } from '../../support/tests'
 
 const PROSPECT_STAGE_ID = '8a320cc9-ae2e-443e-9d26-2f36452c2ced'
 const MY_ADVISER_ID = '7d19d407-9aec-4d06-b190-d3f404627f21'
@@ -23,30 +21,6 @@ const PROJECT_STATUS_ABANDONED = 'abandoned'
 const FDI_INVESTMENT_TYPE_ID = '3e143372-496c-4d1e-8278-6fdd3da9b48b'
 const MEDIUM_LIKELIHOOD_TO_LAND_ID = '683ca57b-bd69-462c-852f-d2177e35b2eb'
 const INVOLVEMENT_LEVEL_UNSPECIFIED = 'unspecified'
-
-/**
- * Tests that a typeahead functions correctly by inputing a value and selecting
- */
-const testTypeahead = ({
-  element,
-  legend,
-  placeholder,
-  input,
-  expectedOption,
-}) => {
-  assertTypeaheadHints({ element, legend, placeholder })
-  selectFirstTypeaheadOption({ element, input })
-  assertTypeaheadOptionSelected({ element, expectedOption })
-}
-
-/**
- * Tests that clicking the first indicator button clears a filter element
- */
-const testRemoveChip = ({ element, placeholder = null }) => {
-  cy.get('#filter-chips').as('filterChips').find('button').click()
-  cy.get('@filterChips').should('be.empty')
-  placeholder && cy.get(element).should('contain', placeholder)
-}
 
 describe('Investments Collections Filter', () => {
   beforeEach(() => {

--- a/test/functional/cypress/support/tests.js
+++ b/test/functional/cypress/support/tests.js
@@ -1,0 +1,35 @@
+/**
+ * Resuable test functions - these combine an action with an assertion.
+ *
+ * These are distinct from assertions because unlike an assertion, these have
+ * side effects as a result of the action taken.
+ */
+import { selectFirstTypeaheadOption } from './actions'
+import {
+  assertTypeaheadHints,
+  assertTypeaheadOptionSelected,
+} from './assertions'
+
+/**
+ * Tests that a typeahead functions correctly by inputing a value and selecting
+ */
+export const testTypeahead = ({
+  element,
+  legend,
+  placeholder,
+  input,
+  expectedOption,
+}) => {
+  assertTypeaheadHints({ element, legend, placeholder })
+  selectFirstTypeaheadOption({ element, input })
+  assertTypeaheadOptionSelected({ element, expectedOption })
+}
+
+/**
+ * Tests that clicking the first indicator button clears a filter element
+ */
+export const testRemoveChip = ({ element, placeholder = null }) => {
+  cy.get('#filter-chips').as('filterChips').find('button').click()
+  cy.get('@filterChips').should('be.empty')
+  placeholder && cy.get(element).should('contain', placeholder)
+}


### PR DESCRIPTION
Note that this duplicates metadata task for getting sector options - I have a plan to refactor how the metadata is picked up so this will be changed soon.

## Description of change

Adds sector filter to companies collection list page - see https://uktrade.atlassian.net/browse/RR-27

## Test instructions

Go to '/companies/react' - there should now be a Sector typeahead - you should be able to pick multiple options, which then appear in the url and as chips above the filtered results.

## Screenshots

![Screenshot from 2021-06-04 17-31-12](https://user-images.githubusercontent.com/1234577/120834263-b0456b00-c55a-11eb-89c8-75bed387913a.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
