### PR TITLE
Add scrollable checkbox options to Storybook

### DIFF
--- a/src/client/components/CheckboxGroupField/__stories__/CheckboxGroupField.stories.jsx
+++ b/src/client/components/CheckboxGroupField/__stories__/CheckboxGroupField.stories.jsx
@@ -50,7 +50,7 @@ storiesOf('Filters/Checkbox', module)
   ))
   .add('Overflow with scroll', () => (
     <CheckboxGroupField
-      visibleHeight={215}
+      maxScrollHeight={215}
       name="countries"
       legend="What are your favourite countries?"
       options={[

--- a/src/client/components/CheckboxGroupField/__stories__/CheckboxGroupField.stories.jsx
+++ b/src/client/components/CheckboxGroupField/__stories__/CheckboxGroupField.stories.jsx
@@ -48,3 +48,35 @@ storiesOf('Filters/Checkbox', module)
       options={options}
     />
   ))
+  .add('Overflow with scroll', () => (
+    <CheckboxGroupField
+      visibleHeight={215}
+      name="countries"
+      legend="What are your favourite countries?"
+      options={[
+        ...options,
+        {
+          label: 'Spain',
+          value: 'sp',
+        },
+        {
+          label: 'New Zealand',
+          value: 'nz',
+        },
+        {
+          label: 'China',
+          value: 'ch',
+        },
+      ]}
+      selectedOptions={[
+        {
+          label: 'Italy',
+          value: 'it',
+        },
+        {
+          label: 'Poland',
+          value: 'pl',
+        },
+      ]}
+    />
+  ))

--- a/src/client/components/CheckboxGroupField/index.jsx
+++ b/src/client/components/CheckboxGroupField/index.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import MultiChoice from '@govuk-react/multi-choice'
+import PropTypes from 'prop-types'
 import { GREY_2, YELLOW } from 'govuk-colours'
 import styled, { css } from 'styled-components'
-import { FONT_SIZE } from '@govuk-react/constants'
+import { FONT_SIZE, SPACING } from '@govuk-react/constants'
 
 import Checkbox from '../Checkbox'
 import FieldWrapper from '../Form/elements/FieldWrapper'
@@ -50,12 +51,12 @@ const checkboxGroupElementStyles = css`
 `
 
 const StyledFieldWrapper = styled(FieldWrapper)`
-  ${({ visibleHeight }) =>
-    visibleHeight
+  ${({ maxScrollHeight }) =>
+    maxScrollHeight
       ? `
       fieldset > div {
         overflow-y: scroll;
-        max-height: ${visibleHeight}px;
+        max-height: ${maxScrollHeight}px;
         padding-left: 10px;
         margin-left: -10px;
         /* Taken from Gov.uk, these rules allow us to retain a permanent scrollbar */
@@ -76,7 +77,7 @@ const StyledFieldWrapper = styled(FieldWrapper)`
 const SelectedCount = styled('span')`
   font-size: ${FONT_SIZE.SIZE_14};
   display: block;
-  padding: 5px 0;
+  padding: ${SPACING.SCALE_1} 0;
 `
 
 const StyledList = styled('ul')`
@@ -95,7 +96,9 @@ const StyledList = styled('ul')`
  * @param {Func} loadOptions - function to load options
  * @param {Array} selectedOptions - the options that have been selected
  * @param {Func} onChange - callback function that passes on the selected options
+ * @param {number} maxScrollHeight - sets the visible area for the checkboxes before the overflow is set
  */
+
 const CheckboxGroupField = ({
   legend,
   name,
@@ -105,7 +108,7 @@ const CheckboxGroupField = ({
   selectedOptions = [],
   onChange = () => null,
   id,
-  visibleHeight = 0,
+  maxScrollHeight = 0,
   ...props
 }) => {
   const [options, setOptions] = useState(initialOptions)
@@ -122,7 +125,7 @@ const CheckboxGroupField = ({
 
   return (
     <StyledFieldWrapper
-      visibleHeight={visibleHeight}
+      maxScrollHeight={maxScrollHeight}
       legend={legend}
       name={name}
       hint={hint}
@@ -133,7 +136,7 @@ const CheckboxGroupField = ({
         'Loading...'
       ) : (
         <>
-          {visibleHeight > 0 && selectedOptions.length > 0 && (
+          {maxScrollHeight > 0 && selectedOptions.length > 0 && (
             <SelectedCount>{`${selectedOptions.length} selected`}</SelectedCount>
           )}
           <MultiChoice>
@@ -183,6 +186,28 @@ const CheckboxGroupField = ({
       )}
     </StyledFieldWrapper>
   )
+}
+
+CheckboxGroupField.propTypes = {
+  legend: PropTypes.string,
+  name: PropTypes.string,
+  hint: PropTypes.string,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    })
+  ).isRequired,
+  loadOptions: PropTypes.func,
+  selectedOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    })
+  ).isRequired,
+  onChange: PropTypes.func,
+  id: PropTypes.string,
+  maxScrollHeight: PropTypes.number,
 }
 
 export default CheckboxGroupField

--- a/src/client/components/CheckboxGroupField/index.jsx
+++ b/src/client/components/CheckboxGroupField/index.jsx
@@ -1,24 +1,19 @@
 import React, { useState, useEffect } from 'react'
 import MultiChoice from '@govuk-react/multi-choice'
 import { GREY_2, YELLOW } from 'govuk-colours'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+import { FONT_SIZE } from '@govuk-react/constants'
 
 import Checkbox from '../Checkbox'
 import FieldWrapper from '../Form/elements/FieldWrapper'
 
-const StyledFieldWrapper = styled(FieldWrapper)`
-  ${({ overflow }) =>
-    overflow &&
-    `fieldset > div {
-    overflow-y: ${overflow};
-    max-height: 400px;
-    }
-  `}
+const checkboxGroupElementStyles = css`
   label {
     font-weight: normal;
     margin-bottom: 4px;
+    padding-left: 0;
   }
-  label:not(:first-child) {
+  li label {
     padding-left: 20px;
   }
   input {
@@ -54,6 +49,42 @@ const StyledFieldWrapper = styled(FieldWrapper)`
   }
 `
 
+const StyledFieldWrapper = styled(FieldWrapper)`
+  ${({ visibleHeight }) =>
+    visibleHeight
+      ? `
+      fieldset > div {
+        overflow-y: scroll;
+        max-height: ${visibleHeight}px;
+        padding-left: 10px;
+        margin-left: -10px;
+        /* Taken from Gov.uk, these rules allow us to retain a permanent scrollbar */
+        &::-webkit-scrollbar {
+          -webkit-appearance: none;
+          width: 7px;
+        }
+        &::-webkit-scrollbar-thumb {
+          border-radius: 4px;
+          background-color: rgba(0, 0, 0, 0.5);
+          -webkit-box-shadow: 0 0 1px rgb(255 255 255 / 87%);
+        }
+      }
+      ${checkboxGroupElementStyles}`
+      : checkboxGroupElementStyles}
+`
+
+const SelectedCount = styled('span')`
+  font-size: ${FONT_SIZE.SIZE_14};
+  display: block;
+  padding: 5px 0;
+`
+
+const StyledList = styled('ul')`
+  padding: 0;
+  margin: 0;
+  list-style: none;
+`
+
 /**
  * Check box group field - shows a number of options as checkboxes
  *
@@ -74,6 +105,7 @@ const CheckboxGroupField = ({
   selectedOptions = [],
   onChange = () => null,
   id,
+  visibleHeight = 0,
   ...props
 }) => {
   const [options, setOptions] = useState(initialOptions)
@@ -90,6 +122,7 @@ const CheckboxGroupField = ({
 
   return (
     <StyledFieldWrapper
+      visibleHeight={visibleHeight}
       legend={legend}
       name={name}
       hint={hint}
@@ -99,45 +132,54 @@ const CheckboxGroupField = ({
       {loading ? (
         'Loading...'
       ) : (
-        <MultiChoice>
-          {options.map((option, i) => {
-            const {
-              value: optionValue,
-              label: optionLabel,
-              ...optionProps
-            } = option
-            const checked = selectedOptions
-              .map(({ value }) => value)
-              .includes(optionValue)
-            const otherOptions = [
-              ...selectedOptions.filter(
-                ({ value: otherOptionValue }) =>
-                  otherOptionValue !== optionValue
-              ),
-            ]
-            const handleChange = (event) => {
-              if (event.target.checked) {
-                onChange([...otherOptions, option])
-              } else {
-                onChange(otherOptions)
-              }
-            }
-            return (
-              <Checkbox
-                id={`field-${name}-${i + 1}`}
-                key={optionValue}
-                name={name}
-                initialChecked={checked}
-                value={optionValue}
-                onChange={handleChange}
-                aria-label={optionLabel}
-                {...optionProps}
-              >
-                {optionLabel}
-              </Checkbox>
-            )
-          })}
-        </MultiChoice>
+        <>
+          {visibleHeight > 0 && selectedOptions.length > 0 && (
+            <SelectedCount>{`${selectedOptions.length} selected`}</SelectedCount>
+          )}
+          <MultiChoice>
+            <StyledList>
+              {options.map((option, i) => {
+                const {
+                  value: optionValue,
+                  label: optionLabel,
+                  ...optionProps
+                } = option
+                const checked = selectedOptions
+                  .map(({ value }) => value)
+                  .includes(optionValue)
+                const otherOptions = [
+                  ...selectedOptions.filter(
+                    ({ value: otherOptionValue }) =>
+                      otherOptionValue !== optionValue
+                  ),
+                ]
+                const handleChange = (event) => {
+                  if (event.target.checked) {
+                    onChange([...otherOptions, option])
+                  } else {
+                    onChange(otherOptions)
+                  }
+                }
+                return (
+                  <li>
+                    <Checkbox
+                      id={`field-${name}-${i + 1}`}
+                      key={optionValue}
+                      name={name}
+                      initialChecked={checked}
+                      value={optionValue}
+                      onChange={handleChange}
+                      aria-label={optionLabel}
+                      {...optionProps}
+                    >
+                      {optionLabel}
+                    </Checkbox>
+                  </li>
+                )
+              })}
+            </StyledList>
+          </MultiChoice>
+        </>
       )}
     </StyledFieldWrapper>
   )

--- a/src/client/components/CheckboxGroupField/usage.md
+++ b/src/client/components/CheckboxGroupField/usage.md
@@ -1,1 +1,30 @@
-CheckboxGroupField
+# Checkboxes
+
+### Description
+
+Let users select one or more options by using the checkboxes component.
+
+If you have a lot of options to display consider using the `visibleHeight` 
+property to create a scrollable area. Selected option count will only show
+when you use the `visibleHeight` property.
+
+### Usage
+
+```jsx
+<CheckboxGroupField
+  visibleHeight={215}
+  name="countries"
+  legend="What are your favourite countries?"
+  options={moreThanFiveOptions}
+  selectedOptions={[
+    {
+      label: 'Italy',
+      value: 'it',
+    },
+    {
+      label: 'Poland',
+      value: 'pl',
+    },
+  ]}
+/>
+```


### PR DESCRIPTION
## Description of change
As we are building out the new React collection lists we noticed that the long lists of checkbox options you get on the likes of the interactions list page looks strange in comparison to the old component. This is because the new design has no obvious container around the options and no fixed scroll so its hard to just by looking at it that you can scroll the options.

The changes we have made are an iteration towards this example you can see on the Gov.uk website - https://www.gov.uk/search/all?keywords=cars&order=relevance in the next iteration we look at adding the input field so the user can search (similar to how the typeahead behaves)
![Screenshot 2021-07-07 at 17 03 45](https://user-images.githubusercontent.com/10154302/124792924-64b12300-df45-11eb-9b85-8c84af92e03d.png)

For now this does the following:

1. You can now specify a scrollable area via the new property `visibleHeight`. This enables the developer to customise how large/high the container is before it overflows with a scroll. As labels can vary in size this is very hard to set a height that suits all scenarios so setting a height is the best option for now.
2. The scroll will always visible
3. As the user clicks on the checkboxes a count will appear (scrollable version only)

## Test instructions
1. Run Storybook and look at the "Overflow with scroll" option for "CheckboxGroupField"

## Screenshots
![Screenshot 2021-07-07 at 16 52 39](https://user-images.githubusercontent.com/10154302/124793646-1d776200-df46-11eb-82da-ec1a890b7c46.png)

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
