### PR TITLE
Ignore minor releases to reduce dependabot spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,4 +35,7 @@ updates:
   - dependency-name: cypress
     versions:
     - 6.1.0
+  # ignore all GitHub linguist patch updates
+  - dependency-name: "github-linguist"
+    update-types: ["version-update:semver-patch"]
   rebase-strategy: disabled


### PR DESCRIPTION
## Description of change

The intent of this PR is to reduce circleci usage.

We only use circleci resources when a PR is created. Dependabot creates PR for every new version released for a given package. In general minor releases are rarely useful to be updated. By disabling PRs being generated by dependabot for minor releases, we should reduce the circleci usage significantly.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
