### PR TITLE
Fix activity feed date bug

### DIFF
--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -25,9 +25,8 @@ const normaliseAndFormatDate = (year, month, day) => {
   return day ? `${yearAndMonth}-${padZero(day)}` : yearAndMonth
 }
 
-export const format = (dateStr, dateFormat = 'dd MMM yyyy') => {
-  return formatFNS(parseISO(dateStr), dateFormat)
-}
+export const format = (dateStr, dateFormat = 'dd MMM yyyy') =>
+  dateStr ? formatFNS(parseISO(dateStr), dateFormat) : null
 
 export const today = () => {
   return formatFNS(new Date(), 'dd MMM yyyy')

--- a/test/sandbox/fixtures/v4/activity-feed/data-hub-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/data-hub-activities.json
@@ -83,6 +83,55 @@
         "sort": [
           1560787348796
         ]
+      },
+      {
+        "_index": "activities__feed_id_datahub",
+        "_type": "_doc",
+        "_id": "dit:DataHubInvestmentProject:d9e25847-6199-e211-a939-e4115bead28a:Add",
+        "_score": null,
+        "_source": {
+           "actor":{
+              "dit:emailAddress":"CDMS\\CDMSInstall",
+              "id":"dit:DataHubAdviser:419fe8a8-3e95-e211-a939-e4115bead28a",
+              "name":"CDMSInstall Last name",
+              "type":[
+                 "Person",
+                 "dit:Adviser"
+              ]
+           },
+           "generator":{
+              "name":"dit:dataHub",
+              "type":"Application"
+           },
+           "id":"dit:DataHubInvestmentProject:d9e25847-6199-e211-a939-e4115bead28a:Add",
+           "object":{
+              "attributedTo":[
+                 {
+                    "dit:companiesHouseNumber":null,
+                    "dit:dunsNumber":"656147733",
+                    "id":"dit:DataHubCompany:81ee3ac7-a098-e211-a939-e4115bead28a",
+                    "name":"ASUSTEK COMPUTER INCORPORATION",
+                    "type":[
+                       "Organization",
+                       "dit:Company"
+                    ]
+                 }
+              ],
+              "dit:investmentType":{
+                 "name":"FDI"
+              },
+              "dit:numberNewJobs":20,
+              "id":"dit:DataHubInvestmentProject:d9e25847-6199-e211-a939-e4115bead28a",
+              "name":"Asus UK expansion",
+              "startTime":"2011-11-23T00:00:00Z",
+              "type":[
+                 "dit:InvestmentProject"
+              ],
+              "url":"https://www.datahub.trade.gov.uk/investments/projects/d9e25847-6199-e211-a939-e4115bead28a"
+           },
+           "published":"2011-11-23T00:00:00Z",
+           "type":"Add"
+        }
       }
     ]
   }


### PR DESCRIPTION
## Description of change

Fixes a bug on the company activity feed page when the estimated land date was not set the page went blank.

## Test instructions

Go to a companies page eg /companies/00009ae3-1912-e411-8a2b-e4115bead28a/activity

The activity feed should appear correctly.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
