### PR TITLE
Add day to Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+    day: "monday"
     time: "00:00"
     timezone: Europe/London
   open-pull-requests-limit: 10


### PR DESCRIPTION
## Description of change

In order to prevent additional rounds of Dependabot PRs coming through (as has happened today), I've set the config to only open PRs on mondays.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
