### PR TITLE
Filter company list by status

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -42,7 +42,6 @@ const CompaniesCollection = ({
     id: ID,
     progressMessage: 'loading metadata',
     startOnRender: {
-      payload: {},
       onSuccessDispatch: COMPANIES__SET_COMPANIES_METADATA,
     },
   }
@@ -105,6 +104,14 @@ const CompaniesCollection = ({
           options={optionMetadata.ukRegionOptions}
           selectedOptions={selectedFilters.selectedUkRegions}
           data-test="uk-region-filter"
+        />
+        <RoutedCheckboxGroupField
+          legend="Status"
+          name="archived"
+          qsParam="archived"
+          options={optionMetadata.companyStatuses}
+          selectedOptions={selectedFilters.selectedCompanyStatuses}
+          data-test="company-status-filter"
         />
         <RoutedTypeahead
           isMulti={true}

--- a/src/apps/companies/client/filters.js
+++ b/src/apps/companies/client/filters.js
@@ -5,46 +5,44 @@ import {
 import * as labels from './labels'
 import { COMPANY_STATUS_OPTIONS } from './metadata'
 
-export const buildSelectedFilters = (queryParams, metadata) => {
-  return {
-    selectedCountries: buildOptionsFilter({
-      options: metadata.countryOptions,
-      value: queryParams.country,
-      categoryLabel: labels.COUNTRY,
-    }),
-    selectedHeadquarterTypes: buildOptionsFilter({
-      options: metadata.headquarterTypeOptions,
-      value: queryParams.headquarter_type,
-      categoryLabel: labels.HEADQUARTER_TYPE,
-    }),
-    selectedName: buildInputFieldFilter({
-      value: queryParams.name,
-      categoryLabel: labels.COMPANY_NAME,
-    }),
-    selectedSectors: buildOptionsFilter({
-      options: metadata.sectorOptions,
-      value: queryParams.sector_descends,
-      categoryLabel: labels.SECTOR,
-    }),
-    selectedUkRegions: buildOptionsFilter({
-      options: metadata.ukRegionOptions,
-      value: queryParams.uk_region,
-      categoryLabel: labels.UK_REGION,
-    }),
-    selectedCompanyStatuses: buildOptionsFilter({
-      options: COMPANY_STATUS_OPTIONS,
-      value: queryParams.archived,
-      categoryLabel: labels.COMPANY_STATUS,
-    }),
-    selectedExportToCountries: buildOptionsFilter({
-      options: metadata.countryOptions,
-      value: queryParams.export_to_countries,
-      categoryLabel: labels.CURRENTLY_EXPORTING_TO,
-    }),
-    selectedFutureCountriesOfInterest: buildOptionsFilter({
-      options: metadata.countryOptions,
-      value: queryParams.future_interest_countries,
-      categoryLabel: labels.FUTURE_COUNTRIES_OF_INTEREST,
-    }),
-  }
-}
+export const buildSelectedFilters = (queryParams, metadata) => ({
+  selectedCountries: buildOptionsFilter({
+    options: metadata.countryOptions,
+    value: queryParams.country,
+    categoryLabel: labels.COUNTRY,
+  }),
+  selectedHeadquarterTypes: buildOptionsFilter({
+    options: metadata.headquarterTypeOptions,
+    value: queryParams.headquarter_type,
+    categoryLabel: labels.HEADQUARTER_TYPE,
+  }),
+  selectedName: buildInputFieldFilter({
+    value: queryParams.name,
+    categoryLabel: labels.COMPANY_NAME,
+  }),
+  selectedSectors: buildOptionsFilter({
+    options: metadata.sectorOptions,
+    value: queryParams.sector_descends,
+    categoryLabel: labels.SECTOR,
+  }),
+  selectedUkRegions: buildOptionsFilter({
+    options: metadata.ukRegionOptions,
+    value: queryParams.uk_region,
+    categoryLabel: labels.UK_REGION,
+  }),
+  selectedCompanyStatuses: buildOptionsFilter({
+    options: COMPANY_STATUS_OPTIONS,
+    value: queryParams.archived,
+    categoryLabel: labels.COMPANY_STATUS,
+  }),
+  selectedExportToCountries: buildOptionsFilter({
+    options: metadata.countryOptions,
+    value: queryParams.export_to_countries,
+    categoryLabel: labels.CURRENTLY_EXPORTING_TO,
+  }),
+  selectedFutureCountriesOfInterest: buildOptionsFilter({
+    options: metadata.countryOptions,
+    value: queryParams.future_interest_countries,
+    categoryLabel: labels.FUTURE_COUNTRIES_OF_INTEREST,
+  }),
+})

--- a/src/apps/companies/client/filters.js
+++ b/src/apps/companies/client/filters.js
@@ -1,0 +1,66 @@
+import { COMPANY_STATUS_OPTIONS } from './metadata'
+import * as labels from './labels'
+
+const buildOptionsFilter = ({
+  options = [],
+  value = [],
+  categoryLabel = '',
+}) => {
+  const optionsFilter = options.filter((option) => value.includes(option.value))
+  if (categoryLabel) {
+    return optionsFilter.map(({ value, label }) => ({
+      value,
+      label,
+      categoryLabel,
+    }))
+  } else {
+    return optionsFilter
+  }
+}
+
+const buildInputFieldFilter = ({ value, categoryLabel }) =>
+  value ? [{ value, label: value, categoryLabel }] : []
+
+export const buildSelectedFilters = (queryParams, metadata) => {
+  return {
+    selectedCountries: buildOptionsFilter({
+      options: metadata.countryOptions,
+      value: queryParams.country,
+      categoryLabel: labels.COUNTRY,
+    }),
+    selectedHeadquarterTypes: buildOptionsFilter({
+      options: metadata.headquarterTypeOptions,
+      value: queryParams.headquarter_type,
+      categoryLabel: labels.HEADQUARTER_TYPE,
+    }),
+    selectedName: buildInputFieldFilter({
+      value: queryParams.name,
+      categoryLabel: labels.COMPANY_NAME,
+    }),
+    selectedSectors: buildOptionsFilter({
+      options: metadata.sectorOptions,
+      value: queryParams.sector_descends,
+      categoryLabel: labels.SECTOR,
+    }),
+    selectedUkRegions: buildOptionsFilter({
+      options: metadata.ukRegionOptions,
+      value: queryParams.uk_region,
+      categoryLabel: labels.UK_REGION,
+    }),
+    selectedCompanyStatuses: buildOptionsFilter({
+      options: COMPANY_STATUS_OPTIONS,
+      value: queryParams.archived,
+      categoryLabel: labels.COMPANY_STATUS,
+    }),
+    selectedExportToCountries: buildOptionsFilter({
+      options: metadata.countryOptions,
+      value: queryParams.export_to_countries,
+      categoryLabel: labels.CURRENTLY_EXPORTING_TO,
+    }),
+    selectedFutureCountriesOfInterest: buildOptionsFilter({
+      options: metadata.countryOptions,
+      value: queryParams.future_interest_countries,
+      categoryLabel: labels.FUTURE_COUNTRIES_OF_INTEREST,
+    }),
+  }
+}

--- a/src/apps/companies/client/filters.js
+++ b/src/apps/companies/client/filters.js
@@ -1,25 +1,9 @@
-import { COMPANY_STATUS_OPTIONS } from './metadata'
+import {
+  buildOptionsFilter,
+  buildInputFieldFilter,
+} from '../../../client/filters'
 import * as labels from './labels'
-
-const buildOptionsFilter = ({
-  options = [],
-  value = [],
-  categoryLabel = '',
-}) => {
-  const optionsFilter = options.filter((option) => value.includes(option.value))
-  if (categoryLabel) {
-    return optionsFilter.map(({ value, label }) => ({
-      value,
-      label,
-      categoryLabel,
-    }))
-  } else {
-    return optionsFilter
-  }
-}
-
-const buildInputFieldFilter = ({ value, categoryLabel }) =>
-  value ? [{ value, label: value, categoryLabel }] : []
+import { COMPANY_STATUS_OPTIONS } from './metadata'
 
 export const buildSelectedFilters = (queryParams, metadata) => {
   return {

--- a/src/apps/companies/client/metadata.js
+++ b/src/apps/companies/client/metadata.js
@@ -1,4 +1,4 @@
 export const COMPANY_STATUS_OPTIONS = [
-  { label: 'Active', value: false },
-  { label: 'Inactive', value: true },
+  { label: 'Active', value: 'false' },
+  { label: 'Inactive', value: 'true' },
 ]

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -6,31 +6,15 @@ export const TASK_GET_COMPANIES_METADATA = 'TASK_GET_COMPANIES_METADATA'
 
 export const ID = 'companiesList'
 
-import * as labels from './labels'
+import { buildSelectedFilters } from './filters'
 import { COMPANY_STATUS_OPTIONS } from './metadata'
+import { transformArchivedToApi } from './transformers'
 
-const getFilteredQueryParams = (router) => {
-  const queryParams = router.location.search.slice(1)
-  const filteredQueryParams = omitBy({ ...qs.parse(queryParams) }, isEmpty)
+const parseQueryString = (queryString) => {
+  const queryStringObject = omitBy({ ...qs.parse(queryString) }, isEmpty)
   return {
-    ...filteredQueryParams,
-    page: parseInt(filteredQueryParams.page || 1, 10),
-  }
-}
-
-/**
- * Build the options filter to include value, label and category label
- */
-const buildOptionsFilter = ({ options = [], value, categoryLabel = '' }) => {
-  const optionsFilter = options.filter((option) => value.includes(option.value))
-  if (categoryLabel) {
-    return optionsFilter.map(({ value, label }) => ({
-      value,
-      label,
-      categoryLabel,
-    }))
-  } else {
-    return optionsFilter
+    ...queryStringObject,
+    page: parseInt(queryStringObject.page || 1, 10),
   }
 }
 
@@ -38,69 +22,20 @@ const buildOptionsFilter = ({ options = [], value, categoryLabel = '' }) => {
  * Convert both location and redux state to props
  */
 export const state2props = ({ router, ...state }) => {
-  const queryProps = qs.parse(router.location.search.slice(1))
-  const filteredQueryProps = getFilteredQueryParams(router)
-  const {
-    country = [],
-    headquarter_type = [],
-    name,
-    sector_descends = [],
-    uk_region = [],
-    archived = [],
-    export_to_countries = [],
-    future_interest_countries = [],
-  } = queryProps
+  const queryString = router.location.search.slice(1)
+  const queryParams = parseQueryString(queryString)
+  const archived = transformArchivedToApi(queryParams.archived)
+
   const { metadata } = state[ID]
 
-  const selectedFilters = {
-    selectedCountries: buildOptionsFilter({
-      options: metadata.countryOptions,
-      value: country,
-      categoryLabel: labels.COUNTRY,
-    }),
-    selectedHeadquarterTypes: buildOptionsFilter({
-      options: metadata.headquarterTypeOptions,
-      value: headquarter_type,
-      categoryLabel: labels.HEADQUARTER_TYPE,
-    }),
-    selectedName: name
-      ? [
-          {
-            value: name,
-            label: name,
-            categoryLabel: labels.COMPANY_NAME,
-          },
-        ]
-      : [],
-    selectedSectors: buildOptionsFilter({
-      options: metadata.sectorOptions,
-      value: sector_descends,
-      categoryLabel: labels.SECTOR,
-    }),
-    selectedUkRegions: buildOptionsFilter({
-      options: metadata.ukRegionOptions,
-      value: uk_region,
-      categoryLabel: labels.UK_REGION,
-    }),
-    selectedCompanyStatuses: buildOptionsFilter({
-      options: COMPANY_STATUS_OPTIONS,
-      value: archived,
-      categoryLabel: labels.COMPANY_STATUS,
-    }),
-    selectedExportToCountries: buildOptionsFilter({
-      options: metadata.countryOptions,
-      value: export_to_countries,
-      categoryLabel: labels.CURRENTLY_EXPORTING_TO,
-    }),
-    selectedFutureCountriesOfInterest: buildOptionsFilter({
-      options: metadata.countryOptions,
-      value: future_interest_countries,
-      categoryLabel: labels.FUTURE_COUNTRIES_OF_INTEREST,
-    }),
-  }
+  const selectedFilters = buildSelectedFilters(queryParams, metadata)
+
   return {
     ...state[ID],
-    payload: filteredQueryProps,
+    payload: {
+      ...queryParams,
+      archived,
+    },
     optionMetadata: {
       sortOptions: [],
       companyStatuses: COMPANY_STATUS_OPTIONS,

--- a/src/apps/companies/client/state.js
+++ b/src/apps/companies/client/state.js
@@ -7,6 +7,7 @@ export const TASK_GET_COMPANIES_METADATA = 'TASK_GET_COMPANIES_METADATA'
 export const ID = 'companiesList'
 
 import * as labels from './labels'
+import { COMPANY_STATUS_OPTIONS } from './metadata'
 
 const getFilteredQueryParams = (router) => {
   const queryParams = router.location.search.slice(1)
@@ -45,6 +46,7 @@ export const state2props = ({ router, ...state }) => {
     name,
     sector_descends = [],
     uk_region = [],
+    archived = [],
     export_to_countries = [],
     future_interest_countries = [],
   } = queryProps
@@ -80,6 +82,11 @@ export const state2props = ({ router, ...state }) => {
       value: uk_region,
       categoryLabel: labels.UK_REGION,
     }),
+    selectedCompanyStatuses: buildOptionsFilter({
+      options: COMPANY_STATUS_OPTIONS,
+      value: archived,
+      categoryLabel: labels.COMPANY_STATUS,
+    }),
     selectedExportToCountries: buildOptionsFilter({
       options: metadata.countryOptions,
       value: export_to_countries,
@@ -94,7 +101,11 @@ export const state2props = ({ router, ...state }) => {
   return {
     ...state[ID],
     payload: filteredQueryProps,
-    optionMetadata: { sortOptions: [], ...metadata },
+    optionMetadata: {
+      sortOptions: [],
+      companyStatuses: COMPANY_STATUS_OPTIONS,
+      ...metadata,
+    },
     selectedFilters,
   }
 }

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -11,14 +11,9 @@ import { transformResponseToCompanyCollection } from './transformers'
 
 const handleError = (error) => Promise.reject(Error(error.response.data.detail))
 
-const getCompanies = ({ limit = 10, page, archived, ...rest }) => {
+const getCompanies = ({ limit = 10, page, ...rest }) => {
   const offset = limit * (parseInt(page, 10) - 1) || 0
   let options = { limit, offset, ...rest }
-
-  // The archived param only needs to be present when a single option is picked
-  if (archived && archived.length === 1) {
-    options.archived = archived[0] === 'true'
-  }
 
   return axios
     .post('/api-proxy/v4/search/company', options)

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -11,15 +11,33 @@ import { transformResponseToCompanyCollection } from './transformers'
 
 const handleError = (error) => Promise.reject(Error(error.response.data.detail))
 
-const getCompanies = ({ limit = 10, page, ...rest }) => {
-  const offset = limit * (parseInt(page, 10) - 1) || 0
-  let options = { limit, offset, ...rest }
-
-  return axios
-    .post('/api-proxy/v4/search/company', options)
+const getCompanies = ({
+  limit = 10,
+  page,
+  headquarter_type,
+  name,
+  sector_descends,
+  country,
+  uk_region,
+  archived,
+  export_to_countries,
+  future_interest_countries,
+}) =>
+  axios
+    .post('/api-proxy/v4/search/company', {
+      limit,
+      offset: limit * (parseInt(page, 10) - 1) || 0,
+      headquarter_type,
+      name,
+      sector_descends,
+      country,
+      uk_region,
+      archived,
+      export_to_countries,
+      future_interest_countries,
+    })
     .then(({ data }) => transformResponseToCompanyCollection(data))
     .catch(handleError)
-}
 
 /**
  * Get the options for each of the metadata urls.
@@ -28,8 +46,8 @@ const getCompanies = ({ limit = 10, page, ...rest }) => {
  *
  * @returns {promise} - the promise containing a list of options for each category
  */
-const getCompaniesMetadata = () => {
-  return Promise.all([
+const getCompaniesMetadata = () =>
+  Promise.all([
     getSectorOptions(urls.metadata.sector()),
     getHeadquarterTypeOptions(urls.metadata.headquarterType()),
     getMetadataOptions(urls.metadata.ukRegion()),
@@ -49,6 +67,5 @@ const getCompaniesMetadata = () => {
       })
     )
     .catch(handleError)
-}
 
 export { getCompanies, getCompaniesMetadata }

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -11,15 +11,17 @@ import { transformResponseToCompanyCollection } from './transformers'
 
 const handleError = (error) => Promise.reject(Error(error.response.data.detail))
 
-function getCompanies({ limit = 10, page, ...rest }) {
-  let offset = limit * (parseInt(page, 10) - 1) || 0
+const getCompanies = ({ limit = 10, page, archived, ...rest }) => {
+  const offset = limit * (parseInt(page, 10) - 1) || 0
+  let options = { limit, offset, ...rest }
+
+  // The archived param only needs to be present when a single option is picked
+  if (archived && archived.length === 1) {
+    options.archived = archived[0] === 'true'
+  }
 
   return axios
-    .post('/api-proxy/v4/search/company', {
-      limit,
-      offset,
-      ...rest,
-    })
+    .post('/api-proxy/v4/search/company', options)
     .then(({ data }) => transformResponseToCompanyCollection(data))
     .catch(handleError)
 }
@@ -31,7 +33,7 @@ function getCompanies({ limit = 10, page, ...rest }) {
  *
  * @returns {promise} - the promise containing a list of options for each category
  */
-function getCompaniesMetadata() {
+const getCompaniesMetadata = () => {
   return Promise.all([
     getSectorOptions(urls.metadata.sector()),
     getHeadquarterTypeOptions(urls.metadata.headquarterType()),

--- a/src/apps/companies/client/transformers.js
+++ b/src/apps/companies/client/transformers.js
@@ -6,6 +6,9 @@ import urls from '../../../lib/urls'
 import { addressToString } from '../../../client/utils/addresses'
 import { format, formatWithTime } from '../../../client/utils/date-utils'
 
+export const transformArchivedToApi = (archived) =>
+  archived?.length === 1 ? archived[0] === 'true' : undefined
+
 const transformCompanyToListItem = ({
   id,
   name,

--- a/src/apps/contacts/client/ContactsCollection.jsx
+++ b/src/apps/contacts/client/ContactsCollection.jsx
@@ -42,7 +42,6 @@ const ContactsCollection = ({
     id: ID,
     progressMessage: 'loading metadata',
     startOnRender: {
-      payload: {},
       onSuccessDispatch: CONTACTS__METADATA_LOADED,
     },
   }

--- a/src/apps/contacts/client/filters.js
+++ b/src/apps/contacts/client/filters.js
@@ -1,4 +1,9 @@
 import {
+  buildOptionsFilter,
+  buildInputFieldFilter,
+} from '../../../client/filters'
+
+import {
   SECTOR,
   COUNTRY,
   UK_REGION,
@@ -8,26 +13,6 @@ import {
 } from './labels'
 
 import { STATUS_OPTIONS } from './metadata'
-
-const buildOptionsFilter = ({ options = [], value, categoryLabel }) =>
-  options
-    .filter((option) => value && value.includes(option.value))
-    .map(({ value, label }) => ({
-      value,
-      label,
-      categoryLabel,
-    }))
-
-const buildInputFieldFilter = ({ value, label, categoryLabel }) =>
-  value
-    ? [
-        {
-          value,
-          label,
-          categoryLabel,
-        },
-      ]
-    : []
 
 export const buildSelectedFilters = (
   {
@@ -52,7 +37,6 @@ export const buildSelectedFilters = (
   }),
   selectedCompanyName: buildInputFieldFilter({
     value: company_name,
-    label: company_name,
     categoryLabel: COMPANY_NAME,
   }),
   selectedCompanySectors: buildOptionsFilter({

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -250,6 +250,10 @@ function FilteredCollectionHeader({
           qsParamName="company_name"
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedCompanyStatuses}
+          qsParamName="archived"
+        />
+        <RoutedFilterChips
           selectedOptions={
             selectedFilters.selectedInvestableCapital?.min
               ? [

--- a/src/client/filters.js
+++ b/src/client/filters.js
@@ -1,0 +1,19 @@
+export const buildOptionsFilter = ({
+  options = [],
+  value = [],
+  categoryLabel = '',
+}) => {
+  const optionsFilter = options.filter((option) => value.includes(option.value))
+  if (categoryLabel) {
+    return optionsFilter.map(({ value, label }) => ({
+      value,
+      label,
+      categoryLabel,
+    }))
+  } else {
+    return optionsFilter
+  }
+}
+
+export const buildInputFieldFilter = ({ value, categoryLabel }) =>
+  value ? [{ value, label: value, categoryLabel }] : []

--- a/test/functional/cypress/specs/companies/filter-react-spec.js
+++ b/test/functional/cypress/specs/companies/filter-react-spec.js
@@ -25,6 +25,7 @@ describe('Investments Collections Filter', () => {
       cy.get('[data-test="sector-filter"]').as('sectorFilter')
       cy.get('[data-test="country-filter"]').as('countryFilter')
       cy.get('[data-test="uk-region-filter"]').as('ukRegionFilter')
+      cy.get('[data-test="company-status-filter"]').as('statusFilter')
       cy.get('[data-test="currently-exporting-to-country-filter"]').as(
         'currentlyExportingToFilter'
       )
@@ -112,6 +113,35 @@ describe('Investments Collections Filter', () => {
       })
     })
 
+    it('should filter by status', () => {
+      cy.get('@statusFilter')
+        .find('label')
+        .as('statusOptions')
+        .should('have.length', 2)
+      cy.get('@statusOptions')
+        .eq(0)
+        .should('contain', 'Active')
+        .find('input')
+        .should('have.value', 'false')
+      cy.get('@statusOptions')
+        .eq(1)
+        .should('contain', 'Inactive')
+        .find('input')
+        .should('have.value', 'true')
+      clickCheckboxGroupOption({
+        element: '@statusFilter',
+        value: 'false',
+      })
+      assertCheckboxGroupOption({
+        element: '@statusFilter',
+        value: 'false',
+        checked: true,
+      })
+      assertChipExists({ label: 'Active', position: 1 })
+
+      testRemoveChip({ element: '@statusFilter' })
+    })
+
     it('should filter by currently exporting to country', () => {
       testTypeahead({
         element: '@currentlyExportingToFilter',
@@ -153,6 +183,7 @@ describe('Investments Collections Filter', () => {
           name: TEST_COMPANY_NAME_QUERY,
           sector_descends: ADVANCED_ENGINEERING_SECTOR_ID,
           uk_region: SOUTH_EAST_UK_REGION_ID,
+          archived: ['true'],
           country: UK_COUNTRY_ID,
           export_to_countries: UK_COUNTRY_ID,
           future_interest_countries: UK_COUNTRY_ID,
@@ -163,6 +194,7 @@ describe('Investments Collections Filter', () => {
       cy.get('[data-test="sector-filter"]').as('sectorFilter')
       cy.get('[data-test="country-filter"]').as('countryFilter')
       cy.get('[data-test="uk-region-filter"]').as('ukRegionFilter')
+      cy.get('[data-test="company-status-filter"]').as('statusFilter')
       cy.get('[data-test="currently-exporting-to-country-filter"]').as(
         'currentlyExportingToFilter'
       )
@@ -185,6 +217,7 @@ describe('Investments Collections Filter', () => {
       assertChipExists({ position: 5, label: 'South East' })
       assertChipExists({ position: 6, label: 'Global HQ' })
       assertChipExists({ position: 7, label: TEST_COMPANY_NAME_QUERY })
+      assertChipExists({ position: 8, label: 'Inactive' })
       assertCheckboxGroupOption({
         element: '@hqTypeFilter',
         value: GLOBAL_HQ_ID,
@@ -194,6 +227,11 @@ describe('Investments Collections Filter', () => {
       cy.get('@sectorFilter').should('contain', 'Advanced Engineering')
       cy.get('@countryFilter').should('contain', 'United Kingdom')
       cy.get('@ukRegionFilter').should('contain', 'South East')
+      assertCheckboxGroupOption({
+        element: '@statusFilter',
+        value: 'true',
+        checked: true,
+      })
       cy.get('@currentlyExportingToFilter').should('contain', 'United Kingdom')
       cy.get('@futureCountriesOfInterestFilter').should(
         'contain',
@@ -204,7 +242,7 @@ describe('Investments Collections Filter', () => {
     it('should clear all filters', () => {
       cy.get('#filter-chips').find('button').as('chips')
       cy.get('#clear-filters').as('clearFilters')
-      cy.get('@chips').should('have.length', 7)
+      cy.get('@chips').should('have.length', 8)
       cy.get('@clearFilters').click()
       cy.get('@chips').should('have.length', 0)
 
@@ -213,6 +251,7 @@ describe('Investments Collections Filter', () => {
       cy.get('@sectorFilter').should('contain', 'Search sectors')
       cy.get('@countryFilter').should('contain', 'Search country')
       cy.get('@ukRegionFilter').should('contain', 'Search UK regions')
+      assertCheckboxGroupNoneSelected('@statusFilter')
       cy.get('@currentlyExportingToFilter').should('contain', 'Search country')
       cy.get('@futureCountriesOfInterestFilter').should(
         'contain',


### PR DESCRIPTION
## Description of change

Filters the new company collection list by status (Active / Inactive). Note that this actually relates to whether or not a company is archived (which is used in the url).

## Test instructions

Go the new react companies collection list page (/companies/react). There should be the option to filter by status (active / inactive). This should update the url accordingly (adding archived[0]=true / archived[1]=false etc). A chip should appear above the list of companies showing Active / Inactive.

## Screenshots

![Screenshot from 2021-06-08 12-39-54](https://user-images.githubusercontent.com/1234577/121178667-ad968e80-c856-11eb-9777-f0d6af7dd2dc.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
