### PR TITLE
React interactions collection list - sort by

### DIFF
--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -13,3 +13,8 @@ export const KIND_OPTIONS = [
   { label: LABELS.interaction, value: 'interaction' },
   { label: LABELS.serviceDelivery, value: 'service_delivery' },
 ]
+
+export const SORT_OPTIONS = [
+  { value: 'date:desc', name: 'Recently created' },
+  { value: 'subject', name: 'Subject A-Z' },
+]

--- a/src/apps/interactions/client/state.js
+++ b/src/apps/interactions/client/state.js
@@ -9,6 +9,7 @@ export const TASK_GET_INTERACTIONS_METADATA = 'TASK_GET_INTERACTIONS_METADATA'
 export const ID = 'interactionsList'
 
 import { buildSelectedFilters } from './filters'
+import { SORT_OPTIONS } from './constants'
 
 const parseQueryString = (queryString) => {
   const queryProps = omitBy({ ...qs.parse(queryString) }, isEmpty)
@@ -34,7 +35,7 @@ export const state2props = ({ router, ...state }) => {
     ...state[ID],
     payload: queryParams,
     optionMetadata: {
-      sortOptions: [],
+      sortOptions: SORT_OPTIONS,
       ...metadata,
     },
     selectedFilters,

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -26,6 +26,7 @@ const getInteractions = ({
   service,
   date_before,
   date_after,
+  sortby,
 }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
@@ -33,7 +34,7 @@ const getInteractions = ({
       kind,
       dit_participants__adviser: adviser,
       offset: limit * (page - 1),
-      sortby: 'date:desc',
+      sortby,
       date_before,
       date_after,
       service,

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -26,7 +26,7 @@ const getInteractions = ({
   service,
   date_before,
   date_after,
-  sortby,
+  sortby = 'date:desc',
 }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {

--- a/test/functional/cypress/specs/interaction/sort-spec-react.js
+++ b/test/functional/cypress/specs/interaction/sort-spec-react.js
@@ -18,10 +18,13 @@ describe('Interactions Collections Sort', () => {
 
     it('should have all sort options', () => {
       cy.get('[data-test="sortby"] option').then((options) => {
-        const sortOptions = [...options].map((o) => [o.value, o.text])
+        const sortOptions = [...options].map((o) => ({
+          value: o.value,
+          label: o.label,
+        }))
         expect(sortOptions).to.deep.eq([
-          ['date:desc', 'Recently created'],
-          ['subject', 'Subject A-Z'],
+          { value: 'date:desc', label: 'Recently created' },
+          { value: 'subject', label: 'Subject A-Z' },
         ])
       })
     })
@@ -37,14 +40,14 @@ describe('Interactions Collections Sort', () => {
     })
 
     it('should sort by "Recently created"', () => {
-      cy.get(element).select('date:desc')
+      cy.get(element).select('Recently created')
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body.sortby).to.equal('date:desc')
       })
     })
 
     it('should sort by "Subject A-Z"', () => {
-      cy.get(element).select('subject')
+      cy.get(element).select('Subject A-Z')
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body.sortby).to.equal('subject')
       })

--- a/test/functional/cypress/specs/interaction/sort-spec-react.js
+++ b/test/functional/cypress/specs/interaction/sort-spec-react.js
@@ -1,0 +1,53 @@
+import urls from '../../../../../src/lib/urls'
+
+const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction'
+
+describe('Interactions Collections Sort', () => {
+  context('Default sort', () => {
+    before(() => {
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.visit(urls.interactions.react())
+      cy.wait('@apiRequest')
+    })
+
+    it('should apply the default sort', () => {
+      cy.wait('@apiRequest').then(({ request }) => {
+        expect(request.body.sortby).to.equal('date:desc')
+      })
+    })
+
+    it('should have all sort options', () => {
+      cy.get('[data-test="sortby"] option').then((options) => {
+        const sortOptions = [...options].map((o) => [o.value, o.text])
+        expect(sortOptions).to.deep.eq([
+          ['date:desc', 'Recently created'],
+          ['subject', 'Subject A-Z'],
+        ])
+      })
+    })
+  })
+
+  context('User sort', () => {
+    const element = '[data-test="sortby"] select'
+
+    beforeEach(() => {
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.visit(`${urls.interactions.react()}?page=1`)
+      cy.wait('@apiRequest')
+    })
+
+    it('should sort by "Recently created"', () => {
+      cy.get(element).select('date:desc')
+      cy.wait('@apiRequest').then(({ request }) => {
+        expect(request.body.sortby).to.equal('date:desc')
+      })
+    })
+
+    it('should sort by "Subject A-Z"', () => {
+      cy.get(element).select('subject')
+      cy.wait('@apiRequest').then(({ request }) => {
+        expect(request.body.sortby).to.equal('subject')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
This adds the sort to the new interactions collection page. 

Note: The labels are different than production as they have been changed for consistency and I have removed "Company A-Z" as this is broken in production. 

## Test instructions

1. Visit `interactions/react`
2. Sort using the two options provided.

## Screenshots
![Screenshot 2021-06-29 at 11 38 21](https://user-images.githubusercontent.com/10154302/123784066-f6c68500-d8ce-11eb-99dd-d8afbf956bc1.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
