### PR TITLE
React interactions collection list - Business intelligence filter

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -7,7 +7,7 @@ import {
   INTERACTIONS__METADATA_LOADED,
 } from '../../../client/actions'
 
-import { LABELS, KIND_OPTIONS } from './constants'
+import { LABELS, KIND_OPTIONS, BUSINESS_INTELLIGENCE_OPTION } from './constants'
 
 import {
   FilteredCollectionList,
@@ -142,6 +142,14 @@ const InteractionCollection = ({
           options={optionMetadata.sectorOptions}
           selectedOptions={selectedFilters.sectors.options}
           data-test="sector-filter"
+        />
+        <RoutedCheckboxGroupField
+          legend={LABELS.businessIntelligence}
+          name="was_policy_feedback_provided"
+          qsParam="was_policy_feedback_provided"
+          options={BUSINESS_INTELLIGENCE_OPTION}
+          selectedOptions={selectedFilters.businessIntelligence.options}
+          data-test="business-intelligence-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -8,11 +8,19 @@ export const LABELS = {
   dateBefore: 'To',
   service: 'Service',
   sector: 'Sector',
+  businessIntelligence: 'Business intelligence',
 }
 
 export const KIND_OPTIONS = [
   { label: LABELS.interaction, value: 'interaction' },
   { label: LABELS.serviceDelivery, value: 'service_delivery' },
+]
+
+export const BUSINESS_INTELLIGENCE_OPTION = [
+  {
+    label: 'Includes business intelligence',
+    value: 'true',
+  },
 ]
 
 export const SORT_OPTIONS = [

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -1,4 +1,4 @@
-import { KIND_OPTIONS, LABELS } from './constants'
+import { KIND_OPTIONS, BUSINESS_INTELLIGENCE_OPTION, LABELS } from './constants'
 
 import { buildOptionsFilter, buildDatesFilter } from '../../../client/filters'
 
@@ -51,6 +51,14 @@ export const buildSelectedFilters = (
       options: metadata.sectorOptions,
       value: queryParams.sector_descends,
       categoryLabel: LABELS.sector,
+    }),
+  },
+  businessIntelligence: {
+    queryParam: 'was_policy_feedback_provided',
+    options: buildOptionsFilter({
+      options: BUSINESS_INTELLIGENCE_OPTION,
+      value: queryParams.was_policy_feedback_provided,
+      categoryLabel: LABELS.businessIntelligence,
     }),
   },
 })

--- a/src/apps/interactions/client/state.js
+++ b/src/apps/interactions/client/state.js
@@ -10,6 +10,7 @@ export const ID = 'interactionsList'
 
 import { buildSelectedFilters } from './filters'
 import { SORT_OPTIONS } from './constants'
+import { transformWasPolicyfeedBackProvidedToApi } from './transformers'
 
 const parseQueryString = (queryString) => {
   const queryProps = omitBy({ ...qs.parse(queryString) }, isEmpty)
@@ -31,7 +32,12 @@ export const state2props = ({ router, ...state }) => {
 
   return {
     ...state[ID],
-    payload: queryParams,
+    payload: {
+      ...queryParams,
+      was_policy_feedback_provided: transformWasPolicyfeedBackProvidedToApi(
+        queryParams.was_policy_feedback_provided
+      ),
+    },
     optionMetadata: {
       sortOptions: SORT_OPTIONS,
       ...metadata,

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -36,6 +36,7 @@ const getInteractions = ({
   date_after,
   sortby = 'date:desc',
   sector_descends,
+  was_policy_feedback_provided,
 }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
@@ -48,6 +49,7 @@ const getInteractions = ({
       date_after,
       service,
       sector_descends,
+      was_policy_feedback_provided,
     })
     .then(({ data }) => transformResponseToCollection(data), handleError)
 

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -78,3 +78,7 @@ export const transformResponseToCollection = ({ count, results = [] }) => ({
   count,
   results: results.map(transformInteractionToListItem),
 })
+
+export const transformWasPolicyfeedBackProvidedToApi = (
+  wasPolicyfeedbackProvided
+) => wasPolicyfeedbackProvided && wasPolicyfeedbackProvided[0] === 'true'

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -394,4 +394,42 @@ describe('Interactions Collections Filter', () => {
       assertFieldEmpty(element)
     })
   })
+
+  context('Business intelligence', () => {
+    const element = '[data-test="business-intelligence-filter"]'
+    const expectedPayload = {
+      ...minimumPayload,
+      was_policy_feedback_provided: true,
+    }
+
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        was_policy_feedback_provided: ['true'],
+      })
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      assertPayload('@apiRequest', expectedPayload)
+      assertCheckboxGroupOption({
+        element,
+        value: 'true',
+        checked: true,
+      })
+      assertChipExists({ label: 'Includes business intelligence', position: 1 })
+    })
+    it('should filter from user input and remove chips', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      cy.wait('@apiRequest')
+      clickCheckboxGroupOption({
+        element,
+        value: 'true',
+      })
+      assertPayload('@apiRequest', expectedPayload)
+      assertChipExists({ label: 'Includes business intelligence', position: 1 })
+      removeChip('true')
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+    })
+  })
 })


### PR DESCRIPTION
## Description of change

This adds the Business intelligence filter to the new react interactions collection list. It basically filters interactions based on wether they have had feedback provided or not.

## Test instructions

1. Go to `/interactions/react` 
2. Filter by "Business intelligence"

## Screenshots
![Screenshot 2021-07-02 at 16 01 33](https://user-images.githubusercontent.com/10154302/124294109-40250780-db4f-11eb-87dc-d89c6aa02199.png)
![Screenshot 2021-07-02 at 16 01 39](https://user-images.githubusercontent.com/10154302/124294134-45825200-db4f-11eb-8605-2101ddcf112c.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
