### PR TITLE
Feature/interactions collection list route

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const InteractionsCollection = (props) => (
+  <>
+    <h2>Interactions Collection</h2>
+    <span>Adviser ID: {props.currentAdviserId}</span>
+  </>
+)
+
+export default InteractionsCollection

--- a/src/apps/interactions/router.js
+++ b/src/apps/interactions/router.js
@@ -1,5 +1,7 @@
 const router = require('express').Router()
 
+const urls = require('../../lib/urls')
+
 const {
   DEFAULT_COLLECTION_QUERY,
   APP_PERMISSIONS,
@@ -38,6 +40,17 @@ router.get(
   getRequestBody(QUERY_FIELDS, QUERY_DATE_FIELDS),
   exportCollection('interaction')
 )
+
+router.get(urls.interactions.react.route, (req, res, next) => {
+  try {
+    const { user } = req.session
+    return res.render('interactions/views/interactions', {
+      props: { currentAdviserId: user.id },
+    })
+  } catch (error) {
+    next(error)
+  }
+})
 
 router.use(subAppRouter)
 

--- a/src/apps/interactions/views/interactions.njk
+++ b/src/apps/interactions/views/interactions.njk
@@ -1,0 +1,11 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-column-full">
+      {% component 'react-slot', {
+        id: 'interactions-collection',
+        props: props
+      }
+      %}
+  </div>
+{% endblock %}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -42,6 +42,7 @@ import PersonalisedDashboard from './components/PersonalisedDashboard'
 import CompanyLocalHeader from './components/CompanyLocalHeader'
 import CompaniesCollection from '../apps/companies/client/CompaniesCollection.jsx'
 import ContactsCollection from '../apps/contacts/client/ContactsCollection.jsx'
+import InteractionsCollection from '../apps/interactions/client/InteractionsCollection'
 import InvestmentProjectsCollection from '../apps/investments/client/projects/ProjectsCollection.jsx'
 import Opportunities from '../apps/investments/client/opportunities/Details/Opportunities.jsx'
 import IEBanner from '../apps/dashboard/client/IEBanner'
@@ -392,6 +393,9 @@ function App() {
       </Mount>
       <Mount selector="#contacts-collection">
         {(props) => <ContactsCollection {...props} />}
+      </Mount>
+      <Mount selector="#interactions-collection">
+        {(props) => <InteractionsCollection {...props} />}
       </Mount>
       <Mount selector="#ie-banner">{() => <IEBanner />}</Mount>
     </Provider>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -63,6 +63,7 @@ function createInteractionsSubApp(mountPoint, pathPrefix = '') {
     createType: url(mountPoint, pathPrefix + '/create/:theme/:kind'),
     edit: url(mountPoint, pathPrefix + '/:interactionId/edit'),
     complete: url(mountPoint, pathPrefix + '/:interactionId/complete'),
+    react: url(mountPoint, pathPrefix + '/react'),
   }
 }
 

--- a/test/a11y/cypress/specs/interactions/collection-spec.js
+++ b/test/a11y/cypress/specs/interactions/collection-spec.js
@@ -1,0 +1,12 @@
+import { interactions } from '../../../../../src/lib/urls'
+
+describe('Interactions Collection - React', () => {
+  before(() => {
+    cy.visit(interactions.react())
+    cy.initA11y()
+  })
+
+  it('should not have any a11y violations', () => {
+    cy.runA11y()
+  })
+})

--- a/test/functional/cypress/specs/interaction/collection-react-spec.js
+++ b/test/functional/cypress/specs/interaction/collection-react-spec.js
@@ -1,0 +1,17 @@
+import { assertBreadcrumbs } from '../../support/assertions'
+import { interactions } from '../../../../../src/lib/urls'
+
+describe('Interactions Collections - React', () => {
+  before(() => {
+    // Visit the new react interactions page - note this will need to be changed
+    // to `interactions.index()` when ready
+    cy.visit(interactions.react())
+  })
+
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: '/',
+      Interactions: null,
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Adds a new route for the react version of the interactions collection list page. When this page is complete, we will need to replace the existing interactions page with this.

For the moment this just shows a basic page with very little content (to be populated in later tickets)

## Test instructions

Visit 'interactions/react' and see the react page - this will be quite empty until we add the collection list.

## Screenshots
![Screenshot 2021-06-07 at 10 49 45](https://user-images.githubusercontent.com/10154302/120996457-3d1c3e80-c77e-11eb-8bdd-307cb46a1394.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
