### PR TITLE
Fix Faker deprecation warnings in unit tests

### DIFF
--- a/src/client/components/CompanyLists/tasks/dummy/index.js
+++ b/src/client/components/CompanyLists/tasks/dummy/index.js
@@ -1,20 +1,23 @@
 import faker from 'faker'
 
 const randomLists = ({ length, max = 10 }) =>
-  Array(length || faker.random.number(max))
+  Array(length || faker.datatype.number(max))
     .fill(null)
-    .reduce((a) => ({ ...a, [faker.random.uuid()]: faker.random.words(3) }), {})
+    .reduce(
+      (a) => ({ ...a, [faker.datatype.uuid()]: faker.random.words(3) }),
+      {}
+    )
 
 const randomList = ({ length, max = 10, id }) =>
-  Array(length || faker.random.number(max))
+  Array(length || faker.datatype.number(max))
     .fill()
     .map(() => ({
-      id: id || faker.random.uuid(),
+      id: id || faker.datatype.uuid(),
       name: faker.random.words(3),
-      interactionId: faker.random.uuid(),
+      interactionId: faker.datatype.uuid(),
       date: faker.date.past(),
       subject: faker.random.words(3),
-      ditParticipants: Array(faker.random.number(2))
+      ditParticipants: Array(faker.datatype.number(2))
         .fill()
         .map(() => ({
           name: faker.name.findName(),

--- a/src/client/components/ReferralList/tasks/dummy/index.js
+++ b/src/client/components/ReferralList/tasks/dummy/index.js
@@ -6,8 +6,8 @@ const randomAdviser = () => ({
 })
 
 const randomReferral = () => ({
-  companyId: faker.random.uuid(),
-  id: faker.random.uuid(),
+  companyId: faker.datatype.uuid(),
+  id: faker.datatype.uuid(),
   subject: faker.lorem.sentence(),
   companyName: faker.company.companyName(),
   date: faker.date.past(1),

--- a/src/lib/__test__/get-export-countries.test.js
+++ b/src/lib/__test__/get-export-countries.test.js
@@ -4,7 +4,7 @@ const { EXPORT_INTEREST_STATUS } = require('../../apps/constants')
 const getExportCountries = require('../get-export-countries')
 
 function generateCountries(length) {
-  return Array.from({ length }).map(faker.random.uuid)
+  return Array.from({ length }).map(faker.datatype.uuid)
 }
 
 describe('getExportCountries', () => {

--- a/src/lib/__test__/group-export-countries.test.js
+++ b/src/lib/__test__/group-export-countries.test.js
@@ -1,4 +1,4 @@
-const { uuid } = require('faker').random
+const { uuid } = require('faker').datatype
 const { EXPORT_INTEREST_STATUS } = require('../../apps/constants')
 
 const {

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -36,8 +36,8 @@ describe('urls', () => {
     let countryId
 
     beforeEach(() => {
-      companyId = faker.random.uuid()
-      countryId = faker.random.uuid()
+      companyId = faker.datatype.uuid()
+      countryId = faker.datatype.uuid()
     })
     it('should return the correct values', () => {
       expect(urls.companies.index.mountPoint).to.equal('/companies')
@@ -159,7 +159,7 @@ describe('urls', () => {
         urls.companies.investments.largeCapitalProfile(companyId)
       ).to.equal(`/companies/${companyId}/investments/large-capital-profile`)
 
-      const globalHqId = faker.random.uuid()
+      const globalHqId = faker.datatype.uuid()
       expect(
         urls.companies.hierarchies.ghq.add(companyId, globalHqId)
       ).to.equal(`/companies/${companyId}/hierarchies/ghq/${globalHqId}/add`)
@@ -179,7 +179,7 @@ describe('urls', () => {
         '/:companyId/hierarchies/ghq/remove'
       )
 
-      const interactionId = faker.random.uuid()
+      const interactionId = faker.datatype.uuid()
       expect(urls.companies.interactions.create.route).to.equal(
         '/:companyId/interactions/create'
       )
@@ -195,7 +195,7 @@ describe('urls', () => {
       )
       expect(urls.companies.orders.route).to.equal('/:companyId/orders')
 
-      const referralId = faker.random.uuid()
+      const referralId = faker.datatype.uuid()
       expect(urls.companies.referrals.send(companyId)).to.equal(
         `/companies/${companyId}/referrals/send`
       )
@@ -238,7 +238,7 @@ describe('urls', () => {
       expect(urls.contacts.index.route).to.equal('/')
       expect(urls.contacts.index()).to.equal('/contacts')
 
-      const contactId = faker.random.uuid()
+      const contactId = faker.datatype.uuid()
       expect(urls.contacts.interactions.create(contactId)).to.equal(
         `/contacts/${contactId}/interactions/create`
       )
@@ -308,7 +308,7 @@ describe('urls', () => {
   })
 
   describe('pipeline', () => {
-    const pipelineItemId = faker.random.uuid()
+    const pipelineItemId = faker.datatype.uuid()
 
     it('should return the correct value', () => {
       expect(urls.pipeline.index()).to.equal('/my-pipeline')

--- a/test/unit/helpers/generate-export-countries.js
+++ b/test/unit/helpers/generate-export-countries.js
@@ -4,7 +4,7 @@ const { EXPORT_INTEREST_STATUS } = require('../../../src/apps/constants')
 
 function generateCountries(length) {
   return Array.from({ length }).map(() => ({
-    id: faker.random.uuid(),
+    id: faker.datatype.uuid(),
     name: faker.address.country(),
   }))
 }


### PR DESCRIPTION
## Description of change

This PR fixes the many deprecation warnings that appear when running the unit tests locally.
<img width="978" alt="Screenshot 2021-06-09 at 11 27 08" src="https://user-images.githubusercontent.com/36161814/121339653-9b7c2500-c916-11eb-906a-0af39215ce23.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
