### PR TITLE
Swap country API call for OMIS market and apply disabled filter

### DIFF
--- a/src/apps/omis/client/OrdersCollection.jsx
+++ b/src/apps/omis/client/OrdersCollection.jsx
@@ -104,8 +104,8 @@ const OrdersCollection = ({
           name="primary_market"
           qsParam="primary_market"
           placeholder="Search countries"
-          options={optionMetadata.countryOptions}
-          selectedOptions={selectedFilters.selectedPrimaryMarkets}
+          options={optionMetadata.omisMarketOptions}
+          selectedOptions={selectedFilters.selectedOmisMarkets}
           data-test="country-filter"
         />
         <RoutedTypeahead

--- a/src/apps/omis/client/filters.js
+++ b/src/apps/omis/client/filters.js
@@ -24,8 +24,8 @@ export const buildSelectedFilters = (queryParams, metadata, statusOptions) => ({
     value: queryParams.sector_descends,
     categoryLabel: LABELS.sector,
   }),
-  selectedPrimaryMarkets: buildOptionsFilter({
-    options: metadata.countryOptions,
+  selectedOmisMarkets: buildOptionsFilter({
+    options: metadata.omisMarketOptions,
     value: queryParams.primary_market,
     categoryLabel: LABELS.country,
   }),

--- a/src/apps/omis/client/tasks.js
+++ b/src/apps/omis/client/tasks.js
@@ -34,12 +34,12 @@ export const getOrders = ({
 export const getOrdersMetadata = () =>
   Promise.all([
     getSectorOptions(metadata.sector()),
-    getMetadataOptions(metadata.country()),
+    getMetadataOptions(metadata.omisMarket()),
     getMetadataOptions(metadata.ukRegion()),
   ])
-    .then(([sectorOptions, countryOptions, ukRegionOptions]) => ({
+    .then(([sectorOptions, omisMarketOptions, ukRegionOptions]) => ({
       sectorOptions,
-      countryOptions,
+      omisMarketOptions,
       ukRegionOptions,
     }))
     .catch(handleError)

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -137,7 +137,7 @@ function FilteredCollectionHeader({
           qsParamName="country"
         />
         <RoutedFilterChips
-          selectedOptions={selectedFilters.selectedPrimaryMarkets}
+          selectedOptions={selectedFilters.selectedOmisMarkets}
           qsParamName="primary_market"
         />
         <RoutedFilterChips

--- a/src/client/metadata.js
+++ b/src/client/metadata.js
@@ -6,15 +6,27 @@ const HQ_TYPE_LABELS = {
   ehq: 'European HQ',
 }
 
+const filterDisabledOption = ({ disabled_on }) =>
+  disabled_on ? Date.parse(disabled_on) > Date.now() : true
+
+const transformMetadataOption = ({ id, name }) => ({
+  value: id,
+  label: name,
+})
+
 /**
- * Get metadata options as a list of values and labels
+ * Get a filtered list of metadata options
+ * @url the metadata endpoint
+ * @filterDisabled whether to filter each option based on its
+ * disabled_on key, defaulting to true
  */
-const getMetadataOptions = (url) =>
-  axios
-    .get(url)
-    .then(({ data }) =>
-      data.map(({ id, name }) => ({ value: id, label: name }))
-    )
+async function getMetadataOptions(url, { filterDisabled = true } = {}) {
+  const { data } = await axios.get(url)
+
+  return filterDisabled
+    ? data.filter(filterDisabledOption).map(transformMetadataOption)
+    : data.map(transformMetadataOption)
+}
 
 /**
  * Get the hq type options as a list of values and labels

--- a/test/functional/cypress/specs/contacts/filter-react-spec.js
+++ b/test/functional/cypress/specs/contacts/filter-react-spec.js
@@ -278,9 +278,9 @@ describe('Contacts Collections Filter', () => {
 
   context('UK Region', () => {
     const element = '[data-test="uk-region-filter"]'
-    const jerseyId = '924cd12a-6095-e211-a939-e4115bead28a'
+    const londonId = '874cd12a-6095-e211-a939-e4115bead28a'
     const expectedPayload = {
-      company_uk_region: [jerseyId],
+      company_uk_region: [londonId],
       limit: 10,
       offset: 0,
       archived: false,
@@ -288,15 +288,15 @@ describe('Contacts Collections Filter', () => {
     }
     it('should filter from the url', () => {
       const queryString = buildQueryString({
-        company_uk_region: [jerseyId],
+        company_uk_region: [londonId],
       })
       cy.intercept('POST', '/api-proxy/v3/search/contact').as('apiRequest')
       cy.visit(`${urls.contacts.react.index()}?${queryString}`)
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body).to.deep.equal(expectedPayload)
       })
-      cy.get(element).should('contain', 'Jersey')
-      assertChipExists({ label: 'Jersey', position: 1 })
+      cy.get(element).should('contain', 'London')
+      assertChipExists({ label: 'London', position: 1 })
     })
     it('should filter from user input and remove the chips', () => {
       const queryString = buildQueryString()
@@ -308,19 +308,19 @@ describe('Contacts Collections Filter', () => {
         element,
         legend: 'UK region',
         placeholder: 'Search UK region',
-        input: 'jer',
-        expectedOption: 'Jersey',
+        input: 'lon',
+        expectedOption: 'London',
       })
 
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body).to.deep.equal(expectedPayload)
       })
 
-      assertQueryParams('company_uk_region', [jerseyId])
-      assertChipExists({ label: 'Jersey', position: 1 })
+      assertQueryParams('company_uk_region', [londonId])
+      assertChipExists({ label: 'London', position: 1 })
       assertChipExists({ label: 'Active', position: 2 })
 
-      removeChip(jerseyId)
+      removeChip(londonId)
       cy.wait('@apiRequest')
       removeChip(activeStatusFlag)
       cy.wait('@apiRequest').then(({ request }) => {
@@ -369,7 +369,7 @@ describe('Contacts Collections Filter', () => {
         company_name: 'Tesco',
         company_sector_descends: 'af959812-6095-e211-a939-e4115bead28a',
         address_country: '80756b9a-5d95-e211-a939-e4115bead28a',
-        company_uk_region: '924cd12a-6095-e211-a939-e4115bead28a',
+        company_uk_region: '874cd12a-6095-e211-a939-e4115bead28a',
         archived: ['false', 'true'],
       })
       cy.visit(`${urls.contacts.react.index()}?${queryString}`)

--- a/test/functional/cypress/specs/omis/filter-react-spec.js
+++ b/test/functional/cypress/specs/omis/filter-react-spec.js
@@ -229,7 +229,7 @@ describe('Orders Collections Filter', () => {
     })
   })
 
-  context('Primary market (AKA country)', () => {
+  context('Primary market (AKA Omis Market)', () => {
     const element = '[data-test="country-filter"]'
     const brazilId = 'b05f66a0-5d95-e211-a939-e4115bead28a'
     const expectedPayload = {
@@ -273,21 +273,21 @@ describe('Orders Collections Filter', () => {
 
   context('UK Region', () => {
     const element = '[data-test="uk-region-filter"]'
-    const jerseyId = '924cd12a-6095-e211-a939-e4115bead28a'
+    const londonId = '874cd12a-6095-e211-a939-e4115bead28a'
     const expectedPayload = {
       ...minimumPayload,
-      uk_region: [jerseyId],
+      uk_region: [londonId],
     }
 
     it('should filter from the url', () => {
       const queryString = buildQueryString({
-        uk_region: [jerseyId],
+        uk_region: [londonId],
       })
       cy.intercept('POST', searchEndpoint).as('apiRequest')
       cy.visit(`${omis.react.index()}?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
-      cy.get(element).should('contain', 'Jersey')
-      assertChipExists({ label: 'Jersey', position: 1 })
+      cy.get(element).should('contain', 'London')
+      assertChipExists({ label: 'London', position: 1 })
     })
 
     it('should filter from user input and remove the chips', () => {
@@ -300,14 +300,14 @@ describe('Orders Collections Filter', () => {
         element,
         legend: 'UK region',
         placeholder: 'Search UK region',
-        input: 'jer',
-        expectedOption: 'Jersey',
+        input: 'lon',
+        expectedOption: 'London',
       })
       assertPayload('@apiRequest', expectedPayload)
-      assertQueryParams('uk_region', [jerseyId])
-      assertChipExists({ label: 'Jersey', position: 1 })
+      assertQueryParams('uk_region', [londonId])
+      assertChipExists({ label: 'London', position: 1 })
 
-      removeChip(jerseyId)
+      removeChip(londonId)
       assertPayload('@apiRequest', minimumPayload)
       assertChipsEmpty()
       assertFieldEmpty(element)
@@ -322,7 +322,7 @@ describe('Orders Collections Filter', () => {
         company_name: 'Tesco',
         sector_descends: 'af959812-6095-e211-a939-e4115bead28a',
         primary_market: '80756b9a-5d95-e211-a939-e4115bead28a',
-        uk_region: '924cd12a-6095-e211-a939-e4115bead28a',
+        uk_region: '874cd12a-6095-e211-a939-e4115bead28a',
       })
       cy.intercept('POST', searchEndpoint).as('apiRequest')
       cy.visit(`${omis.react.index()}?${queryString}`)


### PR DESCRIPTION
## Description of change

Swapped out the OMIS incorrect API call `v4/metadata/country` to `/v4/metadata/omis-market` and applied the default `disabled_on` filter. This means all metadata API calls will now automatically filter out any option that has been disabled. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
