### PR TITLE
React interactions collection list - Add overflow values to filters

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -124,7 +124,7 @@ const InteractionCollection = ({
           data-test="date-before-filter"
         />
         <RoutedCheckboxGroupField
-          overflow="scroll"
+          maxScrollHeight={350}
           legend={LABELS.service}
           name="service"
           qsParam="service"
@@ -151,7 +151,7 @@ const InteractionCollection = ({
           data-test="business-intelligence-filter"
         />
         <RoutedCheckboxGroupField
-          overflow="scroll"
+          maxScrollHeight={345}
           legend={LABELS.policyAreas}
           name="policy_areas"
           qsParam="policy_areas"
@@ -168,7 +168,7 @@ const InteractionCollection = ({
           data-test="policy-issue-type-filter"
         />
         <RoutedCheckboxGroupField
-          overflow="scroll"
+          maxScrollHeight={370}
           legend={LABELS.companyOneListGroupTier}
           name="company_one_list_group_tier"
           qsParam="company_one_list_group_tier"


### PR DESCRIPTION
## Description of change
As we now have a configurable "maxScrollHeight" (max height) property setting on the checkbox group #3782 we can set an overflow with scroll to long lists of checkbox options. This PR just sets the "maxScrollHeight" values to the three filters in the interactions collection list page.

1. Service
2. Policy area(S)
3. Company One List Group Tier 


## Test instructions

1. Go to `/interactions/react`
2. Check that the three filters scroll
3. When you click on a checkbox you should see the selected count above the checkboxes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
