### PR TITLE
CDS-234 Fix validation for US and Canadian area field

### DIFF
--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -128,7 +128,14 @@ const FieldAddress = ({
   const renderUsStateField = () => {
     if (isUS && usStates?.length > 0) {
       return (
-        <FieldSelect type="text" name="area" label="State" options={usStates} />
+        <FieldSelect
+          type="text"
+          name="area"
+          label="State"
+          options={usStates}
+          required="Select a state"
+          emptyOption="-- Select state --"
+        />
       )
     }
   }
@@ -141,6 +148,8 @@ const FieldAddress = ({
           name="area"
           label="Province"
           options={canadaProvinces}
+          required="Select a province"
+          emptyOption="-- Select province --"
         />
       )
     }

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -96,6 +96,46 @@ const goToUKCompanySectorAndRegionPage = () => {
   cy.get(selectors.companyAdd.continueButton).click()
 }
 
+const manualAddUSOrCanadianCompanyForm = () => {
+  cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
+    .parent()
+    .should('be.visible')
+  cy.get(
+    selectors.companyAdd.newCompanyRecordForm.organisationType
+      .governmentDepartmentOrOtherPublicBody
+  )
+    .parent()
+    .should('be.visible')
+  cy.get(
+    selectors.companyAdd.newCompanyRecordForm.organisationType.limitedCompany
+  )
+    .parent()
+    .should('be.visible')
+  cy.get(
+    selectors.companyAdd.newCompanyRecordForm.organisationType
+      .limitedPartnership
+  )
+    .parent()
+    .should('be.visible')
+  cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.partnership)
+    .parent()
+    .should('be.visible')
+  cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader)
+    .parent()
+    .should('be.visible')
+  cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
+    'be.visible'
+  )
+  cy.get(selectors.companyAdd.newCompanyRecordForm.website).should('be.visible')
+  cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should(
+    'be.visible'
+  )
+  cy.get(selectors.companyAdd.newCompanyRecordForm.area).should('be.visible')
+  cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).should(
+    'be.visible'
+  )
+}
+
 describe('Add company form', () => {
   beforeEach(function () {
     Cypress.Cookies.preserveOnce('datahub.sid')
@@ -694,52 +734,7 @@ describe('Add company form', () => {
     })
 
     it('should display the manual entry form', () => {
-      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .governmentDepartmentOrOtherPublicBody
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .limitedCompany
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .limitedPartnership
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.partnership
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.website).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.area).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).should(
-        'be.visible'
-      )
+      manualAddUSOrCanadianCompanyForm()
       cy.get(selectors.companyAdd.form).contains('United States')
     })
 
@@ -767,52 +762,7 @@ describe('Add company form', () => {
     })
 
     it('should display the manual entry form', () => {
-      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .governmentDepartmentOrOtherPublicBody
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .limitedCompany
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .limitedPartnership
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.partnership
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.website).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.area).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).should(
-        'be.visible'
-      )
+      manualAddUSOrCanadianCompanyForm()
       cy.get(selectors.companyAdd.form).contains('Canada')
     })
 

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -96,7 +96,7 @@ const goToUKCompanySectorAndRegionPage = () => {
   cy.get(selectors.companyAdd.continueButton).click()
 }
 
