### PR TITLE
React interactions collection list - Policy areas filter

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -151,6 +151,15 @@ const InteractionCollection = ({
           selectedOptions={selectedFilters.businessIntelligence.options}
           data-test="business-intelligence-filter"
         />
+        <RoutedCheckboxGroupField
+          overflow="scroll"
+          legend={LABELS.policyAreas}
+          name="policy_areas"
+          qsParam="policy_areas"
+          options={optionMetadata.policyAreaOptions}
+          selectedOptions={selectedFilters.policyArea.options}
+          data-test="policy-area-filter"
+        />
       </CollectionFilters>
     </FilteredCollectionList>
   )

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -9,6 +9,7 @@ export const LABELS = {
   service: 'Service',
   sector: 'Sector',
   businessIntelligence: 'Business intelligence',
+  policyAreas: 'Policy area(s)',
 }
 
 export const KIND_OPTIONS = [

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -61,4 +61,12 @@ export const buildSelectedFilters = (
       categoryLabel: LABELS.businessIntelligence,
     }),
   },
+  policyArea: {
+    queryParam: 'policy_areas',
+    options: buildOptionsFilter({
+      options: metadata.policyAreaOptions,
+      value: queryParams.policy_areas,
+      categoryLabel: LABELS.policyAreas,
+    }),
+  },
 })

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -19,10 +19,12 @@ const getInteractionsMetadata = () =>
         level__lte: '0',
       },
     }),
+    getMetadataOptions(urls.metadata.policyArea()),
   ])
-    .then(([serviceOptions, sectorOptions]) => ({
+    .then(([serviceOptions, sectorOptions, policyAreaOptions]) => ({
       serviceOptions: sortServiceOptions(serviceOptions),
       sectorOptions,
+      policyAreaOptions,
     }))
     .catch(handleError)
 
@@ -37,6 +39,7 @@ const getInteractions = ({
   sortby = 'date:desc',
   sector_descends,
   was_policy_feedback_provided,
+  policy_areas,
 }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
@@ -50,6 +53,7 @@ const getInteractions = ({
       service,
       sector_descends,
       was_policy_feedback_provided,
+      policy_areas,
     })
     .then(({ data }) => transformResponseToCollection(data), handleError)
 

--- a/test/functional/cypress/fakers/policy-area.js
+++ b/test/functional/cypress/fakers/policy-area.js
@@ -1,0 +1,16 @@
+import faker from 'faker'
+import { listFaker } from './utils'
+
+const policyAreaFaker = (overrides = {}) => ({
+  id: faker.datatype.uuid(),
+  name: faker.name.jobArea(),
+  disabled_on: null,
+  ...overrides,
+})
+
+const policyAreaListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: policyAreaFaker, length, overrides })
+
+export { policyAreaFaker, policyAreaListFaker }
+
+export default policyAreaListFaker

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -23,6 +23,7 @@ import {
 import { testTypeahead } from '../../support/tests'
 
 import { serviceFaker } from '../../fakers/services'
+import { policyAreaFaker } from '../../fakers/policy-area'
 
 const buildQueryString = (queryParams = {}) =>
   qs.stringify({
@@ -40,6 +41,7 @@ const minimumPayload = {
 const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction'
 const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
 const serviceMetadataEndpoint = '/api-proxy/v4/metadata/service'
+const policyAreaMetadataEndpoint = '/api-proxy/v4/metadata/policy-area'
 const myAdviserId = '7d19d407-9aec-4d06-b190-d3f404627f21'
 const myAdviserEndpoint = `/api-proxy/adviser/${myAdviserId}`
 


### PR DESCRIPTION
## Description of change

This adds the policy area(s) filter to the new React interactions collection list.

## Test instructions

1. Go to `interactions/react`
2. Filter by "Policy area(s)"

## Screenshots
![Screenshot 2021-07-02 at 16 44 26](https://user-images.githubusercontent.com/10154302/124299497-677ed300-db55-11eb-8b6b-08d493a68e8f.png)
![Screenshot 2021-07-02 at 16 44 34](https://user-images.githubusercontent.com/10154302/124299510-6c438700-db55-11eb-92f5-97bdf514c284.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
