### PR TITLE
Fix typo and add tests around the download header

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -78,7 +78,7 @@ const InteractionCollection = ({
       taskProps={collectionListTask}
       selectedFilters={selectedFilters}
       baseDownloadLink="/interactions/export"
-      entityName="interactions"
+      entityName="interaction"
       defaultQueryParams={{
         sortby: 'date:desc',
         page: 1,

--- a/test/functional/cypress/specs/interaction/download-spec.js
+++ b/test/functional/cypress/specs/interaction/download-spec.js
@@ -1,0 +1,122 @@
+import urls from '../../../../../src/lib/urls'
+import qs from 'qs'
+
+import { interactionsListFaker } from '../../fakers/interactions'
+
+const downloadHeader = '[data-test="download-data-header"]'
+const downloadButton = '[data-test="download-data-header"] a'
+const interactionSearchEndpoint = '/api-proxy/v3/search/interaction'
+
+describe('Download CSV', () => {
+  context('When there are 0 interactions', () => {
+    before(() => {
+      cy.intercept('POST', '/api-proxy/v3/search/interaction', {
+        body: {
+          results: [],
+          count: 0,
+        },
+      })
+      cy.visit(urls.interactions.react())
+    })
+    it('should not render the download header', () => {
+      cy.get(downloadHeader).should('not.exist')
+    })
+  })
+  context('When there is a single interaction', () => {
+    const interactionList = interactionsListFaker(1)
+    before(() => {
+      cy.intercept('POST', interactionSearchEndpoint, {
+        body: {
+          results: interactionList,
+          count: interactionList.length,
+        },
+      })
+      cy.visit(urls.interactions.react())
+    })
+    it('should render the download header', () => {
+      cy.get(downloadHeader).should('exist')
+    })
+
+    it('should render a download link', () => {
+      cy.get(downloadButton)
+        .should('exist')
+        .should('have.attr', 'href', '/interactions/export?sortby=date%3Adesc')
+        .and('contain', 'Download')
+    })
+
+    it('should render a download message', () => {
+      cy.get(downloadHeader).should(
+        'contain',
+        'You can now download this interaction'
+      )
+    })
+  })
+  context('When there are 4999 interactions or less', () => {
+    const interactionsList = interactionsListFaker(9)
+    before(() => {
+      cy.intercept('POST', interactionSearchEndpoint, {
+        body: {
+          results: interactionsList,
+          count: 4999,
+        },
+      })
+      cy.visit(urls.interactions.react())
+    })
+    it('should render a download message', () => {
+      cy.get(downloadHeader).should(
+        'contain',
+        'You can now download these 4999 interactions'
+      )
+    })
+  })
+  context('When there are 5000 interactions or more', () => {
+    const interactionsList = interactionsListFaker(10)
+    before(() => {
+      cy.intercept('POST', interactionSearchEndpoint, {
+        body: {
+          results: interactionsList,
+          count: 5000,
+        },
+      })
+      cy.visit(urls.interactions.react())
+    })
+    it('should render a download message', () => {
+      cy.get(downloadHeader).should(
+        'contain',
+        'Filter to fewer than 5,000 interactions to download'
+      )
+    })
+  })
+  context('When there are filters applied', () => {
+    const interactionsList = interactionsListFaker(1)
+    const queryString = qs.stringify({
+      kind: ['interaction', 'service_delivery'],
+      dit_participants__adviser: ['1'],
+      adviser: ['3b42c516-9898-e211-a939-e4115bead28a'],
+      date_after: '2021-06-24',
+      date_before: '2023-06-24',
+      service: ['94a2473d-e898-4e1c-a082-ddfde8f297ff'],
+      sector_descends: ['af959812-6095-e211-a939-e4115bead28a'],
+      was_policy_feedback_provided: true,
+      policy_areas: ['4b9142df-0520-46bd-9da9-94147cdbae13'],
+      policy_issue_types: ['688ac22e-89d4-4d1f-bf0b-013588bf63a7'],
+      company_one_list_group_tier: ['b91bf800-8d53-e311-aef3-441ea13961e2'],
+    })
+    before(() => {
+      cy.intercept('POST', interactionSearchEndpoint, {
+        body: {
+          results: interactionsList,
+          count: interactionsList.length,
+        },
+      })
+      cy.visit(`${urls.interactions.react()}?${queryString}`)
+    })
+    it('should have the correct query string', () => {
+      cy.get(downloadButton).should(
+        'have.attr',
+        'href',
+        `/interactions/export?${queryString}`
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

On the new React interaction collection lists page I noticed there was an extra 's' on the end interactions within the download header. I have fixed the typo and added the tests as these were missing. Tests created are as per other react collection lists.

## Test instructions

1. Go to `/interactions/react`
2. Inspect the download header and there shouldn't be any typos

## Screenshots
### Before
![Screenshot 2021-07-08 at 13 59 02](https://user-images.githubusercontent.com/10154302/124926298-4276de00-dff5-11eb-8560-d073be1552b8.png)

### After
![Screenshot 2021-07-08 at 14 03 15](https://user-images.githubusercontent.com/10154302/124926334-4efb3680-dff5-11eb-9a68-e93532668f0b.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
