### PR TITLE
React interactions collection list - Sector filter

### DIFF
--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -4,7 +4,6 @@ import urls from '../../../lib/urls'
 import {
   getHeadquarterTypeOptions,
   getMetadataOptions,
-  getSectorOptions,
 } from '../../../client/metadata'
 
 import { transformResponseToCompanyCollection } from './transformers'
@@ -54,7 +53,11 @@ const getCompanies = ({
  */
 const getCompaniesMetadata = () =>
   Promise.all([
-    getSectorOptions(urls.metadata.sector()),
+    getMetadataOptions(urls.metadata.sector(), {
+      params: {
+        level__lte: '0',
+      },
+    }),
     getHeadquarterTypeOptions(urls.metadata.headquarterType()),
     getMetadataOptions(urls.metadata.ukRegion()),
     getMetadataOptions(urls.metadata.country()),

--- a/src/apps/contacts/client/tasks.js
+++ b/src/apps/contacts/client/tasks.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 import { transformResponseToCollection } from './transformers'
 import urls from '../../../lib/urls'
-import { getMetadataOptions, getSectorOptions } from '../../../client/metadata'
+import { getMetadataOptions } from '../../../client/metadata'
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
@@ -33,7 +33,11 @@ export const getContacts = ({
 
 export const getContactsMetadata = () =>
   Promise.all([
-    getSectorOptions(urls.metadata.sector()),
+    getMetadataOptions(urls.metadata.sector(), {
+      params: {
+        level__lte: '0',
+      },
+    }),
     getMetadataOptions(urls.metadata.country()),
     getMetadataOptions(urls.metadata.ukRegion()),
   ])

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -61,6 +61,15 @@ const InteractionCollection = ({
     },
   }
 
+  const myInteractionsSelected = selectedFilters.advisers.options
+    .map(({ value }) => value)
+    .includes(currentAdviserId)
+
+  const myInteractionsOption = {
+    label: LABELS.myInteractions,
+    value: currentAdviserId,
+  }
+
   return (
     <FilteredCollectionList
       {...props}
@@ -99,8 +108,8 @@ const InteractionCollection = ({
         <RoutedCheckboxGroupField
           name="dit_participants__adviser"
           qsParam="adviser"
-          options={[{ label: LABELS.myInteractions, value: currentAdviserId }]}
-          selectedOptions={selectedFilters.myInteractions.options}
+          options={[myInteractionsOption]}
+          selectedOptions={myInteractionsSelected ? [myInteractionsOption] : []}
           data-test="my-interactions-filter"
         />
         <RoutedDateField
@@ -131,7 +140,7 @@ const InteractionCollection = ({
           qsParam="sector_descends"
           placeholder="Search sectors"
           options={optionMetadata.sectorOptions}
-          selectedOptions={selectedFilters.selectedSector}
+          selectedOptions={selectedFilters.sectors.options}
           data-test="sector-filter"
         />
       </CollectionFilters>

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -13,6 +13,7 @@ import {
   FilteredCollectionList,
   RoutedCheckboxGroupField,
   RoutedAdvisersTypeahead,
+  RoutedTypeahead,
   RoutedDateField,
   CollectionFilters,
 } from '../../../client/components'
@@ -122,6 +123,16 @@ const InteractionCollection = ({
           options={optionMetadata.serviceOptions}
           selectedOptions={selectedFilters.service.options}
           data-test="service-filter"
+        />
+        <RoutedTypeahead
+          isMulti={true}
+          legend={LABELS.sector}
+          name="sector"
+          qsParam="sector_descends"
+          placeholder="Search sectors"
+          options={optionMetadata.sectorOptions}
+          selectedOptions={selectedFilters.selectedSector}
+          data-test="sector-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -7,6 +7,7 @@ export const LABELS = {
   dateAfter: 'From',
   dateBefore: 'To',
   service: 'Service',
+  sector: 'Sector',
 }
 
 export const KIND_OPTIONS = [

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -23,14 +23,6 @@ export const buildSelectedFilters = (
       categoryLabel: LABELS.advisers,
     })),
   },
-  myInteractions: {
-    queryParam: 'adviser',
-    options: selectedAdvisers.map(({ advisers }) => ({
-      label: advisers.name,
-      value: advisers.id,
-      categoryLabel: LABELS.advisers,
-    })),
-  },
   datesAfter: {
     queryParam: 'date_after',
     options: buildDatesFilter({
@@ -53,12 +45,12 @@ export const buildSelectedFilters = (
       categoryLabel: LABELS.service,
     }),
   },
-  service: {
-    queryParam: 'service',
+  sectors: {
+    queryParam: 'sector_descends',
     options: buildOptionsFilter({
-      options: metadata.serviceOptions,
-      value: queryParams.service,
-      categoryLabel: LABELS.service,
+      options: metadata.sectorOptions,
+      value: queryParams.sector_descends,
+      categoryLabel: LABELS.sector,
     }),
   },
 })

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -53,4 +53,12 @@ export const buildSelectedFilters = (
       categoryLabel: LABELS.service,
     }),
   },
+  service: {
+    queryParam: 'service',
+    options: buildOptionsFilter({
+      options: metadata.serviceOptions,
+      value: queryParams.service,
+      categoryLabel: LABELS.service,
+    }),
+  },
 })

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -4,7 +4,7 @@ import urls from '../../../lib/urls'
 
 import { transformResponseToCollection } from './transformers'
 
-import { getMetadataOptions, getSectorOptions } from '../../../client/metadata'
+import { getMetadataOptions } from '../../../client/metadata'
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
@@ -14,7 +14,11 @@ const sortServiceOptions = (options) =>
 const getInteractionsMetadata = () =>
   Promise.all([
     getMetadataOptions(urls.metadata.service()),
-    getSectorOptions(urls.metadata.sector()),
+    getMetadataOptions(urls.metadata.sector(), {
+      params: {
+        level__lte: '0',
+      },
+    }),
   ])
     .then(([serviceOptions, sectorOptions]) => ({
       serviceOptions: sortServiceOptions(serviceOptions),

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -4,7 +4,7 @@ import urls from '../../../lib/urls'
 
 import { transformResponseToCollection } from './transformers'
 
-import { getMetadataOptions } from '../../../client/metadata'
+import { getMetadataOptions, getSectorOptions } from '../../../client/metadata'
 
 const handleError = (e) => Promise.reject(Error(e.response.data.detail))
 
@@ -12,9 +12,13 @@ const sortServiceOptions = (options) =>
   options.sort((a, b) => (a.label > b.label ? 1 : b.label > a.label ? -1 : 0))
 
 const getInteractionsMetadata = () =>
-  Promise.all([getMetadataOptions(urls.metadata.service())])
-    .then(([serviceOptions]) => ({
+  Promise.all([
+    getMetadataOptions(urls.metadata.service()),
+    getSectorOptions(urls.metadata.sector()),
+  ])
+    .then(([serviceOptions, sectorOptions]) => ({
       serviceOptions: sortServiceOptions(serviceOptions),
+      sectorOptions,
     }))
     .catch(handleError)
 
@@ -27,6 +31,7 @@ const getInteractions = ({
   date_before,
   date_after,
   sortby = 'date:desc',
+  sector_descends,
 }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
@@ -38,6 +43,7 @@ const getInteractions = ({
       date_before,
       date_after,
       service,
+      sector_descends,
     })
     .then(({ data }) => transformResponseToCollection(data), handleError)
 

--- a/src/apps/investments/client/projects/tasks.js
+++ b/src/apps/investments/client/projects/tasks.js
@@ -1,9 +1,6 @@
 import axios from 'axios'
 
-import {
-  getMetadataOptions,
-  getSectorOptions,
-} from '../../../../client/metadata'
+import { getMetadataOptions } from '../../../../client/metadata'
 
 import transformInvestmentProjectToListItem from './transformers'
 
@@ -41,7 +38,11 @@ function getMetadata(metadataUrls) {
   return Promise.all(
     optionCategories.map((name) =>
       name == 'sectorOptions'
-        ? getSectorOptions(metadataUrls[name])
+        ? getMetadataOptions(metadataUrls[name], {
+            params: {
+              level__lte: '0',
+            },
+          })
         : getMetadataOptions(metadataUrls[name])
     ),
     handleError

--- a/src/apps/omis/client/tasks.js
+++ b/src/apps/omis/client/tasks.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { getMetadataOptions, getSectorOptions } from '../../../client/metadata'
+import { getMetadataOptions } from '../../../client/metadata'
 import { transformResponseToCollection } from './transformers'
 import { metadata } from '../../../lib/urls'
 
@@ -43,7 +43,11 @@ export const getOrders = ({
 
 export const getOrdersMetadata = () =>
   Promise.all([
-    getSectorOptions(metadata.sector()),
+    getMetadataOptions(metadata.sector(), {
+      params: {
+        level__lte: '0',
+      },
+    }),
     getMetadataOptions(metadata.omisMarket()),
     getMetadataOptions(metadata.ukRegion()),
   ])

--- a/src/client/metadata.js
+++ b/src/client/metadata.js
@@ -20,9 +20,13 @@ const transformMetadataOption = ({ id, name }) => ({
  * @filterDisabled whether to filter each option based on its
  * disabled_on key, defaulting to true
  */
-async function getMetadataOptions(url, { filterDisabled = true } = {}) {
-  const { data } = await axios.get(url)
-
+async function getMetadataOptions(
+  url,
+  { filterDisabled = true, params = {} } = {}
+) {
+  const { data } = await axios.get(url, {
+    params,
+  })
   return filterDisabled
     ? data.filter(filterDisabledOption).map(transformMetadataOption)
     : data.map(transformMetadataOption)
@@ -41,21 +45,4 @@ const getHeadquarterTypeOptions = (url) =>
       .sort((item1, item2) => (item1.label > item2.label ? 1 : -1))
   )
 
-/**
- * Get the top-level sector options as a list of values and labels
- *
- * Specifying a searchString uses the autocomplete feature to only show
- * matching results.
- */
-const getSectorOptions = (url, searchString) =>
-  axios
-    .get(url, {
-      params: searchString ? { autocomplete: searchString } : {},
-    })
-    .then(({ data }) =>
-      data
-        .filter(({ level }) => level === 0)
-        .map(({ id, name }) => ({ value: id, label: name }))
-    )
-
-export { getMetadataOptions, getHeadquarterTypeOptions, getSectorOptions }
+export { getMetadataOptions, getHeadquarterTypeOptions }

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -238,12 +238,7 @@ describe('Interactions Collections Filter', () => {
         element: myInteractionsFilter,
         value: adviser.id,
       })
-      cy.get(myInteractionsFilter)
-        .find(`input[value="${adviser.id}"]`)
-        .parent()
-        .click()
       cy.wait('@adviserApiRequest')
-
       assertPayload('@apiRequest', expectedPayload)
       assertQueryParams('adviser', [adviser.id])
       assertChipExists({ label: adviser.name, position: 1 })

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -17,7 +17,7 @@ export const selectFirstAdvisersTypeaheadOption = ({ element, input }) =>
  * Clicks the checkbox option with the given value
  */
 export const clickCheckboxGroupOption = ({ element, value }) => {
-  cy.get(element).find(`input[value="${value}"]`).click()
+  cy.get(element).find(`input[value="${value}"]`).parent().click()
 }
 
 /**


### PR DESCRIPTION
## Description of change

This adds the sector filter to the new React interactions collection list. 

Note: This also removes a function `getSectorOptions` as we don't need this anymore after extending the `getMetadataOptions` to accept a second arg of params. As a result of this refactor I have updated all collection pages so they all use one/same function.

## Test instructions

1. Go to `/interactions/react`
2. Filter results by sector

## Screenshots
![Screenshot 2021-06-30 at 17 14 14](https://user-images.githubusercontent.com/10154302/123998182-25c12180-d9c9-11eb-87c7-daef33338c50.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
