### PR TITLE
Add four date filters to the orders(OMIS) collection page

### DIFF
--- a/src/apps/omis/client/OrdersCollection.jsx
+++ b/src/apps/omis/client/OrdersCollection.jsx
@@ -8,6 +8,7 @@ import {
 } from '../../../client/actions'
 
 import {
+  RoutedDateField,
   RoutedTypeahead,
   RoutedInputField,
   CollectionFilters,
@@ -71,6 +72,30 @@ const OrdersCollection = ({
           options={optionMetadata.statusOptions}
           selectedOptions={selectedFilters.selectedStatuses}
           data-test="status-filter"
+        />
+        <RoutedDateField
+          label={LABELS.completedOnAfter}
+          name="completed_on_after"
+          qsParamName="completed_on_after"
+          data-test="completed-on-after-filter"
+        />
+        <RoutedDateField
+          label={LABELS.completedOnBefore}
+          name="completed_on_before"
+          qsParamName="completed_on_before"
+          data-test="completed-on-before-filter"
+        />
+        <RoutedDateField
+          label={LABELS.deliveryDateAfter}
+          name="delivery_date_after"
+          qsParamName="delivery_date_after"
+          data-test="delivery-date-after-filter"
+        />
+        <RoutedDateField
+          label={LABELS.deliveryDateBefore}
+          name="delivery_date_before"
+          qsParamName="delivery_date_before"
+          data-test="deliver-date-before-filter"
         />
         <RoutedInputField
           id="OrdersCollection.reference"

--- a/src/apps/omis/client/constants.js
+++ b/src/apps/omis/client/constants.js
@@ -6,6 +6,10 @@ export const LABELS = {
   country: 'Country of origin',
   contactName: 'Contact name',
   companyName: 'Company name',
+  completedOnAfter: 'Completed date from',
+  completedOnBefore: 'Completed date to',
+  deliveryDateAfter: 'Expected delivery date from',
+  deliveryDateBefore: 'Expected delivery date to',
 }
 
 export const SORT_OPTIONS = [

--- a/src/apps/omis/client/filters.js
+++ b/src/apps/omis/client/filters.js
@@ -1,6 +1,7 @@
 import {
   buildOptionsFilter,
   buildInputFieldFilter,
+  buildDatesFilter,
 } from '../../../client/filters'
 
 import { LABELS } from './constants'
@@ -14,6 +15,22 @@ export const buildSelectedFilters = (queryParams, metadata, statusOptions) => ({
   selectedOrderReference: buildInputFieldFilter({
     value: queryParams.reference,
     categoryLabel: LABELS.reference,
+  }),
+  selectedCompletedOnAfter: buildDatesFilter({
+    value: queryParams.completed_on_after,
+    categoryLabel: LABELS.completedOnAfter,
+  }),
+  selectedCompletedOnBefore: buildDatesFilter({
+    value: queryParams.completed_on_before,
+    categoryLabel: LABELS.completedOnBefore,
+  }),
+  selectedDeliveryDateAfter: buildDatesFilter({
+    value: queryParams.delivery_date_after,
+    categoryLabel: LABELS.deliveryDateAfter,
+  }),
+  selectedDeliveryDateBefore: buildDatesFilter({
+    value: queryParams.delivery_date_before,
+    categoryLabel: LABELS.deliveryDateBefore,
   }),
   selectedCompanyName: buildInputFieldFilter({
     value: queryParams.company_name,

--- a/src/apps/omis/client/tasks.js
+++ b/src/apps/omis/client/tasks.js
@@ -17,6 +17,10 @@ export const getOrders = ({
   contact_name,
   primary_market,
   sector_descends,
+  completed_on_after,
+  completed_on_before,
+  delivery_date_after,
+  delivery_date_before,
 }) =>
   axios
     .post('/api-proxy/v3/search/order', {
@@ -30,6 +34,10 @@ export const getOrders = ({
       contact_name,
       primary_market,
       sector_descends,
+      completed_on_after,
+      completed_on_before,
+      delivery_date_after,
+      delivery_date_before,
     })
     .then(({ data }) => transformResponseToCollection(data), handleError)
 

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -108,6 +108,29 @@ function FilteredCollectionHeader({
           showCategoryLabels={true}
         />
         <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedCompletedOnAfter}
+          qsParamName="completed_on_after"
+          showCategoryLabels={true}
+        />
+
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedCompletedOnBefore}
+          qsParamName="completed_on_before"
+          showCategoryLabels={true}
+        />
+
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedDeliveryDateAfter}
+          qsParamName="delivery_date_after"
+          showCategoryLabels={true}
+        />
+
+        <RoutedFilterChips
+          selectedOptions={selectedFilters.selectedDeliveryDateBefore}
+          qsParamName="delivery_date_before"
+          showCategoryLabels={true}
+        />
+        <RoutedFilterChips
           selectedOptions={selectedFilters.selectedOrderReference}
           qsParamName="reference"
         />

--- a/test/functional/cypress/specs/omis/filter-react-spec.js
+++ b/test/functional/cypress/specs/omis/filter-react-spec.js
@@ -1,8 +1,15 @@
 import { omis } from '../../../../../src/lib/urls'
 import qs from 'qs'
 
-import { removeChip, clickCheckboxGroupOption } from '../../support/actions'
-import { assertCheckboxGroupNoneSelected } from '../../support/assertions'
+import {
+  removeChip,
+  inputDateValue,
+  clickCheckboxGroupOption,
+} from '../../support/actions'
+import {
+  assertDateInput,
+  assertCheckboxGroupNoneSelected,
+} from '../../support/assertions'
 import { testTypeahead } from '../../support/tests'
 import { randomChoice } from '../../fakers/utils'
 
@@ -148,6 +155,202 @@ describe('Orders Collections Filter', () => {
       assertPayload('@apiRequest', minimumPayload)
       assertChipsEmpty()
       assertFieldEmpty(element)
+    })
+  })
+
+  context('Completed date (from/to)', () => {
+    const fromElement = '[data-test="completed-on-after-filter"]'
+    const fromDate = '2020-01-25'
+    const formattedFromDate = '25 January 2020'
+    const toElement = '[data-test="completed-on-before-filter"]'
+    const toDate = '2021-06-24'
+    const formattedToDate = '24 June 2021'
+    const expectedPayload = {
+      ...minimumPayload,
+      completed_on_after: fromDate,
+      completed_on_before: toDate,
+    }
+
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        completed_on_after: fromDate,
+        completed_on_before: toDate,
+      })
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`${omis.react.index()}?${queryString}`)
+      assertPayload('@apiRequest', expectedPayload)
+      assertChipExists({
+        label: `Completed date from: ${formattedFromDate}`,
+        position: 1,
+      })
+      assertChipExists({
+        label: `Completed date to: ${formattedToDate}`,
+        position: 2,
+      })
+      assertDateInput({
+        element: fromElement,
+        label: 'Completed date from',
+        value: fromDate,
+      })
+      assertDateInput({
+        element: toElement,
+        label: 'Completed date to',
+        value: toDate,
+      })
+    })
+
+    it('should filter from user input and remove the chip', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`${omis.react.index()}?${queryString}`)
+      cy.wait('@apiRequest')
+
+      inputDateValue({
+        element: fromElement,
+        value: fromDate,
+      })
+      cy.wait('@apiRequest')
+      inputDateValue({
+        element: toElement,
+        value: toDate,
+      })
+      assertPayload('@apiRequest', expectedPayload)
+
+      assertQueryParams('completed_on_after', fromDate)
+      assertQueryParams('completed_on_before', toDate)
+      assertChipExists({
+        label: `Completed date from: ${formattedFromDate}`,
+        position: 1,
+      })
+      assertChipExists({
+        label: `Completed date to: ${formattedToDate}`,
+        position: 2,
+      })
+      assertDateInput({
+        element: fromElement,
+        label: 'Completed date from',
+        value: fromDate,
+      })
+      assertDateInput({
+        element: toElement,
+        label: 'Completed date to',
+        value: toDate,
+      })
+
+      removeChip(fromDate)
+      cy.wait('@apiRequest')
+      removeChip(toDate)
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+
+      assertDateInput({
+        element: fromElement,
+        label: 'Completed date from',
+        value: '',
+      })
+      assertDateInput({
+        element: toElement,
+        label: 'Completed date to',
+        value: '',
+      })
+    })
+  })
+
+  context('Expected delivery date (from/to)', () => {
+    const fromElement = '[data-test="delivery-date-after-filter"]'
+    const fromDate = '2020-01-25'
+    const formattedFromDate = '25 January 2020'
+    const toElement = '[data-test="deliver-date-before-filter"]'
+    const toDate = '2021-06-24'
+    const formattedToDate = '24 June 2021'
+    const expectedPayload = {
+      ...minimumPayload,
+      delivery_date_after: fromDate,
+      delivery_date_before: toDate,
+    }
+
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        delivery_date_after: fromDate,
+        delivery_date_before: toDate,
+      })
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`${omis.react.index()}?${queryString}`)
+      assertPayload('@apiRequest', expectedPayload)
+      assertChipExists({
+        label: `Expected delivery date from: ${formattedFromDate}`,
+        position: 1,
+      })
+      assertChipExists({
+        label: `Expected delivery date to: ${formattedToDate}`,
+        position: 2,
+      })
+      assertDateInput({
+        element: fromElement,
+        label: 'Expected delivery date from',
+        value: fromDate,
+      })
+      assertDateInput({
+        element: toElement,
+        label: 'Expected delivery date to',
+        value: toDate,
+      })
+    })
+
+    it('should filter from user input and remove the chip', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`${omis.react.index()}?${queryString}`)
+      cy.wait('@apiRequest')
+
+      inputDateValue({
+        element: fromElement,
+        value: fromDate,
+      })
+      cy.wait('@apiRequest')
+      inputDateValue({
+        element: toElement,
+        value: toDate,
+      })
+      assertPayload('@apiRequest', expectedPayload)
+
+      assertQueryParams('delivery_date_after', fromDate)
+      assertQueryParams('delivery_date_before', toDate)
+      assertChipExists({
+        label: `Expected delivery date from: ${formattedFromDate}`,
+        position: 1,
+      })
+      assertChipExists({
+        label: `Expected delivery date to: ${formattedToDate}`,
+        position: 2,
+      })
+      assertDateInput({
+        element: fromElement,
+        label: 'Expected delivery date from',
+        value: fromDate,
+      })
+      assertDateInput({
+        element: toElement,
+        label: 'Expected delivery date to',
+        value: toDate,
+      })
+
+      removeChip(fromDate)
+      cy.wait('@apiRequest')
+      removeChip(toDate)
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+
+      assertDateInput({
+        element: fromElement,
+        label: 'Expected delivery date from',
+        value: '',
+      })
+      assertDateInput({
+        element: toElement,
+        label: 'Expected delivery date to',
+        value: '',
+      })
     })
   })
 


### PR DESCRIPTION
## Description of change

Adding four date filters to the orders (OMIS) collection page

## Test instructions

Navigate to `/omis/react`

## Screenshots
<img width="1014" alt="Screenshot 2021-06-28 at 18 32 27" src="https://user-images.githubusercontent.com/964268/123679650-a18f6280-d83f-11eb-9922-8183fcfb1fe5.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
