### PR TITLE
React interactions collection list - My interactions filter

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -5,6 +5,7 @@ import {
   INTERACTIONS__LOADED,
   INTERACTIONS_SELECTED_ADVISERS,
 } from '../../../client/actions'
+
 import { LABELS, KIND_OPTIONS } from './constants'
 
 import {
@@ -25,6 +26,7 @@ const InteractionCollection = ({
   payload,
   optionMetadata,
   selectedFilters,
+  currentAdviserId,
   ...props
 }) => {
   const collectionListTask = {
@@ -68,6 +70,7 @@ const InteractionCollection = ({
           selectedOptions={selectedFilters.selectedKind}
           data-test="status-filter"
         />
+
         <RoutedAdvisersTypeahead
           taskProps={adviserListTask}
           isMulti={true}
@@ -78,6 +81,14 @@ const InteractionCollection = ({
           noOptionsMessage={() => <>No advisers found</>}
           selectedOptions={selectedFilters.selectedAdvisers}
           data-test="adviser-filter"
+        />
+
+        <RoutedCheckboxGroupField
+          name="dit_participants__adviser"
+          qsParam="adviser"
+          options={[{ label: LABELS.myInteractions, value: currentAdviserId }]}
+          selectedOptions={selectedFilters.selectedMyInteractions}
+          data-test="my-interactions-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -3,6 +3,7 @@ export const LABELS = {
   interaction: 'Interaction',
   serviceDelivery: 'Service delivery',
   advisers: 'Advisers',
+  myInteractions: 'My interactions',
 }
 
 export const KIND_OPTIONS = [

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -13,4 +13,9 @@ export const buildSelectedFilters = ({ queryParams, selectedAdvisers }) => ({
     value: advisers.id,
     categoryLabel: LABELS.advisers,
   })),
+  selectedMyInteractions: selectedAdvisers.map(({ advisers }) => ({
+    label: advisers.name,
+    value: advisers.id,
+    categoryLabel: LABELS.advisers,
+  })),
 })

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -33,14 +33,14 @@ const minimumPayload = {
 
 const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction'
 const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
-const adviserEndpoint =
-  '/api-proxy/adviser/7d19d407-9aec-4d06-b190-d3f404627f21'
+const adviserId = '7d19d407-9aec-4d06-b190-d3f404627f21'
+const adviserEndpoint = `/api-proxy/adviser/${adviserId}`
 
 const advisersFilter = '[data-test="adviser-filter"]'
 const myInteractionsFilter = '[data-test="my-interactions-filter"]'
 
 const adviser = {
-  id: '7d19d407-9aec-4d06-b190-d3f404627f21',
+  id: adviserId,
   name: 'Barry Oling',
   is_active: true,
   last_login: null,

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -7,6 +7,7 @@ import {
   removeChip,
   selectFirstAdvisersTypeaheadOption,
 } from '../../support/actions'
+
 import {
   assertQueryParams,
   assertPayload,
@@ -14,6 +15,7 @@ import {
   assertChipsEmpty,
   assertFieldEmpty,
   assertCheckboxGroupOption,
+  assertTypeaheadOptionSelected,
 } from '../../support/assertions'
 
 const buildQueryString = (queryParams = {}) =>
@@ -30,6 +32,25 @@ const minimumPayload = {
 }
 
 const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction'
+const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
+const adviserEndpoint =
+  '/api-proxy/adviser/7d19d407-9aec-4d06-b190-d3f404627f21'
+
+const advisersFilter = '[data-test="adviser-filter"]'
+const myInteractionsFilter = '[data-test="my-interactions-filter"]'
+
+const adviser = {
+  id: '7d19d407-9aec-4d06-b190-d3f404627f21',
+  name: 'Barry Oling',
+  is_active: true,
+  last_login: null,
+  first_name: 'Barry',
+  last_name: 'Oling',
+  email: 'sewuvar@vonudi.gov',
+  contact_email: '',
+  telephone_number: '',
+  dit_team: null,
+}
 
 describe('Interactions Collections Filter', () => {
   context('Default Params', () => {
@@ -49,7 +70,6 @@ describe('Interactions Collections Filter', () => {
         kind: ['interaction', 'service_delivery'],
       })
       cy.visit(`${interactions.react()}?${queryParams}`)
-
       assertPayload('@apiRequest', {
         ...minimumPayload,
         kind: ['interaction', 'service_delivery'],
@@ -103,48 +123,125 @@ describe('Interactions Collections Filter', () => {
   })
 
   context('Advisers', () => {
-    const element = '[data-test="adviser-filter"]'
-    const adviserId = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
-    const adviserName = 'Puck Head'
     const expectedPayload = {
       offset: 0,
       limit: 10,
       sortby: 'date:desc',
-      dit_participants__adviser: [adviserId],
+      dit_participants__adviser: [adviser.id],
     }
 
     it('should filter from the url', () => {
       const queryParams = buildQueryString({
-        adviser: [adviserId],
+        adviser: [adviser.id],
       })
+
       cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('GET', adviserAutocompleteEndpoint, {
+        count: 1,
+        results: [adviser],
+      }).as('adviserListApiRequest')
+      cy.intercept('GET', adviserEndpoint, adviser).as('adviserApiRequest')
       cy.visit(`${interactions.react()}?${queryParams}`)
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body).to.deep.equal(expectedPayload)
       })
-      cy.get(element).should('contain', adviserName)
-      assertChipExists({ label: adviserName, position: 1 })
+      assertTypeaheadOptionSelected({
+        element: advisersFilter,
+        expectedOption: adviser.name,
+      })
+      assertChipExists({ label: adviser.name, position: 1 })
+      // Asserts the "My interactions" filter checkbox as this should be checked if the adviser chosen is the same as the current user.
+      assertCheckboxGroupOption({
+        element: myInteractionsFilter,
+        value: adviser.id,
+        checked: true,
+      })
     })
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
       cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('GET', adviserAutocompleteEndpoint, {
+        count: 1,
+        results: [adviser],
+      }).as('adviserListApiRequest')
+      cy.intercept('GET', adviserEndpoint, adviser).as('adviserApiRequest')
+
       cy.visit(`${interactions.react()}?${queryString}`)
       cy.wait('@apiRequest')
-
-      selectFirstAdvisersTypeaheadOption({ element, input: adviserName })
+      selectFirstAdvisersTypeaheadOption({
+        element: advisersFilter,
+        input: adviser.name,
+      })
+      cy.wait('@adviserApiRequest')
+      cy.wait('@adviserListApiRequest')
       assertPayload('@apiRequest', expectedPayload)
-      assertQueryParams('adviser', [adviserId])
+      assertQueryParams('adviser', [adviser.id])
+      assertTypeaheadOptionSelected({
+        element: advisersFilter,
+        expectedOption: adviser.name,
+      })
+      // Asserts the "My interactions" filter checkbox as this should be checked if the adviser chosen is the same as the current user.
+      assertCheckboxGroupOption({
+        element: myInteractionsFilter,
+        value: adviser.id,
+        checked: true,
+      })
       assertChipExists({
-        label: adviserName,
+        label: adviser.name,
         position: 1,
       })
-      removeChip(adviserId)
+      removeChip(adviser.id)
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body).to.deep.equal(minimumPayload)
       })
       assertChipsEmpty()
-      assertFieldEmpty(element)
+      assertFieldEmpty(advisersFilter)
+    })
+  })
+
+  context('My interactions', () => {
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        adviser: [adviser.id],
+      })
+      cy.intercept('GET', adviserEndpoint, adviser).as('adviserApiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      cy.wait('@adviserApiRequest')
+      // Asserts the "Adviser typeahead" filter is selected with the current user as this is the same as selecting "My interactions".
+      assertTypeaheadOptionSelected({
+        element: advisersFilter,
+        expectedOption: adviser.name,
+      })
+      assertCheckboxGroupOption({
+        element: myInteractionsFilter,
+        value: adviser.id,
+        checked: true,
+      })
+      assertChipExists({ label: adviser.name, position: 1 })
+    })
+
+    it('should filter from user input and remove chips', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('GET', adviserEndpoint, adviser).as('adviserApiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      cy.wait('@apiRequest')
+      clickCheckboxGroupOption({
+        element: myInteractionsFilter,
+        value: adviser.id,
+      })
+      cy.wait('@adviserApiRequest')
+      assertPayload('@apiRequest', {
+        ...minimumPayload,
+        dit_participants__adviser: [adviser.id],
+      })
+      assertQueryParams('adviser', [adviser.id])
+      assertChipExists({ label: adviser.name, position: 1 })
+      removeChip(adviser.id)
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+      assertFieldEmpty(myInteractionsFilter)
     })
   })
 })

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -42,14 +42,6 @@ const myInteractionsFilter = '[data-test="my-interactions-filter"]'
 const adviser = {
   id: adviserId,
   name: 'Barry Oling',
-  is_active: true,
-  last_login: null,
-  first_name: 'Barry',
-  last_name: 'Oling',
-  email: 'sewuvar@vonudi.gov',
-  contact_email: '',
-  telephone_number: '',
-  dit_team: null,
 }
 
 describe('Interactions Collections Filter', () => {
@@ -124,9 +116,7 @@ describe('Interactions Collections Filter', () => {
 
   context('Advisers', () => {
     const expectedPayload = {
-      offset: 0,
-      limit: 10,
-      sortby: 'date:desc',
+      ...minimumPayload,
       dit_participants__adviser: [adviser.id],
     }
 
@@ -150,7 +140,10 @@ describe('Interactions Collections Filter', () => {
         expectedOption: adviser.name,
       })
       assertChipExists({ label: adviser.name, position: 1 })
-      // Asserts the "My interactions" filter checkbox as this should be checked if the adviser chosen is the same as the current user.
+      /*
+       Asserts the "My interactions" filter checkbox as this should
+      be checked if the adviser chosen is the same as the current user.
+      */
       assertCheckboxGroupOption({
         element: myInteractionsFilter,
         value: adviser.id,
@@ -181,7 +174,10 @@ describe('Interactions Collections Filter', () => {
         element: advisersFilter,
         expectedOption: adviser.name,
       })
-      // Asserts the "My interactions" filter checkbox as this should be checked if the adviser chosen is the same as the current user.
+      /*
+       Asserts the "My interactions" filter checkbox as this should
+      be checked if the adviser chosen is the same as the current user.
+      */
       assertCheckboxGroupOption({
         element: myInteractionsFilter,
         value: adviser.id,
@@ -208,7 +204,10 @@ describe('Interactions Collections Filter', () => {
       cy.intercept('GET', adviserEndpoint, adviser).as('adviserApiRequest')
       cy.visit(`${interactions.react()}?${queryString}`)
       cy.wait('@adviserApiRequest')
-      // Asserts the "Adviser typeahead" filter is selected with the current user as this is the same as selecting "My interactions".
+      /*
+      Asserts the "Adviser typeahead" filter is selected with the
+      current user as this is the same as selecting "My interactions".
+      */
       assertTypeaheadOptionSelected({
         element: advisersFilter,
         expectedOption: adviser.name,


### PR DESCRIPTION
## Description of change

This adds the "My interactions filter" to the new React interactions collection list.

## Test instructions

1. Go to `/interactions/react`
2. Toggle the "My interactions" filter

Note: this should also select the you (as the current user) in the "Advisers" typeahead and visa versa. Tests do cover this behaviour (See second screenshot).

## Screenshots
![Screenshot 2021-06-23 at 14 34 28](https://user-images.githubusercontent.com/10154302/123106363-7caa8200-d430-11eb-8a4a-c1a5c996b0fc.png)

![Screenshot 2021-06-23 at 14 37 57](https://user-images.githubusercontent.com/10154302/123106657-b9767900-d430-11eb-88f7-97cb0267f709.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
