### PR TITLE
Add the Interactions kind filter to the new React interactions collection list

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -2,8 +2,13 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import { INTERACTIONS__LOADED } from '../../../client/actions'
+import { INTERACTION, SERVICE_DELIVERY } from './constants'
 
-import { FilteredCollectionList } from '../../../client/components'
+import {
+  FilteredCollectionList,
+  RoutedCheckboxGroupField,
+  CollectionFilters,
+} from '../../../client/components'
 
 import { ID, state2props, TASK_GET_INTERACTIONS_LIST } from './state'
 
@@ -22,17 +27,40 @@ const InteractionCollection = ({
       onSuccessDispatch: INTERACTIONS__LOADED,
     },
   }
-
   return (
     <FilteredCollectionList
       {...props}
-      collectionName="Interaction"
+      collectionName={INTERACTION.label}
       sortOptions={optionMetadata.sortOptions}
       taskProps={collectionListTask}
       selectedFilters={selectedFilters}
       baseDownloadLink="/interactions/export"
       entityName="interactions"
-    ></FilteredCollectionList>
+      defaultQueryParams={{
+        sortby: 'date:desc',
+        page: 1,
+      }}
+    >
+      <CollectionFilters>
+        <RoutedCheckboxGroupField
+          legend="Kind"
+          name="kind"
+          qsParam="kind"
+          options={[
+            {
+              label: INTERACTION.label,
+              value: INTERACTION.value,
+            },
+            {
+              label: SERVICE_DELIVERY.label,
+              value: SERVICE_DELIVERY.value,
+            },
+          ]}
+          selectedOptions={selectedFilters.selectedKind}
+          data-test="status-filter"
+        />
+      </CollectionFilters>
+    </FilteredCollectionList>
   )
 }
 

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -30,7 +30,7 @@ const InteractionCollection = ({
   return (
     <FilteredCollectionList
       {...props}
-      collectionName={KIND_OPTIONS.interaction.label}
+      collectionName="interaction"
       sortOptions={optionMetadata.sortOptions}
       taskProps={collectionListTask}
       selectedFilters={selectedFilters}
@@ -46,16 +46,7 @@ const InteractionCollection = ({
           legend={LABELS.kind}
           name="kind"
           qsParam="kind"
-          options={[
-            {
-              label: KIND_OPTIONS.interaction.label,
-              value: KIND_OPTIONS.interaction.value,
-            },
-            {
-              label: KIND_OPTIONS.serviceDelivery.label,
-              value: KIND_OPTIONS.serviceDelivery.value,
-            },
-          ]}
+          options={KIND_OPTIONS}
           selectedOptions={selectedFilters.selectedKind}
           data-test="status-filter"
         />

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import { INTERACTIONS__LOADED } from '../../../client/actions'
-import { INTERACTION, SERVICE_DELIVERY } from './constants'
+import { INTERACTION, SERVICE_DELIVERY, KIND } from './constants'
 
 import {
   FilteredCollectionList,
@@ -43,7 +43,7 @@ const InteractionCollection = ({
     >
       <CollectionFilters>
         <RoutedCheckboxGroupField
-          legend="Kind"
+          legend={KIND}
           name="kind"
           qsParam="kind"
           options={[

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 
 import { INTERACTIONS__LOADED } from '../../../client/actions'
-import { INTERACTION, SERVICE_DELIVERY, KIND } from './constants'
+import { LABELS, KIND_OPTIONS } from './constants'
 
 import {
   FilteredCollectionList,
@@ -30,7 +30,7 @@ const InteractionCollection = ({
   return (
     <FilteredCollectionList
       {...props}
-      collectionName={INTERACTION.label}
+      collectionName={KIND_OPTIONS.interaction.label}
       sortOptions={optionMetadata.sortOptions}
       taskProps={collectionListTask}
       selectedFilters={selectedFilters}
@@ -43,17 +43,17 @@ const InteractionCollection = ({
     >
       <CollectionFilters>
         <RoutedCheckboxGroupField
-          legend={KIND}
+          legend={LABELS.KIND}
           name="kind"
           qsParam="kind"
           options={[
             {
-              label: INTERACTION.label,
-              value: INTERACTION.value,
+              label: KIND_OPTIONS.interaction.label,
+              value: KIND_OPTIONS.interaction.value,
             },
             {
-              label: SERVICE_DELIVERY.label,
-              value: SERVICE_DELIVERY.value,
+              label: KIND_OPTIONS.serviceDelivery.label,
+              value: KIND_OPTIONS.serviceDelivery.value,
             },
           ]}
           selectedOptions={selectedFilters.selectedKind}

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -43,7 +43,7 @@ const InteractionCollection = ({
     >
       <CollectionFilters>
         <RoutedCheckboxGroupField
-          legend={LABELS.KIND}
+          legend={LABELS.kind}
           name="kind"
           qsParam="kind"
           options={[

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -1,0 +1,10 @@
+export const KIND = 'Kind'
+
+export const INTERACTION = {
+  label: 'Interaction',
+  value: 'interaction',
+}
+export const SERVICE_DELIVERY = {
+  label: 'Service delivery',
+  value: 'service_delivery',
+}

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -1,10 +1,14 @@
-export const KIND = 'Kind'
-
-export const INTERACTION = {
-  label: 'Interaction',
-  value: 'interaction',
+export const LABELS = {
+  kind: 'Kind',
 }
-export const SERVICE_DELIVERY = {
-  label: 'Service delivery',
-  value: 'service_delivery',
+
+export const KIND_OPTIONS = {
+  interaction: {
+    label: 'Interaction',
+    value: 'interaction',
+  },
+  serviceDelivery: {
+    label: 'Service delivery',
+    value: 'service_delivery',
+  },
 }

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -1,14 +1,10 @@
 export const LABELS = {
   kind: 'Kind',
+  interaction: 'Interaction',
+  serviceDelivery: 'Service delivery',
 }
 
-export const KIND_OPTIONS = {
-  interaction: {
-    label: 'Interaction',
-    value: 'interaction',
-  },
-  serviceDelivery: {
-    label: 'Service delivery',
-    value: 'service_delivery',
-  },
-}
+export const KIND_OPTIONS = [
+  { label: LABELS.interaction, value: 'interaction' },
+  { label: LABELS.serviceDelivery, value: 'service_delivery' },
+]

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -1,0 +1,21 @@
+import { INTERACTION, SERVICE_DELIVERY, KIND } from './constants'
+
+const buildOptionsFilter = ({ options = [], value, categoryLabel }) =>
+  options
+    .filter((option) => value && value.includes(option.value))
+    .map(({ value, label }) => ({
+      value,
+      label,
+      categoryLabel,
+    }))
+
+export const buildSelectedFilters = ({ kind }, {}) => ({
+  selectedKind: buildOptionsFilter({
+    options: [
+      { label: INTERACTION.label, value: INTERACTION.value },
+      { label: SERVICE_DELIVERY.label, value: SERVICE_DELIVERY.value },
+    ],
+    value: kind,
+    categoryLabel: KIND,
+  }),
+})

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -1,4 +1,4 @@
-import { INTERACTION, SERVICE_DELIVERY, KIND } from './constants'
+import { KIND_OPTIONS, LABELS } from './constants'
 
 const buildOptionsFilter = ({ options = [], value, categoryLabel }) =>
   options
@@ -12,10 +12,16 @@ const buildOptionsFilter = ({ options = [], value, categoryLabel }) =>
 export const buildSelectedFilters = ({ kind }, {}) => ({
   selectedKind: buildOptionsFilter({
     options: [
-      { label: INTERACTION.label, value: INTERACTION.value },
-      { label: SERVICE_DELIVERY.label, value: SERVICE_DELIVERY.value },
+      {
+        label: KIND_OPTIONS.interaction.label,
+        value: KIND_OPTIONS.interaction.value,
+      },
+      {
+        label: KIND_OPTIONS.serviceDelivery.label,
+        value: KIND_OPTIONS.serviceDelivery.value,
+      },
     ],
     value: kind,
-    categoryLabel: KIND,
+    categoryLabel: LABELS.kind,
   }),
 })

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -1,26 +1,10 @@
 import { KIND_OPTIONS, LABELS } from './constants'
 
-const buildOptionsFilter = ({ options = [], value, categoryLabel }) =>
-  options
-    .filter((option) => value && value.includes(option.value))
-    .map(({ value, label }) => ({
-      value,
-      label,
-      categoryLabel,
-    }))
+import { buildOptionsFilter } from '../../../client/filters'
 
 export const buildSelectedFilters = ({ kind }, {}) => ({
   selectedKind: buildOptionsFilter({
-    options: [
-      {
-        label: KIND_OPTIONS.interaction.label,
-        value: KIND_OPTIONS.interaction.value,
-      },
-      {
-        label: KIND_OPTIONS.serviceDelivery.label,
-        value: KIND_OPTIONS.serviceDelivery.value,
-      },
-    ],
+    options: KIND_OPTIONS,
     value: kind,
     categoryLabel: LABELS.kind,
   }),

--- a/src/apps/interactions/client/state.js
+++ b/src/apps/interactions/client/state.js
@@ -8,23 +8,23 @@ export const ID = 'interactionsList'
 import { buildSelectedFilters } from './filters'
 
 const parseQueryString = (queryString) => {
-  const queryStringObject = omitBy({ ...qs.parse(queryString) }, isEmpty)
+  const queryProps = omitBy({ ...qs.parse(queryString) }, isEmpty)
   return {
-    ...queryStringObject,
-    page: parseInt(queryStringObject.page || 1, 10),
+    ...queryProps,
+    page: parseInt(queryProps.page || 1, 10),
   }
 }
 
 export const state2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)
-  const queryStringObject = parseQueryString(queryString)
+  const queryProps = parseQueryString(queryString)
   const { metadata } = state[ID]
-  const selectedFilters = buildSelectedFilters(queryStringObject, metadata)
+  const selectedFilters = buildSelectedFilters(queryProps, metadata)
 
   return {
     ...state[ID],
     selectedFilters,
-    payload: queryStringObject,
+    payload: queryProps,
     optionMetadata: {
       sortOptions: [],
       ...metadata,

--- a/src/apps/interactions/client/state.js
+++ b/src/apps/interactions/client/state.js
@@ -2,25 +2,29 @@ import { omitBy, isEmpty } from 'lodash'
 import qs from 'qs'
 
 export const TASK_GET_INTERACTIONS_LIST = 'TASK_GET_INTERACTIONS_LIST'
+
 export const ID = 'interactionsList'
 
-const getFilteredQueryParams = (router) => {
-  const queryParams = router.location.search.slice(1)
-  const filteredQueryParams = omitBy({ ...qs.parse(queryParams) }, isEmpty)
+import { buildSelectedFilters } from './filters'
+
+const parseQueryString = (queryString) => {
+  const queryStringObject = omitBy({ ...qs.parse(queryString) }, isEmpty)
   return {
-    ...filteredQueryParams,
-    page: parseInt(filteredQueryParams.page || 1, 10),
+    ...queryStringObject,
+    page: parseInt(queryStringObject.page || 1, 10),
   }
 }
 
 export const state2props = ({ router, ...state }) => {
-  const filteredQueryParams = getFilteredQueryParams(router)
+  const queryString = router.location.search.slice(1)
+  const queryStringObject = parseQueryString(queryString)
   const { metadata } = state[ID]
+  const selectedFilters = buildSelectedFilters(queryStringObject, metadata)
 
   return {
     ...state[ID],
-    selectedFilters: {},
-    payload: filteredQueryParams,
+    selectedFilters,
+    payload: queryStringObject,
     optionMetadata: {
       sortOptions: [],
       ...metadata,

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -4,10 +4,11 @@ import { transformResponseToCollection } from './transformers'
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
-export const getInteractions = ({ limit = 10, page = 1 }) =>
+export const getInteractions = ({ limit = 10, page = 1, kind }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
       limit,
+      kind,
       offset: limit * (page - 1),
       sortby: 'date:desc',
     })

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -4,7 +4,7 @@ const { get } = require('lodash')
 const { format } = require('../../../client/utils/date-utils')
 const urls = require('../../../lib/urls')
 
-import { KIND_OPTIONS } from './constants'
+import { LABELS } from './constants'
 
 const formatContacts = (contacts) =>
   contacts.length > 1
@@ -28,8 +28,8 @@ const formatParticipants = (dit_participants) =>
 
 const getbadgeLabel = (type, hasFeedback = false) => {
   const badges = {
-    interaction: KIND_OPTIONS.interaction.label,
-    service_delivery: KIND_OPTIONS.serviceDelivery.label,
+    interaction: LABELS.interaction,
+    service_delivery: LABELS.serviceDelivery,
   }
   return [
     {

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -4,6 +4,8 @@ const { get } = require('lodash')
 const { format } = require('../../../client/utils/date-utils')
 const urls = require('../../../lib/urls')
 
+import { INTERACTION, SERVICE_DELIVERY } from './constants'
+
 const formatContacts = (contacts) =>
   contacts.length > 1
     ? 'Multiple contacts'
@@ -26,8 +28,8 @@ const formatParticipants = (dit_participants) =>
 
 const getbadgeLabel = (type, hasFeedback = false) => {
   const badges = {
-    interaction: 'Interaction',
-    service_delivery: 'Service delivery',
+    interaction: INTERACTION.label,
+    service_delivery: SERVICE_DELIVERY.label,
   }
   return [
     {

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -4,7 +4,7 @@ const { get } = require('lodash')
 const { format } = require('../../../client/utils/date-utils')
 const urls = require('../../../lib/urls')
 
-import { INTERACTION, SERVICE_DELIVERY } from './constants'
+import { KIND_OPTIONS } from './constants'
 
 const formatContacts = (contacts) =>
   contacts.length > 1
@@ -28,8 +28,8 @@ const formatParticipants = (dit_participants) =>
 
 const getbadgeLabel = (type, hasFeedback = false) => {
   const badges = {
-    interaction: INTERACTION.label,
-    service_delivery: SERVICE_DELIVERY.label,
+    interaction: KIND_OPTIONS.interaction.label,
+    service_delivery: KIND_OPTIONS.serviceDelivery.label,
   }
   return [
     {

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -98,6 +98,10 @@ function FilteredCollectionHeader({
         thus the chips should not be hardcoded here
         */}
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedKind}
+          qsParamName="kind"
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedStages}
           qsParamName="stage"
         />

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -12,11 +12,6 @@ import {
   assertCheckboxGroupOption,
 } from '../../support/assertions'
 
-import {
-  INTERACTION,
-  SERVICE_DELIVERY,
-} from '../../../../../src/apps/interactions/client/constants'
-
 const buildQueryString = (queryParams = {}) =>
   qs.stringify({
     // Default query params
@@ -74,7 +69,7 @@ describe('Interactions Collections Filter', () => {
 
       clickCheckboxGroupOption({
         element,
-        value: INTERACTION.value,
+        value: 'interaction',
       })
       assertPayload('@apiRequest', {
         ...taskParams,
@@ -82,7 +77,7 @@ describe('Interactions Collections Filter', () => {
       })
       clickCheckboxGroupOption({
         element,
-        value: SERVICE_DELIVERY.value,
+        value: 'service_delivery',
       })
       assertPayload('@apiRequest', {
         ...taskParams,
@@ -90,8 +85,8 @@ describe('Interactions Collections Filter', () => {
       })
 
       assertQueryParams('kind', ['interaction', 'service_delivery'])
-      assertChipExists({ label: INTERACTION.label, position: 1 })
-      assertChipExists({ label: SERVICE_DELIVERY.label, position: 2 })
+      assertChipExists({ label: 'Interaction', position: 1 })
+      assertChipExists({ label: 'Service delivery', position: 2 })
       removeChip('interaction')
       cy.wait('@apiRequest')
       removeChip('service_delivery')

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -50,12 +50,12 @@ describe('Interactions Collections Filter', () => {
       })
       assertCheckboxGroupOption({
         element,
-        value: INTERACTION.value,
+        value: 'Interaction',
         checked: true,
       })
       assertCheckboxGroupOption({
         element,
-        value: SERVICE_DELIVERY.value,
+        value: 'Service delivery',
         checked: true,
       })
       assertChipExists({ label: 'Interaction', position: 1 })

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -19,7 +19,7 @@ const buildQueryString = (queryParams = {}) =>
     ...queryParams,
   })
 
-const taskParams = {
+const minimumPayload = {
   limit: 10,
   offset: 0,
   sortby: 'date:desc',
@@ -31,7 +31,7 @@ describe('Interactions Collections Filter', () => {
       cy.intercept('POST', '/api-proxy/v3/search/interaction').as('apiRequest')
       cy.visit(interactions.react())
       cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body).to.deep.equal(taskParams)
+        expect(request.body).to.deep.equal(minimumPayload)
       })
     })
   })
@@ -45,17 +45,17 @@ describe('Interactions Collections Filter', () => {
       cy.visit(`${interactions.react()}?${queryParams}`)
 
       assertPayload('@apiRequest', {
-        ...taskParams,
+        ...minimumPayload,
         kind: ['interaction', 'service_delivery'],
       })
       assertCheckboxGroupOption({
         element,
-        value: 'Interaction',
+        value: 'interaction',
         checked: true,
       })
       assertCheckboxGroupOption({
         element,
-        value: 'Service delivery',
+        value: 'service_delivery',
         checked: true,
       })
       assertChipExists({ label: 'Interaction', position: 1 })
@@ -72,7 +72,7 @@ describe('Interactions Collections Filter', () => {
         value: 'interaction',
       })
       assertPayload('@apiRequest', {
-        ...taskParams,
+        ...minimumPayload,
         kind: ['interaction'],
       })
       clickCheckboxGroupOption({
@@ -80,7 +80,7 @@ describe('Interactions Collections Filter', () => {
         value: 'service_delivery',
       })
       assertPayload('@apiRequest', {
-        ...taskParams,
+        ...minimumPayload,
         kind: ['interaction', 'service_delivery'],
       })
 
@@ -90,7 +90,7 @@ describe('Interactions Collections Filter', () => {
       removeChip('interaction')
       cy.wait('@apiRequest')
       removeChip('service_delivery')
-      assertPayload('@apiRequest', taskParams)
+      assertPayload('@apiRequest', minimumPayload)
       assertChipsEmpty()
       assertFieldEmpty(element)
     })

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -1,0 +1,103 @@
+import qs from 'qs'
+
+import { interactions } from '../../../../../src/lib/urls'
+
+import { clickCheckboxGroupOption, removeChip } from '../../support/actions'
+import {
+  assertQueryParams,
+  assertPayload,
+  assertChipExists,
+  assertChipsEmpty,
+  assertFieldEmpty,
+  assertCheckboxGroupOption,
+} from '../../support/assertions'
+
+import {
+  INTERACTION,
+  SERVICE_DELIVERY,
+} from '../../../../../src/apps/interactions/client/constants'
+
+const buildQueryString = (queryParams = {}) =>
+  qs.stringify({
+    // Default query params
+    sortby: 'date:desc',
+    ...queryParams,
+  })
+
+const taskParams = {
+  limit: 10,
+  offset: 0,
+  sortby: 'date:desc',
+}
+
+describe('Interactions Collections Filter', () => {
+  context('Default Params', () => {
+    it('should set the default params', () => {
+      cy.intercept('POST', '/api-proxy/v3/search/interaction').as('apiRequest')
+      cy.visit(interactions.react())
+      cy.wait('@apiRequest').then(({ request }) => {
+        expect(request.body).to.deep.equal(taskParams)
+      })
+    })
+  })
+  context('Interaction Kind', () => {
+    const element = '[data-test="status-filter"]'
+    it('should filter from the url', () => {
+      cy.intercept('POST', '/api-proxy/v3/search/interaction').as('apiRequest')
+      const queryParams = buildQueryString({
+        kind: ['interaction', 'service_delivery'],
+      })
+      cy.visit(`${interactions.react()}?${queryParams}`)
+
+      assertPayload('@apiRequest', {
+        ...taskParams,
+        kind: ['interaction', 'service_delivery'],
+      })
+      assertCheckboxGroupOption({
+        element,
+        value: INTERACTION.value,
+        checked: true,
+      })
+      assertCheckboxGroupOption({
+        element,
+        value: SERVICE_DELIVERY.value,
+        checked: true,
+      })
+      assertChipExists({ label: 'Interaction', position: 1 })
+    })
+
+    it('should filter from user input and remove the chips', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', '/api-proxy/v3/search/interaction').as('apiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      cy.wait('@apiRequest')
+
+      clickCheckboxGroupOption({
+        element,
+        value: INTERACTION.value,
+      })
+      assertPayload('@apiRequest', {
+        ...taskParams,
+        kind: ['interaction'],
+      })
+      clickCheckboxGroupOption({
+        element,
+        value: SERVICE_DELIVERY.value,
+      })
+      assertPayload('@apiRequest', {
+        ...taskParams,
+        kind: ['interaction', 'service_delivery'],
+      })
+
+      assertQueryParams('kind', ['interaction', 'service_delivery'])
+      assertChipExists({ label: INTERACTION.label, position: 1 })
+      assertChipExists({ label: SERVICE_DELIVERY.label, position: 2 })
+      removeChip('interaction')
+      cy.wait('@apiRequest')
+      removeChip('service_delivery')
+      assertPayload('@apiRequest', taskParams)
+      assertChipsEmpty()
+      assertFieldEmpty(element)
+    })
+  })
+})

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -506,6 +506,10 @@ const assertElementsInOrder = ({ parentElement, expectedIdentifiers }) => {
   }
 }
 
+/**
+ * Assert the expected payload to the API
+ */
+
 const assertPayload = (apiRequest, expectedParams) => {
   cy.wait(apiRequest).then(({ request }) => {
     expect(request.body).to.deep.equal(expectedParams)


### PR DESCRIPTION
## Description of change

Added interaction kind filter to the new interactions React page allowing users to filter out interactions by kind/type

## Test instructions

This should work the same as the current interaction kind filter on the interaction collection list

Go to `/interactions/react`

## Screenshots
### Before
![Screenshot 2021-06-17 at 12 03 05](https://user-images.githubusercontent.com/10154302/122384853-01465d80-cf64-11eb-8ddf-8c39ebb5c859.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
