### PR TITLE
Add state and province filters to company collection list

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -114,6 +114,26 @@ const CompaniesCollection = ({
           selectedOptions={selectedFilters.countries.options}
           data-test="country-filter"
         />
+        <RoutedTypeahead
+          isMulti={true}
+          legend={LABELS.usState}
+          name="us_state"
+          qsParam="us_state"
+          placeholder="Search US state"
+          options={optionMetadata.usStateOptions}
+          selectedOptions={selectedFilters.usStates.options}
+          data-test="us-state-filter"
+        />
+        <RoutedTypeahead
+          isMulti={true}
+          legend={LABELS.canadianProvince}
+          name="canadian_province"
+          qsParam="canadian_province"
+          placeholder="Search Canadian province"
+          options={optionMetadata.canadianProvinceOptions}
+          selectedOptions={selectedFilters.canadianProvinces.options}
+          data-test="canadian-province-filter"
+        />
         <RoutedInputField
           id="CompanyCollection.postcode"
           qsParam="uk_postcode"

--- a/src/apps/companies/client/constants.js
+++ b/src/apps/companies/client/constants.js
@@ -3,6 +3,8 @@ export const LABELS = {
   companyName: 'Company name',
   sector: 'Sector',
   country: 'Country',
+  usState: 'US state',
+  canadianProvince: 'Canadian province',
   ukPostcode: 'UK postcode',
   ukRegion: 'UK region',
   companyStatus: 'Status',
@@ -34,3 +36,8 @@ export const SORT_OPTIONS = [
     value: 'latest_interaction_date:desc',
   },
 ]
+
+export const COUNTRIES = {
+  usa: '81756b9a-5d95-e211-a939-e4115bead28a',
+  canada: '5daf72a6-5d95-e211-a939-e4115bead28a',
+}

--- a/src/apps/companies/client/constants.js
+++ b/src/apps/companies/client/constants.js
@@ -36,8 +36,3 @@ export const SORT_OPTIONS = [
     value: 'latest_interaction_date:desc',
   },
 ]
-
-export const COUNTRIES = {
-  usa: '81756b9a-5d95-e211-a939-e4115bead28a',
-  canada: '5daf72a6-5d95-e211-a939-e4115bead28a',
-}

--- a/src/apps/companies/client/filters.js
+++ b/src/apps/companies/client/filters.js
@@ -55,6 +55,22 @@ export const buildSelectedFilters = (
       categoryLabel: LABELS.ukRegion,
     }),
   },
+  usStates: {
+    queryParam: 'us_state',
+    options: buildOptionsFilter({
+      options: metadata.usStateOptions,
+      value: queryParams.us_state,
+      categoryLabel: LABELS.usState,
+    }),
+  },
+  canadianProvinces: {
+    queryParam: 'canadian_province',
+    options: buildOptionsFilter({
+      options: metadata.canadianProvinceOptions,
+      value: queryParams.canadian_province,
+      categoryLabel: LABELS.canadianProvince,
+    }),
+  },
   companyStatuses: {
     queryParam: 'archived',
     options: buildOptionsFilter({

--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -7,7 +7,9 @@ import {
 } from '../../../client/metadata'
 
 import { transformResponseToCompanyCollection } from './transformers'
-import { COUNTRIES } from './constants'
+
+const usa = '81756b9a-5d95-e211-a939-e4115bead28a'
+const canada = '5daf72a6-5d95-e211-a939-e4115bead28a'
 
 const handleError = (error) => Promise.reject(Error(error.response.data.detail))
 
@@ -69,10 +71,10 @@ const getCompaniesMetadata = () =>
     getHeadquarterTypeOptions(urls.metadata.headquarterType()),
     getMetadataOptions(urls.metadata.ukRegion()),
     getMetadataOptions(urls.metadata.administrativeArea(), {
-      params: { country: COUNTRIES.usa },
+      params: { country: usa },
     }),
     getMetadataOptions(urls.metadata.administrativeArea(), {
-      params: { country: COUNTRIES.canada },
+      params: { country: canada },
     }),
     getMetadataOptions(urls.metadata.country()),
   ])

--- a/test/functional/cypress/fakers/administrative-areas.js
+++ b/test/functional/cypress/fakers/administrative-areas.js
@@ -1,0 +1,19 @@
+import faker from 'faker'
+
+import { listFaker } from './utils'
+
+export const administrativeAreaFaker = () => ({
+  id: faker.datatype.uuid(),
+  name: faker.address.state(),
+  country: {
+    name: faker.address.country(),
+    id: faker.datatype.uuid(),
+  },
+  area_code: faker.address.stateAbbr(),
+  disabled_on: null,
+})
+
+export const administrativeAreaListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: administrativeAreaFaker, length, overrides })
+
+export default administrativeAreaListFaker


### PR DESCRIPTION
## Description of change

Adds state and province filters to new react company collection list

## Test instructions

Go to /companies/react - there should be new filters for US states and Canadian Provinces. Selecting these should update the url and show a chip.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
