### PR TITLE
Add new react orders (OMIS) collection express route

### DIFF
--- a/src/apps/omis/apps/list/orders.js
+++ b/src/apps/omis/apps/list/orders.js
@@ -1,0 +1,16 @@
+const renderOrdersView = async (req, res, next) => {
+  try {
+    const props = {
+      title: 'Orders',
+      heading: 'Orders',
+    }
+
+    return res.render('omis/apps/view/views/orders', { props })
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  renderOrdersView,
+}

--- a/src/apps/omis/apps/list/router.js
+++ b/src/apps/omis/apps/list/router.js
@@ -1,4 +1,5 @@
 const router = require('express').Router()
+const urls = require('../../../../lib/urls')
 
 const { ENTITIES } = require('../../../search/constants')
 
@@ -12,6 +13,7 @@ const { setDefaultQuery } = require('../../../middleware')
 const { getRequestBody } = require('../../../../middleware/collection')
 
 const { renderList } = require('./controllers')
+const { renderOrdersView } = require('./orders')
 const { setRequestBody } = require('./middleware')
 const { transformOrderToListItem } = require('../../transformers')
 
@@ -26,6 +28,9 @@ router.get(
   getCollection('order', ENTITIES, transformOrderToListItem),
   renderList
 )
+
+// New react route (to replace the old companies list route above when complete)
+router.get(urls.omis.react.index.route, renderOrdersView)
 
 router.get(
   '/export',

--- a/src/apps/omis/apps/view/views/orders.njk
+++ b/src/apps/omis/apps/view/views/orders.njk
@@ -1,0 +1,11 @@
+{% extends "_layouts/template.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-column-full">
+      {% component 'react-slot', {
+        id: 'orders-collection',
+        props: props
+      }
+      %}
+  </div>
+{% endblock %}

--- a/src/apps/omis/client/OrdersCollection.jsx
+++ b/src/apps/omis/client/OrdersCollection.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const OrdersCollection = () => {
+  return (
+    <div>
+      <h2>Orders Collection to go here...</h2>
+    </div>
+  )
+}
+
+export default OrdersCollection

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -42,6 +42,7 @@ import PersonalisedDashboard from './components/PersonalisedDashboard'
 import CompanyLocalHeader from './components/CompanyLocalHeader'
 import CompaniesCollection from '../apps/companies/client/CompaniesCollection.jsx'
 import ContactsCollection from '../apps/contacts/client/ContactsCollection.jsx'
+import OrdersCollection from '../apps/omis/client/OrdersCollection.jsx'
 import EventsCollection from '../apps/events/client/EventsCollection.jsx'
 import InteractionsCollection from '../apps/interactions/client/InteractionsCollection'
 import InvestmentProjectsCollection from '../apps/investments/client/projects/ProjectsCollection.jsx'
@@ -418,6 +419,9 @@ function App() {
       </Mount>
       <Mount selector="#contacts-collection">
         {(props) => <ContactsCollection {...props} />}
+      </Mount>
+      <Mount selector="#orders-collection">
+        {(props) => <OrdersCollection {...props} />}
       </Mount>
       <Mount selector="#events-collection">
         {(props) => <EventsCollection {...props} />}

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -409,6 +409,10 @@ module.exports = {
   },
   omis: {
     index: url('/omis'),
+    // React routes (Work in progress) - to be released on completion
+    react: {
+      index: url('/omis', '/react'),
+    },
     export: url('/omis', '/export'),
     create: url('/omis/create?company=', ':companyId'),
     reconciliation: url('/omis/reconciliation'),

--- a/test/a11y/cypress/specs/orders/collection-spec.js
+++ b/test/a11y/cypress/specs/orders/collection-spec.js
@@ -1,0 +1,12 @@
+import { omis } from '../../../../../src/lib/urls'
+
+describe('Orders (OMIS) Collection - React', () => {
+  before(() => {
+    cy.visit(omis.react.index())
+    cy.initA11y()
+  })
+
+  it('should not have any a11y violations', () => {
+    cy.runA11y()
+  })
+})

--- a/test/end-to-end/cypress/specs/DIT/export-data.js
+++ b/test/end-to-end/cypress/specs/DIT/export-data.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const urls = require('../../../../../src/lib/urls')
 
 const csvHeadings = {
-  companies: `Name,Link,Sector,Country,Area,UK region,Countries exported to,Countries of interest,Archived,Date created,Number of employees,Annual turnover,Headquarter type`,
+  companies: `Name,Link,Sector,Country,UK region,Countries exported to,Countries of interest,Archived,Date created,Number of employees,Annual turnover,Headquarter type`,
   contacts: `Name,Job title,Date created,Archived,Link,Company,Company sector,Company link,Company UK region,Country,Postcode,Phone number,Email address,Accepts DIT email marketing,Date of latest interaction,Teams of latest interaction,Created by team`,
   interactions: `Date,Type,Service,Subject,Link,Company,Company link,Company country,Company UK region,Company sector,Contacts,Advisers,Event,Communication channel,Service delivery status,Net company receipt,Policy issue types,Policy areas,Policy feedback notes`,
   investment_projects: `Date created,Project reference,Project name,Investor company,Investor company town or city,Country of origin,Investment type,Status,Stage,Link,Actual land date,Estimated land date,FDI value,Sector,Date of latest interaction,Project manager,Client relationship manager,Global account manager,Project assurance adviser,Other team members,Delivery partners,Possible UK regions,Actual UK regions,Specific investment programme,Referral source activity,Referral source activity website,Total investment,New jobs,Average salary of new jobs,Safeguarded jobs,Level of involvement,R&D budget,Associated non-FDI R&D project,New to world tech,Likelihood to land,FDI type,Foreign equity investment,GVA multiplier,GVA`,

--- a/test/functional/cypress/specs/omis/collection-react-spec.js
+++ b/test/functional/cypress/specs/omis/collection-react-spec.js
@@ -1,0 +1,17 @@
+import { assertBreadcrumbs } from '../../support/assertions'
+import { omis } from '../../../../../src/lib/urls'
+
+describe('Orders (OMIS) Collection List Page - React', () => {
+  before(() => {
+    // Visit the new react events page - note this will need to be changed
+    // to `omis.index()` when ready
+    cy.visit(omis.react.index())
+  })
+
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: '/',
+      'Orders (OMIS)': null,
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Added an Express.js route for the new "Orders (OMIS)" React collection list page.

## Test instructions

A very basic page `/omis/react` to build on.

## Screenshots
<img width="1480" alt="Screenshot 2021-06-22 at 13 33 22" src="https://user-images.githubusercontent.com/964268/122928078-6d103800-d361-11eb-8142-101927366850.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
