### PR TITLE
Add status filters to the order (OMIS) collection page

### DIFF
--- a/src/apps/omis/client/OrdersCollection.jsx
+++ b/src/apps/omis/client/OrdersCollection.jsx
@@ -12,6 +12,7 @@ import {
   RoutedInputField,
   CollectionFilters,
   FilteredCollectionList,
+  RoutedCheckboxGroupField,
 } from '../../../client/components'
 
 import {
@@ -63,6 +64,14 @@ const OrdersCollection = ({
       }}
     >
       <CollectionFilters taskProps={collectionListMetadataTask}>
+        <RoutedCheckboxGroupField
+          legend={LABELS.status}
+          name="status"
+          qsParam="status"
+          options={optionMetadata.statusOptions}
+          selectedOptions={selectedFilters.selectedStatuses}
+          data-test="status-filter"
+        />
         <RoutedInputField
           id="OrdersCollection.company-name"
           qsParam="company_name"

--- a/src/apps/omis/client/constants.js
+++ b/src/apps/omis/client/constants.js
@@ -1,5 +1,5 @@
 export const LABELS = {
-  status: 'Status',
+  status: 'Order status',
   sector: 'Sector',
   ukRegion: 'UK region',
   country: 'Country of origin',
@@ -16,7 +16,7 @@ export const SORT_OPTIONS = [
   { value: 'delivery_date:desc', name: 'Latest delivery date' },
 ]
 
-export const ORDER_STATES = [
+export const STATUSES = [
   {
     value: 'draft',
     label: 'Draft',

--- a/src/apps/omis/client/filters.js
+++ b/src/apps/omis/client/filters.js
@@ -5,7 +5,12 @@ import {
 
 import { LABELS } from './constants'
 
-export const buildSelectedFilters = (queryParams, metadata) => ({
+export const buildSelectedFilters = (queryParams, metadata, statusOptions) => ({
+  selectedStatuses: buildOptionsFilter({
+    options: statusOptions,
+    value: queryParams.status,
+    categoryLabel: LABELS.status,
+  }),
   selectedCompanyName: buildInputFieldFilter({
     value: queryParams.company_name,
     categoryLabel: LABELS.companyName,

--- a/src/apps/omis/client/state.js
+++ b/src/apps/omis/client/state.js
@@ -2,7 +2,7 @@ import { omitBy, isEmpty } from 'lodash'
 import qs from 'qs'
 
 import { buildSelectedFilters } from './filters'
-import { SORT_OPTIONS } from './constants'
+import { SORT_OPTIONS, STATUSES } from './constants'
 
 export const ID = 'ordersList'
 export const TASK_GET_ORDERS_LIST = 'TASK_GET_ORDERS_LIST'
@@ -20,13 +20,14 @@ export const state2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)
   const queryParams = parseQueryString(queryString)
   const { metadata } = state[ID]
-  const selectedFilters = buildSelectedFilters(queryParams, metadata)
+  const selectedFilters = buildSelectedFilters(queryParams, metadata, STATUSES)
   return {
     ...state[ID],
     payload: { ...queryParams },
     optionMetadata: {
-      sortOptions: SORT_OPTIONS,
       ...metadata,
+      sortOptions: SORT_OPTIONS,
+      statusOptions: STATUSES,
     },
     selectedFilters,
   }

--- a/src/apps/omis/client/tasks.js
+++ b/src/apps/omis/client/tasks.js
@@ -9,6 +9,7 @@ const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 export const getOrders = ({
   page,
   limit = 10,
+  status,
   sortby,
   uk_region,
   company_name,
@@ -20,6 +21,7 @@ export const getOrders = ({
     .post('/api-proxy/v3/search/order', {
       offset: limit * (page - 1),
       limit,
+      status,
       sortby,
       uk_region,
       company_name,

--- a/src/apps/omis/client/transformers.js
+++ b/src/apps/omis/client/transformers.js
@@ -1,7 +1,7 @@
 import { find } from 'lodash'
 
 import { format, formatWithTime } from '../../../client/utils/date-utils'
-import { ORDER_STATES } from './constants'
+import { STATUSES } from './constants'
 import { omis } from '../../../lib/urls'
 
 export const transformOrderToListItem = ({
@@ -17,7 +17,7 @@ export const transformOrderToListItem = ({
   delivery_date,
   primary_market,
 } = {}) => {
-  const orderState = find(ORDER_STATES, { value: status })
+  const orderState = find(STATUSES, { value: status })
 
   const metadata = [
     {

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -206,6 +206,10 @@ function FilteredCollectionHeader({
           qsParamName="status"
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedStatuses}
+          qsParamName="status"
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedInvestmentTypes}
           qsParamName="investment_type"
         />


### PR DESCRIPTION
## Description of change

Added six status filters to the orders (OMIS) collection page

## Test instructions

Navigate to `/omis/react` to view the new React collection page

## Screenshots
<img width="1034" alt="after" src="https://user-images.githubusercontent.com/964268/123383107-aa0b4300-d58a-11eb-9c43-7b77cc5be649.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