-const manualAddUSOrCanadianCompanyForm = () => {
+const assertUSOrCanadianCompanyFormFields = () => {
   cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
     .parent()
     .should('be.visible')
@@ -734,7 +734,7 @@ describe('Add company form', () => {
     })
 
     it('should display the manual entry form', () => {
-      manualAddUSOrCanadianCompanyForm()
+      assertUSOrCanadianCompanyFormFields()
       cy.get(selectors.companyAdd.form).contains('United States')
     })
 
@@ -762,7 +762,7 @@ describe('Add company form', () => {
     })
 
     it('should display the manual entry form', () => {
-      manualAddUSOrCanadianCompanyForm()
+      assertUSOrCanadianCompanyFormFields()
       cy.get(selectors.companyAdd.form).contains('Canada')
     })
 

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -27,6 +27,13 @@ const goToUSCompanySearchPage = () => {
   cy.get(selectors.companyAdd.continueButton).click()
 }
 
+const goToCanadianCompanySearchPage = () => {
+  cy.visit(urls.companies.create())
+  cy.get(selectors.companyAdd.form).find('[type="radio"]').check('overseas')
+  cy.get(selectors.companyAdd.form).find('select').select('Canada')
+  cy.get(selectors.companyAdd.continueButton).click()
+}
+
 const goToUKCompanySearchResultsPage = () => {
   cy.visit(urls.companies.create())
   cy.get(selectors.companyAdd.form).find('[type="radio"]').check('GB')
@@ -45,6 +52,14 @@ const goToUSCompanySearchResultsPage = () => {
   goToUSCompanySearchPage()
   cy.get(selectors.companyAdd.entitySearch.companyNameField).type(
     'a US company'
+  )
+  cy.get(selectors.companyAdd.entitySearch.searchButton).click()
+}
+
+const goToCandianCompanySearchResultsPage = () => {
+  goToCanadianCompanySearchPage()
+  cy.get(selectors.companyAdd.entitySearch.companyNameField).type(
+    'a Canadian company'
   )
   cy.get(selectors.companyAdd.entitySearch.searchButton).click()
 }
@@ -595,80 +610,6 @@ describe('Add company form', () => {
     })
   })
 
-  context('when manually adding a new US company', () => {
-    before(() => {
-      cy.visit(urls.companies.create())
-      cy.get(selectors.companyAdd.form).find('[type="radio"]').check('overseas')
-      cy.get(selectors.companyAdd.form).find('select').select('United States')
-      cy.get(selectors.companyAdd.continueButton).click()
-      cy.get(selectors.companyAdd.entitySearch.companyNameField).type(
-        'a US company'
-      )
-      cy.get(selectors.companyAdd.entitySearch.searchButton).click()
-
-      cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
-      cy.get(
-        selectors.companyAdd.entitySearch.cannotFind.stillCannotFind
-      ).click()
-    })
-
-    it('should display the manual entry form', () => {
-      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .governmentDepartmentOrOtherPublicBody
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .limitedCompany
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType
-          .limitedPartnership
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.partnership
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(
-        selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader
-      )
-        .parent()
-        .should('be.visible')
-      cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.website).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.area).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).should(
-        'be.visible'
-      )
-      cy.get(selectors.companyAdd.form).contains('United States')
-    })
-
-    it('should not show a disabled state', () => {
-      cy.get(selectors.companyAdd.newCompanyRecordForm.area)
-        .contains('Disabled US State')
-        .should('not.exist')
-    })
-  })
-
   context('when "UK" is selected for the company location', () => {
     beforeEach(() => {
       const { results } = selectors.companyAdd.entitySearch
@@ -800,6 +741,91 @@ describe('Add company form', () => {
         'be.visible'
       )
       cy.get(selectors.companyAdd.form).contains('United States')
+    })
+
+    it('should show errors when the form is not completed', () => {
+      cy.get(selectors.companyAdd.continueButton).click()
+      cy.get(selectors.companyAdd.form).contains('Select organisation type')
+      cy.get(selectors.companyAdd.form).contains('Enter name')
+      cy.get(selectors.companyAdd.form).contains(
+        'Enter a website or phone number'
+      )
+      cy.get(selectors.companyAdd.form).contains('Enter address line 1')
+      cy.get(selectors.companyAdd.form).contains('Enter town or city')
+      cy.get(selectors.companyAdd.form).contains('Select a state')
+    })
+  })
+
+  context('when manually adding a new Canadian company', () => {
+    before(() => {
+      goToCandianCompanySearchResultsPage()
+
+      cy.get(selectors.companyAdd.entitySearch.cannotFind.summary).click()
+      cy.get(
+        selectors.companyAdd.entitySearch.cannotFind.stillCannotFind
+      ).click()
+    })
+
+    it('should display the manual entry form', () => {
+      cy.get(selectors.companyAdd.newCompanyRecordForm.organisationType.charity)
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType
+          .governmentDepartmentOrOtherPublicBody
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType
+          .limitedCompany
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType
+          .limitedPartnership
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType.partnership
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(
+        selectors.companyAdd.newCompanyRecordForm.organisationType.soleTrader
+      )
+        .parent()
+        .should('be.visible')
+      cy.get(selectors.companyAdd.newCompanyRecordForm.companyName).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.website).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.telephone).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.area).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).should(
+        'be.visible'
+      )
+      cy.get(selectors.companyAdd.form).contains('Canada')
+    })
+
+    it('should show errors when the form is not completed', () => {
+      cy.get(selectors.companyAdd.continueButton).click()
+      cy.get(selectors.companyAdd.form).contains('Select organisation type')
+      cy.get(selectors.companyAdd.form).contains('Enter name')
+      cy.get(selectors.companyAdd.form).contains(
+        'Enter a website or phone number'
+      )
+      cy.get(selectors.companyAdd.form).contains('Enter address line 1')
+      cy.get(selectors.companyAdd.form).contains('Enter town or city')
+      cy.get(selectors.companyAdd.form).contains('Select a province')
     })
   })
 })

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -1,5 +1,6 @@
 const { convertUsdToGbp } = require('../../../../../src/common/currency')
 const { roundToSignificantDigits } = require('../../../../../src/common/number')
