### PR TITLE
Resolve feature flag not applying correctly to Add Company Form

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -127,6 +127,7 @@ function AddCompanyForm({
               <CompanyNotFoundStep
                 organisationTypes={organisationTypes}
                 country={country}
+                features={features}
               />
             )}
             {values.cannotFind && (

--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -55,7 +55,7 @@ const nameValidator = (value) => {
     ? 'Enter a valid name'
     : null
 }
-function CompanyNotFoundStep({ organisationTypes, country }) {
+function CompanyNotFoundStep({ organisationTypes, country, features }) {
   return (
     <Step name="unhappy">
       <Details summary="Why am I seeing this?">
@@ -99,6 +99,7 @@ function CompanyNotFoundStep({ organisationTypes, country }) {
           name: country.label,
         }}
         apiEndpoint="/api/postcodelookup"
+        features={features}
       />
     </Step>
   )

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -37,6 +37,8 @@ async function renderAddCompanyForm(req, res, next) {
           features: {
             isAddressAreaEnabled:
               res.locals.features['address-area-company-search'],
+            areaFormField:
+              res.locals.features['edit-business-details-area-fields'],
           },
         },
       })

--- a/src/apps/companies/apps/edit-company/controllers.js
+++ b/src/apps/companies/apps/edit-company/controllers.js
@@ -15,7 +15,6 @@ const { isItaTierDAccount } = require('../../../../lib/is-tier-type-company')
 async function renderEditCompanyForm(req, res, next) {
   try {
     const { company } = res.locals
-    const features = res.locals.features
 
     const [turnoverRanges, employeeRanges, regions, sectors, headquarterTypes] =
       await Promise.all([
@@ -45,7 +44,10 @@ async function renderEditCompanyForm(req, res, next) {
           regions,
           sectors,
           headquarterTypes,
-          features,
+          features: {
+            areaFormField:
+              res.locals.features['edit-business-details-area-fields'],
+          },
         },
       })
   } catch (error) {

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -45,8 +45,7 @@ const FieldAddress = ({
   onSelectUKAddress,
   features,
 }) => {
-  const areaFieldEnabled =
-    features && features['edit-business-details-area-fields']
+  const areaFieldEnabled = features && features.areaFormField
   const findAdministrativeAreas = useAdministrativeAreaLookup()
   const {
     onAdministrativeAreaSearch,

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -20,6 +20,13 @@ const gotoOverseasCompanySearchResultsPage = () => {
   cy.get(selectors.companyAdd.entitySearch.searchButton).click()
 }
 
+const gotoUsCompanySearchPage = () => {
+  cy.visit(urls.companies.create())
+  cy.get(selectors.companyAdd.form).find('[type="radio"]').check('overseas')
+  cy.get(selectors.companyAdd.form).find('select').select('United States')
+  cy.get(selectors.companyAdd.continueButton).click()
+}
+
 const gotoUKCompanySearchResultsPage = () => {
   cy.visit(urls.companies.create())
   cy.get(selectors.companyAdd.form).find('[type="radio"]').check('GB')
@@ -32,6 +39,14 @@ const gotoAddUKCompanyPage = (listItem) => {
   gotoUKCompanySearchResultsPage()
   cy.get(listItem).click()
   cy.get(selectors.companyAdd.continueButton).click()
+}
+
+const gotoUsCompanySearchResultsPage = () => {
+  gotoUsCompanySearchPage()
+  cy.get(selectors.companyAdd.entitySearch.companyNameField).type(
+    'a US company'
+  )
+  cy.get(selectors.companyAdd.entitySearch.searchButton).click()
 }
 
 const gotoManualAddUKCompanyPage = () => {
@@ -650,6 +665,67 @@ describe('Add company form', () => {
         .next()
         .find('select option:selected')
         .should('have.text', '-- Select DIT region --')
+    })
+  })
+
+  context('when manually adding a new US company', () => {
+    before(() => {
+      gotoUsCompanySearchResultsPage()
+
+      cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
+      cy.get(
+        selectors.companyAdd.entitySearch.cannotFind.stillCannotFind
+      ).click()
+    })
+
+    it('should display the manual entry form', () => {
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType
+          .governmentDepartmentOrOtherPublicBody
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType
+          .limitedCompany
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType
+          .limitedPartnership
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType.partnership
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.website).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.area).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.form).contains('United States')
     })
   })
 })

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -7,27 +7,27 @@ const fixtures = require('../../fixtures')
 const { assertBreadcrumbs } = require('../../support/assertions')
 const urls = require('../../../../../src/lib/urls')
 
