### PR TITLE
Filter the service metadata correctly

### DIFF
--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -2,7 +2,10 @@ import axios from 'axios'
 
 import urls from '../../../lib/urls'
 
-import { transformResponseToCollection } from './transformers'
+import {
+  transformResponseToCollection,
+  filterServiceNames,
+} from './transformers'
 
 import { getMetadataOptions } from '../../../client/metadata'
 
@@ -13,7 +16,9 @@ const sortServiceOptions = (options) =>
 
 const getInteractionsMetadata = () =>
   Promise.all([
-    getMetadataOptions(urls.metadata.service()),
+    getMetadataOptions(urls.metadata.service(), {
+      filterDisabled: false,
+    }),
     getMetadataOptions(urls.metadata.sector(), {
       params: {
         level__lte: '0',
@@ -31,7 +36,7 @@ const getInteractionsMetadata = () =>
         policyIssueTypeOptions,
         companyOneListTierOptions,
       ]) => ({
-        serviceOptions: sortServiceOptions(serviceOptions),
+        serviceOptions: filterServiceNames(sortServiceOptions(serviceOptions)),
         sectorOptions,
         policyAreaOptions,
         policyIssueTypeOptions,

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -86,29 +86,21 @@ export const transformWasPolicyfeedBackProvidedToApi = (
 export const filterServiceNames = (services) => {
   if (!services) return
 
-  const excludedServiceStrings = [
+  const excludedParentServices = [
     'A Specific DIT Export Service or Funding',
     'A Specific Service',
     'Enquiry or Referral Received',
     'Enquiry Received',
   ]
-
   const filteredServiceNames = services
     .map((service) => {
-      const splitServiceName = service.label.split(' : ')
-      const name =
-        splitServiceName[1] &&
-        excludedServiceStrings.includes(splitServiceName[0])
-          ? splitServiceName[1]
-          : service.label
-      return { ...service, label: name }
+      const [parent, child] = service.label.split(' : ')
+      const isParentExcluded = excludedParentServices.includes(parent)
+      const label = isParentExcluded && child ? child : service.label
+      const value = service.value
+      return { label, value }
     })
-    .sort(function (a, b) {
-      const textA = a.label
-      const textB = b.label
-
-      return textA.localeCompare(textB)
-    })
+    .sort((a, b) => a.label.localeCompare(b.label))
 
   return filteredServiceNames
 }

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -82,3 +82,33 @@ export const transformResponseToCollection = ({ count, results = [] }) => ({
 export const transformWasPolicyfeedBackProvidedToApi = (
   wasPolicyfeedbackProvided
 ) => wasPolicyfeedbackProvided && wasPolicyfeedbackProvided[0] === 'true'
+
+export const filterServiceNames = (services) => {
+  if (!services) return
+
+  const excludedServiceStrings = [
+    'A Specific DIT Export Service or Funding',
+    'A Specific Service',
+    'Enquiry or Referral Received',
+    'Enquiry Received',
+  ]
+
+  const filteredServiceNames = services
+    .map((service) => {
+      const splitServiceName = service.label.split(' : ')
+      const name =
+        splitServiceName[1] &&
+        excludedServiceStrings.includes(splitServiceName[0])
+          ? splitServiceName[1]
+          : service.label
+      return { ...service, label: name }
+    })
+    .sort(function (a, b) {
+      const textA = a.label
+      const textB = b.label
+
+      return textA.localeCompare(textB)
+    })
+
+  return filteredServiceNames
+}


### PR DESCRIPTION
## Description of change

Currently the services in the new react interactions collection list filter are not being filtered correctly as per legacy version. By default `filterDisabled: true` gets passed to the API as default and we needed to override this to `false` in order to get the right list back.

## Test instructions

1. Go to `interactions/react`
2. Compare the list of options in the services filter against the options in the live version `/interaction`

They should be exactly the same.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