+const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
 
@@ -249,6 +250,12 @@ describe('Company edit', () => {
         },
       ],
     })
+
+    it('renders errors correctly', () => {
+      cy.get(selectors.companyEdit.address.area).select('-- Select state --')
+      cy.contains('Submit').click()
+      cy.get(selectors.companyEdit.form).contains('Select a state')
+    })
   })
 
   context('when editing unmatched Canadian company NOT on the One List', () => {
@@ -326,6 +333,12 @@ describe('Company edit', () => {
           assert: assertFieldRadios,
         },
       ],
+    })
+
+    it('renders errors correctly', () => {
+      cy.get(selectors.companyEdit.address.area).select('-- Select province --')
+      cy.contains('Submit').click()
+      cy.get(selectors.companyEdit.form).contains('Select a province')
     })
   })
 

--- a/test/selectors/company/add-company.js
+++ b/test/selectors/company/add-company.js
@@ -48,7 +48,6 @@ module.exports = {
       findUkAddress: 'form button:contains("Find UK address")',
       options: 'label:contains("Select an address") select',
     },
-    area: 'select#area',
     region: 'select#uk_region',
     sector: 'select#sector',
     area: 'select#area',

--- a/test/selectors/company/edit.js
+++ b/test/selectors/company/edit.js
@@ -1,4 +1,5 @@
 module.exports = {
+  form: 'form',
   tradingName: 'input[name="trading_names"]',
   vatNumber: 'input[name="vat_number"]',
   annualTurnover: 'input[name="turnover_range"]',
@@ -12,6 +13,7 @@ module.exports = {
     town: 'input[name="city"]',
     county: 'input[name="county"]',
     postcode: 'input[name="postcode"]',
+    area: 'select#area',
   },
   registeredAddressLegend: 'fieldset legend:contains("Registered address")',
   region: 'select#uk_region',


### PR DESCRIPTION
## Description of change

Previously, the add company and edit company forms were not validating against the state/province fields when they were present.

## Test instructions

Go to Add a new company to US/Canada. Fill in all address fields apart from State/Province and attempt to submit, you should receive an error asking you to fill in that field.

Go to Edit an existing US/Canadian company's business details. Empty the State/Province field and attempt to submit, you should receive an error asking you to fill in that field.

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/126344326-302fdfaf-1e96-4a99-9136-6c7dd8422028.png)

### After

![image](https://user-images.githubusercontent.com/20663545/126354171-12194800-dd40-4213-8a36-9a35d15323b4.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
