### PR TITLE
React interactions collection list - Add policy issue type filter

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -160,6 +160,14 @@ const InteractionCollection = ({
           selectedOptions={selectedFilters.policyArea.options}
           data-test="policy-area-filter"
         />
+        <RoutedCheckboxGroupField
+          legend={LABELS.policyIssueType}
+          name="policy_issue_types"
+          qsParam="policy_issue_types"
+          options={optionMetadata.policyIssueTypeOptions}
+          selectedOptions={selectedFilters.policyIssueType.options}
+          data-test="policy-issue-type-filter"
+        />
       </CollectionFilters>
     </FilteredCollectionList>
   )

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -10,6 +10,7 @@ export const LABELS = {
   sector: 'Sector',
   businessIntelligence: 'Business intelligence',
   policyAreas: 'Policy area(s)',
+  policyIssueType: 'Policy issue type',
 }
 
 export const KIND_OPTIONS = [

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -69,4 +69,12 @@ export const buildSelectedFilters = (
       categoryLabel: LABELS.policyAreas,
     }),
   },
+  policyIssueType: {
+    queryParam: 'policy_issue_types',
+    options: buildOptionsFilter({
+      options: metadata.policyIssueTypeOptions,
+      value: queryParams.policy_issue_types,
+      categoryLabel: LABELS.policyIssueType,
+    }),
+  },
 })

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -20,12 +20,21 @@ const getInteractionsMetadata = () =>
       },
     }),
     getMetadataOptions(urls.metadata.policyArea()),
+    getMetadataOptions(urls.metadata.policyIssueType()),
   ])
-    .then(([serviceOptions, sectorOptions, policyAreaOptions]) => ({
-      serviceOptions: sortServiceOptions(serviceOptions),
-      sectorOptions,
-      policyAreaOptions,
-    }))
+    .then(
+      ([
+        serviceOptions,
+        sectorOptions,
+        policyAreaOptions,
+        policyIssueTypeOptions,
+      ]) => ({
+        serviceOptions: sortServiceOptions(serviceOptions),
+        sectorOptions,
+        policyAreaOptions,
+        policyIssueTypeOptions,
+      })
+    )
     .catch(handleError)
 
 const getInteractions = ({
@@ -40,6 +49,7 @@ const getInteractions = ({
   sector_descends,
   was_policy_feedback_provided,
   policy_areas,
+  policy_issue_types,
 }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
@@ -54,6 +64,7 @@ const getInteractions = ({
       sector_descends,
       was_policy_feedback_provided,
       policy_areas,
+      policy_issue_types,
     })
     .then(({ data }) => transformResponseToCollection(data), handleError)
 

--- a/test/functional/cypress/fakers/policy-issue-type.js
+++ b/test/functional/cypress/fakers/policy-issue-type.js
@@ -1,0 +1,16 @@
+import faker from 'faker'
+import { listFaker } from './utils'
+
+const policyIssueTypeFaker = (overrides = {}) => ({
+  id: faker.datatype.uuid(),
+  name: faker.name.jobArea(),
+  disabled_on: null,
+  ...overrides,
+})
+
+const policyIssueTypeListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: policyIssueTypeFaker, length, overrides })
+
+export { policyIssueTypeFaker, policyIssueTypeListFaker }
+
+export default policyIssueTypeListFaker

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -446,10 +446,6 @@ describe('Interactions Collections Filter', () => {
     }
 
     it('should filter from the url', () => {
-      const expectedPayload = {
-        ...minimumPayload,
-        policy_areas: [policyArea.id],
-      }
       const queryString = buildQueryString({
         policy_areas: [policyArea.id],
       })

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -24,6 +24,7 @@ import { testTypeahead } from '../../support/tests'
 
 import { serviceFaker } from '../../fakers/services'
 import { policyAreaFaker } from '../../fakers/policy-area'
+import { policyIssueTypeFaker } from '../../fakers/policy-issue-type'
 
 const buildQueryString = (queryParams = {}) =>
   qs.stringify({
@@ -42,6 +43,8 @@ const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction'
 const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
 const serviceMetadataEndpoint = '/api-proxy/v4/metadata/service'
 const policyAreaMetadataEndpoint = '/api-proxy/v4/metadata/policy-area'
+const policyIssueTypeMetadataEndpoint =
+  '/api-proxy/v4/metadata/policy-issue-type'
 const myAdviserId = '7d19d407-9aec-4d06-b190-d3f404627f21'
 const myAdviserEndpoint = `/api-proxy/adviser/${myAdviserId}`
 
@@ -483,6 +486,57 @@ describe('Interactions Collections Filter', () => {
       assertQueryParams('policy_areas', [policyArea.id])
       assertChipExists({ label: policyArea.name, position: 1 })
       removeChip(policyArea.id)
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+      assertFieldEmpty(element)
+    })
+  })
+
+  context('Policy issue types', () => {
+    const element = '[data-test="policy-issue-type-filter"]'
+    const policyIssueType = policyIssueTypeFaker()
+    const expectedPayload = {
+      ...minimumPayload,
+      policy_issue_types: [policyIssueType.id],
+    }
+
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        policy_issue_types: [policyIssueType.id],
+      })
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('GET', policyIssueTypeMetadataEndpoint, [
+        policyIssueType,
+      ]).as('metaApiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      assertPayload('@apiRequest', expectedPayload)
+      cy.wait('@metaApiRequest')
+      assertCheckboxGroupOption({
+        element,
+        value: policyIssueType.id,
+        checked: true,
+      })
+      assertChipExists({ label: policyIssueType.name, position: 1 })
+    })
+
+    it('should filter from user input and remove the chips', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('GET', policyIssueTypeMetadataEndpoint, [
+        policyIssueType,
+      ]).as('metaApiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      cy.wait('@apiRequest')
+      cy.wait('@metaApiRequest')
+
+      clickCheckboxGroupOption({
+        element,
+        value: policyIssueType.id,
+      })
+      assertPayload('@apiRequest', expectedPayload)
+      assertQueryParams('policy_issue_types', [policyIssueType.id])
+      assertChipExists({ label: policyIssueType.name, position: 1 })
+      removeChip(policyIssueType.id)
       assertPayload('@apiRequest', minimumPayload)
       assertChipsEmpty()
       assertFieldEmpty(element)


### PR DESCRIPTION
## Description of change

This adds the "Policy issue types" filter to the new interactions collection list.

## Test instructions

1. Go to `/interactions/react`
2. Filter by policy issue type

## Screenshots
![Screenshot 2021-07-05 at 16 00 38](https://user-images.githubusercontent.com/10154302/124490747-672b4580-ddaa-11eb-851f-a9e3c28d0d77.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
