### PR TITLE
React collection list style tweaks

### DIFF
--- a/src/client/components/RoutedInput/Filter.js
+++ b/src/client/components/RoutedInput/Filter.js
@@ -1,13 +1,13 @@
 import styled from 'styled-components'
-import { FONT_SIZE } from '@govuk-react/constants'
+import { FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
 import { FOCUS_COLOUR, BLACK } from 'govuk-colours'
 
 import RoutedInput from '../RoutedInput'
 
 export default styled(RoutedInput)({
-  fontSize: FONT_SIZE.SIZE_19,
+  fontSize: FONT_SIZE.SIZE_16,
   lineHeight: '25px',
-  padding: 6,
+  padding: '6px 10px',
   marginTop: 5,
   border: `2px solid ${BLACK}`,
   appearance: null,
@@ -17,5 +17,9 @@ export default styled(RoutedInput)({
   '&:focus': {
     outline: `3px solid ${FOCUS_COLOUR}`,
     outlineOffset: 0,
+  },
+
+  [MEDIA_QUERIES.TABLET]: {
+    fontSize: FONT_SIZE.SIZE_19,
   },
 })

--- a/src/client/components/Typeahead/styles.js
+++ b/src/client/components/Typeahead/styles.js
@@ -75,6 +75,7 @@ const defaultStyles = {
     padding: 0,
   }),
   placeholder: (styles) => ({
+    whiteSpace: 'nowrap',
     ...styles,
     fontSize: FONT_SIZE.SIZE_16,
     color: GREY_1,


### PR DESCRIPTION
## Description of change

Fixes a couple of issues that Pauline noticed on styles on the new react collection list pages:

- typeahead placeholders are fixed so that the line does not break
- font size for typeaheads and standard input filters are now consistent with each other on small screens - the font size is 16px below 768px and 19px above

## Test instructions

View the react collection list pages for example `/investments`, `/companies/react` and `/contacts/react`

Above issues should be fixed

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
