### PR TITLE
Add default query params to the FilteredCollectionList

### DIFF
--- a/src/apps/contacts/client/ContactsCollection.jsx
+++ b/src/apps/contacts/client/ContactsCollection.jsx
@@ -55,6 +55,10 @@ const ContactsCollection = ({
       selectedFilters={selectedFilters}
       baseDownloadLink="/contacts/export"
       entityName="contact"
+      defaultQueryParams={{
+        archived: ['false'],
+        page: 1,
+      }}
     >
       <CollectionFilters taskProps={collectionListMetadataTask}>
         <RoutedInputField

--- a/src/client/components/FilterReset/index.jsx
+++ b/src/client/components/FilterReset/index.jsx
@@ -17,7 +17,7 @@ const FilterReset = ({ children, ...props }) => (
         <StyledButtonLink
           {...props}
           onClick={() => {
-            history.push(pathname)
+            history.push(`${pathname}?page=1`)
           }}
         >
           {children}

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -86,11 +86,13 @@ function FilteredCollectionHeader({
             </StyledResultCount>{' '}
             {counterSuffix}
           </StyledHeaderText>
-          <FilterReset id="clear-filters">Remove all filters</FilterReset>
+          <FilterReset data-test="clear-filters" id="clear-filters">
+            Remove all filters
+          </FilterReset>
         </StyledDiv>
       </CollectionHeaderRow>
 
-      <CollectionHeaderRow id="filter-chips">
+      <CollectionHeaderRow data-test="filter-chips" id="filter-chips">
         {/*
         FIXME: This is supposed to be a generic component,
         thus the chips should not be hardcoded here

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -3,8 +3,10 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-
+import { Route } from 'react-router-dom'
 import { GridRow, GridCol } from 'govuk-react'
+import { isEmpty } from 'lodash'
+import qs from 'qs'
 
 import Task from '../Task'
 
@@ -31,52 +33,70 @@ const FilteredCollectionList = ({
   entityName,
   entityNamePlural,
   addItemUrl,
+  defaultQueryParams,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
-    <GridRow data-test="collection-list">
-      {children}
-      <GridCol setWidth="two-thirds">
-        <article>
-          {isComplete && (
-            <FilteredCollectionHeader
-              totalItems={count}
-              collectionName={collectionName}
-              selectedFilters={selectedFilters}
-              addItemUrl={addItemUrl}
-            />
-          )}
-          {sortOptions && (
-            <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
-          )}
-          {baseDownloadLink && (
-            <RoutedDownloadDataHeader
-              count={count}
-              maxItems={maxItemsToDownload}
-              data-test="download-data-header"
-              baseDownloadLink={baseDownloadLink}
-              entityName={entityName}
-              entityNamePlural={entityNamePlural}
-            />
-          )}
-          <Task.Status {...taskProps}>
-            {() =>
-              isComplete && (
-                <>
-                  {results.map((item) => (
-                    <CollectionItem {...item} key={item.id} />
-                  ))}
-                  <RoutedPagination
-                    qsParamName="page"
+    <Route>
+      {({ history, location }) => {
+        const qsParams = qs.parse(location.search.slice(1))
+        if (defaultQueryParams && isEmpty(qsParams)) {
+          history.push({
+            search: qs.stringify({
+              ...defaultQueryParams,
+            }),
+          })
+        }
+        return (
+          <GridRow data-test="collection-list">
+            {children}
+            <GridCol setWidth="two-thirds">
+              <article>
+                {isComplete && (
+                  <FilteredCollectionHeader
+                    totalItems={count}
+                    collectionName={collectionName}
+                    selectedFilters={selectedFilters}
+                    addItemUrl={addItemUrl}
+                  />
+                )}
+                {sortOptions && (
+                  <CollectionSort
+                    sortOptions={sortOptions}
                     totalPages={totalPages}
                   />
-                </>
-              )
-            }
-          </Task.Status>
-        </article>
-      </GridCol>
-    </GridRow>
+                )}
+                {baseDownloadLink && (
+                  <RoutedDownloadDataHeader
+                    count={count}
+                    maxItems={maxItemsToDownload}
+                    data-test="download-data-header"
+                    baseDownloadLink={baseDownloadLink}
+                    entityName={entityName}
+                    entityNamePlural={entityNamePlural}
+                  />
+                )}
+                <Task.Status {...taskProps}>
+                  {() =>
+                    isComplete && (
+                      <>
+                        {results.map((item) => (
+                          <CollectionItem {...item} key={item.id} />
+                        ))}
+                        <RoutedPagination
+                          qsParamName="page"
+                          totalPages={totalPages}
+                        />
+                      </>
+                    )
+                  }
+                </Task.Status>
+              </article>
+            </GridCol>
+          </GridRow>
+        )
+      }}
+    </Route>
   )
 }
 
@@ -108,6 +128,7 @@ FilteredCollectionList.propTypes = {
     label: PropTypes.string,
     value: PropTypes.string,
   }),
+  defaultQueryParams: PropTypes.object,
 }
 
 export default FilteredCollectionList


### PR DESCRIPTION
## Description of change

Added an optional query param object to the `FilteredCollectionList` which also updates the browser's query params.

This change gives us the ability to apply default filters to the collection list, for example, both contacts and companies have a default active filter applied when the page initially loads, filtering out any contact or company that's been archived. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