-const gotoOverseasCompanySearchPage = () => {
+const goToOverseasCompanySearchPage = () => {
   cy.visit(urls.companies.create())
   cy.get(selectors.companyAdd.form).find('[type="radio"]').check('overseas')
   cy.get(selectors.companyAdd.form).find('select').select('Poland')
   cy.get(selectors.companyAdd.continueButton).click()
 }
 
-const gotoOverseasCompanySearchResultsPage = () => {
-  gotoOverseasCompanySearchPage()
+const goToOverseasCompanySearchResultsPage = () => {
+  goToOverseasCompanySearchPage()
   cy.get(selectors.companyAdd.entitySearch.companyNameField).type('a company')
   cy.get(selectors.companyAdd.entitySearch.searchButton).click()
 }
 
-const gotoUsCompanySearchPage = () => {
+const goToUSCompanySearchPage = () => {
   cy.visit(urls.companies.create())
   cy.get(selectors.companyAdd.form).find('[type="radio"]').check('overseas')
   cy.get(selectors.companyAdd.form).find('select').select('United States')
   cy.get(selectors.companyAdd.continueButton).click()
 }
 
-const gotoUKCompanySearchResultsPage = () => {
+const goToUKCompanySearchResultsPage = () => {
   cy.visit(urls.companies.create())
   cy.get(selectors.companyAdd.form).find('[type="radio"]').check('GB')
   cy.get(selectors.companyAdd.continueButton).click()
@@ -35,28 +35,28 @@ const gotoUKCompanySearchResultsPage = () => {
   cy.get(selectors.companyAdd.entitySearch.searchButton).click()
 }
 
-const gotoAddUKCompanyPage = (listItem) => {
-  gotoUKCompanySearchResultsPage()
+const goToAddUKCompanyPage = (listItem) => {
+  goToUKCompanySearchResultsPage()
   cy.get(listItem).click()
   cy.get(selectors.companyAdd.continueButton).click()
 }
 
-const gotoUsCompanySearchResultsPage = () => {
-  gotoUsCompanySearchPage()
+const goToUSCompanySearchResultsPage = () => {
+  goToUSCompanySearchPage()
   cy.get(selectors.companyAdd.entitySearch.companyNameField).type(
     'a US company'
   )
   cy.get(selectors.companyAdd.entitySearch.searchButton).click()
 }
 
-const gotoManualAddUKCompanyPage = () => {
-  gotoUKCompanySearchResultsPage()
+const goToManualAddUKCompanyPage = () => {
+  goToUKCompanySearchResultsPage()
   cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
   cy.get(selectors.companyAdd.entitySearch.cannotFind.stillCannotFind).click()
 }
 
-const gotoUKCompanySectorAndRegionPage = () => {
-  gotoManualAddUKCompanyPage()
+const goToUKCompanySectorAndRegionPage = () => {
+  goToManualAddUKCompanyPage()
   cy.get(
     selectors.companyAdd.newCompanyRecordForm.organisationType.limitedCompany
   ).click()
@@ -90,7 +90,7 @@ describe('Add company form', () => {
     'when viewing a company in the list thats already in Data Hub',
     () => {
       it('should show that the company is already in Data Hub', () => {
-        gotoUKCompanySearchResultsPage()
+        goToUKCompanySearchResultsPage()
         cy.get('[data-test="entity-list"] li')
           .eq(1)
           .find('h3')
@@ -187,7 +187,7 @@ describe('Add company form', () => {
 
   context('when an overseas country is picked', () => {
     before(() => {
-      gotoOverseasCompanySearchPage()
+      goToOverseasCompanySearchPage()
     })
 
     it('should display the "Find the company" heading', () => {
@@ -241,7 +241,7 @@ describe('Add company form', () => {
 
   context('when an overseas company is searched', () => {
     before(() => {
-      gotoOverseasCompanySearchResultsPage()
+      goToOverseasCompanySearchResultsPage()
     })
 
     it('should display the entity search results', () => {
@@ -256,7 +256,7 @@ describe('Add company form', () => {
 
   context('when a company is picked that does not exist on Data Hub', () => {
     before(() => {
-      gotoOverseasCompanySearchResultsPage()
+      goToOverseasCompanySearchResultsPage()
       cy.contains('Some unmatched company').click()
     })
 
@@ -295,7 +295,7 @@ describe('Add company form', () => {
 
   context('when adding a company that does not exist on Data Hub', () => {
     beforeEach(() => {
-      gotoOverseasCompanySearchResultsPage()
+      goToOverseasCompanySearchResultsPage()
       cy.contains('Some unmatched company').click()
       cy.get(selectors.companyAdd.continueButton).click()
     })
@@ -346,7 +346,7 @@ describe('Add company form', () => {
 
   context('when manually adding a new UK-based company', () => {
     beforeEach(() => {
-      gotoManualAddUKCompanyPage()
+      goToManualAddUKCompanyPage()
     })
 
     it('should display the manual entry form', () => {
@@ -476,7 +476,7 @@ describe('Add company form', () => {
 
   context('when valid details are submitted for a new UK company', () => {
     beforeEach(() => {
-      gotoUKCompanySectorAndRegionPage()
+      goToUKCompanySectorAndRegionPage()
     })
 
     it('should render the region and sector fields', () => {
@@ -508,7 +508,7 @@ describe('Add company form', () => {
 
   context('when a valid sector and region are submitted', () => {
     before(() => {
-      gotoUKCompanySectorAndRegionPage()
+      goToUKCompanySectorAndRegionPage()
       cy.get(selectors.companyAdd.newCompanyRecordForm.region).select('London')
       cy.get(selectors.companyAdd.newCompanyRecordForm.sector).select(
         'Advanced Engineering'
@@ -533,7 +533,7 @@ describe('Add company form', () => {
 
   context('when manually adding a new overseas company', () => {
     before(() => {
-      gotoOverseasCompanySearchResultsPage()
+      goToOverseasCompanySearchResultsPage()
 
       cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
       cy.get(
@@ -598,7 +598,7 @@ describe('Add company form', () => {
   context('when "UK" is selected for the company location', () => {
     beforeEach(() => {
       const { results } = selectors.companyAdd.entitySearch
-      gotoAddUKCompanyPage(results.someCompanyName)
+      goToAddUKCompanyPage(results.someCompanyName)
     })
 
     it('should render an "Add a company" H1 element', () => {
@@ -657,7 +657,7 @@ describe('Add company form', () => {
   context('when a UK company postcode is unknown', () => {
     before(() => {
       const { results } = selectors.companyAdd.entitySearch
-      gotoAddUKCompanyPage(results.companyUnknownPostcode)
+      goToAddUKCompanyPage(results.companyUnknownPostcode)
     })
 
     it('should prompt the user to select a "Region"', () => {
@@ -670,7 +670,7 @@ describe('Add company form', () => {
 
   context('when manually adding a new US company', () => {
     before(() => {
-      gotoUsCompanySearchResultsPage()
+      goToUSCompanySearchResultsPage()
 
       cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
       cy.get(

--- a/test/selectors/company/add-company.js
+++ b/test/selectors/company/add-company.js
@@ -50,6 +50,7 @@ module.exports = {
     },
     region: 'select#uk_region',
     sector: 'select#sector',
+    area: 'select#area',
   },
   companyDetails: {
     subheader: 'form h2',


### PR DESCRIPTION
## Description of change

Feature flag to show State/Province on the Add Company Form wasn't working previously as it wasn't passed down correctly. This PR resolves that issue and updates it to match the pattern for passing down other feature flags.

## Test instructions

Enable the feature flag `edit-business-details-area-fields` and add a new company (manually, not via dnb). If you select United States or Canada as the country, you should have a field called State or Province with the relevant options listed.

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/123826122-62bce380-d8f7-11eb-9b44-42d66499b755.png)

### After

![image](https://user-images.githubusercontent.com/20663545/123827111-3f466880-d8f8-11eb-857e-e40e755d75fe.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
