### PR TITLE
Move Footer links to URL module

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -183,7 +183,7 @@ const StepInteractionDetails = ({
   const isServiceDelivery = values.kind === KINDS.SERVICE_DELIVERY
 
   const helpUrl = (position) =>
-    urls.external.policyFeedbackHelp +
+    urls.external.helpCentre.policyFeedback() +
     '?' +
     qs.stringify({
       ..._.pick(values, ['theme', 'kind']),

--- a/src/client/components/Footer/__stories__/usage.md
+++ b/src/client/components/Footer/__stories__/usage.md
@@ -3,9 +3,7 @@ Footer
 
 ### Description
 
-The Footer displayed in all pages across the datahub site.
-All links are hardcoded for now.
-
+The Footer displayed in all pages across the Data Hub site.
 
 ### Usage
 

--- a/src/client/components/Footer/index.jsx
+++ b/src/client/components/Footer/index.jsx
@@ -93,7 +93,7 @@ export default function Footer() {
           </li>
           <li>
             <FooterLink
-              href="https://data-services-help.trade.gov.uk/data-hub/"
+              href={urls.external.helpCentre.dhHomepage()}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -102,7 +102,7 @@ export default function Footer() {
           </li>
           <li>
             <FooterLink
-              href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/data-hub-privacy-policy/"
+              href={urls.external.digitalWorkspace.privacyPolicy}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -111,7 +111,7 @@ export default function Footer() {
           </li>
           <li>
             <FooterLink
-              href="https://data-services-help.trade.gov.uk/accessibility-statement/"
+              href={urls.external.helpCentre.accessibilityStatement()}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -120,7 +120,7 @@ export default function Footer() {
           </li>
         </StyleList>
         <CopyrightLink
-          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+          href={urls.external.copyright}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -81,15 +81,22 @@ module.exports = {
     digitalWorkspace: {
       teams:
         'https://people.trade.gov.uk/teams/department-for-international-trade',
+      privacyPolicy:
+        'https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/data-hub-privacy-policy/',
     },
-    policyFeedbackHelp:
-      'https://data-services-help.trade.gov.uk/data-hub/how-articles/interactions-and-service-delivery/record-business-intelligence-interaction/',
     helpCentre: {
+      accessibilityStatement: () =>
+        'https://data-services-help.trade.gov.uk/data-hub/how-articles/data-hub-accessibility-statement/data-hub-accessibility-statement/',
+      dhHomepage: () => 'https://data-services-help.trade.gov.uk/data-hub/',
       pipeline: () =>
         'https://data-services-help.trade.gov.uk/data-hub/how-articles/account-management/my-pipeline/',
+      policyFeedback: () =>
+        'https://data-services-help.trade.gov.uk/data-hub/how-articles/interactions-and-service-delivery/record-business-intelligence-interaction/',
       tradeagreementGuidance: () =>
         'https://data-services-help.trade.gov.uk/data-hub/how-articles/trade-agreement-activity/recording-trade-agreement-activity/',
     },
+    copyright:
+      'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/',
   },
   dashboard: url('/'),
   oauth: {


### PR DESCRIPTION
## Description of change

This PR moves all the hardcoded links from the footer into the URL module. I've also moved the Policy Feedback link in with the other help centre URLs. 

## Test instructions

The links in the footer should work the same as before.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
