### PR TITLE
Add 3 filters by country and filter by region to companies collection list page

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import urls from '../../../lib/urls'
 import {
   COMPANIES__LOADED,
   COMPANIES__SET_COMPANIES_METADATA,
@@ -43,10 +42,7 @@ const CompaniesCollection = ({
     id: ID,
     progressMessage: 'loading metadata',
     startOnRender: {
-      payload: {
-        headquarterTypeOptions: urls.metadata.headquarterType(),
-        sectorOptions: urls.metadata.sector(),
-      },
+      payload: {},
       onSuccessDispatch: COMPANIES__SET_COMPANIES_METADATA,
     },
   }
@@ -89,6 +85,46 @@ const CompaniesCollection = ({
           options={optionMetadata.sectorOptions}
           selectedOptions={selectedFilters.selectedSectors}
           data-test="sector-filter"
+        />
+        <RoutedTypeahead
+          isMulti={true}
+          legend="Country"
+          name="country"
+          qsParam="country"
+          placeholder="Search country"
+          options={optionMetadata.countryOptions}
+          selectedOptions={selectedFilters.selectedCountries}
+          data-test="country-filter"
+        />
+        <RoutedTypeahead
+          isMulti={true}
+          legend="UK Region"
+          name="uk_region"
+          qsParam="uk_region"
+          placeholder="Search UK regions"
+          options={optionMetadata.ukRegionOptions}
+          selectedOptions={selectedFilters.selectedUkRegions}
+          data-test="uk-region-filter"
+        />
+        <RoutedTypeahead
+          isMulti={true}
+          legend="Currently exporting to"
+          name="export_to_countries"
+          qsParam="export_to_countries"
+          placeholder="Search country"
+          options={optionMetadata.countryOptions}
+          selectedOptions={selectedFilters.selectedExportToCountries}
+          data-test="currently-exporting-to-country-filter"
+        />
+        <RoutedTypeahead
+          isMulti={true}
+          legend="Future countries of interest"
+          name="future_interest_countries"
+          qsParam="future_interest_countries"
+          placeholder="Search country"
+          options={optionMetadata.countryOptions}
+          selectedOptions={selectedFilters.selectedFutureCountriesOfInterest}
+          data-test="future-countries-of-interest-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/companies/client/labels.js
+++ b/src/apps/companies/client/labels.js
@@ -1,3 +1,8 @@
 export const HEADQUARTER_TYPE = 'Type'
 export const COMPANY_NAME = 'Company Name'
 export const SECTOR = 'Sector'
+export const COUNTRY = 'Country'
+export const UK_REGION = 'UK Region'
+export const COMPANY_STATUS = 'Status'
+export const CURRENTLY_EXPORTING_TO = 'Currently exporting to'
+export const FUTURE_COUNTRIES_OF_INTEREST = 'Future country of interest'

--- a/src/apps/companies/client/metadata.js
+++ b/src/apps/companies/client/metadata.js
@@ -1,0 +1,4 @@
+export const COMPANY_STATUS_OPTIONS = [
+  { label: 'Active', value: false },
+  { label: 'Inactive', value: true },
+]

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -39,10 +39,23 @@ const buildOptionsFilter = ({ options = [], value, categoryLabel = '' }) => {
 export const state2props = ({ router, ...state }) => {
   const queryProps = qs.parse(router.location.search.slice(1))
   const filteredQueryProps = getFilteredQueryParams(router)
-  const { headquarter_type = [], name, sector_descends = [] } = queryProps
+  const {
+    country = [],
+    headquarter_type = [],
+    name,
+    sector_descends = [],
+    uk_region = [],
+    export_to_countries = [],
+    future_interest_countries = [],
+  } = queryProps
   const { metadata } = state[ID]
 
   const selectedFilters = {
+    selectedCountries: buildOptionsFilter({
+      options: metadata.countryOptions,
+      value: country,
+      categoryLabel: labels.COUNTRY,
+    }),
     selectedHeadquarterTypes: buildOptionsFilter({
       options: metadata.headquarterTypeOptions,
       value: headquarter_type,
@@ -61,6 +74,21 @@ export const state2props = ({ router, ...state }) => {
       options: metadata.sectorOptions,
       value: sector_descends,
       categoryLabel: labels.SECTOR,
+    }),
+    selectedUkRegions: buildOptionsFilter({
+      options: metadata.ukRegionOptions,
+      value: uk_region,
+      categoryLabel: labels.UK_REGION,
+    }),
+    selectedExportToCountries: buildOptionsFilter({
+      options: metadata.countryOptions,
+      value: export_to_countries,
+      categoryLabel: labels.CURRENTLY_EXPORTING_TO,
+    }),
+    selectedFutureCountriesOfInterest: buildOptionsFilter({
+      options: metadata.countryOptions,
+      value: future_interest_countries,
+      categoryLabel: labels.FUTURE_COUNTRIES_OF_INTEREST,
     }),
   }
   return {

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -36,11 +36,21 @@ function getCompaniesMetadata() {
     getSectorOptions(urls.metadata.sector()),
     getHeadquarterTypeOptions(urls.metadata.headquarterType()),
     getMetadataOptions(urls.metadata.ukRegion()),
+    getMetadataOptions(urls.metadata.country()),
   ])
-    .then(([sectorOptions, headquarterTypeOptions]) => ({
-      sectorOptions,
-      headquarterTypeOptions,
-    }))
+    .then(
+      ([
+        sectorOptions,
+        headquarterTypeOptions,
+        ukRegionOptions,
+        countryOptions,
+      ]) => ({
+        sectorOptions,
+        headquarterTypeOptions,
+        ukRegionOptions,
+        countryOptions,
+      })
+    )
     .catch(handleError)
 }
 

--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -128,7 +128,7 @@ const ProjectsCollection = ({
           qsParam="country_investment_originates_from"
           placeholder="Search countries"
           options={optionMetadata.countryOptions}
-          selectedOptions={selectedFilters.selectedCountries}
+          selectedOptions={selectedFilters.selectedInvestmentOriginCountries}
           data-test="country-filter"
         />
         <RoutedTypeahead

--- a/src/apps/investments/client/projects/state.js
+++ b/src/apps/investments/client/projects/state.js
@@ -130,7 +130,7 @@ export const state2props = ({ router, ...state }) => {
       value: sector_descends,
       categoryLabel: sectorLabel,
     }),
-    selectedCountries: buildOptionsFilter({
+    selectedInvestmentOriginCountries: buildOptionsFilter({
       options: metadata.countryOptions,
       value: country_investment_originates_from,
       categoryLabel: countryLabel,

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -108,8 +108,22 @@ function FilteredCollectionHeader({
           qsParamName="sector_descends"
         />
         <RoutedFilterChips
-          selectedOptions={selectedFilters.selectedCountries}
+          selectedOptions={selectedFilters.selectedInvestmentOriginCountries}
           qsParamName="country_investment_originates_from"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedCountries}
+          qsParamName="country"
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedExportToCountries}
+          qsParamName="export_to_countries"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedFutureCountriesOfInterest}
+          qsParamName="future_interest_countries"
+          showCategoryLabels={true}
         />
         <RoutedFilterChips
           selectedOptions={selectedFilters.selectedCountryOfOrigin}

--- a/test/functional/cypress/specs/companies/filter-react-spec.js
+++ b/test/functional/cypress/specs/companies/filter-react-spec.js
@@ -11,6 +11,8 @@ import { testTypeahead, testRemoveChip } from '../../support/tests'
 const GLOBAL_HQ_ID = '43281c5e-92a4-4794-867b-b4d5f801e6f3'
 const ADVANCED_ENGINEERING_SECTOR_ID = 'af959812-6095-e211-a939-e4115bead28a'
 const TEST_COMPANY_NAME_QUERY = 'Test Company'
+const UK_COUNTRY_ID = '80756b9a-5d95-e211-a939-e4115bead28a'
+const SOUTH_EAST_UK_REGION_ID = '884cd12a-6095-e211-a939-e4115bead28a'
 
 describe('Investments Collections Filter', () => {
   context('when the url contains no state', () => {
@@ -21,6 +23,14 @@ describe('Investments Collections Filter', () => {
       cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
       cy.get('[data-test="company-name-filter"]').as('companyNameFilter')
       cy.get('[data-test="sector-filter"]').as('sectorFilter')
+      cy.get('[data-test="country-filter"]').as('countryFilter')
+      cy.get('[data-test="uk-region-filter"]').as('ukRegionFilter')
+      cy.get('[data-test="currently-exporting-to-country-filter"]').as(
+        'currentlyExportingToFilter'
+      )
+      cy.get('[data-test="future-countries-of-interest-filter"]').as(
+        'futureCountriesOfInterestFilter'
+      )
     })
 
     it('should filter by Headquarter Type', () => {
@@ -71,6 +81,66 @@ describe('Investments Collections Filter', () => {
         placeholder: 'Search sectors',
       })
     })
+
+    it('should filter by country', () => {
+      testTypeahead({
+        element: '@countryFilter',
+        legend: 'Country',
+        placeholder: 'Search country',
+        input: 'hond',
+        expectedOption: 'Honduras',
+      })
+
+      testRemoveChip({
+        element: '@countryFilter',
+        placeholder: 'Search country',
+      })
+    })
+
+    it('should filter by UK region', () => {
+      testTypeahead({
+        element: '@ukRegionFilter',
+        legend: 'UK Region',
+        placeholder: 'Search UK regions',
+        input: 'york',
+        expectedOption: 'Yorkshire and The Humber',
+      })
+
+      testRemoveChip({
+        element: '@ukRegionFilter',
+        placeholder: 'Search UK regions',
+      })
+    })
+
+    it('should filter by currently exporting to country', () => {
+      testTypeahead({
+        element: '@currentlyExportingToFilter',
+        legend: 'Currently exporting to',
+        placeholder: 'Search country',
+        input: 'arg',
+        expectedOption: 'Argentina',
+      })
+
+      testRemoveChip({
+        element: '@currentlyExportingToFilter',
+        placeholder: 'Search country',
+      })
+    })
+
+    it('should filter by future countries of interest', () => {
+      testTypeahead({
+        element: '@futureCountriesOfInterestFilter',
+        legend: 'Future countries of interest',
+        placeholder: 'Search country',
+        input: 'guat',
+        expectedOption: 'Guatemala',
+      })
+
+      testRemoveChip({
+        element: '@futureCountriesOfInterestFilter',
+        placeholder: 'Search country',
+      })
+    })
   })
 
   context('when the url contains state', () => {
@@ -82,17 +152,39 @@ describe('Investments Collections Filter', () => {
           headquarter_type: GLOBAL_HQ_ID,
           name: TEST_COMPANY_NAME_QUERY,
           sector_descends: ADVANCED_ENGINEERING_SECTOR_ID,
+          uk_region: SOUTH_EAST_UK_REGION_ID,
+          country: UK_COUNTRY_ID,
+          export_to_countries: UK_COUNTRY_ID,
+          future_interest_countries: UK_COUNTRY_ID,
         },
       })
       cy.get('[data-test="headquarter-type-filter"]').as('hqTypeFilter')
       cy.get('[data-test="company-name-filter"]').as('companyNameFilter')
       cy.get('[data-test="sector-filter"]').as('sectorFilter')
+      cy.get('[data-test="country-filter"]').as('countryFilter')
+      cy.get('[data-test="uk-region-filter"]').as('ukRegionFilter')
+      cy.get('[data-test="currently-exporting-to-country-filter"]').as(
+        'currentlyExportingToFilter'
+      )
+      cy.get('[data-test="future-countries-of-interest-filter"]').as(
+        'futureCountriesOfInterestFilter'
+      )
     })
 
     it('should set the selected filter values and filter indicators', () => {
       assertChipExists({ position: 1, label: 'Advanced Engineering' })
-      assertChipExists({ position: 2, label: 'Global HQ' })
-      assertChipExists({ position: 3, label: TEST_COMPANY_NAME_QUERY })
+      assertChipExists({ position: 2, label: 'United Kingdom' })
+      assertChipExists({
+        position: 3,
+        label: 'Currently exporting to: United Kingdom',
+      })
+      assertChipExists({
+        position: 4,
+        label: 'Future country of interest: United Kingdom',
+      })
+      assertChipExists({ position: 5, label: 'South East' })
+      assertChipExists({ position: 6, label: 'Global HQ' })
+      assertChipExists({ position: 7, label: TEST_COMPANY_NAME_QUERY })
       assertCheckboxGroupOption({
         element: '@hqTypeFilter',
         value: GLOBAL_HQ_ID,
@@ -100,18 +192,32 @@ describe('Investments Collections Filter', () => {
       })
       cy.get('@companyNameFilter').should('have.value', TEST_COMPANY_NAME_QUERY)
       cy.get('@sectorFilter').should('contain', 'Advanced Engineering')
+      cy.get('@countryFilter').should('contain', 'United Kingdom')
+      cy.get('@ukRegionFilter').should('contain', 'South East')
+      cy.get('@currentlyExportingToFilter').should('contain', 'United Kingdom')
+      cy.get('@futureCountriesOfInterestFilter').should(
+        'contain',
+        'United Kingdom'
+      )
     })
 
     it('should clear all filters', () => {
       cy.get('#filter-chips').find('button').as('chips')
       cy.get('#clear-filters').as('clearFilters')
-      cy.get('@chips').should('have.length', 3)
+      cy.get('@chips').should('have.length', 7)
       cy.get('@clearFilters').click()
       cy.get('@chips').should('have.length', 0)
 
       assertCheckboxGroupNoneSelected('@hqTypeFilter')
       cy.get('@companyNameFilter').should('have.value', '')
       cy.get('@sectorFilter').should('contain', 'Search sectors')
+      cy.get('@countryFilter').should('contain', 'Search country')
+      cy.get('@ukRegionFilter').should('contain', 'Search UK regions')
+      cy.get('@currentlyExportingToFilter').should('contain', 'Search country')
+      cy.get('@futureCountriesOfInterestFilter').should(
+        'contain',
+        'Search country'
+      )
     })
   })
 })


### PR DESCRIPTION
## Description of change

Adds filters to new company collection list page for:

- Country
- UK Region
- Currently Exporting To
- Future Countries of Interest

## Test instructions

Go to /companies/react

Due to the way the chips work I had to rename one of the existing investment projects filters ("country investment originates from"), so you'll need to make sure the investment projects (/investments/projects) page is not broken as a result.

Applying the filters should update the url accordingly and chips should show above the list of results.

## Screenshots

![Screenshot from 2021-06-07 17-39-20](https://user-images.githubusercontent.com/1234577/121057638-5f7e7e00-c7b7-11eb-84c8-588915a0c6ff.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
