### PR TITLE
Resolve issue with unverified companies not saving with undefined area

### DIFF
--- a/src/apps/companies/apps/add-company/__test__/transformers.test.js
+++ b/src/apps/companies/apps/add-company/__test__/transformers.test.js
@@ -1,6 +1,8 @@
+const faker = require('faker')
 const {
   transformToDnbStubCompany,
   transformToCreateDnbCompanyInvestigation,
+  transformFormData,
 } = require('../transformers')
 
 describe('Companies add company transformers', () => {
@@ -223,6 +225,82 @@ describe('Companies add company transformers', () => {
             country: 'country',
           },
         })
+      })
+    })
+  })
+
+  describe('#transformFormData', () => {
+    context('when area is populated', () => {
+      it('returns area correctly', () => {
+        const area = faker.datatype.uuid
+        const formData = {
+          name: faker.name,
+          website: faker.internet.domainName,
+          telephone_number: faker.phone,
+          address1: faker.address.streetAddress,
+          address2: faker.address.streetAddress,
+          city: faker.address.city,
+          county: faker.address.county,
+          postcode: faker.address.zipCode,
+          country: faker.address.country,
+          area: area,
+        }
+        const response = transformFormData(formData, {
+          locals: { features: { 'address-area-company-search': true } },
+        })
+        const expected = {
+          name: formData.name,
+          website: formData.website,
+          telephone_number: formData.telephone_number,
+          address: {
+            line_1: formData.address1,
+            line_2: formData.address2 || '',
+            town: formData.city,
+            county: formData.county || '',
+            postcode: formData.postcode,
+            country: { id: formData.country },
+            area: { id: formData.area },
+          },
+        }
+
+        expect(response).to.deep.equal(expected)
+      })
+    })
+
+    context('when area is undefined', () => {
+      it('returns area as undefined without an id', () => {
+        const area = undefined
+        const formData = {
+          name: faker.name,
+          website: faker.internet.domainName,
+          telephone_number: faker.phone,
+          address1: faker.address.streetAddress,
+          address2: faker.address.streetAddress,
+          city: faker.address.city,
+          county: faker.address.county,
+          postcode: faker.address.zipCode,
+          country: faker.address.country,
+          area: area,
+        }
+        const response = transformFormData(formData, {
+          locals: { features: { 'address-area-company-search': true } },
+        })
+        const expected = {
+          name: formData.name,
+          website: formData.website,
+          telephone_number: formData.telephone_number,
+          address: {
+            line_1: formData.address1,
+            line_2: formData.address2 || '',
+            town: formData.city,
+            county: formData.county || '',
+            postcode: formData.postcode,
+            country: { id: formData.country },
+            area: undefined,
+          },
+        }
+
+        expect(response).to.deep.equal(expected)
       })
     })
   })

--- a/src/apps/companies/apps/add-company/transformers.js
+++ b/src/apps/companies/apps/add-company/transformers.js
@@ -62,4 +62,5 @@ const transformToCreateDnbCompanyInvestigation = (formData, companyId, res) => {
 module.exports = {
   transformToDnbStubCompany,
   transformToCreateDnbCompanyInvestigation,
+  transformFormData,
 }

--- a/src/apps/companies/apps/add-company/transformers.js
+++ b/src/apps/companies/apps/add-company/transformers.js
@@ -15,6 +15,17 @@ const transformFormData = (
   res,
   countryAsObject = true
 ) => {
+  const sanitiseArea = (area) => {
+    if (area === undefined) {
+      return {
+        area: undefined,
+      }
+    }
+    return {
+      area: { id: area },
+    }
+  }
+
   return {
     name,
     website,
@@ -26,9 +37,8 @@ const transformFormData = (
       county: county || '',
       postcode: postcode,
       country: countryAsObject ? { id: country } : country,
-      ...(res.locals.features['address-area-company-search'] && {
-        area: { id: area },
-      }),
+      ...(res.locals.features['address-area-company-search'] &&
+        sanitiseArea(area)),
     },
   }
 }


### PR DESCRIPTION
## Description of change

Resolves an issue where unverified companies with no address area were failing to save correctly.

## Test instructions

Go to add an unverified company that is not located in the united states or Canada. The company should save correctly without and address area (i.e. State or Province) correctly.

## Screenshots
### Before

n/a

### After

n/a

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
