### PR TITLE
React interactions collection list - date filters

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -12,6 +12,7 @@ import {
   FilteredCollectionList,
   RoutedCheckboxGroupField,
   RoutedAdvisersTypeahead,
+  RoutedDateField,
   CollectionFilters,
 } from '../../../client/components'
 
@@ -82,13 +83,24 @@ const InteractionCollection = ({
           selectedOptions={selectedFilters.selectedAdvisers}
           data-test="adviser-filter"
         />
-
         <RoutedCheckboxGroupField
           name="dit_participants__adviser"
           qsParam="adviser"
           options={[{ label: LABELS.myInteractions, value: currentAdviserId }]}
           selectedOptions={selectedFilters.selectedMyInteractions}
           data-test="my-interactions-filter"
+        />
+        <RoutedDateField
+          label={LABELS.dateAfter}
+          name="date_after"
+          qsParamName="date_after"
+          data-test="date-after-filter"
+        />
+        <RoutedDateField
+          label={LABELS.dateBefore}
+          name="date_before"
+          qsParamName="date_before"
+          data-test="date-before-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -4,6 +4,8 @@ export const LABELS = {
   serviceDelivery: 'Service delivery',
   advisers: 'Advisers',
   myInteractions: 'My interactions',
+  dateAfter: 'From',
+  dateBefore: 'To',
 }
 
 export const KIND_OPTIONS = [

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -1,6 +1,6 @@
 import { KIND_OPTIONS, LABELS } from './constants'
 
-import { buildOptionsFilter } from '../../../client/filters'
+import { buildOptionsFilter, buildDatesFilter } from '../../../client/filters'
 
 export const buildSelectedFilters = ({ queryParams, selectedAdvisers }) => ({
   selectedKind: buildOptionsFilter({
@@ -18,4 +18,12 @@ export const buildSelectedFilters = ({ queryParams, selectedAdvisers }) => ({
     value: advisers.id,
     categoryLabel: LABELS.advisers,
   })),
+  selectedDatesAfter: buildDatesFilter({
+    value: queryParams.date_after,
+    categoryLabel: LABELS.dateAfter,
+  }),
+  selectedDatesBefore: buildDatesFilter({
+    value: queryParams.date_before,
+    categoryLabel: LABELS.dateBefore,
+  }),
 })

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -4,7 +4,14 @@ import { transformResponseToCollection } from './transformers'
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
-export const getInteractions = ({ limit = 10, page = 1, kind, adviser }) =>
+export const getInteractions = ({
+  limit = 10,
+  page = 1,
+  kind,
+  adviser,
+  date_before,
+  date_after,
+}) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
       limit,
@@ -12,5 +19,7 @@ export const getInteractions = ({ limit = 10, page = 1, kind, adviser }) =>
       dit_participants__adviser: adviser,
       offset: limit * (page - 1),
       sortby: 'date:desc',
+      date_before,
+      date_after,
     })
     .then(({ data }) => transformResponseToCollection(data), handleError)

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -98,6 +98,16 @@ function FilteredCollectionHeader({
         thus the chips should not be hardcoded here
         */}
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedDatesAfter}
+          qsParamName="date_after"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedDatesBefore}
+          qsParamName="date_before"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedKind}
           qsParamName="kind"
         />

--- a/src/client/filters.js
+++ b/src/client/filters.js
@@ -1,3 +1,8 @@
+import { format, parseISO } from 'date-fns'
+
+const getDateLabel = (value) =>
+  value ? `${format(parseISO(value), 'd MMMM yyyy')}` : ''
+
 export const buildOptionsFilter = ({
   options = [],
   value = [],
@@ -17,3 +22,6 @@ export const buildOptionsFilter = ({
 
 export const buildInputFieldFilter = ({ value, categoryLabel }) =>
   value ? [{ value, label: value, categoryLabel }] : []
+
+export const buildDatesFilter = ({ value, categoryLabel = '' }) =>
+  value ? [{ label: getDateLabel(value), value, categoryLabel }] : []

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -35,3 +35,10 @@ export const selectFirstTypeaheadOption = ({ element, input }) => {
 export const removeChip = (dataValue) => {
   cy.get('[data-test=filter-chips]').find(`[data-value="${dataValue}"]`).click()
 }
+
+/**
+ * Adds a date to the any given date input field
+ */
+export const inputDateValue = ({ element, value }) => {
+  cy.get(element).type(value)
+}

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -519,6 +519,18 @@ const assertPayload = (apiRequest, expectedParams) => {
   })
 }
 
+/**
+ * Assert that the label and value exist on the date input
+ */
+
+const assertDateInput = ({ element, label, value }) => {
+  cy.get(element)
+    .find('label')
+    .should('contain', label)
+    .next()
+    .should('have.attr', 'value', value)
+}
+
 module.exports = {
   assertKeyValueTable,
   assertValueTable,
@@ -555,4 +567,5 @@ module.exports = {
   assertQueryParams,
   assertElementsInOrder,
   assertPayload,
+  assertDateInput,
 }


### PR DESCRIPTION
## Description of change

This adds the date filters to the new React interaction collection list

## Test instructions

1. Go to `/interactions/react`
2. Filter using the date filters

## Screenshots
![Screenshot 2021-06-24 at 12 35 48](https://user-images.githubusercontent.com/10154302/123257055-94920c80-d4e9-11eb-9567-5d5732a7175b.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
