### PR TITLE
React interaction collection list - Company one list filter

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -168,6 +168,15 @@ const InteractionCollection = ({
           selectedOptions={selectedFilters.policyIssueType.options}
           data-test="policy-issue-type-filter"
         />
+        <RoutedCheckboxGroupField
+          overflow="scroll"
+          legend={LABELS.companyOneListGroupTier}
+          name="company_one_list_group_tier"
+          qsParam="company_one_list_group_tier"
+          options={optionMetadata.companyOneListTierOptions}
+          selectedOptions={selectedFilters.companyOneListGroupTier.options}
+          data-test="company-one-list-group-tier-filter"
+        />
       </CollectionFilters>
     </FilteredCollectionList>
   )

--- a/src/apps/interactions/client/constants.js
+++ b/src/apps/interactions/client/constants.js
@@ -11,6 +11,7 @@ export const LABELS = {
   businessIntelligence: 'Business intelligence',
   policyAreas: 'Policy area(s)',
   policyIssueType: 'Policy issue type',
+  companyOneListGroupTier: 'Company One List Group Tier',
 }
 
 export const KIND_OPTIONS = [

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -77,4 +77,12 @@ export const buildSelectedFilters = (
       categoryLabel: LABELS.policyIssueType,
     }),
   },
+  companyOneListGroupTier: {
+    queryParam: 'company_one_list_group_tier',
+    options: buildOptionsFilter({
+      options: metadata.companyOneListTierOptions,
+      value: queryParams.company_one_list_group_tier,
+      categoryLabel: LABELS.policyIssueType,
+    }),
+  },
 })

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -21,6 +21,7 @@ const getInteractionsMetadata = () =>
     }),
     getMetadataOptions(urls.metadata.policyArea()),
     getMetadataOptions(urls.metadata.policyIssueType()),
+    getMetadataOptions(urls.metadata.oneListTier()),
   ])
     .then(
       ([
@@ -28,11 +29,13 @@ const getInteractionsMetadata = () =>
         sectorOptions,
         policyAreaOptions,
         policyIssueTypeOptions,
+        companyOneListTierOptions,
       ]) => ({
         serviceOptions: sortServiceOptions(serviceOptions),
         sectorOptions,
         policyAreaOptions,
         policyIssueTypeOptions,
+        companyOneListTierOptions,
       })
     )
     .catch(handleError)
@@ -50,6 +53,7 @@ const getInteractions = ({
   was_policy_feedback_provided,
   policy_areas,
   policy_issue_types,
+  company_one_list_group_tier,
 }) =>
   axios
     .post('/api-proxy/v3/search/interaction', {
@@ -65,6 +69,7 @@ const getInteractions = ({
       was_policy_feedback_provided,
       policy_areas,
       policy_issue_types,
+      company_one_list_group_tier,
     })
     .then(({ data }) => transformResponseToCollection(data), handleError)
 

--- a/test/functional/cypress/fakers/company-one-list-group-tier.js
+++ b/test/functional/cypress/fakers/company-one-list-group-tier.js
@@ -1,0 +1,16 @@
+import faker from 'faker'
+import { listFaker } from './utils'
+
+const companyOneListgroupTierFaker = (overrides = {}) => ({
+  id: faker.datatype.uuid(),
+  name: faker.name.jobArea(),
+  disabled_on: null,
+  ...overrides,
+})
+
+const companyOneListgroupTierListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: companyOneListgroupTierFaker, length, overrides })
+
+export { companyOneListgroupTierFaker, companyOneListgroupTierListFaker }
+
+export default companyOneListgroupTierListFaker

--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -25,6 +25,7 @@ import { testTypeahead } from '../../support/tests'
 import { serviceFaker } from '../../fakers/services'
 import { policyAreaFaker } from '../../fakers/policy-area'
 import { policyIssueTypeFaker } from '../../fakers/policy-issue-type'
+import { companyOneListgroupTierFaker } from '../../fakers/company-one-list-group-tier'
 
 const buildQueryString = (queryParams = {}) =>
   qs.stringify({
@@ -45,6 +46,9 @@ const serviceMetadataEndpoint = '/api-proxy/v4/metadata/service'
 const policyAreaMetadataEndpoint = '/api-proxy/v4/metadata/policy-area'
 const policyIssueTypeMetadataEndpoint =
   '/api-proxy/v4/metadata/policy-issue-type'
+const companyOneListTierGroupMetadataEndpoint =
+  '/api-proxy/v4/metadata/one-list-tier'
+
 const myAdviserId = '7d19d407-9aec-4d06-b190-d3f404627f21'
 const myAdviserEndpoint = `/api-proxy/adviser/${myAdviserId}`
 
@@ -533,6 +537,58 @@ describe('Interactions Collections Filter', () => {
       assertQueryParams('policy_issue_types', [policyIssueType.id])
       assertChipExists({ label: policyIssueType.name, position: 1 })
       removeChip(policyIssueType.id)
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+      assertFieldEmpty(element)
+    })
+  })
+  context('Company One List Group Tier', () => {
+    const element = '[data-test="company-one-list-group-tier-filter"]'
+    const companyOneListgroupTier = companyOneListgroupTierFaker()
+    const expectedPayload = {
+      ...minimumPayload,
+      company_one_list_group_tier: [companyOneListgroupTier.id],
+    }
+
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        company_one_list_group_tier: [companyOneListgroupTier.id],
+      })
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('GET', companyOneListTierGroupMetadataEndpoint, [
+        companyOneListgroupTier,
+      ]).as('metaApiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      assertPayload('@apiRequest', expectedPayload)
+      cy.wait('@metaApiRequest')
+      assertCheckboxGroupOption({
+        element,
+        value: companyOneListgroupTier.id,
+        checked: true,
+      })
+      assertChipExists({ label: companyOneListgroupTier.name, position: 1 })
+    })
+
+    it('should filter from user input and remove the chips', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('GET', companyOneListTierGroupMetadataEndpoint, [
+        companyOneListgroupTier,
+      ]).as('metaApiRequest')
+      cy.visit(`${interactions.react()}?${queryString}`)
+      cy.wait('@apiRequest')
+      cy.wait('@metaApiRequest')
+
+      clickCheckboxGroupOption({
+        element,
+        value: companyOneListgroupTier.id,
+      })
+      assertPayload('@apiRequest', expectedPayload)
+      assertQueryParams('company_one_list_group_tier', [
+        companyOneListgroupTier.id,
+      ])
+      assertChipExists({ label: companyOneListgroupTier.name, position: 1 })
+      removeChip(companyOneListgroupTier.id)
       assertPayload('@apiRequest', minimumPayload)
       assertChipsEmpty()
       assertFieldEmpty(element)


### PR DESCRIPTION
## Description of change

This adds the company one list tier filter to the new interactions collection list.

## Test instructions

1. Go to `interactions/react`
2. Filter by company one list tier options

## Screenshots
![Screenshot 2021-07-06 at 08 50 46](https://user-images.githubusercontent.com/10154302/124563515-ffbbd700-de37-11eb-8721-2a8f525e3fba.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
