### PR TITLE
Update address fields to include address area

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -27,6 +27,7 @@ function AddCompanyForm({
   organisationTypes,
   regions,
   sectors,
+  features,
 }) {
   const optionCountryUK = countries.find(({ value }) => value === ISO_CODE.UK)
   const overseasCountries = countries.filter(
@@ -106,6 +107,7 @@ function AddCompanyForm({
               countryName={countryName}
               countryIsoCode={countryIsoCode}
               csrfToken={csrfToken}
+              features={features}
             />
 
             {!values.cannotFind && (

--- a/src/apps/companies/apps/add-company/client/CompanySearchStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanySearchStep.jsx
@@ -56,7 +56,12 @@ function getDnbEntityText(companyId, isOutOfBusiness, companyName) {
   return null
 }
 
-function CompanySearchStep({ countryName, countryIsoCode, csrfToken }) {
+function CompanySearchStep({
+  countryName,
+  countryIsoCode,
+  csrfToken,
+  features,
+}) {
   const { setFieldValue, goForward } = useFormContext()
   return (
     <Step name="companySearch" forwardButton={null} backButton={null}>
@@ -72,6 +77,7 @@ function CompanySearchStep({ countryName, countryIsoCode, csrfToken }) {
           setFieldValue('cannotFind', true)
           goForward()
         }}
+        features={features}
       />
     </Step>
   )

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -34,6 +34,10 @@ async function renderAddCompanyForm(req, res, next) {
           organisationTypes,
           regions,
           sectors,
+          features: {
+            isAddressAreaEnabled:
+              res.locals.features['address-area-company-search'],
+          },
         },
       })
   } catch (error) {

--- a/src/apps/search/__test__/controllers.test.js
+++ b/src/apps/search/__test__/controllers.test.js
@@ -29,6 +29,11 @@ describe('Search Controller #renderSearchResults', () => {
     this.res = {
       breadcrumb: this.breadcrumbStub,
       render: this.renderFunction,
+      locals: {
+        features: {
+          'address-area-company-search': true,
+        },
+      },
     }
   })
 

--- a/src/apps/search/controllers.js
+++ b/src/apps/search/controllers.js
@@ -84,6 +84,9 @@ async function renderSearchResults(req, res) {
     searchEntity,
     searchTerm,
     results,
+    features: {
+      isAddressAreaEnabled: res.locals.features['address-area-company-search'],
+    },
   })
 }
 

--- a/src/apps/search/view.njk
+++ b/src/apps/search/view.njk
@@ -16,7 +16,8 @@
 {% block main_grid_right_column %}
   {{
     CollectionContent(results | assign({
-      actionButtons: actionButtons
+      actionButtons: actionButtons,
+      features: features
     }))
   }}
 {% endblock %}

--- a/src/client/components/EntityList/useDnbSearch.jsx
+++ b/src/client/components/EntityList/useDnbSearch.jsx
@@ -12,7 +12,8 @@ function getTradingNames(dnb_company) {
       }
 }
 
-function getAddress(dnb_company) {
+function getAddress(dnb_company, features) {
+  const isAddressAreaEnabled = features && features.isAddressAreaEnabled
   return {
     label: 'Location at',
     value: compact([
@@ -20,20 +21,23 @@ function getAddress(dnb_company) {
       dnb_company.address_line_2,
       dnb_company.address_town,
       dnb_company.address_county,
-      dnb_company.address_area_name,
+      isAddressAreaEnabled ? dnb_company.address_area_name : null,
       dnb_company.address_postcode,
     ]).join(', '),
   }
 }
 
-function useDnbSearch(apiEndpoint) {
+function useDnbSearch(apiEndpoint, features) {
   function transformCompanyRecord(record) {
     const { dnb_company } = record
 
     return {
       id: dnb_company.duns_number,
       heading: dnb_company.primary_name,
-      meta: compact([getTradingNames(dnb_company), getAddress(dnb_company)]),
+      meta: compact([
+        getTradingNames(dnb_company),
+        getAddress(dnb_company, features),
+      ]),
       data: record,
     }
   }

--- a/src/client/components/EntityList/useDnbSearch.jsx
+++ b/src/client/components/EntityList/useDnbSearch.jsx
@@ -20,6 +20,7 @@ function getAddress(dnb_company) {
       dnb_company.address_line_2,
       dnb_company.address_town,
       dnb_company.address_county,
+      dnb_company.address_area_name,
       dnb_company.address_postcode,
     ]).join(', '),
   }

--- a/src/client/components/Form/elements/FieldDnbCompany/index.jsx
+++ b/src/client/components/Form/elements/FieldDnbCompany/index.jsx
@@ -52,9 +52,10 @@ const FieldDnbCompany = ({
   entityRenderer,
   onCannotFind,
   searchResultsMessage,
+  features,
 }) => {
   const { values, goBack, validateForm, setIsLoading } = useFormContext()
-  const { findCompany } = useDnbSearch(apiEndpoint)
+  const { findCompany } = useDnbSearch(apiEndpoint, features)
   const { onEntitySearch, searching, searched, error, entities } =
     useEntitySearch(findCompany)
 


### PR DESCRIPTION
## Description of change

Since we have added an address area field to US and Canadian countries there are a couple of places where the full address still doesn't display the new area field. This PR will fix that. 

## Test instructions
Navigate to `http://localhost:3000/search/companies?`
Any US (e.g. Mars Exports) or Canadian (e.g. Motorleaf) companies addresses will NOT contain address area.

Navigate to `http://localhost:3000/companies/create`
Select US as a company and search for Apple. When Apple is displayed, the address field will NOT contain address area.
Repeat for Canadian company. 

Go to Django Admin and activate a feature flag called `address-area-company-search`. 
VPN needs to be switched on for DNB search.

Navigating to the same pages as before, both will have an address area within the address field (e.g. a state or province).

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/70902973/123617879-987ea100-d7ff-11eb-93e4-18578da31061.png)

![image](https://user-images.githubusercontent.com/70902973/123627192-9cafbc00-d809-11eb-84ee-4e5b251f9b0b.png)


### After
![image](https://user-images.githubusercontent.com/70902973/123617798-8866c180-d7ff-11eb-914b-632ca8bfa411.png)

![image](https://user-images.githubusercontent.com/70902973/123617451-28701b00-d7ff-11eb-9f69-79396cc3ec41.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
