### PR TITLE
Add the total value of OMIS orders 

### DIFF
--- a/src/apps/omis/client/transformers.js
+++ b/src/apps/omis/client/transformers.js
@@ -65,7 +65,12 @@ export const transformOrderToListItem = ({
   return retVal
 }
 
-export const transformResponseToCollection = ({ count, results = [] }) => ({
+export const transformResponseToCollection = ({
   count,
+  results = [],
+  summary,
+}) => ({
+  count,
+  summary,
   results: results.map(transformOrderToListItem),
 })

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { BLACK, GREY_3 } from 'govuk-colours'
+import { HEADING_SIZES, SPACING } from '@govuk-react/constants'
+import { FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
+import { H2 } from '@govuk-react/heading'
 import Button from '@govuk-react/button'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
-import { H2 } from '@govuk-react/heading'
-import { BLACK, GREY_3 } from 'govuk-colours'
-import { HEADING_SIZES, SPACING } from '@govuk-react/constants'
 
 import {
   CollectionHeaderRow,
@@ -56,6 +57,14 @@ const StyledDiv = styled('div')`
   }
 `
 
+const StyledSummary = styled('div')`
+  font-size: ${FONT_SIZE.SIZE_16};
+`
+
+const StyledSummaryTotal = styled('span')`
+  font-weight: ${FONT_WEIGHTS.bold};
+`
+
 const RoutedFilterChipsCollection = ({ selectedFilters }) => {
   return (
     <>
@@ -71,6 +80,7 @@ const RoutedFilterChipsCollection = ({ selectedFilters }) => {
 }
 function FilteredCollectionHeader({
   totalItems,
+  summary,
   collectionName = 'result',
   addItemUrl = null,
   selectedFilters,
@@ -104,6 +114,14 @@ function FilteredCollectionHeader({
           </FilterReset>
         </StyledDiv>
       </CollectionHeaderRow>
+      {summary && (
+        <StyledSummary data-test="summary">
+          Total value:{' '}
+          <StyledSummaryTotal>
+            £{decimal(summary.total_subtotal_cost / 100)}
+          </StyledSummaryTotal>
+        </StyledSummary>
+      )}
       <CollectionHeaderRow data-test="filter-chips" id="filter-chips">
         <RoutedFilterChipsCollection selectedFilters={selectedFilters} />
       </CollectionHeaderRow>
@@ -113,6 +131,7 @@ function FilteredCollectionHeader({
 
 FilteredCollectionHeader.propTypes = {
   totalItems: PropTypes.number.isRequired,
+  summary: PropTypes.object,
   collectionName: PropTypes.string.isRequired,
   addItemUrl: PropTypes.string,
   selectedFilters: PropTypes.objectOf(

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -20,6 +20,7 @@ import {
 
 const FilteredCollectionList = ({
   results = [],
+  summary = null,
   itemsPerPage = 10,
   sortOptions = null,
   taskProps,
@@ -55,6 +56,7 @@ const FilteredCollectionList = ({
                 {isComplete && (
                   <FilteredCollectionHeader
                     totalItems={count}
+                    summary={summary}
                     collectionName={collectionName}
                     selectedFilters={selectedFilters}
                     addItemUrl={addItemUrl}
@@ -128,6 +130,7 @@ FilteredCollectionList.propTypes = {
     label: PropTypes.string,
     value: PropTypes.string,
   }),
+  summary: PropTypes.object,
   defaultQueryParams: PropTypes.object,
 }
 

--- a/test/functional/cypress/specs/omis/collection-react-spec.js
+++ b/test/functional/cypress/specs/omis/collection-react-spec.js
@@ -38,6 +38,9 @@ describe('Orders (OMIS) Collection List Page - React', () => {
       body: {
         count: ordersList.length,
         results: ordersList,
+        summary: {
+          total_subtotal_cost: 23218.0,
+        },
       },
     }).as('apiRequest')
     cy.visit(omis.react.index())
@@ -67,6 +70,12 @@ describe('Orders (OMIS) Collection List Page - React', () => {
       .should('exist')
       .should('contain', 'Add order')
       .should('have.attr', 'href', '/omis/create')
+  })
+
+  it('should have the total value', () => {
+    cy.get('[data-test="summary"]')
+      .should('exist')
+      .should('contain', 'Total value: £232.18')
   })
 
   it('should display a list of contacts', () => {


### PR DESCRIPTION
## Description of change

Added the **total value** of OMIS orders above the collection list 

## Test instructions

View the new react version here: `/omis/react`

## Screenshots
<img width="980" alt="Screenshot 2021-07-08 at 16 59 42" src="https://user-images.githubusercontent.com/964268/124954470-03a15200-e00e-11eb-9743-5461af227b28.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
