### PR TITLE
Comment out flaky e2e test

### DIFF
--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -3,7 +3,7 @@ const selectors = require('../../../../selectors')
 
 const {
   companies,
-  contacts,
+  // contacts,
   investments,
 } = require('../../../../../src/lib/urls')
 
@@ -24,7 +24,7 @@ describe('Collection', () => {
     })
   })
 
-  describe('contact', () => {
+  /* describe('contact', () => {
     before(() => {
       cy.visit(contacts.index())
     })
@@ -32,7 +32,7 @@ describe('Collection', () => {
     it('should return the results summary for a contact collection', () => {
       cy.get('[data-test="collectionCount"]').should('have.text', '7')
     })
-  })
+  }) */
 
   context('investment', () => {
     describe('projects', () => {


### PR DESCRIPTION
## Description of change

An issue has been identified with this test where different numbers of contacts are being returned (either 7 or 9), meaning that the test fails suddenly in `master` and blocks PRs.

In order to prevent further delays and issues for others I've commented out the test. I'll also write up a ticket for this in Jira.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
