### PR TITLE
Add new react events collection route

### DIFF
--- a/src/apps/events/client/EventsCollection.jsx
+++ b/src/apps/events/client/EventsCollection.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const EventsCollection = () => <div>React Events Page</div>
+
+export default EventsCollection

--- a/src/apps/events/controllers/events.js
+++ b/src/apps/events/controllers/events.js
@@ -1,0 +1,20 @@
+const renderEventsView = async (req, res, next) => {
+  try {
+    const { user } = req.session
+    const currentAdviserId = user.id
+
+    const props = {
+      title: 'Events',
+      heading: 'Events',
+      currentAdviserId,
+    }
+
+    return res.render('events/views/events', { props })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderEventsView,
+}

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -1,5 +1,7 @@
 const router = require('express').Router()
 
+const urls = require('../../lib/urls')
+
 const { ENTITIES } = require('../search/constants')
 const {
   DEFAULT_COLLECTION_QUERY,
@@ -21,7 +23,11 @@ const {
 const { renderDetailsPage } = require('./controllers/details')
 const { renderEditPage } = require('./controllers/edit')
 const { postDetails, getEventDetails } = require('./middleware/details')
+
 const { renderEventList } = require('./controllers/list')
+// New react view (in progress) - to replace 'renderEventList' when finished
+const { renderEventsView } = require('./controllers/events')
+
 const attendeesRouter = require('./attendees/router')
 
 const { transformEventToListItem } = require('./transformers')
@@ -32,18 +38,21 @@ router.route('/create').post(postDetails, renderEditPage).get(renderEditPage)
 
 router.param('eventId', getEventDetails)
 
-router.use(
-  '/:eventId',
-  handleRoutePermissions(LOCAL_NAV),
-  setLocalNav(LOCAL_NAV)
-)
-
 router.get(
   '/',
   setDefaultQuery(DEFAULT_COLLECTION_QUERY),
   getRequestBody(QUERY_FIELDS, QUERY_DATE_FIELDS),
   getCollection('event', ENTITIES, transformEventToListItem),
   renderEventList
+)
+
+// New react route (to replace the old events list route above when complete)
+router.get(urls.events.react.index.route, renderEventsView)
+
+router.use(
+  '/:eventId',
+  handleRoutePermissions(LOCAL_NAV),
+  setLocalNav(LOCAL_NAV)
 )
 
 router

--- a/src/apps/events/views/events.njk
+++ b/src/apps/events/views/events.njk
@@ -1,0 +1,11 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-column-full">
+      {% component 'react-slot', {
+        id: 'events-collection',
+        props: props
+      }
+      %}
+  </div>
+{% endblock %}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -42,6 +42,7 @@ import PersonalisedDashboard from './components/PersonalisedDashboard'
 import CompanyLocalHeader from './components/CompanyLocalHeader'
 import CompaniesCollection from '../apps/companies/client/CompaniesCollection.jsx'
 import ContactsCollection from '../apps/contacts/client/ContactsCollection.jsx'
+import EventsCollection from '../apps/events/client/EventsCollection.jsx'
 import InteractionsCollection from '../apps/interactions/client/InteractionsCollection'
 import InvestmentProjectsCollection from '../apps/investments/client/projects/ProjectsCollection.jsx'
 import Opportunities from '../apps/investments/client/opportunities/Details/Opportunities.jsx'
@@ -403,6 +404,9 @@ function App() {
       </Mount>
       <Mount selector="#contacts-collection">
         {(props) => <ContactsCollection {...props} />}
+      </Mount>
+      <Mount selector="#events-collection">
+        {(props) => <EventsCollection {...props} />}
       </Mount>
       <Mount selector="#interactions-collection">
         {(props) => <InteractionsCollection {...props} />}

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -227,6 +227,10 @@ module.exports = {
     ),
   },
   events: {
+    // React routes (Work in progress) - to be released on completion
+    react: {
+      index: url('/events', '/react'),
+    },
     index: url('/events'),
     create: url('/events/create'),
     details: url('/events', '/:eventId/details'),

--- a/test/a11y/cypress/specs/events/collection-spec.js
+++ b/test/a11y/cypress/specs/events/collection-spec.js
@@ -1,0 +1,12 @@
+import { events } from '../../../../../src/lib/urls'
+
+describe('Events Collection - React', () => {
+  before(() => {
+    cy.visit(events.react.index())
+    cy.initA11y()
+  })
+
+  it('should not have any a11y violations', () => {
+    cy.runA11y()
+  })
+})

--- a/test/functional/cypress/specs/events/collection-react-spec.js
+++ b/test/functional/cypress/specs/events/collection-react-spec.js
@@ -1,0 +1,17 @@
+import { assertBreadcrumbs } from '../../support/assertions'
+import { events } from '../../../../../src/lib/urls'
+
+describe('Event Collection List Page - React', () => {
+  before(() => {
+    // Visit the new react events page - note this will need to be changed
+    // to `events.index()` when ready
+    cy.visit(events.react.index())
+  })
+
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: '/',
+      Events: null,
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Adds a new route to stage the new react events collection list page.

## Test instructions

A basic page with no events on it at `/events/react`

## Screenshots

![Screenshot from 2021-06-21 13-02-06](https://user-images.githubusercontent.com/1234577/122758647-f60b6e80-d290-11eb-83f7-87edf7d92934.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
